### PR TITLE
Explain dangling comments in the formatter

### DIFF
--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -104,7 +104,7 @@ print("hello world")  # Trailing comment (end-of-line)
 # Trailing comment (own line)
 ```
 
-Comment are automatically attached as `Leading` or `Trailing` to a node close to them, or `Dangling`
+Comments are automatically attached as `Leading` or `Trailing` to a node close to them, or `Dangling`
 if there are only tokens and no nodes surrounding it. Categorization is automatic but sometimes
 needs to be overridden in `place_comment` in `placement.rs`, which this section is about.
 

--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -106,7 +106,9 @@ print("hello world")  # Trailing comment (end-of-line)
 
 Comments are automatically attached as `Leading` or `Trailing` to a node close to them, or `Dangling`
 if there are only tokens and no nodes surrounding it. Categorization is automatic but sometimes
-needs to be overridden in [`place_comment`](https://github.com/astral-sh/ruff/blob/be11cae619d5a24adb4da34e64d3c5f270f9727b/crates/ruff_python_formatter/src/comments/placement.rs#L13) in `placement.rs`, which this section is about.
+needs to be overridden in
+[`place_comment`](https://github.com/astral-sh/ruff/blob/be11cae619d5a24adb4da34e64d3c5f270f9727b/crates/ruff_python_formatter/src/comments/placement.rs#L13)
+in `placement.rs`, which this section is about.
 
 ```Python
 [
@@ -173,7 +175,8 @@ The preceding token of the leading else comment is the `break`, which has a node
 token is the `else`, which lacks a node, so by default the comment would be marked as trailing
 the `break` and wrongly formatted as such. We avoid this by finding comments between
 two bodies that have the same indentation level as the keyword in
-[`handle_in_between_bodies_own_line_comment`](https://github.com/astral-sh/ruff/blob/be11cae619d5a24adb4da34e64d3c5f270f9727b/crates/ruff_python_formatter/src/comments/placement.rs#L196) and marking them as dangling. Similarly, we find and
+[`handle_in_between_bodies_own_line_comment`](https://github.com/astral-sh/ruff/blob/be11cae619d5a24adb4da34e64d3c5f270f9727b/crates/ruff_python_formatter/src/comments/placement.rs#L196)
+and marking them as dangling. Similarly, we find and
 mark comment after the colon(s).
 
 The comments don't carry any extra information such as why we marked the comment as trailing,

--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -94,9 +94,20 @@ write!(f, [if_group_breaks(&text(","))])
 If you need avoid second mutable borrows with a builder, you can use `format_with(|f| { ... })` as
 a formattable element similar to `text()` or `group()`.
 
-The generic comment formatting in `FormatNodeRule` handles comments correctly for most nodes, e.g.
-preceding and end-of-line comments depending on the node range. Sometimes however, you may have
-dangling comments that are not before or after a node but inside of it, e.g.
+## Comments
+
+Comments can either be own line or end-of-line and can be marked as `Leading`, `Trailing` and `Dangling`.
+
+```python
+# Leading comment (always own line)
+print("hello world")  # Trailing comment (end-of-line)
+# Trailing comment (own line)
+```
+
+Comment are automatically attached as `Leading` or `Trailing` to a node close to them categorization
+is automatic except when overridden in `place_comment` in `placement.rs`, which this section is
+about. A `Dangling` comment happens when there is node that the comment would be leading or trailing
+to.
 
 ```Python
 [
@@ -104,8 +115,8 @@ dangling comments that are not before or after a node but inside of it, e.g.
 ]
 ```
 
-Here, you have to call `dangling_comments` manually and stubbing out `fmt_dangling_comments` in list
-formatting.
+Here, you have to call `dangling_comments` manually and stubbing out `fmt_dangling_comments` default
+from `FormatNodeRule` in `FormatExprList`.
 
 ```rust
 impl FormatNodeRule<ExprList> for FormatExprList {
@@ -116,7 +127,7 @@ impl FormatNodeRule<ExprList> for FormatExprList {
             f,
             [group(&format_args![
                 text("["),
-                dangling_comments(dangling),
+                dangling_comments(dangling), // Gets all the comments marked as dangling for the node
                 soft_block_indent(&items),
                 text("]")
             ])]
@@ -130,8 +141,67 @@ impl FormatNodeRule<ExprList> for FormatExprList {
 }
 ```
 
-Comments are categorized into `Leading`, `Trailing` and `Dangling`, you can override this in
-`place_comment`.
+A common challenge is that we want to attach comments to tokens (think keywords and syntactically
+meaningful characters such as `:`) that have no node on their own. A slightly simplified version of
+the `while` node in our AST looks like the following:
+
+```rust
+pub struct StmtWhile {
+    pub range: TextRange,
+    pub test: Box<Expr<TextRange>>,
+    pub body: Vec<Stmt<TextRange>>,
+    pub orelse: Vec<Stmt<TextRange>>,
+}
+```
+
+That means in
+
+```python
+while True:  # Trailing cond comment
+    if f():
+        break
+    # trailing while comment
+# leading else comment
+else:
+    print("while-else")
+```
+
+the `else` has no node, we're just getting the statements in its body.
+
+By default, the comment would get misattributed and moved to the `break` (the first node before the
+comment) or the `print` call (the first node after it). We avoid this by finding comments between
+two bodies that have the same indentation level as the keyword in
+`handle_in_between_bodies_own_line_comment` and marking them as dangling. Similarly, we find and
+mark comment after the colon(s). In `FormatStmtWhile`, we take the list of all dangling comments and
+split it into after-colon-comments, before-else-comments, etc. and manually insert them in the right
+position.
+
+A simplified implementation with only those two kinds comments:
+
+```rust
+fn fmt_fields(&self, item: &StmtWhile, f: &mut PyFormatter) -> FormatResult<()> {
+
+    // ...
+
+    let (trailing_condition_comments, or_else_comments) =
+        dangling_comments.split_at(or_else_comments_start);
+
+    write!(
+        f,
+        [
+            text("while"),
+            space(),
+            test.format(),
+            text(":"),
+            trailing_comments(trailing_condition_comments),
+            block_indent(&body.format())
+            leading_comments(or_else_comments),
+            text("else:"),
+            block_indent(&orelse.format())
+        ]
+    )?;
+}
+```
 
 ## Development notes
 

--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -173,18 +173,22 @@ the `else` has no node, we're just getting the statements in its body.
 
 The preceding token of the leading else comment is the `break`, which has a node, the following
 token is the `else`, which lacks a node, so by default the comment would be marked as trailing
-the `break` and wrongly formatted as such. We avoid this by finding comments between
-two bodies that have the same indentation level as the keyword in
+the `break` and wrongly formatted as such. We can identify these cases by looking for comments
+between two bodies that have the same indentation level as the keyword, e.g. in our case the
+leading else comment is inside the `while` node (which spans the entire snippet) and on the same
+level as the `else`. We identify those case in
 [`handle_in_between_bodies_own_line_comment`](https://github.com/astral-sh/ruff/blob/be11cae619d5a24adb4da34e64d3c5f270f9727b/crates/ruff_python_formatter/src/comments/placement.rs#L196)
-and marking them as dangling. Similarly, we find and
-mark comment after the colon(s).
+and mark them as dangling for manual formatting later. Similarly, we find and mark comment after
+the colon(s) in
+[`handle_trailing_end_of_line_condition_comment`](https://github.com/astral-sh/ruff/blob/main/crates/ruff_python_formatter/src/comments/placement.rs#L518)
+.
 
 The comments don't carry any extra information such as why we marked the comment as trailing,
-instead they are collect into one list of leading, one list of trailing and one list of dangling
+instead they are sorted into one list of leading, one list of trailing and one list of dangling
 comments per node. In `FormatStmtWhile`, we can have multiple types of dangling comments, so we
-have to split them into after-colon-comments, before-else-comments, etc. by some element
-separating them (e.g. all comments trailing the colon come before the first statement in the body)
-and manually insert them in the right position.
+have to split the dangling list into after-colon-comments, before-else-comments, etc. by some
+element separating them (e.g. all comments trailing the colon come before the first statement in
+the body) and manually insert them in the right position.
 
 A simplified implementation with only those two kinds of comments:
 

--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -158,7 +158,7 @@ pub struct StmtWhile {
 That means in
 
 ```python
-while True:  # Trailing cond comment
+while True:  # Trailing condition comment
     if f():
         break
     # trailing while comment
@@ -174,10 +174,14 @@ token is the `else`, which lacks a node, so by default the comment would be mark
 the `break` and wrongly formatted as such. We avoid this by finding comments between
 two bodies that have the same indentation level as the keyword in
 [`handle_in_between_bodies_own_line_comment`](https://github.com/astral-sh/ruff/blob/be11cae619d5a24adb4da34e64d3c5f270f9727b/crates/ruff_python_formatter/src/comments/placement.rs#L196) and marking them as dangling. Similarly, we find and
-mark comment after the colon(s). In `FormatStmtWhile`, we take the list of all dangling comments,
-split them into after-colon-comments, before-else-comments, etc. by some element separating them
-(e.g. all comments trailing the colon come before the first statement in the body) and manually
-insert them in the right position.
+mark comment after the colon(s).
+
+The comments don't carry any extra information such as why we marked the comment as trailing,
+instead they are collect into one list of leading, one list of trailing and one list of dangling
+comments per node. In `FormatStmtWhile`, we can have multiple types of dangling comments, so we
+have to split them into after-colon-comments, before-else-comments, etc. by some element
+separating them (e.g. all comments trailing the colon come before the first statement in the body)
+and manually insert them in the right position.
 
 A simplified implementation with only those two kinds of comments:
 

--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -173,7 +173,7 @@ The preceding token of the leading else comment is the `break`, which has a node
 token is the `else`, which lacks a node, so by default the comment would be marked as trailing
 the `break` and wrongly formatted as such. We avoid this by finding comments between
 two bodies that have the same indentation level as the keyword in
-`handle_in_between_bodies_own_line_comment` and marking them as dangling. Similarly, we find and
+[`handle_in_between_bodies_own_line_comment`](https://github.com/astral-sh/ruff/blob/be11cae619d5a24adb4da34e64d3c5f270f9727b/crates/ruff_python_formatter/src/comments/placement.rs#L196) and marking them as dangling. Similarly, we find and
 mark comment after the colon(s). In `FormatStmtWhile`, we take the list of all dangling comments,
 split them into after-colon-comments, before-else-comments, etc. by some element separating them
 (e.g. all comments trailing the colon come before the first statement in the body) and manually

--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -106,7 +106,7 @@ print("hello world")  # Trailing comment (end-of-line)
 
 Comments are automatically attached as `Leading` or `Trailing` to a node close to them, or `Dangling`
 if there are only tokens and no nodes surrounding it. Categorization is automatic but sometimes
-needs to be overridden in `place_comment` in `placement.rs`, which this section is about.
+needs to be overridden in [`place_comment`](https://github.com/astral-sh/ruff/blob/be11cae619d5a24adb4da34e64d3c5f270f9727b/crates/ruff_python_formatter/src/comments/placement.rs#L13) in `placement.rs`, which this section is about.
 
 ```Python
 [


### PR DESCRIPTION
This documentation change improves the section on dangling comments in the formatter.