### PR TITLE
Run `rustfmt` on nightly to clean up erroneous comments

### DIFF
--- a/crates/ruff/src/docstrings/sections.rs
+++ b/crates/ruff/src/docstrings/sections.rs
@@ -205,8 +205,8 @@ impl<'a> SectionContexts<'a> {
 }
 
 impl<'a> IntoIterator for &'a SectionContexts<'a> {
-    type Item = SectionContext<'a>;
     type IntoIter = SectionContextsIter<'a>;
+    type Item = SectionContext<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/crates/ruff/src/message/diff.rs
+++ b/crates/ruff/src/message/diff.rs
@@ -60,7 +60,7 @@ impl Display for Diff<'_> {
             Applicability::Automatic => "Fix",
             Applicability::Suggested => "Suggested fix",
             Applicability::Manual => "Possible fix",
-            Applicability::Unspecified => "Suggested fix", // For backwards compatibility, unspecified fixes are 'suggested'
+            Applicability::Unspecified => "Suggested fix", /* For backwards compatibility, unspecified fixes are 'suggested' */
         };
         writeln!(f, "ℹ {}", message.blue())?;
 

--- a/crates/ruff/src/message/mod.rs
+++ b/crates/ruff/src/message/mod.rs
@@ -94,6 +94,7 @@ struct MessageWithLocation<'a> {
 
 impl Deref for MessageWithLocation<'_> {
     type Target = Message;
+
     fn deref(&self) -> &Self::Target {
         self.message
     }

