### PR TITLE
Avoid erroneous RUF013 violations for quoted annotations

### DIFF
--- a/crates/ruff/resources/test/fixtures/ruff/RUF013_0.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF013_0.py
@@ -185,3 +185,18 @@ def f(arg: Union[Annotated[int, ...], Annotated[Optional[float], ...]] = None):
 
 def f(arg: Union[Annotated[int, ...], Union[str, bytes]] = None):  # RUF011
     pass
+
+
+# Quoted
+
+
+def f(arg: "int" = None):
+    pass
+
+
+def f(arg: "str" = None):
+    pass
+
+
+def f(arg: "Optional[int]" = None):
+    pass

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__PY39_RUF013_RUF013_0.py.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__PY39_RUF013_RUF013_0.py.snap
@@ -312,5 +312,7 @@ RUF013_0.py:186:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
 186     |-def f(arg: Union[Annotated[int, ...], Union[str, bytes]] = None):  # RUF011
     186 |+def f(arg: Optional[Union[Annotated[int, ...], Union[str, bytes]]] = None):  # RUF011
 187 187 |     pass
+188 188 | 
+189 189 | 
 
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF013_RUF013_0.py.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF013_RUF013_0.py.snap
@@ -312,5 +312,7 @@ RUF013_0.py:186:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
 186     |-def f(arg: Union[Annotated[int, ...], Union[str, bytes]] = None):  # RUF011
     186 |+def f(arg: Union[Annotated[int, ...], Union[str, bytes]] | None = None):  # RUF011
 187 187 |     pass
+188 188 | 
+189 189 | 
 
 


### PR DESCRIPTION
## Summary

Temporary fix for #5231: if we can't flag and fix these properly, just disabling them for now.

\cc @dhruvmanila 

## Test Plan

`cargo test`
