### PR TITLE
Visit AugAssign target after value

### DIFF
--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -167,9 +167,9 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
             value,
             range: _range,
         }) => {
-            visitor.visit_expr(target);
-            visitor.visit_operator(op);
             visitor.visit_expr(value);
+            visitor.visit_operator(op);
+            visitor.visit_expr(target);
         }
         Stmt::AnnAssign(ast::StmtAnnAssign {
             target,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

When visiting AugAssign in evaluation order, the AugAssign `target` should be visited after it's `value`. Based on my testing, the pseudo code for `a += b` is effectively:
```python
tmp = a
a = tmp.__iadd__(b)
```

That is, an ideal traversal order would look something like this:
1. load a
2. b
3. op
4. store a

But, there is only a single AST node which captures `a` in the statement `a += b`, so it cannot be traversed both before and after the traversal of `b` and the `op`.

Nonetheless, I think traversing `a` after `b` and the `op` makes the most sense for a number of reasons:
1. All the other assignment expressions traverse their `value`s before their `target`s. Having `AugAssign` traverse in the same order would be more consistent.
2. Within the AST, the `ctx` of the `target` for an `AugAssign` is `Store` (though technically this is a `Load` and `Store` operation, the AST only indicates it as a `Store`). Since the the store portion of the `AugAssign` occurs last, I think it makes sense to traverse the `target` last as well.

The effect of this is marginal, but it may have an impact on the behavior of #5271.