### PR TITLE
Add `cargo dev repeat` for profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ github_search*.jsonl
 schemastore
 .venv*
 scratch.py
+perf.data
+perf.data.old
+flamegraph.svg
+# Additional target directories that don't invalidate the main compile cache when changing linker settings
+/target*
 
 ###
 # Rust.gitignore

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -68,7 +68,7 @@ pub enum Command {
     },
 }
 
-#[derive(Debug, clap::Args)]
+#[derive(Clone, Debug, clap::Args)]
 #[allow(clippy::struct_excessive_bools, clippy::module_name_repetitions)]
 pub struct CheckArgs {
     /// List of files or directories to check.

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -159,7 +159,7 @@ fn format(files: &[PathBuf]) -> Result<ExitStatus> {
     Ok(ExitStatus::Success)
 }
 
-fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
+pub fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
     let (cli, overrides) = args.partition();
 
     // Construct the "default" settings. These are used when no `pyproject.toml`

--- a/crates/ruff_dev/src/main.rs
+++ b/crates/ruff_dev/src/main.rs
@@ -29,6 +29,7 @@ struct Args {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 enum Command {
     /// Run all code and documentation generation steps.
     GenerateAll(generate_all::Args),


### PR DESCRIPTION
## Summary

This adds a new subcommand that can be used as

```shell
cargo build --bin ruff_dev --profile=release-debug
perf record -g -F 999 target/release-debug/ruff_dev repeat --repeat 30 --exit-zero --no-cache path/to/cpython > /dev/null
flamegraph --perfdata perf.data
```

## Test Plan

This is a ruff internal script. I successfully used it to profile cpython with the instructions above

