### PR TITLE
Implement rule for WPS111

### DIFF
--- a/crates/ruff/resources/test/fixtures/wemake_python_styleguide/WPS111.py
+++ b/crates/ruff/resources/test/fixtures/wemake_python_styleguide/WPS111.py
@@ -1,0 +1,7 @@
+# Errors
+x = 1
+y = 2
+
+# OK
+x_coordinate = 1
+abscissa = 2

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -48,7 +48,7 @@ use crate::rules::{
     flake8_pytest_style, flake8_raise, flake8_return, flake8_self, flake8_simplify,
     flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments, flake8_use_pathlib, mccabe,
     numpy, pandas_vet, pep8_naming, pycodestyle, pydocstyle, pyflakes, pygrep_hooks, pylint,
-    pyupgrade, ruff, tryceratops,
+    pyupgrade, ruff, tryceratops, wemake_python_styleguide,
 };
 use crate::settings::types::PythonVersion;
 use crate::settings::{flags, Settings};
@@ -1850,6 +1850,23 @@ where
                 if self.is_stub {
                     if self.settings.rules.enabled(Rule::AssignmentDefaultInStub) {
                         flake8_pyi::rules::assignment_default_in_stub(self, value, None);
+                    }
+                }
+
+                if self.settings.rules.enabled(Rule::TooShortName) {
+                    for target in targets.iter() {
+                        if let ExprKind::Name { id, .. } = &target.node {
+                            if let Some(diagnostic) =
+                                wemake_python_styleguide::rules::too_short_name(
+                                    stmt,
+                                    id,
+                                    self.settings.wemake_python_styleguide.min_name_length,
+                                    self.locator,
+                                )
+                            {
+                                self.diagnostics.push(diagnostic);
+                            };
+                        }
                     }
                 }
             }

--- a/crates/ruff/src/codes.rs
+++ b/crates/ruff/src/codes.rs
@@ -722,6 +722,9 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<Rule> {
         (Flake8Django, "012") => Rule::DjangoUnorderedBodyContentInModel,
         (Flake8Django, "013") => Rule::DjangoNonLeadingReceiverDecorator,
 
+        // wemake-python-styleguide
+        (WemakePythonStyleguide, "111") => Rule::TooShortName,
+
         _ => return None,
     })
 }

--- a/crates/ruff/src/flake8_to_ruff/converter.rs
+++ b/crates/ruff/src/flake8_to_ruff/converter.rs
@@ -16,7 +16,7 @@ use crate::rules::flake8_tidy_imports::relative_imports::Strictness;
 use crate::rules::pydocstyle::settings::Convention;
 use crate::rules::{
     flake8_annotations, flake8_bugbear, flake8_builtins, flake8_errmsg, flake8_pytest_style,
-    flake8_quotes, flake8_tidy_imports, mccabe, pep8_naming, pydocstyle,
+    flake8_quotes, flake8_tidy_imports, mccabe, pep8_naming, pydocstyle, wemake_python_styleguide,
 };
 use crate::settings::options::Options;
 use crate::settings::pyproject::Pyproject;
