### PR TITLE
Remove `FixMode::None`

### DIFF
--- a/crates/ruff/src/settings/flags.rs
+++ b/crates/ruff/src/settings/flags.rs
@@ -1,19 +1,8 @@
-#[derive(Debug, Copy, Clone, Hash)]
+#[derive(Debug, Copy, Clone, Hash, is_macro::Is)]
 pub enum FixMode {
     Generate,
     Apply,
     Diff,
-    None,
-}
-
-impl From<bool> for FixMode {
-    fn from(value: bool) -> Self {
-        if value {
-            Self::Apply
-        } else {
-            Self::None
-        }
-    }
 }
 
 #[derive(Debug, Copy, Clone, Hash, result_like::BoolLike)]

--- a/crates/ruff_cli/src/commands/run.rs
+++ b/crates/ruff_cli/src/commands/run.rs
@@ -247,21 +247,21 @@ mod test {
             &overrides,
             Cache::Disabled,
             Noqa::Enabled,
-            FixMode::None,
+            FixMode::Generate,
         )?;
 
         let printer = Printer::new(
             SerializationFormat::Text,
             LogLevel::Default,
-            FixMode::None,
+            FixMode::Generate,
             Flags::SHOW_VIOLATIONS,
         );
         let mut writer: Vec<u8> = Vec::new();
-        // Mute the terminal color codes
+        // Mute the terminal color codes.
         colored::control::set_override(false);
         printer.write_once(&diagnostics, &mut writer)?;
         // TODO(konstin): Set jupyter notebooks as none-fixable for now
-        // TODO(konstin) 2: Make jupyter notebooks fixable
+        // TODO(konstin): Make jupyter notebooks fixable
         let expected = format!(
             "{valid_ipynb}:cell 1:2:5: F841 [*] Local variable `x` is assigned to but never used
 {valid_ipynb}:cell 3:1:24: B006 Do not use mutable data structures for argument defaults

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -141,9 +141,9 @@ impl Printer {
                     .sum::<usize>();
                 if fixed > 0 {
                     let s = if fixed == 1 { "" } else { "s" };
-                    if matches!(self.autofix_level, flags::FixMode::Apply) {
+                    if self.autofix_level.is_apply() {
                         writeln!(stdout, "Fixed {fixed} error{s}.")?;
-                    } else if matches!(self.autofix_level, flags::FixMode::Diff) {
+                    } else {
                         writeln!(stdout, "Would fix {fixed} error{s}.")?;
                     }
                 }
@@ -391,7 +391,7 @@ const fn show_fix_status(autofix_level: flags::FixMode) -> bool {
     // this pass! (We're occasionally unable to determine whether a specific
     // violation is fixable without trying to fix it, so if autofix is not
     // enabled, we may inadvertently indicate that a rule is fixable.)
-    !matches!(autofix_level, flags::FixMode::Apply)
+    !autofix_level.is_apply()
 }
 
 fn print_fix_summary<T: Write>(stdout: &mut T, fixed: &FxHashMap<String, FixTable>) -> Result<()> {


### PR DESCRIPTION
## Summary

We now _always_ generate fixes, so `FixMode::None` and `FixMode::Generate` are redundant. We can also remove the TODO around `--fix-dry-run`, since that's our default behavior.

Closes #5081.
