### PR TITLE
Add isort line-length independent config

### DIFF
--- a/crates/ruff/resources/test/fixtures/isort/pyproject.toml
+++ b/crates/ruff/resources/test/fixtures/isort/pyproject.toml
@@ -1,7 +1,8 @@
 [tool.ruff]
-line-length = 88
+line-length = 120
 
 [tool.ruff.isort]
+line-length = 88
 lines-after-imports = 3
 lines-between-types = 2
 known-local-folder = ["ruff"]

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -113,12 +113,20 @@ pub(crate) fn organize_imports(
         trailing_lines_end(block.imports.last().unwrap(), locator)
     };
 
+    // If isort line length setting is explicitly set and greater than default
+    // ruff line line length we use that, otherwise we fall back to default ruff length
+    let line_length = match settings.isort.line_length {
+        Some(isort_length) if isort_length < settings.line_length => settings.line_length,
+        Some(isort_length) => isort_length,
+        None => settings.line_length,
+    };
+
     // Generate the sorted import block.
     let expected = format_imports(
         block,
         comments,
         locator,
-        settings.line_length,
+        line_length,
         LineWidth::new(settings.tab_size).add_str(indentation),
         stylist,
         &settings.src,

--- a/crates/ruff/src/rules/isort/settings.rs
+++ b/crates/ruff/src/rules/isort/settings.rs
@@ -9,6 +9,7 @@ use strum::IntoEnumIterator;
 
 use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
+use crate::line_width::LineLength;
 use crate::rules::isort::categorize::KnownModules;
 use crate::rules::isort::ImportType;
 use crate::warn_user_once;
@@ -43,6 +44,16 @@ impl Default for RelativeImportsOrder {
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Options {
+    #[option(
+        default = "",
+        value_type = "int",
+        example = r#"
+        # Allow import lines to be as long as 120 characters.
+        line-length = 120
+        "#
+    )]
+    /// The line length to use when enforcing I001 violations, long import lines.
+    pub line_length: Option<LineLength>,
     #[option(
         default = r#"false"#,
         value_type = "bool",
@@ -299,6 +310,7 @@ pub struct Options {
 #[derive(Debug, CacheKey)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Settings {
+    pub line_length: Option<LineLength>,
     pub required_imports: BTreeSet<String>,
     pub combine_as_imports: bool,
     pub force_single_line: bool,
@@ -323,6 +335,7 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Self {
+            line_length: None,
             required_imports: BTreeSet::new(),
             combine_as_imports: false,
             force_single_line: false,
@@ -425,6 +438,7 @@ impl From<Options> for Settings {
         }
 
         Self {
+            line_length: options.line_length,
             required_imports: BTreeSet::from_iter(options.required_imports.unwrap_or_default()),
             combine_as_imports: options.combine_as_imports.unwrap_or(false),
             force_single_line: options.force_single_line.unwrap_or(false),
@@ -459,6 +473,7 @@ impl From<Options> for Settings {
 impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
+            line_length: settings.line_length,
             required_imports: Some(settings.required_imports.into_iter().collect()),
             combine_as_imports: Some(settings.combine_as_imports),
             extra_standard_library: Some(

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1192,6 +1192,17 @@
             "type": "string"
           }
         },
+        "line-length": {
+          "description": "The line length to use when enforcing I001 violations, long import lines.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LineLength"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "lines-after-imports": {
           "description": "The number of blank lines to place after imports. Use `-1` for automatic determination.",
           "type": [


### PR DESCRIPTION
## Summary

Fixes #3206.

This PR adds a `line-length` config for `isort`, this way users will be able to specify a different line length that differs from default Ruff config.

I handled three different cases:

* `ruff.isort.line-length` is not set: use `tool.ruff.line-length`
* `ruff.isort.line-length` is smaller than `tool.ruff.line-length`: use `tool.ruff.line-length`
* `ruff.isort.line-length` is greater than `tool.ruff.line-length`: use `tool.ruff.isort.line-length`


## Test Plan

I tested it by adding the `tool.ruff.isort.line-length` config in `crates/ruff/resources/test/fixtures/isort/pyproject.toml` and running the following command:

```
cargo run -p ruff_cli -- check crates/ruff/resources/test/fixtures/isort/fit_line_length.py --no-cache
```

I decided to leave the `tool.ruff.line-length` in `pyproject.toml` to verify that it's ignored if it's greater than the `isort` one.

I'd like to add an automatic test in case `tool.ruff.line-length` is less than `tool.ruff.isort.line-length` but I'm not sure how to proceed on this. If anyone could point to similar tests I'll gladly try to add a new one.