@@ -111,6 +111,7 @@ pub fn convert(
     let mut mccabe = mccabe::settings::Options::default();
     let mut pep8_naming = pep8_naming::settings::Options::default();
     let mut pydocstyle = pydocstyle::settings::Options::default();
+    let mut wemake_python_styleguide = wemake_python_styleguide::settings::Options::default();
     for (key, value) in flake8 {
         if let Some(value) = value {
             match key.as_str() {
@@ -347,6 +348,15 @@ pub fn convert(
                         }
                     }
                 }
+                // wemake-python-styleguide
+                "min-name-length" | "min_name_length" => match value.parse::<usize>() {
+                    Ok(min_name_length) => {
+                        wemake_python_styleguide.min_name_length = Some(min_name_length);
+                    }
+                    Err(e) => {
+                        warn_user!("Unable to parse '{key}' property: {e}");
+                    }
+                },
                 // Unknown
                 _ => {
                     warn_user!("Skipping unsupported property: {}", key);
@@ -397,6 +407,9 @@ pub fn convert(
     }
     if pydocstyle != pydocstyle::settings::Options::default() {
         options.pydocstyle = Some(pydocstyle);
+    }
+    if wemake_python_styleguide != wemake_python_styleguide::settings::Options::default() {
+        options.wemake_python_styleguide = Some(wemake_python_styleguide);
     }
 
     // Extract any settings from the existing `pyproject.toml`.

--- a/crates/ruff/src/flake8_to_ruff/plugin.rs
+++ b/crates/ruff/src/flake8_to_ruff/plugin.rs
@@ -42,6 +42,7 @@ pub enum Plugin {
     PandasVet,
     Pyupgrade,
     Tryceratops,
+    WemakePythonStyleguide,
 }
 
 impl FromStr for Plugin {
@@ -82,6 +83,7 @@ impl FromStr for Plugin {
             "pandas-vet" => Ok(Plugin::PandasVet),
             "pyupgrade" => Ok(Plugin::Pyupgrade),
             "tryceratops" => Ok(Plugin::Tryceratops),
+            "wemake-python-styleguide" => Ok(Plugin::WemakePythonStyleguide),
             _ => Err(anyhow!("Unknown plugin: {string}")),
         }
     }
@@ -126,6 +128,7 @@ impl fmt::Debug for Plugin {
                 Plugin::PandasVet => "pandas-vet",
                 Plugin::Pyupgrade => "pyupgrade",
                 Plugin::Tryceratops => "tryceratops",
+                Plugin::WemakePythonStyleguide => "wemake-python-styleguide",
             }
         )
     }
@@ -167,6 +170,7 @@ impl From<&Plugin> for Linter {
             Plugin::PandasVet => Linter::PandasVet,
             Plugin::Pyupgrade => Linter::Pyupgrade,
             Plugin::Tryceratops => Linter::Tryceratops,
+            Plugin::WemakePythonStyleguide => Linter::WemakePythonStyleguide,
         }
     }
 }
@@ -327,6 +331,7 @@ pub fn infer_plugins_from_codes(selectors: &HashSet<RuleSelector>) -> Vec<Plugin
         Plugin::PEP8Naming,
         Plugin::PandasVet,
         Plugin::Tryceratops,
