### PR TITLE
Move `dead_scopes` to `deferred.scopes`

### DIFF
--- a/crates/ruff/src/checkers/ast/deferred.rs
+++ b/crates/ruff/src/checkers/ast/deferred.rs
@@ -1,13 +1,14 @@
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::Expr;
 
-use ruff_python_semantic::Snapshot;
+use ruff_python_semantic::{ScopeId, Snapshot};
 
 /// A collection of AST nodes that are deferred for later analysis.
 /// Used to, e.g., store functions, whose bodies shouldn't be analyzed until all
 /// module-level definitions have been analyzed.
 #[derive(Debug, Default)]
 pub(crate) struct Deferred<'a> {
+    pub(crate) scopes: Vec<ScopeId>,
     pub(crate) string_type_definitions: Vec<(TextRange, &'a str, Snapshot)>,
     pub(crate) future_type_definitions: Vec<(&'a Expr, Snapshot)>,
     pub(crate) functions: Vec<Snapshot>,

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -40,7 +40,6 @@ pub struct SemanticModel<'a> {
     /// Stack of all scopes, along with the identifier of the current scope.
     pub scopes: Scopes<'a>,
     pub scope_id: ScopeId,
-    pub dead_scopes: Vec<ScopeId>,
 
     /// Stack of all definitions created in any scope, at any point in execution.
     pub definitions: Definitions<'a>,
@@ -130,7 +129,6 @@ impl<'a> SemanticModel<'a> {
             exprs: Vec::default(),
             scopes: Scopes::default(),
             scope_id: ScopeId::global(),
-            dead_scopes: Vec::default(),
             definitions: Definitions::for_module(module),
             definition_id: DefinitionId::module(),
             bindings: Bindings::default(),
@@ -596,7 +594,6 @@ impl<'a> SemanticModel<'a> {
 
     /// Pop the current [`Scope`] off the stack.
     pub fn pop_scope(&mut self) {
-        self.dead_scopes.push(self.scope_id);
         self.scope_id = self.scopes[self.scope_id]
             .parent
             .expect("Attempted to pop without scope");


### PR DESCRIPTION
## Summary

This is more consistent with the rest of the `deferred` patterns.