### PR TITLE
Use global cache directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ dependencies = [
 name = "ruff_cache"
 version = "0.0.0"
 dependencies = [
+ "dirs 5.0.1",
  "filetime",
  "glob",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ bitflags = { version = "2.3.1" }
 chrono = { version = "0.4.23", default-features = false, features = ["clock"] }
 clap = { version = "4.1.8", features = ["derive"] }
 colored = { version = "2.0.0" }
+dirs = { version = "5.0.0" }
 filetime = { version = "0.2.20" }
 glob = { version = "0.3.1" }
 globset = { version = "0.4.10" }

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -32,7 +32,7 @@ bitflags = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "string"], optional = true }
 colored = { workspace = true }
-dirs = { version = "5.0.0" }
+dirs = { workspace = true }
 fern = { version = "0.6.1" }
 glob = { workspace = true }
 globset = { workspace = true }

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -50,10 +50,7 @@ impl AllSettings {
     pub fn from_configuration(config: Configuration, project_root: &Path) -> Result<Self> {
         Ok(Self {
             cli: CliSettings {
-                cache_dir: config
-                    .cache_dir
-                    .clone()
-                    .unwrap_or_else(|| cache_dir(project_root)),
+                cache_dir: cache_dir(config.cache_dir.clone(), project_root),
                 fix: config.fix.unwrap_or(false),
                 fix_only: config.fix_only.unwrap_or(false),
                 format: config.format.unwrap_or_default(),

--- a/crates/ruff/src/settings/options.rs
+++ b/crates/ruff/src/settings/options.rs
@@ -49,11 +49,11 @@ pub struct Options {
     )]
     /// A path to the cache directory.
     ///
-    /// By default, Ruff stores cache results in a `.ruff_cache` directory in
-    /// the current project root.
+    /// By default, Ruff stores cache results in the global OS cache, falling
+    /// back to a `.ruff_cache` directory in the current project root.
     ///
     /// However, Ruff will also respect the `RUFF_CACHE_DIR` environment
-    /// variable, which takes precedence over that default.
+    /// variable, which takes precedence over those defaults.
     ///
     /// This setting will override even the `RUFF_CACHE_DIR` environment
     /// variable, if set.

--- a/crates/ruff_cache/Cargo.toml
+++ b/crates/ruff_cache/Cargo.toml
@@ -16,7 +16,7 @@ glob = { workspace = true }
 globset = { workspace = true }
 regex = { workspace = true }
 filetime = { workspace = true }
-dirs = { version = "5.0.0" }
+dirs = { workspace = true }
 
 [dev-dependencies]
 ruff_macros = { path = "../ruff_macros" }

--- a/crates/ruff_cache/Cargo.toml
+++ b/crates/ruff_cache/Cargo.toml
@@ -16,6 +16,7 @@ glob = { workspace = true }
 globset = { workspace = true }
 regex = { workspace = true }
 filetime = { workspace = true }
+dirs = { version = "5.0.0" }
 
 [dev-dependencies]
 ruff_macros = { path = "../ruff_macros" }

--- a/crates/ruff_cache/src/lib.rs
+++ b/crates/ruff_cache/src/lib.rs
@@ -9,6 +9,18 @@ pub mod globset;
 pub const CACHE_DIR_NAME: &str = ".ruff_cache";
 
 /// Return the cache directory for a given project root.
-pub fn cache_dir(project_root: &Path) -> PathBuf {
-    project_root.join(CACHE_DIR_NAME)
+pub fn cache_dir(overwrite: Option<PathBuf>, project_root: &Path) -> PathBuf {
+    match overwrite {
+        // User defined directory.
+        Some(overwrite) => overwrite,
+        // Default to the global directory.
+        None => match dirs::cache_dir() {
+            Some(mut path) => {
+                path.push("ruff");
+                path
+            }
+            // Falling back to a directory in the project.
+            None => project_root.join(CACHE_DIR_NAME),
+        },
+    }
 }

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -55,7 +55,11 @@ pub enum Command {
     },
     /// Clear any caches in the current directory and any subdirectories.
     #[clap(alias = "--clean")]
-    Clean,
+    Clean {
+        /// Path to the cache directory.
+        #[arg(long, env = "RUFF_CACHE_DIR", help_heading = "Miscellaneous")]
+        cache_dir: Option<PathBuf>,
+    },
     /// Generate shell completion.
     #[clap(alias = "--generate-shell-completion", hide = true)]
     GenerateShellCompletion { shell: clap_complete_command::Shell },

--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::hash::Hasher;
-use std::io::{self, BufReader, BufWriter, Write};
+use std::io::{self, BufReader, BufWriter};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::SystemTime;
@@ -244,15 +244,12 @@ pub(crate) fn init(path: &Path) -> Result<()> {
     fs::create_dir_all(path)?;
 
     // Add the CACHEDIR.TAG.
-    if !cachedir::is_tagged(path)? {
-        cachedir::add_tag(path)?;
-    }
+    cachedir::ensure_tag(path)?;
 
     // Add the .gitignore.
     let gitignore_path = path.join(".gitignore");
     if !gitignore_path.exists() {
-        let mut file = fs::File::create(gitignore_path)?;
-        file.write_all(b"*")?;
+        fs::write(gitignore_path, b"*")?;
     }
 
     Ok(())

--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -50,7 +50,7 @@ impl PackageCache {
 
         let mut buf = itoa::Buffer::new();
         let key = Path::new(buf.format(cache_key(&package_root, settings)));
-        let path = PathBuf::from_iter([cache_dir, Path::new("content"), key]);
+        let path = PathBuf::from_iter([cache_dir, key]);
 
         let file = match File::open(&path) {
             Ok(file) => file,
@@ -241,7 +241,7 @@ fn cache_key(package_root: &Path, settings: &Settings) -> u64 {
 /// Initialize the cache at the specified `Path`.
 pub(crate) fn init(path: &Path) -> Result<()> {
     // Create the cache directories.
-    fs::create_dir_all(path.join("content"))?;
+    fs::create_dir_all(path)?;
 
     // Add the CACHEDIR.TAG.
     if !cachedir::is_tagged(path)? {

--- a/crates/ruff_cli/src/commands/clean.rs
+++ b/crates/ruff_cli/src/commands/clean.rs
@@ -16,14 +16,22 @@ pub(crate) fn clean(cache_dir_overwrite: Option<PathBuf>, level: LogLevel) -> Re
     let mut stderr = BufWriter::new(io::stderr().lock());
     let pwd = std::env::current_dir()?;
     let path = cache_dir(cache_dir_overwrite, &pwd);
-    if level >= LogLevel::Default {
+    if cachedir::is_tagged(&path)? {
+        if level >= LogLevel::Default {
+            writeln!(
+                stderr,
+                "Removing cache at: {}",
+                fs::relativize_path(&path).bold()
+            )?;
+        }
+        remove_dir_all(path)?;
+    } else if level >= LogLevel::Default {
         writeln!(
             stderr,
-            "Removing cache at: {}",
+            "Not removing cache at: {}, not a cache directory created by Ruff",
             fs::relativize_path(&path).bold()
         )?;
     }
-    remove_dir_all(path)?;
 
     // This code removes the old caches that are not based on the global caches.
     //

--- a/crates/ruff_cli/src/commands/clean.rs
+++ b/crates/ruff_cli/src/commands/clean.rs
@@ -1,5 +1,6 @@
 use std::fs::remove_dir_all;
 use std::io::{self, BufWriter, Write};
+use std::path::PathBuf;
 
 use anyhow::Result;
 use colored::Colorize;
@@ -8,11 +9,26 @@ use walkdir::WalkDir;
 
 use ruff::fs;
 use ruff::logging::LogLevel;
-use ruff_cache::CACHE_DIR_NAME;
+use ruff_cache::{cache_dir, CACHE_DIR_NAME};
 
 /// Clear any caches in the current directory or any subdirectories.
-pub(crate) fn clean(level: LogLevel) -> Result<()> {
+pub(crate) fn clean(cache_dir_overwrite: Option<PathBuf>, level: LogLevel) -> Result<()> {
     let mut stderr = BufWriter::new(io::stderr().lock());
+    let pwd = std::env::current_dir()?;
+    let path = cache_dir(cache_dir_overwrite, &pwd);
+    if level >= LogLevel::Default {
+        writeln!(
+            stderr,
+            "Removing cache at: {}",
+            fs::relativize_path(&path).bold()
+        )?;
+    }
+    remove_dir_all(path)?;
+
+    // This code removes the old caches that are not based on the global caches.
+    //
+    // TODO: after everybody moved to the new global cache usage we can remove
+    // this.
     for entry in WalkDir::new(&*path_dedot::CWD)
         .into_iter()
         .filter_map(Result::ok)
@@ -30,5 +46,6 @@ pub(crate) fn clean(level: LogLevel) -> Result<()> {
             remove_dir_all(&cache)?;
         }
     }
+
     Ok(())
 }

--- a/crates/ruff_cli/src/commands/run.rs
+++ b/crates/ruff_cli/src/commands/run.rs
@@ -14,7 +14,7 @@ use ruff_text_size::{TextRange, TextSize};
 
 use ruff::message::Message;
 use ruff::registry::Rule;
-use ruff::resolver::{PyprojectConfig, PyprojectDiscoveryStrategy};
+use ruff::resolver::PyprojectConfig;
 use ruff::settings::{flags, AllSettings};
 use ruff::{fs, packaging, resolver, warn_user_once, IOError};
 use ruff_diagnostics::Diagnostic;
@@ -48,21 +48,9 @@ pub(crate) fn run(
 
     // Initialize the cache.
     if cache.into() {
-        fn init_cache(path: &Path) {
-            if let Err(e) = cache::init(path) {
-                error!("Failed to initialize cache at {}: {e:?}", path.display());
-            }
-        }
-
-        match pyproject_config.strategy {
-            PyprojectDiscoveryStrategy::Fixed => {
-                init_cache(&pyproject_config.settings.cli.cache_dir);
-            }
-            PyprojectDiscoveryStrategy::Hierarchical => {
-                for settings in std::iter::once(&pyproject_config.settings).chain(resolver.iter()) {
-                    init_cache(&settings.cli.cache_dir);
-                }
-            }
+        let path = &pyproject_config.settings.cli.cache_dir;
+        if let Err(e) = cache::init(path) {
+            error!("Failed to initialize cache at {}: {e:?}", path.display());
         }
     };
 

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -115,7 +115,7 @@ quoting the executed command, along with the relevant file contents and `pyproje
         Command::Rule { rule, format } => commands::rule::rule(rule, format)?,
         Command::Config { option } => return Ok(commands::config::config(option.as_deref())),
         Command::Linter { format } => commands::linter::linter(format)?,
-        Command::Clean => commands::clean::clean(log_level)?,
+        Command::Clean { cache_dir } => commands::clean::clean(cache_dir, log_level)?,
         Command::GenerateShellCompletion { shell } => {
             shell.generate(&mut Args::command(), &mut io::stdout());
         }

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -26,7 +26,7 @@
       }
     },
     "cache-dir": {
-      "description": "A path to the cache directory.\n\nBy default, Ruff stores cache results in a `.ruff_cache` directory in the current project root.\n\nHowever, Ruff will also respect the `RUFF_CACHE_DIR` environment variable, which takes precedence over that default.\n\nThis setting will override even the `RUFF_CACHE_DIR` environment variable, if set.",
+      "description": "A path to the cache directory.\n\nBy default, Ruff stores cache results in the global OS cache, falling back to a `.ruff_cache` directory in the current project root.\n\nHowever, Ruff will also respect the `RUFF_CACHE_DIR` environment variable, which takes precedence over those defaults.\n\nThis setting will override even the `RUFF_CACHE_DIR` environment variable, if set.",
       "type": [
         "string",
         "null"


### PR DESCRIPTION
## Summary

This is based on https://github.com/astral-sh/ruff/pull/5117.

Updates #1292.

Falling back to the old .ruff_cache directory in the current directory
if the global cache directory can't be determined.

For reference a number of other Python tools also use global caches (by
default):

 * Black: https://github.com/psf/black/blob/35722dff623f3cdf5018e3f1183cd4e02e91caa8/src/black/cache.py#L21-L34.
 * Pip: https://github.com/pypa/pip/blob/8a1eea4aaedb1fb1c6b4c652cd0c43502f05ff37/src/pip/_internal/locations/base.py#L13, https://github.com/pypa/pip/blob/8a1eea4aaedb1fb1c6b4c652cd0c43502f05ff37/src/pip/_internal/utils/appdirs.py#L16.
 * Pylint: https://github.com/pylint-dev/pylint/blob/507dfc5ebd0cd9712ac4840cae3bea8623206554/doc/faq.rst#where-is-the-persistent-data-stored-to-compare-between-successive-runs.
* Poetry: https://github.com/python-poetry/poetry/blob/6d57e843b4a709f5a5156c9cc5661cdd0f718979/src/poetry/locations.py#LL18C30-L18C30,
* Pycharm: https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs.

Python projects that don't:

* CPython uses a local dir (`__pycache__`).
* MyPy uses a local dir: https://github.com/python/mypy/blob/66b96ed54b255495288ba539e3fd1f54f21d4abe/mypy/defaults.py#L17.
* Pytest uses a local dir: https://github.com/pytest-dev/pytest/blob/b55c02c3c9914a48e00fe8ab1cd7d903ab3b08c0/src/_pytest/cacheprovider.py#LL105C21-L105C21.

Other tools:

* Pyright doesn't seem to do any caching on-disk (?) https://github.com/microsoft/pyright/discussions/4809.

## Test Plan

Existing tests should keep working.
