### PR TITLE
Fix `deprecated-import` false positives

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP035.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP035.py
@@ -48,3 +48,9 @@ if True: from collections import (
 
 # OK
 from a import b
+
+from typing_extensions import SupportsIndex
+
+isinstance(42, SupportsIndex)  # this check is much faster than the `typing` version
+
+from typing_extensions import dataclass_transform  # `typing` version won't have `frozen_default` arg until 3.12

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -171,7 +171,6 @@ const TYPING_EXTENSIONS_TO_TYPING_38: &[&str] = &[
     "Literal",
     "OrderedDict",
     "Protocol",
-    "SupportsIndex",
     "runtime_checkable",
 ];
 
@@ -268,7 +267,6 @@ const TYPING_EXTENSIONS_TO_TYPING_311: &[&str] = &[
     "assert_never",
     "assert_type",
     "clear_overloads",
-    "dataclass_transform",
     "final",
     "get_overloads",
     "overload",


### PR DESCRIPTION
## Summary

Remove recommendations to replace `typing_extensions.dataclass_transform` and `typing_extensions.SupportsIndex` with their `typing` library counterparts.

Closes #5112.

## Test Plan

Added extra checks to the test fixture.

`cargo test`