### PR TITLE
Remove defaults from fixtures/pyproject.toml

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyproject.toml
+++ b/crates/ruff/resources/test/fixtures/pyproject.toml
@@ -1,53 +1,8 @@
 [tool.ruff]
-allowed-confusables = ["−", "ρ", "∗"]
 line-length = 88
 extend-exclude = [
   "excluded_file.py",
   "migrations",
   "with_excluded_file/other_excluded_file.py",
 ]
-external = ["V101"]
 per-file-ignores = { "__init__.py" = ["F401"] }
-
-[tool.ruff.flake8-bugbear]
-extend-immutable-calls = ["fastapi.Depends", "fastapi.Query"]
-
-[tool.ruff.flake8-builtins]
-builtins-ignorelist = ["id", "dir"]
-
-[tool.ruff.flake8-quotes]
-inline-quotes = "single"
-multiline-quotes = "double"
-docstring-quotes = "double"
-avoid-escape = true
-
-[tool.ruff.mccabe]
-max-complexity = 10
-
-[tool.ruff.pep8-naming]
-classmethod-decorators = ["pydantic.validator"]
-
-[tool.ruff.flake8-tidy-imports]
-ban-relative-imports = "parents"
-
-[tool.ruff.flake8-tidy-imports.banned-api]
-"cgi".msg = "The cgi module is deprecated."
-"typing.TypedDict".msg = "Use typing_extensions.TypedDict instead."
-
-[tool.ruff.flake8-errmsg]
-max-string-length = 20
-
-[tool.ruff.flake8-import-conventions.aliases]
-pandas = "pd"
-
-[tool.ruff.flake8-import-conventions.extend-aliases]
-"dask.dataframe" = "dd"
-
-[tool.ruff.flake8-pytest-style]
-fixture-parentheses = false
-parametrize-names-type = "csv"
-parametrize-values-type = "tuple"
-parametrize-values-row-type = "list"
-raises-require-match-for = ["Exception", "TypeError", "KeyError"]
-raises-extend-require-match-for = ["requests.RequestException"]
-mark-parentheses = false

