### PR TITLE
Remove unused `Scope#delete` method

### DIFF
--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -85,11 +85,6 @@ impl<'a> Scope<'a> {
         }
     }
 
-    /// Removes the binding with the given name.
-    pub fn delete(&mut self, name: &'a str) -> Option<BindingId> {
-        self.bindings.remove(name)
-    }
-
     /// Returns `true` if this scope has a binding with the given name.
     pub fn has(&self, name: &str) -> bool {
         self.bindings.contains_key(name)


### PR DESCRIPTION
## Summary

This is now intentionally unused and is now made impossible (via this PR).