### PR TITLE
UP035: Deprecate `typing.Union` and `typing.NoReturn`

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP035.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP035.py
@@ -48,3 +48,6 @@ if True: from collections import (
 
 # OK
 from a import b
+
+# Deprecated in 3.10
+from typing import Union

--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP035_py311.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP035_py311.py
@@ -1,0 +1,3 @@
+# Deprecated in 3.11, use typing.Never
+from typing import NoReturn
+

--- a/crates/ruff/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff/src/rules/pyupgrade/mod.rs
@@ -149,4 +149,17 @@ mod tests {
         assert_messages!(diagnostics);
         Ok(())
     }
+
+    #[test]
+    fn typing_noreturn_deprecated_py311() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("pyupgrade/UP035_py311.py"),
+            &settings::Settings {
+                target_version: PythonVersion::Py311,
+                ..settings::Settings::for_rule(Rule::DeprecatedImport)
+            },
+        )?;
+        assert_messages!(diagnostics);
+        Ok(())
+    }
 }

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -237,6 +237,9 @@ const TYPING_TO_RENAME_PY39: &[(&str, &str)] = &[
 
 // Python 3.10+
 
+// Members of `typing` that were deprecated.
+const TYPING_DEPRECATED_310: &[(&str, &str)] = &[("Union", "|")];
+
 // Members of `typing` that were moved to `collections.abc`.
 const TYPING_TO_COLLECTIONS_ABC_310: &[&str] = &["Callable"];
 
@@ -275,6 +278,9 @@ const TYPING_EXTENSIONS_TO_TYPING_311: &[&str] = &[
     "reveal_type",
 ];
 
+// Members of `typing` that were deprecated.
+const TYPING_DEPRECATED_311: &[(&str, &str)] = &[("NoReturn", "typing.Never")];
+
 struct ImportReplacer<'a> {
     stmt: &'a Stmt,
     module: &'a str,
@@ -305,11 +311,22 @@ impl<'a> ImportReplacer<'a> {
 
     /// Return a list of deprecated imports whose members were renamed.
     fn with_renames(&self) -> Vec<WithRename> {
+        let mut deprecations = vec![];
+        if self.version >= PythonVersion::Py39 {
+            deprecations.extend(TYPING_TO_RENAME_PY39);
+        };
+        if self.version >= PythonVersion::Py310 {
+            deprecations.extend(TYPING_DEPRECATED_310);
+        };
+        if self.version >= PythonVersion::Py311 {
+            deprecations.extend(TYPING_DEPRECATED_311);
+        };
+
         let mut operations = vec![];
         if self.module == "typing" {
             if self.version >= PythonVersion::Py39 {
                 for member in self.members {
-                    if let Some(target) = TYPING_TO_RENAME_PY39.iter().find_map(|(name, target)| {
+                    if let Some(target) = deprecations.iter().find_map(|(name, target)| {
                         if &member.name == *name {
                             Some(*target)
                         } else {

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP035.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP035.py.snap
@@ -420,4 +420,11 @@ UP035.py:46:10: UP035 Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
+UP035.py:53:1: UP035 `typing.Union` is deprecated, use `|` instead
+   |
+52 | # Deprecated in 3.10
+53 | from typing import Union
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ UP035
+   |
+
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__typing_noreturn_deprecated_py311.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__typing_noreturn_deprecated_py311.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff/src/rules/pyupgrade/mod.rs
+---
+UP035_py311.py:2:1: UP035 `typing.NoReturn` is deprecated, use `typing.Never` instead
+  |
+1 | # Deprecated in 3.11, use typing.Never
+2 | from typing import NoReturn
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP035
+  |
+
+


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Update UP035 to catch the following:

Python > 3.11
```
from typing import NoReturn
>> `typing.NoReturn` is deprecated, use `typing.Never` instead
```

Python > 3.10
```
from typing import Union
>> `typing.Union` is deprecated, use `|` instead
```

## Test Plan

Added additional fixture for 3.11 and amended existing file with updated examples

## Issue Link

Fixes: #5111 