### PR TITLE
Add rule documentation URL to JSON output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 rust-version = "1.70"
-homepage = "https://beta.ruff.rs/docs/"
-documentation = "https://beta.ruff.rs/docs/"
+homepage = "https://beta.ruff.rs/docs"
+documentation = "https://beta.ruff.rs/docs"
 repository = "https://github.com/astral-sh/ruff"
 authors = ["Charlie Marsh <charlie.r.marsh@gmail.com>"]
 license = "MIT"

--- a/crates/ruff/src/message/json.rs
+++ b/crates/ruff/src/message/json.rs
@@ -63,6 +63,7 @@ pub(crate) fn message_to_json_value(message: &Message) -> Value {
 
     json!({
         "code": message.kind.rule().noqa_code().to_string(),
+        "url": message.kind.rule().url(),
         "message": message.kind.body,
         "fix": fix,
         "location": start_location,

--- a/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
@@ -32,7 +32,8 @@ expression: content
       "row": 1
     },
     "message": "`os` imported but unused",
-    "noqa_row": 1
+    "noqa_row": 1,
+    "url": "https://beta.ruff.rs/docs/rules/unused-import"
   },
   {
     "code": "F841",
@@ -63,7 +64,8 @@ expression: content
       "row": 6
     },
     "message": "Local variable `x` is assigned to but never used",
-    "noqa_row": 6
+    "noqa_row": 6,
+    "url": "https://beta.ruff.rs/docs/rules/unused-variable"
   },
   {
     "code": "F821",
@@ -78,6 +80,7 @@ expression: content
       "row": 1
     },
     "message": "Undefined name `a`",
-    "noqa_row": 1
+    "noqa_row": 1,
+    "url": "https://beta.ruff.rs/docs/rules/undefined-name"
   }
 ]

--- a/crates/ruff/src/message/snapshots/ruff__message__json_lines__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__json_lines__tests__output.snap
@@ -2,7 +2,7 @@
 source: crates/ruff/src/message/json_lines.rs
 expression: content
 ---
-{"code":"F401","end_location":{"column":10,"row":1},"filename":"fib.py","fix":{"applicability":"Suggested","edits":[{"content":"","end_location":{"column":1,"row":2},"location":{"column":1,"row":1}}],"message":"Remove unused import: `os`"},"location":{"column":8,"row":1},"message":"`os` imported but unused","noqa_row":1}
-{"code":"F841","end_location":{"column":6,"row":6},"filename":"fib.py","fix":{"applicability":"Suggested","edits":[{"content":"","end_location":{"column":10,"row":6},"location":{"column":5,"row":6}}],"message":"Remove assignment to unused variable `x`"},"location":{"column":5,"row":6},"message":"Local variable `x` is assigned to but never used","noqa_row":6}
-{"code":"F821","end_location":{"column":5,"row":1},"filename":"undef.py","fix":null,"location":{"column":4,"row":1},"message":"Undefined name `a`","noqa_row":1}
+{"code":"F401","end_location":{"column":10,"row":1},"filename":"fib.py","fix":{"applicability":"Suggested","edits":[{"content":"","end_location":{"column":1,"row":2},"location":{"column":1,"row":1}}],"message":"Remove unused import: `os`"},"location":{"column":8,"row":1},"message":"`os` imported but unused","noqa_row":1,"url":"https://beta.ruff.rs/docs/rules/unused-import"}
+{"code":"F841","end_location":{"column":6,"row":6},"filename":"fib.py","fix":{"applicability":"Suggested","edits":[{"content":"","end_location":{"column":10,"row":6},"location":{"column":5,"row":6}}],"message":"Remove assignment to unused variable `x`"},"location":{"column":5,"row":6},"message":"Local variable `x` is assigned to but never used","noqa_row":6,"url":"https://beta.ruff.rs/docs/rules/unused-variable"}
+{"code":"F821","end_location":{"column":5,"row":1},"filename":"undef.py","fix":null,"location":{"column":4,"row":1},"message":"Undefined name `a`","noqa_row":1,"url":"https://beta.ruff.rs/docs/rules/undefined-name"}
 

--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -347,6 +347,13 @@ impl Rule {
             _ => LintSource::Ast,
         }
     }
+
+    /// Return the URL for the rule documentation, if it exists.
+    pub fn url(&self) -> Option<String> {
+        self.explanation()
+            .is_some()
+            .then(|| format!("{}/rules/{}", env!("CARGO_PKG_HOMEPAGE"), self.as_ref()))
+    }
 }
 
 /// Pairs of checks that shouldn't be enabled together.

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -118,7 +118,8 @@ fn stdin_json() -> Result<()> {
       "row": 1
     }},
     "message": "`os` imported but unused",
-    "noqa_row": 1
+    "noqa_row": 1,
+    "url": "https://beta.ruff.rs/docs/rules/unused-import"
   }}
 ]"#
         )


### PR DESCRIPTION
## Summary

I want to include URLs to the rule documentation in the LSP (the LSP has a native `code_description` field for this, which, if specified, causes the source to be rendered as a link to the docs). This PR exposes the URL to the documentation in the Ruff JSON output.
