### PR TITLE
Format function argument separator comments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/function.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/function.py
@@ -97,3 +97,137 @@ def foo(
     b=3 + 2  # comment
 ):
     ...
+
+
+# Comments on the slash or the star, both of which don't have a node
+def f11(
+    a,
+    # positional only comment, leading
+    /, # positional only comment, trailing
+    b,
+):
+    pass
+
+def f12(
+    a=1,
+    # positional only comment, leading
+    /, # positional only comment, trailing
+    b=2,
+):
+    pass
+
+def f13(
+    a,
+    # positional only comment, leading
+    /, # positional only comment, trailing
+):
+    pass
+
+def f21(
+    a=1,
+    # keyword only comment, leading
+    *, # keyword only comment, trailing
+    b=2,
+):
+    pass
+
+def f22(
+    a,
+    # keyword only comment, leading
+    *, # keyword only comment, trailing
+    b,
+):
+    pass
+
+def f23(
+    a,
+    # keyword only comment, leading
+    *args, # keyword only comment, trailing
+    b,
+):
+    pass
+
+def f24(
+    # keyword only comment, leading
+    *, # keyword only comment, trailing
+    a
+):
+    pass
+
+
+def f31(
+    a=1,
+    # positional only comment, leading
+    /, # positional only comment, trailing
+    b=2,
+    # keyword only comment, leading
+    *, # keyword only comment, trailing
+    c=3,
+):
+    pass
+
+def f32(
+    a,
+    # positional only comment, leading
+    /, # positional only comment, trailing
+    b,
+    # keyword only comment, leading
+    *, # keyword only comment, trailing
+    c,
+):
+    pass
+
+def f33(
+    a,
+    # positional only comment, leading
+    /,  # positional only comment, trailing
+    # keyword only comment, leading
+    *args, # keyword only comment, trailing
+    c,
+):
+    pass
+
+
+def f34(
+    a,
+    # positional only comment, leading
+    /,  # positional only comment, trailing
+    # keyword only comment, leading
+    *, # keyword only comment, trailing
+    c,
+):
+    pass
+
+def f35(
+    # keyword only comment, leading
+    *, # keyword only comment, trailing
+    c,
+):
+    pass
+
+# Multiple trailing comments
+def f41(
+    a,
+    / # 1
+    , # 2
+    # 3
+    * # 4
+    , # 5
+    c,
+):
+    pass
+
+# Multiple trailing comments strangely places. The goal here is only stable formatting,
+# the comments are placed to strangely to keep their relative position intact
+def f42(
+    a,
+    / # 1
+    # 2
+    , # 3
+    # 4
+    * # 5
+    # 6
+    , # 7
+    c,
+):
+    pass

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -643,11 +643,11 @@ fn handle_arguments_separator_comment<'a>(
         return CommentPlacement::Default(comment);
     };
 
-    let slash_and_star = find_argument_separators(locator.contents(), arguments);
+    let (slash, star) = find_argument_separators(locator.contents(), arguments);
     let comment_range = comment.slice().range();
     let placement = assign_argument_separator_comment_placement(
-        slash_and_star.slash,
-        slash_and_star.star,
+        slash.as_ref(),
+        star.as_ref(),
         comment_range,
         comment.line_position(),
     );

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -1,12 +1,14 @@
 use crate::comments::visitor::{CommentPlacement, DecoratedComment};
-use crate::comments::CommentLinePosition;
 use crate::expression::expr_slice::{assign_comment_in_slice, ExprSliceCommentSection};
+use crate::other::arguments::{
+    assign_argument_separator_comment_placement, find_argument_separators,
+};
 use crate::trivia::{first_non_trivia_token_rev, SimpleTokenizer, Token, TokenKind};
 use ruff_python_ast::node::{AnyNodeRef, AstNode};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::whitespace;
 use ruff_python_whitespace::{PythonWhitespace, UniversalNewlines};
-use ruff_text_size::{TextRange, TextSize};
+use ruff_text_size::TextRange;
 use rustpython_parser::ast::{Expr, ExprSlice, Ranged};
 use std::cmp::Ordering;
 
