### PR TITLE
Detect continuations at start-of-file

### DIFF
--- a/crates/ruff_python_ast/src/source_code/indexer.rs
+++ b/crates/ruff_python_ast/src/source_code/indexer.rs
@@ -49,10 +49,7 @@ impl Indexer {
                 }
 
                 // Newlines after a newline never form a continuation.
-                if !matches!(
-                    prev_token,
-                    Some(Tok::Newline | Tok::NonLogicalNewline) | None
-                ) {
+                if !matches!(prev_token, Some(Tok::Newline | Tok::NonLogicalNewline)) {
                     continuation_lines.push(line_start);
                 }
 


### PR DESCRIPTION
## Summary

Given:

```python
\
import os
```

Deleting `import os` leaves a syntax error: a file can't end in a continuation. We have code to handle this case, but it failed to pick up continuations at the _very start_ of a file.

Closes #5156.
