### PR TITLE
Rename `*Importation` structs to `*Import`

### DIFF
--- a/crates/ruff/src/renamer.rs
+++ b/crates/ruff/src/renamer.rs
@@ -217,7 +217,7 @@ impl Renamer {
     /// Rename a [`Binding`] reference.
     fn rename_binding(binding: &Binding, name: &str, target: &str) -> Option<Edit> {
         match &binding.kind {
-            BindingKind::Importation(_) | BindingKind::FromImportation(_) => {
+            BindingKind::Import(_) | BindingKind::FromImport(_) => {
                 if binding.is_alias() {
                     // Ex) Rename `import pandas as alias` to `import pandas as pd`.
                     Some(Edit::range_replacement(target.to_string(), binding.range))
@@ -229,7 +229,7 @@ impl Renamer {
                     ))
                 }
             }
-            BindingKind::SubmoduleImportation(import) => {
+            BindingKind::SubmoduleImport(import) => {
                 // Ex) Rename `import pandas.core` to `import pandas as pd`.
                 let module_name = import.qualified_name.split('.').next().unwrap();
                 Some(Edit::range_replacement(
@@ -238,7 +238,7 @@ impl Renamer {
                 ))
             }
             // Avoid renaming builtins and other "special" bindings.
-            BindingKind::FutureImportation | BindingKind::Builtin | BindingKind::Export(_) => None,
+            BindingKind::FutureImport | BindingKind::Builtin | BindingKind::Export(_) => None,
             // By default, replace the binding's name with the target name.
             BindingKind::Annotation
             | BindingKind::Argument

--- a/crates/ruff/src/rules/flake8_pyi/rules/unaliased_collections_abc_set_import.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unaliased_collections_abc_set_import.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::{BindingKind, FromImportation, Scope};
+use ruff_python_semantic::{BindingKind, FromImport, Scope};
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -53,7 +53,7 @@ pub(crate) fn unaliased_collections_abc_set_import(
 ) {
     for (name, binding_id) in scope.all_bindings() {
         let binding = checker.semantic().binding(binding_id);
-        let BindingKind::FromImportation(FromImportation { qualified_name }) = &binding.kind else {
+        let BindingKind::FromImport(FromImport { qualified_name }) = &binding.kind else {
             continue;
         };
         if qualified_name.as_str() != "collections.abc.Set" {

--- a/crates/ruff/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/helpers.rs
@@ -7,9 +7,7 @@ use ruff_python_semantic::{Binding, BindingKind, ScopeKind, SemanticModel};
 pub(crate) fn is_valid_runtime_import(binding: &Binding, semantic: &SemanticModel) -> bool {
     if matches!(
         binding.kind,
-        BindingKind::Importation(..)
-            | BindingKind::FromImportation(..)
-            | BindingKind::SubmoduleImportation(..)
+        BindingKind::Import(..) | BindingKind::FromImport(..) | BindingKind::SubmoduleImport(..)
     ) {
         binding.context.is_runtime()
             && binding

--- a/crates/ruff/src/rules/pandas_vet/helpers.rs
+++ b/crates/ruff/src/rules/pandas_vet/helpers.rs
@@ -1,7 +1,7 @@
 use rustpython_parser::ast;
 use rustpython_parser::ast::Expr;
 
-use ruff_python_semantic::{BindingKind, Importation, SemanticModel};
+use ruff_python_semantic::{BindingKind, Import, SemanticModel};
 
 pub(super) enum Resolution {
     /// The expression resolves to an irrelevant expression type (e.g., a constant).
@@ -39,7 +39,7 @@ pub(super) fn test_expression(expr: &Expr, semantic: &SemanticModel) -> Resoluti
                         | BindingKind::LoopVar
                         | BindingKind::Global
                         | BindingKind::Nonlocal(_) => Resolution::RelevantLocal,
-                        BindingKind::Importation(Importation {
+                        BindingKind::Import(Import {
                             qualified_name: module,
                         }) if module == "pandas" => Resolution::PandasModule,
                         _ => Resolution::IrrelevantBinding,

--- a/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::{BindingKind, Importation};
+use ruff_python_semantic::{BindingKind, Import};
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -70,7 +70,7 @@ pub(crate) fn inplace_argument(
             .map_or(false, |binding| {
                 matches!(
                     binding.kind,
-                    BindingKind::Importation(Importation {
+                    BindingKind::Import(Import {
                         qualified_name: "pandas"
                     })
                 )

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -82,33 +82,33 @@ impl<'a> Binding<'a> {
     /// Return `true` if this binding redefines the given binding.
     pub fn redefines(&self, existing: &'a Binding) -> bool {
         match &self.kind {
-            BindingKind::Importation(Importation { qualified_name }) => {
-                if let BindingKind::SubmoduleImportation(SubmoduleImportation {
+            BindingKind::Import(Import { qualified_name }) => {
+                if let BindingKind::SubmoduleImport(SubmoduleImport {
                     qualified_name: existing,
                 }) = &existing.kind
                 {
                     return qualified_name == existing;
                 }
             }
-            BindingKind::FromImportation(FromImportation { qualified_name }) => {
-                if let BindingKind::SubmoduleImportation(SubmoduleImportation {
+            BindingKind::FromImport(FromImport { qualified_name }) => {
+                if let BindingKind::SubmoduleImport(SubmoduleImport {
                     qualified_name: existing,
                 }) = &existing.kind
                 {
                     return qualified_name == existing;
                 }
             }
-            BindingKind::SubmoduleImportation(SubmoduleImportation { qualified_name }) => {
+            BindingKind::SubmoduleImport(SubmoduleImport { qualified_name }) => {
                 match &existing.kind {
-                    BindingKind::Importation(Importation {
+                    BindingKind::Import(Import {
                         qualified_name: existing,
                     })
-                    | BindingKind::SubmoduleImportation(SubmoduleImportation {
+                    | BindingKind::SubmoduleImport(SubmoduleImport {
                         qualified_name: existing,
                     }) => {
                         return qualified_name == existing;
                     }
-                    BindingKind::FromImportation(FromImportation {
+                    BindingKind::FromImport(FromImport {
                         qualified_name: existing,
                     }) => {
                         return qualified_name == existing;
@@ -118,7 +118,7 @@ impl<'a> Binding<'a> {
             }
             BindingKind::Deletion
             | BindingKind::Annotation
-            | BindingKind::FutureImportation
+            | BindingKind::FutureImport
             | BindingKind::Builtin => {
                 return false;
             }
@@ -128,20 +128,18 @@ impl<'a> Binding<'a> {
             existing.kind,
             BindingKind::ClassDefinition
                 | BindingKind::FunctionDefinition
-                | BindingKind::Importation(..)
-                | BindingKind::FromImportation(..)
-                | BindingKind::SubmoduleImportation(..)
+                | BindingKind::Import(..)
+                | BindingKind::FromImport(..)
+                | BindingKind::SubmoduleImport(..)
         )
     }
 
     /// Returns the fully-qualified symbol name, if this symbol was imported from another module.
     pub fn qualified_name(&self) -> Option<&str> {
         match &self.kind {
-            BindingKind::Importation(Importation { qualified_name }) => Some(qualified_name),
-            BindingKind::FromImportation(FromImportation { qualified_name }) => {
-                Some(qualified_name)
-            }
-            BindingKind::SubmoduleImportation(SubmoduleImportation { qualified_name }) => {
+            BindingKind::Import(Import { qualified_name }) => Some(qualified_name),
+            BindingKind::FromImport(FromImport { qualified_name }) => Some(qualified_name),
+            BindingKind::SubmoduleImport(SubmoduleImport { qualified_name }) => {
                 Some(qualified_name)
             }
             _ => None,
@@ -152,11 +150,11 @@ impl<'a> Binding<'a> {
     /// symbol was imported from another module.
     pub fn module_name(&self) -> Option<&str> {
         match &self.kind {
-            BindingKind::Importation(Importation { qualified_name })
-            | BindingKind::SubmoduleImportation(SubmoduleImportation { qualified_name }) => {
+            BindingKind::Import(Import { qualified_name })
+            | BindingKind::SubmoduleImport(SubmoduleImport { qualified_name }) => {
                 Some(qualified_name.split('.').next().unwrap_or(qualified_name))
             }
-            BindingKind::FromImportation(FromImportation { qualified_name }) => Some(
+            BindingKind::FromImport(FromImport { qualified_name }) => Some(
                 qualified_name
                     .rsplit_once('.')
                     .map_or(qualified_name, |(module, _)| module),
@@ -275,7 +273,7 @@ impl<'a> FromIterator<Binding<'a>> for Bindings<'a> {
 }
 
 #[derive(Debug, Clone)]
-pub struct StarImportation<'a> {
+pub struct StarImport<'a> {
     /// The level of the import. `None` or `Some(0)` indicate an absolute import.
     pub level: Option<u32>,
     /// The module being imported. `None` indicates a wildcard import.
@@ -292,7 +290,7 @@ pub struct Export<'a> {
 /// Ex) `import foo` would be keyed on "foo".
 /// Ex) `import foo as bar` would be keyed on "bar".
 #[derive(Debug, Clone)]
-pub struct Importation<'a> {
+pub struct Import<'a> {
     /// The full name of the module being imported.
     /// Ex) Given `import foo`, `qualified_name` would be "foo".
     /// Ex) Given `import foo as bar`, `qualified_name` would be "foo".
@@ -303,7 +301,7 @@ pub struct Importation<'a> {
 /// Ex) `from foo import bar` would be keyed on "bar".
 /// Ex) `from foo import bar as baz` would be keyed on "baz".
 #[derive(Debug, Clone)]
-pub struct FromImportation {
+pub struct FromImport {
     /// The full name of the member being imported.
     /// Ex) Given `from foo import bar`, `qualified_name` would be "foo.bar".
     /// Ex) Given `from foo import bar as baz`, `qualified_name` would be "foo.bar".
@@ -313,7 +311,7 @@ pub struct FromImportation {
 /// A binding for a submodule imported from a module, keyed on the name of the parent module.
 /// Ex) `import foo.bar` would be keyed on "foo".
 #[derive(Debug, Clone)]
-pub struct SubmoduleImportation<'a> {
+pub struct SubmoduleImport<'a> {
     /// The full name of the submodule being imported.
     /// Ex) Given `import foo.bar`, `qualified_name` would be "foo.bar".
     pub qualified_name: &'a str,
@@ -401,25 +399,25 @@ pub enum BindingKind<'a> {
     /// ```python
     /// from __future__ import annotations
     /// ```
-    FutureImportation,
+    FutureImport,
 
     /// A binding for a straight `import`, like `foo` in:
     /// ```python
     /// import foo
     /// ```
-    Importation(Importation<'a>),
+    Import(Import<'a>),
 
     /// A binding for a member imported from a module, like `bar` in:
     /// ```python
     /// from foo import bar
     /// ```
-    FromImportation(FromImportation),
+    FromImport(FromImport),
 
     /// A binding for a submodule imported from a module, like `bar` in:
     /// ```python
     /// import foo.bar
     /// ```
-    SubmoduleImportation(SubmoduleImportation<'a>),
+    SubmoduleImport(SubmoduleImport<'a>),
 
     /// A binding for a deletion, like `x` in:
     /// ```python

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -8,7 +8,7 @@ use rustpython_parser::ast;
 
 use ruff_index::{newtype_index, Idx, IndexSlice, IndexVec};
 
-use crate::binding::{BindingId, StarImportation};
+use crate::binding::{BindingId, StarImport};
 use crate::globals::GlobalsId;
 
 #[derive(Debug)]
@@ -21,7 +21,7 @@ pub struct Scope<'a> {
 
     /// A list of star imports in this scope. These represent _module_ imports (e.g., `sys` in
     /// `from sys import *`), rather than individual bindings (e.g., individual members in `sys`).
-    star_imports: Vec<StarImportation<'a>>,
+    star_imports: Vec<StarImport<'a>>,
 
     /// A map from bound name to binding ID.
     bindings: FxHashMap<&'a str, BindingId>,
@@ -126,7 +126,7 @@ impl<'a> Scope<'a> {
     }
 
     /// Adds a reference to a star import (e.g., `from sys import *`) to this scope.
-    pub fn add_star_import(&mut self, import: StarImportation<'a>) {
+    pub fn add_star_import(&mut self, import: StarImport<'a>) {
         self.star_imports.push(import);
     }
 
@@ -136,7 +136,7 @@ impl<'a> Scope<'a> {
     }
 
     /// Returns an iterator over all star imports (e.g., `from sys import *`) in this scope.
-    pub fn star_imports(&self) -> impl Iterator<Item = &StarImportation<'a>> {
+    pub fn star_imports(&self) -> impl Iterator<Item = &StarImport<'a>> {
         self.star_imports.iter()
     }
 


### PR DESCRIPTION
## Summary

I find "Importation" a bit awkward, it may not even be grammatically correct here.
