### PR TITLE
Extend revised `RET504` implementation to `with` statements

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_return/RET504.py
+++ b/crates/ruff/resources/test/fixtures/flake8_return/RET504.py
@@ -276,20 +276,25 @@ def str_to_bool(val):
 
 # Mixed assignments
 def function_assignment(x):
-    def f(): ...
+    def f():
+        ...
 
     return f
 
 
 def class_assignment(x):
-    class Foo: ...
+    class Foo:
+        ...
 
     return Foo
 
 
 def mixed_function_assignment(x):
     if x:
-        def f(): ...
+
+        def f():
+            ...
+
     else:
         f = 42
 
@@ -298,8 +303,32 @@ def mixed_function_assignment(x):
 
 def mixed_class_assignment(x):
     if x:
-        class Foo: ...
+
+        class Foo:
+            ...
+
     else:
         Foo = 42
 
     return Foo
+
+
+# `with` statements
+def foo():
+    with open("foo.txt", "r") as f:
+        x = f.read()
+    return x
+
+
+def foo():
+    with open("foo.txt", "r") as f:
+        x = f.read()
+        print(x)
+    return x
+
+
+def foo():
+    with open("foo.txt", "r") as f:
+        x = f.read()
+    print(x)
+    return x

--- a/crates/ruff/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff/src/rules/flake8_return/rules/function.rs
@@ -504,7 +504,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
 
 /// RET504
 fn unnecessary_assign(checker: &mut Checker, stack: &Stack) {
-    for (stmt_assign, stmt_return) in &stack.assignments {
+    for (stmt_assign, stmt_return) in &stack.assignment_return {
         // Identify, e.g., `return x`.
         let Some(value) = stmt_return.value.as_ref() else {
             continue;

--- a/crates/ruff/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET504_RET504.py.snap
+++ b/crates/ruff/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET504_RET504.py.snap
@@ -41,4 +41,12 @@ RET504.py:268:12: RET504 Unnecessary assignment to `val` before `return` stateme
     |            ^^^ RET504
     |
 
+RET504.py:320:12: RET504 Unnecessary assignment to `x` before `return` statement
+    |
+318 |     with open("foo.txt", "r") as f:
+319 |         x = f.read()
+320 |     return x
+    |            ^ RET504
+    |
+
 


### PR DESCRIPTION
## Summary

This PR extends the new `RET504` implementation to handle cases like:

```py
def foo():
    with open("foo.txt", "r") as f:
        x = f.read()
    return x
```

This was originally suggested in https://github.com/astral-sh/ruff/issues/2950#issuecomment-1433441503.
