### PR TITLE
Avoid running RUF100 rules when code contains syntax errors

### DIFF
--- a/crates/ruff/src/checkers/noqa.rs
+++ b/crates/ruff/src/checkers/noqa.rs
@@ -18,10 +18,9 @@ pub(crate) fn check_noqa(
     locator: &Locator,
     comment_ranges: &[TextRange],
     noqa_line_for: &NoqaMapping,
+    analyze_directives: bool,
     settings: &Settings,
 ) -> Vec<usize> {
-    let enforce_noqa = settings.rules.enabled(Rule::UnusedNOQA);
-
     // Identify any codes that are globally exempted (within the current file).
     let exemption = noqa::file_exemption(locator.contents(), comment_ranges);
 
@@ -93,7 +92,7 @@ pub(crate) fn check_noqa(
     }
 
     // Enforce that the noqa directive was actually used (RUF100).
-    if enforce_noqa {
+    if analyze_directives && settings.rules.enabled(Rule::UnusedNOQA) {
         for line in noqa_directives.lines() {
             match &line.directive {
                 Directive::All(leading_spaces, noqa_range, trailing_spaces) => {

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -214,6 +214,7 @@ pub fn check_path(
             locator,
             indexer.comment_ranges(),
             &directives.noqa_line_for,
+            error.is_none(),
             settings,
         );
         if noqa.into() {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR turns off RUF100 for files that contain syntax errors. If a file contains a syntax error, then we're unable to run all rules over it, and so enforcing the validity of `noqa` directives becomes an invalid operation.

Closes: #4849.

## Test Plan

Copied over:

```py
def function(*):
    """Veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long."""  # noqa: W505
```

Ran: `cargo run -p ruff_cli -- check foo.py -n --select E,W,RUF`:

```
foo.py:2:89: E501 Line too long (110 > 88 characters)
foo.py:2:99: RUF100 [*] Unused `noqa` directive (unused: `W505`)
Found 2 errors.
[*] 1 potentially fixable with the --fix option
```
