### PR TITLE
Consistently name comment own line/end-of-line `line_position()`

### DIFF
--- a/crates/ruff_python_formatter/src/comments/debug.rs
+++ b/crates/ruff_python_formatter/src/comments/debug.rs
@@ -26,7 +26,7 @@ impl Debug for DebugComment<'_> {
 
         strut
             .field("text", &self.comment.slice.text(self.source_code))
-            .field("position", &self.comment.position);
+            .field("position", &self.comment.line_position);
 
         #[cfg(debug_assertions)]
         strut.field("formatted", &self.comment.formatted.get());
@@ -177,7 +177,7 @@ impl Debug for DebugNodeCommentSlice<'_> {
 #[cfg(test)]
 mod tests {
     use crate::comments::map::MultiMap;
-    use crate::comments::{CommentTextPosition, Comments, CommentsMap, SourceComment};
+    use crate::comments::{CommentLinePosition, Comments, CommentsMap, SourceComment};
     use insta::assert_debug_snapshot;
     use ruff_formatter::SourceCode;
     use ruff_python_ast::node::AnyNode;
@@ -208,7 +208,7 @@ break;
             continue_statement.as_ref().into(),
             SourceComment::new(
                 source_code.slice(TextRange::at(TextSize::new(0), TextSize::new(17))),
-                CommentTextPosition::OwnLine,
+                CommentLinePosition::OwnLine,
             ),
         );
 
@@ -216,7 +216,7 @@ break;
             continue_statement.as_ref().into(),
             SourceComment::new(
                 source_code.slice(TextRange::at(TextSize::new(28), TextSize::new(10))),
-                CommentTextPosition::EndOfLine,
+                CommentLinePosition::EndOfLine,
             ),
         );
 
@@ -224,7 +224,7 @@ break;
             break_statement.as_ref().into(),
             SourceComment::new(
                 source_code.slice(TextRange::at(TextSize::new(39), TextSize::new(15))),
-                CommentTextPosition::OwnLine,
+                CommentLinePosition::OwnLine,
             ),
         );
 

