### PR TITLE
Experimental release for Jupyter notebook integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,7 @@ dependencies = [
  "ruff_cli",
  "ruff_diagnostics",
  "ruff_python_formatter",
+ "ruff_python_stdlib",
  "ruff_textwrap",
  "rustpython-format",
  "rustpython-parser",

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -87,4 +87,3 @@ colored = { workspace = true, features = ["no-color"] }
 [features]
 default = []
 schemars = ["dep:schemars"]
-jupyter_notebook = []

--- a/crates/ruff/src/jupyter/notebook.rs
+++ b/crates/ruff/src/jupyter/notebook.rs
@@ -39,15 +39,6 @@ pub fn round_trip(path: &Path) -> anyhow::Result<String> {
     Ok(String::from_utf8(writer)?)
 }
 
-/// Return `true` if the [`Path`] appears to be that of a jupyter notebook file (`.ipynb`).
-pub fn is_jupyter_notebook(path: &Path) -> bool {
-    path.extension()
-        .map_or(false, |ext| ext == JUPYTER_NOTEBOOK_EXT)
-        // For now this is feature gated here, the long term solution depends on
-        // https://github.com/astral-sh/ruff/issues/3410
-        && cfg!(feature = "jupyter_notebook")
-}
-
 impl Cell {
     /// Return the [`SourceValue`] of the cell.
     fn source(&self) -> &SourceValue {
@@ -452,8 +443,6 @@ mod tests {
     use test_case::test_case;
 
     use crate::jupyter::index::JupyterIndex;
-    #[cfg(feature = "jupyter_notebook")]
-    use crate::jupyter::is_jupyter_notebook;
     use crate::jupyter::schema::Cell;
     use crate::jupyter::Notebook;
     use crate::registry::Rule;
@@ -510,16 +499,6 @@ mod tests {
     fn test_is_valid_code_cell(path: &Path, expected: bool) -> Result<()> {
         assert_eq!(read_jupyter_cell(path)?.is_valid_code_cell(), expected);
         Ok(())
-    }
-
-    #[test]
-    #[cfg(feature = "jupyter_notebook")]
-    fn inclusions() {
-        let path = Path::new("foo/bar/baz");
-        assert!(!is_jupyter_notebook(path));
-
-        let path = Path::new("foo/bar/baz.ipynb");
-        assert!(is_jupyter_notebook(path));
     }
 
     #[test]

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -67,9 +67,6 @@ wild = { version = "2" }
 assert_cmd = { version = "2.0.8" }
 ureq = { version = "2.6.2", features = [] }
 
-[features]
-jupyter_notebook = ["ruff/jupyter_notebook"]
-
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = "0.1.34"
 

--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -14,7 +14,7 @@ use rustc_hash::FxHashMap;
 use similar::TextDiff;
 
 use ruff::fs;
-use ruff::jupyter::{is_jupyter_notebook, Notebook};
+use ruff::jupyter::Notebook;
 use ruff::linter::{lint_fix, lint_only, FixTable, FixerResult, LinterResult};
 use ruff::logging::DisplayParseError;
 use ruff::message::Message;
@@ -23,7 +23,7 @@ use ruff::settings::{flags, AllSettings, Settings};
 use ruff::source_kind::SourceKind;
 use ruff_python_ast::imports::ImportMap;
 use ruff_python_ast::source_code::{LineIndex, SourceCode, SourceFileBuilder};
-use ruff_python_stdlib::path::is_project_toml;
+use ruff_python_stdlib::path::{is_jupyter_notebook, is_project_toml};
 
 use crate::cache::Cache;
 

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -15,6 +15,7 @@ ruff = { path = "../ruff", features = ["schemars"] }
 ruff_cli = { path = "../ruff_cli" }
 ruff_diagnostics = { path = "../ruff_diagnostics" }
 ruff_python_formatter = { path = "../ruff_python_formatter" }
+ruff_python_stdlib = { path = "../ruff_python_stdlib" }
 ruff_textwrap = { path = "../ruff_textwrap" }
 
 anyhow = { workspace = true }

--- a/crates/ruff_dev/src/round_trip.rs
+++ b/crates/ruff_dev/src/round_trip.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 
 use ruff::jupyter;
 use ruff::round_trip;
+use ruff_python_stdlib::path::is_jupyter_notebook;
 
 #[derive(clap::Args)]
 pub(crate) struct Args {
@@ -18,7 +19,7 @@ pub(crate) struct Args {
 
 pub(crate) fn main(args: &Args) -> Result<()> {
     let path = args.file.as_path();
-    if jupyter::is_jupyter_notebook(path) {
+    if is_jupyter_notebook(path) {
         println!("{}", jupyter::round_trip(path)?);
     } else {
         let contents = fs::read_to_string(&args.file)?;

--- a/crates/ruff_python_stdlib/src/path.rs
+++ b/crates/ruff_python_stdlib/src/path.rs
@@ -17,11 +17,16 @@ pub fn is_python_stub_file(path: &Path) -> bool {
     path.extension().map_or(false, |ext| ext == "pyi")
 }
 
+/// Return `true` if the [`Path`] appears to be that of a Jupyter notebook (`.ipynb`).
+pub fn is_jupyter_notebook(path: &Path) -> bool {
+    path.extension().map_or(false, |ext| ext == "ipynb")
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;
 
-    use crate::path::is_python_file;
+    use crate::path::{is_jupyter_notebook, is_python_file};
 
     #[test]
     fn inclusions() {
@@ -36,5 +41,14 @@ mod tests {
 
         let path = Path::new("foo/bar/baz");
         assert!(!is_python_file(path));
+    }
+
+    #[test]
+    fn test_is_jupyter_notebook() {
+        let path = Path::new("foo/bar/baz.ipynb");
+        assert!(is_jupyter_notebook(path));
+
+        let path = Path::new("foo/bar/baz.py");
+        assert!(!is_jupyter_notebook(path));
     }
 }


### PR DESCRIPTION
## Summary

Experimental release for Jupyter Notebook integration.

Currently, this requires a user to explicitly opt-in using the [include](https://beta.ruff.rs/docs/settings/#include) configuration:

```toml
[tool.ruff]
include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
```

Or, a user can pass in the file directly:

```sh
ruff check path/to/notebook.ipynb
```

For known limitations, please refer #5188 

## Test Plan

Following command should work without the `--all-features` flag:

```sh
cargo dev round-trip /path/to/notebook.ipynb
```

Following command should work with the above config file along with `select = ["ALL"]`:

```sh
cargo run --bin ruff -- check --no-cache --config=../test-repos/openai-cookbook/pyproject.toml --fix ../test-repos/openai-cookbook/
```

Passing the Jupyter notebook directly:

```sh
cargo run --bin ruff -- check --no-cache --isolated --select=ALL --fix ../test-repos/openai-cookbook/examples/Classification_using_embeddings.ipynb
```
