### PR TITLE
Fixed typo in numpy deprecated type alias rule documentation

### DIFF
--- a/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
+++ b/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
@@ -12,7 +12,7 @@ use crate::registry::AsRule;
 /// ## Why is this bad?
 /// NumPy's `np.int` has long been an alias of the builtin `int`. The same
 /// goes for `np.float`, `np.bool`, and others. These aliases exist
-/// primarily primarily for historic reasons, and have been a cause of
+/// primarily for historic reasons, and have been a cause of
 /// frequent confusion for newcomers.
 ///
 /// These aliases were been deprecated in 1.20, and removed in 1.24.


### PR DESCRIPTION
## Summary

It is a very simple typo fix in the "numy deprecated type alias" documentation.
