### PR TITLE
Publish GitHub release as draft

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -491,14 +491,14 @@ jobs:
       - name: "Publish to GitHub"
         uses: softprops/action-gh-release@v1
         with:
-          draft: false
+          draft: true
           files: binaries/*
           tag_name: v${{ inputs.tag }}
 
   # After the release has been published, we update downstream repositories
   # This is separate because if this fails the release is still fine, we just need to do some manual workflow triggers
   update-dependents:
-    name: Release
+    name: Update dependents
     runs-on: ubuntu-latest
     needs: publish-release
     steps:


### PR DESCRIPTION
I accidentally changed `draft: false` to `draft: true` in #5240. I actually think Copilot did this without me realizing.