### PR TITLE
Don't treat annotations as resolved in forward references

### DIFF
--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -3160,6 +3160,20 @@ mod tests {
         T: object
         def g(t: 'T'): pass
         "#,
+            &[Rule::UndefinedName],
+        );
+        flakes(
+            r#"
+        T = object
+        def f(t: T): pass
+        "#,
+            &[],
+        );
+        flakes(
+            r#"
+        T = object
+        def g(t: 'T'): pass
+        "#,
             &[],
         );
         flakes(
@@ -3348,6 +3362,16 @@ mod tests {
             r#"
         from __future__ import annotations
         T: object
+        def f(t: T): pass
+        def g(t: 'T'): pass
+        "#,
+            &[Rule::UndefinedName, Rule::UndefinedName],
+        );
+
+        flakes(
+            r#"
+        from __future__ import annotations
+        T = object
         def f(t: T): pass
         def g(t: 'T'): pass
         "#,


### PR DESCRIPTION
## Summary

This behavior dates back to a Pyflakes commit (5fc37cbd), which was used to allow this test to pass:

```py
from __future__ import annotations
T: object
def f(t: T): pass
def g(t: 'T'): pass
```

But, I think this is an error. Mypy and Pyright don't accept it -- you can only use variables as type annotations if they're type aliases (i.e., annotated with `TypeAlias`), in which case, there has to be an assignment on the right-hand side (see: [PEP 613](https://peps.python.org/pep-0613/)).
