### PR TITLE
Improve top-of-file insertions for required imports

### DIFF
--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__combined_required_imports_docstring.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__combined_required_imports_docstring.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "\nfrom __future__ import annotations"
+      - content: "from __future__ import annotations\n"
         location:
-          row: 1
-          column: 19
+          row: 2
+          column: 0
         end_location:
-          row: 1
-          column: 19
+          row: 2
+          column: 0
   parent: ~
 - kind:
     name: MissingRequiredImport
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "\nfrom __future__ import generator_stop"
+      - content: "from __future__ import generator_stop\n"
         location:
-          row: 1
-          column: 19
+          row: 2
+          column: 0
         end_location:
-          row: 1
-          column: 19
+          row: 2
+          column: 0
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_docstring.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_docstring.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "\nfrom __future__ import annotations"
+      - content: "from __future__ import annotations\n"
         location:
-          row: 1
-          column: 19
+          row: 2
+          column: 0
         end_location:
-          row: 1
-          column: 19
+          row: 2
+          column: 0
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_multiline_docstring.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_multiline_docstring.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "\nfrom __future__ import annotations"
+      - content: "from __future__ import annotations\n"
         location:
-          row: 3
-          column: 3
+          row: 4
+          column: 0
         end_location:
-          row: 3
-          column: 3
+          row: 4
+          column: 0
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_imports_docstring.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_imports_docstring.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "\nfrom __future__ import annotations"
+      - content: "from __future__ import annotations\n"
         location:
-          row: 1
-          column: 19
+          row: 2
+          column: 0
         end_location:
-          row: 1
-          column: 19
+          row: 2
+          column: 0
   parent: ~
 - kind:
     name: MissingRequiredImport
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "\nfrom __future__ import generator_stop"
+      - content: "from __future__ import generator_stop\n"
         location:
-          row: 1
-          column: 19
+          row: 2
+          column: 0
         end_location:
-          row: 1
-          column: 19
+          row: 2
+          column: 0
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__straight_required_import_docstring.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__straight_required_import_docstring.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "\nimport os"
+      - content: "import os\n"
         location:
-          row: 1
-          column: 19
+          row: 2
+          column: 0
         end_location:
-          row: 1
-          column: 19
+          row: 2
+          column: 0
   parent: ~
 


### PR DESCRIPTION
## Summary

Small refactor to our "insert at top-of-file" logic, to move more logic into a helper (which we'll reuse elsewhere in the future).

The behavior is also a bit better in some strange cases. For example, given:

```py
"""My docstring"""; x = 1
```

We now modify to:

```py
"""My docstring"""; from __future__ import annotations; x = 1
```

Whereas before, we did:

```py
"""My docstring"""
from __future__ import annotations; x = 1
```