### PR TITLE
Enable autofix for unconventional imports rule

### DIFF
--- a/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__custom.snap
+++ b/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__custom.snap
@@ -10,6 +10,7 @@ custom.py:3:8: ICN001 `altair` should be imported as `alt`
 4 | import dask.array  # unconventional
 5 | import dask.dataframe  # unconventional
   |
+  = help: Alias `altair` to `alt`
 
 custom.py:4:8: ICN001 `dask.array` should be imported as `da`
   |
@@ -19,6 +20,7 @@ custom.py:4:8: ICN001 `dask.array` should be imported as `da`
 5 | import dask.dataframe  # unconventional
 6 | import matplotlib.pyplot  # unconventional
   |
+  = help: Alias `dask.array` to `da`
 
 custom.py:5:8: ICN001 `dask.dataframe` should be imported as `dd`
   |
@@ -29,6 +31,7 @@ custom.py:5:8: ICN001 `dask.dataframe` should be imported as `dd`
 6 | import matplotlib.pyplot  # unconventional
 7 | import numpy  # unconventional
   |
+  = help: Alias `dask.dataframe` to `dd`
 
 custom.py:6:8: ICN001 `matplotlib.pyplot` should be imported as `plt`
   |
@@ -39,6 +42,7 @@ custom.py:6:8: ICN001 `matplotlib.pyplot` should be imported as `plt`
 7 | import numpy  # unconventional
 8 | import pandas  # unconventional
   |
+  = help: Alias `matplotlib.pyplot` to `plt`
 
 custom.py:7:8: ICN001 `numpy` should be imported as `np`
   |
@@ -49,6 +53,7 @@ custom.py:7:8: ICN001 `numpy` should be imported as `np`
 8 | import pandas  # unconventional
 9 | import seaborn  # unconventional
   |
+  = help: Alias `numpy` to `np`
 
 custom.py:8:8: ICN001 `pandas` should be imported as `pd`
    |
@@ -59,6 +64,7 @@ custom.py:8:8: ICN001 `pandas` should be imported as `pd`
  9 | import seaborn  # unconventional
 10 | import tensorflow  # unconventional
    |
+   = help: Alias `pandas` to `pd`
 
 custom.py:9:8: ICN001 `seaborn` should be imported as `sns`
    |
@@ -69,6 +75,7 @@ custom.py:9:8: ICN001 `seaborn` should be imported as `sns`
 10 | import tensorflow  # unconventional
 11 | import holoviews  # unconventional
    |
+   = help: Alias `seaborn` to `sns`
 
 custom.py:10:8: ICN001 `tensorflow` should be imported as `tf`
    |
@@ -79,6 +86,7 @@ custom.py:10:8: ICN001 `tensorflow` should be imported as `tf`
 11 | import holoviews  # unconventional
 12 | import panel  # unconventional
    |
+   = help: Alias `tensorflow` to `tf`
 
 custom.py:11:8: ICN001 `holoviews` should be imported as `hv`
    |
@@ -89,6 +97,7 @@ custom.py:11:8: ICN001 `holoviews` should be imported as `hv`
 12 | import panel  # unconventional
 13 | import plotly.express  # unconventional
    |
+   = help: Alias `holoviews` to `hv`
 
 custom.py:12:8: ICN001 `panel` should be imported as `pn`
    |
@@ -99,6 +108,7 @@ custom.py:12:8: ICN001 `panel` should be imported as `pn`
 13 | import plotly.express  # unconventional
 14 | import matplotlib  # unconventional
    |
+   = help: Alias `panel` to `pn`
 
 custom.py:13:8: ICN001 `plotly.express` should be imported as `px`
    |
@@ -109,6 +119,7 @@ custom.py:13:8: ICN001 `plotly.express` should be imported as `px`
 14 | import matplotlib  # unconventional
 15 | import polars  # unconventional
    |
+   = help: Alias `plotly.express` to `px`
 
 custom.py:14:8: ICN001 `matplotlib` should be imported as `mpl`
    |
