### PR TITLE
Small CI improvements

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -14,7 +14,7 @@ jobs:
     name: "Run | ${{ matrix.os }}"
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -29,10 +29,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: "PR - Build benchmarks"
-        uses: actions-rs/cargo@v1
-        with:
-          command: bench
-          args: -p ruff_benchmark --no-run
+        run: cargo bench -p ruff_benchmark --no-run
 
       - name: "PR - Run benchmarks"
         run: cargo benchmark --save-baseline=pr
@@ -47,10 +44,7 @@ jobs:
         run: rustup show
 
       - name: "Main - Build benchmarks"
-        uses: actions-rs/cargo@v1
-        with:
-          command: bench
-          args: -p ruff_benchmark --no-run
+        run: cargo bench -p ruff_benchmark --no-run
 
       - name: "Main - Run benchmarks"
         run: cargo benchmark --save-baseline=main
@@ -78,11 +72,10 @@ jobs:
       - name: "Install Rust toolchain"
         run: rustup show
 
-      - name: "Install cargo-binstall"
-        uses: taiki-e/install-action@cargo-binstall
-
       - name: "Install critcmp"
-        run: cargo binstall critcmp -y
+        uses: taiki-e/install-action@v2
+        with:
+          tool: critcmp
 
       - name: "Linux | Download PR benchmark results"
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
   workflow_dispatch:
 
@@ -54,7 +54,7 @@ jobs:
   cargo-test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     name: "cargo test | ${{ matrix.os }}"
     steps:
@@ -194,12 +194,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: "Install nightly Rust toolchain"
         # Only pinned to make caching work, update freely
-        run: rustup toolchain install nightly-2023-03-30
+        run: rustup toolchain install nightly-2023-06-08
       - uses: Swatinem/rust-cache@v2
       - name: "Install cargo-udeps"
         uses: taiki-e/install-action@cargo-udeps
       - name: "Run cargo-udeps"
-        run: cargo +nightly-2023-03-30 udeps
+        run: cargo +nightly-2023-06-08 udeps
 
 
   python-package:
@@ -211,6 +211,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
+      - uses: Swatinem/rust-cache@v2
       - name: "Prep README.md"
         run: python scripts/transform_readme.py --target pypi
       - name: "Build wheels"
@@ -223,6 +224,8 @@ jobs:
           pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
           ruff --help
           python -m ruff --help
+      - name: "Remove wheels from cache"
+        run: rm -rf target/wheels
 
   pre-commit:
     name: "pre-commit"
@@ -240,8 +243,8 @@ jobs:
       - name: "Cache pre-commit"
         uses: actions/cache@v3
         with:
-            path: ~/.cache/pre-commit
-            key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: "Run pre-commit"
         run: |
           echo '```console' > $GITHUB_STEP_SUMMARY

--- a/.github/workflows/flake8-to-ruff.yaml
+++ b/.github/workflows/flake8-to-ruff.yaml
@@ -66,7 +66,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        target: [x64, x86]
+        target: [ x64, x86 ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, i686]
+        target: [ x86_64, i686 ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [aarch64, armv7, s390x, ppc64le, ppc64]
+        target: [ aarch64, armv7, s390x, ppc64le, ppc64 ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -2,8 +2,8 @@ name: PR Check Comment
 
 on:
   workflow_run:
-    workflows: [CI, Benchmark]
-    types: [completed]
+    workflows: [ CI, Benchmark ]
+    types: [ completed ]
   workflow_dispatch:
     inputs:
       workflow_run_id:


### PR DESCRIPTION
* Replace the unmaintained actions-rs/cargo that github actions complains about using an old node version with plain cargo (this was the original motivation for this PR)
* Use taiki-e/install-action to install critcmp directly
* Use a rust 1.70 nightly toolchain for udeps
* Cache python package build (this should cut a good chunk of ci time)
* yaml formatting courtesy of pycharm

Test Plan: CI itself
