### PR TITLE
Run shadowed-variable analyses in deferred handlers

### DIFF
--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -1890,7 +1890,7 @@ mod tests {
         try: pass
         except Exception as fu: pass
         "#,
-            &[Rule::RedefinedWhileUnused, Rule::UnusedVariable],
+            &[Rule::UnusedVariable, Rule::RedefinedWhileUnused],
         );
     }
 

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -94,7 +94,6 @@ impl<'a> Binding<'a> {
             existing.kind,
             BindingKind::ClassDefinition
                 | BindingKind::FunctionDefinition
-                | BindingKind::Builtin
                 | BindingKind::Importation(..)
                 | BindingKind::FromImportation(..)
                 | BindingKind::SubmoduleImportation(..)

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -805,6 +805,69 @@ impl<'a> SemanticModel<'a> {
     pub const fn future_annotations(&self) -> bool {
         self.flags.contains(SemanticModelFlags::FUTURE_ANNOTATIONS)
     }
+
+    /// Return an iterator over all bindings shadowed by the given [`BindingId`], within the
+    /// containing scope, and across scopes.
+    pub fn shadowed_bindings(
+        &self,
+        scope_id: ScopeId,
+        binding_id: BindingId,
+    ) -> impl Iterator<Item = ShadowedBinding> + '_ {
+        let mut first = true;
+        let mut binding_id = binding_id;
+        std::iter::from_fn(move || {
+            // First, check whether this binding is shadowing another binding in a different scope.
+            if std::mem::take(&mut first) {
+                if let Some(shadowed_id) = self.shadowed_bindings.get(&binding_id).copied() {
+                    return Some(ShadowedBinding {
+                        binding_id,
+                        shadowed_id,
+                        same_scope: false,
+                    });
+                }
+            }
+
+            // Otherwise, check whether this binding is shadowing another binding in the same scope.
+            if let Some(shadowed_id) = self.scopes[scope_id].shadowed_binding(binding_id) {
+                let next = ShadowedBinding {
+                    binding_id,
+                    shadowed_id,
+                    same_scope: true,
+                };
+
+                // Advance to the next binding in the scope.
+                first = true;
+                binding_id = shadowed_id;
+
+                return Some(next);
+            }
+
+            None
+        })
+    }
+}
+
+pub struct ShadowedBinding {
+    /// The binding that is shadowing another binding.
+    binding_id: BindingId,
+    /// The binding that is being shadowed.
+    shadowed_id: BindingId,
+    /// Whether the shadowing and shadowed bindings are in the same scope.
+    same_scope: bool,
+}
+
+impl ShadowedBinding {
+    pub const fn binding_id(&self) -> BindingId {
+        self.binding_id
+    }
+
+    pub const fn shadowed_id(&self) -> BindingId {
+        self.shadowed_id
+    }
+
+    pub const fn same_scope(&self) -> bool {
+        self.same_scope
+    }
 }
 
 bitflags! {

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -87,6 +87,11 @@ impl<'a> Scope<'a> {
         self.bindings.iter().map(|(&name, &id)| (name, id))
     }
 
+    /// Returns a tuple of the name and id of all bindings defined in this scope.
+    pub fn shadowed_binding(&self, id: BindingId) -> Option<BindingId> {
+        self.shadowed_bindings.get(&id).copied()
+    }
+
     /// Returns an iterator over all [bindings](BindingId) bound to the given name, including
     /// those that were shadowed by later bindings.
     pub fn bindings_for_name(&self, name: &str) -> impl Iterator<Item = BindingId> + '_ {


### PR DESCRIPTION
## Summary

More to come.

This doesn't properly handle deletions, but I want to create the draft PR so that I don't lose the benchmarks.

On main:

```
Benchmark 1: ./target/release/ruff crates/ruff/resources/test/cpython --silent -e --no-cache --select F402,F811
  Time (mean ± σ):     208.5 ms ±   7.3 ms    [User: 1724.4 ms, System: 64.6 ms]
  Range (min … max):   199.2 ms … 241.5 ms    100 runs

Benchmark 1: ./target/release/ruff crates/ruff/resources/test/cpython --silent -e --no-cache --select F402,F811
  Time (mean ± σ):     213.2 ms ±   8.2 ms    [User: 1764.5 ms, System: 63.8 ms]
  Range (min … max):   202.5 ms … 243.4 ms    100 runs
```

On `charlie/move-bindings`:

```
Benchmark 1: ./target/release/ruff crates/ruff/resources/test/cpython --silent -e --no-cache --select F402,F811
  Time (mean ± σ):     208.3 ms ±   6.0 ms    [User: 1734.5 ms, System: 63.2 ms]
  Range (min … max):   200.6 ms … 240.2 ms    100 runs

Benchmark 1: ./target/release/ruff crates/ruff/resources/test/cpython --silent -e --no-cache --select F402,F811
  Time (mean ± σ):     212.8 ms ±   7.5 ms    [User: 1770.8 ms, System: 63.3 ms]
  Range (min … max):   203.9 ms … 248.9 ms    100 runs
```

`cargo benchmark` showed no significant changes.
