### PR TITLE
Improve debuggability of `place_comment`

### DIFF
--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -14,7 +14,7 @@ pub(super) fn place_comment<'a>(
     mut comment: DecoratedComment<'a>,
     locator: &Locator,
 ) -> CommentPlacement<'a> {
-    let handlers = [
+    static HANDLERS: &[for<'a> fn(DecoratedComment<'a>, &Locator) -> CommentPlacement<'a>] = &[
         handle_in_between_except_handlers_or_except_handler_and_else_or_finally_comment,
         handle_match_comment,
         handle_in_between_bodies_own_line_comment,
@@ -28,7 +28,7 @@ pub(super) fn place_comment<'a>(
         handle_leading_function_with_decorators_comment,
         handle_dict_unpacking_comment,
     ];
-    for handler in handlers {
+    for handler in HANDLERS {
         comment = match handler(comment, locator) {
             CommentPlacement::Default(comment) => comment,
             placement => return placement,

--- a/crates/ruff_python_formatter/src/comments/visitor.rs
+++ b/crates/ruff_python_formatter/src/comments/visitor.rs
@@ -608,18 +608,6 @@ impl<'a> CommentPlacement<'a> {
             comment: comment.into(),
         }
     }
-
-    /// Returns the placement if it isn't [`CommentPlacement::Default`], otherwise calls `f` and returns the result.
-    #[inline]
-    pub(super) fn or_else<F>(self, f: F) -> Self
-    where
-        F: FnOnce(DecoratedComment<'a>) -> CommentPlacement<'a>,
-    {
-        match self {
-            CommentPlacement::Default(comment) => f(comment),
-            placement => placement,
-        }
-    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]


### PR DESCRIPTION
## Summary

I found it hard to figure out which function decides placement for a specific comment. An explicit loop makes this easier to debug

## Test Plan

There should be no functional changes, no changes to the formatting of the fixtures.