@@ -119,6 +130,7 @@ custom.py:14:8: ICN001 `matplotlib` should be imported as `mpl`
 15 | import polars  # unconventional
 16 | import pyarrow  # unconventional
    |
+   = help: Alias `matplotlib` to `mpl`
 
 custom.py:15:8: ICN001 `polars` should be imported as `pl`
    |
@@ -128,6 +140,7 @@ custom.py:15:8: ICN001 `polars` should be imported as `pl`
    |        ^^^^^^ ICN001
 16 | import pyarrow  # unconventional
    |
+   = help: Alias `polars` to `pl`
 
 custom.py:16:8: ICN001 `pyarrow` should be imported as `pa`
    |
@@ -138,6 +151,7 @@ custom.py:16:8: ICN001 `pyarrow` should be imported as `pa`
 17 | 
 18 | import altair as altr  # unconventional
    |
+   = help: Alias `pyarrow` to `pa`
 
 custom.py:18:18: ICN001 `altair` should be imported as `alt`
    |
@@ -148,6 +162,7 @@ custom.py:18:18: ICN001 `altair` should be imported as `alt`
 19 | import matplotlib.pyplot as plot  # unconventional
 20 | import dask.array as darray  # unconventional
    |
+   = help: Alias `altair` to `alt`
 
 custom.py:19:29: ICN001 `matplotlib.pyplot` should be imported as `plt`
    |
@@ -157,6 +172,7 @@ custom.py:19:29: ICN001 `matplotlib.pyplot` should be imported as `plt`
 20 | import dask.array as darray  # unconventional
 21 | import dask.dataframe as ddf  # unconventional
    |
+   = help: Alias `matplotlib.pyplot` to `plt`
 
 custom.py:20:22: ICN001 `dask.array` should be imported as `da`
    |
@@ -167,6 +183,7 @@ custom.py:20:22: ICN001 `dask.array` should be imported as `da`
 21 | import dask.dataframe as ddf  # unconventional
 22 | import numpy as nmp  # unconventional
    |
+   = help: Alias `dask.array` to `da`
 
 custom.py:21:26: ICN001 `dask.dataframe` should be imported as `dd`
    |
@@ -177,6 +194,7 @@ custom.py:21:26: ICN001 `dask.dataframe` should be imported as `dd`
 22 | import numpy as nmp  # unconventional
 23 | import pandas as pdas  # unconventional
    |
+   = help: Alias `dask.dataframe` to `dd`
 
 custom.py:22:17: ICN001 `numpy` should be imported as `np`
    |
@@ -187,6 +205,7 @@ custom.py:22:17: ICN001 `numpy` should be imported as `np`
 23 | import pandas as pdas  # unconventional
 24 | import seaborn as sbrn  # unconventional
    |
+   = help: Alias `numpy` to `np`
 
 custom.py:23:18: ICN001 `pandas` should be imported as `pd`
    |
@@ -197,6 +216,7 @@ custom.py:23:18: ICN001 `pandas` should be imported as `pd`
 24 | import seaborn as sbrn  # unconventional
 25 | import tensorflow as tfz  # unconventional
    |
+   = help: Alias `pandas` to `pd`
 
 custom.py:24:19: ICN001 `seaborn` should be imported as `sns`
    |
@@ -207,6 +227,7 @@ custom.py:24:19: ICN001 `seaborn` should be imported as `sns`
 25 | import tensorflow as tfz  # unconventional
 26 | import holoviews as hsv  # unconventional
    |
+   = help: Alias `seaborn` to `sns`
 
 custom.py:25:22: ICN001 `tensorflow` should be imported as `tf`
    |
@@ -217,6 +238,7 @@ custom.py:25:22: ICN001 `tensorflow` should be imported as `tf`
 26 | import holoviews as hsv  # unconventional
 27 | import panel as pns  # unconventional
    |
