### PR TITLE
Use `matches!` for `CallPath` comparisons

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -3566,19 +3566,20 @@ where
                         .match_typing_call_path(&call_path, "TypedDict")
                     {
                         Some(typing::Callable::TypedDict)
-                    } else if [
-                        "Arg",
-                        "DefaultArg",
-                        "NamedArg",
-                        "DefaultNamedArg",
-                        "VarArg",
-                        "KwArg",
-                    ]
-                    .iter()
-                    .any(|target| call_path.as_slice() == ["mypy_extensions", target])
-                    {
+                    } else if matches!(
+                        call_path.as_slice(),
+                        [
+                            "mypy_extensions",
+                            "Arg"
+                                | "DefaultArg"
+                                | "NamedArg"
+                                | "DefaultNamedArg"
+                                | "VarArg"
+                                | "KwArg"
+                        ]
+                    ) {
                         Some(typing::Callable::MypyExtension)
-                    } else if call_path.as_slice() == ["", "bool"] {
+                    } else if matches!(call_path.as_slice(), ["", "bool"]) {
                         Some(typing::Callable::Bool)
                     } else {
                         None

--- a/crates/ruff/src/rules/flake8_2020/rules/name_or_attribute.rs
+++ b/crates/ruff/src/rules/flake8_2020/rules/name_or_attribute.rs
@@ -20,7 +20,9 @@ pub(crate) fn name_or_attribute(checker: &mut Checker, expr: &Expr) {
     if checker
         .semantic()
         .resolve_call_path(expr)
-        .map_or(false, |call_path| call_path.as_slice() == ["six", "PY3"])
+        .map_or(false, |call_path| {
+            matches!(call_path.as_slice(), ["six", "PY3"])
+        })
     {
         checker
             .diagnostics

--- a/crates/ruff/src/rules/flake8_bandit/helpers.rs
+++ b/crates/ruff/src/rules/flake8_bandit/helpers.rs
@@ -29,16 +29,14 @@ pub(super) fn is_untyped_exception(type_: Option<&Expr>, semantic: &SemanticMode
                 semantic
                     .resolve_call_path(type_)
                     .map_or(false, |call_path| {
-                        call_path.as_slice() == ["", "Exception"]
-                            || call_path.as_slice() == ["", "BaseException"]
+                        matches!(call_path.as_slice(), ["", "Exception" | "BaseException"])
                     })
             })
         } else {
             semantic
                 .resolve_call_path(type_)
                 .map_or(false, |call_path| {
-                    call_path.as_slice() == ["", "Exception"]
-                        || call_path.as_slice() == ["", "BaseException"]
+                    matches!(call_path.as_slice(), ["", "Exception" | "BaseException"])
                 })
         }
     })