@@ -24,7 +26,7 @@ pub(super) fn place_comment<'a>(
         handle_trailing_end_of_line_body_comment,
         handle_trailing_end_of_line_condition_comment,
         handle_module_level_own_line_comment_before_class_or_function_comment,
-        handle_positional_only_arguments_separator_comment,
+        handle_arguments_separator_comment,
         handle_trailing_binary_expression_left_or_operator_comment,
         handle_leading_function_with_decorators_comment,
         handle_dict_unpacking_comment,
@@ -629,18 +631,11 @@ fn handle_trailing_end_of_line_condition_comment<'a>(
     CommentPlacement::Default(comment)
 }
 
-/// Attaches comments for the positional-only arguments separator `/` as trailing comments to the
-/// enclosing [`Arguments`] node.
+/// Attaches comments for the positional only arguments separator `/` or the keywords only arguments
+/// separator `*` as dangling comments to the enclosing [`Arguments`] node.
 ///
-/// ```python
-/// def test(
-///     a,
-///     # Positional arguments only after here
-///     /, # trailing positional argument comment.
-///     b,
-/// ): pass
-/// ```
-fn handle_positional_only_arguments_separator_comment<'a>(
+/// See [`assign_argument_separator_comment_placement`]
+fn handle_arguments_separator_comment<'a>(
     comment: DecoratedComment<'a>,
     locator: &Locator,
 ) -> CommentPlacement<'a> {
@@ -648,45 +643,19 @@ fn handle_positional_only_arguments_separator_comment<'a>(
         return CommentPlacement::Default(comment);
     };
 
-    // Using the `/` without any leading arguments is a syntax error.
-    let Some(last_argument_or_default) = comment.preceding_node() else {
-        return CommentPlacement::Default(comment);
-    };
-
-    let is_last_positional_argument =
-        are_same_optional(last_argument_or_default, arguments.posonlyargs.last());
-
-    if !is_last_positional_argument {
-        return CommentPlacement::Default(comment);
+    let slash_and_star = find_argument_separators(locator.contents(), arguments);
+    let comment_range = comment.slice().range();
+    let placement = assign_argument_separator_comment_placement(
+        slash_and_star.slash,
+        slash_and_star.star,
+        comment_range,
+        comment.line_position(),
+    );
+    if placement.is_some() {
+        return CommentPlacement::dangling(comment.enclosing_node(), comment);
     }
 
-    let trivia_end = comment
-        .following_node()
-        .map_or(arguments.end(), |following| following.start());
-    let trivia_range = TextRange::new(last_argument_or_default.end(), trivia_end);
-
-    if let Some(slash_offset) = find_pos_only_slash_offset(trivia_range, locator) {
-        let comment_start = comment.slice().range().start();
-        let is_slash_comment = match comment.line_position() {
-            CommentLinePosition::EndOfLine => {
-                let preceding_end_line = locator.line_end(last_argument_or_default.end());
-                let slash_comments_start = preceding_end_line.min(slash_offset);
-
-                comment_start >= slash_comments_start
-                    && locator.line_end(slash_offset) > comment_start
-            }
-            CommentLinePosition::OwnLine => comment_start < slash_offset,
-        };
-
-        if is_slash_comment {
-            CommentPlacement::dangling(comment.enclosing_node(), comment)
-        } else {
-            CommentPlacement::Default(comment)
-        }
-    } else {
-        // Should not happen, but let's go with it
-        CommentPlacement::Default(comment)
-    }
+    CommentPlacement::Default(comment)
 }
 
 /// Handles comments between the left side and the operator of a binary expression (trailing comments of the left),
@@ -935,35 +904,6 @@ fn handle_slice_comments<'a>(
     } else {
         CommentPlacement::dangling(expr_slice.as_any_node_ref(), comment)
     }