+   = help: Alias `tensorflow` to `tf`
 
 custom.py:26:21: ICN001 `holoviews` should be imported as `hv`
    |
@@ -227,6 +249,7 @@ custom.py:26:21: ICN001 `holoviews` should be imported as `hv`
 27 | import panel as pns  # unconventional
 28 | import plotly.express as pltx  # unconventional
    |
+   = help: Alias `holoviews` to `hv`
 
 custom.py:27:17: ICN001 `panel` should be imported as `pn`
    |
@@ -237,6 +260,7 @@ custom.py:27:17: ICN001 `panel` should be imported as `pn`
 28 | import plotly.express as pltx  # unconventional
 29 | import matplotlib as ml  # unconventional
    |
+   = help: Alias `panel` to `pn`
 
 custom.py:28:26: ICN001 `plotly.express` should be imported as `px`
    |
@@ -247,6 +271,7 @@ custom.py:28:26: ICN001 `plotly.express` should be imported as `px`
 29 | import matplotlib as ml  # unconventional
 30 | import polars as ps # unconventional
    |
+   = help: Alias `plotly.express` to `px`
 
 custom.py:29:22: ICN001 `matplotlib` should be imported as `mpl`
    |
@@ -257,6 +282,7 @@ custom.py:29:22: ICN001 `matplotlib` should be imported as `mpl`
 30 | import polars as ps # unconventional
 31 | import pyarrow as arr  # unconventional
    |
+   = help: Alias `matplotlib` to `mpl`
 
 custom.py:30:18: ICN001 `polars` should be imported as `pl`
    |
@@ -266,6 +292,7 @@ custom.py:30:18: ICN001 `polars` should be imported as `pl`
    |                  ^^ ICN001
 31 | import pyarrow as arr  # unconventional
    |
+   = help: Alias `polars` to `pl`
 
 custom.py:31:19: ICN001 `pyarrow` should be imported as `pa`
    |
@@ -276,5 +303,6 @@ custom.py:31:19: ICN001 `pyarrow` should be imported as `pa`
 32 | 
 33 | import altair as alt  # conventional
    |
+   = help: Alias `pyarrow` to `pa`
 
 

--- a/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__defaults.snap
+++ b/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__defaults.snap
@@ -10,6 +10,7 @@ defaults.py:3:8: ICN001 `altair` should be imported as `alt`
 4 | import matplotlib.pyplot  # unconventional
 5 | import numpy  # unconventional
   |
+  = help: Alias `altair` to `alt`
 
 defaults.py:4:8: ICN001 `matplotlib.pyplot` should be imported as `plt`
   |
@@ -19,6 +20,7 @@ defaults.py:4:8: ICN001 `matplotlib.pyplot` should be imported as `plt`
 5 | import numpy  # unconventional
 6 | import pandas  # unconventional
   |
+  = help: Alias `matplotlib.pyplot` to `plt`
 
 defaults.py:5:8: ICN001 `numpy` should be imported as `np`
   |
@@ -29,6 +31,7 @@ defaults.py:5:8: ICN001 `numpy` should be imported as `np`
 6 | import pandas  # unconventional
 7 | import seaborn  # unconventional
   |
+  = help: Alias `numpy` to `np`
 
 defaults.py:6:8: ICN001 `pandas` should be imported as `pd`
   |
@@ -38,6 +41,7 @@ defaults.py:6:8: ICN001 `pandas` should be imported as `pd`
   |        ^^^^^^ ICN001
 7 | import seaborn  # unconventional
   |
+  = help: Alias `pandas` to `pd`
 
 defaults.py:7:8: ICN001 `seaborn` should be imported as `sns`
   |
@@ -48,6 +52,7 @@ defaults.py:7:8: ICN001 `seaborn` should be imported as `sns`
 8 | 
 9 | import altair as altr  # unconventional
   |
+  = help: Alias `seaborn` to `sns`
 
 defaults.py:9:18: ICN001 `altair` should be imported as `alt`
    |
