### PR TITLE
Avoid `mutable-class-default` (`RUF012`) for fully untyped classes

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF012.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF012.py
@@ -59,3 +59,7 @@ class F(BaseSettings):
     without_annotation = []
     class_variable: ClassVar[list[int]] = []
     final_variable: Final[list[int]] = []
+
+
+class E:
+    without_annotation = []

--- a/crates/ruff_linter/src/rules/ruff/rules/mutable_class_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/mutable_class_default.rs
@@ -24,6 +24,10 @@ use crate::rules::ruff::rules::helpers::{
 /// `typing.ClassVar`. When mutability is not required, values should be
 /// immutable types, like `tuple` or `frozenset`.
 ///
+/// As a heuristic, this rule is only applied to classes with at least one
+/// annotated attribute, as unannotated classes are assumed to be deliberately
+/// untyped.
+///
 /// ## Examples
 /// ```python
 /// class A:
@@ -52,6 +56,10 @@ impl Violation for MutableClassDefault {
 
 /// RUF012
 pub(crate) fn mutable_class_default(checker: &mut Checker, class_def: &ast::StmtClassDef) {
+    if !class_def.body.iter().any(Stmt::is_ann_assign_stmt) {
+        return;
+    }
+
     for statement in &class_def.body {
         match statement {
             Stmt::AnnAssign(ast::StmtAnnAssign {


### PR DESCRIPTION
## Summary

This PR attempts to avoid flagging mutable class attributes (and suggesting that they be annotated with `ClassVar`) for classes that are fully untyped. I'm somewhat undecided on it (the underlying _issue_ is still present, but the suggested fix isn't applicable), but you can see the discussion in #5243.
