### PR TITLE
Add days-old flag to ruff clean

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -59,6 +59,10 @@ pub enum Command {
         /// Path to the cache directory.
         #[arg(long, env = "RUFF_CACHE_DIR", help_heading = "Miscellaneous")]
         cache_dir: Option<PathBuf>,
+        /// Only remove cache files older than `days_old` days old (by default
+        /// all cache files will be removed).
+        #[arg(long)]
+        days_old: Option<usize>,
     },
     /// Generate shell completion.
     #[clap(alias = "--generate-shell-completion", hide = true)]

--- a/crates/ruff_cli/src/commands/clean.rs
+++ b/crates/ruff_cli/src/commands/clean.rs
@@ -1,6 +1,7 @@
-use std::fs::remove_dir_all;
+use std::fs::{read_dir, remove_dir_all, remove_file};
 use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
 
 use anyhow::Result;
 use colored::Colorize;
@@ -12,19 +13,48 @@ use ruff::logging::LogLevel;
 use ruff_cache::{cache_dir, CACHE_DIR_NAME};
 
 /// Clear any caches in the current directory or any subdirectories.
-pub(crate) fn clean(cache_dir_overwrite: Option<PathBuf>, level: LogLevel) -> Result<()> {
+pub(crate) fn clean(
+    cache_dir_overwrite: Option<PathBuf>,
+    days_old: Option<usize>,
+    level: LogLevel,
+) -> Result<()> {
     let mut stderr = BufWriter::new(io::stderr().lock());
     let pwd = std::env::current_dir()?;
     let path = cache_dir(cache_dir_overwrite, &pwd);
+
     if cachedir::is_tagged(&path)? {
-        if level >= LogLevel::Default {
-            writeln!(
-                stderr,
-                "Removing cache at: {}",
-                fs::relativize_path(&path).bold()
-            )?;
+        if let Some(days_old) = days_old {
+            let cutoff = SystemTime::now() - Duration::from_secs(days_old as u64 * 24 * 60 * 60);
+            for entry in read_dir(&path)? {
+                let entry = entry?;
+
+                let last_modified = entry.metadata()?.modified()?;
+                if last_modified >= cutoff {
+                    continue;
+                }
+
+                let path = entry.path();
+                if level >= LogLevel::Default {
+                    writeln!(
+                        stderr,
+                        "Removing cache at: {}",
+                        fs::relativize_path(&path).bold()
+                    )?;
+                }
+                // NOTE: we don't expect any directories here, but if there are
+                // this will fail.
+                remove_file(&path)?;
+            }
+        } else {
+            if level >= LogLevel::Default {
+                writeln!(
+                    stderr,
+                    "Removing cache at: {}",
+                    fs::relativize_path(&path).bold()
+                )?;
+            }
+            remove_dir_all(path)?;
         }
-        remove_dir_all(path)?;
     } else if level >= LogLevel::Default {
         writeln!(
             stderr,

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -115,7 +115,10 @@ quoting the executed command, along with the relevant file contents and `pyproje
         Command::Rule { rule, format } => commands::rule::rule(rule, format)?,
         Command::Config { option } => return Ok(commands::config::config(option.as_deref())),
         Command::Linter { format } => commands::linter::linter(format)?,
-        Command::Clean { cache_dir } => commands::clean::clean(cache_dir, log_level)?,
+        Command::Clean {
+            cache_dir,
+            days_old,
+        } => commands::clean::clean(cache_dir, days_old, log_level)?,
         Command::GenerateShellCompletion { shell } => {
             shell.generate(&mut Args::command(), &mut io::stdout());
         }


### PR DESCRIPTION
## Summary

Change the cleaning to only include files that are of a certain age.

Based on https://github.com/astral-sh/ruff/pull/5122.

## Test Plan

Manually tested.