--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -136,7 +136,7 @@ impl Format<PyFormatContext<'_>> for FormatTrailingComments<'_> {
         {
             let slice = trailing.slice();
 
-            has_trailing_own_line_comment |= trailing.position().is_own_line();
+            has_trailing_own_line_comment |= trailing.line_position().is_own_line();
 
             if has_trailing_own_line_comment {
                 let lines_before_comment = lines_before(slice.start(), f.context().contents());
@@ -208,7 +208,7 @@ impl Format<PyFormatContext<'_>> for FormatDanglingComments<'_> {
             .iter()
             .filter(|comment| comment.is_unformatted())
         {
-            if first && comment.position().is_end_of_line() {
+            if first && comment.line_position().is_end_of_line() {
                 write!(f, [space(), space()])?;
             }
 

--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -117,14 +117,14 @@ pub(crate) struct SourceComment {
     slice: SourceCodeSlice,
     /// Whether the comment has been formatted or not.
     formatted: Cell<bool>,
-    position: CommentTextPosition,
+    line_position: CommentLinePosition,
 }
 
 impl SourceComment {
-    fn new(slice: SourceCodeSlice, position: CommentTextPosition) -> Self {
+    fn new(slice: SourceCodeSlice, position: CommentLinePosition) -> Self {
         Self {
             slice,
-            position,
+            line_position: position,
             formatted: Cell::new(false),
         }
     }
@@ -135,8 +135,8 @@ impl SourceComment {
         &self.slice
     }
 
-    pub(crate) const fn position(&self) -> CommentTextPosition {
-        self.position
+    pub(crate) const fn line_position(&self) -> CommentLinePosition {
+        self.line_position
     }
 
     /// Marks the comment as formatted
@@ -163,7 +163,7 @@ impl SourceComment {
 
 /// The position of a comment in the source text.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub(crate) enum CommentTextPosition {
+pub(crate) enum CommentLinePosition {
     /// A comment that is on the same line as the preceding token and is separated by at least one line break from the following token.
     ///
     /// # Examples
@@ -176,7 +176,7 @@ pub(crate) enum CommentTextPosition {
     /// ```
     ///
     /// `# comment` is an end of line comments because it is separated by at least one line break from the following token `b`.
-    /// Comments that not only end, but also start on a new line are [`OwnLine`](CommentTextPosition::OwnLine) comments.
+    /// Comments that not only end, but also start on a new line are [`OwnLine`](CommentLinePosition::OwnLine) comments.
     EndOfLine,
 
     /// A Comment that is separated by at least one line break from the preceding token.
@@ -193,13 +193,13 @@ pub(crate) enum CommentTextPosition {
     OwnLine,
 }
 
-impl CommentTextPosition {
+impl CommentLinePosition {
     pub(crate) const fn is_own_line(self) -> bool {
-        matches!(self, CommentTextPosition::OwnLine)
+        matches!(self, CommentLinePosition::OwnLine)
     }
 
     pub(crate) const fn is_end_of_line(self) -> bool {
-        matches!(self, CommentTextPosition::EndOfLine)
+        matches!(self, CommentLinePosition::EndOfLine)
     }
 }
 
@@ -309,7 +309,7 @@ impl<'a> Comments<'a> {
     pub(crate) fn has_trailing_own_line_comments(&self, node: AnyNodeRef) -> bool {
         self.trailing_comments(node)
             .iter()
-            .any(|comment| comment.position().is_own_line())
+            .any(|comment| comment.line_position().is_own_line())
     }
 
     /// Returns an iterator over the [leading](self#leading-comments) and [trailing comments](self#trailing-comments) of `node`.

--- a/crates/ruff_python_formatter/src/comments/visitor.rs
+++ b/crates/ruff_python_formatter/src/comments/visitor.rs
@@ -1,6 +1,6 @@
 use crate::comments::node_key::NodeRefEqualityKey;
 use crate::comments::placement::place_comment;
-use crate::comments::{CommentTextPosition, CommentsMap, SourceComment};
+use crate::comments::{CommentLinePosition, CommentsMap, SourceComment};
 use ruff_formatter::{SourceCode, SourceCodeSlice};
 use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::prelude::*;
@@ -66,7 +66,7 @@ impl<'a> CommentsVisitor<'a> {
                 preceding: self.preceding_node,
                 following: Some(node),
                 parent: self.parents.iter().rev().nth(1).copied(),
-                text_position: text_position(*comment_range, self.source_code),
+                line_position: text_position(*comment_range, self.source_code),
                 slice: self.source_code.slice(*comment_range),
             };
 
@@ -125,7 +125,7 @@ impl<'a> CommentsVisitor<'a> {
                 preceding: self.preceding_node,
                 parent: self.parents.last().copied(),
                 following: None,
-                text_position: text_position(*comment_range, self.source_code),
+                line_position: text_position(*comment_range, self.source_code),
                 slice: self.source_code.slice(*comment_range),
             };
 
@@ -273,7 +273,7 @@ impl<'ast> PreorderVisitor<'ast> for CommentsVisitor<'ast> {
     }
 }
 
-fn text_position(comment_range: TextRange, source_code: SourceCode) -> CommentTextPosition {
+fn text_position(comment_range: TextRange, source_code: SourceCode) -> CommentLinePosition {
     let before = &source_code.as_str()[TextRange::up_to(comment_range.start())];
 
     for c in before.chars().rev() {
@@ -282,11 +282,11 @@ fn text_position(comment_range: TextRange, source_code: SourceCode) -> CommentTe
                 break;
             }
             c if is_python_whitespace(c) => continue,
-            _ => return CommentTextPosition::EndOfLine,
+            _ => return CommentLinePosition::EndOfLine,
         }
     }
 
-    CommentTextPosition::OwnLine
+    CommentLinePosition::OwnLine
 }
 
 /// A comment decorated with additional information about its surrounding context in the source document.
@@ -298,7 +298,7 @@ pub(super) struct DecoratedComment<'a> {
     preceding: Option<AnyNodeRef<'a>>,
     following: Option<AnyNodeRef<'a>>,
     parent: Option<AnyNodeRef<'a>>,
-    text_position: CommentTextPosition,
+    line_position: CommentLinePosition,
     slice: SourceCodeSlice,
 }
 
@@ -436,14 +436,14 @@ impl<'a> DecoratedComment<'a> {
     }
 
     /// The position of the comment in the text.
-    pub(super) fn text_position(&self) -> CommentTextPosition {
-        self.text_position
+    pub(super) fn line_position(&self) -> CommentLinePosition {
+        self.line_position
     }
 }
 
 impl From<DecoratedComment<'_>> for SourceComment {
     fn from(decorated: DecoratedComment) -> Self {
-        Self::new(decorated.slice, decorated.text_position)
+        Self::new(decorated.slice, decorated.line_position)
     }
 }
 
@@ -652,8 +652,8 @@ impl<'a> CommentsBuilder<'a> {
                 self.push_dangling_comment(node, comment);
             }
             CommentPlacement::Default(comment) => {
-                match comment.text_position() {
-                    CommentTextPosition::EndOfLine => {
+                match comment.line_position() {
+                    CommentLinePosition::EndOfLine => {
                         match (comment.preceding_node(), comment.following_node()) {
                             (Some(preceding), Some(_)) => {
                                 // Attach comments with both preceding and following node to the preceding
@@ -675,7 +675,7 @@ impl<'a> CommentsBuilder<'a> {
                             }
                         }
                     }
-                    CommentTextPosition::OwnLine => {
+                    CommentLinePosition::OwnLine => {
                         match (comment.preceding_node(), comment.following_node()) {
                             // Following always wins for a leading comment
                             // ```python

--- a/crates/ruff_python_formatter/src/expression/expr_list.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_list.rs
@@ -1,4 +1,4 @@
-use crate::comments::{dangling_comments, CommentTextPosition, Comments};
+use crate::comments::{dangling_comments, CommentLinePosition, Comments};
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -30,11 +30,12 @@ impl FormatNodeRule<ExprList> for FormatExprList {
         // ```
         // In all other cases comments get assigned to a list element
         if elts.is_empty() {
-            let end_of_line_split = dangling
-                .partition_point(|comment| comment.position() == CommentTextPosition::EndOfLine);
+            let end_of_line_split = dangling.partition_point(|comment| {
+                comment.line_position() == CommentLinePosition::EndOfLine
+            });
             debug_assert!(dangling[end_of_line_split..]
                 .iter()
-                .all(|comment| comment.position() == CommentTextPosition::OwnLine));
+                .all(|comment| comment.line_position() == CommentLinePosition::OwnLine));
             return write!(
                 f,
                 [group(&format_args![

--- a/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
@@ -39,7 +39,7 @@ impl FormatRule<AnyFunctionDefinition<'_>, PyFormatContext<'_>> for FormatAnyFun
 
         let dangling_comments = comments.dangling_comments(item.into());
         let trailing_definition_comments_start =
-            dangling_comments.partition_point(|comment| comment.position().is_own_line());
+            dangling_comments.partition_point(|comment| comment.line_position().is_own_line());
 
         let (leading_function_definition_comments, trailing_definition_comments) =
             dangling_comments.split_at(trailing_definition_comments_start);

--- a/crates/ruff_python_formatter/src/statement/stmt_if.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_if.rs
@@ -73,7 +73,7 @@ impl FormatNodeRule<StmtIf> for FormatStmtIf {
         if !orelse.is_empty() {
             // Leading comments are always own line comments
             let leading_else_comments_end =
-                else_comments.partition_point(|comment| comment.position().is_own_line());
+                else_comments.partition_point(|comment| comment.line_position().is_own_line());
             let (else_leading, else_trailing) = else_comments.split_at(leading_else_comments_end);
 
             write!(

--- a/crates/ruff_python_formatter/src/statement/stmt_while.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_while.rs
@@ -44,7 +44,7 @@ impl FormatNodeRule<StmtWhile> for FormatStmtWhile {
             // Split between leading comments before the `else` keyword and end of line comments at the end of
             // the `else:` line.
             let trailing_start =
-                or_else_comments.partition_point(|comment| comment.position().is_own_line());
+                or_else_comments.partition_point(|comment| comment.line_position().is_own_line());
             let (leading, trailing) = or_else_comments.split_at(trailing_start);
 
             write!(


### PR DESCRIPTION
## Summary

Previously, `DecoratedComment` used `text_position()` and `SourceComment` used `position()`. This PR unifies this to `line_position` everywhere.

## Test Plan

This is a rename refactoring.