### PR TITLE
Option (`-o`/`--output-file`) to write output to a file

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -107,7 +107,7 @@ pub struct CheckArgs {
     /// Output serialization format for violations.
     #[arg(long, value_enum, env = "RUFF_FORMAT")]
     pub format: Option<SerializationFormat>,
-    /// Specify file to write output to (default: stdout).
+    /// Specify file to write the linter output to (default: stdout).
     #[arg(short, long)]
     pub output_file: Option<PathBuf>,
     /// The minimum Python version that should be supported.

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -107,6 +107,9 @@ pub struct CheckArgs {
     /// Output serialization format for violations.
     #[arg(long, value_enum, env = "RUFF_FORMAT")]
     pub format: Option<SerializationFormat>,
+    /// Specify file to write output to (default: stdout).
+    #[arg(short, long)]
+    pub output_file: Option<PathBuf>,
     /// The minimum Python version that should be supported.
     #[arg(long, value_enum)]
     pub target_version: Option<PythonVersion>,
@@ -399,6 +402,7 @@ impl CheckArgs {
                 ignore_noqa: self.ignore_noqa,
                 isolated: self.isolated,
                 no_cache: self.no_cache,
+                output_file: self.output_file,
                 show_files: self.show_files,
                 show_settings: self.show_settings,
                 statistics: self.statistics,
@@ -465,6 +469,7 @@ pub struct Arguments {
     pub ignore_noqa: bool,
     pub isolated: bool,
     pub no_cache: bool,
+    pub output_file: Option<PathBuf>,
     pub show_files: bool,
     pub show_settings: bool,
     pub statistics: bool,

--- a/crates/ruff_cli/src/commands/show_files.rs
+++ b/crates/ruff_cli/src/commands/show_files.rs
@@ -1,4 +1,4 @@
-use std::io::{self, BufWriter, Write};
+use std::io::Write;
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -14,6 +14,7 @@ pub(crate) fn show_files(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
     overrides: &Overrides,
+    writer: &mut impl Write,
 ) -> Result<()> {
     // Collect all files in the hierarchy.
     let (paths, _resolver) = resolver::python_files_in_path(files, pyproject_config, overrides)?;
@@ -24,13 +25,12 @@ pub(crate) fn show_files(
     }
 
     // Print the list of files.
-    let mut stdout = BufWriter::new(io::stdout().lock());
     for entry in paths
         .iter()
         .flatten()
         .sorted_by(|a, b| a.path().cmp(b.path()))
     {
-        writeln!(stdout, "{}", entry.path().to_string_lossy())?;
+        writeln!(writer, "{}", entry.path().to_string_lossy())?;
     }
 
     Ok(())

--- a/crates/ruff_cli/src/commands/show_settings.rs
+++ b/crates/ruff_cli/src/commands/show_settings.rs
@@ -1,4 +1,4 @@
-use std::io::{self, BufWriter, Write};
+use std::io::Write;
 use std::path::PathBuf;
 
 use anyhow::{bail, Result};
@@ -14,6 +14,7 @@ pub(crate) fn show_settings(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
     overrides: &Overrides,
+    writer: &mut impl Write,
 ) -> Result<()> {
     // Collect all files in the hierarchy.
     let (paths, resolver) = resolver::python_files_in_path(files, pyproject_config, overrides)?;
@@ -28,12 +29,11 @@ pub(crate) fn show_settings(
     let path = entry.path();
     let settings = resolver.resolve(path, pyproject_config);
 
-    let mut stdout = BufWriter::new(io::stdout().lock());
-    writeln!(stdout, "Resolved settings for: {path:?}")?;
+    writeln!(writer, "Resolved settings for: {path:?}")?;
     if let Some(settings_path) = pyproject_config.path.as_ref() {
-        writeln!(stdout, "Settings path: {settings_path:?}")?;
+        writeln!(writer, "Settings path: {settings_path:?}")?;
     }
-    writeln!(stdout, "{settings:#?}")?;
+    writeln!(writer, "{settings:#?}")?;
 
     Ok(())
 }

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -319,7 +319,7 @@ pub fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
             noqa.into(),
             autofix,
         )?;
-        printer.write_continuously(&messages)?;
+        printer.write_continuously(&mut writer, &messages)?;
 
         // In watch mode, we may need to re-resolve the configuration.
         // TODO(charlie): Re-compute other derivative values, like the `printer`.
@@ -351,7 +351,7 @@ pub fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
                         noqa.into(),
                         autofix,
                     )?;
-                    printer.write_continuously(&messages)?;
+                    printer.write_continuously(&mut writer, &messages)?;
                 }
                 Err(err) => return Err(err.into()),
             }

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -1,3 +1,4 @@
+use std::fs::File;
 use std::io::{self, stdout, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -171,12 +172,26 @@ pub fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
         cli.stdin_filename.as_deref(),
     )?;
 
+    let mut writer: Box<dyn Write> = match cli.output_file {
+        Some(path) if !cli.watch => {
+            colored::control::set_override(false);
+            let file = File::create(path)?;
+            Box::new(BufWriter::new(file))
+        }
+        _ => Box::new(BufWriter::new(io::stdout().lock())),
+    };
+
     if cli.show_settings {
-        commands::show_settings::show_settings(&cli.files, &pyproject_config, &overrides)?;
+        commands::show_settings::show_settings(
+            &cli.files,
+            &pyproject_config,
+            &overrides,
+            &mut writer,
+        )?;
         return Ok(ExitStatus::Success);
     }
     if cli.show_files {
-        commands::show_files::show_files(&cli.files, &pyproject_config, &overrides)?;
+        commands::show_files::show_files(&cli.files, &pyproject_config, &overrides, &mut writer)?;
         return Ok(ExitStatus::Success);
     }
 
@@ -341,10 +356,9 @@ pub fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
         // source code goes to stdout).
         if !(is_stdin && matches!(autofix, flags::FixMode::Apply | flags::FixMode::Diff)) {
             if cli.statistics {
-                printer.write_statistics(&diagnostics)?;
+                printer.write_statistics(&diagnostics, &mut writer)?;
             } else {
-                let mut stdout = BufWriter::new(io::stdout().lock());
-                printer.write_once(&diagnostics, &mut stdout)?;
+                printer.write_once(&diagnostics, &mut writer)?;
             }
         }
 

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -15,7 +15,7 @@ use ruff::settings::{flags, CliSettings};
 use ruff::{fs, warn_user_once};
 use ruff_python_formatter::format_module;
 
-use crate::args::{Args, CheckArgs, Command};
+use crate::args::{Args, Arguments, CheckArgs, Command};
 use crate::commands::run_stdin::read_from_stdin;
 use crate::printer::{Flags as PrinterFlags, Printer};
 
@@ -58,16 +58,13 @@ enum OutputWriter {
     File(BufWriter<File>),
 }
 
-impl<P> TryFrom<Option<P>> for OutputWriter
-where
-    P: AsRef<Path>,
-{
+impl TryFrom<&Arguments> for OutputWriter {
     type Error = anyhow::Error;
 
-    fn try_from(path: Option<P>) -> Result<Self> {
-        Ok(match path {
-            Some(path) => OutputWriter::File(BufWriter::new(File::create(path)?)),
-            None => OutputWriter::Stdout(BufWriter::new(io::stdout())),
+    fn try_from(args: &Arguments) -> Result<Self> {
+        Ok(match args.output_file.as_ref() {
+            Some(path) if !args.watch => OutputWriter::File(BufWriter::new(File::create(path)?)),
+            _ => OutputWriter::Stdout(BufWriter::new(io::stdout())),
         })
     }
 }
@@ -207,11 +204,7 @@ pub fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
         cli.stdin_filename.as_deref(),
     )?;
 
-    let mut writer = if !cli.watch {
-        OutputWriter::try_from(cli.output_file)?
-    } else {
-        OutputWriter::try_from(None)?
-    };
+    let mut writer = OutputWriter::try_from(&cli)?;
     if matches!(writer, OutputWriter::File(_)) {
         colored::control::set_override(false);
     }

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -241,7 +241,11 @@ impl Printer {
         Ok(())
     }
 
-    pub(crate) fn write_statistics(&self, diagnostics: &Diagnostics) -> Result<()> {
+    pub(crate) fn write_statistics(
+        &self,
+        diagnostics: &Diagnostics,
+        writer: &mut impl Write,
+    ) -> Result<()> {
         let statistics: Vec<ExpandedStatistics> = diagnostics
             .messages
             .iter()
@@ -277,7 +281,6 @@ impl Printer {
             return Ok(());
         }
 
-        let mut stdout = BufWriter::new(io::stdout().lock());
         match self.format {
             SerializationFormat::Text => {
                 // Compute the maximum number of digits in the count and code, for all messages,
@@ -302,7 +305,7 @@ impl Printer {
                 // By default, we mimic Flake8's `--statistics` format.
                 for statistic in statistics {
                     writeln!(
-                        stdout,
+                        writer,
                         "{:>count_width$}\t{:<code_width$}\t{}{}",
                         statistic.count.to_string().bold(),
                         statistic.code.to_string().red().bold(),
@@ -321,7 +324,7 @@ impl Printer {
                 return Ok(());
             }
             SerializationFormat::Json => {
-                writeln!(stdout, "{}", serde_json::to_string_pretty(&statistics)?)?;
+                writeln!(writer, "{}", serde_json::to_string_pretty(&statistics)?)?;
             }
             _ => {
                 anyhow::bail!(
@@ -331,7 +334,7 @@ impl Printer {
             }
         }
 
-        stdout.flush()?;
+        writer.flush()?;
 
         Ok(())
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,7 +211,7 @@ Options:
       --ignore-noqa
           Ignore any `# noqa` comments
       --format <FORMAT>
-          Output serialization format for violations [env: RUFF_FORMAT=] [possible values: text, json, junit, grouped, github, gitlab, pylint, azure]
+          Output serialization format for violations [env: RUFF_FORMAT=] [possible values: text, json, json-lines, junit, grouped, github, gitlab, pylint, azure]
   -o, --output-file <OUTPUT_FILE>
           Specify file to write the linter output to (default: stdout)
       --target-version <TARGET_VERSION>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,7 +213,7 @@ Options:
       --format <FORMAT>
           Output serialization format for violations [env: RUFF_FORMAT=] [possible values: text, json, junit, grouped, github, gitlab, pylint, azure]
   -o, --output-file <OUTPUT_FILE>
-          Specify file to write output to (default: stdout)
+          Specify file to write the linter output to (default: stdout)
       --target-version <TARGET_VERSION>
           The minimum Python version that should be supported [possible values: py37, py38, py39, py310, py311]
       --config <CONFIG>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,7 +211,9 @@ Options:
       --ignore-noqa
           Ignore any `# noqa` comments
       --format <FORMAT>
-          Output serialization format for violations [env: RUFF_FORMAT=] [possible values: text, json, json-lines, junit, grouped, github, gitlab, pylint, azure]
+          Output serialization format for violations [env: RUFF_FORMAT=] [possible values: text, json, junit, grouped, github, gitlab, pylint, azure]
+  -o, --output-file <OUTPUT_FILE>
+          Specify file to write output to (default: stdout)
       --target-version <TARGET_VERSION>
           The minimum Python version that should be supported [possible values: py37, py38, py39, py310, py311]
       --config <CONFIG>


### PR DESCRIPTION
## Summary

A new CLI option (`-o`/`--output-file`) to write output to a file instead of stdout.

Major change is to remove the lock acquired on stdout. The argument is that the output is buffered and thus the lock is acquired only when writing a block (8kb). As per the benchmark below there is a slight performance penalty.

Reference: https://rustmagazine.org/issue-3/javascript-compiler/#printing-is-slow

## Benchmarks

_Output is truncated to only contain useful information:_

Command: `check --isolated --no-cache --select=ALL --show-source ./test-repos/cpython"`

Latest HEAD (361d45f2b2f7e69d37d4e6d8270e448f72cae9a7) with and without the manual lock on stdout:

```console
Benchmark 1: With lock
  Time (mean ± σ):      5.687 s ±  0.075 s    [User: 17.110 s, System: 0.486 s]
  Range (min … max):    5.615 s …  5.860 s    10 runs

Benchmark 2: Without lock
  Time (mean ± σ):      5.719 s ±  0.064 s    [User: 17.095 s, System: 0.491 s]
  Range (min … max):    5.640 s …  5.865 s    10 runs

Summary
  (1) ran 1.01 ± 0.02 times faster than (2)
```

This PR:

```console
Benchmark 1: This PR
  Time (mean ± σ):      5.855 s ±  0.058 s    [User: 17.197 s, System: 0.491 s]
  Range (min … max):    5.786 s …  5.987 s    10 runs
 
Benchmark 2: Latest HEAD with lock
  Time (mean ± σ):      5.645 s ±  0.033 s    [User: 16.922 s, System: 0.495 s]
  Range (min … max):    5.600 s …  5.712 s    10 runs
 
Summary
  (2) ran 1.04 ± 0.01 times faster than (1)
```

## Test Plan

Run all of the commands which gives output with and without the `--output-file=ruff.out` option:
* `--show-settings`
* `--show-files`
* `--show-fixes`
* `--diff`
* `--select=ALL`
* `--select=All --show-source`
* `--watch` (only stdout allowed)

resolves: #4754 
