### PR TITLE
Complete documentation for `flake8-blind-except` and `flake8-raise` rules

### DIFF
--- a/crates/ruff/src/rules/flake8_blind_except/rules/blind_except.rs
+++ b/crates/ruff/src/rules/flake8_blind_except/rules/blind_except.rs
@@ -7,6 +7,35 @@ use ruff_python_semantic::analyze::logging;
 
 use crate::checkers::ast::Checker;
 
+/// ## What it does
+/// Checks for blind `except` clauses.
+///
+/// ## Why is this bad?
+/// Blind exception handling can hide bugs and make debugging difficult. It can
+/// also lead to unexpected behavior, such as catching `KeyboardInterrupt` or
+/// `SystemExit` exceptions that prevent the user from exiting the program.
+///
+/// Instead of catching all exceptions, catch only the exceptions you expect.
+///
+/// ## Example
+/// ```python
+/// try:
+///     foo()
+/// except BaseException:
+///     ...
+/// ```
+///
+/// Use instead:
+/// ```python
+/// try:
+///     foo()
+/// except FileNotFoundError:
+///     ...
+/// ```
+///
+/// ## References
+/// - [Python documentation: The `try` statement](https://docs.python.org/3/reference/compound_stmts.html#the-try-statement)
+/// - [Python documentation: Exception hierarchy](https://docs.python.org/3/library/exceptions.html#exception-hierarchy)
 #[violation]
 pub struct BlindExcept {
     name: String,

--- a/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -7,6 +7,28 @@ use ruff_python_ast::helpers::match_parens;
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 
+/// ## What it does
+/// Checks for unnecessary parentheses on raised exceptions.
+///
+/// ## Why is this bad?
+/// If no arguments are passed to exception, parentheses are not required. This
+/// is because the `raise` statement accepts either an exception instance or an
+/// exception class (which is then implicitly instantiated).
+///
+/// Removing unnecessary parentheses makes code more readable and idiomatic.
+///
+/// ## Example
+/// ```python
+/// raise TypeError()
+/// ```
+///
+/// Use instead:
+/// ```python
+/// raise TypeError
+/// ```
+///
+/// ## References
+/// - [Python documentation: The `raise` statement](https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement)
 #[violation]
 pub struct UnnecessaryParenOnRaiseException;
 

--- a/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -11,9 +11,9 @@ use crate::registry::AsRule;
 /// Checks for unnecessary parentheses on raised exceptions.
 ///
 /// ## Why is this bad?
-/// If no arguments are passed to exception, parentheses are not required. This
-/// is because the `raise` statement accepts either an exception instance or an
-/// exception class (which is then implicitly instantiated).
+/// If no arguments are passed to an exception, parentheses are not required.
+/// This is because the `raise` statement accepts either an exception instance
+/// or an exception class (which is then implicitly instantiated).
 ///
 /// Removing unnecessary parentheses makes code more readable and idiomatic.
 ///


### PR DESCRIPTION
## Summary

Completes the documentation for the `flake8-blind-except` and `flake8-raise` rules.

Related to #2646.

## Test Plan

`python scripts/check_docs_formatted.py`
