### PR TITLE
Add supports for TID253/relative-siblings rule

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_tidy_imports/TID253.py
+++ b/crates/ruff/resources/test/fixtures/flake8_tidy_imports/TID253.py
@@ -1,0 +1,7 @@
+# OK: TID253 rule is only active in packages
+from TID253 import _
+from TID253.module import _
+from TID253.nested import _
+from TID253.nested.module import _
+from TID253.not_a_pkg import _
+from TID253.not_a_pkg.module import _

--- a/crates/ruff/resources/test/fixtures/flake8_tidy_imports/TID253/__init__.py
+++ b/crates/ruff/resources/test/fixtures/flake8_tidy_imports/TID253/__init__.py
@@ -1,0 +1,11 @@
+# OK
+from . import _
+from .module import _
+from .nested import _
+from .nested.module import _
+
+# TID253
+from TID253 import _
+from TID253.module import _
+from TID253.nested import _
+from TID253.nested.module import _

--- a/crates/ruff/resources/test/fixtures/flake8_tidy_imports/TID253/module.py
+++ b/crates/ruff/resources/test/fixtures/flake8_tidy_imports/TID253/module.py
@@ -1,0 +1,11 @@
+# OK
+from . import _
+from .module import _
+from .nested import _
+from .nested.module import _
+
+# TID253
+from TID253 import _
+from TID253.module import _
+from TID253.nested import _
+from TID253.nested.module import _

--- a/crates/ruff/resources/test/fixtures/flake8_tidy_imports/TID253/nested/__init__.py
+++ b/crates/ruff/resources/test/fixtures/flake8_tidy_imports/TID253/nested/__init__.py
@@ -1,0 +1,13 @@
+# OK
+from . import _
+from .module import _
+from .nested import _
+from .nested.module import _
+from .unknown import _
+from .unknown.module import _
+from TID253 import _
+from TID253.module import _
+
+# TID253
+from TID253.nested import _
+from TID253.nested.module import _

--- a/crates/ruff/resources/test/fixtures/flake8_tidy_imports/TID253/nested/module.py
+++ b/crates/ruff/resources/test/fixtures/flake8_tidy_imports/TID253/nested/module.py
@@ -1,0 +1,13 @@
+# OK
+from . import _
+from .module import _
+from .nested import _
+from .nested.module import _
+from .unknown import _
+from .unknown.module import _
+from TID253 import _
+from TID253.module import _
+
+# TID253
+from TID253.nested import _
+from TID253.nested.more import _

--- a/crates/ruff/resources/test/fixtures/flake8_tidy_imports/TID253/not_a_pkg/module.py
+++ b/crates/ruff/resources/test/fixtures/flake8_tidy_imports/TID253/not_a_pkg/module.py
@@ -1,0 +1,5 @@
+# OK: TID253 rule is only active in packages
+from TID253 import _
+from TID253.module import _
+from TID253.not_a_pkg import _
+from TID253.not_a_pkg.module import _

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -1325,6 +1325,21 @@ where
                         }
                     }
 
