### PR TITLE
Move unconventional import rule to post-binding phase

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -950,18 +950,6 @@ where
                             }
                         }
                     }
-                    if self.enabled(Rule::UnconventionalImportAlias) {
-                        if let Some(diagnostic) =
-                            flake8_import_conventions::rules::conventional_import_alias(
-                                stmt,
-                                &alias.name,
-                                alias.asname.as_deref(),
-                                &self.settings.flake8_import_conventions.aliases,
-                            )
-                        {
-                            self.diagnostics.push(diagnostic);
-                        }
-                    }
                     if self.enabled(Rule::BannedImportAlias) {
                         if let Some(asname) = &alias.asname {
                             if let Some(diagnostic) =
@@ -1162,20 +1150,6 @@ where
                             self.diagnostics.push(diagnostic);
                         }
                     }
-                    if self.enabled(Rule::UnconventionalImportAlias) {
-                        let qualified_name =
-                            helpers::format_import_from_member(level, module, &alias.name);
-                        if let Some(diagnostic) =
-                            flake8_import_conventions::rules::conventional_import_alias(
-                                stmt,
-                                &qualified_name,
-                                alias.asname.as_deref(),
-                                &self.settings.flake8_import_conventions.aliases,
-                            )
-                        {
-                            self.diagnostics.push(diagnostic);
-                        }
-                    }
                     if self.enabled(Rule::BannedImportAlias) {
                         if let Some(asname) = &alias.asname {
                             let qualified_name =
@@ -1192,7 +1166,6 @@ where
                             }
                         }
                     }
-
                     if let Some(asname) = &alias.asname {
                         if self.enabled(Rule::ConstantImportedAsNonConstant) {
                             if let Some(diagnostic) =
@@ -1259,8 +1232,6 @@ where
                                 self.diagnostics.push(diagnostic);
                             }
                         }
