### PR TITLE
Move check filtering to linter.rs

### DIFF
--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -970,17 +970,14 @@ where
             }
             ExprKind::Tuple { elts, ctx } | ExprKind::List { elts, ctx } => {
                 if matches!(ctx, ExprContext::Store) {
-                    let check_too_many_expressions =
-                        self.settings.enabled.contains(&CheckCode::F621);
-                    let check_two_starred_expressions =
-                        self.settings.enabled.contains(&CheckCode::F622);
-                    if let Some(check) = pyflakes::checks::starred_expressions(
-                        elts,
-                        check_too_many_expressions,
-                        check_two_starred_expressions,
-                        Range::from_located(expr),
-                    ) {
-                        self.add_check(check);
+                    if self.settings.enabled.contains(&CheckCode::F621)
+                        || self.settings.enabled.contains(&CheckCode::F622)
+                    {
+                        if let Some(check) =
+                            pyflakes::checks::starred_expressions(elts, Range::from_located(expr))
+                        {
+                            self.add_check(check);
+                        }
                     }
                 }
             }
@@ -1279,17 +1276,10 @@ where
                 }
             }
             ExprKind::Dict { keys, .. } => {
-                let check_repeated_literals = self.settings.enabled.contains(&CheckCode::F601);
-                let check_repeated_variables = self.settings.enabled.contains(&CheckCode::F602);
-                if check_repeated_literals || check_repeated_variables {
-                    self.add_checks(
-                        pyflakes::checks::repeated_keys(
-                            keys,
-                            check_repeated_literals,
-                            check_repeated_variables,
-                        )
-                        .into_iter(),
-                    );
+                if self.settings.enabled.contains(&CheckCode::F601)
+                    || self.settings.enabled.contains(&CheckCode::F602)
+                {
+                    self.add_checks(pyflakes::checks::repeated_keys(keys).into_iter());
                 }
             }
             ExprKind::Yield { .. } | ExprKind::YieldFrom { .. } | ExprKind::Await { .. } => {
@@ -1328,13 +1318,10 @@ where
                 }
             }
             ExprKind::UnaryOp { op, operand } => {
-                let check_not_in = self.settings.enabled.contains(&CheckCode::E713);
-                let check_not_is = self.settings.enabled.contains(&CheckCode::E714);
-                if check_not_in || check_not_is {
-                    self.add_checks(
-                        pycodestyle::checks::not_tests(op, operand, check_not_in, check_not_is)
-                            .into_iter(),
-                    );
+                if self.settings.enabled.contains(&CheckCode::E713)
+                    || self.settings.enabled.contains(&CheckCode::E714)
+                {
+                    self.add_checks(pycodestyle::checks::not_tests(op, operand).into_iter());
                 }
 
                 if self.settings.enabled.contains(&CheckCode::B002) {
@@ -1346,18 +1333,12 @@ where
                 ops,
                 comparators,
             } => {
-                let check_none_comparisons = self.settings.enabled.contains(&CheckCode::E711);
-                let check_true_false_comparisons = self.settings.enabled.contains(&CheckCode::E712);
-                if check_none_comparisons || check_true_false_comparisons {
+                if self.settings.enabled.contains(&CheckCode::E711)
+                    || self.settings.enabled.contains(&CheckCode::E712)
+                {
                     self.add_checks(
-                        pycodestyle::checks::literal_comparisons(
-                            left,
-                            ops,
-                            comparators,
-                            check_none_comparisons,
-                            check_true_false_comparisons,
-                        )
-                        .into_iter(),
+                        pycodestyle::checks::literal_comparisons(left, ops, comparators)
+                            .into_iter(),
                     );
                 }
 

--- a/src/flake8_annotations/plugins.rs
+++ b/src/flake8_annotations/plugins.rs
@@ -4,7 +4,7 @@ use crate::ast::types::Range;
 use crate::ast::visitor;
 use crate::ast::visitor::Visitor;
 use crate::check_ast::Checker;
-use crate::checks::{CheckCode, CheckKind};
+use crate::checks::CheckKind;
 use crate::docstrings::definition::{Definition, DefinitionKind};
 use crate::visibility::Visibility;
 use crate::{visibility, Check};
@@ -92,12 +92,10 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                     if !(checker.settings.flake8_annotations.suppress_dummy_args
                         && checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
                     {
-                        if checker.settings.enabled.contains(&CheckCode::ANN001) {
-                            checker.add_check(Check::new(
-                                CheckKind::MissingTypeFunctionArgument(arg.node.arg.to_string()),
-                                Range::from_located(arg),
-                            ));
-                        }
+                        checker.add_check(Check::new(
+                            CheckKind::MissingTypeFunctionArgument(arg.node.arg.to_string()),
+                            Range::from_located(arg),
+                        ));
                     }
                 }
             }
@@ -108,12 +106,10 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                     if !(checker.settings.flake8_annotations.suppress_dummy_args
                         && checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
                     {
-                        if checker.settings.enabled.contains(&CheckCode::ANN002) {
-                            checker.add_check(Check::new(
-                                CheckKind::MissingTypeArgs(arg.node.arg.to_string()),
-                                Range::from_located(arg),
-                            ));
-                        }
+                        checker.add_check(Check::new(
+                            CheckKind::MissingTypeArgs(arg.node.arg.to_string()),
+                            Range::from_located(arg),
+                        ));
                     }
                 }
             }
@@ -124,12 +120,10 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                     if !(checker.settings.flake8_annotations.suppress_dummy_args
                         && checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
                     {
-                        if checker.settings.enabled.contains(&CheckCode::ANN003) {
-                            checker.add_check(Check::new(
-                                CheckKind::MissingTypeKwargs(arg.node.arg.to_string()),
-                                Range::from_located(arg),
-                            ));
-                        }
+                        checker.add_check(Check::new(
+                            CheckKind::MissingTypeKwargs(arg.node.arg.to_string()),
+                            Range::from_located(arg),
+                        ));
                     }
                 }
             }
@@ -146,20 +140,16 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
 
                 match visibility {
                     Visibility::Public => {
-                        if checker.settings.enabled.contains(&CheckCode::ANN201) {
-                            checker.add_check(Check::new(
-                                CheckKind::MissingReturnTypePublicFunction(name.to_string()),
-                                Range::from_located(stmt),
-                            ));
-                        }
+                        checker.add_check(Check::new(
+                            CheckKind::MissingReturnTypePublicFunction(name.to_string()),
+                            Range::from_located(stmt),
+                        ));
                     }
                     Visibility::Private => {
-                        if checker.settings.enabled.contains(&CheckCode::ANN202) {
-                            checker.add_check(Check::new(
-                                CheckKind::MissingReturnTypePrivateFunction(name.to_string()),
-                                Range::from_located(stmt),
-                            ));
-                        }
+                        checker.add_check(Check::new(
+                            CheckKind::MissingReturnTypePrivateFunction(name.to_string()),
+                            Range::from_located(stmt),
+                        ));
                     }
                 }
             }
