### PR TITLE
Track "delayed" annotations in the semantic model

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -4328,10 +4328,16 @@ impl<'a> Checker<'a> {
         }
 
         // If there's an existing binding in this scope, copy its references.
-        if let Some(shadowed) = self.semantic_model.scopes[scope_id]
-            .get(name)
-            .map(|binding_id| &self.semantic_model.bindings[binding_id])
-        {
+        if let Some(shadowed_id) = self.semantic_model.scopes[scope_id].get(name) {
+            // If this is an annotation, and we already have an existing value in the same scope,
+            // don't treat it as an assignment, but track it as a delayed annotation.
+            if self.semantic_model.binding(binding_id).kind.is_annotation() {
+                self.semantic_model
+                    .add_delayed_annotation(binding_id, shadowed_id);
+                return binding_id;
+            }
+
+            let shadowed = &self.semantic_model.bindings[binding_id];
             match &shadowed.kind {
                 BindingKind::Builtin | BindingKind::Deletion | BindingKind::UnboundException => {
                     // Avoid overriding builtins.
@@ -4347,12 +4353,6 @@ impl<'a> Checker<'a> {
                     let references = shadowed.references.clone();
                     self.semantic_model.bindings[binding_id].references = references;
                 }
-            }
-
-            // If this is an annotation, and we already have an existing value in the same scope,
-            // don't treat it as an assignment (i.e., avoid adding it to the scope).
-            if self.semantic_model.binding(binding_id).kind.is_annotation() {
-                return binding_id;
             }
         }
 

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -4333,11 +4333,11 @@ impl<'a> Checker<'a> {
             // don't treat it as an assignment, but track it as a delayed annotation.
             if self.semantic_model.binding(binding_id).kind.is_annotation() {
                 self.semantic_model
-                    .add_delayed_annotation(binding_id, shadowed_id);
+                    .add_delayed_annotation(shadowed_id, binding_id);
                 return binding_id;
             }
 
-            let shadowed = &self.semantic_model.bindings[binding_id];
+            let shadowed = &self.semantic_model.bindings[shadowed_id];
             match &shadowed.kind {
                 BindingKind::Builtin | BindingKind::Deletion | BindingKind::UnboundException => {
                     // Avoid overriding builtins.

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -80,8 +80,18 @@ pub struct SemanticModel<'a> {
     /// ```
     ///
     /// In this case, the binding created by `x = 1` is annotated by the binding created by
-    /// `x: int`. We don't consider the latter binding to shadow the former, because it doesn't
-    /// change the value of the binding, but we do want to track the annotation.
+    /// `x: int`. We don't consider the latter binding to _shadow_ the former, because it doesn't
+    /// change the value of the binding, and so we don't store in on the scope. But we _do_ want to
+    /// track the annotation in some form, since it's a reference to `x`.
+    ///
+    /// Note that, given:
+    /// ```python
+    /// x: int
+    /// ```
+    ///
+    /// In this case, we _do_ store the binding created by `x: int` directly on the scope, and not
+    /// as a delayed annotation. Annotations are thus treated as bindings only when they are the
+    /// first binding in a scope; any annotations that follow are treated as "delayed" annotations.
     delayed_annotations: HashMap<BindingId, Vec<BindingId>, BuildNoHashHasher<BindingId>>,
 
     /// Body iteration; used to peek at siblings.

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -11,6 +11,46 @@ use ruff_index::{newtype_index, Idx, IndexSlice, IndexVec};
 use crate::binding::{BindingId, StarImportation};
 use crate::globals::GlobalsId;
 
+/// Cases to consider:
+/// ```python
+/// x: int
+/// x = 1
+///
+/// print(x)  # OK
+/// ```
+///
+/// ```python
+/// x = 1
+/// x: int
+///
+/// print(x)  # OK
+/// ```
+///
+/// ```python
+/// x: int
+///
+/// print(x)  # NameError, but the annotation is used
+/// ```
+///
+/// ```python
+/// x: int  # Unused annotation
+/// ```
+///
+/// In each case, we want to track the annotations.
+///
+/// What if we:
+/// - Remove `Annotation` from `Bindings`.
+///
+/// Then, we'd still need a way to get the reference for rewrites.
+/// We'd also be unable to raise "Unused annotation" warnings.
+///
+/// What if we:
+/// - Remove `Annotation` from `Bindings`.
+/// - Add a new `Annotations` map to `Scope`.
+///
+/// I think the lazy thing to do is: keep our current model, but add a vector of annotations
+/// for each binding. This is a bit wasteful, but it's also simple.
+
 #[derive(Debug)]
 pub struct Scope<'a> {
     /// The kind of scope.

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -11,46 +11,6 @@ use ruff_index::{newtype_index, Idx, IndexSlice, IndexVec};
 use crate::binding::{BindingId, StarImportation};
 use crate::globals::GlobalsId;
 
-/// Cases to consider:
-/// ```python
-/// x: int
-/// x = 1
-///
-/// print(x)  # OK
-/// ```
-///
-/// ```python
-/// x = 1
-/// x: int
-///
-/// print(x)  # OK
-/// ```
-///
-/// ```python
-/// x: int
-///
-/// print(x)  # NameError, but the annotation is used
-/// ```
-///
-/// ```python
-/// x: int  # Unused annotation
-/// ```
-///
-/// In each case, we want to track the annotations.
-///
-/// What if we:
-/// - Remove `Annotation` from `Bindings`.
-///
-/// Then, we'd still need a way to get the reference for rewrites.
-/// We'd also be unable to raise "Unused annotation" warnings.
-///
-/// What if we:
-/// - Remove `Annotation` from `Bindings`.
-/// - Add a new `Annotations` map to `Scope`.
-///
-/// I think the lazy thing to do is: keep our current model, but add a vector of annotations
-/// for each binding. This is a bit wasteful, but it's also simple.
-
 #[derive(Debug)]
 pub struct Scope<'a> {
     /// The kind of scope.


### PR DESCRIPTION
## Summary

This PR tackles a corner case that we'll need to support local symbol renaming. It relates to a nuance in how we want handle annotations (i.e., `AnnAssign` statements with no value, like `x: int` in a function body).

When we see a statement like:

```python
x: int
```

We create a `BindingKind::Annotation` for `x`. This is a special `BindingKind` that the resolver isn't allowed to return. For example, given:

```python
x: int
print(x)
```

The second line will yield an `undefined-name` error.

So why does this `BindingKind` exist at all? In Pyflakes, to support the `unused-annotation` lint:

```python
def f():
    x: int  # unused-annotation
```

If we don't track `BindingKind::Annotation`, we can't lint for unused variables that are only "defined" via annotations.

There are a few other wrinkles to `BindingKind::Annotation`. One is that, if a binding already exists in the scope, we actually just discard the `BindingKind`. So in this case:

```python
x = 1
x: int
```

When we go to create the `BindingKind::Annotation` for the second statement, we notice that (1) we're creating an annotation but (2) the scope already has binding for the name -- so we just drop the binding on the floor. This has the nice property that annotations aren't considered to "shadow" another binding, which is important in a bunch of places (e.g., if we have `import os; os: int`, we still consider `os` to be an import, as we should). But it also means that these "delayed" annotations are one of the few remaining references that we don't track anywhere in the semantic model.

This PR adds explicit support for these via a new `delayed_annotations` attribute on the semantic model. These should be extremely rare, but we do need to track them if we want to support local symbol renaming.

### This isn't the right way to model this

This isn't the right way to model this.

Here's an alternative:

- Remove `BindingKind::Annotation`, and treat annotations as their own, separate concept.
- Instead of storing a map from name to `BindingId` on each `Scope`, store a map from name to... `SymbolId`.
- Introduce a `Symbol` abstraction, where a symbol can point to a current binding, and a list of annotations, like:

```rust
pub struct Symbol {
  binding: Option<BindingId>,
  annotations: Vec<AnnotationId>
}
```

If we did this, we could appropriately model the semantics described above. When we go to resolve a binding, we ignore annotations (always). When we try to find unused variables, we look through the list of symbols, and have sufficient information to discriminate between annotations and bound variables. Etc.

The main downside of this `Symbol`-based approach is that it's going to take a lot more work to implement, and it'll be less performant (we'll be storing more data per symbol, and our binding lookups will have an added layer of indirection).
