### PR TITLE
Fix subprocess.run on Windows Python 3.7

### DIFF
--- a/python/ruff/__main__.py
+++ b/python/ruff/__main__.py
@@ -32,5 +32,7 @@ def find_ruff_bin() -> Path:
 
 if __name__ == "__main__":
     ruff = find_ruff_bin()
-    completed_process = subprocess.run([ruff, *sys.argv[1:]])
+    # Passing a path-like to `subprocess.run()` on windows is only supported in 3.8+,
+    # but we also support 3.7
+    completed_process = subprocess.run([os.fsdecode(ruff), *sys.argv[1:]])
     sys.exit(completed_process.returncode)


### PR DESCRIPTION
## Summary

From the [subprocess docs](https://docs.python.org/3/library/subprocess.html#subprocess.Popen):

> Changed in version 3.6: args parameter accepts a path-like object if shell is False and a sequence containing path-like objects on POSIX.
>
> Changed in version 3.8: args parameter accepts a path-like object if shell is False and a sequence containing bytes and path-like objects on Windows.

We want to support python 3.7 on windows, so we need to convert the `Path` into a `str`
