### PR TITLE
Add autofix for `Set`-to-`AbstractSet` rewrite using reference tracking

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_pyi/PYI025.py
+++ b/crates/ruff/resources/test/fixtures/flake8_pyi/PYI025.py
@@ -1,19 +1,19 @@
-from collections.abc import Set as AbstractSet  # Ok
+def f():
+    from collections.abc import Set as AbstractSet  # Ok
 
 
-from collections.abc import Set  # Ok
+def f():
+    from collections.abc import Container, Sized, Set as AbstractSet, ValuesView  # Ok
 
 
-from collections.abc import (
-    Container,
-    Sized,
-    Set,  # Ok
-    ValuesView
-)
+def f():
+    from collections.abc import Set  # PYI025
 
-from collections.abc import (
-    Container,
-    Sized,
-    Set as AbstractSet,  # Ok
-    ValuesView
-)
+
+def f():
+    from collections.abc import Container, Sized, Set, ValuesView  # PYI025
+
+    GLOBAL: Set[int] = set()
+
+    class Class:
+        member: Set[int]

--- a/crates/ruff/resources/test/fixtures/flake8_pyi/PYI025.pyi
+++ b/crates/ruff/resources/test/fixtures/flake8_pyi/PYI025.pyi
@@ -1,19 +1,12 @@
 from collections.abc import Set as AbstractSet  # Ok
 
+from collections.abc import Container, Sized, Set as AbstractSet, ValuesView  # Ok
 
 from collections.abc import Set  # PYI025
 
+from collections.abc import Container, Sized, Set, ValuesView  # PYI025
 
-from collections.abc import (
-    Container,
-    Sized,
-    Set,  # PYI025
-    ValuesView
-)
+GLOBAL: Set[int] = set()
 
-from collections.abc import (
-    Container,
-    Sized,
-    Set as AbstractSet,
-    ValuesView # Ok
-)
+class Class:
+    member: Set[int]

--- a/crates/ruff/resources/test/fixtures/flake8_pyi/PYI025.pyi
+++ b/crates/ruff/resources/test/fixtures/flake8_pyi/PYI025.pyi
@@ -1,12 +1,16 @@
-from collections.abc import Set as AbstractSet  # Ok
+def f():
+    from collections.abc import Set as AbstractSet  # Ok
 
-from collections.abc import Container, Sized, Set as AbstractSet, ValuesView  # Ok
+def f():
+    from collections.abc import Container, Sized, Set as AbstractSet, ValuesView  # Ok
 
-from collections.abc import Set  # PYI025
+def f():
+    from collections.abc import Set  # PYI025
 
-from collections.abc import Container, Sized, Set, ValuesView  # PYI025
+def f():
+    from collections.abc import Container, Sized, Set, ValuesView  # PYI025
 
-GLOBAL: Set[int] = set()
+    GLOBAL: Set[int] = set()
 
