### PR TITLE
Small binary size optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ toml = { version = "0.7.2" }
 
 [profile.release]
 lto = "fat"
+codegen-units = 1
 
 [profile.dev.package.insta]
 opt-level = 3


### PR DESCRIPTION
This is a small PR that reduces the size of stripped release binaries by about ~11%. I haven't done any perf tests (I'll let the CI system do that for me), though eliminating more code should only improve performance (one would hope).

I heard about this from optimization from the [min-sized-rust](https://github.com/johnthagen/min-sized-rust#reduce-parallel-code-generation-units-to-increase-optimization) repository.

Some stats:

| Branch            | Size           | Size (stripped) |
|-------------------|----------------|-----------------|
| `main` (4cc3cdba) | 25234904 (25M) | 15267032 (15M)  |
| This PR           | 22502240 (22M) | 13681880 (14M)  |

