### PR TITLE
Correctly handle left/right breaking of binary expression

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
@@ -52,3 +52,138 @@ if (
     ccccccccccc
 ):
     pass
+
+
+# Left only breaks
+if [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+] & aaaaaaaaaaaaaaaaaaaaaaaaaa:
+    ...
+
+if [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+] & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+    ...
+
+# Right only can break
+if aaaaaaaaaaaaaaaaaaaaaaaaaa & [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+]:
+    ...
+
+if aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+]:
+    ...
+
+
+# Left or right can break
+if [2222, 333] & [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+]:
+    ...
+
+if [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+] & [2222, 333]:
+    ...
+
+if [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+] & [fffffffffffffffff, gggggggggggggggggggg, hhhhhhhhhhhhhhhhhhhhh, iiiiiiiiiiiiiiii, jjjjjjjjjjjjj]:
+    ...
+
+if (
+    # comment
+    [
+        aaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbb,
+        cccccccccccccccccccc,
+        dddddddddddddddddddd,
+        eeeeeeeeee,
+    ]
+) & [
+    fffffffffffffffff,
+    gggggggggggggggggggg,
+    hhhhhhhhhhhhhhhhhhhhh,
+    iiiiiiiiiiiiiiii,
+    jjjjjjjjjjjjj,
+]:
+    pass
+
+    ...
+
+# Nesting
+if (aaaa + b) & [
+    fffffffffffffffff,
+    gggggggggggggggggggg,
+    hhhhhhhhhhhhhhhhhhhhh,
+    iiiiiiiiiiiiiiii,
+    jjjjjjjjjjjjj,
+]:
+    ...
+
+if [
+    fffffffffffffffff,
+    gggggggggggggggggggg,
+    hhhhhhhhhhhhhhhhhhhhh,
+    iiiiiiiiiiiiiiii,
+    jjjjjjjjjjjjj,
+] & (a + b):
+    ...
+
+
+if [
+    fffffffffffffffff,
+    gggggggggggggggggggg,
+    hhhhhhhhhhhhhhhhhhhhh,
+    iiiiiiiiiiiiiiii,
+    jjjjjjjjjjjjj,
+] & (
+    # comment
+    a
+    + b
+):
+    ...
+
+if (
+    [
+        fffffffffffffffff,
+        gggggggggggggggggggg,
+        hhhhhhhhhhhhhhhhhhhhh,
+        iiiiiiiiiiiiiiii,
+        jjjjjjjjjjjjj,
+    ]
+    &
+    # comment
+    a + b
+):
+    ...

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__expression__binary_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__expression__binary_py.snap
@@ -58,6 +58,141 @@ if (
     ccccccccccc
 ):
     pass
