### PR TITLE
Don't mistake a following if for an elif

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/dict.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/dict.py
@@ -48,3 +48,11 @@ mapping = {
     C: 0.1 * (10.0 / 12),
     D: 0.1 * (10.0 / 12),
 }
+
+# Regression test for formatter panic with comment after parenthesized dict value
+# Originally found in https://github.com/bolucat/Firefox/blob/636a717ef025c16434997dc89e42351ef740ee6b/testing/marionette/client/marionette_driver/geckoinstance.py#L109
+a = {
+    1: (2),
+    # comment
+    3: True,
+}

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/if.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/if.py
@@ -62,3 +62,12 @@ else:
     pass
 # Don't drop this comment 3
 x = 3
+
+# Regression test for a following if that could get confused for an elif
+# Originally found in https://github.com/gradio-app/gradio/blob/1570b94a02d23d051ae137e0063974fd8a48b34e/gradio/external.py#L478
+if True:
+    pass
+else:  # Comment
+    if False:
+        pass
+    pass

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -991,14 +991,22 @@ fn handle_dict_unpacking_comment<'a>(
     .skip_trivia();
 
     // we start from the preceding node but we skip its token
-    if let Some(first) = tokens.next() {
-        debug_assert!(matches!(
-            first,
-            Token {
-                kind: TokenKind::LBrace | TokenKind::Comma | TokenKind::Colon,
-                ..
-            }
-        ));
+    for token in tokens.by_ref() {
+        // Skip closing parentheses that are not part of the node range
+        if token.kind == TokenKind::RParen {
+            continue;
+        }
+        debug_assert!(
+            matches!(
+                token,
+                Token {
+                    kind: TokenKind::LBrace | TokenKind::Comma | TokenKind::Colon,
+                    ..
+                }
+            ),
+            "{token:?}",
+        );
+        break;
     }
 
     // if the remaining tokens from the previous node is exactly `**`,

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__expression__dict_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__expression__dict_py.snap
@@ -54,6 +54,14 @@ mapping = {
     C: 0.1 * (10.0 / 12),
     D: 0.1 * (10.0 / 12),
 }
+
+# Regression test for formatter panic with comment after parenthesized dict value
+# Originally found in https://github.com/bolucat/Firefox/blob/636a717ef025c16434997dc89e42351ef740ee6b/testing/marionette/client/marionette_driver/geckoinstance.py#L109
+a = {
+    1: (2),
+    # comment
+    3: True,
+}
 ```
 
 
@@ -111,6 +119,14 @@ mapping = {
     B: 0.1 * (10.0 / 12),
     C: 0.1 * (10.0 / 12),
     D: 0.1 * (10.0 / 12),
+}
+
+# Regression test for formatter panic with comment after parenthesized dict value
+# Originally found in https://github.com/bolucat/Firefox/blob/636a717ef025c16434997dc89e42351ef740ee6b/testing/marionette/client/marionette_driver/geckoinstance.py#L109
+a = {
+    1: (2),
+    # comment
+    3: True,
 }
 ```
 

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__statement__if_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__statement__if_py.snap
@@ -68,6 +68,15 @@ else:
     pass
 # Don't drop this comment 3
 x = 3
+
+# Regression test for a following if that could get confused for an elif
+# Originally found in https://github.com/gradio-app/gradio/blob/1570b94a02d23d051ae137e0063974fd8a48b34e/gradio/external.py#L478
+if True:
+    pass
+else:  # Comment
+    if False:
+        pass
+    pass
 ```
 
 
@@ -137,6 +146,15 @@ else:
     pass
 # Don't drop this comment 3
 x = 3
+
+# Regression test for a following if that could get confused for an elif
+# Originally found in https://github.com/gradio-app/gradio/blob/1570b94a02d23d051ae137e0063974fd8a48b34e/gradio/external.py#L478
+if True:
+    pass
+else:  # Comment
+    if False:
+        pass
+    pass
 ```
 
 


### PR DESCRIPTION
In the following code, the comment used to get wrongly associated with the `if False` since it looked like an elif. This fixes it by checking the indentation and adding a regression test
```python
if True:
    pass
else:  # Comment
    if False:
        pass
    pass
```
    
Originally found in https://github.com/gradio-app/gradio/blob/1570b94a02d23d051ae137e0063974fd8a48b34e/gradio/external.py#L478
