### PR TITLE
Avoid `.unwrap()` on cache access

### DIFF
--- a/crates/ruff_cli/src/commands/run.rs
+++ b/crates/ruff_cli/src/commands/run.rs
@@ -107,9 +107,7 @@ pub(crate) fn run(
 
                     let settings = resolver.resolve_all(path, pyproject_config);
                     let package_root = package.unwrap_or_else(|| path.parent().unwrap_or(path));
-                    let cache = caches
-                        .as_ref()
-                        .map(|caches| caches.get(&package_root).unwrap());
+                    let cache = caches.as_ref().and_then(|caches| caches.get(&package_root));
 
                     lint_path(path, package, settings, cache, noqa, autofix).map_err(|e| {
                         (Some(path.to_owned()), {


### PR DESCRIPTION
## Summary

I haven't been able to determine why / when this is happening, but in some cases, users are reporting that this `unwrap()` is causing a panic. It's fine to just return `None` here and fallback to "No cache", certainly better than panicking (while we figure out the edge case).

Closes #5225.

Closes #5228.