+
+
+# Left only breaks
+if [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+] & aaaaaaaaaaaaaaaaaaaaaaaaaa:
+    ...
+
+if [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+] & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+    ...
+
+# Right only can break
+if aaaaaaaaaaaaaaaaaaaaaaaaaa & [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+]:
+    ...
+
+if aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+]:
+    ...
+
+
+# Left or right can break
+if [2222, 333] & [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+]:
+    ...
+
+if [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+] & [2222, 333]:
+    ...
+
+if [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+] & [fffffffffffffffff, gggggggggggggggggggg, hhhhhhhhhhhhhhhhhhhhh, iiiiiiiiiiiiiiii, jjjjjjjjjjjjj]:
+    ...
+
+if (
+    # comment
+    [
+        aaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbb,
+        cccccccccccccccccccc,
+        dddddddddddddddddddd,
+        eeeeeeeeee,
+    ]
+) & [
+    fffffffffffffffff,
+    gggggggggggggggggggg,
+    hhhhhhhhhhhhhhhhhhhhh,
+    iiiiiiiiiiiiiiii,
+    jjjjjjjjjjjjj,
+]:
+    pass
+
+    ...
+
+# Nesting
+if (aaaa + b) & [
+    fffffffffffffffff,
+    gggggggggggggggggggg,
+    hhhhhhhhhhhhhhhhhhhhh,
+    iiiiiiiiiiiiiiii,
+    jjjjjjjjjjjjj,
+]:
+    ...
+
+if [
+    fffffffffffffffff,
+    gggggggggggggggggggg,
+    hhhhhhhhhhhhhhhhhhhhh,
+    iiiiiiiiiiiiiiii,
+    jjjjjjjjjjjjj,
+] & (a + b):
+    ...
+
+
+if [
+    fffffffffffffffff,
+    gggggggggggggggggggg,
+    hhhhhhhhhhhhhhhhhhhhh,
+    iiiiiiiiiiiiiiii,
+    jjjjjjjjjjjjj,
+] & (
+    # comment
+    a
+    + b
+):
+    ...
+
+if (
+    [
+        fffffffffffffffff,
+        gggggggggggggggggggg,
+        hhhhhhhhhhhhhhhhhhhhh,
+        iiiiiiiiiiiiiiii,
+        jjjjjjjjjjjjj,
+    ]
+    &
+    # comment
+    a + b
+):
+    ...
 ```
 
 
@@ -139,6 +274,158 @@ if (
     ccccccccccc
 ):
     pass
+
+
+# Left only breaks
+if [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+] & aaaaaaaaaaaaaaaaaaaaaaaaaa:
+    ...
+
+if (
+    [
+        aaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbb,
+        cccccccccccccccccccc,
+        dddddddddddddddddddd,
+        eeeeeeeeee,
+    ]
+    & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    ...
+
+# Right only can break
+if aaaaaaaaaaaaaaaaaaaaaaaaaa & [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+]:
+    ...
+
+if (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    & [
+        aaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbb,
+        cccccccccccccccccccc,
+        dddddddddddddddddddd,
+        eeeeeeeeee,
+    ]
+):
+    ...
+
+
+# Left or right can break
+if [2222, 333] & [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+]:
+    ...
+
+if [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+] & [2222, 333]:
+    ...
+
+if [
+    aaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+    dddddddddddddddddddd,
+    eeeeeeeeee,
+] & [
+    fffffffffffffffff,
+    gggggggggggggggggggg,
+    hhhhhhhhhhhhhhhhhhhhh,
+    iiiiiiiiiiiiiiii,
+    jjjjjjjjjjjjj,
+]:
+    ...
+
+if (
+    # comment
+    [
+        aaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbb,
+        cccccccccccccccccccc,
+        dddddddddddddddddddd,
+        eeeeeeeeee,
+    ]
+) & [
+    fffffffffffffffff,
+    gggggggggggggggggggg,
+    hhhhhhhhhhhhhhhhhhhhh,
+    iiiiiiiiiiiiiiii,
+    jjjjjjjjjjjjj,
+]:
+    pass
+
+    ...
+
+# Nesting
+if (aaaa + b) & [
+    fffffffffffffffff,
+    gggggggggggggggggggg,
+    hhhhhhhhhhhhhhhhhhhhh,
+    iiiiiiiiiiiiiiii,
+    jjjjjjjjjjjjj,
+]:
+    ...
+
+if [
+    fffffffffffffffff,
+    gggggggggggggggggggg,
+    hhhhhhhhhhhhhhhhhhhhh,
+    iiiiiiiiiiiiiiii,
+    jjjjjjjjjjjjj,
+] & (a + b):
+    ...
+
+
+if (
+    [
+        fffffffffffffffff,
+        gggggggggggggggggggg,
+        hhhhhhhhhhhhhhhhhhhhh,
+        iiiiiiiiiiiiiiii,
+        jjjjjjjjjjjjj,
+    ]
+    &
+    (
+        # comment
+        a
+        + b
+    )
+):
+    ...
+
+if (
+    [
+        fffffffffffffffff,
+        gggggggggggggggggggg,
+        hhhhhhhhhhhhhhhhhhhhh,
+        iiiiiiiiiiiiiiii,
+        jjjjjjjjjjjjj,
+    ]
+    &
+    # comment
+    a
+    + b
+):
+    ...
 ```
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Black supports for layouts when it comes to breaking binary expressions:

```rust
#[derive(Copy, Clone, Debug, Eq, PartialEq)]
enum BinaryLayout {
    /// Put each operand on their own line if either side expands
    Default,

    /// Try to expand the left to make it fit. Add parentheses if the left or right don't fit.
    ///
    ///```python
    /// [
    ///     a,
    ///     b
    /// ] & c
    ///```
    ExpandLeft,

    /// Try to expand the right to make it fix. Add parentheses if the left or right don't fit.
    ///
    /// ```python
    /// a & [
    ///     b,
    ///     c
    /// ]
    /// ```
    ExpandRight,

    /// Both the left and right side can be expanded. Try in the following order:
    /// * expand the right side
    /// * expand the left side
    /// * expand both sides
    ///
    /// to make the expression fit
    ///
    /// ```python
    /// [
    ///     a,
    ///     b
    /// ] & [
    ///     c,
    ///     d
    /// ]
    /// ```
    ExpandRightThenLeft,
}
```

Our current implementation only handles `ExpandRight` and `Default` correctly. This PR adds support for `ExpandRightThenLeft` and `ExpandLeft`. 

## Test Plan

I added tests that play through all 4 binary expression layouts.
