### PR TITLE
Trailing own line comments before func or class

### DIFF
--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__comments9_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__comments9_py.snap
@@ -162,7 +162,7 @@ def bar():
  
  
  some = statement
-@@ -14,148 +13,78 @@
+@@ -14,24 +13,21 @@
  # This multiline comments section
  # should be split from the statement
  # above by two lines.
@@ -190,11 +190,9 @@ def bar():
  
  
  some = statement
-+
-+
- # This should be stick to the statement above
+@@ -39,123 +35,55 @@
  
--
+ 
  # This should be split from the above by two lines
 -class MyClassWithComplexLeadingComments:
 -    pass
@@ -257,41 +255,40 @@ def bar():
 -# leading 4 that already has an empty line
 -def decorated_with_split_leading_comments():
 -    pass
--
--
++NOT_YET_IMPLEMENTED_StmtFunctionDef
+ 
+ 
 -def main():
 -    if a:
 -        # Leading comment before inline function
 -        def inline():
 -            pass
-+NOT_YET_IMPLEMENTED_StmtFunctionDef
- 
+-
 -        # Another leading comment
 -        def another_inline():
 -            pass
++NOT_YET_IMPLEMENTED_StmtFunctionDef
  
 -    else:
 -        # More leading comments
 -        def inline_after_else():
 -            pass
-+NOT_YET_IMPLEMENTED_StmtFunctionDef
- 
+-
  
 -if a:
 -    # Leading comment before "top-level inline" function
 -    def top_level_quote_inline():
 -        pass
-+NOT_YET_IMPLEMENTED_StmtIf
- 
+-
 -    # Another leading comment
 -    def another_top_level_quote_inline_inline():
 -        pass
- 
+-
 -else:
 -    # More leading comments
 -    def top_level_quote_inline_after_else():
 -        pass
-+NOT_YET_IMPLEMENTED_StmtClassDef
++NOT_YET_IMPLEMENTED_StmtIf
  
  
 -class MyClass:
@@ -299,8 +296,9 @@ def bar():
 -    # More comments.
 -    def first_method(self):
 -        pass
--
--
++NOT_YET_IMPLEMENTED_StmtClassDef
+ 
+ 
  # Regression test for https://github.com/psf/black/issues/3454.
 -def foo():
 -    pass
@@ -367,9 +365,8 @@ NOT_YET_IMPLEMENTED_StmtClassDef
 
 
 some = statement
-
-
 # This should be stick to the statement above
+
 
 # This should be split from the above by two lines
 NOT_YET_IMPLEMENTED_StmtClassDef

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__fmtonoff2_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__fmtonoff2_py.snap
@@ -60,9 +60,9 @@ def test_calculate_fades():
  TmSt = 1
  TmEx = 2
  
-+
  # fmt: off
  
++
  # Test data:
  #   Position, Volume, State, TmSt/TmEx/None, [call, [arg1...]]
  
@@ -113,8 +113,8 @@ NOT_YET_IMPLEMENTED_StmtImport
 TmSt = 1
 TmEx = 2
 
-
 # fmt: off