+                    if self.settings.rules.enabled(Rule::RelativeSiblings) {
+                        if let Some(diagnostic) =
+                            flake8_tidy_imports::relative_imports::force_siblings(
+                                self,
+                                stmt,
+                                *level,
+                                module.as_deref(),
+                                self.module_path.as_ref(),
+                                &self.settings.flake8_tidy_imports.ban_relative_imports,
+                            )
+                        {
+                            self.diagnostics.push(diagnostic);
+                        }
+                    }
+
                     // flake8-debugger
                     if self.settings.rules.enabled(Rule::Debugger) {
                         if let Some(diagnostic) = flake8_debugger::rules::debugger_import(

--- a/crates/ruff/src/codes.rs
+++ b/crates/ruff/src/codes.rs
@@ -275,6 +275,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<Rule> {
         // flake8-tidy-imports
         (Flake8TidyImports, "251") => Rule::BannedApi,
         (Flake8TidyImports, "252") => Rule::RelativeImports,
+        (Flake8TidyImports, "253") => Rule::RelativeSiblings,
 
         // flake8-return
         (Flake8Return, "501") => Rule::UnnecessaryReturnNone,

--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -253,6 +253,7 @@ ruff_macros::register_rules!(
     // flake8-tidy-imports
     rules::flake8_tidy_imports::banned_api::BannedApi,
     rules::flake8_tidy_imports::relative_imports::RelativeImports,
+    rules::flake8_tidy_imports::relative_imports::RelativeSiblings,
     // flake8-return
     rules::flake8_return::rules::UnnecessaryReturnNone,
     rules::flake8_return::rules::ImplicitReturnValue,

--- a/crates/ruff/src/rule_redirects.rs
+++ b/crates/ruff/src/rule_redirects.rs
@@ -66,6 +66,7 @@ static REDIRECTS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
         ("I2", "TID2"),
         ("I25", "TID25"),
         ("I252", "TID252"),
+        ("I253", "TID253"),
         ("M", "RUF100"),
         ("M0", "RUF100"),
         ("M001", "RUF100"),

--- a/crates/ruff/src/rules/flake8_tidy_imports/options.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/options.rs
@@ -21,7 +21,7 @@ use super::Settings;
 pub struct Options {
     #[option(
         default = r#""parents""#,
-        value_type = r#""parents" | "all""#,
+        value_type = r#""parents" | "all" | "force-siblings" "#,
         example = r#"
             # Disallow all relative imports.
             ban-relative-imports = "all"
@@ -29,6 +29,7 @@ pub struct Options {
     )]
     /// Whether to ban all relative imports (`"all"`), or only those imports
     /// that extend into the parent module or beyond (`"parents"`).
+    /// `"force-siblings"` force relative imports for siblings and ban parent imports like `"parents"`
     pub ban_relative_imports: Option<Strictness>,
     #[option(
         default = r#"{}"#,

--- a/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__TID253.snap
+++ b/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__TID253.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+---
+

--- a/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__TID253__init.snap
+++ b/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__TID253__init.snap
@@ -1,0 +1,78 @@
+---
+source: crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+---
+__init__.py:8:1: TID253 [*] Relative imports for sibling modules are required
+   |
+ 8 | # TID253
+ 9 | from TID253 import _
+   | ^^^^^^^^^^^^^^^^^^^^ TID253
+10 | from TID253.module import _
+11 | from TID253.nested import _
+   |
+   = help: Replace absolute sibling imports with relative imports
+
+ℹ Suggested fix
+5 5 | from .nested.module import _
+6 6 | 
+7 7 | # TID253
+8   |-from TID253 import _
+  8 |+from . import _
+9 9 | from TID253.module import _
+10 10 | from TID253.nested import _
+11 11 | from TID253.nested.module import _
+
+__init__.py:9:1: TID253 [*] Relative imports for sibling modules are required
+   |
+ 9 | # TID253
+10 | from TID253 import _
+11 | from TID253.module import _
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID253
+12 | from TID253.nested import _
+13 | from TID253.nested.module import _
+   |
+   = help: Replace absolute sibling imports with relative imports
+
+ℹ Suggested fix
+6  6  | 
+7  7  | # TID253
+8  8  | from TID253 import _
+9     |-from TID253.module import _
+   9  |+from .module import _
+10 10 | from TID253.nested import _
+11 11 | from TID253.nested.module import _
+
+__init__.py:10:1: TID253 [*] Relative imports for sibling modules are required
+   |
+10 | from TID253 import _
+11 | from TID253.module import _
+12 | from TID253.nested import _
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID253
+13 | from TID253.nested.module import _
+   |
+   = help: Replace absolute sibling imports with relative imports
+
+ℹ Suggested fix
+7  7  | # TID253
+8  8  | from TID253 import _
+9  9  | from TID253.module import _
+10    |-from TID253.nested import _
+   10 |+from .nested import _
+11 11 | from TID253.nested.module import _
+
+__init__.py:11:1: TID253 [*] Relative imports for sibling modules are required
+   |
+11 | from TID253.module import _
+12 | from TID253.nested import _
+13 | from TID253.nested.module import _
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID253
+   |
+   = help: Replace absolute sibling imports with relative imports
+
+ℹ Suggested fix
+8  8  | from TID253 import _
+9  9  | from TID253.module import _
+10 10 | from TID253.nested import _
+11    |-from TID253.nested.module import _
+   11 |+from .nested.module import _
+
+

--- a/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__TID253__module.snap
+++ b/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__TID253__module.snap
@@ -1,0 +1,78 @@
+---
+source: crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+---
+module.py:8:1: TID253 [*] Relative imports for sibling modules are required
+   |
+ 8 | # TID253
+ 9 | from TID253 import _
+   | ^^^^^^^^^^^^^^^^^^^^ TID253
+10 | from TID253.module import _
+11 | from TID253.nested import _
+   |
+   = help: Replace absolute sibling imports with relative imports
+
+ℹ Suggested fix
+5 5 | from .nested.module import _
+6 6 | 
+7 7 | # TID253
+8   |-from TID253 import _
+  8 |+from . import _
+9 9 | from TID253.module import _
+10 10 | from TID253.nested import _
+11 11 | from TID253.nested.module import _
+
+module.py:9:1: TID253 [*] Relative imports for sibling modules are required
+   |
+ 9 | # TID253
+10 | from TID253 import _
+11 | from TID253.module import _
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID253
+12 | from TID253.nested import _
+13 | from TID253.nested.module import _
+   |
+   = help: Replace absolute sibling imports with relative imports
+
+ℹ Suggested fix
+6  6  | 
+7  7  | # TID253
+8  8  | from TID253 import _
+9     |-from TID253.module import _
+   9  |+from .module import _
+10 10 | from TID253.nested import _
+11 11 | from TID253.nested.module import _
+
+module.py:10:1: TID253 [*] Relative imports for sibling modules are required
+   |
+10 | from TID253 import _
+11 | from TID253.module import _
+12 | from TID253.nested import _
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID253
+13 | from TID253.nested.module import _
+   |
+   = help: Replace absolute sibling imports with relative imports
+
+ℹ Suggested fix
+7  7  | # TID253
+8  8  | from TID253 import _
+9  9  | from TID253.module import _
+10    |-from TID253.nested import _
+   10 |+from .nested import _
+11 11 | from TID253.nested.module import _
+
+module.py:11:1: TID253 [*] Relative imports for sibling modules are required
+   |
+11 | from TID253.module import _
+12 | from TID253.nested import _
+13 | from TID253.nested.module import _
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID253
+   |
+   = help: Replace absolute sibling imports with relative imports
+
+ℹ Suggested fix
+8  8  | from TID253 import _
+9  9  | from TID253.module import _
+10 10 | from TID253.nested import _
+11    |-from TID253.nested.module import _
+   11 |+from .nested.module import _
+
+

--- a/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__TID253__nested__init.snap
+++ b/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__TID253__nested__init.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+---
+__init__.py:12:1: TID253 [*] Relative imports for sibling modules are required
+   |
+12 | # TID253
+13 | from TID253.nested import _
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID253
+14 | from TID253.nested.module import _
+   |
+   = help: Replace absolute sibling imports with relative imports
+
+ℹ Suggested fix
+9  9  | from TID253.module import _
+10 10 | 
+11 11 | # TID253
+12    |-from TID253.nested import _
+   12 |+from . import _
+13 13 | from TID253.nested.module import _
+
+__init__.py:13:1: TID253 [*] Relative imports for sibling modules are required
+   |
+13 | # TID253
+14 | from TID253.nested import _
+15 | from TID253.nested.module import _
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID253
+   |
+   = help: Replace absolute sibling imports with relative imports
+
+ℹ Suggested fix
+10 10 | 
+11 11 | # TID253
+12 12 | from TID253.nested import _
+13    |-from TID253.nested.module import _
+   13 |+from .module import _
+
+

--- a/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__TID253__nested__module.snap
+++ b/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__TID253__nested__module.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+---
+module.py:12:1: TID253 [*] Relative imports for sibling modules are required
+   |
+12 | # TID253
+13 | from TID253.nested import _
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID253
+14 | from TID253.nested.more import _
+   |
+   = help: Replace absolute sibling imports with relative imports
+
+ℹ Suggested fix
+9  9  | from TID253.module import _
+10 10 | 
+11 11 | # TID253
+12    |-from TID253.nested import _
+   12 |+from . import _
+13 13 | from TID253.nested.more import _
+
+module.py:13:1: TID253 [*] Relative imports for sibling modules are required
+   |
+13 | # TID253
+14 | from TID253.nested import _
+15 | from TID253.nested.more import _
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID253
+   |
+   = help: Replace absolute sibling imports with relative imports
+
+ℹ Suggested fix
+10 10 | 
+11 11 | # TID253
+12 12 | from TID253.nested import _
+13    |-from TID253.nested.more import _
+   13 |+from .more import _
+
+

--- a/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__TID253__not_a_pkg__module.snap
+++ b/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__TID253__not_a_pkg__module.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+---
+

--- a/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_parent_imports-2.snap
+++ b/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_parent_imports-2.snap
@@ -1,0 +1,147 @@
+---
+source: crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+---
+TID252.py:9:1: TID252 [*] Relative imports from parent modules are banned
+   |
+ 9 | from . import sibling
+10 | from .sibling import example
+11 | from .. import parent
+   | ^^^^^^^^^^^^^^^^^^^^^ TID252
+12 | from ..parent import example
+13 | from ... import grandparent
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+TID252.py:10:1: TID252 [*] Relative imports from parent modules are banned
+   |
+10 | from .sibling import example
+11 | from .. import parent
+12 | from ..parent import example
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+13 | from ... import grandparent
+14 | from ...grandparent import example
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+TID252.py:11:1: TID252 [*] Relative imports from parent modules are banned
+   |
+11 | from .. import parent
+12 | from ..parent import example
+13 | from ... import grandparent
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+14 | from ...grandparent import example
+15 | from  .parent import hello
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+TID252.py:12:1: TID252 [*] Relative imports from parent modules are banned
+   |
+12 | from ..parent import example
+13 | from ... import grandparent
+14 | from ...grandparent import example
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+15 | from  .parent import hello
+16 | from .\
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+TID252.py:17:1: TID252 [*] Relative imports from parent modules are banned
+   |
+17 |       parent import \
+18 |           hello_world
+19 | / from \
+20 | |     ..parent\
+21 | |     import \
+22 | |     world_hello
+   | |_______________^ TID252
+23 |   from ..... import ultragrantparent
+24 |   from ...... import ultragrantparent
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+TID252.py:21:1: TID252 [*] Relative imports from parent modules are banned
+   |
+21 |     import \
+22 |     world_hello
+23 | from ..... import ultragrantparent
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+24 | from ...... import ultragrantparent
+25 | from ....... import ultragrantparent
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+TID252.py:22:1: TID252 [*] Relative imports from parent modules are banned
+   |
+22 |     world_hello
+23 | from ..... import ultragrantparent
+24 | from ...... import ultragrantparent
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+25 | from ....... import ultragrantparent
+26 | from ......... import ultragrantparent
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+TID252.py:23:1: TID252 [*] Relative imports from parent modules are banned
+   |
+23 | from ..... import ultragrantparent
+24 | from ...... import ultragrantparent
+25 | from ....... import ultragrantparent
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+26 | from ......... import ultragrantparent
+27 | from ........................... import ultragrantparent
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+TID252.py:24:1: TID252 [*] Relative imports from parent modules are banned
+   |
+24 | from ...... import ultragrantparent
+25 | from ....... import ultragrantparent
+26 | from ......... import ultragrantparent
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+27 | from ........................... import ultragrantparent
+28 | from .....parent import ultragrantparent
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+TID252.py:25:1: TID252 [*] Relative imports from parent modules are banned
+   |
+25 | from ....... import ultragrantparent
+26 | from ......... import ultragrantparent
+27 | from ........................... import ultragrantparent
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+28 | from .....parent import ultragrantparent
+29 | from .........parent import ultragrantparent
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+TID252.py:26:1: TID252 [*] Relative imports from parent modules are banned
+   |
+26 | from ......... import ultragrantparent
+27 | from ........................... import ultragrantparent
+28 | from .....parent import ultragrantparent
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+29 | from .........parent import ultragrantparent
+30 | from ...........................parent import ultragrantparent
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+TID252.py:27:1: TID252 [*] Relative imports from parent modules are banned
+   |
+27 | from ........................... import ultragrantparent
+28 | from .....parent import ultragrantparent
+29 | from .........parent import ultragrantparent
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+30 | from ...........................parent import ultragrantparent
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+TID252.py:28:1: TID252 [*] Relative imports from parent modules are banned
+   |
+28 | from .....parent import ultragrantparent
+29 | from .........parent import ultragrantparent
+30 | from ...........................parent import ultragrantparent
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+

--- a/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_parent_imports_package-2.snap
+++ b/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_parent_imports_package-2.snap
@@ -1,0 +1,132 @@
+---
+source: crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+---
+application.py:5:1: TID252 [*] Relative imports from parent modules are banned
+  |
+5 | import attrs
+6 | 
+7 | from ....import unknown
+  | ^^^^^^^^^^^^^^^^^^^^^^^ TID252
+8 | from ..protocol import commands, definitions, responses
+9 | from ..server import example
+  |
+  = help: Replace relative imports from parent modules with absolute imports
+
+application.py:6:1: TID252 [*] Relative imports from parent modules are banned
+  |
+6 | from ....import unknown
+7 | from ..protocol import commands, definitions, responses
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+8 | from ..server import example
+9 | from .. import server
+  |
+  = help: Replace relative imports from parent modules with absolute imports
+
+ℹ Suggested fix
+3 3 | import attrs
+4 4 | 
+5 5 | from ....import unknown
+6   |-from ..protocol import commands, definitions, responses
+  6 |+from my_package.sublib.protocol import commands, definitions, responses
+7 7 | from ..server import example
+8 8 | from .. import server
+9 9 | from . import logger, models
+
+application.py:6:1: TID252 [*] Relative imports from parent modules are banned
+  |
+6 | from ....import unknown
+7 | from ..protocol import commands, definitions, responses
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+8 | from ..server import example
+9 | from .. import server
+  |
+  = help: Replace relative imports from parent modules with absolute imports
+
+ℹ Suggested fix
+3 3 | import attrs
+4 4 | 
+5 5 | from ....import unknown
+6   |-from ..protocol import commands, definitions, responses
+  6 |+from my_package.sublib.protocol import commands, definitions, responses
+7 7 | from ..server import example
+8 8 | from .. import server
+9 9 | from . import logger, models
+
+application.py:6:1: TID252 [*] Relative imports from parent modules are banned
+  |
+6 | from ....import unknown
+7 | from ..protocol import commands, definitions, responses
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+8 | from ..server import example
+9 | from .. import server
+  |
+  = help: Replace relative imports from parent modules with absolute imports
+
+ℹ Suggested fix
+3 3 | import attrs
+4 4 | 
+5 5 | from ....import unknown
+6   |-from ..protocol import commands, definitions, responses
+  6 |+from my_package.sublib.protocol import commands, definitions, responses
+7 7 | from ..server import example
+8 8 | from .. import server
+9 9 | from . import logger, models
+
+application.py:7:1: TID252 [*] Relative imports from parent modules are banned
+   |
+ 7 | from ....import unknown
+ 8 | from ..protocol import commands, definitions, responses
+ 9 | from ..server import example
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+10 | from .. import server
+11 | from . import logger, models
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+ℹ Suggested fix
+4 4 | 
+5 5 | from ....import unknown
+6 6 | from ..protocol import commands, definitions, responses
+7   |-from ..server import example
+  7 |+from my_package.sublib.server import example
+8 8 | from .. import server
+9 9 | from . import logger, models
+10 10 | from ..protocol.UpperCaseModule import some_function
+
+application.py:8:1: TID252 [*] Relative imports from parent modules are banned
+   |
+ 8 | from ..protocol import commands, definitions, responses
+ 9 | from ..server import example
+10 | from .. import server
+   | ^^^^^^^^^^^^^^^^^^^^^ TID252
+11 | from . import logger, models
+12 | from ..protocol.UpperCaseModule import some_function
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+ℹ Suggested fix
+5 5 | from ....import unknown
+6 6 | from ..protocol import commands, definitions, responses
+7 7 | from ..server import example
+8   |-from .. import server
+  8 |+from my_package.sublib import server
+9 9 | from . import logger, models
+10 10 | from ..protocol.UpperCaseModule import some_function
+
+application.py:10:1: TID252 [*] Relative imports from parent modules are banned
+   |
+10 | from .. import server
+11 | from . import logger, models
+12 | from ..protocol.UpperCaseModule import some_function
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
+   |
+   = help: Replace relative imports from parent modules with absolute imports
+
+ℹ Suggested fix
+7  7  | from ..server import example
+8  8  | from .. import server
+9  9  | from . import logger, models
+10    |-from ..protocol.UpperCaseModule import some_function
+   10 |+from my_package.sublib.protocol.UpperCaseModule import some_function
+
+

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -940,7 +940,7 @@
       "type": "object",
       "properties": {
         "ban-relative-imports": {
-          "description": "Whether to ban all relative imports (`\"all\"`), or only those imports that extend into the parent module or beyond (`\"parents\"`).",
+          "description": "Whether to ban all relative imports (`\"all\"`), or only those imports that extend into the parent module or beyond (`\"parents\"`). `\"force-siblings\"` force relative imports for siblings and ban parent imports like `\"parents\"`",
           "anyOf": [
             {
               "$ref": "#/definitions/Strictness"
@@ -2275,6 +2275,7 @@
         "TID25",
         "TID251",
         "TID252",
+        "TID253",
         "TRY",
         "TRY0",
         "TRY00",
@@ -2396,6 +2397,13 @@
           "type": "string",
           "enum": [
             "all"
+          ]
+        },
+        {
+          "description": "Ban parent imports but force relative imports for siblings.",
+          "type": "string",
+          "enum": [
+            "force-siblings"
           ]
         }
       ]


### PR DESCRIPTION
This PR is the `ruff` counterpart of adamchainz/flake8-tidy-imports#441.

Fixes #1014 