@@ -58,6 +63,7 @@ defaults.py:9:18: ICN001 `altair` should be imported as `alt`
 10 | import matplotlib.pyplot as plot  # unconventional
 11 | import numpy as nmp  # unconventional
    |
+   = help: Alias `altair` to `alt`
 
 defaults.py:10:29: ICN001 `matplotlib.pyplot` should be imported as `plt`
    |
@@ -67,6 +73,7 @@ defaults.py:10:29: ICN001 `matplotlib.pyplot` should be imported as `plt`
 11 | import numpy as nmp  # unconventional
 12 | import pandas as pdas  # unconventional
    |
+   = help: Alias `matplotlib.pyplot` to `plt`
 
 defaults.py:11:17: ICN001 `numpy` should be imported as `np`
    |
@@ -77,6 +84,7 @@ defaults.py:11:17: ICN001 `numpy` should be imported as `np`
 12 | import pandas as pdas  # unconventional
 13 | import seaborn as sbrn  # unconventional
    |
+   = help: Alias `numpy` to `np`
 
 defaults.py:12:18: ICN001 `pandas` should be imported as `pd`
    |
@@ -86,6 +94,7 @@ defaults.py:12:18: ICN001 `pandas` should be imported as `pd`
    |                  ^^^^ ICN001
 13 | import seaborn as sbrn  # unconventional
    |
+   = help: Alias `pandas` to `pd`
 
 defaults.py:13:19: ICN001 `seaborn` should be imported as `sns`
    |
@@ -96,5 +105,6 @@ defaults.py:13:19: ICN001 `seaborn` should be imported as `sns`
 14 | 
 15 | import altair as alt  # conventional
    |
+   = help: Alias `seaborn` to `sns`
 
 

--- a/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__from_imports.snap
+++ b/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__from_imports.snap
@@ -10,6 +10,7 @@ from_imports.py:3:8: ICN001 `xml.dom.minidom` should be imported as `md`
 4 | import xml.dom.minidom as wrong
 5 | from xml.dom import minidom as wrong
   |
+  = help: Alias `xml.dom.minidom` to `md`
 
 from_imports.py:4:27: ICN001 `xml.dom.minidom` should be imported as `md`
   |
@@ -20,6 +21,7 @@ from_imports.py:4:27: ICN001 `xml.dom.minidom` should be imported as `md`
 5 | from xml.dom import minidom as wrong
 6 | from xml.dom import minidom
   |
+  = help: Alias `xml.dom.minidom` to `md`
 
 from_imports.py:5:32: ICN001 `xml.dom.minidom` should be imported as `md`
   |
@@ -30,6 +32,7 @@ from_imports.py:5:32: ICN001 `xml.dom.minidom` should be imported as `md`
 6 | from xml.dom import minidom
 7 | from xml.dom.minidom import parseString as wrong  # Ensure ICN001 throws on function import.
   |
+  = help: Alias `xml.dom.minidom` to `md`
 
 from_imports.py:6:21: ICN001 `xml.dom.minidom` should be imported as `md`
   |
@@ -40,6 +43,7 @@ from_imports.py:6:21: ICN001 `xml.dom.minidom` should be imported as `md`
 7 | from xml.dom.minidom import parseString as wrong  # Ensure ICN001 throws on function import.
 8 | from xml.dom.minidom import parseString
   |
+  = help: Alias `xml.dom.minidom` to `md`
 
 from_imports.py:7:44: ICN001 `xml.dom.minidom.parseString` should be imported as `pstr`
   |
@@ -50,6 +54,7 @@ from_imports.py:7:44: ICN001 `xml.dom.minidom.parseString` should be imported as
 8 | from xml.dom.minidom import parseString
 9 | from xml.dom.minidom import parse, parseString
   |
+  = help: Alias `xml.dom.minidom.parseString` to `pstr`
 
 from_imports.py:8:29: ICN001 `xml.dom.minidom.parseString` should be imported as `pstr`
    |
