### PR TITLE
Use package roots rather than package members for cache initialization

### DIFF
--- a/crates/ruff_cli/src/commands/run.rs
+++ b/crates/ruff_cli/src/commands/run.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 use anyhow::Result;
 use colored::Colorize;
 use ignore::Error;
+use itertools::Itertools;
 use log::{debug, error, warn};
 #[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
@@ -80,8 +81,10 @@ pub(crate) fn run(
     // Load the caches.
     let caches = bool::from(cache).then(|| {
         package_roots
-            .par_iter()
-            .map(|(package_root, _)| {
+            .values()
+            .flatten()
+            .dedup()
+            .map(|package_root| {
                 let settings = resolver.resolve_all(package_root, pyproject_config);
                 let cache = Cache::open(
                     &settings.cli.cache_dir,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This is a proper fix for the issue patched-over in https://github.com/astral-sh/ruff/pull/5229, thanks to an extremely helpful repro from @tlambert03 in that thread. It looks like we were using the keys of `package_roots` rather than the values to initialize the cache -- but it's a map from package to package root.

## Test Plan

Reverted #5229, then ran through the plan that @tlambert03 included in https://github.com/astral-sh/ruff/pull/5229#issuecomment-1599723226. Verified the panic before but not after this change.
