### PR TITLE
Refactor magic trailing comma

### DIFF
--- a/crates/ruff_python_formatter/src/builders.rs
+++ b/crates/ruff_python_formatter/src/builders.rs
@@ -1,8 +1,9 @@
 use crate::context::NodeLevel;
 use crate::prelude::*;
-use crate::trivia::{lines_after, skip_trailing_trivia};
+use crate::trivia::{first_non_trivia_token, lines_after, skip_trailing_trivia, Token, TokenKind};
+use crate::USE_MAGIC_TRAILING_COMMA;
 use ruff_formatter::write;
-use ruff_text_size::TextSize;
+use ruff_text_size::{TextRange, TextSize};
 use rustpython_parser::ast::Ranged;
 
 /// Provides Python specific extensions to [`Formatter`].
@@ -143,6 +144,17 @@ impl<'fmt, 'ast, 'buf> JoinNodesBuilder<'fmt, 'ast, 'buf> {
     pub(crate) fn finish(&mut self) -> FormatResult<()> {
         self.result
     }
+}
+
+pub(crate) fn use_magic_trailing_comma(f: &mut PyFormatter, range: TextRange) -> bool {
+    USE_MAGIC_TRAILING_COMMA
+        && matches!(
+            first_non_trivia_token(range.end(), f.context().contents()),
+            Some(Token {
+                kind: TokenKind::Comma,
+                ..
+            })
+        )
 }
 
 #[cfg(test)]

--- a/crates/ruff_python_formatter/src/expression/expr_dict.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_dict.rs
@@ -1,12 +1,10 @@
+use crate::builders::use_magic_trailing_comma;
 use crate::comments::{dangling_node_comments, leading_comments, Comments};
 use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
 use crate::prelude::*;
-use crate::trivia::Token;
-use crate::trivia::{first_non_trivia_token, TokenKind};
-use crate::USE_MAGIC_TRAILING_COMMA;
 use crate::{FormatNodeRule, PyFormatter};
 use ruff_formatter::format_args;
 use ruff_formatter::{write, Buffer, FormatResult};
@@ -69,14 +67,7 @@ impl FormatNodeRule<ExprDict> for FormatExprDict {
             }
             [.., last] => last,
         };
-        let magic_trailing_comma = USE_MAGIC_TRAILING_COMMA
-            && matches!(
-                first_non_trivia_token(last.range().end(), f.context().contents()),
-                Some(Token {
-                    kind: TokenKind::Comma,
-                    ..
-                })
-            );
+        let magic_trailing_comma = use_magic_trailing_comma(f, last.range());
 
         debug_assert_eq!(keys.len(), values.len());
 

--- a/crates/ruff_python_formatter/src/expression/expr_tuple.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_tuple.rs
@@ -1,11 +1,10 @@
+use crate::builders::use_magic_trailing_comma;
 use crate::comments::{dangling_node_comments, Comments};
 use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
-use crate::trivia::Token;
-use crate::trivia::{first_non_trivia_token, TokenKind};
-use crate::{AsFormat, FormatNodeRule, FormattedIterExt, PyFormatter, USE_MAGIC_TRAILING_COMMA};
+use crate::{AsFormat, FormatNodeRule, FormattedIterExt, PyFormatter};
 use ruff_formatter::formatter::Formatter;
 use ruff_formatter::prelude::{
     block_indent, group, if_group_breaks, soft_block_indent, soft_line_break_or_space, text,
@@ -88,14 +87,7 @@ impl FormatNodeRule<ExprTuple> for FormatExprTuple {
             [.., last] => last,
         };
 
-        let magic_trailing_comma = USE_MAGIC_TRAILING_COMMA
-            && matches!(
-                first_non_trivia_token(last.range().end(), f.context().contents()),
-                Some(Token {
-                    kind: TokenKind::Comma,
-                    ..
-                })
-            );
+        let magic_trailing_comma = use_magic_trailing_comma(f, last.range());
 
         if magic_trailing_comma {
             // A magic trailing comma forces us to print in expanded mode since we have more than


### PR DESCRIPTION
## Summary

This is small refactoring to reuse the code that detects the magic trailing comma across functions. I make this change now to avoid copying code in a later PR. @MichaReiser is planning on making a larger refactoring later that integrates with the join nodes builder

## Test Plan

No functional changes. The magic trailing comma behaviour is checked by the fixtures.