+        Plugin::WemakePythonStyleguide,
     ]
     .into_iter()
     .filter(|plugin| {

--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -663,6 +663,8 @@ ruff_macros::register_rules!(
     rules::flake8_django::rules::DjangoModelWithoutDunderStr,
     rules::flake8_django::rules::DjangoUnorderedBodyContentInModel,
     rules::flake8_django::rules::DjangoNonLeadingReceiverDecorator,
+    // wemake-python-styleguide
+    rules::wemake_python_styleguide::rules::TooShortName,
 );
 
 pub trait AsRule {
@@ -824,6 +826,9 @@ pub enum Linter {
     /// Ruff-specific rules
     #[prefix = "RUF"]
     Ruff,
+    /// [wemake-python-styleguide](https://wemake-python-styleguide.readthedocs.io/)
+    #[prefix = "WPS"]
+    WemakePythonStyleguide,
 }
 
 pub trait RuleNamespace: Sized {

--- a/crates/ruff/src/rules/mod.rs
+++ b/crates/ruff/src/rules/mod.rs
@@ -45,3 +45,4 @@ pub mod pylint;
 pub mod pyupgrade;
 pub mod ruff;
 pub mod tryceratops;
+pub mod wemake_python_styleguide;

--- a/crates/ruff/src/rules/wemake_python_styleguide/mod.rs
+++ b/crates/ruff/src/rules/wemake_python_styleguide/mod.rs
@@ -1,0 +1,29 @@
+//! Rules from [wemake-python-styleguide](https://wemake-python-styleguide.readthedocs.io/).
+pub(crate) mod rules;
+pub mod settings;
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use anyhow::Result;
+
+    use test_case::test_case;
+
+    use crate::registry::Rule;
+    use crate::test::test_path;
+    use crate::{assert_messages, settings};
+
+    #[test_case(Rule::TooShortName, Path::new("WPS111.py"); "WPS111")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("wemake_python_styleguide").join(path).as_path(),
+            &settings::Settings {
+                ..settings::Settings::for_rule(rule_code)
+            },
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+}

--- a/crates/ruff/src/rules/wemake_python_styleguide/rules/mod.rs
+++ b/crates/ruff/src/rules/wemake_python_styleguide/rules/mod.rs
@@ -1,0 +1,3 @@
+pub use too_short_name::{too_short_name, TooShortName};
+
+mod too_short_name;

--- a/crates/ruff/src/rules/wemake_python_styleguide/rules/too_short_name.rs
+++ b/crates/ruff/src/rules/wemake_python_styleguide/rules/too_short_name.rs
@@ -1,0 +1,58 @@
+use rustpython_parser::ast::Stmt;
+
+use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::helpers::identifier_range;
+use ruff_python_ast::source_code::Locator;
+
+/// ## What it does
+/// Checks for short variable or module names.
+///
+/// ## Why is this bad?
+/// It is hard to understand what the variable means and why it is used, if its name is too short.
+///
+/// ## Options
+/// - `wemake-python-styleguide.min-name-length`
+///
+/// ## Example
+/// ```python
+/// x = 1
+/// y = 2
+/// ```
+///
+/// Use instead:
+/// ```python
+/// x_coordinate = 1
+/// abscissa = 2
+/// ```
+#[violation]
+pub struct TooShortName {
+    pub name: String,
+}
+
+impl Violation for TooShortName {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let TooShortName { name } = self;
+        format!("Found too short name: `{name}`")
+    }
+}
+
+/// WPS111
+pub fn too_short_name(
+    stmt: &Stmt,
+    name: &str,
+    _min_name_length: usize,
+    locator: &Locator,
+) -> Option<Diagnostic> {
+    if name.len() >= 2 {
+        return None;
+    }
+
+    Some(Diagnostic::new(
+        TooShortName {
+            name: name.to_string(),
+        },
+        identifier_range(stmt, locator),
+    ))
+}

--- a/crates/ruff/src/rules/wemake_python_styleguide/settings.rs
+++ b/crates/ruff/src/rules/wemake_python_styleguide/settings.rs
@@ -1,0 +1,53 @@
+//! Settings for the `wemake-python-styleguide` plugin.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use ruff_macros::{CacheKey, ConfigurationOptions};
+
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, JsonSchema,
+)]
+#[serde(
+    deny_unknown_fields,
+    rename_all = "kebab-case",
+    rename = "WemakePythonStyleguideOptions"
+)]
+pub struct Options {
+    #[option(
+        default = r#"2"#,
+        value_type = "int",
+        example = r#"
+            min-name-length = 3
+        "#
+    )]
+    /// Minimum name length for variables and methods.
+    pub min_name_length: Option<usize>,
+}
+
+#[derive(Debug, CacheKey)]
+pub struct Settings {
+    pub min_name_length: usize,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self { min_name_length: 2 }
+    }
+}
+
+impl From<Options> for Settings {
+    fn from(options: Options) -> Self {
+        Self {
+            min_name_length: options.min_name_length.unwrap_or_default(),
+        }
+    }
+}
+
+impl From<Settings> for Options {
+    fn from(settings: Settings) -> Self {
+        Self {
+            min_name_length: Some(settings.min_name_length),
+        }
+    }
+}