-class Class:
-    member: Set[int]
+    class Class:
+        member: Set[int]

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -4753,7 +4753,7 @@ impl<'a> Checker<'a> {
         let exports: Vec<(&str, TextRange)> = {
             let global_scope = self.semantic_model.global_scope();
             global_scope
-                .bindings_for_name("__all__")
+                .get_all("__all__")
                 .map(|binding_id| &self.semantic_model.bindings[binding_id])
                 .filter_map(|binding| match &binding.kind {
                     BindingKind::Export(Export { names }) => {
@@ -5034,7 +5034,7 @@ impl<'a> Checker<'a> {
         let exports: Option<Vec<&str>> = {
             let global_scope = self.semantic_model.global_scope();
             global_scope
-                .bindings_for_name("__all__")
+                .get_all("__all__")
                 .map(|binding_id| &self.semantic_model.bindings[binding_id])
                 .filter_map(|binding| match &binding.kind {
                     BindingKind::Export(Export { names }) => Some(names.iter().copied()),

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -1062,9 +1062,6 @@ where
                 }
 
                 if self.is_stub {
-                    if self.enabled(Rule::UnaliasedCollectionsAbcSetImport) {
-                        flake8_pyi::rules::unaliased_collections_abc_set_import(self, import_from);
-                    }
                     if self.enabled(Rule::FutureAnnotationsInStub) {
                         flake8_pyi::rules::from_future_import(self, import_from);
                     }
@@ -4737,23 +4734,18 @@ impl<'a> Checker<'a> {
     }
 
     fn check_dead_scopes(&mut self) {
-        let enforce_typing_imports = !self.is_stub
-            && self.any_enabled(&[
-                Rule::GlobalVariableNotAssigned,
-                Rule::RuntimeImportInTypeCheckingBlock,
-                Rule::TypingOnlyFirstPartyImport,
-                Rule::TypingOnlyThirdPartyImport,
-                Rule::TypingOnlyStandardLibraryImport,
-            ]);
-
-        if !(enforce_typing_imports
-            || self.any_enabled(&[
-                Rule::UnusedImport,
-                Rule::UndefinedLocalWithImportStarUsage,
-                Rule::RedefinedWhileUnused,
-                Rule::UndefinedExport,
-            ]))
-        {
+        if !self.any_enabled(&[
+            Rule::UnusedImport,
+            Rule::GlobalVariableNotAssigned,
+            Rule::UndefinedLocalWithImportStarUsage,
+            Rule::RedefinedWhileUnused,
+            Rule::RuntimeImportInTypeCheckingBlock,
+            Rule::TypingOnlyFirstPartyImport,
+            Rule::TypingOnlyThirdPartyImport,
+            Rule::TypingOnlyStandardLibraryImport,
+            Rule::UndefinedExport,
+            Rule::UnaliasedCollectionsAbcSetImport,
+        ]) {
             return;
         }
 
@@ -4786,6 +4778,16 @@ impl<'a> Checker<'a> {
         // Identify any valid runtime imports. If a module is imported at runtime, and
         // used at runtime, then by default, we avoid flagging any other
         // imports from that model as typing-only.
+        let enforce_typing_imports = if self.is_stub {
+            false
+        } else {
+            self.any_enabled(&[
+                Rule::RuntimeImportInTypeCheckingBlock,
+                Rule::TypingOnlyFirstPartyImport,
+                Rule::TypingOnlyThirdPartyImport,
+                Rule::TypingOnlyStandardLibraryImport,
+            ])
+        };
         let runtime_imports: Vec<Vec<&Binding>> = if enforce_typing_imports {
             if self.settings.flake8_type_checking.strict {
                 vec![]
@@ -4939,6 +4941,16 @@ impl<'a> Checker<'a> {
 
             if self.enabled(Rule::UnusedImport) {
                 pyflakes::rules::unused_import(self, scope, &mut diagnostics);
+            }
+
+            if self.is_stub {
+                if self.enabled(Rule::UnaliasedCollectionsAbcSetImport) {
+                    flake8_pyi::rules::unaliased_collections_abc_set_import(
+                        self,
+                        scope,
+                        &mut diagnostics,
+                    );
+                }
             }
         }
         self.diagnostics.extend(diagnostics);

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -156,7 +156,7 @@ pub(crate) fn unused_loop_control_variable(checker: &mut Checker, target: &Expr,
                 // used _after_ the loop.
                 let scope = checker.semantic_model().scope();
                 if scope
-                    .bindings_for_name(name)
+                    .get_all(name)
                     .map(|binding_id| &checker.semantic_model().bindings[binding_id])
                     .all(|binding| !binding.is_used())
                 {

--- a/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI025_PYI025.pyi.snap
+++ b/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI025_PYI025.pyi.snap
@@ -1,50 +1,48 @@
 ---
 source: crates/ruff/src/rules/flake8_pyi/mod.rs
 ---
-PYI025.pyi:5:29: PYI025 [*] Use `from collections.abc import Set as AbstractSet` to avoid confusion with the `set` builtin
-  |
-3 | from collections.abc import Container, Sized, Set as AbstractSet, ValuesView  # Ok
-4 | 
-5 | from collections.abc import Set  # PYI025
-  |                             ^^^ PYI025
-6 | 
-7 | from collections.abc import Container, Sized, Set, ValuesView  # PYI025
-  |
-  = help: Alias `Set` to `AbstractSet`
+PYI025.pyi:8:33: PYI025 [*] Use `from collections.abc import Set as AbstractSet` to avoid confusion with the `set` builtin
+   |
+ 7 | def f():
+ 8 |     from collections.abc import Set  # PYI025
+   |                                 ^^^ PYI025
+ 9 | 
+10 | def f():
+   |
+   = help: Alias `Set` to `AbstractSet`
 
 ℹ Suggested fix
-2 2 | 
-3 3 | from collections.abc import Container, Sized, Set as AbstractSet, ValuesView  # Ok
-4 4 | 
-5   |-from collections.abc import Set  # PYI025
-  5 |+from collections.abc import Set as AbstractSet  # PYI025
+5 5 |     from collections.abc import Container, Sized, Set as AbstractSet, ValuesView  # Ok
 6 6 | 
-7 7 | from collections.abc import Container, Sized, Set, ValuesView  # PYI025
-8 8 | 
+7 7 | def f():
+8   |-    from collections.abc import Set  # PYI025
+  8 |+    from collections.abc import Set as AbstractSet  # PYI025
+9 9 | 
+10 10 | def f():
+11 11 |     from collections.abc import Container, Sized, Set, ValuesView  # PYI025
 
-PYI025.pyi:7:47: PYI025 [*] Use `from collections.abc import Set as AbstractSet` to avoid confusion with the `set` builtin
-  |
-5 | from collections.abc import Set  # PYI025
-6 | 
-7 | from collections.abc import Container, Sized, Set, ValuesView  # PYI025
-  |                                               ^^^ PYI025
-8 | 
-9 | GLOBAL: Set[int] = set()
-  |
-  = help: Alias `Set` to `AbstractSet`
+PYI025.pyi:11:51: PYI025 [*] Use `from collections.abc import Set as AbstractSet` to avoid confusion with the `set` builtin
+   |
+10 | def f():
+11 |     from collections.abc import Container, Sized, Set, ValuesView  # PYI025
+   |                                                   ^^^ PYI025
+12 | 
+13 |     GLOBAL: Set[int] = set()
+   |
+   = help: Alias `Set` to `AbstractSet`
 
 ℹ Suggested fix
-4  4  | 
-5  5  | from collections.abc import Set  # PYI025
-6  6  | 
-7     |-from collections.abc import Container, Sized, Set, ValuesView  # PYI025
-   7  |+from collections.abc import Container, Sized, Set as AbstractSet, ValuesView  # PYI025
-8  8  | 
-9     |-GLOBAL: Set[int] = set()
-   9  |+GLOBAL: AbstractSet[int] = set()
-10 10 | 
-11 11 | class Class:
-12    |-    member: Set[int]
-   12 |+    member: AbstractSet[int]
+8  8  |     from collections.abc import Set  # PYI025
+9  9  | 
+10 10 | def f():
+11    |-    from collections.abc import Container, Sized, Set, ValuesView  # PYI025
+   11 |+    from collections.abc import Container, Sized, Set as AbstractSet, ValuesView  # PYI025
+12 12 | 
+13    |-    GLOBAL: Set[int] = set()
+   13 |+    GLOBAL: AbstractSet[int] = set()
+14 14 | 
+15 15 |     class Class:
+16    |-        member: Set[int]
+   16 |+        member: AbstractSet[int]
 
 

--- a/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI025_PYI025.pyi.snap
+++ b/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI025_PYI025.pyi.snap
@@ -1,22 +1,50 @@
 ---
 source: crates/ruff/src/rules/flake8_pyi/mod.rs
 ---
-PYI025.pyi:4:29: PYI025 Use `from collections.abc import Set as AbstractSet` to avoid confusion with the `set` builtin
+PYI025.pyi:5:29: PYI025 [*] Use `from collections.abc import Set as AbstractSet` to avoid confusion with the `set` builtin
   |
-4 | from collections.abc import Set  # PYI025
+3 | from collections.abc import Container, Sized, Set as AbstractSet, ValuesView  # Ok
+4 | 
+5 | from collections.abc import Set  # PYI025
   |                             ^^^ PYI025
+6 | 
+7 | from collections.abc import Container, Sized, Set, ValuesView  # PYI025
   |
   = help: Alias `Set` to `AbstractSet`
 
-PYI025.pyi:10:5: PYI025 Use `from collections.abc import Set as AbstractSet` to avoid confusion with the `set` builtin
-   |
- 8 |     Container,
- 9 |     Sized,
-10 |     Set,  # PYI025
-   |     ^^^ PYI025
-11 |     ValuesView
-12 | )
-   |
-   = help: Alias `Set` to `AbstractSet`
+ℹ Suggested fix
+2 2 | 
+3 3 | from collections.abc import Container, Sized, Set as AbstractSet, ValuesView  # Ok
+4 4 | 
+5   |-from collections.abc import Set  # PYI025
+  5 |+from collections.abc import Set as AbstractSet  # PYI025
+6 6 | 
+7 7 | from collections.abc import Container, Sized, Set, ValuesView  # PYI025
+8 8 | 
+
+PYI025.pyi:7:47: PYI025 [*] Use `from collections.abc import Set as AbstractSet` to avoid confusion with the `set` builtin
+  |
+5 | from collections.abc import Set  # PYI025
+6 | 
+7 | from collections.abc import Container, Sized, Set, ValuesView  # PYI025
+  |                                               ^^^ PYI025
+8 | 
+9 | GLOBAL: Set[int] = set()
+  |
+  = help: Alias `Set` to `AbstractSet`
+
+ℹ Suggested fix
+4  4  | 
+5  5  | from collections.abc import Set  # PYI025
+6  6  | 
+7     |-from collections.abc import Container, Sized, Set, ValuesView  # PYI025
+   7  |+from collections.abc import Container, Sized, Set as AbstractSet, ValuesView  # PYI025
+8  8  | 
+9     |-GLOBAL: Set[int] = set()
+   9  |+GLOBAL: AbstractSet[int] = set()
+10 10 | 
+11 11 | class Class:
+12    |-    member: Set[int]
+   12 |+    member: AbstractSet[int]
 
 

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1353,7 +1353,7 @@ impl<'a> SimpleCallArgs<'a> {
     ) -> Self {
         let args = args
             .into_iter()
-            .take_while(|arg| !matches!(arg, Expr::Starred(_)))
+            .take_while(|arg| !arg.is_starred_expr())
             .collect();
 
         let kwargs = keywords

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -702,11 +702,11 @@ impl<'a> SemanticModel<'a> {
         self.references.resolve(reference_id)
     }
 
-    /// Return the [`TextRange`]s of all references to the given [`BindingId`].
-    pub fn references(&self, name: &str, scope: &Scope) -> Vec<TextRange> {
+    /// Return the [`TextRange`] of every read and write reference to a given symbol.
+    pub fn spans(&self, name: &str, scope: &Scope) -> Vec<TextRange> {
         let mut references = Vec::new();
 
-        for binding_id in scope.bindings_for_name(name) {
+        for binding_id in scope.get_all(name) {
             // Add the "write" reference that created this binding.
             references.push(self.bindings[binding_id].range);
 

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -702,6 +702,24 @@ impl<'a> SemanticModel<'a> {
         self.references.resolve(reference_id)
     }
 
+    /// Return the [`TextRange`]s of all references to the given [`BindingId`].
+    pub fn references(&self, name: &str, scope: &Scope) -> Vec<TextRange> {
+        let mut references = Vec::new();
+
+        for binding_id in scope.bindings_for_name(name) {
+            // Add the "write" reference that created this binding.
+            references.push(self.bindings[binding_id].range);
+
+            // Add all "read" references that use this binding.
+            for reference_id in &self.bindings[binding_id].references {
+                let reference = self.references.resolve(*reference_id);
+                references.push(reference.range());
+            }
+        }
+
+        references
+    }
+
     /// Return the [`ExecutionContext`] of the current scope.
     pub const fn execution_context(&self) -> ExecutionContext {
         if self.in_type_checking_block()

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -109,31 +109,38 @@ impl<'a> Scope<'a> {
         self.has(name) || self.deleted_symbols.contains(&name)
     }
 
-    /// Returns the ids of all bindings defined in this scope.
+    /// Returns the IDs of all bindings defined in this scope.
     pub fn binding_ids(&self) -> impl Iterator<Item = BindingId> + '_ {
         self.bindings.values().copied()
     }
 
-    /// Returns a tuple of the name and id of all bindings defined in this scope.
+    /// Returns a tuple of the name and ID of all bindings defined in this scope.
     pub fn bindings(&self) -> impl Iterator<Item = (&str, BindingId)> + '_ {
         self.bindings.iter().map(|(&name, &id)| (name, id))
     }
 
-    pub fn all_bindings(&self) -> impl Iterator<Item = (&str, BindingId)> + '_ {
-        self.bindings
-            .iter()
-            .map(|(name, id)| {
-                std::iter::successors(Some(*id), |id| self.shadowed_bindings.get(id).copied())
-                    .map(|id| (*name, id))
-            })
-            .flatten()
-    }
-
-    /// Returns an iterator over all [bindings](BindingId) bound to the given name, including
+    /// Like [`Scope::get`], but returns all bindings with the given name, including
     /// those that were shadowed by later bindings.
-    pub fn bindings_for_name(&self, name: &str) -> impl Iterator<Item = BindingId> + '_ {
+    pub fn get_all(&self, name: &str) -> impl Iterator<Item = BindingId> + '_ {
         std::iter::successors(self.bindings.get(name).copied(), |id| {
             self.shadowed_bindings.get(id).copied()
+        })
+    }
+
+    /// Like [`Scope::binding_ids`], but returns all bindings that were added to the scope,
+    /// including those that were shadowed by later bindings.
+    pub fn all_binding_ids(&self) -> impl Iterator<Item = BindingId> + '_ {
+        self.bindings.values().copied().flat_map(|id| {
+            std::iter::successors(Some(id), |id| self.shadowed_bindings.get(id).copied())
+        })
+    }
+
+    /// Like [`Scope::bindings`], but returns all bindings added to the scope, including those that
+    /// were shadowed by later bindings.
+    pub fn all_bindings(&self) -> impl Iterator<Item = (&str, BindingId)> + '_ {
+        self.bindings.iter().flat_map(|(&name, &id)| {
+            std::iter::successors(Some(id), |id| self.shadowed_bindings.get(id).copied())
+                .map(move |id| (name, id))
         })
     }
 
@@ -158,7 +165,7 @@ impl<'a> Scope<'a> {
     }
 
     /// Returns the globals pointer for this scope.
-    pub fn globals_id(&self) -> Option<GlobalsId> {
+    pub const fn globals_id(&self) -> Option<GlobalsId> {
         self.globals_id
     }
 

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -119,6 +119,16 @@ impl<'a> Scope<'a> {
         self.bindings.iter().map(|(&name, &id)| (name, id))
     }
 
+    pub fn all_bindings(&self) -> impl Iterator<Item = (&str, BindingId)> + '_ {
+        self.bindings
+            .iter()
+            .map(|(name, id)| {
+                std::iter::successors(Some(*id), |id| self.shadowed_bindings.get(id).copied())
+                    .map(|id| (*name, id))
+            })
+            .flatten()
+    }
+
     /// Returns an iterator over all [bindings](BindingId) bound to the given name, including
     /// those that were shadowed by later bindings.
     pub fn bindings_for_name(&self, name: &str) -> impl Iterator<Item = BindingId> + '_ {


### PR DESCRIPTION
## Summary

This PR enables autofix behavior for the `flake8-pyi` rule that asks you to alias `Set` to `AbstractSet` when importing `collections.abc.Set`.

The fix here requires that we rename all local references to `Set`, so it's a good introduction to local symbol renaming.

There are a few outstanding TODOs here -- namely, we need to handle other aliases (like `from collections.abc import Set as Foo`).
