### PR TITLE
Fix annotation and format spec visitors

### DIFF
--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -20,7 +20,7 @@ pub trait Visitor<'a> {
         walk_stmt(self, stmt);
     }
     fn visit_annotation(&mut self, expr: &'a Expr) {
-        self.visit_expr(expr);
+        walk_annotation(self, expr);
     }
     fn visit_decorator(&mut self, decorator: &'a Decorator) {
         walk_decorator(self, decorator);
@@ -53,7 +53,7 @@ pub trait Visitor<'a> {
         walk_except_handler(self, except_handler);
     }
     fn visit_format_spec(&mut self, format_spec: &'a Expr) {
-        self.visit_expr(format_spec);
+        walk_format_spec(self, format_spec);
     }
     fn visit_arguments(&mut self, arguments: &'a Arguments) {
         walk_arguments(self, arguments);
@@ -320,6 +320,10 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
         }) => visitor.visit_expr(value),
         Stmt::Pass(_) | Stmt::Break(_) | Stmt::Continue(_) => {}
     }
+}
+
+pub fn walk_annotation<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
+    visitor.visit_expr(expr);
 }
 
 pub fn walk_decorator<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, decorator: &'a Decorator) {
@@ -600,6 +604,10 @@ pub fn walk_except_handler<'a, V: Visitor<'a> + ?Sized>(
             visitor.visit_body(body);
         }
     }
+}
+
+pub fn walk_format_spec<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, format_spec: &'a Expr) {
+    visitor.visit_expr(format_spec);
 }
 
 pub fn walk_arguments<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, arguments: &'a Arguments) {

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -20,7 +20,7 @@ pub trait Visitor<'a> {
         walk_stmt(self, stmt);
     }
     fn visit_annotation(&mut self, expr: &'a Expr) {
-        walk_expr(self, expr);
+        self.visit_expr(expr);
     }
     fn visit_decorator(&mut self, decorator: &'a Decorator) {
         walk_decorator(self, decorator);
@@ -53,7 +53,7 @@ pub trait Visitor<'a> {
         walk_except_handler(self, except_handler);
     }
     fn visit_format_spec(&mut self, format_spec: &'a Expr) {
-        walk_expr(self, format_spec);
+        self.visit_expr(format_spec);
     }
     fn visit_arguments(&mut self, arguments: &'a Arguments) {
         walk_arguments(self, arguments);

--- a/crates/ruff_python_ast/src/visitor/preorder.rs
+++ b/crates/ruff_python_ast/src/visitor/preorder.rs
@@ -11,7 +11,7 @@ pub trait PreorderVisitor<'a> {
     }
 
     fn visit_annotation(&mut self, expr: &'a Expr) {
-        walk_expr(self, expr);
+        self.visit_expr(expr);
     }
 
     fn visit_expr(&mut self, expr: &'a Expr) {
@@ -51,7 +51,7 @@ pub trait PreorderVisitor<'a> {
     }
 
     fn visit_format_spec(&mut self, format_spec: &'a Expr) {
-        walk_expr(self, format_spec);
+        self.visit_expr(format_spec);
     }
 
     fn visit_arguments(&mut self, arguments: &'a Arguments) {

--- a/crates/ruff_python_ast/src/visitor/preorder.rs
+++ b/crates/ruff_python_ast/src/visitor/preorder.rs
@@ -11,7 +11,7 @@ pub trait PreorderVisitor<'a> {
     }
 
     fn visit_annotation(&mut self, expr: &'a Expr) {
-        self.visit_expr(expr);
+        walk_annotation(self, expr);
     }
 
     fn visit_expr(&mut self, expr: &'a Expr) {
@@ -51,7 +51,7 @@ pub trait PreorderVisitor<'a> {
     }
 
     fn visit_format_spec(&mut self, format_spec: &'a Expr) {
-        self.visit_expr(format_spec);
+        walk_format_spec(self, format_spec);
     }
 
     fn visit_arguments(&mut self, arguments: &'a Arguments) {
@@ -395,6 +395,10 @@ where
     }
 }
 
+pub fn walk_annotation<'a, V: PreorderVisitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
+    visitor.visit_expr(expr);
+}
+
 pub fn walk_decorator<'a, V>(visitor: &mut V, decorator: &'a Decorator)
 where
     V: PreorderVisitor<'a> + ?Sized,
@@ -724,6 +728,13 @@ where
             visitor.visit_body(body);
         }
     }
+}
+
+pub fn walk_format_spec<'a, V: PreorderVisitor<'a> + ?Sized>(
+    visitor: &mut V,
+    format_spec: &'a Expr,
+) {
+    visitor.visit_expr(format_spec);
 }
 
 pub fn walk_arguments<'a, V>(visitor: &mut V, arguments: &'a Arguments)


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The `Visitor` and `preorder::Visitor` traits provide some convenience functions, `visit_annotation` and `visit_format_spec`, for handling annotation and format spec expressions respectively. Both of these functions accept an `&Expr` and have a default implementation which delegates to `walk_expr`. The problem with this approach is that any custom handling done in `visit_expr` will be skipped for annotations and format specs. Instead, to capture any custom logic implemented in `visit_expr`, both of these function's default implementations should delegate to `visit_expr` instead of `walk_expr`.

## Example

Consider the below `Visitor` implementation:
```rust
impl<'a> Visitor<'a> for Example<'a> {
    fn visit_expr(&mut self, expr: &'a Expr) {
        match expr {
            Expr::Name(ExprName { id, .. }) => println!("Visiting {:?}", id),
            _ => walk_expr(self, expr),
        }
    }
}
```

Run on the following Python snippet:
```python
a: b
```

I would expect such a visitor to print the following:
```
Visiting b
Visiting a
```

But it instead prints the following:
```
Visiting a
```

Our custom `visit_expr` handler is not invoked for the annotation.

## Test Plan

Tests added in #5271 caught this behavior.
