### PR TITLE
Use trait for labels instead of `TypeId`

### DIFF
--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -528,7 +528,22 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 /// use ruff_formatter::prelude::*;
 /// use ruff_formatter::{format, write, LineWidth};
 ///
-/// enum SomeLabelId {}
+/// #[derive(Debug, Copy, Clone)]
+/// enum MyLabels {
+///     Main
+/// }
+///
+/// impl tag::LabelDefinition for MyLabels {
+///     fn value(&self) -> u64 {
+///         *self as u64
+///     }
+///
+///     fn name(&self) -> &'static str {
+///         match self {
+///             Self::Main => "Main"
+///         }
+///     }
+/// }
 ///
 /// # fn main() -> FormatResult<()> {
 /// let formatted = format!(
@@ -537,24 +552,24 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 ///         let mut recording = f.start_recording();
 ///         write!(recording, [
 ///             labelled(
-///                 LabelId::of::<SomeLabelId>(),
+///                 LabelId::of(MyLabels::Main),
 ///                 &text("'I have a label'")
 ///             )
 ///         ])?;
 ///
 ///         let recorded = recording.stop();
 ///
-///         let is_labelled = recorded.first().map_or(false, |element| element.has_label(LabelId::of::<SomeLabelId>()));
+///         let is_labelled = recorded.first().map_or(false, |element| element.has_label(LabelId::of(MyLabels::Main)));
 ///
 ///         if is_labelled {
-///             write!(f, [text(" has label SomeLabelId")])
+///             write!(f, [text(" has label `Main`")])
 ///         } else {
-///             write!(f, [text(" doesn't have label SomeLabelId")])
+///             write!(f, [text(" doesn't have label `Main`")])
 ///         }
 ///     })]
 /// )?;
 ///
-/// assert_eq!("'I have a label' has label SomeLabelId", formatted.print()?.as_code());
+/// assert_eq!("'I have a label' has label `Main`", formatted.print()?.as_code());
 /// # Ok(())
 /// # }
 /// ```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes https://github.com/astral-sh/ruff/issues/5263

Rust 1.72.0 changes `TypeId` from a `u64` to a `u128`. This breaks Ruffs release build because it increases the size of `FormatElement`.

This PR removes the dependency on `TypeId` for `LabelId` and instead introduces a new trait that downstream crates should implement on an `enum` defining all labels for that project. 

This approach has two downsides:

* The API cannot statically enforce that a project uses a single `LabelDefinition`. Mixing two `LabelDefinition` could result in two labels being equal that should not be equal. I added a 
debug assertion that compares the names of the labels to mitigate the risk. 
* Implementing the first `Label` requires more boilerplate code than before

One main upside is that it allows a project to define all labels in a single place (and search for all label usages).  

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

* `cargo test`
* `cargo build -p ruff_python_formatter --release` on Rust 1.72.0
<!-- How was it tested? -->