--- a/crates/ruff/src/rules/wemake_python_styleguide/snapshots/ruff__rules__wemake_python_styleguide__tests__WPS111_WPS111.py.snap
+++ b/crates/ruff/src/rules/wemake_python_styleguide/snapshots/ruff__rules__wemake_python_styleguide__tests__WPS111_WPS111.py.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff/src/rules/wemake_python_styleguide/mod.rs
+---
+WPS111.py:2:1: WPS111 Found too short name: `x`
+  |
+2 | # Errors
+3 | x = 1
+  | ^^^^^ WPS111
+4 | y = 2
+  |
+
+WPS111.py:3:1: WPS111 Found too short name: `y`
+  |
+3 | # Errors
+4 | x = 1
+5 | y = 2
+  | ^^^^^ WPS111
+6 | 
+7 | # OK
+  |
+
+

--- a/crates/ruff/src/settings/configuration.rs
+++ b/crates/ruff/src/settings/configuration.rs
@@ -19,7 +19,7 @@ use crate::rules::{
     flake8_errmsg, flake8_gettext, flake8_implicit_str_concat, flake8_import_conventions,
     flake8_pytest_style, flake8_quotes, flake8_self, flake8_tidy_imports, flake8_type_checking,
     flake8_unused_arguments, isort, mccabe, pep8_naming, pycodestyle, pydocstyle, pylint,
-    pyupgrade,
+    pyupgrade, wemake_python_styleguide,
 };
 use crate::settings::options::Options;
 use crate::settings::types::{
@@ -89,6 +89,7 @@ pub struct Configuration {
     pub pydocstyle: Option<pydocstyle::settings::Options>,
     pub pylint: Option<pylint::settings::Options>,
     pub pyupgrade: Option<pyupgrade::settings::Options>,
+    pub wemake_python_styleguide: Option<wemake_python_styleguide::settings::Options>,
 }
 
 impl Configuration {
@@ -225,6 +226,7 @@ impl Configuration {
             pydocstyle: options.pydocstyle,
             pylint: options.pylint,
             pyupgrade: options.pyupgrade,
+            wemake_python_styleguide: options.wemake_python_styleguide,
         })
     }
 
@@ -302,6 +304,9 @@ impl Configuration {
             pydocstyle: self.pydocstyle.or(config.pydocstyle),
             pylint: self.pylint.or(config.pylint),
             pyupgrade: self.pyupgrade.or(config.pyupgrade),
+            wemake_python_styleguide: self
+                .wemake_python_styleguide
+                .or(config.wemake_python_styleguide),
         }
     }
 }

--- a/crates/ruff/src/settings/defaults.rs
+++ b/crates/ruff/src/settings/defaults.rs
@@ -14,7 +14,7 @@ use crate::rules::{
     flake8_errmsg, flake8_gettext, flake8_implicit_str_concat, flake8_import_conventions,
     flake8_pytest_style, flake8_quotes, flake8_self, flake8_tidy_imports, flake8_type_checking,
     flake8_unused_arguments, isort, mccabe, pep8_naming, pycodestyle, pydocstyle, pylint,
-    pyupgrade,
+    pyupgrade, wemake_python_styleguide,
 };
 use crate::settings::types::FilePatternSet;
 
@@ -106,6 +106,7 @@ impl Default for Settings {
             pydocstyle: pydocstyle::settings::Settings::default(),
             pylint: pylint::settings::Settings::default(),
             pyupgrade: pyupgrade::settings::Settings::default(),
+            wemake_python_styleguide: wemake_python_styleguide::settings::Settings::default(),
         }
     }
 }

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -20,7 +20,7 @@ use crate::rules::{
     flake8_errmsg, flake8_gettext, flake8_implicit_str_concat, flake8_import_conventions,
     flake8_pytest_style, flake8_quotes, flake8_self, flake8_tidy_imports, flake8_type_checking,
     flake8_unused_arguments, isort, mccabe, pep8_naming, pycodestyle, pydocstyle, pylint,
-    pyupgrade,
+    pyupgrade, wemake_python_styleguide,
 };
 use crate::settings::configuration::Configuration;
 use crate::settings::types::{FilePatternSet, PerFileIgnore, PythonVersion, SerializationFormat};
