### PR TITLE
Suggest combining async with statements

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_simplify/SIM117.py
+++ b/crates/ruff/resources/test/fixtures/flake8_simplify/SIM117.py
@@ -33,17 +33,17 @@ with A() as a:
         print("hello")
     a()
 
-# OK
+# OK, can't merge async with and with.
 async with A() as a:
     with B() as b:
         print("hello")
 
-# OK
+# OK, can't merge async with and with.
 with A() as a:
     async with B() as b:
         print("hello")
 
-# OK
+# SIM117
 async with A() as a:
     async with B() as b:
         print("hello")
@@ -100,3 +100,11 @@ with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as a:
 with A("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ890") as a:
     with B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
         print("hello")
+
+# From issue #3025.
+async def main():
+    async with A() as a: # SIM117.
+        async with B() as b:
+            print("async-inside!")
+
+    return 0

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -1511,7 +1511,8 @@ where
                     pygrep_hooks::rules::non_existent_mock_method(self, test);
                 }
             }
-            Stmt::With(ast::StmtWith { items, body, .. }) => {
+            Stmt::With(ast::StmtWith { items, body, .. })
+            | Stmt::AsyncWith(ast::StmtAsyncWith { items, body, .. }) => {
                 if self.enabled(Rule::AssertRaisesException) {
                     flake8_bugbear::rules::assert_raises_exception(self, stmt, items);
                 }

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM117_SIM117.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM117_SIM117.py.snap
@@ -85,6 +85,29 @@ SIM117.py:19:1: SIM117 [*] Use a single `with` statement with multiple contexts 
 24 23 | # OK
 25 24 | with A() as a:
 
+SIM117.py:47:1: SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
+   |
+46 |   # SIM117
+47 | / async with A() as a:
+48 | |     async with B() as b:
+   | |________________________^ SIM117
+49 |           print("hello")
+   |
+   = help: Combine `with` statements
+
+ℹ Suggested fix
+44 44 |         print("hello")
+45 45 | 
+46 46 | # SIM117
+47    |-async with A() as a:
+48    |-    async with B() as b:
+49    |-        print("hello")
+   47 |+async with A() as a, B() as b:
+   48 |+    print("hello")
+50 49 | 
+51 50 | while True:
+52 51 |     # SIM117
+
 SIM117.py:53:5: SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
    |
 51 |   while True:
@@ -246,6 +269,18 @@ SIM117.py:100:1: SIM117 Use a single `with` statement with multiple contexts ins
 101 | |     with B("01ß9💣2ℝ8901ß9💣2ℝ8901ß9💣2ℝ89") as b:
     | |__________________________________________________^ SIM117
 102 |           print("hello")
+    |
+    = help: Combine `with` statements
+
+SIM117.py:106:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
+    |
+104 |   # From issue #3025.
+105 |   async def main():
+106 |       async with A() as a: # SIM117.
+    |  _____^
+107 | |         async with B() as b:
+    | |____________________________^ SIM117
+108 |               print("async-inside!")
     |
     = help: Combine `with` statements
 


### PR DESCRIPTION
## Summary

Previously the rule for SIM117 explicitly ignored `async with` statements as it would incorrectly suggestion to merge `async with` and regular `with` statements as reported in issue #1902.

This partially reverts the fix for that (commit     396be5edeac0c5724de87e93c5a885dacf201f05) by enabling the rules for `async with` statements again, but with a check ensuring that the statements are both of the same kind, i.e. both `async with` or both (just) `with` statements.

Closes #3025

## Test Plan

Updated and existing test and added a new test case from #3025.