-}
-
-/// Finds the offset of the `/` that separates the positional only and arguments from the other arguments.
-/// Returns `None` if the positional only separator `/` isn't present in the specified range.
-fn find_pos_only_slash_offset(
-    between_arguments_range: TextRange,
-    locator: &Locator,
-) -> Option<TextSize> {
-    let mut tokens =
-        SimpleTokenizer::new(locator.contents(), between_arguments_range).skip_trivia();
-
-    if let Some(comma) = tokens.next() {
-        debug_assert_eq!(comma.kind(), TokenKind::Comma);
-
-        if let Some(maybe_slash) = tokens.next() {
-            if maybe_slash.kind() == TokenKind::Slash {
-                return Some(maybe_slash.start());
-            }
-
-            debug_assert_eq!(
-                maybe_slash.kind(),
-                TokenKind::RParen,
-                "{:?}",
-                maybe_slash.kind()
-            );
-        }
-    }
-
-    None
 }
 
 /// Handles own line comments between the last function decorator and the *header* of the function.

--- a/crates/ruff_python_formatter/src/other/arguments.rs
+++ b/crates/ruff_python_formatter/src/other/arguments.rs
@@ -268,10 +268,7 @@ pub(crate) fn find_argument_separators(
 ) -> (Option<ArgumentSeparator>, Option<ArgumentSeparator>) {
     // We only compute preceding_end and token location here since following_start depends on the
     // star location, but the star location depends on slash's position
-    let slash = if arguments.posonlyargs.is_empty() {
-        // If there are no positional only arguments the default handling below is wrong
-        None
-    } else if let Some(preceding_end) = arguments.posonlyargs.last().map(Ranged::end) {
+    let slash = if let Some(preceding_end) = arguments.posonlyargs.last().map(Ranged::end) {
         // ```text
         // def f(a1=1, a2=2, /, a3, a4): pass
         //                 ^^^^^^^^^^^ the range (defaults)
@@ -296,12 +293,10 @@ pub(crate) fn find_argument_separators(
     };
 
     // If we have a vararg we have a node that the comments attach to
-    let star = if arguments.kwonlyargs.is_empty() || arguments.vararg.is_some() {
-        // If there are no keyword only arguments the default handling below is wrong.
+    let star = if arguments.vararg.is_some() {
         // When the vararg is present the comments attach there and we don't need to do manual
         // formatting
         None
-        // No keyword only arguments, no star
     } else if let Some(first_keyword_argument) = arguments.kwonlyargs.first() {
         // Check in that order:
         // * `f(a, /, b, *, c)` and `f(a=1, /, b=2, *, c)`

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__statement__function_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__statement__function_py.snap
@@ -103,6 +103,140 @@ def foo(
     b=3 + 2  # comment
 ):
     ...
+
+
+# Comments on the slash or the star, both of which don't have a node
+def f11(
+    a,
+    # positional only comment, leading
+    /, # positional only comment, trailing
+    b,
+):
+    pass
+
+def f12(
+    a=1,
+    # positional only comment, leading
+    /, # positional only comment, trailing
+    b=2,
+):
+    pass
+
+def f13(
+    a,
+    # positional only comment, leading
+    /, # positional only comment, trailing
+):
+    pass
+
+def f21(
+    a=1,
+    # keyword only comment, leading
+    *, # keyword only comment, trailing
+    b=2,
+):
+    pass
+
+def f22(
+    a,
+    # keyword only comment, leading
+    *, # keyword only comment, trailing
+    b,
+):
+    pass
+
+def f23(
+    a,
+    # keyword only comment, leading
+    *args, # keyword only comment, trailing
+    b,
+):
+    pass
+
+def f24(
+    # keyword only comment, leading
+    *, # keyword only comment, trailing
+    a
+):
+    pass
+
+
+def f31(
+    a=1,
+    # positional only comment, leading
+    /, # positional only comment, trailing
+    b=2,
+    # keyword only comment, leading
+    *, # keyword only comment, trailing
+    c=3,
+):
+    pass
+
+def f32(
+    a,
+    # positional only comment, leading
+    /, # positional only comment, trailing
+    b,
+    # keyword only comment, leading
+    *, # keyword only comment, trailing
+    c,
+):
+    pass
+
+def f33(
+    a,
+    # positional only comment, leading
+    /,  # positional only comment, trailing
+    # keyword only comment, leading
+    *args, # keyword only comment, trailing
+    c,
+):
+    pass
+
+
+def f34(
+    a,
+    # positional only comment, leading
+    /,  # positional only comment, trailing
+    # keyword only comment, leading
+    *, # keyword only comment, trailing
+    c,
+):
+    pass
+
+def f35(
+    # keyword only comment, leading
+    *, # keyword only comment, trailing
+    c,
+):
+    pass
+
+# Multiple trailing comments
+def f41(
+    a,
+    / # 1
+    , # 2
+    # 3
+    * # 4
+    , # 5
+    c,
+):
+    pass
+
+# Multiple trailing comments strangely places. The goal here is only stable formatting,
+# the comments are placed to strangely to keep their relative position intact
+def f42(
+    a,
+    / # 1
+    # 2
+    , # 3
+    # 4
+    * # 5
+    # 6
+    , # 7
+    c,
+):
+    pass
 ```
 
 
@@ -237,6 +371,148 @@ def foo(
     b=3 + 2,  # comment
 ):
     ...
+
+
+# Comments on the slash or the star, both of which don't have a node
+def f11(
+    a,
+    # positional only comment, leading
+    /,  # positional only comment, trailing
+    b,
+):
+    pass
+
+
+def f12(
+    a=1,
+    # positional only comment, leading
+    /,  # positional only comment, trailing
+    b=2,
+):
+    pass
+
+
+def f13(
+    a,
+    # positional only comment, leading
+    /,  # positional only comment, trailing
+):
+    pass
+
+
+def f21(
+    a=1,
+    # keyword only comment, leading
+    *,  # keyword only comment, trailing
+    b=2,
+):
+    pass
+
+
+def f22(
+    a,
+    # keyword only comment, leading
+    *,  # keyword only comment, trailing
+    b,
+):
+    pass
+
+
+def f23(
+    a,
+    # keyword only comment, leading
+    *args,  # keyword only comment, trailing
+    b,
+):
+    pass
+
+
+def f24(
+    # keyword only comment, leading
+    *,  # keyword only comment, trailing
+    a,
+):
+    pass
+
+
+def f31(
+    a=1,
+    # positional only comment, leading
+    /,  # positional only comment, trailing
+    b=2,
+    # keyword only comment, leading
+    *,  # keyword only comment, trailing
+    c=3,
+):
+    pass
+
+
+def f32(
+    a,
+    # positional only comment, leading
+    /,  # positional only comment, trailing
+    b,
+    # keyword only comment, leading
+    *,  # keyword only comment, trailing
+    c,
+):
+    pass
+
+
+def f33(
+    a,
+    # positional only comment, leading
+    /,  # positional only comment, trailing
+    # keyword only comment, leading
+    *args,  # keyword only comment, trailing
+    c,
+):
+    pass
+
+
+def f34(
+    a,
+    # positional only comment, leading
+    /,  # positional only comment, trailing
+    # keyword only comment, leading
+    *,  # keyword only comment, trailing
+    c,
+):
+    pass
+
+
+def f35(
+    # keyword only comment, leading
+    *,  # keyword only comment, trailing
+    c,
+):
+    pass
+
+
+# Multiple trailing comments
+def f41(
+    a,
+    /,  # 1  # 2
+    # 3
+    *,  # 4  # 5
+    c,
+):
+    pass
+
+
+# Multiple trailing comments strangely places. The goal here is only stable formatting,
+# the comments are placed to strangely to keep their relative position intact
+def f42(
+    a,
+    /,  # 1
+    # 2
+    # 3
+    # 4
+    *,  # 5  # 7
+    # 6
+    c,
+):
+    pass
 ```
 
 


### PR DESCRIPTION
## Summary

This is a complete rewrite of the handling of `/` and `*` comment handling in function signatures. The key problem is that slash and star don't have a note. We now parse out the positions of slash and star and their respective preceding and following note. I've left code comments for each possible case of function signature structure and comment placement

## Test Plan

I extended the function statement fixtures with cases that i found. If you have more weird edge cases your input would be appreciated.
