### PR TITLE
Enable UTC-import for `datetime-utc-alias` fix

### DIFF
--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__datetime_utc_alias_py311.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__datetime_utc_alias_py311.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/pyupgrade/mod.rs
 ---
-UP017.py:7:7: UP017 Use `datetime.UTC` alias
+UP017.py:7:7: UP017 [*] Use `datetime.UTC` alias
   |
 6 | print(datetime.timezone(-1))
 7 | print(timezone.utc)
@@ -10,7 +10,17 @@ UP017.py:7:7: UP017 Use `datetime.UTC` alias
   |
   = help: Convert to `datetime.UTC` alias
 
-UP017.py:8:7: UP017 Use `datetime.UTC` alias
+ℹ Suggested fix
+4 4 | from datetime import timezone as tz
+5 5 | 
+6 6 | print(datetime.timezone(-1))
+7   |-print(timezone.utc)
+  7 |+print(datetime.UTC)
+8 8 | print(tz.utc)
+9 9 | 
+10 10 | print(datetime.timezone.utc)
+
+UP017.py:8:7: UP017 [*] Use `datetime.UTC` alias
    |
  6 | print(datetime.timezone(-1))
  7 | print(timezone.utc)
@@ -20,6 +30,16 @@ UP017.py:8:7: UP017 Use `datetime.UTC` alias
 10 | print(datetime.timezone.utc)
    |
    = help: Convert to `datetime.UTC` alias
+
+ℹ Suggested fix
+5 5 | 
+6 6 | print(datetime.timezone(-1))
+7 7 | print(timezone.utc)
+8   |-print(tz.utc)
+  8 |+print(datetime.UTC)
+9 9 | 
+10 10 | print(datetime.timezone.utc)
+11 11 | print(dt.timezone.utc)
 
 UP017.py:10:7: UP017 [*] Use `datetime.UTC` alias
    |
@@ -39,12 +59,19 @@ UP017.py:10:7: UP017 [*] Use `datetime.UTC` alias
    10 |+print(datetime.UTC)
 11 11 | print(dt.timezone.utc)
 
-UP017.py:11:7: UP017 Use `datetime.UTC` alias
+UP017.py:11:7: UP017 [*] Use `datetime.UTC` alias
    |
 10 | print(datetime.timezone.utc)
 11 | print(dt.timezone.utc)
    |       ^^^^^^^^^^^^^^^ UP017
    |
    = help: Convert to `datetime.UTC` alias
+
+ℹ Suggested fix
+8  8  | print(tz.utc)
+9  9  | 
+10 10 | print(datetime.timezone.utc)
+11    |-print(dt.timezone.utc)
+   11 |+print(datetime.UTC)
 
 


### PR DESCRIPTION
## Summary

Small update to leverage `get_or_import_symbol` to fix `UP017` in more cases (e.g., when we need to import `UTC`, or access it from an alias or something).

## Test Plan

Check out the updated snapshot.
