### PR TITLE
Add documentation to `flake8-executable` rules

### DIFF
--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
@@ -12,15 +12,18 @@ use crate::registry::AsRule;
 use crate::rules::flake8_executable::helpers::is_executable;
 
 /// ## What it does
-/// Checks for executable `.py` files that do not have a shebang directive.
+/// Checks for executable `.py` files that do not have a shebang.
 ///
 /// ## Why is this bad?
-/// Shebangs indicate that a text file is executable. If a `.py` file has
-/// executable permissions but no shebang, then the absence of a shebang is
-/// misleading and is likely a mistake.
+/// In Python, a shebang (also known as a hashbang) is the first line of a
+/// script, which specifies the interpreter that should be used to run the
+/// script.
 ///
-/// Instead, add a shebang or remove the executable permissions with
-/// `chmod -x`.
+/// If a `.py` file is executable, but does not have a shebang, it may be run
+/// with the wrong interpreter, or fail to run at all.
+///
+/// If the file is meant to be executable, add a shebang; otherwise, remove the
+/// executable bit from the file.
 ///
 /// _This rule is only available on Unix-like systems._
 ///

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
@@ -15,8 +15,8 @@ use crate::rules::flake8_executable::helpers::is_executable;
 /// Checks for executable `.py` files that do not have a shebang directive.
 ///
 /// ## Why is this bad?
-/// Shebangs indicate that a file is executable. If the file has executable
-/// permissions but no shebang, then the absence of a shebang is potentially
+/// Shebangs indicate that a text file is executable. If a `.py` file has
+/// executable permissions but no shebang, then the absence of a shebang is
 /// misleading and is likely a mistake.
 ///
 /// Instead, add a shebang or remove the executable permissions with

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
@@ -12,7 +12,7 @@ use crate::registry::AsRule;
 use crate::rules::flake8_executable::helpers::is_executable;
 
 /// ## What it does
-/// Checks for executable files that do not have a shebang directive.
+/// Checks for executable `.py` files that do not have a shebang directive.
 ///
 /// ## Why is this bad?
 /// Shebangs indicate that a file is executable. If the file has executable

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
@@ -11,6 +11,21 @@ use crate::registry::AsRule;
 #[cfg(target_family = "unix")]
 use crate::rules::flake8_executable::helpers::is_executable;
 
+/// ## What it does
+/// Checks for executable files that do not have a shebang directive.
+///
+/// ## Why is this bad?
+/// Shebangs indicate that a file is executable. If the file has executable
+/// permissions but no shebang, then the absence of a shebang is potentially
+/// misleading and is likely a mistake.
+///
+/// Instead, add a shebang or remove the executable permissions with
+/// `chmod -x`.
+///
+/// _This rule is only available on Unix-like systems._
+///
+/// ## References
+/// - [Python documentation: Executable Python Scripts](https://docs.python.org/3/tutorial/appendix.html#executable-python-scripts)
 #[violation]
 pub struct ShebangMissingExecutableFile;
 

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_newline.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_newline.rs
@@ -5,6 +5,28 @@ use ruff_macros::{derive_message_formats, violation};
 
 use crate::rules::flake8_executable::helpers::ShebangDirective;
 
+/// ## What it does
+/// Checks for a shebang directive that is not at the beginning of the file.
+///
+/// ## Why is this bad?
+/// The shebang `#!` must be the first two characters of a file. If the shebang
+/// is not at the beginning of the file, the shebang will have no effect. This
+/// is likely a mistake.
+///
+/// ## Example
+/// ```python
+/// foo = 1
+/// #!/usr/bin/env python3
+/// ```
+///
+/// Use instead:
+/// ```python
+/// #!/usr/bin/env python3
+/// foo = 1
+/// ```
+///
+/// ## References
+/// - [Python documentation: Executable Python Scripts](https://docs.python.org/3/tutorial/appendix.html#executable-python-scripts)
 #[violation]
 pub struct ShebangNotFirstLine;
 

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_newline.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_newline.rs
@@ -9,8 +9,12 @@ use crate::rules::flake8_executable::helpers::ShebangDirective;
 /// Checks for a shebang directive that is not at the beginning of the file.
 ///
 /// ## Why is this bad?
-/// The shebang `#!` must be the first two characters of a file. If the shebang
-/// is not at the beginning of the file, the shebang will have no effect. This
+/// In Python, a shebang (also known as a hashbang) is the first line of a
+/// script, which specifies the interpreter that should be used to run the
+/// script.
+///
+/// The shebang's `#!` prefix must be the first two characters of a file. If
+/// the shebang is not at the beginning of the file, it will be ignored, which
 /// is likely a mistake.
 ///
 /// ## Example

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -16,11 +16,16 @@ use crate::rules::flake8_executable::helpers::ShebangDirective;
 /// Checks for a shebang directive in a file that is not executable.
 ///
 /// ## Why is this bad?
-/// Shebangs indicate that a file is executable. If the file is not executable,
-/// then the shebang is misleading and is likely a mistake.
+/// In Python, a shebang (also known as a hashbang) is the first line of a
+/// script, which specifies the interpreter that should be used to run the
+/// script.
 ///
