### PR TITLE
Ignore type aliases for RUF013

### DIFF
--- a/crates/ruff/resources/test/fixtures/ruff/RUF013_0.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF013_0.py
@@ -221,3 +221,23 @@ def f(arg: Union["No" "ne", "int"] = None):
 # Avoid flagging when there's a parse error in the forward reference
 def f(arg: Union["<>", "int"] = None):
     pass
+
+
+# Type aliases
+
+Text = str | bytes
+
+
+def f(arg: Text = None):
+    pass
+
+
+def f(arg: "Text" = None):
+    pass
+
+
+from custom_typing import MaybeInt
+
+
+def f(arg: MaybeInt = None):
+    pass

--- a/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
@@ -11,7 +11,7 @@ use ruff_python_ast::helpers::is_const_none;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::typing::parse_type_annotation;
 use ruff_python_semantic::SemanticModel;
-use ruff_python_stdlib::sys::KNOWN_STANDARD_LIBRARY;
+use ruff_python_stdlib::sys::is_known_standard_library;
 
 use crate::checkers::ast::Checker;
 use crate::importer::ImportRequest;
@@ -162,10 +162,7 @@ impl<'a> Iterator for PEP604UnionIterator<'a> {
 fn is_known_type(call_path: &CallPath, target_version: PythonVersion) -> bool {
     match call_path.as_slice() {
         ["" | "builtins" | "typing_extensions", _] => true,
-        _ => KNOWN_STANDARD_LIBRARY
-            .get(&target_version.as_tuple())
-            .unwrap()
-            .contains(call_path.first().unwrap()),
+        _ => is_known_standard_library(target_version.minor(), call_path.first().unwrap()),
     }
 }
 

--- a/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
@@ -161,8 +161,9 @@ impl<'a> Iterator for PEP604UnionIterator<'a> {
 /// or a type from the `typing_extensions` module.
 fn is_known_type(call_path: &CallPath, target_version: PythonVersion) -> bool {
     match call_path.as_slice() {
-        ["" | "builtins" | "typing_extensions", _] => true,
-        _ => is_known_standard_library(target_version.minor(), call_path.first().unwrap()),
+        ["" | "typing_extensions", ..] => true,
+        [module, ..] => is_known_standard_library(target_version.minor(), module),
+        _ => false,
     }
 }
 

--- a/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
@@ -72,7 +72,7 @@ use crate::settings::types::PythonVersion;
 ///
 ///
 /// def foo(arg: Text = None):
-///    pass
+///     pass
 /// ```
 ///
 /// ## Options


### PR DESCRIPTION
## Summary

Ignore type aliases for RUF013 to avoid flagging false positives:

```python
from typing import Optional

MaybeInt = Optional[int]


def f(arg: MaybeInt = None):
    pass
```

But, at the expense of having false negatives:

```python
Text = str | bytes


def f(arg: Text = None):
    pass
```

## Test Plan

`cargo test`

fixes: #5295
