### PR TITLE
Add space when migrating to raw string

### DIFF
--- a/crates/ruff/resources/test/fixtures/pycodestyle/W605_0.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/W605_0.py
@@ -22,6 +22,11 @@ in the middle
 #: W605:1:38
 value = 'new line\nand invalid escape \_ here'
 
+
+def f():
+    #: W605:1:11
+    return'\.png$'
+
 #: Okay
 regex = r'\.png$'
 regex = '\\.png$'

--- a/crates/ruff/resources/test/fixtures/pycodestyle/W605_1.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/W605_1.py
@@ -19,6 +19,11 @@ with \_ somewhere
 in the middle
 """
 
+
+def f():
+    #: W605:1:11
+    return'\.png$'
+
 #: Okay
 regex = r'\.png$'
 regex = '\\.png$'

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_0.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_0.py.snap
@@ -85,8 +85,6 @@ W605_0.py:23:39: W605 [*] Invalid escape sequence: `\_`
 22 | #: W605:1:38
 23 | value = 'new line\nand invalid escape \_ here'
    |                                       ^^ W605
-24 | 
-25 | #: Okay
    |
    = help: Add backslash to escape sequence
 
@@ -97,7 +95,28 @@ W605_0.py:23:39: W605 [*] Invalid escape sequence: `\_`
 23    |-value = 'new line\nand invalid escape \_ here'
    23 |+value = 'new line\nand invalid escape \\_ here'
 24 24 | 
-25 25 | #: Okay
-26 26 | regex = r'\.png$'
+25 25 | 
+26 26 | def f():
+
+W605_0.py:28:12: W605 [*] Invalid escape sequence: `\.`
+   |
+26 | def f():
+27 |     #: W605:1:11
+28 |     return'\.png$'
+   |            ^^ W605
+29 | 
+30 | #: Okay
+   |
+   = help: Add backslash to escape sequence
+
+ℹ Fix
+25 25 | 
+26 26 | def f():
+27 27 |     #: W605:1:11
+28    |-    return'\.png$'
+   28 |+    return r'\.png$'
+29 29 | 
+30 30 | #: Okay
+31 31 | regex = r'\.png$'
 
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_1.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_1.py.snap
@@ -80,4 +80,25 @@ W605_1.py:18:6: W605 [*] Invalid escape sequence: `\_`
 17 17 | literal
 18 18 | with \_ somewhere
 
+W605_1.py:25:12: W605 [*] Invalid escape sequence: `\.`
+   |
+23 | def f():
+24 |     #: W605:1:11
+25 |     return'\.png$'
+   |            ^^ W605
+26 | 
+27 | #: Okay
+   |
+   = help: Add backslash to escape sequence
+
+ℹ Fix
+22 22 | 
+23 23 | def f():
+24 24 |     #: W605:1:11
+25    |-    return'\.png$'
+   25 |+    return r'\.png$'
+26 26 | 
+27 27 | #: Okay
+28 28 | regex = r'\.png$'
+
 


### PR DESCRIPTION
## Summary

We had to do this for f-strings too -- if we add a prefix to `"foo"` in `return"foo"`, we also need to add a leading space.