### PR TITLE
Add a `--no-parallel` command-line flag

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -95,6 +95,9 @@ pub struct CheckArgs {
     /// Ignore any `# noqa` comments.
     #[arg(long)]
     ignore_noqa: bool,
+    /// Run in a single thread, rather than using all available cores.
+    #[clap(long, hide = true)]
+    no_parallel: bool,
     /// Output serialization format for violations.
     #[arg(long, value_enum, env = "RUFF_FORMAT")]
     pub format: Option<SerializationFormat>,
@@ -267,6 +270,7 @@ pub struct CheckArgs {
         conflicts_with = "show_settings",
         // Unsupported default-command arguments.
         conflicts_with = "ignore_noqa",
+        conflicts_with = "no_parallel",
         conflicts_with = "statistics",
         conflicts_with = "stdin_filename",
         conflicts_with = "watch",
@@ -282,6 +286,7 @@ pub struct CheckArgs {
         conflicts_with = "show_settings",
         // Unsupported default-command arguments.
         conflicts_with = "ignore_noqa",
+        conflicts_with = "no_parallel",
         conflicts_with = "statistics",
         conflicts_with = "stdin_filename",
         conflicts_with = "watch",
@@ -296,6 +301,7 @@ pub struct CheckArgs {
         // conflicts_with = "show_settings",
         // Unsupported default-command arguments.
         conflicts_with = "ignore_noqa",
+        conflicts_with = "no_parallel",
         conflicts_with = "statistics",
         conflicts_with = "stdin_filename",
         conflicts_with = "watch",
@@ -371,6 +377,7 @@ impl CheckArgs {
                 ignore_noqa: self.ignore_noqa,
                 isolated: self.isolated,
                 no_cache: self.no_cache,
+                no_parallel: self.no_parallel,
                 show_files: self.show_files,
                 show_settings: self.show_settings,
                 statistics: self.statistics,
@@ -435,6 +442,7 @@ pub struct Arguments {
     pub ignore_noqa: bool,
     pub isolated: bool,
     pub no_cache: bool,
+    pub no_parallel: bool,
     pub show_files: bool,
     pub show_settings: bool,
     pub statistics: bool,

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -140,6 +140,7 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
     };
     let cache = !cli.no_cache;
     let noqa = !cli.ignore_noqa;
+    let parallel = !cli.no_parallel;
     let mut printer_flags = PrinterFlags::empty();
     if !(cli.diff || fix_only) {
         printer_flags |= PrinterFlags::SHOW_VIOLATIONS;
@@ -153,6 +154,14 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
         // `--no-cache` doesn't respect code changes, and so is often confusing during
         // development.
         warn_user_once!("Detected debug build without --no-cache.");
+    }
+
+    if !parallel {
+        // If we're not running in parallel, we need to set up a single-threaded
+        // executor.
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build_global()?;
     }
 
     if cli.add_noqa {


### PR DESCRIPTION
## Summary

Right now, it's tough to debug panics, since we always run in parallel, and we don't show users the checked files as we go (and we don't catch-and-report panics). You can turn off parallelism with the `RAYON_NUM_THREADS=1` environment variable, but this PR adds a CLI argument for convenience. It's not exposed in `--help`, since I see this as an advanced flag for debugging only, but I could be convinced to expose it...

Closes: #3423.
