### PR TITLE
Fix unstable set comprehension formatting

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
@@ -187,3 +187,8 @@ if (
     a + b
 ):
     ...
+
+
+# Unstable formatting in https://github.com/realtyem/synapse-unraid/blob/unraid_develop/synapse/handlers/presence.py
+for user_id in set(target_user_ids) - {u.user_id for u in updates}:
+    updates.append(UserPresenceState.default(user_id))

--- a/crates/ruff_python_formatter/src/expression/expr_set_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_set_comp.rs
@@ -2,7 +2,7 @@ use crate::comments::Comments;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
-use crate::{not_yet_implemented, FormatNodeRule, PyFormatter};
+use crate::{not_yet_implemented_custom_text, FormatNodeRule, PyFormatter};
 use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprSetComp;
 
@@ -10,8 +10,13 @@ use rustpython_parser::ast::ExprSetComp;
 pub struct FormatExprSetComp;
 
 impl FormatNodeRule<ExprSetComp> for FormatExprSetComp {
-    fn fmt_fields(&self, item: &ExprSetComp, f: &mut PyFormatter) -> FormatResult<()> {
-        write!(f, [not_yet_implemented(item)])
+    fn fmt_fields(&self, _item: &ExprSetComp, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(
+            f,
+            [not_yet_implemented_custom_text(
+                "{NOT_IMPLEMENTED_set_value for value in NOT_IMPLEMENTED_set}"
+            )]
+        )
     }
 }
 

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__expression_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__expression_py.snap
@@ -386,10 +386,10 @@ last_call()
 -    k: v
 -    for k, v in this_is_a_very_long_variable_which_will_cause_a_trailing_comma_which_breaks_the_comprehension
 -}
-+NOT_YET_IMPLEMENTED_ExprSetComp
-+NOT_YET_IMPLEMENTED_ExprSetComp
-+NOT_YET_IMPLEMENTED_ExprSetComp
-+NOT_YET_IMPLEMENTED_ExprSetComp
++{NOT_IMPLEMENTED_set_value for value in NOT_IMPLEMENTED_set}
++{NOT_IMPLEMENTED_set_value for value in NOT_IMPLEMENTED_set}
++{NOT_IMPLEMENTED_set_value for value in NOT_IMPLEMENTED_set}
++{NOT_IMPLEMENTED_set_value for value in NOT_IMPLEMENTED_set}
 +[i for i in []]
 +[i for i in []]
 +[i for i in []]
@@ -767,10 +767,10 @@ NOT_IMPLEMENTED_true if NOT_IMPLEMENTED_cond else NOT_IMPLEMENTED_false
     another,
     NOT_YET_IMPLEMENTED_ExprStarred,
 ]
-NOT_YET_IMPLEMENTED_ExprSetComp
-NOT_YET_IMPLEMENTED_ExprSetComp
-NOT_YET_IMPLEMENTED_ExprSetComp
-NOT_YET_IMPLEMENTED_ExprSetComp
+{NOT_IMPLEMENTED_set_value for value in NOT_IMPLEMENTED_set}
+{NOT_IMPLEMENTED_set_value for value in NOT_IMPLEMENTED_set}
+{NOT_IMPLEMENTED_set_value for value in NOT_IMPLEMENTED_set}
+{NOT_IMPLEMENTED_set_value for value in NOT_IMPLEMENTED_set}
 [i for i in []]
 [i for i in []]
 [i for i in []]

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__expression__binary_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__ruff_test__expression__binary_py.snap
@@ -193,6 +193,11 @@ if (
     a + b
 ):
     ...
+
+
+# Unstable formatting in https://github.com/realtyem/synapse-unraid/blob/unraid_develop/synapse/handlers/presence.py
+for user_id in set(target_user_ids) - {u.user_id for u in updates}:
+    updates.append(UserPresenceState.default(user_id))
 ```
 
 
@@ -241,7 +246,7 @@ aaaaaaaaaaaaaa + {
 }
 aaaaaaaaaaaaaa + [i for i in []]
 aaaaaaaaaaaaaa + (i for i in [])
-aaaaaaaaaaaaaa + NOT_YET_IMPLEMENTED_ExprSetComp
+aaaaaaaaaaaaaa + {NOT_IMPLEMENTED_set_value for value in NOT_IMPLEMENTED_set}
 
 # Wraps it in parentheses if it needs to break both left and right
 (
@@ -251,7 +256,7 @@ aaaaaaaaaaaaaa + NOT_YET_IMPLEMENTED_ExprSetComp
 
 
 # But only for expressions that have a statement parent.
-not (aaaaaaaaaaaaaa + NOT_YET_IMPLEMENTED_ExprSetComp)
+not (aaaaaaaaaaaaaa + {NOT_IMPLEMENTED_set_value for value in NOT_IMPLEMENTED_set})
 [
     a
     + [
@@ -432,6 +437,13 @@ if (
     + b
 ):
     ...
+
+
+# Unstable formatting in https://github.com/realtyem/synapse-unraid/blob/unraid_develop/synapse/handlers/presence.py
+for (
+    user_id
+) in NOT_IMPLEMENTED_call(NOT_IMPLEMENTED_arg) - {NOT_IMPLEMENTED_set_value for value in NOT_IMPLEMENTED_set}:
+    NOT_IMPLEMENTED_call(NOT_IMPLEMENTED_arg)
 ```
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR fixes unstable formatting related to set comprehension. The issue was that the stub implementation of set comprehension emited an identifier expression *but*, which made the binary like formatting pick another layout on reformat


<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Added a regression test

<!-- How was it tested? -->