@@ -60,6 +65,7 @@ from_imports.py:8:29: ICN001 `xml.dom.minidom.parseString` should be imported as
  9 | from xml.dom.minidom import parse, parseString
 10 | from xml.dom.minidom import parse as ps, parseString as wrong
    |
+   = help: Alias `xml.dom.minidom.parseString` to `pstr`
 
 from_imports.py:9:36: ICN001 `xml.dom.minidom.parseString` should be imported as `pstr`
    |
@@ -69,6 +75,7 @@ from_imports.py:9:36: ICN001 `xml.dom.minidom.parseString` should be imported as
    |                                    ^^^^^^^^^^^ ICN001
 10 | from xml.dom.minidom import parse as ps, parseString as wrong
    |
+   = help: Alias `xml.dom.minidom.parseString` to `pstr`
 
 from_imports.py:10:57: ICN001 `xml.dom.minidom.parseString` should be imported as `pstr`
    |
@@ -79,5 +86,6 @@ from_imports.py:10:57: ICN001 `xml.dom.minidom.parseString` should be imported a
 11 | 
 12 | # No ICN001 violations
    |
+   = help: Alias `xml.dom.minidom.parseString` to `pstr`
 
 

--- a/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__override_default.snap
+++ b/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__override_default.snap
@@ -10,6 +10,7 @@ override_default.py:3:8: ICN001 `altair` should be imported as `alt`
 4 | import matplotlib.pyplot  # unconventional
 5 | import numpy  # unconventional
   |
+  = help: Alias `altair` to `alt`
 
 override_default.py:4:8: ICN001 `matplotlib.pyplot` should be imported as `plt`
   |
@@ -19,6 +20,7 @@ override_default.py:4:8: ICN001 `matplotlib.pyplot` should be imported as `plt`
 5 | import numpy  # unconventional
 6 | import pandas  # unconventional
   |
+  = help: Alias `matplotlib.pyplot` to `plt`
 
 override_default.py:5:8: ICN001 `numpy` should be imported as `nmp`
   |
@@ -29,6 +31,7 @@ override_default.py:5:8: ICN001 `numpy` should be imported as `nmp`
 6 | import pandas  # unconventional
 7 | import seaborn  # unconventional
   |
+  = help: Alias `numpy` to `nmp`
 
 override_default.py:6:8: ICN001 `pandas` should be imported as `pd`
   |
@@ -38,6 +41,7 @@ override_default.py:6:8: ICN001 `pandas` should be imported as `pd`
   |        ^^^^^^ ICN001
 7 | import seaborn  # unconventional
   |
+  = help: Alias `pandas` to `pd`
 
 override_default.py:7:8: ICN001 `seaborn` should be imported as `sns`
   |
@@ -48,6 +52,7 @@ override_default.py:7:8: ICN001 `seaborn` should be imported as `sns`
 8 | 
 9 | import altair as altr  # unconventional
   |
+  = help: Alias `seaborn` to `sns`
 
 override_default.py:9:18: ICN001 `altair` should be imported as `alt`
    |
@@ -58,6 +63,7 @@ override_default.py:9:18: ICN001 `altair` should be imported as `alt`
 10 | import matplotlib.pyplot as plot  # unconventional
 11 | import numpy as np  # unconventional
    |
+   = help: Alias `altair` to `alt`
 
 override_default.py:10:29: ICN001 `matplotlib.pyplot` should be imported as `plt`
    |