-/// Instead, remove the shebang or give the file executable permissions with
-/// `chmod +x`.
+/// The presence of a shebang suggests that a file is intended to be
+/// executable. If a file contains a shebang but is not executable, then the
+/// shebang is misleading, or the file is missing the executable bit.
+///
+/// If the file is meant to be executable, add a shebang; otherwise, remove the
+/// executable bit from the file.
 ///
 /// _This rule is only available on Unix-like systems._
 ///

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -12,6 +12,20 @@ use crate::registry::AsRule;
 use crate::rules::flake8_executable::helpers::is_executable;
 use crate::rules::flake8_executable::helpers::ShebangDirective;
 
+/// ## What it does
+/// Checks for a shebang directive in a file that is not executable.
+///
+/// ## Why is this bad?
+/// Shebangs indicate that a file is executable. If the file is not executable,
+/// then the shebang is misleading and is likely a mistake.
+///
+/// Instead, remove the shebang or give the file executable permissions with
+/// `chmod +x`.
+///
+/// _This rule is only available on Unix-like systems._
+///
+/// ## References
+/// - [Python documentation: Executable Python Scripts](https://docs.python.org/3/tutorial/appendix.html#executable-python-scripts)
 #[violation]
 pub struct ShebangNotExecutable;
 

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_python.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_python.rs
@@ -5,6 +5,27 @@ use ruff_macros::{derive_message_formats, violation};
 
 use crate::rules::flake8_executable::helpers::ShebangDirective;
 
+/// ## What it does
+/// Checks for a shebang directive that does not contain `python`.
+///
+/// ## Why is this bad?
+/// The shebang directive must contain `python` to indicate that the file is a
+/// Python script. If the shebang does not contain `python`, then the file is
+/// unlikely to be executed as a Python script. This is either a mistake or
+/// misleading.
+///
+/// ## Example
+/// ```python
+/// #!/usr/bin/env bash
+/// ```
+///
+/// Use instead:
+/// ```python
+/// #!/usr/bin/env python3
+/// ```
+///
+/// ## References
+/// - [Python documentation: Executable Python Scripts](https://docs.python.org/3/tutorial/appendix.html#executable-python-scripts)
 #[violation]
 pub struct ShebangMissingPython;
 

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_python.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_python.rs
@@ -6,7 +6,7 @@ use ruff_macros::{derive_message_formats, violation};
 use crate::rules::flake8_executable::helpers::ShebangDirective;
 
 /// ## What it does
-/// Checks for a shebang directive that does not contain `python`.
+/// Checks for a shebang directive in `.py` files that does not contain `python`.
 ///
 /// ## Why is this bad?
 /// The shebang directive must contain `python` to indicate that the file is a

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_python.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_python.rs
@@ -9,10 +9,14 @@ use crate::rules::flake8_executable::helpers::ShebangDirective;
 /// Checks for a shebang directive in `.py` files that does not contain `python`.
 ///
 /// ## Why is this bad?
-/// The shebang directive must contain `python` to indicate that the file is a
-/// Python script. If the shebang does not contain `python`, then the file is
-/// unlikely to be executed as a Python script. This is either a mistake or
-/// misleading.
+/// In Python, a shebang (also known as a hashbang) is the first line of a
+/// script, which specifies the interpreter that should be used to run the
+/// script.
+///
+/// For Python scripts, the shebang must contain `python` to indicate that the
+/// script should be executed as a Python script. If the shebang does not
+/// contain `python`, then the file will be executed with the default
+/// interpreter, which is likely a mistake.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_whitespace.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_whitespace.rs
@@ -5,6 +5,26 @@ use ruff_macros::{derive_message_formats, violation};
 
 use crate::rules::flake8_executable::helpers::ShebangDirective;
 
+/// ## What it does
+/// Checks for whitespace before a shebang directive.
+///
+/// ## Why is this bad?
+/// The shebang `#!` must be the first two characters of a file. If there is
+/// whitespace before the shebang, the shebang will have no effect. This is
+/// likely a mistake.
+///
+/// ## Example
+/// ```python
+///  #!/usr/bin/env python3
+/// ```
+///
+/// Use instead:
+/// ```python
+/// #!/usr/bin/env python3
+/// ```
+///
+/// ## References
+/// - [Python documentation: Executable Python Scripts](https://docs.python.org/3/tutorial/appendix.html#executable-python-scripts)
 #[violation]
 pub struct ShebangLeadingWhitespace;
 

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_whitespace.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_whitespace.rs
@@ -9,9 +9,13 @@ use crate::rules::flake8_executable::helpers::ShebangDirective;
 /// Checks for whitespace before a shebang directive.
 ///
 /// ## Why is this bad?
-/// The shebang `#!` must be the first two characters of a file. If there is
-/// whitespace before the shebang, the shebang will have no effect. This is
-/// likely a mistake.
+/// In Python, a shebang (also known as a hashbang) is the first line of a
+/// script, which specifies the interpreter that should be used to run the
+/// script.
+///
+/// The shebang's `#!` prefix must be the first two characters of a file. The
+/// presence of whitespace before the shebang will cause the shebang to be
+/// ignored, which is likely a mistake.
 ///
 /// ## Example
 /// ```python

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -44,6 +44,7 @@ KNOWN_FORMATTING_VIOLATIONS = [
     "no-space-after-inline-comment",
     "over-indented",
     "prohibited-trailing-comma",
+    "shebang-leading-whitespace",
     "too-few-spaces-before-inline-comment",
     "trailing-comma-on-bare-tuple",
     "unexpected-indentation-comment",


### PR DESCRIPTION
## Summary

Completes the documentation for the `flake8-executable` rules.

Related to #2646.

## Test Plan

`python scripts/check_docs_formatted.py`