### PR TITLE
Re-export `ruff_python_semantic` members

### DIFF
--- a/crates/ruff/src/checkers/ast/deferred.rs
+++ b/crates/ruff/src/checkers/ast/deferred.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::Expr;
 
-use ruff_python_semantic::model::Snapshot;
+use ruff_python_semantic::Snapshot;
 
 /// A collection of AST nodes that are deferred for later analysis.
 /// Used to, e.g., store functions, whose bodies shouldn't be analyzed until all

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -22,15 +22,15 @@ use ruff_python_semantic::analyze;
 use ruff_python_semantic::analyze::branch_detection;
 use ruff_python_semantic::analyze::typing::{Callable, SubscriptKind};
 use ruff_python_semantic::analyze::visibility::ModuleSource;
-use ruff_python_semantic::binding::{
+use ruff_python_semantic::ExecutionContext;
+use ruff_python_semantic::Globals;
+use ruff_python_semantic::{
     Binding, BindingFlags, BindingId, BindingKind, Exceptions, Export, FromImportation,
     Importation, StarImportation, SubmoduleImportation,
 };
-use ruff_python_semantic::context::ExecutionContext;
-use ruff_python_semantic::definition::{ContextualizedDefinition, Module, ModuleKind};
-use ruff_python_semantic::globals::Globals;
-use ruff_python_semantic::model::{ResolvedRead, SemanticModel, SemanticModelFlags};
-use ruff_python_semantic::scope::{Scope, ScopeId, ScopeKind};
+use ruff_python_semantic::{ContextualizedDefinition, Module, ModuleKind};
+use ruff_python_semantic::{ResolvedRead, SemanticModel, SemanticModelFlags};
+use ruff_python_semantic::{Scope, ScopeId, ScopeKind};
 use ruff_python_stdlib::builtins::{BUILTINS, MAGIC_GLOBALS};
 use ruff_python_stdlib::path::is_python_stub_file;
 

--- a/crates/ruff/src/docstrings/extraction.rs
+++ b/crates/ruff/src/docstrings/extraction.rs
@@ -2,7 +2,7 @@
 
 use rustpython_parser::ast::{self, Constant, Expr, Stmt};
 
-use ruff_python_semantic::definition::{Definition, DefinitionId, Definitions, Member, MemberKind};
+use ruff_python_semantic::{Definition, DefinitionId, Definitions, Member, MemberKind};
 
 /// Extract a docstring from a function or class body.
 pub(crate) fn docstring_from(suite: &[Stmt]) -> Option<&Expr> {

--- a/crates/ruff/src/docstrings/mod.rs
+++ b/crates/ruff/src/docstrings/mod.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 use ruff_text_size::{TextRange, TextSize};
 use rustpython_parser::ast::{Expr, Ranged};
 
-use ruff_python_semantic::definition::Definition;
+use ruff_python_semantic::Definition;
 
 pub(crate) mod extraction;
 pub(crate) mod google;

--- a/crates/ruff/src/importer/mod.rs
+++ b/crates/ruff/src/importer/mod.rs
@@ -10,7 +10,7 @@ use rustpython_parser::ast::{self, Ranged, Stmt, Suite};
 use ruff_diagnostics::Edit;
 use ruff_python_ast::imports::{AnyImport, Import, ImportFrom};
 use ruff_python_ast::source_code::{Locator, Stylist};
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 use ruff_textwrap::indent;
 
 use crate::autofix;

--- a/crates/ruff/src/rules/flake8_2020/helpers.rs
+++ b/crates/ruff/src/rules/flake8_2020/helpers.rs
@@ -1,5 +1,6 @@
-use ruff_python_semantic::SemanticModel;
 use rustpython_parser::ast::Expr;
+
+use ruff_python_semantic::SemanticModel;
 
 pub(super) fn is_sys(model: &SemanticModel, expr: &Expr, target: &str) -> bool {
     model

--- a/crates/ruff/src/rules/flake8_2020/helpers.rs
+++ b/crates/ruff/src/rules/flake8_2020/helpers.rs
@@ -1,4 +1,4 @@
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 use rustpython_parser::ast::Expr;
 
 pub(super) fn is_sys(model: &SemanticModel, expr: &Expr, target: &str) -> bool {

--- a/crates/ruff/src/rules/flake8_annotations/helpers.rs
+++ b/crates/ruff/src/rules/flake8_annotations/helpers.rs
@@ -2,8 +2,7 @@ use rustpython_parser::ast::{self, Arguments, Expr, Stmt};
 
 use ruff_python_ast::cast;
 use ruff_python_semantic::analyze::visibility;
-use ruff_python_semantic::SemanticModel;
-use ruff_python_semantic::{Definition, Member, MemberKind};
+use ruff_python_semantic::{Definition, Member, MemberKind, SemanticModel};
 
 pub(super) fn match_function_def(
     stmt: &Stmt,

--- a/crates/ruff/src/rules/flake8_annotations/helpers.rs
+++ b/crates/ruff/src/rules/flake8_annotations/helpers.rs
@@ -2,8 +2,8 @@ use rustpython_parser::ast::{self, Arguments, Expr, Stmt};
 
 use ruff_python_ast::cast;
 use ruff_python_semantic::analyze::visibility;
-use ruff_python_semantic::definition::{Definition, Member, MemberKind};
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
+use ruff_python_semantic::{Definition, Member, MemberKind};
 
 pub(super) fn match_function_def(
     stmt: &Stmt,

--- a/crates/ruff/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff/src/rules/flake8_annotations/rules/definition.rs
@@ -6,9 +6,7 @@ use ruff_python_ast::helpers::ReturnStatementVisitor;
 use ruff_python_ast::statement_visitor::StatementVisitor;
 use ruff_python_ast::{cast, helpers};
 use ruff_python_semantic::analyze::visibility;
-use ruff_python_semantic::analyze::visibility::Visibility;
-use ruff_python_semantic::SemanticModel;
-use ruff_python_semantic::{Definition, Member, MemberKind};
+use ruff_python_semantic::{Definition, Member, MemberKind, SemanticModel};
 use ruff_python_stdlib::typing::SIMPLE_MAGIC_RETURN_TYPES;
 
 use crate::checkers::ast::Checker;
@@ -453,7 +451,7 @@ fn check_dynamically_typed<F>(
 pub(crate) fn definition(
     checker: &Checker,
     definition: &Definition,
-    visibility: Visibility,
+    visibility: visibility::Visibility,
 ) -> Vec<Diagnostic> {
     // TODO(charlie): Consider using the AST directly here rather than `Definition`.
     // We could adhere more closely to `flake8-annotations` by defining public
@@ -705,7 +703,7 @@ pub(crate) fn definition(
             }
         } else {
             match visibility {
-                Visibility::Public => {
+                visibility::Visibility::Public => {
                     if checker.enabled(Rule::MissingReturnTypeUndocumentedPublicFunction) {
                         diagnostics.push(Diagnostic::new(
                             MissingReturnTypeUndocumentedPublicFunction {
@@ -715,7 +713,7 @@ pub(crate) fn definition(
                         ));
                     }
                 }
-                Visibility::Private => {
+                visibility::Visibility::Private => {
                     if checker.enabled(Rule::MissingReturnTypePrivateFunction) {
                         diagnostics.push(Diagnostic::new(
                             MissingReturnTypePrivateFunction {

--- a/crates/ruff/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff/src/rules/flake8_annotations/rules/definition.rs
@@ -7,8 +7,8 @@ use ruff_python_ast::statement_visitor::StatementVisitor;
 use ruff_python_ast::{cast, helpers};
 use ruff_python_semantic::analyze::visibility;
 use ruff_python_semantic::analyze::visibility::Visibility;
-use ruff_python_semantic::definition::{Definition, Member, MemberKind};
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
+use ruff_python_semantic::{Definition, Member, MemberKind};
 use ruff_python_stdlib::typing::SIMPLE_MAGIC_RETURN_TYPES;
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/flake8_bandit/helpers.rs
+++ b/crates/ruff/src/rules/flake8_bandit/helpers.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rustpython_parser::ast::{self, Constant, Expr};
 
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 static PASSWORD_CANDIDATE_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"(^|_)(?i)(pas+wo?r?d|pass(phrase)?|pwd|token|secrete?)($|_)").unwrap()

--- a/crates/ruff/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -5,7 +5,7 @@ use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::Truthiness;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::{
     checkers::ast::Checker, registry::Rule, rules::flake8_bandit::helpers::string_literal,

--- a/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -4,7 +4,7 @@ use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_semantic::analyze::visibility::{is_abstract, is_overload};
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{self, Decorator, Expr, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
@@ -8,7 +8,7 @@ use ruff_python_ast::call_path::{compose_call_path, from_qualified_name, CallPat
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_semantic::analyze::typing::is_immutable_func;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 use crate::rules::flake8_bugbear::rules::mutable_argument_default::is_mutable_func;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{self, Arguments, Expr, Ranged};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_semantic::analyze::typing::is_immutable_annotation;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{self, Expr, Keyword, Ranged};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::is_const_none;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_django/rules/helpers.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/helpers.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Expr;
 
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 /// Return `true` if a Python class appears to be a Django model, based on its base classes.
 pub(super) fn is_model(model: &SemanticModel, base: &Expr) -> bool {

--- a/crates/ruff/src/rules/flake8_django/rules/locals_in_render_function.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/locals_in_render_function.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{self, Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_django/rules/model_without_dunder_str.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/model_without_dunder_str.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{self, Constant, Expr, Ranged, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_django/rules/unordered_body_content_in_model.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/unordered_body_content_in_model.rs
@@ -4,7 +4,7 @@ use rustpython_parser::ast::{self, Expr, Ranged, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -4,7 +4,6 @@ use rustpython_parser::ast::{self, Constant, Expr, Keyword, Operator, Ranged};
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_python_ast::helpers::{find_keyword, SimpleCallArgs};
 use ruff_python_semantic::analyze::logging;
-use ruff_python_semantic::analyze::logging::exc_info;
 use ruff_python_stdlib::logging::LoggingLevel;
 
 use crate::checkers::ast::Checker;
@@ -197,7 +196,7 @@ pub(crate) fn logging_call(
                 if !checker.semantic_model().in_exception_handler() {
                     return;
                 }
-                let Some(exc_info) = exc_info(keywords, checker.semantic_model()) else {
+                let Some(exc_info) = logging::exc_info(keywords, checker.semantic_model()) else {
                     return;
                 };
                 if let LoggingCallType::LevelCall(logging_level) = logging_call_type {

--- a/crates/ruff/src/rules/flake8_pyi/rules/iter_method_return_iterable.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/iter_method_return_iterable.rs
@@ -4,7 +4,7 @@ use rustpython_parser::ast::{Ranged, Stmt};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::prelude::Expr;
-use ruff_python_semantic::definition::{Definition, Member, MemberKind};
+use ruff_python_semantic::{Definition, Member, MemberKind};
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -4,8 +4,8 @@ use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{identifier_range, map_subscript};
 use ruff_python_semantic::analyze::visibility::{is_abstract, is_final, is_overload};
-use ruff_python_semantic::model::SemanticModel;
-use ruff_python_semantic::scope::ScopeKind;
+use ruff_python_semantic::ScopeKind;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -4,8 +4,7 @@ use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{identifier_range, map_subscript};
 use ruff_python_semantic::analyze::visibility::{is_abstract, is_final, is_overload};
-use ruff_python_semantic::ScopeKind;
-use ruff_python_semantic::SemanticModel;
+use ruff_python_semantic::{ScopeKind, SemanticModel};
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -3,8 +3,7 @@ use rustpython_parser::ast::{self, Arguments, Constant, Expr, Operator, Ranged, 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
-use ruff_python_semantic::ScopeKind;
-use ruff_python_semantic::SemanticModel;
+use ruff_python_semantic::{ScopeKind, SemanticModel};
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;

--- a/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -3,8 +3,8 @@ use rustpython_parser::ast::{self, Arguments, Constant, Expr, Operator, Ranged, 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
-use ruff_python_semantic::model::SemanticModel;
-use ruff_python_semantic::scope::ScopeKind;
+use ruff_python_semantic::ScopeKind;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -14,7 +14,7 @@ use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{helpers, visitor};
 use ruff_python_semantic::analyze::visibility::is_abstract;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::autofix::edits::remove_argument;
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{self, Constant, Decorator, Expr, Keyword};
 
 use ruff_python_ast::call_path::{collect_call_path, CallPath};
 use ruff_python_ast::helpers::map_callable;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 use ruff_python_whitespace::PythonWhitespace;
 
 pub(super) fn get_mark_decorators(

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
@@ -4,7 +4,7 @@ use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::format_call_path;
 use ruff_python_ast::call_path::from_qualified_name;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff/src/rules/flake8_return/rules/function.rs
@@ -10,7 +10,7 @@ use ruff_python_ast::helpers::elif_else_range;
 use ruff_python_ast::helpers::is_const_none;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::whitespace::indentation;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::autofix::edits;
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{self, Expr, Ranged};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::collect_call_path;
-use ruff_python_semantic::scope::ScopeKind;
+use ruff_python_semantic::ScopeKind;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -9,7 +9,7 @@ use ruff_python_ast::comparable::{ComparableConstant, ComparableExpr, Comparable
 use ruff_python_ast::helpers::{
     any_over_expr, contains_effect, first_colon_range, has_comments, has_comments_in,
 };
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 use ruff_python_whitespace::UniversalNewlines;
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{self, Cmpop, Expr, ExprContext, Ranged, Stmt, Unary
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::scope::ScopeKind;
+use ruff_python_semantic::ScopeKind;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;

--- a/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{self, Expr, Ranged, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/helpers.rs
@@ -2,9 +2,7 @@ use rustpython_parser::ast;
 
 use ruff_python_ast::call_path::from_qualified_name;
 use ruff_python_ast::helpers::map_callable;
-use ruff_python_semantic::ScopeKind;
-use ruff_python_semantic::SemanticModel;
-use ruff_python_semantic::{Binding, BindingKind};
+use ruff_python_semantic::{Binding, BindingKind, ScopeKind, SemanticModel};
 
 pub(crate) fn is_valid_runtime_import(semantic_model: &SemanticModel, binding: &Binding) -> bool {
     if matches!(

--- a/crates/ruff/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/helpers.rs
@@ -2,9 +2,9 @@ use rustpython_parser::ast;
 
 use ruff_python_ast::call_path::from_qualified_name;
 use ruff_python_ast::helpers::map_callable;
-use ruff_python_semantic::binding::{Binding, BindingKind};
-use ruff_python_semantic::model::SemanticModel;
-use ruff_python_semantic::scope::ScopeKind;
+use ruff_python_semantic::ScopeKind;
+use ruff_python_semantic::SemanticModel;
+use ruff_python_semantic::{Binding, BindingKind};
 
 pub(crate) fn is_valid_runtime_import(semantic_model: &SemanticModel, binding: &Binding) -> bool {
     if matches!(

--- a/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -4,9 +4,9 @@ use rustc_hash::FxHashMap;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::node::NodeId;
-use ruff_python_semantic::reference::ReferenceId;
-use ruff_python_semantic::scope::Scope;
+use ruff_python_semantic::NodeId;
+use ruff_python_semantic::ReferenceId;
+use ruff_python_semantic::Scope;
 
 use crate::autofix;
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -4,9 +4,7 @@ use rustc_hash::FxHashMap;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::NodeId;
-use ruff_python_semantic::ReferenceId;
-use ruff_python_semantic::Scope;
+use ruff_python_semantic::{NodeId, ReferenceId, Scope};
 
 use crate::autofix;
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -4,10 +4,7 @@ use rustc_hash::FxHashMap;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, DiagnosticKind, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::Binding;
-use ruff_python_semantic::NodeId;
-use ruff_python_semantic::ReferenceId;
-use ruff_python_semantic::Scope;
+use ruff_python_semantic::{Binding, NodeId, ReferenceId, Scope};
 
 use crate::autofix;
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -4,10 +4,10 @@ use rustc_hash::FxHashMap;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, DiagnosticKind, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::binding::Binding;
-use ruff_python_semantic::node::NodeId;
-use ruff_python_semantic::reference::ReferenceId;
-use ruff_python_semantic::scope::Scope;
+use ruff_python_semantic::Binding;
+use ruff_python_semantic::NodeId;
+use ruff_python_semantic::ReferenceId;
+use ruff_python_semantic::Scope;
 
 use crate::autofix;
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
@@ -10,8 +10,8 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_semantic::analyze::function_type;
 use ruff_python_semantic::analyze::function_type::FunctionType;
 use ruff_python_semantic::analyze::visibility;
-use ruff_python_semantic::model::SemanticModel;
-use ruff_python_semantic::scope::{Scope, ScopeKind};
+use ruff_python_semantic::SemanticModel;
+use ruff_python_semantic::{Scope, ScopeKind};
 
 use crate::checkers::ast::Checker;
 use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
@@ -7,11 +7,8 @@ use rustpython_parser::ast::{Arg, Arguments};
 use ruff_diagnostics::DiagnosticKind;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::analyze::function_type;
-use ruff_python_semantic::analyze::function_type::FunctionType;
-use ruff_python_semantic::analyze::visibility;
-use ruff_python_semantic::SemanticModel;
-use ruff_python_semantic::{Scope, ScopeKind};
+use ruff_python_semantic::analyze::{function_type, visibility};
+use ruff_python_semantic::{Scope, ScopeKind, SemanticModel};
 
 use crate::checkers::ast::Checker;
 use crate::registry::Rule;
@@ -327,7 +324,7 @@ pub(crate) fn unused_arguments(
                 &checker.settings.pep8_naming.classmethod_decorators,
                 &checker.settings.pep8_naming.staticmethod_decorators,
             ) {
-                FunctionType::Function => {
+                function_type::FunctionType::Function => {
                     if checker.enabled(Argumentable::Function.rule_code())
                         && !visibility::is_overload(checker.semantic_model(), decorator_list)
                     {
@@ -346,7 +343,7 @@ pub(crate) fn unused_arguments(
                         vec![]
                     }
                 }
-                FunctionType::Method => {
+                function_type::FunctionType::Method => {
                     if checker.enabled(Argumentable::Method.rule_code())
                         && !helpers::is_empty(body)
                         && (!visibility::is_magic(name)
@@ -372,7 +369,7 @@ pub(crate) fn unused_arguments(
                         vec![]
                     }
                 }
-                FunctionType::ClassMethod => {
+                function_type::FunctionType::ClassMethod => {
                     if checker.enabled(Argumentable::ClassMethod.rule_code())
                         && !helpers::is_empty(body)
                         && (!visibility::is_magic(name)
@@ -398,7 +395,7 @@ pub(crate) fn unused_arguments(
                         vec![]
                     }
                 }
-                FunctionType::StaticMethod => {
+                function_type::FunctionType::StaticMethod => {
                     if checker.enabled(Argumentable::StaticMethod.rule_code())
                         && !helpers::is_empty(body)
                         && (!visibility::is_magic(name)

--- a/crates/ruff/src/rules/pandas_vet/helpers.rs
+++ b/crates/ruff/src/rules/pandas_vet/helpers.rs
@@ -1,8 +1,7 @@
 use rustpython_parser::ast;
 use rustpython_parser::ast::Expr;
 
-use ruff_python_semantic::SemanticModel;
-use ruff_python_semantic::{BindingKind, Importation};
+use ruff_python_semantic::{BindingKind, Importation, SemanticModel};
 
 pub(super) enum Resolution {
     /// The expression resolves to an irrelevant expression type (e.g., a constant).

--- a/crates/ruff/src/rules/pandas_vet/helpers.rs
+++ b/crates/ruff/src/rules/pandas_vet/helpers.rs
@@ -1,8 +1,8 @@
 use rustpython_parser::ast;
 use rustpython_parser::ast::Expr;
 
-use ruff_python_semantic::binding::{BindingKind, Importation};
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
+use ruff_python_semantic::{BindingKind, Importation};
 
 pub(super) enum Resolution {
     /// The expression resolves to an irrelevant expression type (e.g., a constant).

--- a/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::binding::{BindingKind, Importation};
+use ruff_python_semantic::{BindingKind, Importation};
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;

--- a/crates/ruff/src/rules/pep8_naming/helpers.rs
+++ b/crates/ruff/src/rules/pep8_naming/helpers.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use rustpython_parser::ast::{self, Expr, Stmt};
 
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 use ruff_python_stdlib::str::{is_lower, is_upper};
 
 pub(super) fn is_camelcase(name: &str) -> bool {

--- a/crates/ruff/src/rules/pep8_naming/rules/dunder_function_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/dunder_function_name.rs
@@ -4,7 +4,7 @@ use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
-use ruff_python_semantic::scope::{Scope, ScopeKind};
+use ruff_python_semantic::{Scope, ScopeKind};
 
 use crate::settings::types::IdentifierPattern;
 

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{Arguments, Decorator, Ranged};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_semantic::analyze::function_type;
-use ruff_python_semantic::scope::Scope;
+use ruff_python_semantic::Scope;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{Arguments, Decorator, Ranged};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_semantic::analyze::function_type;
-use ruff_python_semantic::scope::Scope;
+use ruff_python_semantic::Scope;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_function_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_function_name.rs
@@ -5,7 +5,7 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_semantic::analyze::visibility;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::settings::types::IdentifierPattern;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -5,7 +5,7 @@ use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{has_leading_content, has_trailing_content};
 use ruff_python_ast::source_code::Generator;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 use ruff_python_whitespace::{leading_indentation, UniversalNewlines};
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pydocstyle/helpers.rs
+++ b/crates/ruff/src/rules/pydocstyle/helpers.rs
@@ -4,8 +4,8 @@ use ruff_python_ast::call_path::from_qualified_name;
 use ruff_python_ast::cast;
 use ruff_python_ast::helpers::map_callable;
 use ruff_python_ast::str::is_implicit_concatenation;
-use ruff_python_semantic::definition::{Definition, Member, MemberKind};
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
+use ruff_python_semantic::{Definition, Member, MemberKind};
 use ruff_python_whitespace::UniversalNewlines;
 
 /// Return the index of the first logical line in a string.

--- a/crates/ruff/src/rules/pydocstyle/helpers.rs
+++ b/crates/ruff/src/rules/pydocstyle/helpers.rs
@@ -4,8 +4,7 @@ use ruff_python_ast::call_path::from_qualified_name;
 use ruff_python_ast::cast;
 use ruff_python_ast::helpers::map_callable;
 use ruff_python_ast::str::is_implicit_concatenation;
-use ruff_python_semantic::SemanticModel;
-use ruff_python_semantic::{Definition, Member, MemberKind};
+use ruff_python_semantic::{Definition, Member, MemberKind, SemanticModel};
 use ruff_python_whitespace::UniversalNewlines;
 
 /// Return the index of the first logical line in a string.

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::Ranged;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::definition::{Definition, Member, MemberKind};
+use ruff_python_semantic::{Definition, Member, MemberKind};
 use ruff_python_whitespace::{PythonWhitespace, UniversalNewlineIterator, UniversalNewlines};
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
@@ -5,7 +5,7 @@ use rustpython_parser::ast::Ranged;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::definition::{Definition, Member, MemberKind};
+use ruff_python_semantic::{Definition, Member, MemberKind};
 use ruff_python_whitespace::{PythonWhitespace, UniversalNewlineIterator, UniversalNewlines};
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pydocstyle/rules/capitalized.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/capitalized.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::Ranged;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::definition::{Definition, Member, MemberKind};
+use ruff_python_semantic::{Definition, Member, MemberKind};
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::Docstring;

--- a/crates/ruff/src/rules/pydocstyle/rules/if_needed.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/if_needed.rs
@@ -3,7 +3,7 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::cast;
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_semantic::analyze::visibility::is_overload;
-use ruff_python_semantic::definition::{Definition, Member, MemberKind};
+use ruff_python_semantic::{Definition, Member, MemberKind};
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::Docstring;

--- a/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -4,7 +4,7 @@ use rustpython_parser::ast::Ranged;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::{is_triple_quote, leading_quote};
-use ruff_python_semantic::definition::{Definition, Member};
+use ruff_python_semantic::{Definition, Member};
 use ruff_python_whitespace::{NewlineWithTrailingNewline, UniversalNewlineIterator};
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pydocstyle/rules/no_signature.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/no_signature.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{self, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::definition::{Definition, Member, MemberKind};
+use ruff_python_semantic::{Definition, Member, MemberKind};
 use ruff_python_whitespace::UniversalNewlines;
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pydocstyle/rules/non_imperative_mood.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/non_imperative_mood.rs
@@ -8,7 +8,7 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::{from_qualified_name, CallPath};
 use ruff_python_ast::cast;
 use ruff_python_semantic::analyze::visibility::{is_property, is_test};
-use ruff_python_semantic::definition::{Definition, Member, MemberKind};
+use ruff_python_semantic::{Definition, Member, MemberKind};
 use ruff_python_whitespace::UniversalNewlines;
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
@@ -7,7 +7,7 @@ use ruff_python_ast::helpers::identifier_range;
 use ruff_python_semantic::analyze::visibility::{
     is_call, is_init, is_magic, is_new, is_overload, is_override, Visibility,
 };
-use ruff_python_semantic::definition::{Definition, Member, MemberKind, Module, ModuleKind};
+use ruff_python_semantic::{Definition, Member, MemberKind, Module, ModuleKind};
 
 use crate::checkers::ast::Checker;
 use crate::registry::Rule;

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -12,7 +12,7 @@ use ruff_python_ast::cast;
 use ruff_python_ast::docstrings::{clean_space, leading_space};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_semantic::analyze::visibility::is_staticmethod;
-use ruff_python_semantic::definition::{Definition, Member, MemberKind};
+use ruff_python_semantic::{Definition, Member, MemberKind};
 use ruff_python_whitespace::NewlineWithTrailingNewline;
 use ruff_textwrap::dedent;
 

--- a/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{Ranged, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::scope::ScopeKind;
+use ruff_python_semantic::ScopeKind;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
@@ -2,7 +2,7 @@ use ruff_text_size::TextRange;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::scope::Scope;
+use ruff_python_semantic::Scope;
 
 /// ## What it does
 /// Checks for undefined names in `__all__`.

--- a/crates/ruff/src/rules/pyflakes/rules/unused_annotation.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_annotation.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::scope::ScopeId;
+use ruff_python_semantic::ScopeId;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_import.rs
@@ -4,9 +4,7 @@ use rustc_hash::FxHashMap;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::Exceptions;
-use ruff_python_semantic::NodeId;
-use ruff_python_semantic::Scope;
+use ruff_python_semantic::{Exceptions, NodeId, Scope};
 
 use crate::autofix;
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_import.rs
@@ -4,9 +4,9 @@ use rustc_hash::FxHashMap;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::binding::Exceptions;
-use ruff_python_semantic::node::NodeId;
-use ruff_python_semantic::scope::Scope;
+use ruff_python_semantic::Exceptions;
+use ruff_python_semantic::NodeId;
+use ruff_python_semantic::Scope;
 
 use crate::autofix;
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -7,7 +7,7 @@ use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::contains_effect;
 use ruff_python_ast::source_code::Locator;
-use ruff_python_semantic::scope::ScopeId;
+use ruff_python_semantic::ScopeId;
 
 use crate::autofix::edits::delete_stmt;
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
@@ -4,7 +4,7 @@ use rustpython_parser::ast::{Expr, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::scope::ScopeKind;
+use ruff_python_semantic::ScopeKind;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/pylint/helpers.rs
+++ b/crates/ruff/src/rules/pylint/helpers.rs
@@ -1,10 +1,10 @@
-use ruff_python_semantic::analyze::function_type;
-use ruff_python_semantic::analyze::function_type::FunctionType;
-use ruff_python_semantic::ScopeKind;
-use ruff_python_semantic::SemanticModel;
+use std::fmt;
+
 use rustpython_parser::ast;
 use rustpython_parser::ast::Cmpop;
-use std::fmt;
+
+use ruff_python_semantic::analyze::function_type;
+use ruff_python_semantic::{ScopeKind, SemanticModel};
 
 use crate::settings::Settings;
 
@@ -40,7 +40,7 @@ pub(super) fn in_dunder_init(model: &SemanticModel, settings: &Settings) -> bool
             &settings.pep8_naming.classmethod_decorators,
             &settings.pep8_naming.staticmethod_decorators,
         ),
-        FunctionType::Method
+        function_type::FunctionType::Method
     ) {
         return false;
     }

--- a/crates/ruff/src/rules/pylint/helpers.rs
+++ b/crates/ruff/src/rules/pylint/helpers.rs
@@ -1,7 +1,7 @@
 use ruff_python_semantic::analyze::function_type;
 use ruff_python_semantic::analyze::function_type::FunctionType;
-use ruff_python_semantic::model::SemanticModel;
-use ruff_python_semantic::scope::ScopeKind;
+use ruff_python_semantic::ScopeKind;
+use ruff_python_semantic::SemanticModel;
 use rustpython_parser::ast;
 use rustpython_parser::ast::Cmpop;
 use std::fmt;

--- a/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
@@ -4,7 +4,7 @@ use rustpython_parser::ast::{self, Expr, Keyword, Ranged};
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::has_comments;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::{checkers::ast::Checker, registry::AsRule};
 

--- a/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
+++ b/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
@@ -8,7 +8,7 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::ComparableExpr;
 use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 use ruff_python_ast::types::Node;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -7,7 +7,7 @@ use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::is_dunder;
 use ruff_python_ast::source_code::Generator;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 use ruff_python_stdlib::identifiers::is_identifier;
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -7,7 +7,7 @@ use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::is_dunder;
 use ruff_python_ast::source_code::Generator;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 use ruff_python_stdlib::identifiers::is_identifier;
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -4,7 +4,7 @@ use rustpython_parser::ast::{self, Excepthandler, Expr, ExprContext, Ranged};
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::compose_call_path;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;

--- a/crates/ruff/src/rules/ruff/rules/helpers.rs
+++ b/crates/ruff/src/rules/ruff/rules/helpers.rs
@@ -1,7 +1,7 @@
 use ruff_python_ast::helpers::map_callable;
 use rustpython_parser::ast::{self, Expr};
 
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 pub(super) fn is_mutable_expr(expr: &Expr) -> bool {
     matches!(

--- a/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
@@ -5,7 +5,7 @@ use rustpython_parser::ast::{self, Arguments, Constant, Expr, Operator, Ranged};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 use ruff_text_size::TextRange;
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/tryceratops/helpers.rs
+++ b/crates/ruff/src/rules/tryceratops/helpers.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{self, Expr};
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_semantic::analyze::logging;
-use ruff_python_semantic::model::SemanticModel;
+use ruff_python_semantic::SemanticModel;
 
 /// Collect `logging`-like calls from an AST.
 pub(super) struct LoggerCandidateVisitor<'a, 'b> {

--- a/crates/ruff_python_semantic/src/lib.rs
+++ b/crates/ruff_python_semantic/src/lib.rs
@@ -1,9 +1,18 @@
 pub mod analyze;
-pub mod binding;
-pub mod context;
-pub mod definition;
-pub mod globals;
-pub mod model;
-pub mod node;
-pub mod reference;
-pub mod scope;
+mod binding;
+mod context;
+mod definition;
+mod globals;
+mod model;
+mod node;
+mod reference;
+mod scope;
+
+pub use binding::*;
+pub use context::*;
+pub use definition::*;
+pub use globals::*;
+pub use model::*;
+pub use node::*;
+pub use reference::*;
+pub use scope::*;

--- a/crates/ruff_python_semantic/src/node.rs
+++ b/crates/ruff_python_semantic/src/node.rs
@@ -28,7 +28,7 @@ struct Node<'a> {
 
 /// The nodes of a program indexed by [`NodeId`]
 #[derive(Debug, Default)]
-pub struct Nodes<'a> {
+pub(crate) struct Nodes<'a> {
     nodes: IndexVec<NodeId, Node<'a>>,
     node_to_id: FxHashMap<RefEquality<'a, Stmt>, NodeId>,
 }

--- a/crates/ruff_python_semantic/src/node.rs
+++ b/crates/ruff_python_semantic/src/node.rs
@@ -28,7 +28,7 @@ struct Node<'a> {
 
 /// The nodes of a program indexed by [`NodeId`]
 #[derive(Debug, Default)]
-pub(crate) struct Nodes<'a> {
+pub struct Nodes<'a> {
     nodes: IndexVec<NodeId, Node<'a>>,
     node_to_id: FxHashMap<RefEquality<'a, Stmt>, NodeId>,
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,0 @@
-edition = "2021"
-group_imports = "StdExternalCrate"
-unstable_features = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2021"
+group_imports = "StdExternalCrate"
+unstable_features = true


### PR DESCRIPTION
## Summary

This PR adds a more unified public API to `ruff_python_semantic`, so that we don't need to do deeply nested imports all over the place.