### PR TITLE
Implement StmtPass

### DIFF
--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__statement__while_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__statement__while_py.snap
@@ -41,14 +41,14 @@ while (
 ## Output
 ```py
 while 34:  # trailing test comment
-    NOT_YET_IMPLEMENTED_StmtPass  # trailing last statement comment
+    pass  # trailing last statement comment
 
     # trailing while body comment
 
 # leading else comment
 
 else:  # trailing else comment
-    NOT_YET_IMPLEMENTED_StmtPass
+    pass
 
     # trailing else body comment
 
@@ -56,7 +56,7 @@ else:  # trailing else comment
 while (
     aVeryLongConditionThatSpillsOverToTheNextLineBecauseItIsExtremelyLongAndGoesOnAndOnAndOnAndOnAndOnAndOnAndOnAndOnAndOn
 ):  # trailing comment
-    NOT_YET_IMPLEMENTED_StmtPass
+    pass
 
 else:
     ...

--- a/crates/ruff_python_formatter/src/statement/stmt_pass.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_pass.rs
@@ -1,12 +1,13 @@
-use crate::{not_yet_implemented, FormatNodeRule, PyFormatter};
-use ruff_formatter::{write, Buffer, FormatResult};
+use crate::{FormatNodeRule, PyFormatter};
+use ruff_formatter::prelude::text;
+use ruff_formatter::{Format, FormatResult};
 use rustpython_parser::ast::StmtPass;
 
 #[derive(Default)]
 pub struct FormatStmtPass;
 
 impl FormatNodeRule<StmtPass> for FormatStmtPass {
-    fn fmt_fields(&self, item: &StmtPass, f: &mut PyFormatter) -> FormatResult<()> {
-        write!(f, [not_yet_implemented(item)])
+    fn fmt_fields(&self, _item: &StmtPass, f: &mut PyFormatter) -> FormatResult<()> {
+        text("pass").fmt(f)
     }
 }


### PR DESCRIPTION
This implements StmtPass as `pass`.

The snapshot diff is small because pass mainly occurs in bodies of functions (#4951) and if/for/while statements.
