### PR TITLE
Format implicit string continuation

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
@@ -60,3 +60,51 @@ String '"""
 '''Multiline
 String \"\"\"
 '''
+
+# String continuation
+
+"Let's" "start" "with" "a" "simple" "example"
+
+"Let's" "start" "with" "a" "simple" "example" "now repeat after me:" "I am confident" "I am confident" "I am confident" "I am confident" "I am confident"
+
+(
+    "Let's" "start" "with" "a" "simple" "example" "now repeat after me:" "I am confident" "I am confident" "I am confident" "I am confident" "I am confident"
+)
+
+if (
+    a + "Let's"
+        "start"
+        "with"
+        "a"
+        "simple"
+        "example"
+        "now repeat after me:"
+        "I am confident"
+        "I am confident"
+        "I am confident"
+        "I am confident"
+        "I am confident"
+):
+    pass
+
+if "Let's" "start" "with" "a" "simple" "example" "now repeat after me:" "I am confident" "I am confident" "I am confident" "I am confident" "I am confident":
+    pass
+
+(
+    # leading
+    "a" # trailing part commen
+
+    # leading part comment
+
+    "b" # trailing second part comment
+    # trailing
+)
+
+test_particular = [
+    # squares
+    '1.00000000100000000025',
+    '1.0000000000000000000000000100000000000000000000000' #...
+    '00025',
+    '1.0000000000000000000000000000000000000000000010000' #...
+    '0000000000000000000000000000000000000000025',
+]

--- a/crates/ruff_python_formatter/src/expression/expr_tuple.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_tuple.rs
@@ -1,13 +1,10 @@
-use crate::builders::PyFormatterExtensions;
+use crate::builders::optional_parentheses;
 use crate::comments::{dangling_node_comments, Comments};
-use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
-use crate::{AsFormat, FormatNodeRule, PyFormatter};
-use ruff_formatter::formatter::Formatter;
-use ruff_formatter::prelude::{block_indent, group, if_group_breaks, soft_block_indent, text};
-use ruff_formatter::{format_args, write, Buffer, Format, FormatResult, FormatRuleWithOptions};
+use crate::prelude::*;
+use ruff_formatter::{format_args, write, FormatRuleWithOptions};
 use ruff_python_ast::prelude::{Expr, Ranged};
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::ExprTuple;
@@ -100,17 +97,7 @@ impl FormatNodeRule<ExprTuple> for FormatExprTuple {
                     ])]
                 )
             }
-            elts => {
-                write!(
-                    f,
-                    [group(&format_args![
-                        // If there were previously no parentheses, add them only if the group breaks
-                        if_group_breaks(&text("(")),
-                        soft_block_indent(&ExprSequence::new(elts)),
-                        if_group_breaks(&text(")")),
-                    ])]
-                )
-            }
+            elts => optional_parentheses(&ExprSequence::new(elts)).fmt(f),
         }
     }
 

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -1,7 +1,9 @@
+use crate::builders::optional_parentheses;
 use crate::comments::Comments;
 use crate::context::NodeLevel;
 use crate::expression::expr_tuple::TupleParentheses;
 use crate::expression::parentheses::{NeedsParentheses, Parentheses, Parenthesize};
+use crate::expression::string::StringLayout;
 use crate::prelude::*;
 use ruff_formatter::{
     format_args, write, FormatOwnedWithRule, FormatRefWithRule, FormatRule, FormatRuleWithOptions,
@@ -37,7 +39,7 @@ pub(crate) mod expr_unary_op;
 pub(crate) mod expr_yield;
 pub(crate) mod expr_yield_from;
 pub(crate) mod parentheses;
-mod string;
+pub(crate) mod string;
 
 #[derive(Default)]
 pub struct FormatExpr {
@@ -81,7 +83,10 @@ impl FormatRule<Expr, PyFormatContext<'_>> for FormatExpr {
             Expr::Call(expr) => expr.format().fmt(f),
             Expr::FormattedValue(expr) => expr.format().fmt(f),
             Expr::JoinedStr(expr) => expr.format().fmt(f),
-            Expr::Constant(expr) => expr.format().fmt(f),
+            Expr::Constant(expr) => expr
+                .format()
+                .with_options(StringLayout::Default(Some(parentheses)))
+                .fmt(f),
             Expr::Attribute(expr) => expr.format().fmt(f),
             Expr::Subscript(expr) => expr.format().fmt(f),
             Expr::Starred(expr) => expr.format().fmt(f),
@@ -109,16 +114,7 @@ impl FormatRule<Expr, PyFormatContext<'_>> for FormatExpr {
                 )
             }
             // Add optional parentheses. Ignore if the item renders parentheses itself.