@@ -129,6 +129,7 @@ pub struct Settings {
     pub pydocstyle: pydocstyle::settings::Settings,
     pub pylint: pylint::settings::Settings,
     pub pyupgrade: pyupgrade::settings::Settings,
+    pub wemake_python_styleguide: wemake_python_styleguide::settings::Settings,
 }
 
 impl Settings {
@@ -230,6 +231,10 @@ impl Settings {
             pydocstyle: config.pydocstyle.map(Into::into).unwrap_or_default(),
             pylint: config.pylint.map(Into::into).unwrap_or_default(),
             pyupgrade: config.pyupgrade.map(Into::into).unwrap_or_default(),
+            wemake_python_styleguide: config
+                .wemake_python_styleguide
+                .map(Into::into)
+                .unwrap_or_default(),
         })
     }
 

--- a/crates/ruff/src/settings/options.rs
+++ b/crates/ruff/src/settings/options.rs
@@ -11,7 +11,7 @@ use crate::rules::{
     flake8_errmsg, flake8_gettext, flake8_implicit_str_concat, flake8_import_conventions,
     flake8_pytest_style, flake8_quotes, flake8_self, flake8_tidy_imports, flake8_type_checking,
     flake8_unused_arguments, isort, mccabe, pep8_naming, pycodestyle, pydocstyle, pylint,
-    pyupgrade,
+    pyupgrade, wemake_python_styleguide,
 };
 use crate::settings::types::{PythonVersion, SerializationFormat, Version};
 
@@ -522,6 +522,9 @@ pub struct Options {
     #[option_group]
     /// Options for the `pyupgrade` plugin.
     pub pyupgrade: Option<pyupgrade::settings::Options>,
+    #[option_group]
+    /// Options for the `wemake-python-styleguide` plugin.
+    pub wemake_python_styleguide: Option<wemake_python_styleguide::settings::Options>,
     // Tables are required to go last.
     #[option(
         default = "{}",

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -13,7 +13,7 @@ use ruff::rules::{
     flake8_errmsg, flake8_gettext, flake8_implicit_str_concat, flake8_import_conventions,
     flake8_pytest_style, flake8_quotes, flake8_self, flake8_tidy_imports, flake8_type_checking,
     flake8_unused_arguments, isort, mccabe, pep8_naming, pycodestyle, pydocstyle, pylint,
-    pyupgrade,
+    pyupgrade, wemake_python_styleguide,
 };
 use ruff::settings::configuration::Configuration;
 use ruff::settings::options::Options;
@@ -158,6 +158,9 @@ pub fn defaultSettings() -> Result<JsValue, JsValue> {
         pydocstyle: Some(pydocstyle::settings::Settings::default().into()),
         pylint: Some(pylint::settings::Settings::default().into()),
         pyupgrade: Some(pyupgrade::settings::Settings::default().into()),
+        wemake_python_styleguide: Some(
+            wemake_python_styleguide::settings::Settings::default().into(),
+        ),
     })?)
 }
 

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -538,6 +538,17 @@
         "boolean",
         "null"
       ]
+    },
+    "wemake-python-styleguide": {
+      "description": "Options for the `wemake-python-styleguide` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/WemakePythonStyleguideOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "additionalProperties": false,
@@ -2350,6 +2361,10 @@
         "W6",
         "W60",
         "W605",
+        "WPS",
+        "WPS1",
+        "WPS11",
+        "WPS111",
         "YTT",
         "YTT1",
         "YTT10",
@@ -2402,6 +2417,21 @@
     },
     "Version": {
       "type": "string"
+    },
+    "WemakePythonStyleguideOptions": {
+      "type": "object",
+      "properties": {
+        "min-name-length": {
+          "description": "Minimum name length for variables and methods.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
     }
   }
 }


### PR DESCRIPTION
This is one of the many rules one would need to implement for #3845. This PR implements WPS11, which checks that the names are not too short.

- [ ] modules (not sure about that one. Filesystem checker?)
- [x] variables
- [ ] attributes
- [ ] functions
- [ ] methods
- [ ] classes

Being new to the project (and Rust in general), I _really_ hope I am doing this right :D