### PR TITLE
Support glob patterns in pep8_naming ignore-names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,6 +1880,7 @@ name = "ruff_cache"
 version = "0.0.0"
 dependencies = [
  "filetime",
+ "glob",
  "globset",
  "itertools",
  "regex",

--- a/crates/ruff/resources/test/fixtures/pep8_naming/ignore_names/N802.py
+++ b/crates/ruff/resources/test/fixtures/pep8_naming/ignore_names/N802.py
@@ -1,0 +1,14 @@
+import unittest
+
+def badAllowed():
+    pass
+
+def stillBad():
+    pass
+
+class Test(unittest.TestCase):
+    def badAllowed(self):
+        return super().tearDown()
+
+    def stillBad(self):
+        return super().tearDown()

--- a/crates/ruff/resources/test/fixtures/pep8_naming/ignore_names/N803.py
+++ b/crates/ruff/resources/test/fixtures/pep8_naming/ignore_names/N803.py
@@ -1,0 +1,12 @@
+def func(_, a, badAllowed):
+    return _, a, badAllowed
+
+def func(_, a, stillBad):
+    return _, a, stillBad
+
+class Class:
+    def method(self, _, a, badAllowed):
+        return _, a, badAllowed
+
+    def method(self, _, a, stillBad):
+        return _, a, stillBad

--- a/crates/ruff/resources/test/fixtures/pep8_naming/ignore_names/N804.py
+++ b/crates/ruff/resources/test/fixtures/pep8_naming/ignore_names/N804.py
@@ -1,0 +1,22 @@
+from abc import ABCMeta
+
+
+class Class:
+    def __init_subclass__(self, default_name, **kwargs):
+        ...
+
+    @classmethod
+    def badAllowed(self, x, /, other):
+        ...
+
+    @classmethod
+    def stillBad(self, x, /, other):
+        ...
+
+
+class MetaClass(ABCMeta):
+    def badAllowed(self):
+        pass
+
+    def stillBad(self):
+        pass

--- a/crates/ruff/resources/test/fixtures/pep8_naming/ignore_names/N805.py
+++ b/crates/ruff/resources/test/fixtures/pep8_naming/ignore_names/N805.py
@@ -1,0 +1,42 @@
+from abc import ABCMeta
+
+import pydantic
+
+
+class Class:
+    def badAllowed(this):
+        pass
+
+    def stillBad(this):
+        pass
+
+    if False:
+
+        def badAllowed(this):
+            pass
+
+        def stillBad(this):
+            pass
+
+    @pydantic.validator
+    def badAllowed(cls, my_field: str) -> str:
+        pass
+
+    @pydantic.validator
+    def stillBad(cls, my_field: str) -> str:
+        pass
+
+    @pydantic.validator("my_field")
+    def badAllowed(cls, my_field: str) -> str:
+        pass
+
+    @pydantic.validator("my_field")
+    def stillBad(cls, my_field: str) -> str:
+        pass
+
+class PosOnlyClass:
+    def badAllowed(this, blah, /, self, something: str):
+        pass
+
+    def stillBad(this, blah, /, self, something: str):
+        pass

--- a/crates/ruff/resources/test/fixtures/pep8_naming/ignore_names/N806.py
+++ b/crates/ruff/resources/test/fixtures/pep8_naming/ignore_names/N806.py
@@ -1,0 +1,6 @@
+def assign():
+    badAllowed = 0
+    stillBad = 0
+
+    BAD_ALLOWED = 0
+    STILL_BAD = 0

--- a/crates/ruff/resources/test/fixtures/pep8_naming/ignore_names/N815.py
+++ b/crates/ruff/resources/test/fixtures/pep8_naming/ignore_names/N815.py
@@ -1,0 +1,19 @@
+class C:
+    badAllowed = 0
+    stillBad = 0
+
+    _badAllowed = 0
+    _stillBad = 0
+
+    bad_Allowed = 0
+    still_Bad = 0
+
+class D(TypedDict):
+    badAllowed: bool
+    stillBad: bool
+
+    _badAllowed: list
+    _stillBad: list
+
+    bad_Allowed: set
+    still_Bad: set

--- a/crates/ruff/resources/test/fixtures/pep8_naming/ignore_names/N816.py
+++ b/crates/ruff/resources/test/fixtures/pep8_naming/ignore_names/N816.py
@@ -1,0 +1,8 @@
+badAllowed = 0
+stillBad = 0
+
+_badAllowed = 0
+_stillBad = 0
+
+bad_Allowed = 0
+still_Bad = 0

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_argument_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_argument_name.rs
@@ -3,6 +3,8 @@ use rustpython_parser::ast::{Arg, Ranged};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 
+use crate::settings::types::IdenifierMatcher;
+
 /// ## What it does
 /// Checks for argument names that do not follow the `snake_case` convention.
 ///
@@ -48,9 +50,12 @@ impl Violation for InvalidArgumentName {
 pub(crate) fn invalid_argument_name(
     name: &str,
     arg: &Arg,
-    ignore_names: &[String],
+    ignore_names: &[IdenifierMatcher],
 ) -> Option<Diagnostic> {
-    if ignore_names.iter().any(|ignore_name| ignore_name == name) {
+    if ignore_names
+        .iter()
+        .any(|ignore_name| ignore_name.is_match(name))
+    {
         return None;
     }
     if name.to_lowercase() != name {

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_argument_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_argument_name.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{Arg, Ranged};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 
-use crate::settings::types::IdenifierMatcher;
+use crate::settings::types::IdentifierPattern;
 
 /// ## What it does
 /// Checks for argument names that do not follow the `snake_case` convention.
@@ -50,11 +50,11 @@ impl Violation for InvalidArgumentName {
 pub(crate) fn invalid_argument_name(
     name: &str,
     arg: &Arg,
-    ignore_names: &[IdenifierMatcher],
+    ignore_names: &[IdentifierPattern],
 ) -> Option<Diagnostic> {
     if ignore_names
         .iter()
-        .any(|ignore_name| ignore_name.is_match(name))
+        .any(|ignore_name| ignore_name.matches(name))
     {
         return None;
     }

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
@@ -82,7 +82,7 @@ pub(crate) fn invalid_first_argument_name_for_class_method(
                 .pep8_naming
                 .ignore_names
                 .iter()
-                .any(|ignore_name| ignore_name.is_match(name))
+                .any(|ignore_name| ignore_name.matches(name))
             {
                 return None;
             }

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
@@ -82,7 +82,7 @@ pub(crate) fn invalid_first_argument_name_for_class_method(
                 .pep8_naming
                 .ignore_names
                 .iter()
-                .any(|ignore_name| ignore_name == name)
+                .any(|ignore_name| ignore_name.is_match(name))
             {
                 return None;
             }

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
@@ -81,7 +81,7 @@ pub(crate) fn invalid_first_argument_name_for_method(
         .pep8_naming
         .ignore_names
         .iter()
-        .any(|ignore_name| ignore_name == name)
+        .any(|ignore_name| ignore_name.is_match(name))
     {
         return None;
     }

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
@@ -81,7 +81,7 @@ pub(crate) fn invalid_first_argument_name_for_method(
         .pep8_naming
         .ignore_names
         .iter()
-        .any(|ignore_name| ignore_name.is_match(name))
+        .any(|ignore_name| ignore_name.matches(name))
     {
         return None;
     }

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_function_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_function_name.rs
@@ -7,6 +7,8 @@ use ruff_python_ast::source_code::Locator;
 use ruff_python_semantic::analyze::visibility;
 use ruff_python_semantic::model::SemanticModel;
 
+use crate::settings::types::IdenifierMatcher;
+
 /// ## What it does
 /// Checks for functions names that do not follow the `snake_case` naming
 /// convention.
@@ -52,12 +54,15 @@ pub(crate) fn invalid_function_name(
     stmt: &Stmt,
     name: &str,
     decorator_list: &[Decorator],
-    ignore_names: &[String],
+    ignore_names: &[IdenifierMatcher],
     model: &SemanticModel,
     locator: &Locator,
 ) -> Option<Diagnostic> {
     // Ignore any explicitly-ignored function names.
-    if ignore_names.iter().any(|ignore_name| ignore_name == name) {
+    if ignore_names
+        .iter()
+        .any(|ignore_name| ignore_name.is_match(name))
+    {
         return None;
     }
 

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_function_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_function_name.rs
@@ -7,7 +7,7 @@ use ruff_python_ast::source_code::Locator;
 use ruff_python_semantic::analyze::visibility;
 use ruff_python_semantic::model::SemanticModel;
 
-use crate::settings::types::IdenifierMatcher;
+use crate::settings::types::IdentifierPattern;
 
 /// ## What it does
 /// Checks for functions names that do not follow the `snake_case` naming
@@ -54,14 +54,14 @@ pub(crate) fn invalid_function_name(
     stmt: &Stmt,
     name: &str,
     decorator_list: &[Decorator],
-    ignore_names: &[IdenifierMatcher],
+    ignore_names: &[IdentifierPattern],
     model: &SemanticModel,
     locator: &Locator,
 ) -> Option<Diagnostic> {
     // Ignore any explicitly-ignored function names.
     if ignore_names
         .iter()
-        .any(|ignore_name| ignore_name.is_match(name))
+        .any(|ignore_name| ignore_name.matches(name))
     {
         return None;
     }

--- a/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_class_scope.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_class_scope.rs
@@ -62,7 +62,7 @@ pub(crate) fn mixed_case_variable_in_class_scope(
         .pep8_naming
         .ignore_names
         .iter()
-        .any(|ignore_name| ignore_name.is_match(name))
+        .any(|ignore_name| ignore_name.matches(name))
     {
         return;
     }

--- a/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_class_scope.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_class_scope.rs
@@ -62,7 +62,7 @@ pub(crate) fn mixed_case_variable_in_class_scope(
         .pep8_naming
         .ignore_names
         .iter()
-        .any(|ignore_name| ignore_name == name)
+        .any(|ignore_name| ignore_name.is_match(name))
     {
         return;
     }

--- a/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
@@ -71,7 +71,7 @@ pub(crate) fn mixed_case_variable_in_global_scope(
         .pep8_naming
         .ignore_names
         .iter()
-        .any(|ignore_name| ignore_name == name)
+        .any(|ignore_name| ignore_name.is_match(name))
     {
         return;
     }

--- a/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
@@ -71,7 +71,7 @@ pub(crate) fn mixed_case_variable_in_global_scope(
         .pep8_naming
         .ignore_names
         .iter()
-        .any(|ignore_name| ignore_name.is_match(name))
+        .any(|ignore_name| ignore_name.matches(name))
     {
         return;
     }

--- a/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
@@ -60,7 +60,7 @@ pub(crate) fn non_lowercase_variable_in_function(
         .pep8_naming
         .ignore_names
         .iter()
-        .any(|ignore_name| ignore_name.is_match(name))
+        .any(|ignore_name| ignore_name.matches(name))
     {
         return;
     }

--- a/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
@@ -60,7 +60,7 @@ pub(crate) fn non_lowercase_variable_in_function(
         .pep8_naming
         .ignore_names
         .iter()
-        .any(|ignore_name| ignore_name == name)
+        .any(|ignore_name| ignore_name.is_match(name))
     {
         return;
     }

--- a/crates/ruff/src/rules/pep8_naming/settings.rs
+++ b/crates/ruff/src/rules/pep8_naming/settings.rs
@@ -96,13 +96,10 @@ impl From<Options> for Settings {
     fn from(options: Options) -> Self {
         Self {
             ignore_names: match options.ignore_names {
-                Some(names) => names
-                    .into_iter()
-                    .map(|name| IdenifierMatcher::from(name))
-                    .collect(),
+                Some(names) => names.into_iter().map(IdenifierMatcher::from).collect(),
                 None => IGNORE_NAMES
                     .into_iter()
-                    .map(|name| IdenifierMatcher::from(name))
+                    .map(IdenifierMatcher::from)
                     .collect(),
             },
             classmethod_decorators: options.classmethod_decorators.unwrap_or_default(),

--- a/crates/ruff/src/rules/pep8_naming/settings.rs
+++ b/crates/ruff/src/rules/pep8_naming/settings.rs
@@ -41,7 +41,7 @@ pub struct Options {
             ignore-names = ["callMethod"]
         "#
     )]
-    /// A list of names to ignore when considering `pep8-naming` violations.
+    /// A list of names (or patterns) to ignore when considering `pep8-naming` violations.
     pub ignore_names: Option<Vec<String>>,
     #[option(
         default = r#"[]"#,

--- a/crates/ruff/src/rules/pep8_naming/settings.rs
+++ b/crates/ruff/src/rules/pep8_naming/settings.rs
@@ -87,7 +87,7 @@ impl Default for Settings {
         Self {
             ignore_names: IGNORE_NAMES
                 .iter()
-                .map(|name| IdentifierPattern::new(*name).unwrap())
+                .map(|name| IdentifierPattern::new(name).unwrap())
                 .collect(),
             classmethod_decorators: Vec::new(),
             staticmethod_decorators: Vec::new(),
@@ -104,7 +104,7 @@ impl TryFrom<Options> for Settings {
                 Some(names) => names
                     .into_iter()
                     .map(|name| {
-                        IdentifierPattern::new(&*name).map_err(SettingsError::InvalidIgnoreName)
+                        IdentifierPattern::new(&name).map_err(SettingsError::InvalidIgnoreName)
                     })
                     .collect::<Result<Vec<_>, Self::Error>>()?,
                 None => IGNORE_NAMES

--- a/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__ignore_names_N802_N802.py.snap
+++ b/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__ignore_names_N802_N802.py.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff/src/rules/pep8_naming/mod.rs
+---
+N802.py:6:5: N802 Function name `stillBad` should be lowercase
+  |
+4 |     pass
+5 | 
+6 | def stillBad():
+  |     ^^^^^^^^ N802
+7 |     pass
+  |
+
+N802.py:13:9: N802 Function name `stillBad` should be lowercase
+   |
+11 |         return super().tearDown()
+12 | 
+13 |     def stillBad(self):
+   |         ^^^^^^^^ N802
+14 |         return super().tearDown()
+   |
+
+

--- a/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__ignore_names_N803_N803.py.snap
+++ b/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__ignore_names_N803_N803.py.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff/src/rules/pep8_naming/mod.rs
+---
+N803.py:4:16: N803 Argument name `stillBad` should be lowercase
+  |
+2 |     return _, a, badAllowed
+3 | 
+4 | def func(_, a, stillBad):
+  |                ^^^^^^^^ N803
+5 |     return _, a, stillBad
+  |
+
+N803.py:11:28: N803 Argument name `stillBad` should be lowercase
+   |
+ 9 |         return _, a, badAllowed
+10 | 
+11 |     def method(self, _, a, stillBad):
+   |                            ^^^^^^^^ N803
+12 |         return _, a, stillBad
+   |
+
+

--- a/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__ignore_names_N804_N804.py.snap
+++ b/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__ignore_names_N804_N804.py.snap
@@ -1,0 +1,29 @@
+---
+source: crates/ruff/src/rules/pep8_naming/mod.rs
+---
+N804.py:5:27: N804 First argument of a class method should be named `cls`
+  |
+4 | class Class:
+5 |     def __init_subclass__(self, default_name, **kwargs):
+  |                           ^^^^ N804
+6 |         ...
+  |
+
+N804.py:13:18: N804 First argument of a class method should be named `cls`
+   |
+12 |     @classmethod
+13 |     def stillBad(self, x, /, other):
+   |                  ^^^^ N804
+14 |         ...
+   |
+
+N804.py:21:18: N804 First argument of a class method should be named `cls`
+   |
+19 |         pass
+20 | 
+21 |     def stillBad(self):
+   |                  ^^^^ N804
+22 |         pass
+   |
+
+

--- a/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__ignore_names_N805_N805.py.snap
+++ b/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__ignore_names_N805_N805.py.snap
@@ -1,0 +1,47 @@
+---
+source: crates/ruff/src/rules/pep8_naming/mod.rs
+---
+N805.py:10:18: N805 First argument of a method should be named `self`
+   |
+ 8 |         pass
+ 9 | 
+10 |     def stillBad(this):
+   |                  ^^^^ N805
+11 |         pass
+   |
+
+N805.py:18:22: N805 First argument of a method should be named `self`
+   |
+16 |             pass
+17 | 
+18 |         def stillBad(this):
+   |                      ^^^^ N805
+19 |             pass
+   |
+
+N805.py:26:18: N805 First argument of a method should be named `self`
+   |
+25 |     @pydantic.validator
+26 |     def stillBad(cls, my_field: str) -> str:
+   |                  ^^^ N805
+27 |         pass
+   |
+
+N805.py:34:18: N805 First argument of a method should be named `self`
+   |
+33 |     @pydantic.validator("my_field")
+34 |     def stillBad(cls, my_field: str) -> str:
+   |                  ^^^ N805
+35 |         pass
+   |
+
+N805.py:41:18: N805 First argument of a method should be named `self`
+   |
+39 |         pass
+40 | 
+41 |     def stillBad(this, blah, /, self, something: str):
+   |                  ^^^^ N805
+42 |         pass
+   |
+
+

--- a/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__ignore_names_N806_N806.py.snap
+++ b/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__ignore_names_N806_N806.py.snap
@@ -1,0 +1,21 @@
+---
+source: crates/ruff/src/rules/pep8_naming/mod.rs
+---
+N806.py:3:5: N806 Variable `stillBad` in function should be lowercase
+  |
+1 | def assign():
+2 |     badAllowed = 0
+3 |     stillBad = 0
+  |     ^^^^^^^^ N806
+4 | 
+5 |     BAD_ALLOWED = 0
+  |
+
+N806.py:6:5: N806 Variable `STILL_BAD` in function should be lowercase
+  |
+5 |     BAD_ALLOWED = 0
+6 |     STILL_BAD = 0
+  |     ^^^^^^^^^ N806
+  |
+
+

--- a/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__ignore_names_N815_N815.py.snap
+++ b/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__ignore_names_N815_N815.py.snap
@@ -1,0 +1,58 @@
+---
+source: crates/ruff/src/rules/pep8_naming/mod.rs
+---
+N815.py:3:5: N815 Variable `stillBad` in class scope should not be mixedCase
+  |
+1 | class C:
+2 |     badAllowed = 0
+3 |     stillBad = 0
+  |     ^^^^^^^^ N815
+4 | 
+5 |     _badAllowed = 0
+  |
+
+N815.py:6:5: N815 Variable `_stillBad` in class scope should not be mixedCase
+  |
+5 |     _badAllowed = 0
+6 |     _stillBad = 0
+  |     ^^^^^^^^^ N815
+7 | 
+8 |     bad_Allowed = 0
+  |
+
+N815.py:9:5: N815 Variable `still_Bad` in class scope should not be mixedCase
+   |
+ 8 |     bad_Allowed = 0
+ 9 |     still_Bad = 0
+   |     ^^^^^^^^^ N815
+10 | 
+11 | class D(TypedDict):
+   |
+
+N815.py:13:5: N815 Variable `stillBad` in class scope should not be mixedCase
+   |
+11 | class D(TypedDict):
+12 |     badAllowed: bool
+13 |     stillBad: bool
+   |     ^^^^^^^^ N815
+14 | 
+15 |     _badAllowed: list
+   |
+
+N815.py:16:5: N815 Variable `_stillBad` in class scope should not be mixedCase
+   |
+15 |     _badAllowed: list
+16 |     _stillBad: list
+   |     ^^^^^^^^^ N815
+17 | 
+18 |     bad_Allowed: set
+   |
+
+N815.py:19:5: N815 Variable `still_Bad` in class scope should not be mixedCase
+   |
+18 |     bad_Allowed: set
+19 |     still_Bad: set
+   |     ^^^^^^^^^ N815
+   |
+
+

--- a/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__ignore_names_N816_N816.py.snap
+++ b/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__ignore_names_N816_N816.py.snap
@@ -1,0 +1,29 @@
+---
+source: crates/ruff/src/rules/pep8_naming/mod.rs
+---
+N816.py:2:1: N816 Variable `stillBad` in global scope should not be mixedCase
+  |
+1 | badAllowed = 0
+2 | stillBad = 0
+  | ^^^^^^^^ N816
+3 | 
+4 | _badAllowed = 0
+  |
+
+N816.py:5:1: N816 Variable `_stillBad` in global scope should not be mixedCase
+  |
+4 | _badAllowed = 0
+5 | _stillBad = 0
+  | ^^^^^^^^^ N816
+6 | 
+7 | bad_Allowed = 0
+  |
+
+N816.py:8:1: N816 Variable `still_Bad` in global scope should not be mixedCase
+  |
+7 | bad_Allowed = 0
+8 | still_Bad = 0
+  | ^^^^^^^^^ N816
+  |
+
+

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -265,7 +265,8 @@ impl Settings {
                 .unwrap_or_default(),
             pep8_naming: config
                 .pep8_naming
-                .map(pep8_naming::settings::Settings::from)
+                .map(pep8_naming::settings::Settings::try_from)
+                .transpose()?
                 .unwrap_or_default(),
             pycodestyle: config
                 .pycodestyle

--- a/crates/ruff/src/settings/types.rs
+++ b/crates/ruff/src/settings/types.rs
@@ -5,7 +5,6 @@ use std::str::FromStr;
 use std::string::ToString;
 
 use anyhow::{bail, Result};
-use glob::Pattern;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use pep440_rs::{Version as Pep440Version, VersionSpecifiers};
 use serde::{de, Deserialize, Deserializer, Serialize};
@@ -251,56 +250,15 @@ impl Deref for Version {
     }
 }
 
-/// Match an identifier exactly or by pattern.
-#[derive(Clone, Debug, CacheKey)]
-pub enum IdenifierMatcher {
-    Exact(String),
-    /// # Notes
-    ///
-    /// [`Pattern`] matches a little differently than we ideally want to.
-    /// Specifically it uses `**` to match an arbitrary number of
-    /// subdirectories, luckily this not relevant since identifiers don't
-    /// contains slashes.
-    ///
-    /// For reference pep8-naming uses
-    /// [`fnmatch`](https://docs.python.org/3.11/library/fnmatch.html) for
-    /// pattern matching.
-    Pattern(Pattern),
-}
-
-impl IdenifierMatcher {
-    /// Returns true if `name` matches the pattern in `self`.
-    pub fn is_match(&self, name: &str) -> bool {
-        match self {
-            IdenifierMatcher::Exact(n) => n == name,
-            IdenifierMatcher::Pattern(pattern) => pattern.matches(name),
-        }
-    }
-}
-
-impl From<String> for IdenifierMatcher {
-    fn from(name: String) -> Self {
-        match Pattern::new(&name) {
-            Ok(pattern) => IdenifierMatcher::Pattern(pattern),
-            Err(_) => IdenifierMatcher::Exact(name),
-        }
-    }
-}
-
-impl From<&str> for IdenifierMatcher {
-    fn from(name: &str) -> Self {
-        match Pattern::new(name) {
-            Ok(pattern) => IdenifierMatcher::Pattern(pattern),
-            Err(_) => IdenifierMatcher::Exact(name.to_owned()),
-        }
-    }
-}
-
-impl From<IdenifierMatcher> for String {
-    fn from(name: IdenifierMatcher) -> Self {
-        match name {
-            IdenifierMatcher::Exact(name) => name,
-            IdenifierMatcher::Pattern(pattern) => pattern.as_str().to_owned(),
-        }
-    }
-}
+/// Pattern to match an identifier.
+///
+/// # Notes
+///
+/// [`glob::Pattern`] matches a little differently than we ideally want to.
+/// Specifically it uses `**` to match an arbitrary number of subdirectories,
+/// luckily this not relevant since identifiers don't contains slashes.
+///
+/// For reference pep8-naming uses
+/// [`fnmatch`](https://docs.python.org/3.11/library/fnmatch.html) for
+/// pattern matching.
+pub type IdentifierPattern = glob::Pattern;

--- a/crates/ruff/src/settings/types.rs
+++ b/crates/ruff/src/settings/types.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use std::string::ToString;
 
 use anyhow::{bail, Result};
+use glob::Pattern;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use pep440_rs::{Version as Pep440Version, VersionSpecifiers};
 use serde::{de, Deserialize, Deserializer, Serialize};
@@ -247,5 +248,59 @@ impl Deref for Version {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+/// Match an identifier exactly or by pattern.
+#[derive(Clone, Debug, CacheKey)]
+pub enum IdenifierMatcher {
+    Exact(String),
+    /// # Notes
+    ///
+    /// [`Pattern`] matches a little differently than we ideally want to.
+    /// Specifically it uses `**` to match an arbitrary number of
+    /// subdirectories, luckily this not relevant since identifiers don't
+    /// contains slashes.
+    ///
+    /// For reference pep8-naming uses
+    /// [`fnmatch`](https://docs.python.org/3.11/library/fnmatch.html) for
+    /// pattern matching.
+    Pattern(Pattern),
+}
+
+impl IdenifierMatcher {
+    /// Returns true if `name` matches the pattern in `self`.
+    pub fn is_match(&self, name: &str) -> bool {
+        match self {
+            IdenifierMatcher::Exact(n) => n == name,
+            IdenifierMatcher::Pattern(pattern) => pattern.matches(name),
+        }
+    }
+}
+
+impl From<String> for IdenifierMatcher {
+    fn from(name: String) -> Self {
+        match Pattern::new(&name) {
+            Ok(pattern) => IdenifierMatcher::Pattern(pattern),
+            Err(_) => IdenifierMatcher::Exact(name),
+        }
+    }
+}
+
+impl From<&str> for IdenifierMatcher {
+    fn from(name: &str) -> Self {
+        match Pattern::new(name) {
+            Ok(pattern) => IdenifierMatcher::Pattern(pattern),
+            Err(_) => IdenifierMatcher::Exact(name.to_owned()),
+        }
+    }
+}
+
+impl From<IdenifierMatcher> for String {
+    fn from(name: IdenifierMatcher) -> Self {
+        match name {
+            IdenifierMatcher::Exact(name) => name,
+            IdenifierMatcher::Pattern(pattern) => pattern.as_str().to_owned(),
+        }
     }
 }

--- a/crates/ruff_cache/Cargo.toml
+++ b/crates/ruff_cache/Cargo.toml
@@ -12,6 +12,7 @@ license = { workspace = true }
 
 [dependencies]
 itertools = { workspace = true }
+glob = { workspace = true }
 globset = { workspace = true }
 regex = { workspace = true }
 filetime = { workspace = true }

--- a/crates/ruff_cache/src/cache_key.rs
+++ b/crates/ruff_cache/src/cache_key.rs
@@ -5,6 +5,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 
+use glob::Pattern;
 use itertools::Itertools;
 use regex::Regex;
 
@@ -371,6 +372,12 @@ where
 }
 
 impl CacheKey for Regex {
+    fn cache_key(&self, state: &mut CacheKeyHasher) {
+        self.as_str().cache_key(state);
+    }
+}
+
+impl CacheKey for Pattern {
     fn cache_key(&self, state: &mut CacheKeyHasher) {
         self.as_str().cache_key(state);
     }

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1397,7 +1397,7 @@
           }
         },
         "ignore-names": {
-          "description": "A list of names to ignore when considering `pep8-naming` violations.",
+          "description": "A list of names (or patterns) to ignore when considering `pep8-naming` violations.",
           "type": [
             "array",
             "null"


### PR DESCRIPTION
## Summary

 Support glob patterns in pep8_naming ignore-names.

Closes #2787

## Test Plan

No tests added yet, not sure where to add these.