-            Parentheses::Optional => {
-                write!(
-                    f,
-                    [group(&format_args![
-                        if_group_breaks(&text("(")),
-                        soft_block_indent(&format_expr),
-                        if_group_breaks(&text(")"))
-                    ])]
-                )
-            }
+            Parentheses::Optional => optional_parentheses(&format_expr).fmt(f),
             Parentheses::Custom | Parentheses::Never => Format::fmt(&format_expr, f),
         };
 

--- a/crates/ruff_python_formatter/src/expression/parentheses.rs
+++ b/crates/ruff_python_formatter/src/expression/parentheses.rs
@@ -104,7 +104,7 @@ pub enum Parentheses {
     Never,
 }
 
-fn is_expression_parenthesized(expr: AnyNodeRef, contents: &str) -> bool {
+pub(crate) fn is_expression_parenthesized(expr: AnyNodeRef, contents: &str) -> bool {
     matches!(
         first_non_trivia_token(expr.end(), contents),
         Some(Token {

--- a/crates/ruff_python_formatter/src/expression/string.rs
+++ b/crates/ruff_python_formatter/src/expression/string.rs
@@ -16,6 +16,8 @@ use std::borrow::Cow;
 pub enum StringLayout {
     Default(Option<Parentheses>),
 
+    /// Enforces that implicit continuation strings are printed on a single line even if they exceed
+    /// the configured line width.  
     Flat,
 }
 

--- a/crates/ruff_python_formatter/src/statement/stmt_expr.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_expr.rs
@@ -1,4 +1,5 @@
-use crate::expression::parentheses::Parenthesize;
+use crate::expression::parentheses::{is_expression_parenthesized, Parenthesize};
+use crate::expression::string::StringLayout;
 use crate::prelude::*;
 use crate::FormatNodeRule;
 use rustpython_parser::ast::StmtExpr;
@@ -9,6 +10,14 @@ pub struct FormatStmtExpr;
 impl FormatNodeRule<StmtExpr> for FormatStmtExpr {
     fn fmt_fields(&self, item: &StmtExpr, f: &mut PyFormatter) -> FormatResult<()> {
         let StmtExpr { value, .. } = item;
+
+        if let Some(constant) = value.as_constant_expr() {
+            if constant.value.is_str()
+                && !is_expression_parenthesized(value.as_ref().into(), f.context().contents())
+            {
+                return constant.format().with_options(StringLayout::Flat).fmt(f);
+            }
+        }
 
         value.format().with_options(Parenthesize::Optional).fmt(f)
     }

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -66,6 +66,54 @@ String '"""
 '''Multiline
 String \"\"\"
 '''
+
+# String continuation
+
+"Let's" "start" "with" "a" "simple" "example"
+
+"Let's" "start" "with" "a" "simple" "example" "now repeat after me:" "I am confident" "I am confident" "I am confident" "I am confident" "I am confident"
+
+(
+    "Let's" "start" "with" "a" "simple" "example" "now repeat after me:" "I am confident" "I am confident" "I am confident" "I am confident" "I am confident"
+)
+
+if (
+    a + "Let's"
+        "start"
+        "with"
+        "a"
+        "simple"
+        "example"
+        "now repeat after me:"
+        "I am confident"
+        "I am confident"
+        "I am confident"
+        "I am confident"
+        "I am confident"
+):
+    pass
+
+if "Let's" "start" "with" "a" "simple" "example" "now repeat after me:" "I am confident" "I am confident" "I am confident" "I am confident" "I am confident":
+    pass
+
+(
+    # leading
+    "a" # trailing part commen
+
+    # leading part comment
+
+    "b" # trailing second part comment
+    # trailing
+)
+
+test_particular = [
+    # squares
+    '1.00000000100000000025',
+    '1.0000000000000000000000000100000000000000000000000' #...
+    '00025',
+    '1.0000000000000000000000000000000000000000000010000' #...
+    '0000000000000000000000000000000000000000025',
+]
 ```
 
 ## Outputs
@@ -140,6 +188,77 @@ String '"""
 """Multiline
 String \"\"\"
 """
+
+# String continuation
+
+"Let's" "start" "with" "a" "simple" "example"
+
+"Let's" "start" "with" "a" "simple" "example" "now repeat after me:" "I am confident" "I am confident" "I am confident" "I am confident" "I am confident"
+
+(
+    "Let's"
+    "start"
+    "with"
+    "a"
+    "simple"
+    "example"
+    "now repeat after me:"
+    "I am confident"
+    "I am confident"
+    "I am confident"
+    "I am confident"
+    "I am confident"
+)
+
+if (
+    a
+    + "Let's"
+    "start"
+    "with"
+    "a"
+    "simple"
+    "example"
+    "now repeat after me:"
+    "I am confident"
+    "I am confident"
+    "I am confident"
+    "I am confident"
+    "I am confident"
+):
+    pass
+
+if (
+    "Let's"
+    "start"
+    "with"
+    "a"
+    "simple"
+    "example"
+    "now repeat after me:"
+    "I am confident"
+    "I am confident"
+    "I am confident"
+    "I am confident"
+    "I am confident"
+):
+    pass
+
+(
+    # leading
+    "a"  # trailing part commen
+    # leading part comment
+    "b"  # trailing second part comment
+    # trailing
+)
+
+test_particular = [
+    # squares
+    "1.00000000100000000025",
+    "1.0000000000000000000000000100000000000000000000000"  # ...
+    "00025",
+    "1.0000000000000000000000000000000000000000000010000"  # ...
+    "0000000000000000000000000000000000000000025",
+]
 ```
 
 
@@ -214,6 +333,77 @@ String '"""
 '''Multiline
 String \"\"\"
 '''
+
+# String continuation
+
+"Let's" 'start' 'with' 'a' 'simple' 'example'
+
+"Let's" 'start' 'with' 'a' 'simple' 'example' 'now repeat after me:' 'I am confident' 'I am confident' 'I am confident' 'I am confident' 'I am confident'
+
+(
+    "Let's"
+    'start'
+    'with'
+    'a'
+    'simple'
+    'example'
+    'now repeat after me:'
+    'I am confident'
+    'I am confident'
+    'I am confident'
+    'I am confident'
+    'I am confident'
+)
+
+if (
+    a
+    + "Let's"
+    'start'
+    'with'
+    'a'
+    'simple'
+    'example'
+    'now repeat after me:'
+    'I am confident'
+    'I am confident'
+    'I am confident'
+    'I am confident'
+    'I am confident'
+):
+    pass
+
+if (
+    "Let's"
+    'start'
+    'with'
+    'a'
+    'simple'
+    'example'
+    'now repeat after me:'
+    'I am confident'
+    'I am confident'
+    'I am confident'
+    'I am confident'
+    'I am confident'
+):
+    pass
+
+(
+    # leading
+    'a'  # trailing part commen
+    # leading part comment
+    'b'  # trailing second part comment
+    # trailing
+)
+
+test_particular = [
+    # squares
+    '1.00000000100000000025',
+    '1.0000000000000000000000000100000000000000000000000'  # ...
+    '00025',
+    '1.0000000000000000000000000000000000000000000010000'  # ...
+    '0000000000000000000000000000000000000000025',
+]
 ```
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This Branch adds support for formatting implicit string continuations. We could probably come up with something faster that combines the `preferred_quote` with the detection of implicit continuation but I don't think that it's worth optimizing just yet. 

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I added new unit tests because black's test suite has not a single implicit continuation. 

I ran the stability check against the cpython project.
