### PR TITLE
Ignore pyproject.toml for adding noqa directives

### DIFF
--- a/crates/ruff_cli/src/commands/add_noqa.rs
+++ b/crates/ruff_cli/src/commands/add_noqa.rs
@@ -9,6 +9,7 @@ use rayon::prelude::*;
 use ruff::linter::add_noqa_to_path;
 use ruff::resolver::PyprojectConfig;
 use ruff::{packaging, resolver, warn_user_once};
+use ruff_python_stdlib::path::is_project_toml;
 
 use crate::args::Overrides;
 
@@ -46,6 +47,9 @@ pub(crate) fn add_noqa(
         .flatten()
         .filter_map(|entry| {
             let path = entry.path();
+            if is_project_toml(path) {
+                return None;
+            }
             let package = path
                 .parent()
                 .and_then(|parent| package_roots.get(parent))


### PR DESCRIPTION
## Summary

Ignore pyproject.toml file for adding noqa directives using `--add-noqa`

## Test Plan

`cargo run --bin ruff -- check --add-noqa .`

fixes: #5012
