### PR TITLE
Initialize caches for packages and standalone files

### DIFF
--- a/crates/ruff/src/packaging.rs
+++ b/crates/ruff/src/packaging.rs
@@ -78,7 +78,7 @@ fn detect_package_root_with_cache<'a>(
     current
 }
 
-/// Return a mapping from Python file to its package root.
+/// Return a mapping from Python package to its package root.
 pub fn detect_package_roots<'a>(
     files: &[&'a Path],
     resolver: &'a Resolver,


### PR DESCRIPTION
## Summary

While fixing https://github.com/astral-sh/ruff/pull/5233, I noticed that in FastAPI, 343 out of 823 files weren't hitting the cache. It turns out these are standalone files in the documentation that lack a "package root". Later, when looking up the cache entries, we fallback to the package directory.

This PR ensures that we initialize the cache for both kinds of files: those that are in a package, and those that aren't.

The total size of the FastAPI cache for me is now 388K. I also suspect that this approach is much faster than as initially written, since before, we were probably initializing one cache per _directory_.

## Test Plan

Ran `cargo run -p ruff_cli -- check ../fastapi --verbose`; verified that, on second execution, there were no "Checking" entries in the logs.
