### PR TITLE
Fix attribute chain own line comments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/attribute.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/attribute.py
@@ -27,3 +27,63 @@
 
 
 aaaaaaaaaaaaaaaaaaaaa.lllllllllllllllllllllllllllloooooooooong.chaaaaaaaaaaaaaaaaaaaaaaiiiiiiiiiiiiiiiiiiiiiiinnnnnnnn.ooooooooooooooooooooooooofffffffff.aaaaaaaaaattr
+
+
+# Test that we add parentheses around the outermost attribute access in an attribute
+# chain if and only if we need them, that is if there are own line comments inside
+# the chain.
+x1 = (
+    a1
+    .a2
+    # a
+    .  # b
+    # c
+    a3
+    .a4
+)
+x20 = (
+    a
+    .b
+)
+x21 = (
+    a
+    # trailing name own line
+    .b
+)
+x22 = (
+    ""
+    # leading
+    .b
+)
+x23 = (
+    # leading
+    a
+    .b
+)
+x24 = (
+    a # trailing name end-of-line
+    .b
+)
+x31 = (
+    a
+    .# a
+    b
+)
+x32 = (
+    a
+    .# a
+    b
+    .c
+)
+x4 = (
+    a.
+    # a
+    b
+)
+x5 = (
+    a.b.c
+)
+x61 = askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
+x62 = (
+    askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
+)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/attribute.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/attribute.py
@@ -1,3 +1,7 @@
+from argparse import Namespace
+
+a = Namespace()
+
 (
     a
     # comment
@@ -26,64 +30,74 @@
 )
 
 
-aaaaaaaaaaaaaaaaaaaaa.lllllllllllllllllllllllllllloooooooooong.chaaaaaaaaaaaaaaaaaaaaaaiiiiiiiiiiiiiiiiiiiiiiinnnnnnnn.ooooooooooooooooooooooooofffffffff.aaaaaaaaaattr
+a.aaaaaaaaaaaaaaaaaaaaa.lllllllllllllllllllllllllllloooooooooong.chaaaaaaaaaaaaaaaaaaaaaaiiiiiiiiiiiiiiiiiiiiiiinnnnnnnn.ooooooooooooooooooooooooofffffffff.aaaaaaaaaattr
 
 
 # Test that we add parentheses around the outermost attribute access in an attribute
 # chain if and only if we need them, that is if there are own line comments inside
 # the chain.
 x1 = (
-    a1
-    .a2
-    # a
-    .  # b
-    # c
-    a3
-    .a4
+    a
+    .b
+    # comment 1
+    .  # comment 2
+    # comment 3
+    c
+    .d
 )
+
 x20 = (
     a
     .b
 )
 x21 = (
-    a
-    # trailing name own line
+    # leading name own line
+    a  # trailing name end-of-line
     .b
 )
 x22 = (
-    ""
-    # leading
-    .b
-)
-x23 = (
-    # leading
     a
-    .b
+    # outermost leading own line
+    .b # outermost trailing end-of-line
 )
-x24 = (
-    a # trailing name end-of-line
-    .b
-)
+
 x31 = (
     a
-    .# a
+    # own line between nodes 1
+    .b
+)
+x321 = (
+    a
+    . # end-of-line dot comment
     b
 )
