### PR TITLE
Fix allowed-ellipsis detection

### DIFF
--- a/crates/ruff/resources/test/fixtures/pycodestyle/E70.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/E70.py
@@ -60,3 +60,6 @@ match *0, 1, *2:
 #:
 class Foo:
     match: Optional[Match] = None
+#: E702:2:4
+while 1:
+  1;...

--- a/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
@@ -145,6 +145,12 @@ pub(crate) fn compound_statements(lxr: &[LexResult], settings: &Settings) -> Vec
             Tok::Rbrace => {
                 brace_count = brace_count.saturating_sub(1);
             }
+            Tok::Ellipsis => {
+                if allow_ellipsis {
+                    allow_ellipsis = false;
+                    continue;
+                }
+            }
             _ => {}
         }
 
@@ -195,17 +201,15 @@ pub(crate) fn compound_statements(lxr: &[LexResult], settings: &Settings) -> Vec
                     || with.is_some()
                 {
                     colon = Some((range.start(), range.end()));
-                    allow_ellipsis = true;
+
+                    // Allow `class C: ...`-style definitions in stubs.
+                    allow_ellipsis = class.is_some();
                 }
             }
             Tok::Semi => {
                 semi = Some((range.start(), range.end()));
             }
             Tok::Comment(..) | Tok::Indent | Tok::Dedent | Tok::NonLogicalNewline => {}
-            Tok::Ellipsis if allow_ellipsis => {
-                // Allow `class C: ...`-style definitions in stubs.
-                allow_ellipsis = false;
-            }
             _ => {
                 if let Some((start, end)) = semi {
                     diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E702_E70.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E702_E70.py.snap
@@ -61,4 +61,12 @@ E70.py:56:13: E702 Multiple statements on one line (semicolon)
 58 | match *0, 1, *2:
    |
 
+E70.py:65:4: E702 Multiple statements on one line (semicolon)
+   |
+63 | #: E702:2:4
+64 | while 1:
+65 |   1;...
+   |    ^ E702
+   |
+
 


### PR DESCRIPTION
## Summary

We weren't resetting the `allow_ellipsis` flag properly, which ultimately caused us to treat the semicolon as "unnecessary" rather than "creating a multi-statement line".

Closes #5154.