--- a/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
@@ -110,7 +110,9 @@ pub(crate) fn bad_file_permissions(
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| call_path.as_slice() == ["os", "chmod"])
+        .map_or(false, |call_path| {
+            matches!(call_path.as_slice(), ["os", "chmod"])
+        })
     {
         let call_args = SimpleCallArgs::new(args, keywords);
         if let Some(mode_arg) = call_args.argument("mode", 1) {

--- a/crates/ruff/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
@@ -52,7 +52,7 @@ pub(crate) fn hashlib_insecure_hash_functions(
         .semantic()
         .resolve_call_path(func)
         .and_then(|call_path| {
-            if call_path.as_slice() == ["hashlib", "new"] {
+            if matches!(call_path.as_slice(), ["hashlib", "new"]) {
                 Some(HashlibCall::New)
             } else {
                 WEAK_HASHES

--- a/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -40,7 +40,7 @@ pub(crate) fn jinja2_autoescape_false(
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["jinja2", "Environment"]
+            matches!(call_path.as_slice(), ["jinja2", "Environment"])
         })
     {
         let call_args = SimpleCallArgs::new(args, keywords);

--- a/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
@@ -27,7 +27,7 @@ pub(crate) fn logging_config_insecure_listen(
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["logging", "config", "listen"]
+            matches!(call_path.as_slice(), ["logging", "config", "listen"])
         })
     {
         let call_args = SimpleCallArgs::new(args, keywords);

--- a/crates/ruff/src/rules/flake8_bandit/rules/paramiko_calls.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/paramiko_calls.rs
@@ -21,7 +21,7 @@ pub(crate) fn paramiko_call(checker: &mut Checker, func: &Expr) {
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["paramiko", "exec_command"]
+            matches!(call_path.as_slice(), ["paramiko", "exec_command"])
         })
     {
         checker

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
@@ -28,7 +28,7 @@ pub(crate) fn snmp_insecure_version(
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["pysnmp", "hlapi", "CommunityData"]
+            matches!(call_path.as_slice(), ["pysnmp", "hlapi", "CommunityData"])
         })
     {
         let call_args = SimpleCallArgs::new(args, keywords);

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
@@ -30,7 +30,7 @@ pub(crate) fn snmp_weak_cryptography(
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["pysnmp", "hlapi", "UsmUserData"]
+            matches!(call_path.as_slice(), ["pysnmp", "hlapi", "UsmUserData"])
         })
     {
         let call_args = SimpleCallArgs::new(args, keywords);

--- a/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
@@ -40,7 +40,9 @@ pub(crate) fn unsafe_yaml_load(
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| call_path.as_slice() == ["yaml", "load"])
+        .map_or(false, |call_path| {
+            matches!(call_path.as_slice(), ["yaml", "load"])
+        })
     {
         let call_args = SimpleCallArgs::new(args, keywords);
         if let Some(loader_arg) = call_args.argument("Loader", 1) {
@@ -48,8 +50,7 @@ pub(crate) fn unsafe_yaml_load(
                 .semantic()
                 .resolve_call_path(loader_arg)
                 .map_or(false, |call_path| {
-                    call_path.as_slice() == ["yaml", "SafeLoader"]
-                        || call_path.as_slice() == ["yaml", "CSafeLoader"]
+                    matches!(call_path.as_slice(), ["yaml", "SafeLoader" | "CSafeLoader"])
                 })
             {
                 let loader = match loader_arg {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -42,12 +42,12 @@ fn is_abc_class(bases: &[Expr], keywords: &[Keyword], semantic: &SemanticModel) 
             && semantic
                 .resolve_call_path(&keyword.value)
                 .map_or(false, |call_path| {
-                    call_path.as_slice() == ["abc", "ABCMeta"]
+                    matches!(call_path.as_slice(), ["abc", "ABCMeta"])
                 })
     }) || bases.iter().any(|base| {
-        semantic
-            .resolve_call_path(base)
-            .map_or(false, |call_path| call_path.as_slice() == ["abc", "ABC"])
+        semantic.resolve_call_path(base).map_or(false, |call_path| {
+            matches!(call_path.as_slice(), ["abc", "ABC"])
+        })
     })
 }
 

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -68,7 +68,9 @@ pub(crate) fn assert_raises_exception(checker: &mut Checker, stmt: &Stmt, items:
     if !checker
         .semantic()
         .resolve_call_path(args.first().unwrap())
-        .map_or(false, |call_path| call_path.as_slice() == ["", "Exception"])
+        .map_or(false, |call_path| {
+            matches!(call_path.as_slice(), ["", "Exception"])
+        })
     {
         return;
     }
@@ -81,7 +83,7 @@ pub(crate) fn assert_raises_exception(checker: &mut Checker, stmt: &Stmt, items:
             .semantic()
             .resolve_call_path(func)
             .map_or(false, |call_path| {
-                call_path.as_slice() == ["pytest", "raises"]
+                matches!(call_path.as_slice(), ["pytest", "raises"])
             })
             && !keywords
                 .iter()

--- a/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -20,8 +20,7 @@ impl Violation for CachedInstanceMethod {
 
 fn is_cache_func(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic.resolve_call_path(expr).map_or(false, |call_path| {
-        call_path.as_slice() == ["functools", "lru_cache"]
-            || call_path.as_slice() == ["functools", "cache"]
+        matches!(call_path.as_slice(), ["functools", "lru_cache" | "cache"])
     })
 }
 

--- a/crates/ruff/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
@@ -48,7 +48,7 @@ pub(crate) fn no_explicit_stacklevel(
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["warnings", "warn"]
+            matches!(call_path.as_slice(), ["warnings", "warn"])
         })
     {
         return;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
@@ -345,7 +345,7 @@ pub(crate) fn reuse_of_groupby_generator(
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["itertools", "groupby"]
+            matches!(call_path.as_slice(), ["itertools", "groupby"])
         })
     {
         return;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
@@ -30,7 +30,7 @@ pub(crate) fn useless_contextlib_suppress(
             .semantic()
             .resolve_call_path(func)
             .map_or(false, |call_path| {
-                call_path.as_slice() == ["contextlib", "suppress"]
+                matches!(call_path.as_slice(), ["contextlib", "suppress"])
             })
     {
         checker

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_date_fromtimestamp.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_date_fromtimestamp.rs
@@ -30,7 +30,7 @@ pub(crate) fn call_date_fromtimestamp(checker: &mut Checker, func: &Expr, locati
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["datetime", "date", "fromtimestamp"]
+            matches!(call_path.as_slice(), ["datetime", "date", "fromtimestamp"])
         })
     {
         checker

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_date_today.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_date_today.rs
@@ -30,7 +30,7 @@ pub(crate) fn call_date_today(checker: &mut Checker, func: &Expr, location: Text
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["datetime", "date", "today"]
+            matches!(call_path.as_slice(), ["datetime", "date", "today"])
         })
     {
         checker

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
@@ -31,7 +31,10 @@ pub(crate) fn call_datetime_fromtimestamp(
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["datetime", "datetime", "fromtimestamp"]
+            matches!(
+                call_path.as_slice(),
+                ["datetime", "datetime", "fromtimestamp"]
+            )
         })
     {
         return;

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
@@ -29,7 +29,7 @@ pub(crate) fn call_datetime_now_without_tzinfo(
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["datetime", "datetime", "now"]
+            matches!(call_path.as_slice(), ["datetime", "datetime", "now"])
         })
     {
         return;

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
@@ -31,7 +31,7 @@ pub(crate) fn call_datetime_strptime_without_zone(
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["datetime", "datetime", "strptime"]
+            matches!(call_path.as_slice(), ["datetime", "datetime", "strptime"])
         })
     {
         return;

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_today.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_today.rs
@@ -30,7 +30,7 @@ pub(crate) fn call_datetime_today(checker: &mut Checker, func: &Expr, location: 
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["datetime", "datetime", "today"]
+            matches!(call_path.as_slice(), ["datetime", "datetime", "today"])
         })
     {
         checker

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
@@ -37,7 +37,10 @@ pub(crate) fn call_datetime_utcfromtimestamp(
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["datetime", "datetime", "utcfromtimestamp"]
+            matches!(
+                call_path.as_slice(),
+                ["datetime", "datetime", "utcfromtimestamp"]
+            )
         })
     {
         checker

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_utcnow.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_utcnow.rs
@@ -32,7 +32,7 @@ pub(crate) fn call_datetime_utcnow(checker: &mut Checker, func: &Expr, location:
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["datetime", "datetime", "utcnow"]
+            matches!(call_path.as_slice(), ["datetime", "datetime", "utcnow"])
         })
     {
         checker

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
@@ -28,7 +28,7 @@ pub(crate) fn call_datetime_without_tzinfo(
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["datetime", "datetime"]
+            matches!(call_path.as_slice(), ["datetime", "datetime"])
         })
     {
         return;

--- a/crates/ruff/src/rules/flake8_django/rules/helpers.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/helpers.rs
@@ -5,15 +5,17 @@ use ruff_python_semantic::SemanticModel;
 /// Return `true` if a Python class appears to be a Django model, based on its base classes.
 pub(super) fn is_model(base: &Expr, semantic: &SemanticModel) -> bool {
     semantic.resolve_call_path(base).map_or(false, |call_path| {
-        call_path.as_slice() == ["django", "db", "models", "Model"]
+        matches!(call_path.as_slice(), ["django", "db", "models", "Model"])
     })
 }
 
 /// Return `true` if a Python class appears to be a Django model form, based on its base classes.
 pub(super) fn is_model_form(base: &Expr, semantic: &SemanticModel) -> bool {
     semantic.resolve_call_path(base).map_or(false, |call_path| {
-        call_path.as_slice() == ["django", "forms", "ModelForm"]
-            || call_path.as_slice() == ["django", "forms", "models", "ModelForm"]
+        matches!(
+            call_path.as_slice(),
+            ["django", "forms", "ModelForm"] | ["django", "forms", "models", "ModelForm"]
+        )
     })
 }
 

--- a/crates/ruff/src/rules/flake8_django/rules/locals_in_render_function.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/locals_in_render_function.rs
@@ -54,7 +54,7 @@ pub(crate) fn locals_in_render_function(
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["django", "shortcuts", "render"]
+            matches!(call_path.as_slice(), ["django", "shortcuts", "render"])
         })
     {
         return;
@@ -87,7 +87,7 @@ fn is_locals_call(expr: &Expr, semantic: &SemanticModel) -> bool {
     let Expr::Call(ast::ExprCall { func, .. }) = expr else {
         return false
     };
-    semantic
-        .resolve_call_path(func)
-        .map_or(false, |call_path| call_path.as_slice() == ["", "locals"])
+    semantic.resolve_call_path(func).map_or(false, |call_path| {
+        matches!(call_path.as_slice(), ["", "locals"])
+    })
 }

--- a/crates/ruff/src/rules/flake8_django/rules/non_leading_receiver_decorator.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/non_leading_receiver_decorator.rs
@@ -61,7 +61,7 @@ where
         let is_receiver = match &decorator.expression {
             Expr::Call(ast::ExprCall { func, .. }) => resolve_call_path(func)
                 .map_or(false, |call_path| {
-                    call_path.as_slice() == ["django", "dispatch", "receiver"]
+                    matches!(call_path.as_slice(), ["django", "dispatch", "receiver"])
                 }),
             _ => false,
         };

--- a/crates/ruff/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -108,7 +108,9 @@ fn check_log_record_attr_clash(checker: &mut Checker, extra: &Keyword) {
             if checker
                 .semantic()
                 .resolve_call_path(func)
-                .map_or(false, |call_path| call_path.as_slice() == ["", "dict"])
+                .map_or(false, |call_path| {
+                    matches!(call_path.as_slice(), ["", "dict"])
+                })
             {
                 for keyword in keywords {
                     if let Some(key) = &keyword.arg {

--- a/crates/ruff/src/rules/flake8_pie/rules/non_unique_enums.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules/non_unique_enums.rs
@@ -68,7 +68,9 @@ pub(crate) fn non_unique_enums<'a, 'b>(
         checker
             .semantic()
             .resolve_call_path(expr)
-            .map_or(false, |call_path| call_path.as_slice() == ["enum", "Enum"])
+            .map_or(false, |call_path| {
+                matches!(call_path.as_slice(), ["enum", "Enum"])
+            })
     }) {
         return;
     }
@@ -83,7 +85,9 @@ pub(crate) fn non_unique_enums<'a, 'b>(
             if checker
                 .semantic()
                 .resolve_call_path(func)
-                .map_or(false, |call_path| call_path.as_slice() == ["enum", "auto"])
+                .map_or(false, |call_path| {
+                    matches!(call_path.as_slice(), ["enum", "auto"])
+                })
             {
                 continue;
             }

--- a/crates/ruff/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff/src/rules/flake8_print/rules/print_call.rs
@@ -79,10 +79,9 @@ impl Violation for PPrint {
 pub(crate) fn print_call(checker: &mut Checker, func: &Expr, keywords: &[Keyword]) {
     let diagnostic = {
         let call_path = checker.semantic().resolve_call_path(func);
-        if call_path
-            .as_ref()
-            .map_or(false, |call_path| *call_path.as_slice() == ["", "print"])
-        {
+        if call_path.as_ref().map_or(false, |call_path| {
+            matches!(call_path.as_slice(), ["", "print"])
+        }) {
             // If the print call has a `file=` argument (that isn't `None`, `"sys.stdout"`,
             // or `"sys.stderr"`), don't trigger T201.
             if let Some(keyword) = keywords
@@ -103,7 +102,7 @@ pub(crate) fn print_call(checker: &mut Checker, func: &Expr, keywords: &[Keyword
             }
             Diagnostic::new(Print, func.range())
         } else if call_path.as_ref().map_or(false, |call_path| {
-            *call_path.as_slice() == ["pprint", "pprint"]
+            matches!(call_path.as_slice(), ["pprint", "pprint"])
         }) {
             Diagnostic::new(PPrint, func.range())
         } else {

--- a/crates/ruff/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
@@ -72,7 +72,7 @@ pub(crate) fn bad_version_info_comparison(
         .semantic()
         .resolve_call_path(left)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["sys", "version_info"]
+            matches!(call_path.as_slice(), ["sys", "version_info"])
         })
     {
         return;

--- a/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -106,7 +106,7 @@ pub(crate) fn unrecognized_platform(
         .semantic()
         .resolve_call_path(left)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["sys", "platform"]
+            matches!(call_path.as_slice(), ["sys", "platform"])
         })
     {
         return;

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -233,7 +233,7 @@ where
             }
             Expr::Call(ast::ExprCall { func, .. }) => {
                 if collect_call_path(func).map_or(false, |call_path| {
-                    call_path.as_slice() == ["request", "addfinalizer"]
+                    matches!(call_path.as_slice(), ["request", "addfinalizer"])
                 }) {
                     self.addfinalizer_call = Some(expr);
                 };

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -22,7 +22,7 @@ pub(super) fn get_mark_decorators(
 
 pub(super) fn is_pytest_fail(call: &Expr, semantic: &SemanticModel) -> bool {
     semantic.resolve_call_path(call).map_or(false, |call_path| {
-        call_path.as_slice() == ["pytest", "fail"]
+        matches!(call_path.as_slice(), ["pytest", "fail"])
     })
 }
 
@@ -30,7 +30,7 @@ pub(super) fn is_pytest_fixture(decorator: &Decorator, semantic: &SemanticModel)
     semantic
         .resolve_call_path(map_callable(&decorator.expression))
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["pytest", "fixture"]
+            matches!(call_path.as_slice(), ["pytest", "fixture"])
         })
 }
 
@@ -38,7 +38,7 @@ pub(super) fn is_pytest_yield_fixture(decorator: &Decorator, semantic: &Semantic
     semantic
         .resolve_call_path(map_callable(&decorator.expression))
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["pytest", "yield_fixture"]
+            matches!(call_path.as_slice(), ["pytest", "yield_fixture"])
         })
 }
 
@@ -46,7 +46,7 @@ pub(super) fn is_pytest_parametrize(decorator: &Decorator, semantic: &SemanticMo
     semantic
         .resolve_call_path(map_callable(&decorator.expression))
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["pytest", "mark", "parametrize"]
+            matches!(call_path.as_slice(), ["pytest", "mark", "parametrize"])
         })
 }
 

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
@@ -49,7 +49,7 @@ impl Violation for PytestRaisesWithoutException {
 
 fn is_pytest_raises(func: &Expr, semantic: &SemanticModel) -> bool {
     semantic.resolve_call_path(func).map_or(false, |call_path| {
-        call_path.as_slice() == ["pytest", "raises"]
+        matches!(call_path.as_slice(), ["pytest", "raises"])
     })
 }
 

--- a/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
@@ -136,16 +136,13 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
             if let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() {
                 // Ignore `super()` calls.
                 if let Some(call_path) = collect_call_path(func) {
-                    if call_path.as_slice() == ["super"] {
+                    if matches!(call_path.as_slice(), ["super"]) {
                         return;
                     }
                 }
             } else if let Some(call_path) = collect_call_path(value) {
                 // Ignore `self` and `cls` accesses.
-                if call_path.as_slice() == ["self"]
-                    || call_path.as_slice() == ["cls"]
-                    || call_path.as_slice() == ["mcs"]
-                {
+                if matches!(call_path.as_slice(), ["self" | "cls" | "mcs"]) {
                     return;
                 }
 

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -115,8 +115,10 @@ pub(crate) fn use_capital_environment_variables(checker: &mut Checker, expr: &Ex
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["os", "environ", "get"]
-                || call_path.as_slice() == ["os", "getenv"]
+            matches!(
+                call_path.as_slice(),
+                ["os", "environ", "get"] | ["os", "getenv"]
+            )
         })
     {
         return;

--- a/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -63,7 +63,7 @@ fn match_async_exit_stack(semantic: &SemanticModel) -> bool {
             for item in items {
                 if let Expr::Call(ast::ExprCall { func, .. }) = &item.context_expr {
                     if semantic.resolve_call_path(func).map_or(false, |call_path| {
-                        call_path.as_slice() == ["contextlib", "AsyncExitStack"]
+                        matches!(call_path.as_slice(), ["contextlib", "AsyncExitStack"])
                     }) {
                         return true;
                     }
@@ -94,7 +94,7 @@ fn match_exit_stack(semantic: &SemanticModel) -> bool {
             for item in items {
                 if let Expr::Call(ast::ExprCall { func, .. }) = &item.context_expr {
                     if semantic.resolve_call_path(func).map_or(false, |call_path| {
-                        call_path.as_slice() == ["contextlib", "ExitStack"]
+                        matches!(call_path.as_slice(), ["contextlib", "ExitStack"])
                     }) {
                         return true;
                     }
@@ -110,7 +110,9 @@ pub(crate) fn open_file_with_context_handler(checker: &mut Checker, func: &Expr)
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| call_path.as_slice() == ["", "open"])
+        .map_or(false, |call_path| {
+            matches!(call_path.as_slice(), ["", "open"])
+        })
     {
         if checker.semantic().is_builtin("open") {
             // Ex) `with open("foo.txt") as f: ...`

--- a/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
+++ b/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
@@ -52,15 +52,13 @@ pub(crate) fn deprecated_type_alias(checker: &mut Checker, expr: &Expr) {
         .semantic()
         .resolve_call_path(expr)
         .and_then(|call_path| {
-            if call_path.as_slice() == ["numpy", "bool"]
-                || call_path.as_slice() == ["numpy", "int"]
-                || call_path.as_slice() == ["numpy", "float"]
-                || call_path.as_slice() == ["numpy", "complex"]
-                || call_path.as_slice() == ["numpy", "object"]
-                || call_path.as_slice() == ["numpy", "str"]
-                || call_path.as_slice() == ["numpy", "long"]
-                || call_path.as_slice() == ["numpy", "unicode"]
-            {
+            if matches!(
+                call_path.as_slice(),
+                [
+                    "numpy",
+                    "bool" | "int" | "float" | "complex" | "object" | "str" | "long" | "unicode"
+                ]
+            ) {
                 Some(call_path[1])
             } else {
                 None

--- a/crates/ruff/src/rules/numpy/rules/numpy_legacy_random.rs
+++ b/crates/ruff/src/rules/numpy/rules/numpy_legacy_random.rs
@@ -63,58 +63,64 @@ pub(crate) fn numpy_legacy_random(checker: &mut Checker, expr: &Expr) {
         .resolve_call_path(expr)
         .and_then(|call_path| {
             // seeding state
-            if call_path.as_slice() == ["numpy", "random", "seed"]
-            || call_path.as_slice() == ["numpy", "random", "get_state"]
-            || call_path.as_slice() == ["numpy", "random", "set_state"]
-            // simple random data
-            || call_path.as_slice() == ["numpy", "random", "rand"]
-            || call_path.as_slice() == ["numpy", "random", "randn"]
-            || call_path.as_slice() == ["numpy", "random", "randint"]
-            || call_path.as_slice() == ["numpy", "random", "random_integers"]
-            || call_path.as_slice() == ["numpy", "random", "random_sample"]
-            || call_path.as_slice() == ["numpy", "random", "choice"]
-            || call_path.as_slice() == ["numpy", "random", "bytes"]
-            // permutations
-            || call_path.as_slice() == ["numpy", "random", "shuffle"]
-            || call_path.as_slice() == ["numpy", "random", "permutation"]
-            // distributions
-            || call_path.as_slice() == ["numpy", "random", "beta"]
-            || call_path.as_slice() == ["numpy", "random", "binomial"]
-            || call_path.as_slice() == ["numpy", "random", "chisquare"]
-            || call_path.as_slice() == ["numpy", "random", "dirichlet"]
-            || call_path.as_slice() == ["numpy", "random", "exponential"]
-            || call_path.as_slice() == ["numpy", "random", "f"]
-            || call_path.as_slice() == ["numpy", "random", "gamma"]
-            || call_path.as_slice() == ["numpy", "random", "geometric"]
-            || call_path.as_slice() == ["numpy", "random", "get_state"]
-            || call_path.as_slice() == ["numpy", "random", "gumbel"]
-            || call_path.as_slice() == ["numpy", "random", "hypergeometric"]
-            || call_path.as_slice() == ["numpy", "random", "laplace"]
-            || call_path.as_slice() == ["numpy", "random", "logistic"]
-            || call_path.as_slice() == ["numpy", "random", "lognormal"]
-            || call_path.as_slice() == ["numpy", "random", "logseries"]
-            || call_path.as_slice() == ["numpy", "random", "multinomial"]
-            || call_path.as_slice() == ["numpy", "random", "multivariate_normal"]
-            || call_path.as_slice() == ["numpy", "random", "negative_binomial"]
-            || call_path.as_slice() == ["numpy", "random", "noncentral_chisquare"]
-            || call_path.as_slice() == ["numpy", "random", "noncentral_f"]
-            || call_path.as_slice() == ["numpy", "random", "normal"]
-            || call_path.as_slice() == ["numpy", "random", "pareto"]
-            || call_path.as_slice() == ["numpy", "random", "poisson"]
-            || call_path.as_slice() == ["numpy", "random", "power"]
-            || call_path.as_slice() == ["numpy", "random", "rayleigh"]
-            || call_path.as_slice() == ["numpy", "random", "standard_cauchy"]
-            || call_path.as_slice() == ["numpy", "random", "standard_exponential"]
-            || call_path.as_slice() == ["numpy", "random", "standard_gamma"]
-            || call_path.as_slice() == ["numpy", "random", "standard_normal"]
-            || call_path.as_slice() == ["numpy", "random", "standard_t"]
-            || call_path.as_slice() == ["numpy", "random", "triangular"]
-            || call_path.as_slice() == ["numpy", "random", "uniform"]
-            || call_path.as_slice() == ["numpy", "random", "vonmises"]
-            || call_path.as_slice() == ["numpy", "random", "wald"]
-            || call_path.as_slice() == ["numpy", "random", "weibull"]
-            || call_path.as_slice() == ["numpy", "random", "zipf"]
-            {
+            if matches!(
+                call_path.as_slice(),
+                [
+                    "numpy",
+                    "random",
+                    // Seeds
+                    "seed" |
+                    "get_state" |
+                    "set_state" |
+                    // Simple random data
+                    "rand" |
+                    "randn" |
+                    "randint" |
+                    "random_integers" |
+                    "random_sample" |
+                    "choice" |
+                    "bytes" |
+                    // Permutations
+                    "shuffle" |
+                    "permutation" |
+                    // Distributions
+                    "beta" |
+                    "binomial" |
+                    "chisquare" |
+                    "dirichlet" |
+                    "exponential" |
+                    "f" |
+                    "gamma" |
+                    "geometric" |
+                    "gumbel" |
+                    "hypergeometric" |
+                    "laplace" |
+                    "logistic" |
+                    "lognormal" |
+                    "logseries" |
+                    "multinomial" |
+                    "multivariate_normal" |
+                    "negative_binomial" |
+                    "noncentral_chisquare" |
+                    "noncentral_f" |
+                    "normal" |
+                    "pareto" |
+                    "poisson" |
+                    "power" |
+                    "rayleigh" |
+                    "standard_cauchy" |
+                    "standard_exponential" |
+                    "standard_gamma" |
+                    "standard_normal" |
+                    "standard_t" |
+                    "triangular" |
+                    "uniform" |
+                    "vonmises" |
+                    "wald" |
+                    "weibull" |
+                    "zipf"
+                ]
+            ) {
                 Some(call_path[2])
             } else {
                 None

--- a/crates/ruff/src/rules/pep8_naming/helpers.rs
+++ b/crates/ruff/src/rules/pep8_naming/helpers.rs
@@ -45,7 +45,7 @@ pub(super) fn is_typed_dict_assignment(stmt: &Stmt, semantic: &SemanticModel) ->
         return false;
     };
     semantic.resolve_call_path(func).map_or(false, |call_path| {
-        call_path.as_slice() == ["typing", "TypedDict"]
+        matches!(call_path.as_slice(), ["typing", "TypedDict"])
     })
 }
 
@@ -57,8 +57,7 @@ pub(super) fn is_type_var_assignment(stmt: &Stmt, semantic: &SemanticModel) -> b
         return false;
     };
     semantic.resolve_call_path(func).map_or(false, |call_path| {
-        call_path.as_slice() == ["typing", "TypeVar"]
-            || call_path.as_slice() == ["typing", "NewType"]
+        matches!(call_path.as_slice(), ["typing", "TypeVar" | "NewType"])
     })
 }
 

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -134,7 +134,7 @@ fn extract_types(annotation: &Expr, semantic: &SemanticModel) -> Option<(Vec<Exp
     if !semantic
         .resolve_call_path(value)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["collections", "abc", "Callable"]
+            matches!(call_path.as_slice(), ["collections", "abc", "Callable"])
                 || semantic.match_typing_call_path(&call_path, "Callable")
         })
     {

--- a/crates/ruff/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
@@ -47,7 +47,7 @@ pub(crate) fn deprecated_log_warn(checker: &mut Checker, func: &Expr) {
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["logging", "warn"]
+            matches!(call_path.as_slice(), ["logging", "warn"])
         })
     {
         checker

--- a/crates/ruff/src/rules/pylint/rules/invalid_envvar_default.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_envvar_default.rs
@@ -86,7 +86,9 @@ pub(crate) fn invalid_envvar_default(
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| call_path.as_slice() == ["os", "getenv"])
+        .map_or(false, |call_path| {
+            matches!(call_path.as_slice(), ["os", "getenv"])
+        })
     {
         // Find the `default` argument, if it exists.
         let Some(expr) = args.get(1).or_else(|| {

--- a/crates/ruff/src/rules/pylint/rules/invalid_envvar_value.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_envvar_value.rs
@@ -83,7 +83,9 @@ pub(crate) fn invalid_envvar_value(
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| call_path.as_slice() == ["os", "getenv"])
+        .map_or(false, |call_path| {
+            matches!(call_path.as_slice(), ["os", "getenv"])
+        })
     {
         // Find the `key` argument, if it exists.
         let Some(expr) = args.get(0).or_else(|| {

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -52,9 +52,7 @@ fn match_named_tuple_assign<'a>(
     }) = value else {
         return None;
     };
-    if !semantic.resolve_call_path(func).map_or(false, |call_path| {
-        call_path.as_slice() == ["typing", "NamedTuple"]
-    }) {
+    if !semantic.match_typing_expr(func, "NamedTuple") {
         return None;
     }
     Some((typename, args, keywords, func))

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -52,9 +52,7 @@ fn match_typed_dict_assign<'a>(
     }) = value else {
         return None;
     };
-    if !semantic.resolve_call_path(func).map_or(false, |call_path| {
-        call_path.as_slice() == ["typing", "TypedDict"]
-    }) {
+    if !semantic.match_typing_expr(func, "TypedDict") {
         return None;
     }
     Some((class_name, args, keywords, func))

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -228,9 +228,9 @@ fn format_import_from(
 /// UP026
 pub(crate) fn deprecated_mock_attribute(checker: &mut Checker, expr: &Expr) {
     if let Expr::Attribute(ast::ExprAttribute { value, .. }) = expr {
-        if collect_call_path(value)
-            .map_or(false, |call_path| call_path.as_slice() == ["mock", "mock"])
-        {
+        if collect_call_path(value).map_or(false, |call_path| {
+            matches!(call_path.as_slice(), ["mock", "mock"])
+        }) {
             let mut diagnostic = Diagnostic::new(
                 DeprecatedMockImport {
                     reference_type: MockReference::Attribute,

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -41,7 +41,7 @@ pub(crate) fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list:
                 .semantic()
                 .resolve_call_path(func)
                 .map_or(false, |call_path| {
-                    call_path.as_slice() == ["functools", "lru_cache"]
+                    matches!(call_path.as_slice(), ["functools", "lru_cache"])
                 })
         {
             let Keyword {

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -40,7 +40,7 @@ pub(crate) fn lru_cache_without_parameters(checker: &mut Checker, decorator_list
                 .semantic()
                 .resolve_call_path(func)
                 .map_or(false, |call_path| {
-                    call_path.as_slice() == ["functools", "lru_cache"]
+                    matches!(call_path.as_slice(), ["functools", "lru_cache"])
                 })
         {
             let mut diagnostic = Diagnostic::new(

--- a/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
@@ -27,7 +27,9 @@ pub(crate) fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| call_path.as_slice() == ["io", "open"])
+        .map_or(false, |call_path| {
+            matches!(call_path.as_slice(), ["io", "open"])
+        })
     {
         let mut diagnostic = Diagnostic::new(OpenAlias, expr.range());
         if checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -49,9 +49,9 @@ fn is_alias(expr: &Expr, semantic: &SemanticModel) -> bool {
 
 /// Return `true` if an [`Expr`] is `OSError`.
 fn is_os_error(expr: &Expr, semantic: &SemanticModel) -> bool {
-    semantic
-        .resolve_call_path(expr)
-        .map_or(false, |call_path| call_path.as_slice() == ["", "OSError"])
+    semantic.resolve_call_path(expr).map_or(false, |call_path| {
+        matches!(call_path.as_slice(), ["", "OSError"])
+    })
 }
 
 /// Create a [`Diagnostic`] for a single target, like an [`Expr::Name`].

--- a/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -339,7 +339,7 @@ pub(crate) fn outdated_version_block(
         .semantic()
         .resolve_call_path(left)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["sys", "version_info"]
+            matches!(call_path.as_slice(), ["sys", "version_info"])
         })
     {
         return;

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -64,7 +64,7 @@ pub(crate) fn replace_stdout_stderr(
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["subprocess", "run"]
+            matches!(call_path.as_slice(), ["subprocess", "run"])
         })
     {
         // Find `stdout` and `stderr` kwargs.
@@ -80,13 +80,13 @@ pub(crate) fn replace_stdout_stderr(
             .semantic()
             .resolve_call_path(&stdout.value)
             .map_or(false, |call_path| {
-                call_path.as_slice() == ["subprocess", "PIPE"]
+                matches!(call_path.as_slice(), ["subprocess", "PIPE"])
             })
             || !checker
                 .semantic()
                 .resolve_call_path(&stderr.value)
                 .map_or(false, |call_path| {
-                    call_path.as_slice() == ["subprocess", "PIPE"]
+                    matches!(call_path.as_slice(), ["subprocess", "PIPE"])
                 })
         {
             return;

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -28,7 +28,7 @@ pub(crate) fn replace_universal_newlines(checker: &mut Checker, func: &Expr, kwa
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["subprocess", "run"]
+            matches!(call_path.as_slice(), ["subprocess", "run"])
         })
     {
         let Some(kwarg) = find_keyword(kwargs, "universal_newlines") else { return; };

--- a/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
@@ -34,7 +34,9 @@ pub(crate) fn type_of_primitive(checker: &mut Checker, expr: &Expr, func: &Expr,
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| call_path.as_slice() == ["", "type"])
+        .map_or(false, |call_path| {
+            matches!(call_path.as_slice(), ["", "type"])
+        })
     {
         return;
     }

--- a/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -26,7 +26,7 @@ pub(crate) fn typing_text_str_alias(checker: &mut Checker, expr: &Expr) {
         .semantic()
         .resolve_call_path(expr)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["typing", "Text"]
+            matches!(call_path.as_slice(), ["typing", "Text"])
         })
     {
         let mut diagnostic = Diagnostic::new(TypingTextStrAlias, expr.range());

--- a/crates/ruff/src/rules/ruff/rules/helpers.rs
+++ b/crates/ruff/src/rules/ruff/rules/helpers.rs
@@ -39,7 +39,7 @@ pub(super) fn is_dataclass(class_def: &ast::StmtClassDef, semantic: &SemanticMod
         semantic
             .resolve_call_path(map_callable(&decorator.expression))
             .map_or(false, |call_path| {
-                call_path.as_slice() == ["dataclasses", "dataclass"]
+                matches!(call_path.as_slice(), ["dataclasses", "dataclass"])
             })
     })
 }

--- a/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_class.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_class.rs
@@ -69,7 +69,9 @@ pub(crate) fn raise_vanilla_class(checker: &mut Checker, expr: &Expr) {
         } else {
             expr
         })
-        .map_or(false, |call_path| call_path.as_slice() == ["", "Exception"])
+        .map_or(false, |call_path| {
+            matches!(call_path.as_slice(), ["", "Exception"])
+        })
     {
         checker
             .diagnostics

--- a/crates/ruff/src/rules/tryceratops/rules/type_check_without_type_error.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/type_check_without_type_error.rs
@@ -80,9 +80,10 @@ fn check_type_check_call(checker: &mut Checker, call: &Expr) -> bool {
         .semantic()
         .resolve_call_path(call)
         .map_or(false, |call_path| {
-            call_path.as_slice() == ["", "isinstance"]
-                || call_path.as_slice() == ["", "issubclass"]
-                || call_path.as_slice() == ["", "callable"]
+            matches!(
+                call_path.as_slice(),
+                ["", "isinstance" | "issubclass", "callable"]
+            )
         })
 }
 
@@ -104,25 +105,27 @@ fn is_builtin_exception(checker: &mut Checker, exc: &Expr) -> bool {
         .semantic()
         .resolve_call_path(exc)
         .map_or(false, |call_path| {
-            [
-                "ArithmeticError",
-                "AssertionError",
-                "AttributeError",
-                "BufferError",
-                "EOFError",
-                "Exception",
-                "ImportError",
-                "LookupError",
-                "MemoryError",
-                "NameError",
-                "ReferenceError",
-                "RuntimeError",
-                "SyntaxError",
-                "SystemError",
-                "ValueError",
-            ]
-            .iter()
-            .any(|target| call_path.as_slice() == ["", target])
+            matches!(
+                call_path.as_slice(),
+                [
+                    "",
+                    "ArithmeticError"
+                        | "AssertionError"
+                        | "AttributeError"
+                        | "BufferError"
+                        | "EOFError"
+                        | "Exception"
+                        | "ImportError"
+                        | "LookupError"
+                        | "MemoryError"
+                        | "NameError"
+                        | "ReferenceError"
+                        | "RuntimeError"
+                        | "SyntaxError"
+                        | "SystemError"
+                        | "ValueError"
+                ]
+            )
         });
 }
 

--- a/crates/ruff/src/rules/tryceratops/rules/type_check_without_type_error.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/type_check_without_type_error.rs
@@ -82,7 +82,7 @@ fn check_type_check_call(checker: &mut Checker, call: &Expr) -> bool {
         .map_or(false, |call_path| {
             matches!(
                 call_path.as_slice(),
-                ["", "isinstance" | "issubclass", "callable"]
+                ["", "isinstance" | "issubclass" | "callable"]
             )
         })
 }

--- a/crates/ruff_python_semantic/src/analyze/function_type.rs
+++ b/crates/ruff_python_semantic/src/analyze/function_type.rs
@@ -35,7 +35,7 @@ pub fn classify(
         semantic
             .resolve_call_path(map_callable(&decorator.expression))
             .map_or(false, |call_path| {
-                call_path.as_slice() == ["", "staticmethod"]
+                matches!(call_path.as_slice(), ["", "staticmethod"])
                     || staticmethod_decorators
                         .iter()
                         .any(|decorator| call_path == from_qualified_name(decorator))
@@ -55,7 +55,7 @@ pub fn classify(
         || decorator_list.iter().any(|decorator| {
             // The method is decorated with a class method decorator (like `@classmethod`).
             semantic.resolve_call_path(map_callable(&decorator.expression)).map_or(false, |call_path| {
-                call_path.as_slice() == ["", "classmethod"] ||
+                matches!(call_path.as_slice(), ["", "classmethod"]) ||
                 classmethod_decorators
                     .iter()
                     .any(|decorator| call_path == from_qualified_name(decorator))

--- a/crates/ruff_python_semantic/src/analyze/logging.rs
+++ b/crates/ruff_python_semantic/src/analyze/logging.rs
@@ -58,7 +58,7 @@ pub fn exc_info<'a>(keywords: &'a [Keyword], semantic: &SemanticModel) -> Option
     // Ex) `logging.error("...", exc_info=sys.exc_info())`
     if let Expr::Call(ast::ExprCall { func, .. }) = &exc_info.value {
         if semantic.resolve_call_path(func).map_or(false, |call_path| {
-            call_path.as_slice() == ["sys", "exc_info"]
+            matches!(call_path.as_slice(), ["sys", "exc_info"])
         }) {
             return Some(exc_info);
         }

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -191,16 +191,16 @@ pub fn is_immutable_annotation(expr: &Expr, semantic: &SemanticModel) -> bool {
                     .any(|target| call_path.as_slice() == *target)
                 {
                     true
-                } else if call_path.as_slice() == ["typing", "Union"] {
+                } else if matches!(call_path.as_slice(), ["typing", "Union"]) {
                     if let Expr::Tuple(ast::ExprTuple { elts, .. }) = slice.as_ref() {
                         elts.iter()
                             .all(|elt| is_immutable_annotation(elt, semantic))
                     } else {
                         false
                     }
-                } else if call_path.as_slice() == ["typing", "Optional"] {
+                } else if matches!(call_path.as_slice(), ["typing", "Optional"]) {
                     is_immutable_annotation(slice, semantic)
-                } else if call_path.as_slice() == ["typing", "Annotated"] {
+                } else if matches!(call_path.as_slice(), ["typing", "Annotated"]) {
                     if let Expr::Tuple(ast::ExprTuple { elts, .. }) = slice.as_ref() {
                         elts.first()
                             .map_or(false, |elt| is_immutable_annotation(elt, semantic))
@@ -290,7 +290,7 @@ pub fn is_type_checking_block(stmt: &ast::StmtIf, semantic: &SemanticModel) -> b
 
     // Ex) `if typing.TYPE_CHECKING:`
     if semantic.resolve_call_path(test).map_or(false, |call_path| {
-        call_path.as_slice() == ["typing", "TYPE_CHECKING"]
+        matches!(call_path.as_slice(), ["typing", "TYPE_CHECKING"])
     }) {
         return true;
     }

--- a/crates/ruff_python_semantic/src/analyze/visibility.rs
+++ b/crates/ruff_python_semantic/src/analyze/visibility.rs
@@ -208,8 +208,7 @@ pub(crate) fn method_visibility(stmt: &Stmt) -> Visibility {
             // Is this a setter or deleter?
             if decorator_list.iter().any(|decorator| {
                 collect_call_path(&decorator.expression).map_or(false, |call_path| {
-                    call_path.as_slice() == [name, "setter"]
-                        || call_path.as_slice() == [name, "deleter"]
+                    matches!(call_path.as_slice(), [name, "setter" | "deleter"])
                 })
             }) {
                 return Visibility::Private;

--- a/crates/ruff_python_semantic/src/analyze/visibility.rs
+++ b/crates/ruff_python_semantic/src/analyze/visibility.rs
@@ -19,7 +19,7 @@ pub fn is_staticmethod(decorator_list: &[Decorator], semantic: &SemanticModel) -
         semantic
             .resolve_call_path(map_callable(&decorator.expression))
             .map_or(false, |call_path| {
-                call_path.as_slice() == ["", "staticmethod"]
+                matches!(call_path.as_slice(), ["", "staticmethod"])
             })
     })
 }
@@ -30,7 +30,7 @@ pub fn is_classmethod(decorator_list: &[Decorator], semantic: &SemanticModel) ->
         semantic
             .resolve_call_path(map_callable(&decorator.expression))
             .map_or(false, |call_path| {
-                call_path.as_slice() == ["", "classmethod"]
+                matches!(call_path.as_slice(), ["", "classmethod"])
             })
     })
 }
@@ -81,11 +81,12 @@ pub fn is_property(
         semantic
             .resolve_call_path(map_callable(&decorator.expression))
             .map_or(false, |call_path| {
-                call_path.as_slice() == ["", "property"]
-                    || call_path.as_slice() == ["functools", "cached_property"]
-                    || extra_properties
-                        .iter()
-                        .any(|extra_property| extra_property.as_slice() == call_path.as_slice())
+                matches!(
+                    call_path.as_slice(),
+                    ["", "property"] | ["functools", "cached_property"]
+                ) || extra_properties
+                    .iter()
+                    .any(|extra_property| extra_property.as_slice() == call_path.as_slice())
             })
     })
 }
@@ -208,7 +209,8 @@ pub(crate) fn method_visibility(stmt: &Stmt) -> Visibility {
             // Is this a setter or deleter?
             if decorator_list.iter().any(|decorator| {
                 collect_call_path(&decorator.expression).map_or(false, |call_path| {
-                    matches!(call_path.as_slice(), [name, "setter" | "deleter"])
+                    call_path.as_slice() == [name, "setter"]
+                        || call_path.as_slice() == [name, "deleter"]
                 })
             }) {
                 return Visibility::Private;


### PR DESCRIPTION
## Summary

This PR consistently uses `matches! for static `CallPath` comparisons. In some cases, we can significantly reduce the number of cases or checks.

## Test Plan

`cargo test `