--- a/crates/ruff/src/registry/rule_set.rs
+++ b/crates/ruff/src/registry/rule_set.rs
@@ -13,7 +13,6 @@ pub struct RuleSet([u64; RULESET_SIZE]);
 
 impl RuleSet {
     const EMPTY: [u64; RULESET_SIZE] = [0; RULESET_SIZE];
-
     // 64 fits into a u16 without truncation
     #[allow(clippy::cast_possible_truncation)]
     const SLICE_BITS: u16 = u64::BITS as u16;
@@ -290,8 +289,8 @@ impl Extend<Rule> for RuleSet {
 }
 
 impl IntoIterator for RuleSet {
-    type Item = Rule;
     type IntoIter = RuleSetIterator;
+    type Item = Rule;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -299,8 +298,8 @@ impl IntoIterator for RuleSet {
 }
 
 impl IntoIterator for &RuleSet {
-    type Item = Rule;
     type IntoIter = RuleSetIterator;
+    type Item = Rule;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/crates/ruff/src/rule_selector.rs
+++ b/crates/ruff/src/rule_selector.rs
@@ -145,8 +145,8 @@ impl From<RuleCodePrefix> for RuleSelector {
 }
 
 impl IntoIterator for &RuleSelector {
-    type Item = Rule;
     type IntoIter = RuleSelectorIter;
+    type Item = Rule;
 
     fn into_iter(self) -> Self::IntoIter {
         match self {

--- a/crates/ruff/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
+++ b/crates/ruff/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
@@ -49,6 +49,9 @@ use crate::checkers::ast::Checker;
 /// def func(obj: dict[str, int | None]) -> None:
 ///     ...
 /// ```
+///
+/// ## Options
+/// - `target-version`
 #[violation]
 pub struct FutureRewritableTypeAnnotation {
     name: String,

--- a/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
@@ -20,7 +20,7 @@ use crate::rules::pep8_naming::helpers;
 /// > Modules that are designed for use via from M import * should use the
 /// __all__ mechanism to prevent exporting globals, or use the older
 /// convention of prefixing such globals with an underscore (which you might
-///want to do to indicate these globals are “module non-public”).
+/// want to do to indicate these globals are “module non-public”).
 /// >
 /// > ### Function and Variable Names
 /// > Function names should be lowercase, with words separated by underscores

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/indentation.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/indentation.rs
@@ -82,7 +82,6 @@ impl Violation for IndentationWithInvalidMultipleComment {
 /// ```python
 /// for item in items:
 /// pass
-///
 /// ```
 ///
 /// Use instead:

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/mod.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/mod.rs
@@ -95,8 +95,8 @@ impl Debug for LogicalLines<'_> {
 }
 
 impl<'a> IntoIterator for &'a LogicalLines<'a> {
-    type Item = LogicalLine<'a>;
     type IntoIter = LogicalLinesIter<'a>;
+    type Item = LogicalLine<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         LogicalLinesIter {

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_around_keywords.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_around_keywords.rs
@@ -41,7 +41,6 @@ impl Violation for MultipleSpacesAfterKeyword {
 /// ## Example
 /// ```python
 /// True  and False
-///
 /// ```
 ///
 /// Use instead:
@@ -67,7 +66,6 @@ impl Violation for MultipleSpacesBeforeKeyword {
 /// ## Example
 /// ```python
 /// True and\tFalse
-///
 /// ```
 ///
 /// Use instead:
@@ -93,7 +91,6 @@ impl Violation for TabAfterKeyword {
 /// ## Example
 /// ```python
 /// True\tand False
-///
 /// ```
 ///
 /// Use instead:

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
@@ -116,7 +116,6 @@ impl Violation for NoSpaceAfterBlockComment {
 /// ## Example
 /// ```python
 /// ### Block comment
-///
 /// ```
 ///
 /// Use instead:

--- a/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -50,7 +50,6 @@ impl AlwaysAutofixableViolation for TrailingWhitespace {
 /// ## Example
 /// ```python
 /// class Foo(object):\n    \n    bang = 12
-///
 /// ```
 ///
 /// Use instead:

--- a/crates/ruff/src/rules/pylint/rules/bad_str_strip_call.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_str_strip_call.rs
@@ -17,15 +17,29 @@ use crate::settings::types::PythonVersion;
 /// trailing ends of the string. Including duplicate characters in the call
 /// is redundant and often indicative of a mistake.
 ///
+/// In Python 3.9 and later, you can use `str#removeprefix` and
+/// `str#removesuffix` to remove an exact prefix or suffix from a string,
+/// respectively, which should be preferred when possible.
+///
 /// ## Example
 /// ```python
-/// "bar foo baz".strip("bar baz ")  # "foo"
+/// # Evaluates to "foo".
+/// "bar foo baz".strip("bar baz ")
 /// ```
 ///
 /// Use instead:
 /// ```python
+/// # Evaluates to "foo".
 /// "bar foo baz".strip("abrz ")  # "foo"
 /// ```
+///
+/// Or:
+/// ```python
+/// # Evaluates to "foo".
+/// "bar foo baz".removeprefix("bar ").removesuffix(" baz")
+///
+/// ## Options
+/// - `target-version`
 ///
 /// ## References
 /// - [Python documentation](https://docs.python.org/3/library/stdtypes.html?highlight=strip#str.strip)

--- a/crates/ruff/src/rules/pylint/rules/continue_in_finally.rs
+++ b/crates/ruff/src/rules/pylint/rules/continue_in_finally.rs
@@ -32,6 +32,9 @@ use crate::checkers::ast::Checker;
 ///     else:
 ///         continue
 /// ```
+///
+/// ## Options
+/// - `target-version`
 #[violation]
 pub struct ContinueInFinally;
 

--- a/crates/ruff/src/rules/pylint/rules/repeated_isinstance_calls.rs
+++ b/crates/ruff/src/rules/pylint/rules/repeated_isinstance_calls.rs
@@ -36,6 +36,9 @@ use crate::settings::types::PythonVersion;
 ///     return isinstance(x, int | float | complex)
 /// ```
 ///
+/// ## Options
+/// - `target-version`
+///
 /// ## References
 /// - [Python documentation: `isinstance`](https://docs.python.org/3/library/functions.html#isinstance)
 #[violation]

--- a/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -28,6 +28,9 @@ use crate::registry::AsRule;
 /// datetime.UTC
 /// ```
 ///
+/// ## Options
+/// - `target-version`
+///
 /// ## References
 /// - [Python documentation: `datetime.UTC`](https://docs.python.org/3/library/datetime.html#datetime.UTC)
 #[violation]

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -36,6 +36,9 @@ use crate::registry::AsRule;
 ///     ...
 /// ```
 ///
+/// ## Options
+/// - `target-version`
+///
 /// ## References
 /// - [Python documentation: `@functools.cache`](https://docs.python.org/3/library/functools.html#functools.cache)
 #[violation]

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -34,6 +34,9 @@ use crate::registry::AsRule;
 ///     ...
 /// ```
 ///
+/// ## Options
+/// - `target-version`
+///
 /// ## References
 /// - [Python documentation: `@functools.lru_cache`](https://docs.python.org/3/library/functools.html#functools.lru_cache)
 /// - [Let lru_cache be used as a decorator with no arguments](https://github.com/python/cpython/issues/80953)

--- a/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -42,6 +42,9 @@ use crate::settings::types::PythonVersion;
 /// print("py3")
 /// ```
 ///
+/// ## Options
+/// - `target-version`
+///
 /// ## References
 /// - [Python documentation: `sys.version_info`](https://docs.python.org/3/library/sys.html#sys.version_info)
 #[violation]

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -30,6 +30,9 @@ use crate::registry::AsRule;
 /// print("Hello, world!")
 /// ```
 ///
+/// ## Options
+/// - `target-version`
+///
 /// ## References
 /// - [Python documentation: `__future__` — Future statement definitions](https://docs.python.org/3/library/__future__.html)
 #[violation]

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -35,6 +35,9 @@ use crate::registry::AsRule;
 /// foo: list[int] = [1, 2, 3]
 /// ```
 ///
+/// ## Options
+/// - `target-version`
+///
 /// [PEP 585]: https://peps.python.org/pep-0585/
 #[violation]
 pub struct NonPEP585Annotation {

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -28,6 +28,9 @@ use crate::registry::AsRule;
 /// foo: int | str = 1
 /// ```
 ///
+/// ## Options
+/// - `target-version`
+///
 /// [PEP 604]: https://peps.python.org/pep-0604/
 #[violation]
 pub struct NonPEP604Annotation;

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
@@ -53,6 +53,9 @@ impl CallKind {
 /// isinstance(x, int | float)
 /// ```
 ///
+/// ## Options
+/// - `target-version`
+///
 /// ## References
 /// - [Python documentation: `isinstance`](https://docs.python.org/3/library/functions.html#isinstance)
 /// - [Python documentation: `issubclass`](https://docs.python.org/3/library/functions.html#issubclass)

--- a/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
@@ -55,6 +55,9 @@ use crate::settings::types::PythonVersion;
 ///     pass
 /// ```
 ///
+/// ## Options
+/// - `target-version`
+///
 /// [PEP 484]: https://peps.python.org/pep-0484/#union-types
 #[violation]
 pub struct ImplicitOptional {

--- a/crates/ruff/src/settings/options_base.rs
+++ b/crates/ruff/src/settings/options_base.rs
@@ -70,7 +70,7 @@ impl OptionGroup {
     ///
     /// ### Find a nested options
     ///
-    ///```rust
+    /// ```rust
     /// # use ruff::settings::options_base::{OptionGroup, OptionEntry, OptionField};
     ///
     /// const ignore_options: [(&'static str, OptionEntry); 2] = [
@@ -134,8 +134,8 @@ impl OptionGroup {
 }
 
 impl<'a> IntoIterator for &'a OptionGroup {
-    type Item = &'a (&'a str, OptionEntry);
     type IntoIter = std::slice::Iter<'a, (&'a str, OptionEntry)>;
+    type Item = &'a (&'a str, OptionEntry);
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
@@ -143,8 +143,8 @@ impl<'a> IntoIterator for &'a OptionGroup {
 }
 
 impl IntoIterator for OptionGroup {
-    type Item = &'static (&'static str, OptionEntry);
     type IntoIter = std::slice::Iter<'static, (&'static str, OptionEntry)>;
+    type Item = &'static (&'static str, OptionEntry);
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()

--- a/crates/ruff_cache/src/cache_key.rs
+++ b/crates/ruff_cache/src/cache_key.rs
@@ -24,6 +24,7 @@ impl CacheKeyHasher {
 
 impl Deref for CacheKeyHasher {
     type Target = DefaultHasher;
+
     fn deref(&self) -> &Self::Target {
         &self.inner
     }

--- a/crates/ruff_formatter/src/buffer.rs
+++ b/crates/ruff_formatter/src/buffer.rs
@@ -29,7 +29,6 @@ pub trait Buffer {
     ///
     /// assert_eq!(buffer.into_vec(), vec![FormatElement::StaticText { text: "test" }]);
     /// ```
-    ///
     fn write_element(&mut self, element: FormatElement) -> FormatResult<()>;
 
     /// Returns a slice containing all elements written into this buffer.

--- a/crates/ruff_formatter/src/format_extensions.rs
+++ b/crates/ruff_formatter/src/format_extensions.rs
@@ -57,7 +57,6 @@ pub trait MemoizeFormat<Context> {
     /// # Ok(())
     /// # }
     /// ```
-    ///
     fn memoized(self) -> Memoized<Self, Context>
     where
         Self: Sized + Format<Context>,
@@ -142,7 +141,6 @@ where
     /// assert_eq!("Counter:\n\tCount: 0\nCount: 0\n", formatted.print()?.as_code());
     /// # Ok(())
     /// # }
-    ///
     /// ```
     pub fn inspect(&mut self, f: &mut Formatter<Context>) -> FormatResult<&[FormatElement]> {
         let result = self

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -721,7 +721,6 @@ where
 /// # Ok(())
 /// # }
 /// ```
-///
 #[inline(always)]
 pub fn write<Context>(
     output: &mut dyn Buffer<Context = Context>,

--- a/crates/ruff_index/src/slice.rs
+++ b/crates/ruff_index/src/slice.rs
@@ -127,8 +127,8 @@ impl<I: Idx, T> IndexMut<I> for IndexSlice<I, T> {
 }
 
 impl<'a, I: Idx, T> IntoIterator for &'a IndexSlice<I, T> {
-    type Item = &'a T;
     type IntoIter = std::slice::Iter<'a, T>;
+    type Item = &'a T;
 
     #[inline]
     fn into_iter(self) -> std::slice::Iter<'a, T> {
@@ -137,8 +137,8 @@ impl<'a, I: Idx, T> IntoIterator for &'a IndexSlice<I, T> {
 }
 
 impl<'a, I: Idx, T> IntoIterator for &'a mut IndexSlice<I, T> {
-    type Item = &'a mut T;
     type IntoIter = std::slice::IterMut<'a, T>;
+    type Item = &'a mut T;
 
     #[inline]
     fn into_iter(self) -> std::slice::IterMut<'a, T> {

--- a/crates/ruff_index/src/vec.rs
+++ b/crates/ruff_index/src/vec.rs
@@ -121,8 +121,8 @@ impl<I: Idx, T> FromIterator<T> for IndexVec<I, T> {
 }
 
 impl<I: Idx, T> IntoIterator for IndexVec<I, T> {
-    type Item = T;
     type IntoIter = std::vec::IntoIter<T>;
+    type Item = T;
 
     #[inline]
     fn into_iter(self) -> std::vec::IntoIter<T> {
@@ -131,8 +131,8 @@ impl<I: Idx, T> IntoIterator for IndexVec<I, T> {
 }
 
 impl<'a, I: Idx, T> IntoIterator for &'a IndexVec<I, T> {
-    type Item = &'a T;
     type IntoIter = std::slice::Iter<'a, T>;
+    type Item = &'a T;
 
     #[inline]
     fn into_iter(self) -> std::slice::Iter<'a, T> {
@@ -141,8 +141,8 @@ impl<'a, I: Idx, T> IntoIterator for &'a IndexVec<I, T> {
 }
 
 impl<'a, I: Idx, T> IntoIterator for &'a mut IndexVec<I, T> {
-    type Item = &'a mut T;
     type IntoIter = std::slice::IterMut<'a, T>;
+    type Item = &'a mut T;
 
     #[inline]
     fn into_iter(self) -> std::slice::IterMut<'a, T> {

--- a/crates/ruff_python_ast/src/imports.rs
+++ b/crates/ruff_python_ast/src/imports.rs
@@ -160,8 +160,8 @@ impl ImportMap {
 }
 
 impl<'a> IntoIterator for &'a ImportMap {
-    type Item = (&'a String, &'a Vec<ModuleImport>);
     type IntoIter = std::collections::hash_map::Iter<'a, String, Vec<ModuleImport>>;
+    type Item = (&'a String, &'a Vec<ModuleImport>);
 
     fn into_iter(self) -> Self::IntoIter {
         self.module_to_imports.iter()

--- a/crates/ruff_python_ast/src/source_code/comment_ranges.rs
+++ b/crates/ruff_python_ast/src/source_code/comment_ranges.rs
@@ -25,8 +25,8 @@ impl Debug for CommentRanges {
 }
 
 impl<'a> IntoIterator for &'a CommentRanges {
-    type Item = &'a TextRange;
     type IntoIter = std::slice::Iter<'a, TextRange>;
+    type Item = &'a TextRange;
 
     fn into_iter(self) -> Self::IntoIter {
         self.raw.iter()

--- a/crates/ruff_python_ast/src/source_code/line_index.rs
+++ b/crates/ruff_python_ast/src/source_code/line_index.rs
@@ -245,12 +245,11 @@ impl IndexKind {
 pub struct OneIndexed(NonZeroUsize);
 
 impl OneIndexed {
+    /// The largest value that can be represented by this integer type
+    pub const MAX: Self = unwrap(Self::new(usize::MAX));
     // SAFETY: These constants are being initialized with non-zero values
     /// The smallest value that can be represented by this integer type.
     pub const MIN: Self = unwrap(Self::new(1));
-    /// The largest value that can be represented by this integer type
-    pub const MAX: Self = unwrap(Self::new(usize::MAX));
-
     pub const ONE: NonZeroUsize = unwrap(NonZeroUsize::new(1));
 
     /// Creates a non-zero if the given value is not zero.

--- a/crates/ruff_python_ast/src/visitor/preorder.rs
+++ b/crates/ruff_python_ast/src/visitor/preorder.rs
@@ -1078,23 +1078,29 @@ class A:
             walk_expr(self, expr);
             self.exit_node();
         }
+
         fn visit_expr(&mut self, expr: &Expr) {
             self.enter_node(expr);
             walk_expr(self, expr);
             self.exit_node();
         }
+
         fn visit_constant(&mut self, constant: &Constant) {
             self.emit(&constant);
         }
+
         fn visit_boolop(&mut self, boolop: &Boolop) {
             self.emit(&boolop);
         }
+
         fn visit_operator(&mut self, operator: &Operator) {
             self.emit(&operator);
         }
+
         fn visit_unaryop(&mut self, unaryop: &Unaryop) {
             self.emit(&unaryop);
         }
+
         fn visit_cmpop(&mut self, cmpop: &Cmpop) {
             self.emit(&cmpop);
         }
@@ -1104,51 +1110,61 @@ class A:
             walk_comprehension(self, comprehension);
             self.exit_node();
         }
+
         fn visit_excepthandler(&mut self, excepthandler: &Excepthandler) {
             self.enter_node(excepthandler);
             walk_excepthandler(self, excepthandler);
             self.exit_node();
         }
+
         fn visit_format_spec(&mut self, format_spec: &Expr) {
             self.enter_node(format_spec);
             walk_expr(self, format_spec);
             self.exit_node();
         }
+
         fn visit_arguments(&mut self, arguments: &Arguments) {
             self.enter_node(arguments);
             walk_arguments(self, arguments);
             self.exit_node();
         }
+
         fn visit_arg(&mut self, arg: &Arg) {
             self.enter_node(arg);
             walk_arg(self, arg);
             self.exit_node();
         }
+
         fn visit_keyword(&mut self, keyword: &Keyword) {
             self.enter_node(keyword);
             walk_keyword(self, keyword);
             self.exit_node();
         }
+
         fn visit_alias(&mut self, alias: &Alias) {
             self.enter_node(alias);
             walk_alias(self, alias);
             self.exit_node();
         }
+
         fn visit_withitem(&mut self, withitem: &Withitem) {
             self.enter_node(withitem);
             walk_withitem(self, withitem);
             self.exit_node();
         }
+
         fn visit_match_case(&mut self, match_case: &MatchCase) {
             self.enter_node(match_case);
             walk_match_case(self, match_case);
             self.exit_node();
         }
+
         fn visit_pattern(&mut self, pattern: &Pattern) {
             self.enter_node(pattern);
             walk_pattern(self, pattern);
             self.exit_node();
         }
+
         fn visit_type_ignore(&mut self, type_ignore: &TypeIgnore) {
             self.enter_node(type_ignore);
             walk_type_ignore(self, type_ignore);

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -656,7 +656,7 @@ fn handle_positional_only_arguments_separator_comment<'a>(
 /// Handles comments between the left side and the operator of a binary expression (trailing comments of the left),
 /// and trailing end-of-line comments that are on the same line as the operator.
 ///
-///```python
+/// ```python
 /// a = (
 ///     5 # trailing left comment
 ///     + # trailing operator comment

--- a/crates/ruff_python_formatter/src/comments/visitor.rs
+++ b/crates/ruff_python_formatter/src/comments/visitor.rs
@@ -257,6 +257,7 @@ impl<'ast> PreorderVisitor<'ast> for CommentsVisitor<'ast> {
 
         self.finish_node(withitem);
     }
+
     fn visit_match_case(&mut self, match_case: &'ast MatchCase) {
         if self.start_node(match_case).is_traverse() {
             walk_match_case(self, match_case);

--- a/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
@@ -142,6 +142,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for Operator {
 
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for Operator {
     type Format = FormatOwnedWithRule<Operator, FormatOperator, PyFormatContext<'ast>>;
+
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(self, FormatOperator)
     }

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -163,6 +163,7 @@ impl NeedsParentheses for Expr {
 
 impl<'ast> AsFormat<PyFormatContext<'ast>> for Expr {
     type Format<'a> = FormatRefWithRule<'a, Expr, FormatExpr, PyFormatContext<'ast>>;
+
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, FormatExpr::default())
     }
@@ -170,6 +171,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for Expr {
 
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for Expr {
     type Format = FormatOwnedWithRule<Expr, FormatExpr, PyFormatContext<'ast>>;
+
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(self, FormatExpr::default())
     }

--- a/crates/ruff_python_formatter/src/module/mod.rs
+++ b/crates/ruff_python_formatter/src/module/mod.rs
@@ -24,6 +24,7 @@ impl FormatRule<Mod, PyFormatContext<'_>> for FormatMod {
 
 impl<'ast> AsFormat<PyFormatContext<'ast>> for Mod {
     type Format<'a> = FormatRefWithRule<'a, Mod, FormatMod, PyFormatContext<'ast>>;
+
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, FormatMod::default())
     }
@@ -31,6 +32,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for Mod {
 
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for Mod {
     type Format = FormatOwnedWithRule<Mod, FormatMod, PyFormatContext<'ast>>;
+
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(self, FormatMod::default())
     }

--- a/crates/ruff_python_formatter/src/statement/mod.rs
+++ b/crates/ruff_python_formatter/src/statement/mod.rs
@@ -70,6 +70,7 @@ impl FormatRule<Stmt, PyFormatContext<'_>> for FormatStmt {
 
 impl<'ast> AsFormat<PyFormatContext<'ast>> for Stmt {
     type Format<'a> = FormatRefWithRule<'a, Stmt, FormatStmt, PyFormatContext<'ast>>;
+
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, FormatStmt::default())
     }
@@ -77,6 +78,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for Stmt {
 
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for Stmt {
     type Format = FormatOwnedWithRule<Stmt, FormatStmt, PyFormatContext<'ast>>;
+
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(self, FormatStmt::default())
     }

--- a/crates/ruff_python_formatter/src/statement/stmt_assign.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_assign.rs
@@ -7,7 +7,6 @@ use ruff_formatter::{write, Buffer, Format, FormatResult};
 use ruff_python_ast::prelude::Expr;
 use rustpython_parser::ast::StmtAssign;
 
-//
 // Note: This currently does wrap but not the black way so the types below likely need to be
 // replaced entirely
 //

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -178,6 +178,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for Suite {
 
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for Suite {
     type Format = FormatOwnedWithRule<Suite, FormatSuite, PyFormatContext<'ast>>;
+
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(self, FormatSuite::default())
     }

--- a/crates/ruff_python_semantic/src/definition.rs
+++ b/crates/ruff_python_semantic/src/definition.rs
@@ -202,8 +202,8 @@ impl<'a> Deref for Definitions<'a> {
 }
 
 impl<'a> IntoIterator for Definitions<'a> {
-    type Item = Definition<'a>;
     type IntoIter = std::vec::IntoIter<Self::Item>;
+    type Item = Definition<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -250,6 +250,7 @@ impl Default for Scopes<'_> {
 
 impl<'a> Deref for Scopes<'a> {
     type Target = IndexSlice<ScopeId, Scope<'a>>;
+
     fn deref(&self) -> &Self::Target {
         &self.0
     }


### PR DESCRIPTION
## Summary

This PR runs `rustfmt` with a few nightly options as a one-time fix to catch some malformatted comments. I ended up just running with:

```toml
condense_wildcard_suffixes = true
edition = "2021"
max_width = 100
normalize_comments = true
normalize_doc_attributes = true
reorder_impl_items = true
unstable_features = true
use_field_init_shorthand = true
```

Since these all seem like reasonable things to fix, so may as well while I'm here.