+
 
 # Test data:
 #   Position, Volume, State, TmSt/TmEx/None, [call, [arg1...]]

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__fmtonoff_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__fmtonoff_py.snap
@@ -199,7 +199,7 @@ d={'a':1,
 ```diff
 --- Black
 +++ Ruff
-@@ -1,224 +1,73 @@
+@@ -1,224 +1,72 @@
  #!/usr/bin/env python3
 -import asyncio
 -import sys
@@ -219,13 +219,11 @@ d={'a':1,
  # fmt: on
 -f"trigger 3.6 mode"
 +NOT_YET_IMPLEMENTED_ExprJoinedStr
-+
-+
  # Comment 1
  
  # Comment 2
  
--
+ 
  # fmt: off
 -def func_no_args():
 -  a; b; c
@@ -253,7 +251,12 @@ d={'a':1,
 -    offset = attr.ib(default=attr.Factory(lambda: _r.uniform(1, 2)))
 -    assert task._cancel_stack[: len(old_stack)] == old_stack
 +NOT_YET_IMPLEMENTED_StmtFunctionDef
++
++
++NOT_YET_IMPLEMENTED_StmtAsyncFunctionDef
++
  
++NOT_YET_IMPLEMENTED_StmtFunctionDef
  
 -def spaces_types(
 -    a: int = 1,
@@ -267,21 +270,21 @@ d={'a':1,
 -    i: str = r"",
 -):
 -    ...
-+NOT_YET_IMPLEMENTED_StmtAsyncFunctionDef
  
++# fmt: on
++NOT_YET_IMPLEMENTED_StmtFunctionDef
  
 -def spaces2(result=_core.Value(None)):
 -    ...
-+NOT_YET_IMPLEMENTED_StmtFunctionDef
  
++NOT_YET_IMPLEMENTED_StmtFunctionDef
  
 -something = {
 -    # fmt: off
 -    key: 'value',
 -}
-+# fmt: on
-+NOT_YET_IMPLEMENTED_StmtFunctionDef
  
++NOT_YET_IMPLEMENTED_StmtFunctionDef
  
 -def subscriptlist():
 -    atom[
@@ -292,24 +295,24 @@ d={'a':1,
 -        goes + here,
 -        andhere,
 -    ]
-+NOT_YET_IMPLEMENTED_StmtFunctionDef
  
++something = {NOT_IMPLEMENTED_dict_key: NOT_IMPLEMENTED_dict_value}
  
 -def import_as_names():
 -    # fmt: off
 -    from hello import a,        b
 -    'unformatted'
 -    # fmt: on
-+NOT_YET_IMPLEMENTED_StmtFunctionDef
  
++NOT_YET_IMPLEMENTED_StmtFunctionDef
  
 -def testlist_star_expr():
 -    # fmt: off
 -    a , b = *hello
 -    'unformatted'
 -    # fmt: on
-+something = {NOT_IMPLEMENTED_dict_key: NOT_IMPLEMENTED_dict_value}
  
++NOT_YET_IMPLEMENTED_StmtFunctionDef
  
 -def yield_expr():
 -    # fmt: off
@@ -321,8 +324,8 @@ d={'a':1,
 -    ( yield hello )
 -    'unformatted'
 -    # fmt: on
-+NOT_YET_IMPLEMENTED_StmtFunctionDef
  
++NOT_YET_IMPLEMENTED_StmtFunctionDef
  
 -def example(session):
 -    # fmt: off
@@ -333,24 +336,23 @@ d={'a':1,
 -        .order_by(models.Customer.id.asc())\
 -        .all()
 -    # fmt: on
-+NOT_YET_IMPLEMENTED_StmtFunctionDef
  
++NOT_YET_IMPLEMENTED_StmtFunctionDef
  
 -def off_and_on_without_data():
 -    """All comments here are technically on the same prefix.
-+NOT_YET_IMPLEMENTED_StmtFunctionDef
  
 -    The comments between will be formatted. This is a known limitation.
 -    """
 -    # fmt: off
++NOT_YET_IMPLEMENTED_StmtFunctionDef
  
 -    # hey, that won't work
-+NOT_YET_IMPLEMENTED_StmtFunctionDef
  
 -    # fmt: on
 -    pass
- 
 +NOT_YET_IMPLEMENTED_StmtFunctionDef
+ 
  
 -def on_and_off_broken():
 -    """Another known limitation."""
@@ -364,8 +366,8 @@ d={'a':1,
 -    # fmt: off
 -    # ...but comments still get reformatted even though they should not be
 -    # fmt: on
- 
 +NOT_YET_IMPLEMENTED_StmtFunctionDef
+ 
  
 -def long_lines():
 -    if True:
@@ -406,18 +408,14 @@ d={'a':1,
 -        re.MULTILINE|re.VERBOSE
 -        # fmt: on
 -    )
- 
 +NOT_YET_IMPLEMENTED_StmtFunctionDef
+ 
  
 -def single_literal_yapf_disable():
 -    """Black does not support this."""
 -    BAZ = {(1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12)}  # yapf: disable
++NOT_YET_IMPLEMENTED_StmtFunctionDef
  
-+NOT_YET_IMPLEMENTED_StmtFunctionDef
-+
-+
-+NOT_YET_IMPLEMENTED_StmtFunctionDef
-+
  
 -cfg.rule(
 -    "Default",
@@ -472,11 +470,10 @@ NOT_YET_IMPLEMENTED_StmtImportFrom
 NOT_YET_IMPLEMENTED_StmtImportFrom
 # fmt: on
 NOT_YET_IMPLEMENTED_ExprJoinedStr
-
-
 # Comment 1
 
 # Comment 2
+
 
 # fmt: off
 NOT_YET_IMPLEMENTED_StmtFunctionDef


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR adds special handling for own line comments between a statement and a function or class definition on the module level.

```python
some = statement
# This should be stick to the statement above


# This should be split from the above by two lines
class MyClassWithComplexLeadingComments:
    pass
```

By default, the `# This should be stick to the statement above` would become a leading comment
of the `class` AND the `Suite` formatting separates the comment by two empty lines from the
previous statement, so that the result becomes:

```python
some = statement


#  This should be stick to the statement above


# This should be split from the above by two lines
class MyClassWithComplexLeadingComments:
     pass
 ```

Which is not what we want. The work around is to make the `# This should be stick to the statement above`
a trailing comment of the previous statement.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

You can see that this case is now correctly covered in the Black `comments9.py` test case

<!-- How was it tested? -->
