### PR TITLE
Fix binary expression formatting with leading comments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary_expression.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary_expression.py
@@ -41,3 +41,14 @@ not (aaaaaaaaaaaaaa + {a for x in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     # comment
     content + b
 )
+
+
+if (
+    aaaaaaaaaaaaaaaaaa +
+    # has the child process finished?
+    bbbbbbbbbbbbbbb +
+    # the child process has finished, but the
+    # transport hasn't been notified yet?
+    ccccccccccc
+):
+    pass

--- a/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
@@ -90,9 +90,8 @@ impl FormatNodeRule<ExprBinOp> for FormatExprBinOp {
                 ]
             )?;
 
-            // Format the operator on its own line if the operator has trailing comments and the right side has leading comments.
-            if !operator_comments.is_empty() && comments.has_leading_comments(right.as_ref().into())
-            {
+            // Format the operator on its own line if the right side has any leading comments.
+            if comments.has_leading_comments(right.as_ref().into()) {
                 write!(f, [hard_line_break()])?;
             } else if needs_space {
                 write!(f, [space()])?;

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__expression__binary_expression_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__expression__binary_expression_py.snap
@@ -47,6 +47,17 @@ not (aaaaaaaaaaaaaa + {a for x in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     # comment
     content + b
 )
+
+
+if (
+    aaaaaaaaaaaaaaaaaa +
+    # has the child process finished?
+    bbbbbbbbbbbbbbb +
+    # the child process has finished, but the
+    # transport hasn't been notified yet?
+    ccccccccccc
+):
+    pass
 ```
 
 
@@ -105,6 +116,19 @@ NOT_YET_IMPLEMENTED_ExprUnaryOp
     content
     + b
 )
+
+
+if (
+    aaaaaaaaaaaaaaaaaa
+    +
+    # has the child process finished?
+    bbbbbbbbbbbbbbb
+    +
+    # the child process has finished, but the
+    # transport hasn't been notified yet?
+    ccccccccccc
+):
+    pass
 ```
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR fixes an issue where 

```python

if (
    aaaaaaaaaaaaaaaaaa +
    # has the child process finished?
    bbbbbbbbbbbbbbb +
    # the child process has finished, but the
    # transport hasn't been notified yet?
    ccccccccccc
):
    pass
```

got formatted differently on the second pass. 

It now preserves the formatting, the same as Black.



## Test Plan

I added a new test
