### PR TITLE
Improve `TypedDict` conversion logic for shadowed builtins and dunder methods

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_builtins/A003.py
+++ b/crates/ruff/resources/test/fixtures/flake8_builtins/A003.py
@@ -1,6 +1,6 @@
 class MyClass:
     ImportError = 4
-    id = 5
+    id: int
     dir = "/"
 
     def __init__(self):
@@ -10,3 +10,10 @@ class MyClass:
 
     def str(self):
         pass
+
+
+from typing import TypedDict
+
+
+class MyClass(TypedDict):
+    id: int

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -656,10 +656,11 @@ where
                     pyupgrade::rules::yield_in_for_loop(self, stmt);
                 }
 
-                if self.semantic_model.scope().kind.is_class() {
+                if let ScopeKind::Class(class_def) = self.semantic_model.scope().kind {
                     if self.enabled(Rule::BuiltinAttributeShadowing) {
                         flake8_builtins::rules::builtin_attribute_shadowing(
                             self,
+                            class_def,
                             name,
                             AnyShadowing::from(stmt),
                         );
@@ -2369,10 +2370,11 @@ where
                             }
                         }
 
-                        if self.semantic_model.scope().kind.is_class() {
+                        if let ScopeKind::Class(class_def) = self.semantic_model.scope().kind {
                             if self.enabled(Rule::BuiltinAttributeShadowing) {
                                 flake8_builtins::rules::builtin_attribute_shadowing(
                                     self,
+                                    class_def,
                                     id,
                                     AnyShadowing::from(expr),
                                 );

--- a/crates/ruff/src/rules/flake8_builtins/helpers.rs
+++ b/crates/ruff/src/rules/flake8_builtins/helpers.rs
@@ -1,9 +1,9 @@
+use ruff_text_size::TextRange;
 use rustpython_parser::ast::{Excepthandler, Expr, Ranged, Stmt};
 
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_stdlib::builtins::BUILTINS;
-use ruff_text_size::TextRange;
 
 pub(super) fn shadows_builtin(name: &str, ignorelist: &[String]) -> bool {
     BUILTINS.contains(&name) && ignorelist.iter().all(|ignore| ignore != name)

--- a/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A003_A003.py.snap
+++ b/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A003_A003.py.snap
@@ -6,7 +6,7 @@ A003.py:2:5: A003 Class attribute `ImportError` is shadowing a Python builtin
 1 | class MyClass:
 2 |     ImportError = 4
   |     ^^^^^^^^^^^ A003
-3 |     id = 5
+3 |     id: int
 4 |     dir = "/"
   |
 
@@ -14,7 +14,7 @@ A003.py:3:5: A003 Class attribute `id` is shadowing a Python builtin
   |
 1 | class MyClass:
 2 |     ImportError = 4
-3 |     id = 5
+3 |     id: int
   |     ^^ A003
 4 |     dir = "/"
   |
@@ -22,7 +22,7 @@ A003.py:3:5: A003 Class attribute `id` is shadowing a Python builtin
 A003.py:4:5: A003 Class attribute `dir` is shadowing a Python builtin
   |
 2 |     ImportError = 4
-3 |     id = 5
+3 |     id: int
 4 |     dir = "/"
   |     ^^^ A003
 5 | 

--- a/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A003_A003.py_builtins_ignorelist.snap
+++ b/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A003_A003.py_builtins_ignorelist.snap
@@ -6,7 +6,7 @@ A003.py:2:5: A003 Class attribute `ImportError` is shadowing a Python builtin
 1 | class MyClass:
 2 |     ImportError = 4
   |     ^^^^^^^^^^^ A003
-3 |     id = 5
+3 |     id: int
 4 |     dir = "/"
   |
 

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -5,6 +5,7 @@ use rustpython_parser::ast::{self, Constant, Expr, ExprContext, Keyword, Ranged,
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::helpers::is_dunder;
 use ruff_python_ast::source_code::Generator;
 use ruff_python_semantic::model::SemanticModel;
 use ruff_python_stdlib::identifiers::is_identifier;
@@ -66,19 +67,21 @@ fn create_property_assignment_stmt(
     annotation: &Expr,
     value: Option<&Expr>,
 ) -> Stmt {
-    let node = ast::ExprName {
-        id: property.into(),
-        ctx: ExprContext::Load,
-        range: TextRange::default(),
-    };
-    let node1 = ast::StmtAnnAssign {
-        target: Box::new(node.into()),
+    ast::StmtAnnAssign {
+        target: Box::new(
+            ast::ExprName {
+                id: property.into(),
+                ctx: ExprContext::Load,
+                range: TextRange::default(),
+            }
+            .into(),
+        ),
         annotation: Box::new(annotation.clone()),
         value: value.map(|value| Box::new(value.clone())),
         simple: true,
         range: TextRange::default(),
-    };
-    node1.into()
+    }
+    .into()
 }
 
 /// Match the `defaults` keyword in a `NamedTuple(...)` call.
@@ -140,6 +143,9 @@ fn create_properties_from_args(args: &[Expr], defaults: &[Expr]) -> Result<Vec<S
             if !is_identifier(property) {
                 bail!("Invalid property name: {}", property)
             }
+            if is_dunder(property) {
+                bail!("Cannot use dunder property name: {}", property)
+            }
             Ok(create_property_assignment_stmt(
                 property, annotation, default,
             ))
@@ -150,15 +156,15 @@ fn create_properties_from_args(args: &[Expr], defaults: &[Expr]) -> Result<Vec<S
 /// Generate a `StmtKind:ClassDef` statement based on the provided body and
 /// keywords.
 fn create_class_def_stmt(typename: &str, body: Vec<Stmt>, base_class: &Expr) -> Stmt {
-    let node = ast::StmtClassDef {
+    ast::StmtClassDef {
         name: typename.into(),
         bases: vec![base_class.clone()],
         keywords: vec![],
         body,
         decorator_list: vec![],
         range: TextRange::default(),
-    };
-    node.into()
+    }
+    .into()
 }
 
 /// Generate a `Fix` to convert a `NamedTuple` assignment to a class definition.
@@ -169,8 +175,7 @@ fn convert_to_class(
     base_class: &Expr,
     generator: Generator,
 ) -> Fix {
-    #[allow(deprecated)]
-    Fix::unspecified(Edit::range_replacement(
+    Fix::suggested(Edit::range_replacement(
         generator.stmt(&create_class_def_stmt(typename, body, base_class)),
         stmt.range(),
     ))

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -546,7 +546,7 @@ where
     body.iter().any(|stmt| any_over_stmt(stmt, func))
 }
 
-fn is_dunder(id: &str) -> bool {
+pub fn is_dunder(id: &str) -> bool {
     id.starts_with("__") && id.ends_with("__")
 }
 


### PR DESCRIPTION
## Summary

This PR (1) avoids flagging `TypedDict` and `NamedTuple` conversions when attributes are dunder methods, like `__dict__`, and (2) avoids flagging the `A003` shadowed-attribute rule for `TypedDict` classes at all, where it doesn't really apply (since those attributes are only accessed via subscripting anyway).

Closes #5027.
