### PR TITLE
Avoid `uint8` format in SchemaStore JSON Schema

### DIFF
--- a/scripts/update_schemastore.py
+++ b/scripts/update_schemastore.py
@@ -47,9 +47,16 @@ def update_schemastore(schemastore: Path) -> None:
         cwd=schemastore,
     )
 
-    # Update the schema and format appropriately
+    # Update the schema and format appropriately.
     schema = json.loads(root.joinpath("ruff.schema.json").read_text())
     schema["$id"] = "https://json.schemastore.org/ruff.json"
+
+    # Rewrite any `uint8` types to `uint`. `uint8` seems to be unsupported by
+    # SchemaStore.
+    for definition in schema['definitions']:
+        if schema['definitions'][definition].get("format") == "uint8":
+            schema['definitions'][definition]['format'] = 'uint'
+
     schemastore.joinpath(ruff_json).write_text(
         json.dumps(dict(sorted(schema.items())), indent=2, ensure_ascii=False),
     )


### PR DESCRIPTION
The new `tabSize` property uses `uint8`, but SchemaStore rejects it. (I edited the generated PR manually.)