### PR TITLE
Implement StmtReturn

### DIFF
--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__power_op_spacing_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__power_op_spacing_py.snap
@@ -178,7 +178,7 @@ return np.divide(
 -return np.divide(
 -    where=view.sum_of_weights_of_weight_long**2 > view.sum_of_weights_squared,  # type: ignore
 -)
-+NOT_YET_IMPLEMENTED_StmtReturn
++return NOT_IMPLEMENTED_call()
 ```
 
 ## Ruff Output
@@ -234,7 +234,7 @@ q = [i for i in []]
 # WE SHOULD DEFINITELY NOT EAT THESE COMMENTS (https://github.com/psf/black/issues/2873)
 NOT_YET_IMPLEMENTED_StmtIf
 
-NOT_YET_IMPLEMENTED_StmtReturn
+return NOT_IMPLEMENTED_call()
 ```
 
 ## Black Output

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__statement__while_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__statement__while_py.snap
@@ -41,14 +41,14 @@ while (
 ## Output
 ```py
 while 34:  # trailing test comment
-    NOT_YET_IMPLEMENTED_StmtPass  # trailing last statement comment
+    pass  # trailing last statement comment
 
     # trailing while body comment
 
 # leading else comment
 
 else:  # trailing else comment
-    NOT_YET_IMPLEMENTED_StmtPass
+    pass
 
     # trailing else body comment
 
@@ -56,7 +56,7 @@ else:  # trailing else comment
 while (
     aVeryLongConditionThatSpillsOverToTheNextLineBecauseItIsExtremelyLongAndGoesOnAndOnAndOnAndOnAndOnAndOnAndOnAndOnAndOn
 ):  # trailing comment
-    NOT_YET_IMPLEMENTED_StmtPass
+    pass
 
 else:
     ...

--- a/crates/ruff_python_formatter/src/statement/stmt_pass.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_pass.rs
@@ -1,12 +1,13 @@
-use crate::{not_yet_implemented, FormatNodeRule, PyFormatter};
-use ruff_formatter::{write, Buffer, FormatResult};
+use crate::{FormatNodeRule, PyFormatter};
+use ruff_formatter::prelude::text;
+use ruff_formatter::{Format, FormatResult};
 use rustpython_parser::ast::StmtPass;
 
 #[derive(Default)]
 pub struct FormatStmtPass;
 
 impl FormatNodeRule<StmtPass> for FormatStmtPass {
-    fn fmt_fields(&self, item: &StmtPass, f: &mut PyFormatter) -> FormatResult<()> {
-        write!(f, [not_yet_implemented(item)])
+    fn fmt_fields(&self, _item: &StmtPass, f: &mut PyFormatter) -> FormatResult<()> {
+        text("pass").fmt(f)
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_return.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_return.rs
@@ -1,5 +1,7 @@
-use crate::{not_yet_implemented, FormatNodeRule, PyFormatter};
-use ruff_formatter::{write, Buffer, FormatResult};
+use crate::expression::parentheses::Parenthesize;
+use crate::{AsFormat, FormatNodeRule, PyFormatter};
+use ruff_formatter::prelude::{space, text};
+use ruff_formatter::{write, Buffer, Format, FormatResult};
 use rustpython_parser::ast::StmtReturn;
 
 #[derive(Default)]
@@ -7,6 +9,18 @@ pub struct FormatStmtReturn;
 
 impl FormatNodeRule<StmtReturn> for FormatStmtReturn {
     fn fmt_fields(&self, item: &StmtReturn, f: &mut PyFormatter) -> FormatResult<()> {
-        write!(f, [not_yet_implemented(item)])
+        let StmtReturn { range: _, value } = item;
+        if let Some(value) = value {
+            write!(
+                f,
+                [
+                    text("return"),
+                    space(),
+                    value.format().with_options(Parenthesize::IfBreaks)
+                ]
+            )
+        } else {
+            text("return").fmt(f)
+        }
     }
 }


### PR DESCRIPTION
This implements StmtReturn as `return` or `return {value}`.

The snapshot diff is small because return occurs in functions (#4951).
