### PR TITLE
Add documentation to rules that check docstring quotes (`D3XX`)

### DIFF
--- a/crates/ruff/src/rules/pydocstyle/rules/backslashes.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/backslashes.rs
@@ -8,7 +8,7 @@ use crate::checkers::ast::Checker;
 use crate::docstrings::Docstring;
 
 /// ## What it does
-/// Checks for docstrings that include escape sequences, but are not defined as
+/// Checks for docstrings that include backslashes, but are not defined as
 /// raw string literals.
 ///
 /// ## Why is this bad?

--- a/crates/ruff/src/rules/pydocstyle/rules/backslashes.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/backslashes.rs
@@ -8,13 +8,19 @@ use crate::checkers::ast::Checker;
 use crate::docstrings::Docstring;
 
 /// ## What it does
-/// Checks for docstrings that
+/// Checks for docstrings that include escape sequences, but are not defined as
+/// raw string literals.
 ///
 /// ## Why is this bad?
-/// Backslashes are used to escape characters in strings, unless the string is
-/// defined as a raw string literal. Use the raw string literal prefix `r` when
-/// declaring docstrings with backslashes to avoid confusion and accidental
-/// escaping.
+/// In Python, backslashes are typically used to escape characters in strings.
+/// In raw strings (those prefixed with an `r`), however, backslashes are
+/// treated as literal characters.
+///
+/// [PEP 257](https://peps.python.org/pep-0257/#what-is-a-docstring) recommends
+/// the use of raw strings (i.e., `r"""raw triple double quotes"""`) for
+/// docstrings that include backslashes. The use of a raw string ensures that
+/// any backslashes are treated as literal characters, and not as escape
+/// sequences, which avoids confusion.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/pydocstyle/rules/backslashes.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/backslashes.rs
@@ -7,6 +7,36 @@ use ruff_macros::{derive_message_formats, violation};
 use crate::checkers::ast::Checker;
 use crate::docstrings::Docstring;
 
+/// ## What it does
+/// Checks for docstrings that
+///
+/// ## Why is this bad?
+/// Backslashes are used to escape characters in strings, unless the string is
+/// defined as a raw string literal. Use the raw string literal prefix `r` when
+/// declaring docstrings with backslashes to avoid confusion and accidental
+/// escaping.
+///
+/// ## Example
+/// ```python
+/// def foobar():
+///     """Docstring for foo\bar."""
+///
+///
+/// foobar.__doc__  # "Docstring for foar."
+/// ```
+///
+/// Use instead:
+/// ```python
+/// def foobar():
+///     r"""Docstring for foo\bar."""
+///
+///
+/// foobar.__doc__  # "Docstring for foo\bar."
+/// ```
+///
+/// ## References
+/// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
+/// - [Python documentation: String and Bytes literals](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals)
 #[violation]
 pub struct EscapeSequenceInDocstring;
 

--- a/crates/ruff/src/rules/pydocstyle/rules/triple_quotes.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/triple_quotes.rs
@@ -4,6 +4,29 @@ use ruff_macros::{derive_message_formats, violation};
 use crate::checkers::ast::Checker;
 use crate::docstrings::Docstring;
 
+/// ## What it does
+/// Checks for docstrings defined using single quotes instead of double quotes.
+///
+/// ## Why is this bad?
+/// Use double quotes when defining docstrings for consistency, as per
+/// [PEP 257](https://peps.python.org/pep-0257/#what-is-a-docstring).
+///
+/// ## Example
+/// ```python
+/// def foo():
+///     '''Foo docstring.'''
+/// ```
+///
+/// Use instead:
+/// ```python
+/// def foo():
+///     """Foo docstring."""
+/// ```
+///
+/// ## References
+/// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
+/// - [NumPy Style Guide](https://numpydoc.readthedocs.io/en/latest/format.html)
+/// - [Google Python Style Guide - Docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
 #[violation]
 pub struct TripleSingleQuotes;
 

--- a/crates/ruff/src/rules/pydocstyle/rules/triple_quotes.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/triple_quotes.rs
@@ -5,22 +5,24 @@ use crate::checkers::ast::Checker;
 use crate::docstrings::Docstring;
 
 /// ## What it does
-/// Checks for docstrings defined using single quotes instead of double quotes.
+/// Checks for docstrings that use `'''triple single quotes'''` instead of
+/// `"""triple double quotes"""`.
 ///
 /// ## Why is this bad?
-/// Use double quotes when defining docstrings for consistency, as per
-/// [PEP 257](https://peps.python.org/pep-0257/#what-is-a-docstring).
+/// [PEP 257](https://peps.python.org/pep-0257/#what-is-a-docstring) recommends
+/// the use of `"""triple double quotes"""` for docstrings, to ensure
+/// consistency.
 ///
 /// ## Example
 /// ```python
-/// def foo():
-///     '''Foo docstring.'''
+/// def kos_root():
+///     '''Return the pathname of the KOS root directory.'''
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// def foo():
-///     """Foo docstring."""
+/// def kos_root():
+///     """Return the pathname of the KOS root directory."""
 /// ```
 ///
 /// ## References

--- a/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -37,7 +37,7 @@ use crate::registry::AsRule;
 ///
 /// ## References
 /// - [PEP 448 – Additional Unpacking Generalizations](https://peps.python.org/pep-0448/)
-/// - [Python docs: Sequence Types — `list`, `tuple`, `range`](https://docs.python.org/3/library/stdtypes.html#sequence-types-list-tuple-range)
+/// - [Python documentation: Sequence Types — `list`, `tuple`, `range`](https://docs.python.org/3/library/stdtypes.html#sequence-types-list-tuple-range)
 #[violation]
 pub struct CollectionLiteralConcatenation {
     expr: String,

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -52,6 +52,7 @@ KNOWN_FORMATTING_VIOLATIONS = [
     "shebang-leading-whitespace",
     "too-few-spaces-before-inline-comment",
     "trailing-comma-on-bare-tuple",
+    "triple-single-quotes",
     "unexpected-indentation-comment",
     "unicode-kind-prefix",
     "unnecessary-class-parentheses",


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Add documentation to the `D3XX` rules that check for issues with docstring quotes. Related to #2646.

## Test Plan

`python scripts/check_docs_formatted.py`
