### PR TITLE
Don't treat straight imports of __future__ as `__future__` imports

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyflakes/F401_18.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F401_18.py
@@ -1,0 +1,11 @@
+"""Test that straight `__future__` imports are considered unused."""
+
+
+def f():
+    import __future__
+
+
+def f():
+    import __future__
+
+    print(__future__.absolute_import)

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -805,24 +805,7 @@ where
                 }
 
                 for alias in names {
-                    if &alias.name == "__future__" {
-                        let name = alias.asname.as_ref().unwrap_or(&alias.name);
-                        self.add_binding(
-                            name,
-                            alias.identifier(self.locator),
-                            BindingKind::FutureImportation,
-                            BindingFlags::empty(),
-                        );
-
-                        if self.enabled(Rule::LateFutureImport) {
-                            if self.semantic.seen_futures_boundary() {
-                                self.diagnostics.push(Diagnostic::new(
-                                    pyflakes::rules::LateFutureImport,
-                                    stmt.range(),
-                                ));
-                            }
-                        }
-                    } else if alias.name.contains('.') && alias.asname.is_none() {
+                    if alias.name.contains('.') && alias.asname.is_none() {
                         // Given `import foo.bar`, `name` would be "foo", and `qualified_name` would be
                         // "foo.bar".
                         let name = alias.name.split('.').next().unwrap();

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -43,6 +43,7 @@ mod tests {
     #[test_case(Rule::UnusedImport, Path::new("F401_15.py"))]
     #[test_case(Rule::UnusedImport, Path::new("F401_16.py"))]
     #[test_case(Rule::UnusedImport, Path::new("F401_17.py"))]
+    #[test_case(Rule::UnusedImport, Path::new("F401_18.py"))]
     #[test_case(Rule::ImportShadowedByLoopVar, Path::new("F402.py"))]
     #[test_case(Rule::UndefinedLocalWithImportStar, Path::new("F403.py"))]
     #[test_case(Rule::LateFutureImport, Path::new("F404.py"))]

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_18.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_18.py.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff/src/rules/pyflakes/mod.rs
+---
+F401_18.py:5:12: F401 [*] `__future__` imported but unused
+  |
+4 | def f():
+5 |     import __future__
+  |            ^^^^^^^^^^ F401
+  |
+  = help: Remove unused import: `future`
+
+ℹ Fix
+2 2 | 
+3 3 | 
+4 4 | def f():
+5   |-    import __future__
+  5 |+    pass
+6 6 | 
+7 7 | 
+8 8 | def f():
+
+

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F404_F404.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F404_F404.py.snap
@@ -11,12 +11,4 @@ F404.py:6:1: F404 `from __future__` imports must occur at the beginning of the f
 8 | import __future__
   |
 
-F404.py:8:1: F404 `from __future__` imports must occur at the beginning of the file
-  |
-6 | from __future__ import print_function
-7 | 
-8 | import __future__
-  | ^^^^^^^^^^^^^^^^^ F404
-  |
-
 


### PR DESCRIPTION
## Summary

If you `import __future__`, it's not subject to the same rules as `from __future__ import feature` -- i.e., this is fine:

```python
x = 1

import __future__
```

It doesn't really make sense to treat these as `__future__` imports (though I can't imagine anyone ever does this anyway).