-
-                        // pylint
                         if !self.is_stub {
                             if self.enabled(Rule::UselessImportAlias) {
                                 pylint::rules::useless_import_alias(self, alias);
@@ -4733,6 +4704,7 @@ impl<'a> Checker<'a> {
             Rule::TypingOnlyStandardLibraryImport,
             Rule::UndefinedExport,
             Rule::UnaliasedCollectionsAbcSetImport,
+            Rule::UnconventionalImportAlias,
         ]) {
             return;
         }
@@ -4918,7 +4890,14 @@ impl<'a> Checker<'a> {
             if self.enabled(Rule::UnusedImport) {
                 pyflakes::rules::unused_import(self, scope, &mut diagnostics);
             }
-
+            if self.enabled(Rule::UnconventionalImportAlias) {
+                flake8_import_conventions::rules::unconventional_import_alias(
+                    self,
+                    scope,
+                    &mut diagnostics,
+                    &self.settings.flake8_import_conventions.aliases,
+                );
+            }
             if self.is_stub {
                 if self.enabled(Rule::UnaliasedCollectionsAbcSetImport) {
                     flake8_pyi::rules::unaliased_collections_abc_set_import(

--- a/crates/ruff/src/rules/flake8_import_conventions/rules/mod.rs
+++ b/crates/ruff/src/rules/flake8_import_conventions/rules/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) use banned_import_alias::*;
 pub(crate) use banned_import_from::*;
-pub(crate) use conventional_import_alias::*;
+pub(crate) use unconventional_import_alias::*;
 
 mod banned_import_alias;
 mod banned_import_from;
-mod conventional_import_alias;
+mod unconventional_import_alias;

--- a/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__custom.snap
+++ b/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__custom.snap
@@ -1,278 +1,278 @@
 ---
 source: crates/ruff/src/rules/flake8_import_conventions/mod.rs
 ---
-custom.py:3:1: ICN001 `altair` should be imported as `alt`
+custom.py:3:8: ICN001 `altair` should be imported as `alt`
   |
 1 | import math  # not checked
 2 | 
 3 | import altair  # unconventional
-  | ^^^^^^^^^^^^^ ICN001
+  |        ^^^^^^ ICN001
 4 | import dask.array  # unconventional
 5 | import dask.dataframe  # unconventional
   |
 
-custom.py:4:1: ICN001 `dask.array` should be imported as `da`
+custom.py:4:8: ICN001 `dask.array` should be imported as `da`
   |
 3 | import altair  # unconventional
 4 | import dask.array  # unconventional
-  | ^^^^^^^^^^^^^^^^^ ICN001
+  |        ^^^^ ICN001
 5 | import dask.dataframe  # unconventional
 6 | import matplotlib.pyplot  # unconventional
   |
 
-custom.py:5:1: ICN001 `dask.dataframe` should be imported as `dd`
+custom.py:5:8: ICN001 `dask.dataframe` should be imported as `dd`
   |
 3 | import altair  # unconventional
 4 | import dask.array  # unconventional
 5 | import dask.dataframe  # unconventional
-  | ^^^^^^^^^^^^^^^^^^^^^ ICN001
+  |        ^^^^ ICN001
 6 | import matplotlib.pyplot  # unconventional
 7 | import numpy  # unconventional
   |
 
-custom.py:6:1: ICN001 `matplotlib.pyplot` should be imported as `plt`
+custom.py:6:8: ICN001 `matplotlib.pyplot` should be imported as `plt`
   |
 4 | import dask.array  # unconventional
 5 | import dask.dataframe  # unconventional
 6 | import matplotlib.pyplot  # unconventional
-  | ^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+  |        ^^^^^^^^^^ ICN001
 7 | import numpy  # unconventional
 8 | import pandas  # unconventional
   |
 
-custom.py:7:1: ICN001 `numpy` should be imported as `np`
+custom.py:7:8: ICN001 `numpy` should be imported as `np`
   |
 5 | import dask.dataframe  # unconventional
 6 | import matplotlib.pyplot  # unconventional
 7 | import numpy  # unconventional
-  | ^^^^^^^^^^^^ ICN001
+  |        ^^^^^ ICN001
 8 | import pandas  # unconventional
 9 | import seaborn  # unconventional
   |
 
-custom.py:8:1: ICN001 `pandas` should be imported as `pd`
+custom.py:8:8: ICN001 `pandas` should be imported as `pd`
    |
  6 | import matplotlib.pyplot  # unconventional
  7 | import numpy  # unconventional
  8 | import pandas  # unconventional
-   | ^^^^^^^^^^^^^ ICN001
+   |        ^^^^^^ ICN001
  9 | import seaborn  # unconventional
 10 | import tensorflow  # unconventional
    |
 
-custom.py:9:1: ICN001 `seaborn` should be imported as `sns`
+custom.py:9:8: ICN001 `seaborn` should be imported as `sns`
    |
  7 | import numpy  # unconventional
  8 | import pandas  # unconventional
  9 | import seaborn  # unconventional
-   | ^^^^^^^^^^^^^^ ICN001
+   |        ^^^^^^^ ICN001
 10 | import tensorflow  # unconventional
 11 | import holoviews  # unconventional
    |
 
-custom.py:10:1: ICN001 `tensorflow` should be imported as `tf`
+custom.py:10:8: ICN001 `tensorflow` should be imported as `tf`
    |
  8 | import pandas  # unconventional
  9 | import seaborn  # unconventional
 10 | import tensorflow  # unconventional
-   | ^^^^^^^^^^^^^^^^^ ICN001
+   |        ^^^^^^^^^^ ICN001
 11 | import holoviews  # unconventional
 12 | import panel  # unconventional
    |
 
-custom.py:11:1: ICN001 `holoviews` should be imported as `hv`
+custom.py:11:8: ICN001 `holoviews` should be imported as `hv`
    |
  9 | import seaborn  # unconventional
 10 | import tensorflow  # unconventional
 11 | import holoviews  # unconventional
-   | ^^^^^^^^^^^^^^^^ ICN001
+   |        ^^^^^^^^^ ICN001
 12 | import panel  # unconventional
 13 | import plotly.express  # unconventional
    |
 
-custom.py:12:1: ICN001 `panel` should be imported as `pn`
+custom.py:12:8: ICN001 `panel` should be imported as `pn`
    |
 10 | import tensorflow  # unconventional
 11 | import holoviews  # unconventional
 12 | import panel  # unconventional
-   | ^^^^^^^^^^^^ ICN001
+   |        ^^^^^ ICN001
 13 | import plotly.express  # unconventional
 14 | import matplotlib  # unconventional
    |
 
-custom.py:13:1: ICN001 `plotly.express` should be imported as `px`
+custom.py:13:8: ICN001 `plotly.express` should be imported as `px`
    |
 11 | import holoviews  # unconventional
 12 | import panel  # unconventional
 13 | import plotly.express  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |        ^^^^^^ ICN001
 14 | import matplotlib  # unconventional
 15 | import polars  # unconventional
    |
 
-custom.py:14:1: ICN001 `matplotlib` should be imported as `mpl`
+custom.py:14:8: ICN001 `matplotlib` should be imported as `mpl`
    |
 12 | import panel  # unconventional
 13 | import plotly.express  # unconventional
 14 | import matplotlib  # unconventional
-   | ^^^^^^^^^^^^^^^^^ ICN001
+   |        ^^^^^^^^^^ ICN001
 15 | import polars  # unconventional
 16 | import pyarrow  # unconventional
    |
 
-custom.py:15:1: ICN001 `polars` should be imported as `pl`
+custom.py:15:8: ICN001 `polars` should be imported as `pl`
    |
 13 | import plotly.express  # unconventional
 14 | import matplotlib  # unconventional
 15 | import polars  # unconventional
-   | ^^^^^^^^^^^^^ ICN001
+   |        ^^^^^^ ICN001
 16 | import pyarrow  # unconventional
    |
 
-custom.py:16:1: ICN001 `pyarrow` should be imported as `pa`
+custom.py:16:8: ICN001 `pyarrow` should be imported as `pa`
    |
 14 | import matplotlib  # unconventional
 15 | import polars  # unconventional
 16 | import pyarrow  # unconventional
-   | ^^^^^^^^^^^^^^ ICN001
+   |        ^^^^^^^ ICN001
 17 | 
 18 | import altair as altr  # unconventional
    |
 
-custom.py:18:1: ICN001 `altair` should be imported as `alt`
+custom.py:18:18: ICN001 `altair` should be imported as `alt`
    |
 16 | import pyarrow  # unconventional
 17 | 
 18 | import altair as altr  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                  ^^^^ ICN001
 19 | import matplotlib.pyplot as plot  # unconventional
 20 | import dask.array as darray  # unconventional
    |
 
-custom.py:19:1: ICN001 `matplotlib.pyplot` should be imported as `plt`
+custom.py:19:29: ICN001 `matplotlib.pyplot` should be imported as `plt`
    |
 18 | import altair as altr  # unconventional
 19 | import matplotlib.pyplot as plot  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                             ^^^^ ICN001
 20 | import dask.array as darray  # unconventional
 21 | import dask.dataframe as ddf  # unconventional
    |
 
-custom.py:20:1: ICN001 `dask.array` should be imported as `da`
+custom.py:20:22: ICN001 `dask.array` should be imported as `da`
    |
 18 | import altair as altr  # unconventional
 19 | import matplotlib.pyplot as plot  # unconventional
 20 | import dask.array as darray  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                      ^^^^^^ ICN001
 21 | import dask.dataframe as ddf  # unconventional
 22 | import numpy as nmp  # unconventional
    |
 
-custom.py:21:1: ICN001 `dask.dataframe` should be imported as `dd`
+custom.py:21:26: ICN001 `dask.dataframe` should be imported as `dd`
    |
 19 | import matplotlib.pyplot as plot  # unconventional
 20 | import dask.array as darray  # unconventional
 21 | import dask.dataframe as ddf  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                          ^^^ ICN001
 22 | import numpy as nmp  # unconventional
 23 | import pandas as pdas  # unconventional
    |
 
-custom.py:22:1: ICN001 `numpy` should be imported as `np`
+custom.py:22:17: ICN001 `numpy` should be imported as `np`
    |
 20 | import dask.array as darray  # unconventional
 21 | import dask.dataframe as ddf  # unconventional
 22 | import numpy as nmp  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^ ICN001
+   |                 ^^^ ICN001
 23 | import pandas as pdas  # unconventional
 24 | import seaborn as sbrn  # unconventional
    |
 
-custom.py:23:1: ICN001 `pandas` should be imported as `pd`
+custom.py:23:18: ICN001 `pandas` should be imported as `pd`
    |
 21 | import dask.dataframe as ddf  # unconventional
 22 | import numpy as nmp  # unconventional
 23 | import pandas as pdas  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                  ^^^^ ICN001
 24 | import seaborn as sbrn  # unconventional
 25 | import tensorflow as tfz  # unconventional
    |
 
-custom.py:24:1: ICN001 `seaborn` should be imported as `sns`
+custom.py:24:19: ICN001 `seaborn` should be imported as `sns`
    |
 22 | import numpy as nmp  # unconventional
 23 | import pandas as pdas  # unconventional
 24 | import seaborn as sbrn  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                   ^^^^ ICN001
 25 | import tensorflow as tfz  # unconventional
 26 | import holoviews as hsv  # unconventional
    |
 
-custom.py:25:1: ICN001 `tensorflow` should be imported as `tf`
+custom.py:25:22: ICN001 `tensorflow` should be imported as `tf`
    |
 23 | import pandas as pdas  # unconventional
 24 | import seaborn as sbrn  # unconventional
 25 | import tensorflow as tfz  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                      ^^^ ICN001
 26 | import holoviews as hsv  # unconventional
 27 | import panel as pns  # unconventional
    |
 
-custom.py:26:1: ICN001 `holoviews` should be imported as `hv`
+custom.py:26:21: ICN001 `holoviews` should be imported as `hv`
    |
 24 | import seaborn as sbrn  # unconventional
 25 | import tensorflow as tfz  # unconventional
 26 | import holoviews as hsv  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                     ^^^ ICN001
 27 | import panel as pns  # unconventional
 28 | import plotly.express as pltx  # unconventional
    |
 
-custom.py:27:1: ICN001 `panel` should be imported as `pn`
+custom.py:27:17: ICN001 `panel` should be imported as `pn`
    |
 25 | import tensorflow as tfz  # unconventional
 26 | import holoviews as hsv  # unconventional
 27 | import panel as pns  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^ ICN001
+   |                 ^^^ ICN001
 28 | import plotly.express as pltx  # unconventional
 29 | import matplotlib as ml  # unconventional
    |
 
-custom.py:28:1: ICN001 `plotly.express` should be imported as `px`
+custom.py:28:26: ICN001 `plotly.express` should be imported as `px`
    |
 26 | import holoviews as hsv  # unconventional
 27 | import panel as pns  # unconventional
 28 | import plotly.express as pltx  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                          ^^^^ ICN001
 29 | import matplotlib as ml  # unconventional
 30 | import polars as ps # unconventional
    |
 
-custom.py:29:1: ICN001 `matplotlib` should be imported as `mpl`
+custom.py:29:22: ICN001 `matplotlib` should be imported as `mpl`
    |
 27 | import panel as pns  # unconventional
 28 | import plotly.express as pltx  # unconventional
 29 | import matplotlib as ml  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                      ^^ ICN001
 30 | import polars as ps # unconventional
 31 | import pyarrow as arr  # unconventional
    |
 
-custom.py:30:1: ICN001 `polars` should be imported as `pl`
+custom.py:30:18: ICN001 `polars` should be imported as `pl`
    |
 28 | import plotly.express as pltx  # unconventional
 29 | import matplotlib as ml  # unconventional
 30 | import polars as ps # unconventional
-   | ^^^^^^^^^^^^^^^^^^^ ICN001
+   |                  ^^ ICN001
 31 | import pyarrow as arr  # unconventional
    |
 
-custom.py:31:1: ICN001 `pyarrow` should be imported as `pa`
+custom.py:31:19: ICN001 `pyarrow` should be imported as `pa`
    |
 29 | import matplotlib as ml  # unconventional
 30 | import polars as ps # unconventional
 31 | import pyarrow as arr  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                   ^^^ ICN001
 32 | 
 33 | import altair as alt  # conventional
    |

--- a/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__defaults.snap
+++ b/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__defaults.snap
@@ -1,98 +1,98 @@
 ---
 source: crates/ruff/src/rules/flake8_import_conventions/mod.rs
 ---
-defaults.py:3:1: ICN001 `altair` should be imported as `alt`
+defaults.py:3:8: ICN001 `altair` should be imported as `alt`
   |
 1 | import math  # not checked
 2 | 
 3 | import altair  # unconventional
-  | ^^^^^^^^^^^^^ ICN001
+  |        ^^^^^^ ICN001
 4 | import matplotlib.pyplot  # unconventional
 5 | import numpy  # unconventional
   |
 
-defaults.py:4:1: ICN001 `matplotlib.pyplot` should be imported as `plt`
+defaults.py:4:8: ICN001 `matplotlib.pyplot` should be imported as `plt`
   |
 3 | import altair  # unconventional
 4 | import matplotlib.pyplot  # unconventional
-  | ^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+  |        ^^^^^^^^^^ ICN001
 5 | import numpy  # unconventional
 6 | import pandas  # unconventional
   |
 
-defaults.py:5:1: ICN001 `numpy` should be imported as `np`
+defaults.py:5:8: ICN001 `numpy` should be imported as `np`
   |
 3 | import altair  # unconventional
 4 | import matplotlib.pyplot  # unconventional
 5 | import numpy  # unconventional
-  | ^^^^^^^^^^^^ ICN001
+  |        ^^^^^ ICN001
 6 | import pandas  # unconventional
 7 | import seaborn  # unconventional
   |
 
-defaults.py:6:1: ICN001 `pandas` should be imported as `pd`
+defaults.py:6:8: ICN001 `pandas` should be imported as `pd`
   |
 4 | import matplotlib.pyplot  # unconventional
 5 | import numpy  # unconventional
 6 | import pandas  # unconventional
-  | ^^^^^^^^^^^^^ ICN001
+  |        ^^^^^^ ICN001
 7 | import seaborn  # unconventional
   |
 
-defaults.py:7:1: ICN001 `seaborn` should be imported as `sns`
+defaults.py:7:8: ICN001 `seaborn` should be imported as `sns`
   |
 5 | import numpy  # unconventional
 6 | import pandas  # unconventional
 7 | import seaborn  # unconventional
-  | ^^^^^^^^^^^^^^ ICN001
+  |        ^^^^^^^ ICN001
 8 | 
 9 | import altair as altr  # unconventional
   |
 
-defaults.py:9:1: ICN001 `altair` should be imported as `alt`
+defaults.py:9:18: ICN001 `altair` should be imported as `alt`
    |
  7 | import seaborn  # unconventional
  8 | 
  9 | import altair as altr  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                  ^^^^ ICN001
 10 | import matplotlib.pyplot as plot  # unconventional
 11 | import numpy as nmp  # unconventional
    |
 
-defaults.py:10:1: ICN001 `matplotlib.pyplot` should be imported as `plt`
+defaults.py:10:29: ICN001 `matplotlib.pyplot` should be imported as `plt`
    |
  9 | import altair as altr  # unconventional
 10 | import matplotlib.pyplot as plot  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                             ^^^^ ICN001
 11 | import numpy as nmp  # unconventional
 12 | import pandas as pdas  # unconventional
    |
 
-defaults.py:11:1: ICN001 `numpy` should be imported as `np`
+defaults.py:11:17: ICN001 `numpy` should be imported as `np`
    |
  9 | import altair as altr  # unconventional
 10 | import matplotlib.pyplot as plot  # unconventional
 11 | import numpy as nmp  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^ ICN001
+   |                 ^^^ ICN001
 12 | import pandas as pdas  # unconventional
 13 | import seaborn as sbrn  # unconventional
    |
 
-defaults.py:12:1: ICN001 `pandas` should be imported as `pd`
+defaults.py:12:18: ICN001 `pandas` should be imported as `pd`
    |
 10 | import matplotlib.pyplot as plot  # unconventional
 11 | import numpy as nmp  # unconventional
 12 | import pandas as pdas  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                  ^^^^ ICN001
 13 | import seaborn as sbrn  # unconventional
    |
 
-defaults.py:13:1: ICN001 `seaborn` should be imported as `sns`
+defaults.py:13:19: ICN001 `seaborn` should be imported as `sns`
    |
 11 | import numpy as nmp  # unconventional
 12 | import pandas as pdas  # unconventional
 13 | import seaborn as sbrn  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                   ^^^^ ICN001
 14 | 
 15 | import altair as alt  # conventional
    |

--- a/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__from_imports.snap
+++ b/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__from_imports.snap
@@ -1,81 +1,81 @@
 ---
 source: crates/ruff/src/rules/flake8_import_conventions/mod.rs
 ---
-from_imports.py:3:1: ICN001 `xml.dom.minidom` should be imported as `md`
+from_imports.py:3:8: ICN001 `xml.dom.minidom` should be imported as `md`
   |
 1 | # Test absolute imports
 2 | # Violation cases
 3 | import xml.dom.minidom
-  | ^^^^^^^^^^^^^^^^^^^^^^ ICN001
+  |        ^^^ ICN001
 4 | import xml.dom.minidom as wrong
 5 | from xml.dom import minidom as wrong
   |
 
-from_imports.py:4:1: ICN001 `xml.dom.minidom` should be imported as `md`
+from_imports.py:4:27: ICN001 `xml.dom.minidom` should be imported as `md`
   |
 2 | # Violation cases
 3 | import xml.dom.minidom
 4 | import xml.dom.minidom as wrong
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+  |                           ^^^^^ ICN001
 5 | from xml.dom import minidom as wrong
 6 | from xml.dom import minidom
   |
 
-from_imports.py:5:1: ICN001 `xml.dom.minidom` should be imported as `md`
+from_imports.py:5:32: ICN001 `xml.dom.minidom` should be imported as `md`
   |
 3 | import xml.dom.minidom
 4 | import xml.dom.minidom as wrong
 5 | from xml.dom import minidom as wrong
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+  |                                ^^^^^ ICN001
 6 | from xml.dom import minidom
 7 | from xml.dom.minidom import parseString as wrong  # Ensure ICN001 throws on function import.
   |
 
-from_imports.py:6:1: ICN001 `xml.dom.minidom` should be imported as `md`
+from_imports.py:6:21: ICN001 `xml.dom.minidom` should be imported as `md`
   |
 4 | import xml.dom.minidom as wrong
 5 | from xml.dom import minidom as wrong
 6 | from xml.dom import minidom
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+  |                     ^^^^^^^ ICN001
 7 | from xml.dom.minidom import parseString as wrong  # Ensure ICN001 throws on function import.
 8 | from xml.dom.minidom import parseString
   |
 
-from_imports.py:7:1: ICN001 `xml.dom.minidom.parseString` should be imported as `pstr`
+from_imports.py:7:44: ICN001 `xml.dom.minidom.parseString` should be imported as `pstr`
   |
 5 | from xml.dom import minidom as wrong
 6 | from xml.dom import minidom
 7 | from xml.dom.minidom import parseString as wrong  # Ensure ICN001 throws on function import.
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+  |                                            ^^^^^ ICN001
 8 | from xml.dom.minidom import parseString
 9 | from xml.dom.minidom import parse, parseString
   |
 
-from_imports.py:8:1: ICN001 `xml.dom.minidom.parseString` should be imported as `pstr`
+from_imports.py:8:29: ICN001 `xml.dom.minidom.parseString` should be imported as `pstr`
    |
  6 | from xml.dom import minidom
  7 | from xml.dom.minidom import parseString as wrong  # Ensure ICN001 throws on function import.
  8 | from xml.dom.minidom import parseString
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                             ^^^^^^^^^^^ ICN001
  9 | from xml.dom.minidom import parse, parseString
 10 | from xml.dom.minidom import parse as ps, parseString as wrong
    |
 
-from_imports.py:9:1: ICN001 `xml.dom.minidom.parseString` should be imported as `pstr`
+from_imports.py:9:36: ICN001 `xml.dom.minidom.parseString` should be imported as `pstr`
    |
  7 | from xml.dom.minidom import parseString as wrong  # Ensure ICN001 throws on function import.
  8 | from xml.dom.minidom import parseString
  9 | from xml.dom.minidom import parse, parseString
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                                    ^^^^^^^^^^^ ICN001
 10 | from xml.dom.minidom import parse as ps, parseString as wrong
    |
 
-from_imports.py:10:1: ICN001 `xml.dom.minidom.parseString` should be imported as `pstr`
+from_imports.py:10:57: ICN001 `xml.dom.minidom.parseString` should be imported as `pstr`
    |
  8 | from xml.dom.minidom import parseString
  9 | from xml.dom.minidom import parse, parseString
 10 | from xml.dom.minidom import parse as ps, parseString as wrong
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                                                         ^^^^^ ICN001
 11 | 
 12 | # No ICN001 violations
    |

--- a/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__override_default.snap
+++ b/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__override_default.snap
@@ -1,98 +1,98 @@
 ---
 source: crates/ruff/src/rules/flake8_import_conventions/mod.rs
 ---
-override_default.py:3:1: ICN001 `altair` should be imported as `alt`
+override_default.py:3:8: ICN001 `altair` should be imported as `alt`
   |
 1 | import math  # not checked
 2 | 
 3 | import altair  # unconventional
-  | ^^^^^^^^^^^^^ ICN001
+  |        ^^^^^^ ICN001
 4 | import matplotlib.pyplot  # unconventional
 5 | import numpy  # unconventional
   |
 
-override_default.py:4:1: ICN001 `matplotlib.pyplot` should be imported as `plt`
+override_default.py:4:8: ICN001 `matplotlib.pyplot` should be imported as `plt`
   |
 3 | import altair  # unconventional
 4 | import matplotlib.pyplot  # unconventional
-  | ^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+  |        ^^^^^^^^^^ ICN001
 5 | import numpy  # unconventional
 6 | import pandas  # unconventional
   |
 
-override_default.py:5:1: ICN001 `numpy` should be imported as `nmp`
+override_default.py:5:8: ICN001 `numpy` should be imported as `nmp`
   |
 3 | import altair  # unconventional
 4 | import matplotlib.pyplot  # unconventional
 5 | import numpy  # unconventional
-  | ^^^^^^^^^^^^ ICN001
+  |        ^^^^^ ICN001
 6 | import pandas  # unconventional
 7 | import seaborn  # unconventional
   |
 
-override_default.py:6:1: ICN001 `pandas` should be imported as `pd`
+override_default.py:6:8: ICN001 `pandas` should be imported as `pd`
   |
 4 | import matplotlib.pyplot  # unconventional
 5 | import numpy  # unconventional
 6 | import pandas  # unconventional
-  | ^^^^^^^^^^^^^ ICN001
+  |        ^^^^^^ ICN001
 7 | import seaborn  # unconventional
   |
 
-override_default.py:7:1: ICN001 `seaborn` should be imported as `sns`
+override_default.py:7:8: ICN001 `seaborn` should be imported as `sns`
   |
 5 | import numpy  # unconventional
 6 | import pandas  # unconventional
 7 | import seaborn  # unconventional
-  | ^^^^^^^^^^^^^^ ICN001
+  |        ^^^^^^^ ICN001
 8 | 
 9 | import altair as altr  # unconventional
   |
 
-override_default.py:9:1: ICN001 `altair` should be imported as `alt`
+override_default.py:9:18: ICN001 `altair` should be imported as `alt`
    |
  7 | import seaborn  # unconventional
  8 | 
  9 | import altair as altr  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                  ^^^^ ICN001
 10 | import matplotlib.pyplot as plot  # unconventional
 11 | import numpy as np  # unconventional
    |
 
-override_default.py:10:1: ICN001 `matplotlib.pyplot` should be imported as `plt`
+override_default.py:10:29: ICN001 `matplotlib.pyplot` should be imported as `plt`
    |
  9 | import altair as altr  # unconventional
 10 | import matplotlib.pyplot as plot  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                             ^^^^ ICN001
 11 | import numpy as np  # unconventional
 12 | import pandas as pdas  # unconventional
    |
 
-override_default.py:11:1: ICN001 `numpy` should be imported as `nmp`
+override_default.py:11:17: ICN001 `numpy` should be imported as `nmp`
    |
  9 | import altair as altr  # unconventional
 10 | import matplotlib.pyplot as plot  # unconventional
 11 | import numpy as np  # unconventional
-   | ^^^^^^^^^^^^^^^^^^ ICN001
+   |                 ^^ ICN001
 12 | import pandas as pdas  # unconventional
 13 | import seaborn as sbrn  # unconventional
    |
 
-override_default.py:12:1: ICN001 `pandas` should be imported as `pd`
+override_default.py:12:18: ICN001 `pandas` should be imported as `pd`
    |
 10 | import matplotlib.pyplot as plot  # unconventional
 11 | import numpy as np  # unconventional
 12 | import pandas as pdas  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                  ^^^^ ICN001
 13 | import seaborn as sbrn  # unconventional
    |
 
-override_default.py:13:1: ICN001 `seaborn` should be imported as `sns`
+override_default.py:13:19: ICN001 `seaborn` should be imported as `sns`
    |
 11 | import numpy as np  # unconventional
 12 | import pandas as pdas  # unconventional
 13 | import seaborn as sbrn  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                   ^^^^ ICN001
 14 | 
 15 | import altair as alt  # conventional
    |

--- a/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__remove_default.snap
+++ b/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__remove_default.snap
@@ -1,78 +1,78 @@
 ---
 source: crates/ruff/src/rules/flake8_import_conventions/mod.rs
 ---
-remove_default.py:3:1: ICN001 `altair` should be imported as `alt`
+remove_default.py:3:8: ICN001 `altair` should be imported as `alt`
   |
 1 | import math  # not checked
 2 | 
 3 | import altair  # unconventional
-  | ^^^^^^^^^^^^^ ICN001
+  |        ^^^^^^ ICN001
 4 | import matplotlib.pyplot  # unconventional
 5 | import numpy  # not checked
   |
 
-remove_default.py:4:1: ICN001 `matplotlib.pyplot` should be imported as `plt`
+remove_default.py:4:8: ICN001 `matplotlib.pyplot` should be imported as `plt`
   |
 3 | import altair  # unconventional
 4 | import matplotlib.pyplot  # unconventional
-  | ^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+  |        ^^^^^^^^^^ ICN001
 5 | import numpy  # not checked
 6 | import pandas  # unconventional
   |
 
-remove_default.py:6:1: ICN001 `pandas` should be imported as `pd`
+remove_default.py:6:8: ICN001 `pandas` should be imported as `pd`
   |
 4 | import matplotlib.pyplot  # unconventional
 5 | import numpy  # not checked
 6 | import pandas  # unconventional
-  | ^^^^^^^^^^^^^ ICN001
+  |        ^^^^^^ ICN001
 7 | import seaborn  # unconventional
   |
 
-remove_default.py:7:1: ICN001 `seaborn` should be imported as `sns`
+remove_default.py:7:8: ICN001 `seaborn` should be imported as `sns`
   |
 5 | import numpy  # not checked
 6 | import pandas  # unconventional
 7 | import seaborn  # unconventional
-  | ^^^^^^^^^^^^^^ ICN001
+  |        ^^^^^^^ ICN001
 8 | 
 9 | import altair as altr  # unconventional
   |
 
-remove_default.py:9:1: ICN001 `altair` should be imported as `alt`
+remove_default.py:9:18: ICN001 `altair` should be imported as `alt`
    |
  7 | import seaborn  # unconventional
  8 | 
  9 | import altair as altr  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                  ^^^^ ICN001
 10 | import matplotlib.pyplot as plot  # unconventional
 11 | import numpy as nmp  # not checked
    |
 
-remove_default.py:10:1: ICN001 `matplotlib.pyplot` should be imported as `plt`
+remove_default.py:10:29: ICN001 `matplotlib.pyplot` should be imported as `plt`
    |
  9 | import altair as altr  # unconventional
 10 | import matplotlib.pyplot as plot  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                             ^^^^ ICN001
 11 | import numpy as nmp  # not checked
 12 | import pandas as pdas  # unconventional
    |
 
-remove_default.py:12:1: ICN001 `pandas` should be imported as `pd`
+remove_default.py:12:18: ICN001 `pandas` should be imported as `pd`
    |
 10 | import matplotlib.pyplot as plot  # unconventional
 11 | import numpy as nmp  # not checked
 12 | import pandas as pdas  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                  ^^^^ ICN001
 13 | import seaborn as sbrn  # unconventional
    |
 
-remove_default.py:13:1: ICN001 `seaborn` should be imported as `sns`
+remove_default.py:13:19: ICN001 `seaborn` should be imported as `sns`
    |
 11 | import numpy as nmp  # not checked
 12 | import pandas as pdas  # unconventional
 13 | import seaborn as sbrn  # unconventional
-   | ^^^^^^^^^^^^^^^^^^^^^^ ICN001
+   |                   ^^^^ ICN001
 14 | 
 15 | import altair as alt  # conventional
    |


### PR DESCRIPTION
## Summary

This PR moves the "unconventional import alias" rule (which enforces, e.g., that `pandas` is imported as `pd`) to the "dead scopes" phase, after the main linter pass. This (1) avoids an allocation since we no longer need to create the qualified name in the linter pass; and (2) will allow us to autofix it, since we'll have access to all references.

## Test Plan

`cargo test` -- all changes are to ranges (which are improvements IMO).