-x32 = (
+x322 = (
     a
-    .# a
+    . # end-of-line dot comment 2
     b
     .c
 )
-x4 = (
+x331 = (
     a.
-    # a
+    # own line between nodes 3
     b
 )
-x5 = (
+x332 = (
+    ""
+    # own line between nodes
+    .find
+)
+
+x8 = (
+    (a + a)
+    .b
+)
+
+x51 = (
     a.b.c
 )
-x61 = askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
-x62 = (
-    askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
+x52 = a.askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
+x53 = (
+    a.askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
 )
+

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -1077,7 +1077,19 @@ fn handle_attribute_comment<'a>(
         .expect("Expected the `.` character after the value");
 
     if TextRange::new(dot.end(), attribute.attr.start()).contains(comment.slice().start()) {
-        CommentPlacement::dangling(attribute.into(), comment)
+        if comment.line_position().is_end_of_line() {
+            // Attach to node with b
+            // ```python
+            // x322 = (
+            //     a
+            //     . # end-of-line dot comment 2
+            //     b
+            // )
+            // ```
+            CommentPlacement::trailing(comment.enclosing_node(), comment)
+        } else {
+            CommentPlacement::dangling(attribute.into(), comment)
+        }
     } else {
         CommentPlacement::Default(comment)
     }

--- a/crates/ruff_python_formatter/src/expression/expr_attribute.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_attribute.rs
@@ -27,24 +27,27 @@ impl FormatNodeRule<ExprAttribute> for FormatExprAttribute {
             })
         );
 
-        if needs_parentheses {
-            value.format().with_options(Parenthesize::Always).fmt(f)?;
-        } else {
-            value.format().fmt(f)?;
-        }
-
         let comments = f.context().comments().clone();
-
-        if comments.has_trailing_own_line_comments(value.as_ref()) {
-            hard_line_break().fmt(f)?;
-        }
-
         let dangling_comments = comments.dangling_comments(item);
-
         let leading_attribute_comments_start =
             dangling_comments.partition_point(|comment| comment.line_position().is_end_of_line());
         let (trailing_dot_comments, leading_attribute_comments) =
             dangling_comments.split_at(leading_attribute_comments_start);
+
+        if needs_parentheses {
+            value.format().with_options(Parenthesize::Always).fmt(f)?;
+        } else if let Expr::Attribute(expr_attribute) = value.as_ref() {
+            // We're in a attribute chain (`a.b.c`). The outermost node adds parentheses if
+            // required, the inner ones don't need them so we skip the `Expr` formatting that
+            // normally adds the parentheses.
+            expr_attribute.format().fmt(f)?;
+        } else {
+            value.format().fmt(f)?;
+        }
+
+        if comments.has_trailing_own_line_comments(value.as_ref()) {
+            hard_line_break().fmt(f)?;
+        }
 
         write!(
             f,
@@ -68,6 +71,28 @@ impl FormatNodeRule<ExprAttribute> for FormatExprAttribute {
     }
 }
 
+/// Checks if there are any own line comments in an attribute chain (a.b.c). This method is
+/// recursive up to the innermost expression that the attribute chain starts behind.
+fn has_breaking_comments_attribute_chain(
+    expr_attribute: &ExprAttribute,
+    comments: &Comments,
+) -> bool {
+    if comments
+        .dangling_comments(expr_attribute)
+        .iter()
+        .any(|comment| comment.line_position().is_own_line())
+        || comments.has_trailing_own_line_comments(expr_attribute)
+    {
+        return true;
+    }
+
+    if let Expr::Attribute(inner) = expr_attribute.value.as_ref() {
+        return has_breaking_comments_attribute_chain(inner, comments);
+    }
+
+    return comments.has_trailing_own_line_comments(expr_attribute.value.as_ref());
+}
+
 impl NeedsParentheses for ExprAttribute {
     fn needs_parentheses(
         &self,
@@ -75,6 +100,10 @@ impl NeedsParentheses for ExprAttribute {
         source: &str,
         comments: &Comments,
     ) -> Parentheses {
+        if has_breaking_comments_attribute_chain(self, comments) {
+            return Parentheses::Always;
+        }
+
         match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
             Parentheses::Optional => Parentheses::Never,
             parentheses => parentheses,

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__attribute.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__attribute.py.snap
@@ -33,6 +33,66 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression
 
 
 aaaaaaaaaaaaaaaaaaaaa.lllllllllllllllllllllllllllloooooooooong.chaaaaaaaaaaaaaaaaaaaaaaiiiiiiiiiiiiiiiiiiiiiiinnnnnnnn.ooooooooooooooooooooooooofffffffff.aaaaaaaaaattr
+
+
+# Test that we add parentheses around the outermost attribute access in an attribute
+# chain if and only if we need them, that is if there are own line comments inside
+# the chain.
+x1 = (
+    a1
+    .a2
+    # a
+    .  # b
+    # c
+    a3
+    .a4
+)
+x20 = (
+    a
+    .b
+)
+x21 = (
+    a
+    # trailing name own line
+    .b
+)
+x22 = (
+    ""
+    # leading
+    .b
+)
+x23 = (
+    # leading
+    a
+    .b
+)
+x24 = (
+    a # trailing name end-of-line
+    .b
+)
+x31 = (
+    a
+    .# a
+    b
+)
+x32 = (
+    a
+    .# a
+    b
+    .c
+)
+x4 = (
+    a.
+    # a
+    b
+)
+x5 = (
+    a.b.c
+)
+x61 = askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
+x62 = (
+    askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
+)
 ```
 
 
@@ -68,6 +128,44 @@ aaaaaaaaaaaaaaaaaaaaa.lllllllllllllllllllllllllllloooooooooong.chaaaaaaaaaaaaaaa
 
 
 aaaaaaaaaaaaaaaaaaaaa.lllllllllllllllllllllllllllloooooooooong.chaaaaaaaaaaaaaaaaaaaaaaiiiiiiiiiiiiiiiiiiiiiiinnnnnnnn.ooooooooooooooooooooooooofffffffff.aaaaaaaaaattr
+
+
+# Test that we add parentheses around the outermost attribute access in an attribute
+# chain if and only if we need them, that is if there are own line comments inside
+# the chain.
+x1 = (
+    a1.a2
+    # a
+    .  # b
+    # c
+    a3.a4
+)
+x20 = a.b
+x21 = (
+    a
+    # trailing name own line
+    .b
+)
+x22 = (
+    ""
+    # leading
+    .b
+)
+x23 = (
+    # leading
+    a.b
+)
+x24 = a.b  # trailing name end-of-line
+x31 = a.b  # a
+x32 = a.b.c  # a
+x4 = (
+    a.
+    # a
+    b
+)
+x5 = a.b.c
+x61 = askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
+x62 = askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__attribute.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__attribute.py.snap
@@ -4,6 +4,10 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression
 ---
 ## Input
 ```py
+from argparse import Namespace
+
+a = Namespace()
+
 (
     a
     # comment
@@ -32,73 +36,87 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression
 )
 
 
-aaaaaaaaaaaaaaaaaaaaa.lllllllllllllllllllllllllllloooooooooong.chaaaaaaaaaaaaaaaaaaaaaaiiiiiiiiiiiiiiiiiiiiiiinnnnnnnn.ooooooooooooooooooooooooofffffffff.aaaaaaaaaattr
+a.aaaaaaaaaaaaaaaaaaaaa.lllllllllllllllllllllllllllloooooooooong.chaaaaaaaaaaaaaaaaaaaaaaiiiiiiiiiiiiiiiiiiiiiiinnnnnnnn.ooooooooooooooooooooooooofffffffff.aaaaaaaaaattr
 
 
 # Test that we add parentheses around the outermost attribute access in an attribute
 # chain if and only if we need them, that is if there are own line comments inside
 # the chain.
 x1 = (
-    a1
-    .a2
-    # a
-    .  # b
-    # c
-    a3
-    .a4
+    a
+    .b
+    # comment 1
+    .  # comment 2
+    # comment 3
+    c
+    .d
 )
+
 x20 = (
     a
     .b
 )
 x21 = (
-    a
-    # trailing name own line
+    # leading name own line
+    a  # trailing name end-of-line
     .b
 )
 x22 = (
-    ""
-    # leading
-    .b
-)
-x23 = (
-    # leading
     a
-    .b
+    # outermost leading own line
+    .b # outermost trailing end-of-line
 )
-x24 = (
-    a # trailing name end-of-line
-    .b
-)
+
 x31 = (
     a
-    .# a
+    # own line between nodes 1
+    .b
+)
+x321 = (
+    a
+    . # end-of-line dot comment
     b
 )
-x32 = (
+x322 = (
     a
-    .# a
+    . # end-of-line dot comment 2
     b
     .c
 )
-x4 = (
+x331 = (
     a.
-    # a
+    # own line between nodes 3
     b
 )
-x5 = (
+x332 = (
+    ""
+    # own line between nodes
+    .find
+)
+
+x8 = (
+    (a + a)
+    .b
+)
+
+x51 = (
     a.b.c
 )
-x61 = askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
-x62 = (
-    askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
+x52 = a.askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
+x53 = (
+    a.askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
 )
+
 ```
 
 
 
 ## Output
 ```py
+NOT_YET_IMPLEMENTED_StmtImportFrom
+
+a = NOT_IMPLEMENTED_call()
+
 (
     a
     # comment
@@ -121,51 +139,60 @@ x62 = (
 (
     a
     # comment
-    .  # trailing dot comment
+    .
     # in between
-    b  # trailing identifier comment
+    b  # trailing dot comment  # trailing identifier comment
 )
 
 
-aaaaaaaaaaaaaaaaaaaaa.lllllllllllllllllllllllllllloooooooooong.chaaaaaaaaaaaaaaaaaaaaaaiiiiiiiiiiiiiiiiiiiiiiinnnnnnnn.ooooooooooooooooooooooooofffffffff.aaaaaaaaaattr
+a.aaaaaaaaaaaaaaaaaaaaa.lllllllllllllllllllllllllllloooooooooong.chaaaaaaaaaaaaaaaaaaaaaaiiiiiiiiiiiiiiiiiiiiiiinnnnnnnn.ooooooooooooooooooooooooofffffffff.aaaaaaaaaattr
 
 
 # Test that we add parentheses around the outermost attribute access in an attribute
 # chain if and only if we need them, that is if there are own line comments inside
 # the chain.
 x1 = (
-    a1.a2
-    # a
-    .  # b
-    # c
-    a3.a4
+    a.b
+    # comment 1
+    .
+    # comment 3
+    c.d  # comment 2
 )
+
 x20 = a.b
 x21 = (
-    a
-    # trailing name own line
-    .b
+    # leading name own line
+    a.b  # trailing name end-of-line
 )
 x22 = (
-    ""
-    # leading
+    a
+    # outermost leading own line
+    .b  # outermost trailing end-of-line
+)
+
+x31 = (
+    a
+    # own line between nodes 1
     .b
 )
-x23 = (
-    # leading
-    a.b
-)
-x24 = a.b  # trailing name end-of-line
-x31 = a.b  # a
-x32 = a.b.c  # a
-x4 = (
+x321 = a.b  # end-of-line dot comment
+x322 = a.b.c  # end-of-line dot comment 2
+x331 = (
     a.
-    # a
+    # own line between nodes 3
     b
 )
-x5 = a.b.c
-x61 = askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
-x62 = askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
+x332 = (
+    ""
+    # own line between nodes
+    .find
+)
+
+x8 = (a + a).b
+
+x51 = a.b.c
+x52 = a.askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
+x53 = a.askjdfahdlskjflsajfadhsaf.akjdsf.aksjdlfadhaljsashdfljaf.askjdflhasfdlashdlfaskjfd.asdkjfksahdfkjafs
 ```
 
 


### PR DESCRIPTION
## Motation

Previously,
```python
x = (
    a1
    .a2
    # a
    .  # b
    # c
    a3
)
```
got formatted as
```python
x = a1.a2
# a
.  # b
# c
a3
```
which is invalid syntax. This fixes that.

## Summary

This implements a basic form of attribute chaining (<https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#call-chains>) by checking if any inner attribute access contains an own line comment, and if this is the case, adds parentheses around the outermost attribute access while disabling parentheses for all inner attribute expressions. We want to replace this with an implementation that uses recursion or a stack while formatting instead of in `needs_parentheses` and also includes calls rather sooner than later, but i'm fixing this now because i'm uncomfortable with having known invalid syntax generation in the formatter.

## Test Plan

I added new fixtures.
