### PR TITLE
Create `Short` SerializationFormat 

### DIFF
--- a/crates/ruff/src/settings/types.rs
+++ b/crates/ruff/src/settings/types.rs
@@ -212,6 +212,8 @@ impl FromStr for PatternPrefixPair {
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum SerializationFormat {
+    Short,
+    #[cfg_attr(feature = "clap", value(alias("Short"), hide(true)))]
     Text,
     Json,
     Junit,

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -187,7 +187,7 @@ impl Printer {
             SerializationFormat::Junit => {
                 JunitEmitter::default().emit(writer, &diagnostics.messages, &context)?;
             }
-            SerializationFormat::Text => {
+            SerializationFormat::Short | SerializationFormat::Text => {
                 TextEmitter::default()
                     .with_show_fix_status(show_fix_status(self.autofix_level))
                     .with_show_fix_diff(self.flags.contains(Flags::SHOW_FIX_DIFF))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,7 +211,7 @@ Options:
       --ignore-noqa
           Ignore any `# noqa` comments
       --format <FORMAT>
-          Output serialization format for violations [env: RUFF_FORMAT=] [possible values: text, json, junit, grouped, github, gitlab, pylint, azure]
+          Output serialization format for violations [env: RUFF_FORMAT=] [possible values: short, json, junit, grouped, github, gitlab, pylint, azure]
       --target-version <TARGET_VERSION>
           The minimum Python version that should be supported [possible values: py37, py38, py39, py310, py311]
       --config <CONFIG>

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -2497,6 +2497,7 @@
     "SerializationFormat": {
       "type": "string",
       "enum": [
+        "short",
         "text",
         "json",
         "junit",


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Rename the `Text` `SerializationFormat` to `Short`, but keep the `Text` alias for now.

The motivation for renaming is to introduce a new `Human` format that pretty prints the output.
*Short* works better with Human because both formats are text based. The amin difference is that one shows
extended information, including source frames, whereas the other only shows a brief summary.

I'm open to other names: An alternative that I considered is *brief* .

## Test Plan

I verified that the name `text` is a valid format in the schema. 
I ran ruff with `text` and `short `format and both produce the same output. 
