### PR TITLE
Ensure release tagging has access to repo clone

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -423,8 +423,8 @@ jobs:
             echo "Releasing ${git_sha}"
           fi
 
-  release:
-    name: Release
+  upload-release:
+    name: Upload to PyPI
     runs-on: ubuntu-latest
     needs:
       - macos-universal
@@ -442,8 +442,6 @@ jobs:
     permissions:
       # For pypi trusted publishing
       id-token: write
-      # For GitHub release publishing
-      contents: write
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -455,10 +453,18 @@ jobs:
           skip-existing: true
           packages-dir: wheels
           verbose: true
-      - uses: actions/download-artifact@v3
-        with:
-          name: binaries
-          path: binaries
+
+  tag-release:
+    name: Tag release
+    runs-on: ubuntu-latest
+    needs: upload-release
+    # If you don't set an input tag, it's a dry run (no uploads).
+    if: ${{ inputs.tag }}
+    permissions:
+      # For git tag
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
       - name: git tag
         run: |
           git config user.email "hey@astral.sh"
@@ -467,10 +473,25 @@ jobs:
           # If there is duplicate tag, this will fail. The publish to pypi action will have been a noop (due to skip
           # existing), so we make a non-destructive exit here
           git push --tags
+
+  publish-release:
+    name: Publish to GitHub
+    runs-on: ubuntu-latest
+    needs: tag-release
+    # If you don't set an input tag, it's a dry run (no uploads).
+    if: ${{ inputs.tag }}
+    permissions:
+      # For GitHub release publishing
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: binaries
+          path: binaries
       - name: "Publish to GitHub"
         uses: softprops/action-gh-release@v1
         with:
-          draft: true
+          draft: false
           files: binaries/*
           tag_name: v${{ inputs.tag }}
 


### PR DESCRIPTION
## Summary

The [release failed](https://github.com/astral-sh/ruff/actions/runs/5329733171/jobs/9656004063), but late enough that I was able to do the remaining steps manually. The issue here is that the tagging step requires that we clone the repo. I split the upload (to PyPI), tagging (in Git), and publishing (to GitHub Releases) phases into their own steps, since they need different resources + permissions anyway.