--- a/crates/ruff/src/rules/ruff/mod.rs
+++ b/crates/ruff/src/rules/ruff/mod.rs
@@ -90,13 +90,16 @@ mod tests {
     fn ruf100_0() -> Result<()> {
         let diagnostics = test_path(
             Path::new("ruff/RUF100_0.py"),
-            &settings::Settings::for_rules(vec![
-                Rule::UnusedNOQA,
-                Rule::LineTooLong,
-                Rule::UnusedImport,
-                Rule::UnusedVariable,
-                Rule::TabIndentation,
-            ]),
+            &settings::Settings {
+                external: FxHashSet::from_iter(vec!["V101".to_string()]),
+                ..settings::Settings::for_rules(vec![
+                    Rule::UnusedNOQA,
+                    Rule::LineTooLong,
+                    Rule::UnusedImport,
+                    Rule::UnusedVariable,
+                    Rule::TabIndentation,
+                ])
+            },
         )?;
         assert_messages!(diagnostics);
         Ok(())

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_0.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_0.snap
@@ -80,7 +80,7 @@ RUF100_0.py:19:12: RUF100 [*] Unused `noqa` directive (unused: `F841`, `W191`; n
 21 21 |     # Invalid (but external)
 22 22 |     d = 1  # noqa: F841, V101
 
-RUF100_0.py:22:12: RUF100 [*] Unused `noqa` directive (unused: `F841`; unknown: `V101`)
+RUF100_0.py:22:12: RUF100 [*] Unused `noqa` directive (unused: `F841`)
    |
 21 |     # Invalid (but external)
 22 |     d = 1  # noqa: F841, V101
@@ -95,7 +95,7 @@ RUF100_0.py:22:12: RUF100 [*] Unused `noqa` directive (unused: `F841`; unknown: 
 20 20 | 
 21 21 |     # Invalid (but external)
 22    |-    d = 1  # noqa: F841, V101
-   22 |+    d = 1
+   22 |+    d = 1  # noqa: V101
 23 23 | 
 24 24 |     # fmt: off
 25 25 |     # Invalid - no space before #

--- a/crates/ruff/src/settings/pyproject.rs
+++ b/crates/ruff/src/settings/pyproject.rs
@@ -152,12 +152,6 @@ mod tests {
 
     use crate::codes::{self, RuleCodePrefix};
     use crate::line_width::LineLength;
-    use crate::rules::flake8_quotes::settings::Quote;
-    use crate::rules::flake8_tidy_imports::settings::{ApiBan, Strictness};
-    use crate::rules::{
-        flake8_bugbear, flake8_builtins, flake8_errmsg, flake8_import_conventions,
-        flake8_pytest_style, flake8_quotes, flake8_tidy_imports, mccabe, pep8_naming,
-    };
     use crate::settings::pyproject::{
         find_settings_toml, parse_pyproject_toml, Options, Pyproject, Tools,
     };
@@ -300,95 +294,16 @@ other-attribute = 1
         assert_eq!(
             config,
             Options {
-                allowed_confusables: Some(vec!['−', 'ρ', '∗']),
                 line_length: Some(LineLength::from(88)),
                 extend_exclude: Some(vec![
                     "excluded_file.py".to_string(),
                     "migrations".to_string(),
                     "with_excluded_file/other_excluded_file.py".to_string(),
                 ]),
-                external: Some(vec!["V101".to_string()]),
                 per_file_ignores: Some(FxHashMap::from_iter([(
                     "__init__.py".to_string(),
                     vec![RuleCodePrefix::Pyflakes(codes::Pyflakes::_401).into()]
                 )])),
-                flake8_bugbear: Some(flake8_bugbear::settings::Options {
-                    extend_immutable_calls: Some(vec![
-                        "fastapi.Depends".to_string(),
-                        "fastapi.Query".to_string(),
-                    ]),
-                }),
-                flake8_builtins: Some(flake8_builtins::settings::Options {
-                    builtins_ignorelist: Some(vec!["id".to_string(), "dir".to_string(),]),
-                }),
-                flake8_errmsg: Some(flake8_errmsg::settings::Options {
-                    max_string_length: Some(20),
-                }),
-                flake8_pytest_style: Some(flake8_pytest_style::settings::Options {
-                    fixture_parentheses: Some(false),
-                    parametrize_names_type: Some(
-                        flake8_pytest_style::types::ParametrizeNameType::Csv
-                    ),
-                    parametrize_values_type: Some(
-                        flake8_pytest_style::types::ParametrizeValuesType::Tuple,
-                    ),
-                    parametrize_values_row_type: Some(
-                        flake8_pytest_style::types::ParametrizeValuesRowType::List,
-                    ),
-                    raises_require_match_for: Some(vec![
-                        "Exception".to_string(),
-                        "TypeError".to_string(),
-                        "KeyError".to_string(),
-                    ]),
-                    raises_extend_require_match_for: Some(vec![
-                        "requests.RequestException".to_string(),
-                    ]),
-                    mark_parentheses: Some(false),
-                }),
-                flake8_implicit_str_concat: None,
-                flake8_quotes: Some(flake8_quotes::settings::Options {
-                    inline_quotes: Some(Quote::Single),
-                    multiline_quotes: Some(Quote::Double),
-                    docstring_quotes: Some(Quote::Double),
-                    avoid_escape: Some(true),
-                }),
-                flake8_tidy_imports: Some(flake8_tidy_imports::options::Options {
-                    ban_relative_imports: Some(Strictness::Parents),
-                    banned_api: Some(FxHashMap::from_iter([
-                        (
-                            "cgi".to_string(),
-                            ApiBan {
-                                msg: "The cgi module is deprecated.".to_string()
-                            }
-                        ),
-                        (
-                            "typing.TypedDict".to_string(),
-                            ApiBan {
-                                msg: "Use typing_extensions.TypedDict instead.".to_string()
-                            }
-                        )
-                    ]))
-                }),
-                flake8_import_conventions: Some(flake8_import_conventions::settings::Options {
-                    aliases: Some(FxHashMap::from_iter([(
-                        "pandas".to_string(),
-                        "pd".to_string(),
-                    )])),
-                    extend_aliases: Some(FxHashMap::from_iter([(
-                        "dask.dataframe".to_string(),
-                        "dd".to_string(),
-                    )])),
-                    banned_aliases: None,
-                    banned_from: None,
-                }),
-                mccabe: Some(mccabe::settings::Options {
-                    max_complexity: Some(10),
-                }),
-                pep8_naming: Some(pep8_naming::settings::Options {
-                    ignore_names: None,
-                    classmethod_decorators: Some(vec!["pydantic.validator".to_string()]),
-                    staticmethod_decorators: None,
-                }),
                 ..Options::default()
             }
         );


### PR DESCRIPTION
## Summary

These should be encoded in the tests themselves, rather than here. In fact, I think they're all unused?
