### PR TITLE
Prefer the configured quote style

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.options.json
@@ -1,0 +1,8 @@
+[
+  {
+    "quote_style": "double"
+  },
+  {
+    "quote_style": "single"
+  }
+]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
@@ -12,7 +12,7 @@
 
 # Prefer double quotes for string with equal amount of single and double quotes
 '" \' " " \'\''
-"' \" '' \" \" '"
+"' \" '' \" \""
 
 "\\' \"\""
 '\\\' ""'
@@ -46,6 +46,16 @@ String ""
 '''Multiline
 String """
 '''
+
+'''Multiline
+String "'''
+
+"""Multiline
+String '''
+"""
+
+"""Multiline
+String '"""
 
 '''Multiline
 String \"\"\"

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -109,7 +109,7 @@ impl QuoteStyle {
     }
 
     #[must_use]
-    pub const fn opposite(self) -> QuoteStyle {
+    pub const fn invert(self) -> QuoteStyle {
         match self {
             QuoteStyle::Single => QuoteStyle::Double,
             QuoteStyle::Double => QuoteStyle::Single,

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -18,7 +18,7 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression
 
 # Prefer double quotes for string with equal amount of single and double quotes
 '" \' " " \'\''
-"' \" '' \" \" '"
+"' \" '' \" \""
 
 "\\' \"\""
 '\\\' ""'
@@ -54,11 +54,29 @@ String """
 '''
 
 '''Multiline
+String "'''
+
+"""Multiline
+String '''
+"""
+
+"""Multiline
+String '"""
+
+'''Multiline
 String \"\"\"
 '''
 ```
 
-## Output
+## Outputs
+### Output 1
+```
+indent-style            = Spaces, size: 4
+line-width              = 88
+quote-style             = Double
+magic-trailing-comma    = Respect
+```
+
 ```py
 "' test"
 '" test'
@@ -74,7 +92,7 @@ String \"\"\"
 
 # Prefer double quotes for string with equal amount of single and double quotes
 "\" ' \" \" ''"
-"' \" '' \" \" '"
+"' \" '' \" \""
 
 '\\\' ""'
 '\\\' ""'
@@ -109,9 +127,93 @@ String ""
 String """
 '''
 
+'''Multiline
+String "'''
+
+"""Multiline
+String '''
+"""
+
+"""Multiline
+String '"""
+
 """Multiline
 String \"\"\"
 """
+```
+
+
+### Output 2
+```
+indent-style            = Spaces, size: 4
+line-width              = 88
+quote-style             = Single
+magic-trailing-comma    = Respect
+```
+
+```py
+"' test"
+'" test'
+
+'" test'
+"' test"
+
+# Prefer single quotes for string with more double quotes
+'\' " " \'\' " " \''
+
+# Prefer double quotes for string with more single quotes
+'\' " " \'\' " " \''
+
+# Prefer double quotes for string with equal amount of single and double quotes
+'" \' " " \'\''
+'\' " \'\' " "'
+
+'\\\' ""'
+'\\\' ""'
+
+
+'Test'
+'Test'
+
+r'Test'
+R'Test'
+
+'This string will not include \
+backslashes or newline characters.'
+
+if True:
+    'This string will not include \
+        backslashes or newline characters.'
+
+'''Multiline
+String \"
+'''
+
+'''Multiline
+String \'
+'''
+
+'''Multiline
+String ""
+'''
+
+'''Multiline
+String """
+'''
+
+'''Multiline
+String "'''
+
+"""Multiline
+String '''
+"""
+
+"""Multiline
+String '"""
+
+'''Multiline
+String \"\"\"
+'''
 ```
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR extends the string formatting to respect the configured quote style.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Extended the string test with new cases and set it up to run twice: Once with the `quote_style: Doube`, and once with `quote_style: Single` single and double quotes. 

<!-- How was it tested? -->