@@ -183,12 +173,10 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                     if !(checker.settings.flake8_annotations.suppress_dummy_args
                         && checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
                     {
-                        if checker.settings.enabled.contains(&CheckCode::ANN001) {
-                            checker.add_check(Check::new(
-                                CheckKind::MissingTypeFunctionArgument(arg.node.arg.to_string()),
-                                Range::from_located(arg),
-                            ));
-                        }
+                        checker.add_check(Check::new(
+                            CheckKind::MissingTypeFunctionArgument(arg.node.arg.to_string()),
+                            Range::from_located(arg),
+                        ));
                     }
                 } else {
                     has_any_typed_arg = true;
@@ -201,12 +189,10 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                     if !(checker.settings.flake8_annotations.suppress_dummy_args
                         && checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
                     {
-                        if checker.settings.enabled.contains(&CheckCode::ANN002) {
-                            checker.add_check(Check::new(
-                                CheckKind::MissingTypeArgs(arg.node.arg.to_string()),
-                                Range::from_located(arg),
-                            ));
-                        }
+                        checker.add_check(Check::new(
+                            CheckKind::MissingTypeArgs(arg.node.arg.to_string()),
+                            Range::from_located(arg),
+                        ));
                     }
                 } else {
                     has_any_typed_arg = true;
@@ -219,12 +205,10 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                     if !(checker.settings.flake8_annotations.suppress_dummy_args
                         && checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
                     {
-                        if checker.settings.enabled.contains(&CheckCode::ANN003) {
-                            checker.add_check(Check::new(
-                                CheckKind::MissingTypeKwargs(arg.node.arg.to_string()),
-                                Range::from_located(arg),
-                            ));
-                        }
+                        checker.add_check(Check::new(
+                            CheckKind::MissingTypeKwargs(arg.node.arg.to_string()),
+                            Range::from_located(arg),
+                        ));
                     }
                 } else {
                     has_any_typed_arg = true;
@@ -236,19 +220,15 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                 if let Some(arg) = args.args.first() {
                     if arg.node.annotation.is_none() {
                         if visibility::is_classmethod(stmt) {
-                            if checker.settings.enabled.contains(&CheckCode::ANN102) {
-                                checker.add_check(Check::new(
-                                    CheckKind::MissingTypeCls(arg.node.arg.to_string()),
-                                    Range::from_located(arg),
-                                ));
-                            }
+                            checker.add_check(Check::new(
+                                CheckKind::MissingTypeCls(arg.node.arg.to_string()),
+                                Range::from_located(arg),
+                            ));
                         } else {
-                            if checker.settings.enabled.contains(&CheckCode::ANN101) {
-                                checker.add_check(Check::new(
-                                    CheckKind::MissingTypeSelf(arg.node.arg.to_string()),
-                                    Range::from_located(arg),
-                                ));
-                            }
+                            checker.add_check(Check::new(
+                                CheckKind::MissingTypeSelf(arg.node.arg.to_string()),
+                                Range::from_located(arg),
+                            ));
                         }
                     }
                 }
@@ -265,56 +245,43 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                 }
 
                 if visibility::is_classmethod(stmt) {
-                    if checker.settings.enabled.contains(&CheckCode::ANN206) {
-                        checker.add_check(Check::new(
-                            CheckKind::MissingReturnTypeClassMethod(name.to_string()),
-                            Range::from_located(stmt),
-                        ));
-                    }
+                    checker.add_check(Check::new(
+                        CheckKind::MissingReturnTypeClassMethod(name.to_string()),
+                        Range::from_located(stmt),
+                    ));
                 } else if visibility::is_staticmethod(stmt) {
-                    if checker.settings.enabled.contains(&CheckCode::ANN205) {
-                        checker.add_check(Check::new(
-                            CheckKind::MissingReturnTypeStaticMethod(name.to_string()),
-                            Range::from_located(stmt),
-                        ));
-                    }
+                    checker.add_check(Check::new(
+                        CheckKind::MissingReturnTypeStaticMethod(name.to_string()),
+                        Range::from_located(stmt),
+                    ));
                 } else if visibility::is_magic(stmt) {
-                    if checker.settings.enabled.contains(&CheckCode::ANN204) {
+                    checker.add_check(Check::new(
+                        CheckKind::MissingReturnTypeMagicMethod(name.to_string()),
+                        Range::from_located(stmt),
+                    ));
+                } else if visibility::is_init(stmt) {
+                    // Allow omission of return annotation in `__init__` functions, as long as at
+                    // least one argument is typed.
+                    if !(checker.settings.flake8_annotations.mypy_init_return && has_any_typed_arg)
+                    {
                         checker.add_check(Check::new(
                             CheckKind::MissingReturnTypeMagicMethod(name.to_string()),
                             Range::from_located(stmt),
                         ));
                     }
-                } else if visibility::is_init(stmt) {
-                    // Allow omission of return annotation in `__init__` functions, as long as at
-                    // least one argument is typed.
-                    if checker.settings.enabled.contains(&CheckCode::ANN204) {
-                        if !(checker.settings.flake8_annotations.mypy_init_return
-                            && has_any_typed_arg)
-                        {
-                            checker.add_check(Check::new(
-                                CheckKind::MissingReturnTypeMagicMethod(name.to_string()),
-                                Range::from_located(stmt),
-                            ));
-                        }
-                    }
                 } else {
                     match visibility {
                         Visibility::Public => {
-                            if checker.settings.enabled.contains(&CheckCode::ANN201) {
-                                checker.add_check(Check::new(
-                                    CheckKind::MissingReturnTypePublicFunction(name.to_string()),
-                                    Range::from_located(stmt),
-                                ));
-                            }
+                            checker.add_check(Check::new(
+                                CheckKind::MissingReturnTypePublicFunction(name.to_string()),
+                                Range::from_located(stmt),
+                            ));
                         }
                         Visibility::Private => {
-                            if checker.settings.enabled.contains(&CheckCode::ANN202) {
-                                checker.add_check(Check::new(
-                                    CheckKind::MissingReturnTypePrivateFunction(name.to_string()),
-                                    Range::from_located(stmt),
-                                ));
-                            }
+                            checker.add_check(Check::new(
+                                CheckKind::MissingReturnTypePrivateFunction(name.to_string()),
+                                Range::from_located(stmt),
+                            ));
                         }
                     }
                 }

--- a/src/flake8_print/checks.rs
+++ b/src/flake8_print/checks.rs
@@ -4,24 +4,18 @@ use crate::ast::types::Range;
 use crate::checks::{Check, CheckKind};
 
 /// Check whether a function call is a `print` or `pprint` invocation
-pub fn print_call(
-    expr: &Expr,
-    func: &Expr,
-    check_print: bool,
-    check_pprint: bool,
-    location: Range,
-) -> Option<Check> {
+pub fn print_call(expr: &Expr, func: &Expr, location: Range) -> Option<Check> {
     if let ExprKind::Name { id, .. } = &func.node {
-        if check_print && id == "print" {
+        if id == "print" {
             return Some(Check::new(CheckKind::PrintFound, Range::from_located(expr)));
-        } else if check_pprint && id == "pprint" {
+        } else if id == "pprint" {
             return Some(Check::new(CheckKind::PPrintFound, location));
         }
     }
 
     if let ExprKind::Attribute { value, attr, .. } = &func.node {
         if let ExprKind::Name { id, .. } = &value.node {
-            if check_pprint && id == "pprint" && attr == "pprint" {
+            if id == "pprint" && attr == "pprint" {
                 return Some(Check::new(CheckKind::PPrintFound, location));
             }
         }

--- a/src/flake8_print/plugins/print_call.rs
+++ b/src/flake8_print/plugins/print_call.rs
@@ -4,17 +4,10 @@ use rustpython_ast::{Expr, Stmt, StmtKind};
 use crate::ast::types::Range;
 use crate::autofix::helpers;
 use crate::check_ast::Checker;
-use crate::checks::CheckCode;
 use crate::flake8_print::checks;
 
 pub fn print_call(checker: &mut Checker, expr: &Expr, func: &Expr) {
-    if let Some(mut check) = checks::print_call(
-        expr,
-        func,
-        checker.settings.enabled.contains(&CheckCode::T201),
-        checker.settings.enabled.contains(&CheckCode::T203),
-        Range::from_located(expr),
-    ) {
+    if let Some(mut check) = checks::print_call(expr, func, Range::from_located(expr)) {
         if checker.patch() {
             let context = checker.binding_context();
             if matches!(

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -98,6 +98,12 @@ pub(crate) fn check_path(
     // Run the lines-based checks.
     check_lines(&mut checks, contents, noqa_line_for, settings, autofix);
 
+    // Filter out any disabled checks. Throughout the codebase, we skip work based
+    // on the set of enabled checks, but we don't _guarantee_ that disabled
+    // checks aren't added. (Sometimes, it's not worth repeatedly checking the
+    // code list for similar checks.)
+    checks.retain(|check| settings.enabled.contains(check.kind.code()));
+
     // Create path ignores.
     if !checks.is_empty() && !settings.per_file_ignores.is_empty() {
         let ignores = fs::ignores_from_path(path, &settings.per_file_ignores)?;


### PR DESCRIPTION
Right now, we rely on the various checkers _not_ adding disabled rules to the list of returned checks. This results in a lot of very rigorous validation against `settings.enabled` throughout the codebase. While this does guarantee that we avoid as much useless work as possible, I think it might be overkill, and makes for some very tedious code.

This PR instead adds a step to the core check path to filter out any disabled rules prior to returning. This is safer, in that we're enforcing rule enablement at one singular location, and it means that we can use enablement and disablement purely as a performance optimization (skip unnecessary work) and not as something that we need to track throughout the codebase.

The downside heres here are (1) it does create a situation in which we're not strictly required to skip unnecessary work (since we'll always filter out unneeded checks at the last minute), and (2) technically we're doing a little bit of extra work now in some minor cases.

Resolves #412 (though the approach isn't exactly as-described in that issue).