@@ -67,6 +73,7 @@ override_default.py:10:29: ICN001 `matplotlib.pyplot` should be imported as `plt
 11 | import numpy as np  # unconventional
 12 | import pandas as pdas  # unconventional
    |
+   = help: Alias `matplotlib.pyplot` to `plt`
 
 override_default.py:11:17: ICN001 `numpy` should be imported as `nmp`
    |
@@ -77,6 +84,7 @@ override_default.py:11:17: ICN001 `numpy` should be imported as `nmp`
 12 | import pandas as pdas  # unconventional
 13 | import seaborn as sbrn  # unconventional
    |
+   = help: Alias `numpy` to `nmp`
 
 override_default.py:12:18: ICN001 `pandas` should be imported as `pd`
    |
@@ -86,6 +94,7 @@ override_default.py:12:18: ICN001 `pandas` should be imported as `pd`
    |                  ^^^^ ICN001
 13 | import seaborn as sbrn  # unconventional
    |
+   = help: Alias `pandas` to `pd`
 
 override_default.py:13:19: ICN001 `seaborn` should be imported as `sns`
    |
@@ -96,5 +105,6 @@ override_default.py:13:19: ICN001 `seaborn` should be imported as `sns`
 14 | 
 15 | import altair as alt  # conventional
    |
+   = help: Alias `seaborn` to `sns`
 
 

--- a/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__remove_default.snap
+++ b/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__remove_default.snap
@@ -10,6 +10,7 @@ remove_default.py:3:8: ICN001 `altair` should be imported as `alt`
 4 | import matplotlib.pyplot  # unconventional
 5 | import numpy  # not checked
   |
+  = help: Alias `altair` to `alt`
 
 remove_default.py:4:8: ICN001 `matplotlib.pyplot` should be imported as `plt`
   |
@@ -19,6 +20,7 @@ remove_default.py:4:8: ICN001 `matplotlib.pyplot` should be imported as `plt`
 5 | import numpy  # not checked
 6 | import pandas  # unconventional
   |
+  = help: Alias `matplotlib.pyplot` to `plt`
 
 remove_default.py:6:8: ICN001 `pandas` should be imported as `pd`
   |
@@ -28,6 +30,7 @@ remove_default.py:6:8: ICN001 `pandas` should be imported as `pd`
   |        ^^^^^^ ICN001
 7 | import seaborn  # unconventional
   |
+  = help: Alias `pandas` to `pd`
 
 remove_default.py:7:8: ICN001 `seaborn` should be imported as `sns`
   |
@@ -38,6 +41,7 @@ remove_default.py:7:8: ICN001 `seaborn` should be imported as `sns`
 8 | 
 9 | import altair as altr  # unconventional
   |
+  = help: Alias `seaborn` to `sns`
 
 remove_default.py:9:18: ICN001 `altair` should be imported as `alt`
    |
@@ -48,6 +52,7 @@ remove_default.py:9:18: ICN001 `altair` should be imported as `alt`
 10 | import matplotlib.pyplot as plot  # unconventional
 11 | import numpy as nmp  # not checked
    |
+   = help: Alias `altair` to `alt`
 
 remove_default.py:10:29: ICN001 `matplotlib.pyplot` should be imported as `plt`
    |
@@ -57,6 +62,7 @@ remove_default.py:10:29: ICN001 `matplotlib.pyplot` should be imported as `plt`
 11 | import numpy as nmp  # not checked
 12 | import pandas as pdas  # unconventional
    |
+   = help: Alias `matplotlib.pyplot` to `plt`
 
 remove_default.py:12:18: ICN001 `pandas` should be imported as `pd`
    |
@@ -66,6 +72,7 @@ remove_default.py:12:18: ICN001 `pandas` should be imported as `pd`
    |                  ^^^^ ICN001
 13 | import seaborn as sbrn  # unconventional
    |
+   = help: Alias `pandas` to `pd`
 
 remove_default.py:13:19: ICN001 `seaborn` should be imported as `sns`
    |
@@ -76,5 +83,6 @@ remove_default.py:13:19: ICN001 `seaborn` should be imported as `sns`
 14 | 
 15 | import altair as alt  # conventional
    |
+   = help: Alias `seaborn` to `sns`
 
 


### PR DESCRIPTION
## Summary

We can now automatically rewrite `import pandas` to `import pandas as pd`, with minimal changes needed.
