### PR TITLE
Allow space in filename for powershell + windows + python module

### DIFF
--- a/python/ruff/__main__.py
+++ b/python/ruff/__main__.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 import sysconfig
 from pathlib import Path
@@ -31,4 +32,5 @@ def find_ruff_bin() -> Path:
 
 if __name__ == "__main__":
     ruff = find_ruff_bin()
-    sys.exit(os.spawnv(os.P_WAIT, ruff, ["ruff", *sys.argv[1:]]))
+    completed_process = subprocess.run([ruff, *sys.argv[1:]])
+    sys.exit(completed_process.returncode)


### PR DESCRIPTION
Fixes #5077

## Summary

Previously, in a powershell on windows when using `python -m ruff` instead of `ruff` a call such as `python -m ruff "a b.py"` would fail because the space would be split into two arguments.

The python docs [recommend](https://docs.python.org/3/library/os.html#os.spawnv) using subprocess instead of os.spawn variants, which does fix the problem.

## Test Plan

I manually confirmed that the problem previously occurred and now doesn't anymore. This only happens in a very specific environment (maturin build, windows, powershell), so i could try adding a step on CI for it but i don't think it's worth it.

```
(.venv) PS C:\Users\Konstantin\PycharmProjects\ruff> python -m ruff "a b.py"
warning: Detected debug build without --no-cache.
error: Failed to lint a: The system cannot find the file specified. (os error 2)
error: Failed to lint b.py: The system cannot find the file specified. (os error 2)
a:1:1: E902 The system cannot find the file specified. (os error 2)
b.py:1:1: E902 The system cannot find the file specified. (os error 2)
Found 2 errors.
(.venv) PS C:\Users\Konstantin\PycharmProjects\ruff> python -m ruff "a b.py"
warning: Detected debug build without --no-cache.
a b.py:2:5: F841 [*] Local variable `x` is assigned to but never used
Found 1 error.
[*] 1 potentially fixable with the --fix option.
```