### PR TITLE
Remove prelude from `ruff_python_ast`

### DIFF
--- a/crates/ruff/src/rules/airflow/rules/task_variable_name.rs
+++ b/crates/ruff/src/rules/airflow/rules/task_variable_name.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{Expr, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::prelude::Constant;
+use rustpython_parser::ast::Constant;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/collections_named_tuple.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/collections_named_tuple.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::Expr;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::prelude::Ranged;
+use rustpython_parser::ast::Ranged;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/iter_method_return_iterable.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/iter_method_return_iterable.rs
@@ -3,8 +3,8 @@ use rustpython_parser::ast::{Ranged, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::prelude::Expr;
 use ruff_python_semantic::{Definition, Member, MemberKind};
+use rustpython_parser::ast::Expr;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/no_return_argument_annotation.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/no_return_argument_annotation.rs
@@ -4,7 +4,7 @@ use rustpython_parser::ast::Ranged;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::prelude::Arguments;
+use rustpython_parser::ast::Arguments;
 
 use crate::checkers::ast::Checker;
 use crate::settings::types::PythonVersion::Py311;

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use anyhow::Result;
 use ruff_text_size::{TextLen, TextRange, TextSize};
+use rustpython_parser::ast::Decorator;
 use rustpython_parser::ast::{self, ArgWithDefault, Arguments, Expr, Keyword, Ranged, Stmt};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
@@ -10,7 +11,6 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::collect_call_path;
 use ruff_python_ast::helpers::collect_arg_names;
 use ruff_python_ast::identifier::Identifier;
-use ruff_python_ast::prelude::Decorator;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;

--- a/crates/ruff/src/rules/flake8_slots/rules/no_slots_in_namedtuple_subclass.rs
+++ b/crates/ruff/src/rules/flake8_slots/rules/no_slots_in_namedtuple_subclass.rs
@@ -4,7 +4,7 @@ use rustpython_parser::ast::{Expr, StmtClassDef};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::identifier::Identifier;
-use ruff_python_ast::prelude::Stmt;
+use rustpython_parser::ast::Stmt;
 
 use crate::checkers::ast::Checker;
 use crate::rules::flake8_slots::rules::helpers::has_slots;

--- a/crates/ruff/src/rules/perflint/rules/incorrect_dict_iterator.rs
+++ b/crates/ruff/src/rules/perflint/rules/incorrect_dict_iterator.rs
@@ -6,8 +6,8 @@ use rustpython_parser::{ast, lexer, Mode, Tok};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::prelude::Ranged;
 use ruff_python_ast::source_code::Locator;
+use rustpython_parser::ast::Ranged;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;

--- a/crates/ruff/src/rules/perflint/rules/unnecessary_list_cast.rs
+++ b/crates/ruff/src/rules/perflint/rules/unnecessary_list_cast.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{self, Expr};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::prelude::Stmt;
+use rustpython_parser::ast::Stmt;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -9,7 +9,6 @@ pub mod helpers;
 pub mod identifier;
 pub mod imports;
 pub mod node;
-pub mod prelude;
 pub mod relocate;
 pub mod source_code;
 pub mod statement_visitor;

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -1,5 +1,9 @@
-use crate::prelude::*;
 use ruff_text_size::TextRange;
+use rustpython_ast::{
+    Alias, Arg, ArgWithDefault, Arguments, Comprehension, Decorator, ExceptHandler, Keyword,
+    MatchCase, Mod, Pattern, Stmt, TypeIgnore, WithItem,
+};
+use rustpython_parser::ast::{self, Expr, Ranged};
 use std::ptr::NonNull;
 
 pub trait AstNode: Ranged {
@@ -17,74 +21,74 @@ pub trait AstNode: Ranged {
 
 #[derive(Clone, Debug, is_macro::Is, PartialEq)]
 pub enum AnyNode {
-    ModModule(ModModule),
-    ModInteractive(ModInteractive),
-    ModExpression(ModExpression),
-    ModFunctionType(ModFunctionType),
-    StmtFunctionDef(StmtFunctionDef),
-    StmtAsyncFunctionDef(StmtAsyncFunctionDef),
-    StmtClassDef(StmtClassDef),
-    StmtReturn(StmtReturn),
-    StmtDelete(StmtDelete),
-    StmtAssign(StmtAssign),
-    StmtAugAssign(StmtAugAssign),
-    StmtAnnAssign(StmtAnnAssign),
-    StmtFor(StmtFor),
-    StmtAsyncFor(StmtAsyncFor),
-    StmtWhile(StmtWhile),
-    StmtIf(StmtIf),
-    StmtWith(StmtWith),
-    StmtAsyncWith(StmtAsyncWith),
-    StmtMatch(StmtMatch),
-    StmtRaise(StmtRaise),
-    StmtTry(StmtTry),
-    StmtTryStar(StmtTryStar),
-    StmtAssert(StmtAssert),
-    StmtImport(StmtImport),
-    StmtImportFrom(StmtImportFrom),
-    StmtGlobal(StmtGlobal),
-    StmtNonlocal(StmtNonlocal),
-    StmtExpr(StmtExpr),
-    StmtPass(StmtPass),
-    StmtBreak(StmtBreak),
-    StmtContinue(StmtContinue),
-    ExprBoolOp(ExprBoolOp),
-    ExprNamedExpr(ExprNamedExpr),
-    ExprBinOp(ExprBinOp),
-    ExprUnaryOp(ExprUnaryOp),
-    ExprLambda(ExprLambda),
-    ExprIfExp(ExprIfExp),
-    ExprDict(ExprDict),
-    ExprSet(ExprSet),
-    ExprListComp(ExprListComp),
-    ExprSetComp(ExprSetComp),
-    ExprDictComp(ExprDictComp),
-    ExprGeneratorExp(ExprGeneratorExp),
-    ExprAwait(ExprAwait),
-    ExprYield(ExprYield),
-    ExprYieldFrom(ExprYieldFrom),
-    ExprCompare(ExprCompare),
-    ExprCall(ExprCall),
-    ExprFormattedValue(ExprFormattedValue),
-    ExprJoinedStr(ExprJoinedStr),
-    ExprConstant(ExprConstant),
-    ExprAttribute(ExprAttribute),
-    ExprSubscript(ExprSubscript),
-    ExprStarred(ExprStarred),
-    ExprName(ExprName),
-    ExprList(ExprList),
-    ExprTuple(ExprTuple),
-    ExprSlice(ExprSlice),
-    ExceptHandlerExceptHandler(ExceptHandlerExceptHandler),
-    PatternMatchValue(PatternMatchValue),
-    PatternMatchSingleton(PatternMatchSingleton),
-    PatternMatchSequence(PatternMatchSequence),
-    PatternMatchMapping(PatternMatchMapping),
-    PatternMatchClass(PatternMatchClass),
-    PatternMatchStar(PatternMatchStar),
-    PatternMatchAs(PatternMatchAs),
-    PatternMatchOr(PatternMatchOr),
-    TypeIgnoreTypeIgnore(TypeIgnoreTypeIgnore),
+    ModModule(ast::ModModule),
+    ModInteractive(ast::ModInteractive),
+    ModExpression(ast::ModExpression),
+    ModFunctionType(ast::ModFunctionType),
+    StmtFunctionDef(ast::StmtFunctionDef),
+    StmtAsyncFunctionDef(ast::StmtAsyncFunctionDef),
+    StmtClassDef(ast::StmtClassDef),
+    StmtReturn(ast::StmtReturn),
+    StmtDelete(ast::StmtDelete),
+    StmtAssign(ast::StmtAssign),
+    StmtAugAssign(ast::StmtAugAssign),
+    StmtAnnAssign(ast::StmtAnnAssign),
+    StmtFor(ast::StmtFor),
+    StmtAsyncFor(ast::StmtAsyncFor),
+    StmtWhile(ast::StmtWhile),
+    StmtIf(ast::StmtIf),
+    StmtWith(ast::StmtWith),
+    StmtAsyncWith(ast::StmtAsyncWith),
+    StmtMatch(ast::StmtMatch),
+    StmtRaise(ast::StmtRaise),
+    StmtTry(ast::StmtTry),
+    StmtTryStar(ast::StmtTryStar),
+    StmtAssert(ast::StmtAssert),
+    StmtImport(ast::StmtImport),
+    StmtImportFrom(ast::StmtImportFrom),
+    StmtGlobal(ast::StmtGlobal),
+    StmtNonlocal(ast::StmtNonlocal),
+    StmtExpr(ast::StmtExpr),
+    StmtPass(ast::StmtPass),
+    StmtBreak(ast::StmtBreak),
+    StmtContinue(ast::StmtContinue),
+    ExprBoolOp(ast::ExprBoolOp),
+    ExprNamedExpr(ast::ExprNamedExpr),
+    ExprBinOp(ast::ExprBinOp),
+    ExprUnaryOp(ast::ExprUnaryOp),
+    ExprLambda(ast::ExprLambda),
+    ExprIfExp(ast::ExprIfExp),
+    ExprDict(ast::ExprDict),
+    ExprSet(ast::ExprSet),
+    ExprListComp(ast::ExprListComp),
+    ExprSetComp(ast::ExprSetComp),
+    ExprDictComp(ast::ExprDictComp),
+    ExprGeneratorExp(ast::ExprGeneratorExp),
+    ExprAwait(ast::ExprAwait),
+    ExprYield(ast::ExprYield),
+    ExprYieldFrom(ast::ExprYieldFrom),
+    ExprCompare(ast::ExprCompare),
+    ExprCall(ast::ExprCall),
+    ExprFormattedValue(ast::ExprFormattedValue),
+    ExprJoinedStr(ast::ExprJoinedStr),
+    ExprConstant(ast::ExprConstant),
+    ExprAttribute(ast::ExprAttribute),
+    ExprSubscript(ast::ExprSubscript),
+    ExprStarred(ast::ExprStarred),
+    ExprName(ast::ExprName),
+    ExprList(ast::ExprList),
+    ExprTuple(ast::ExprTuple),
+    ExprSlice(ast::ExprSlice),
+    ExceptHandlerExceptHandler(ast::ExceptHandlerExceptHandler),
+    PatternMatchValue(ast::PatternMatchValue),
+    PatternMatchSingleton(ast::PatternMatchSingleton),
+    PatternMatchSequence(ast::PatternMatchSequence),
+    PatternMatchMapping(ast::PatternMatchMapping),
+    PatternMatchClass(ast::PatternMatchClass),
+    PatternMatchStar(ast::PatternMatchStar),
+    PatternMatchAs(ast::PatternMatchAs),
+    PatternMatchOr(ast::PatternMatchOr),
+    TypeIgnoreTypeIgnore(ast::TypeIgnoreTypeIgnore),
     Comprehension(Comprehension),
     Arguments(Arguments),
     Arg(Arg),
@@ -707,7 +711,7 @@ impl AnyNode {
     }
 }
 
-impl AstNode for ModModule {
+impl AstNode for ast::ModModule {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -735,7 +739,7 @@ impl AstNode for ModModule {
         AnyNode::from(self)
     }
 }
-impl AstNode for ModInteractive {
+impl AstNode for ast::ModInteractive {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -763,7 +767,7 @@ impl AstNode for ModInteractive {
         AnyNode::from(self)
     }
 }
-impl AstNode for ModExpression {
+impl AstNode for ast::ModExpression {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -791,7 +795,7 @@ impl AstNode for ModExpression {
         AnyNode::from(self)
     }
 }
-impl AstNode for ModFunctionType {
+impl AstNode for ast::ModFunctionType {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -819,7 +823,7 @@ impl AstNode for ModFunctionType {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtFunctionDef {
+impl AstNode for ast::StmtFunctionDef {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -847,7 +851,7 @@ impl AstNode for StmtFunctionDef {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtAsyncFunctionDef {
+impl AstNode for ast::StmtAsyncFunctionDef {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -875,7 +879,7 @@ impl AstNode for StmtAsyncFunctionDef {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtClassDef {
+impl AstNode for ast::StmtClassDef {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -903,7 +907,7 @@ impl AstNode for StmtClassDef {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtReturn {
+impl AstNode for ast::StmtReturn {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -931,7 +935,7 @@ impl AstNode for StmtReturn {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtDelete {
+impl AstNode for ast::StmtDelete {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -959,7 +963,7 @@ impl AstNode for StmtDelete {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtAssign {
+impl AstNode for ast::StmtAssign {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -987,7 +991,7 @@ impl AstNode for StmtAssign {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtAugAssign {
+impl AstNode for ast::StmtAugAssign {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1015,7 +1019,7 @@ impl AstNode for StmtAugAssign {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtAnnAssign {
+impl AstNode for ast::StmtAnnAssign {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1043,7 +1047,7 @@ impl AstNode for StmtAnnAssign {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtFor {
+impl AstNode for ast::StmtFor {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1071,7 +1075,7 @@ impl AstNode for StmtFor {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtAsyncFor {
+impl AstNode for ast::StmtAsyncFor {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1099,7 +1103,7 @@ impl AstNode for StmtAsyncFor {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtWhile {
+impl AstNode for ast::StmtWhile {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1127,7 +1131,7 @@ impl AstNode for StmtWhile {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtIf {
+impl AstNode for ast::StmtIf {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1155,7 +1159,7 @@ impl AstNode for StmtIf {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtWith {
+impl AstNode for ast::StmtWith {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1183,7 +1187,7 @@ impl AstNode for StmtWith {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtAsyncWith {
+impl AstNode for ast::StmtAsyncWith {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1211,7 +1215,7 @@ impl AstNode for StmtAsyncWith {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtMatch {
+impl AstNode for ast::StmtMatch {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1239,7 +1243,7 @@ impl AstNode for StmtMatch {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtRaise {
+impl AstNode for ast::StmtRaise {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1267,7 +1271,7 @@ impl AstNode for StmtRaise {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtTry {
+impl AstNode for ast::StmtTry {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1295,7 +1299,7 @@ impl AstNode for StmtTry {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtTryStar {
+impl AstNode for ast::StmtTryStar {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1323,7 +1327,7 @@ impl AstNode for StmtTryStar {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtAssert {
+impl AstNode for ast::StmtAssert {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1351,7 +1355,7 @@ impl AstNode for StmtAssert {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtImport {
+impl AstNode for ast::StmtImport {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1379,7 +1383,7 @@ impl AstNode for StmtImport {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtImportFrom {
+impl AstNode for ast::StmtImportFrom {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1407,7 +1411,7 @@ impl AstNode for StmtImportFrom {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtGlobal {
+impl AstNode for ast::StmtGlobal {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1435,7 +1439,7 @@ impl AstNode for StmtGlobal {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtNonlocal {
+impl AstNode for ast::StmtNonlocal {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1463,7 +1467,7 @@ impl AstNode for StmtNonlocal {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtExpr {
+impl AstNode for ast::StmtExpr {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1491,7 +1495,7 @@ impl AstNode for StmtExpr {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtPass {
+impl AstNode for ast::StmtPass {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1519,7 +1523,7 @@ impl AstNode for StmtPass {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtBreak {
+impl AstNode for ast::StmtBreak {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1547,7 +1551,7 @@ impl AstNode for StmtBreak {
         AnyNode::from(self)
     }
 }
-impl AstNode for StmtContinue {
+impl AstNode for ast::StmtContinue {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1575,7 +1579,7 @@ impl AstNode for StmtContinue {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprBoolOp {
+impl AstNode for ast::ExprBoolOp {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1603,7 +1607,7 @@ impl AstNode for ExprBoolOp {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprNamedExpr {
+impl AstNode for ast::ExprNamedExpr {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1631,7 +1635,7 @@ impl AstNode for ExprNamedExpr {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprBinOp {
+impl AstNode for ast::ExprBinOp {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1659,7 +1663,7 @@ impl AstNode for ExprBinOp {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprUnaryOp {
+impl AstNode for ast::ExprUnaryOp {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1687,7 +1691,7 @@ impl AstNode for ExprUnaryOp {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprLambda {
+impl AstNode for ast::ExprLambda {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1715,7 +1719,7 @@ impl AstNode for ExprLambda {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprIfExp {
+impl AstNode for ast::ExprIfExp {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1743,7 +1747,7 @@ impl AstNode for ExprIfExp {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprDict {
+impl AstNode for ast::ExprDict {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1771,7 +1775,7 @@ impl AstNode for ExprDict {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprSet {
+impl AstNode for ast::ExprSet {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1799,7 +1803,7 @@ impl AstNode for ExprSet {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprListComp {
+impl AstNode for ast::ExprListComp {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1827,7 +1831,7 @@ impl AstNode for ExprListComp {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprSetComp {
+impl AstNode for ast::ExprSetComp {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1855,7 +1859,7 @@ impl AstNode for ExprSetComp {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprDictComp {
+impl AstNode for ast::ExprDictComp {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1883,7 +1887,7 @@ impl AstNode for ExprDictComp {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprGeneratorExp {
+impl AstNode for ast::ExprGeneratorExp {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1911,7 +1915,7 @@ impl AstNode for ExprGeneratorExp {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprAwait {
+impl AstNode for ast::ExprAwait {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1939,7 +1943,7 @@ impl AstNode for ExprAwait {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprYield {
+impl AstNode for ast::ExprYield {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1967,7 +1971,7 @@ impl AstNode for ExprYield {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprYieldFrom {
+impl AstNode for ast::ExprYieldFrom {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -1995,7 +1999,7 @@ impl AstNode for ExprYieldFrom {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprCompare {
+impl AstNode for ast::ExprCompare {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2023,7 +2027,7 @@ impl AstNode for ExprCompare {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprCall {
+impl AstNode for ast::ExprCall {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2051,7 +2055,7 @@ impl AstNode for ExprCall {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprFormattedValue {
+impl AstNode for ast::ExprFormattedValue {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2079,7 +2083,7 @@ impl AstNode for ExprFormattedValue {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprJoinedStr {
+impl AstNode for ast::ExprJoinedStr {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2107,7 +2111,7 @@ impl AstNode for ExprJoinedStr {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprConstant {
+impl AstNode for ast::ExprConstant {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2135,7 +2139,7 @@ impl AstNode for ExprConstant {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprAttribute {
+impl AstNode for ast::ExprAttribute {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2163,7 +2167,7 @@ impl AstNode for ExprAttribute {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprSubscript {
+impl AstNode for ast::ExprSubscript {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2191,7 +2195,7 @@ impl AstNode for ExprSubscript {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprStarred {
+impl AstNode for ast::ExprStarred {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2219,7 +2223,7 @@ impl AstNode for ExprStarred {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprName {
+impl AstNode for ast::ExprName {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2247,7 +2251,7 @@ impl AstNode for ExprName {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprList {
+impl AstNode for ast::ExprList {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2275,7 +2279,7 @@ impl AstNode for ExprList {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprTuple {
+impl AstNode for ast::ExprTuple {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2303,7 +2307,7 @@ impl AstNode for ExprTuple {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExprSlice {
+impl AstNode for ast::ExprSlice {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2331,7 +2335,7 @@ impl AstNode for ExprSlice {
         AnyNode::from(self)
     }
 }
-impl AstNode for ExceptHandlerExceptHandler {
+impl AstNode for ast::ExceptHandlerExceptHandler {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2359,7 +2363,7 @@ impl AstNode for ExceptHandlerExceptHandler {
         AnyNode::from(self)
     }
 }
-impl AstNode for PatternMatchValue {
+impl AstNode for ast::PatternMatchValue {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2387,7 +2391,7 @@ impl AstNode for PatternMatchValue {
         AnyNode::from(self)
     }
 }
-impl AstNode for PatternMatchSingleton {
+impl AstNode for ast::PatternMatchSingleton {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2415,7 +2419,7 @@ impl AstNode for PatternMatchSingleton {
         AnyNode::from(self)
     }
 }
-impl AstNode for PatternMatchSequence {
+impl AstNode for ast::PatternMatchSequence {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2443,7 +2447,7 @@ impl AstNode for PatternMatchSequence {
         AnyNode::from(self)
     }
 }
-impl AstNode for PatternMatchMapping {
+impl AstNode for ast::PatternMatchMapping {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2471,7 +2475,7 @@ impl AstNode for PatternMatchMapping {
         AnyNode::from(self)
     }
 }
-impl AstNode for PatternMatchClass {
+impl AstNode for ast::PatternMatchClass {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2499,7 +2503,7 @@ impl AstNode for PatternMatchClass {
         AnyNode::from(self)
     }
 }
-impl AstNode for PatternMatchStar {
+impl AstNode for ast::PatternMatchStar {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2527,7 +2531,7 @@ impl AstNode for PatternMatchStar {
         AnyNode::from(self)
     }
 }
-impl AstNode for PatternMatchAs {
+impl AstNode for ast::PatternMatchAs {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2555,7 +2559,7 @@ impl AstNode for PatternMatchAs {
         AnyNode::from(self)
     }
 }
-impl AstNode for PatternMatchOr {
+impl AstNode for ast::PatternMatchOr {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2583,7 +2587,7 @@ impl AstNode for PatternMatchOr {
         AnyNode::from(self)
     }
 }
-impl AstNode for TypeIgnoreTypeIgnore {
+impl AstNode for ast::TypeIgnoreTypeIgnore {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2976,410 +2980,410 @@ impl From<TypeIgnore> for AnyNode {
     }
 }
 
-impl From<ModModule> for AnyNode {
-    fn from(node: ModModule) -> Self {
+impl From<ast::ModModule> for AnyNode {
+    fn from(node: ast::ModModule) -> Self {
         AnyNode::ModModule(node)
     }
 }
 
-impl From<ModInteractive> for AnyNode {
-    fn from(node: ModInteractive) -> Self {
+impl From<ast::ModInteractive> for AnyNode {
+    fn from(node: ast::ModInteractive) -> Self {
         AnyNode::ModInteractive(node)
     }
 }
 
-impl From<ModExpression> for AnyNode {
-    fn from(node: ModExpression) -> Self {
+impl From<ast::ModExpression> for AnyNode {
+    fn from(node: ast::ModExpression) -> Self {
         AnyNode::ModExpression(node)
     }
 }
 
-impl From<ModFunctionType> for AnyNode {
-    fn from(node: ModFunctionType) -> Self {
+impl From<ast::ModFunctionType> for AnyNode {
+    fn from(node: ast::ModFunctionType) -> Self {
         AnyNode::ModFunctionType(node)
     }
 }
 
-impl From<StmtFunctionDef> for AnyNode {
-    fn from(node: StmtFunctionDef) -> Self {
+impl From<ast::StmtFunctionDef> for AnyNode {
+    fn from(node: ast::StmtFunctionDef) -> Self {
         AnyNode::StmtFunctionDef(node)
     }
 }
 
-impl From<StmtAsyncFunctionDef> for AnyNode {
-    fn from(node: StmtAsyncFunctionDef) -> Self {
+impl From<ast::StmtAsyncFunctionDef> for AnyNode {
+    fn from(node: ast::StmtAsyncFunctionDef) -> Self {
         AnyNode::StmtAsyncFunctionDef(node)
     }
 }
 
-impl From<StmtClassDef> for AnyNode {
-    fn from(node: StmtClassDef) -> Self {
+impl From<ast::StmtClassDef> for AnyNode {
+    fn from(node: ast::StmtClassDef) -> Self {
         AnyNode::StmtClassDef(node)
     }
 }
 
-impl From<StmtReturn> for AnyNode {
-    fn from(node: StmtReturn) -> Self {
+impl From<ast::StmtReturn> for AnyNode {
+    fn from(node: ast::StmtReturn) -> Self {
         AnyNode::StmtReturn(node)
     }
 }
 
-impl From<StmtDelete> for AnyNode {
-    fn from(node: StmtDelete) -> Self {
+impl From<ast::StmtDelete> for AnyNode {
+    fn from(node: ast::StmtDelete) -> Self {
         AnyNode::StmtDelete(node)
     }
 }
 
-impl From<StmtAssign> for AnyNode {
-    fn from(node: StmtAssign) -> Self {
+impl From<ast::StmtAssign> for AnyNode {
+    fn from(node: ast::StmtAssign) -> Self {
         AnyNode::StmtAssign(node)
     }
 }
 
-impl From<StmtAugAssign> for AnyNode {
-    fn from(node: StmtAugAssign) -> Self {
+impl From<ast::StmtAugAssign> for AnyNode {
+    fn from(node: ast::StmtAugAssign) -> Self {
         AnyNode::StmtAugAssign(node)
     }
 }
 
-impl From<StmtAnnAssign> for AnyNode {
-    fn from(node: StmtAnnAssign) -> Self {
+impl From<ast::StmtAnnAssign> for AnyNode {
+    fn from(node: ast::StmtAnnAssign) -> Self {
         AnyNode::StmtAnnAssign(node)
     }
 }
 
-impl From<StmtFor> for AnyNode {
-    fn from(node: StmtFor) -> Self {
+impl From<ast::StmtFor> for AnyNode {
+    fn from(node: ast::StmtFor) -> Self {
         AnyNode::StmtFor(node)
     }
 }
 
-impl From<StmtAsyncFor> for AnyNode {
-    fn from(node: StmtAsyncFor) -> Self {
+impl From<ast::StmtAsyncFor> for AnyNode {
+    fn from(node: ast::StmtAsyncFor) -> Self {
         AnyNode::StmtAsyncFor(node)
     }
 }
 
-impl From<StmtWhile> for AnyNode {
-    fn from(node: StmtWhile) -> Self {
+impl From<ast::StmtWhile> for AnyNode {
+    fn from(node: ast::StmtWhile) -> Self {
         AnyNode::StmtWhile(node)
     }
 }
 
-impl From<StmtIf> for AnyNode {
-    fn from(node: StmtIf) -> Self {
+impl From<ast::StmtIf> for AnyNode {
+    fn from(node: ast::StmtIf) -> Self {
         AnyNode::StmtIf(node)
     }
 }
 
-impl From<StmtWith> for AnyNode {
-    fn from(node: StmtWith) -> Self {
+impl From<ast::StmtWith> for AnyNode {
+    fn from(node: ast::StmtWith) -> Self {
         AnyNode::StmtWith(node)
     }
 }
 
-impl From<StmtAsyncWith> for AnyNode {
-    fn from(node: StmtAsyncWith) -> Self {
+impl From<ast::StmtAsyncWith> for AnyNode {
+    fn from(node: ast::StmtAsyncWith) -> Self {
         AnyNode::StmtAsyncWith(node)
     }
 }
 
-impl From<StmtMatch> for AnyNode {
-    fn from(node: StmtMatch) -> Self {
+impl From<ast::StmtMatch> for AnyNode {
+    fn from(node: ast::StmtMatch) -> Self {
         AnyNode::StmtMatch(node)
     }
 }
 
-impl From<StmtRaise> for AnyNode {
-    fn from(node: StmtRaise) -> Self {
+impl From<ast::StmtRaise> for AnyNode {
+    fn from(node: ast::StmtRaise) -> Self {
         AnyNode::StmtRaise(node)
     }
 }
 
-impl From<StmtTry> for AnyNode {
-    fn from(node: StmtTry) -> Self {
+impl From<ast::StmtTry> for AnyNode {
+    fn from(node: ast::StmtTry) -> Self {
         AnyNode::StmtTry(node)
     }
 }
 
-impl From<StmtTryStar> for AnyNode {
-    fn from(node: StmtTryStar) -> Self {
+impl From<ast::StmtTryStar> for AnyNode {
+    fn from(node: ast::StmtTryStar) -> Self {
         AnyNode::StmtTryStar(node)
     }
 }
 
-impl From<StmtAssert> for AnyNode {
-    fn from(node: StmtAssert) -> Self {
+impl From<ast::StmtAssert> for AnyNode {
+    fn from(node: ast::StmtAssert) -> Self {
         AnyNode::StmtAssert(node)
     }
 }
 
-impl From<StmtImport> for AnyNode {
-    fn from(node: StmtImport) -> Self {
+impl From<ast::StmtImport> for AnyNode {
+    fn from(node: ast::StmtImport) -> Self {
         AnyNode::StmtImport(node)
     }
 }
 
-impl From<StmtImportFrom> for AnyNode {
-    fn from(node: StmtImportFrom) -> Self {
+impl From<ast::StmtImportFrom> for AnyNode {
+    fn from(node: ast::StmtImportFrom) -> Self {
         AnyNode::StmtImportFrom(node)
     }
 }
 
-impl From<StmtGlobal> for AnyNode {
-    fn from(node: StmtGlobal) -> Self {
+impl From<ast::StmtGlobal> for AnyNode {
+    fn from(node: ast::StmtGlobal) -> Self {
         AnyNode::StmtGlobal(node)
     }
 }
 
-impl From<StmtNonlocal> for AnyNode {
-    fn from(node: StmtNonlocal) -> Self {
+impl From<ast::StmtNonlocal> for AnyNode {
+    fn from(node: ast::StmtNonlocal) -> Self {
         AnyNode::StmtNonlocal(node)
     }
 }
 
-impl From<StmtExpr> for AnyNode {
-    fn from(node: StmtExpr) -> Self {
+impl From<ast::StmtExpr> for AnyNode {
+    fn from(node: ast::StmtExpr) -> Self {
         AnyNode::StmtExpr(node)
     }
 }
 
-impl From<StmtPass> for AnyNode {
-    fn from(node: StmtPass) -> Self {
+impl From<ast::StmtPass> for AnyNode {
+    fn from(node: ast::StmtPass) -> Self {
         AnyNode::StmtPass(node)
     }
 }
 
-impl From<StmtBreak> for AnyNode {
-    fn from(node: StmtBreak) -> Self {
+impl From<ast::StmtBreak> for AnyNode {
+    fn from(node: ast::StmtBreak) -> Self {
         AnyNode::StmtBreak(node)
     }
 }
 
-impl From<StmtContinue> for AnyNode {
-    fn from(node: StmtContinue) -> Self {
+impl From<ast::StmtContinue> for AnyNode {
+    fn from(node: ast::StmtContinue) -> Self {
         AnyNode::StmtContinue(node)
     }
 }
 
-impl From<ExprBoolOp> for AnyNode {
-    fn from(node: ExprBoolOp) -> Self {
+impl From<ast::ExprBoolOp> for AnyNode {
+    fn from(node: ast::ExprBoolOp) -> Self {
         AnyNode::ExprBoolOp(node)
     }
 }
 
-impl From<ExprNamedExpr> for AnyNode {
-    fn from(node: ExprNamedExpr) -> Self {
+impl From<ast::ExprNamedExpr> for AnyNode {
+    fn from(node: ast::ExprNamedExpr) -> Self {
         AnyNode::ExprNamedExpr(node)
     }
 }
 
-impl From<ExprBinOp> for AnyNode {
-    fn from(node: ExprBinOp) -> Self {
+impl From<ast::ExprBinOp> for AnyNode {
+    fn from(node: ast::ExprBinOp) -> Self {
         AnyNode::ExprBinOp(node)
     }
 }
 
-impl From<ExprUnaryOp> for AnyNode {
-    fn from(node: ExprUnaryOp) -> Self {
+impl From<ast::ExprUnaryOp> for AnyNode {
+    fn from(node: ast::ExprUnaryOp) -> Self {
         AnyNode::ExprUnaryOp(node)
     }
 }
 
-impl From<ExprLambda> for AnyNode {
-    fn from(node: ExprLambda) -> Self {
+impl From<ast::ExprLambda> for AnyNode {
+    fn from(node: ast::ExprLambda) -> Self {
         AnyNode::ExprLambda(node)
     }
 }
 
-impl From<ExprIfExp> for AnyNode {
-    fn from(node: ExprIfExp) -> Self {
+impl From<ast::ExprIfExp> for AnyNode {
+    fn from(node: ast::ExprIfExp) -> Self {
         AnyNode::ExprIfExp(node)
     }
 }
 
-impl From<ExprDict> for AnyNode {
-    fn from(node: ExprDict) -> Self {
+impl From<ast::ExprDict> for AnyNode {
+    fn from(node: ast::ExprDict) -> Self {
         AnyNode::ExprDict(node)
     }
 }
 
-impl From<ExprSet> for AnyNode {
-    fn from(node: ExprSet) -> Self {
+impl From<ast::ExprSet> for AnyNode {
+    fn from(node: ast::ExprSet) -> Self {
         AnyNode::ExprSet(node)
     }
 }
 
-impl From<ExprListComp> for AnyNode {
-    fn from(node: ExprListComp) -> Self {
+impl From<ast::ExprListComp> for AnyNode {
+    fn from(node: ast::ExprListComp) -> Self {
         AnyNode::ExprListComp(node)
     }
 }
 
-impl From<ExprSetComp> for AnyNode {
-    fn from(node: ExprSetComp) -> Self {
+impl From<ast::ExprSetComp> for AnyNode {
+    fn from(node: ast::ExprSetComp) -> Self {
         AnyNode::ExprSetComp(node)
     }
 }
 
-impl From<ExprDictComp> for AnyNode {
-    fn from(node: ExprDictComp) -> Self {
+impl From<ast::ExprDictComp> for AnyNode {
+    fn from(node: ast::ExprDictComp) -> Self {
         AnyNode::ExprDictComp(node)
     }
 }
 
-impl From<ExprGeneratorExp> for AnyNode {
-    fn from(node: ExprGeneratorExp) -> Self {
+impl From<ast::ExprGeneratorExp> for AnyNode {
+    fn from(node: ast::ExprGeneratorExp) -> Self {
         AnyNode::ExprGeneratorExp(node)
     }
 }
 
-impl From<ExprAwait> for AnyNode {
-    fn from(node: ExprAwait) -> Self {
+impl From<ast::ExprAwait> for AnyNode {
+    fn from(node: ast::ExprAwait) -> Self {
         AnyNode::ExprAwait(node)
     }
 }
 
-impl From<ExprYield> for AnyNode {
-    fn from(node: ExprYield) -> Self {
+impl From<ast::ExprYield> for AnyNode {
+    fn from(node: ast::ExprYield) -> Self {
         AnyNode::ExprYield(node)
     }
 }
 
-impl From<ExprYieldFrom> for AnyNode {
-    fn from(node: ExprYieldFrom) -> Self {
+impl From<ast::ExprYieldFrom> for AnyNode {
+    fn from(node: ast::ExprYieldFrom) -> Self {
         AnyNode::ExprYieldFrom(node)
     }
 }
 
-impl From<ExprCompare> for AnyNode {
-    fn from(node: ExprCompare) -> Self {
+impl From<ast::ExprCompare> for AnyNode {
+    fn from(node: ast::ExprCompare) -> Self {
         AnyNode::ExprCompare(node)
     }
 }
 
-impl From<ExprCall> for AnyNode {
-    fn from(node: ExprCall) -> Self {
+impl From<ast::ExprCall> for AnyNode {
+    fn from(node: ast::ExprCall) -> Self {
         AnyNode::ExprCall(node)
     }
 }
 
-impl From<ExprFormattedValue> for AnyNode {
-    fn from(node: ExprFormattedValue) -> Self {
+impl From<ast::ExprFormattedValue> for AnyNode {
+    fn from(node: ast::ExprFormattedValue) -> Self {
         AnyNode::ExprFormattedValue(node)
     }
 }
 
-impl From<ExprJoinedStr> for AnyNode {
-    fn from(node: ExprJoinedStr) -> Self {
+impl From<ast::ExprJoinedStr> for AnyNode {
+    fn from(node: ast::ExprJoinedStr) -> Self {
         AnyNode::ExprJoinedStr(node)
     }
 }
 
-impl From<ExprConstant> for AnyNode {
-    fn from(node: ExprConstant) -> Self {
+impl From<ast::ExprConstant> for AnyNode {
+    fn from(node: ast::ExprConstant) -> Self {
         AnyNode::ExprConstant(node)
     }
 }
 
-impl From<ExprAttribute> for AnyNode {
-    fn from(node: ExprAttribute) -> Self {
+impl From<ast::ExprAttribute> for AnyNode {
+    fn from(node: ast::ExprAttribute) -> Self {
         AnyNode::ExprAttribute(node)
     }
 }
 
-impl From<ExprSubscript> for AnyNode {
-    fn from(node: ExprSubscript) -> Self {
+impl From<ast::ExprSubscript> for AnyNode {
+    fn from(node: ast::ExprSubscript) -> Self {
         AnyNode::ExprSubscript(node)
     }
 }
 
-impl From<ExprStarred> for AnyNode {
-    fn from(node: ExprStarred) -> Self {
+impl From<ast::ExprStarred> for AnyNode {
+    fn from(node: ast::ExprStarred) -> Self {
         AnyNode::ExprStarred(node)
     }
 }
 
-impl From<ExprName> for AnyNode {
-    fn from(node: ExprName) -> Self {
+impl From<ast::ExprName> for AnyNode {
+    fn from(node: ast::ExprName) -> Self {
         AnyNode::ExprName(node)
     }
 }
 
-impl From<ExprList> for AnyNode {
-    fn from(node: ExprList) -> Self {
+impl From<ast::ExprList> for AnyNode {
+    fn from(node: ast::ExprList) -> Self {
         AnyNode::ExprList(node)
     }
 }
 
-impl From<ExprTuple> for AnyNode {
-    fn from(node: ExprTuple) -> Self {
+impl From<ast::ExprTuple> for AnyNode {
+    fn from(node: ast::ExprTuple) -> Self {
         AnyNode::ExprTuple(node)
     }
 }
 
-impl From<ExprSlice> for AnyNode {
-    fn from(node: ExprSlice) -> Self {
+impl From<ast::ExprSlice> for AnyNode {
+    fn from(node: ast::ExprSlice) -> Self {
         AnyNode::ExprSlice(node)
     }
 }
 
-impl From<ExceptHandlerExceptHandler> for AnyNode {
-    fn from(node: ExceptHandlerExceptHandler) -> Self {
+impl From<ast::ExceptHandlerExceptHandler> for AnyNode {
+    fn from(node: ast::ExceptHandlerExceptHandler) -> Self {
         AnyNode::ExceptHandlerExceptHandler(node)
     }
 }
 
-impl From<PatternMatchValue> for AnyNode {
-    fn from(node: PatternMatchValue) -> Self {
+impl From<ast::PatternMatchValue> for AnyNode {
+    fn from(node: ast::PatternMatchValue) -> Self {
         AnyNode::PatternMatchValue(node)
     }
 }
 
-impl From<PatternMatchSingleton> for AnyNode {
-    fn from(node: PatternMatchSingleton) -> Self {
+impl From<ast::PatternMatchSingleton> for AnyNode {
+    fn from(node: ast::PatternMatchSingleton) -> Self {
         AnyNode::PatternMatchSingleton(node)
     }
 }
 
-impl From<PatternMatchSequence> for AnyNode {
-    fn from(node: PatternMatchSequence) -> Self {
+impl From<ast::PatternMatchSequence> for AnyNode {
+    fn from(node: ast::PatternMatchSequence) -> Self {
         AnyNode::PatternMatchSequence(node)
     }
 }
 
-impl From<PatternMatchMapping> for AnyNode {
-    fn from(node: PatternMatchMapping) -> Self {
+impl From<ast::PatternMatchMapping> for AnyNode {
+    fn from(node: ast::PatternMatchMapping) -> Self {
         AnyNode::PatternMatchMapping(node)
     }
 }
 
-impl From<PatternMatchClass> for AnyNode {
-    fn from(node: PatternMatchClass) -> Self {
+impl From<ast::PatternMatchClass> for AnyNode {
+    fn from(node: ast::PatternMatchClass) -> Self {
         AnyNode::PatternMatchClass(node)
     }
 }
 
-impl From<PatternMatchStar> for AnyNode {
-    fn from(node: PatternMatchStar) -> Self {
+impl From<ast::PatternMatchStar> for AnyNode {
+    fn from(node: ast::PatternMatchStar) -> Self {
         AnyNode::PatternMatchStar(node)
     }
 }
 
-impl From<PatternMatchAs> for AnyNode {
-    fn from(node: PatternMatchAs) -> Self {
+impl From<ast::PatternMatchAs> for AnyNode {
+    fn from(node: ast::PatternMatchAs) -> Self {
         AnyNode::PatternMatchAs(node)
     }
 }
 
-impl From<PatternMatchOr> for AnyNode {
-    fn from(node: PatternMatchOr) -> Self {
+impl From<ast::PatternMatchOr> for AnyNode {
+    fn from(node: ast::PatternMatchOr) -> Self {
         AnyNode::PatternMatchOr(node)
     }
 }
 
-impl From<TypeIgnoreTypeIgnore> for AnyNode {
-    fn from(node: TypeIgnoreTypeIgnore) -> Self {
+impl From<ast::TypeIgnoreTypeIgnore> for AnyNode {
+    fn from(node: ast::TypeIgnoreTypeIgnore) -> Self {
         AnyNode::TypeIgnoreTypeIgnore(node)
     }
 }
@@ -3516,74 +3520,74 @@ impl Ranged for AnyNode {
 
 #[derive(Copy, Clone, Debug, is_macro::Is, PartialEq)]
 pub enum AnyNodeRef<'a> {
-    ModModule(&'a ModModule),
-    ModInteractive(&'a ModInteractive),
-    ModExpression(&'a ModExpression),
-    ModFunctionType(&'a ModFunctionType),
-    StmtFunctionDef(&'a StmtFunctionDef),
-    StmtAsyncFunctionDef(&'a StmtAsyncFunctionDef),
-    StmtClassDef(&'a StmtClassDef),
-    StmtReturn(&'a StmtReturn),
-    StmtDelete(&'a StmtDelete),
-    StmtAssign(&'a StmtAssign),
-    StmtAugAssign(&'a StmtAugAssign),
-    StmtAnnAssign(&'a StmtAnnAssign),
-    StmtFor(&'a StmtFor),
-    StmtAsyncFor(&'a StmtAsyncFor),
-    StmtWhile(&'a StmtWhile),
-    StmtIf(&'a StmtIf),
-    StmtWith(&'a StmtWith),
-    StmtAsyncWith(&'a StmtAsyncWith),
-    StmtMatch(&'a StmtMatch),
-    StmtRaise(&'a StmtRaise),
-    StmtTry(&'a StmtTry),
-    StmtTryStar(&'a StmtTryStar),
-    StmtAssert(&'a StmtAssert),
-    StmtImport(&'a StmtImport),
-    StmtImportFrom(&'a StmtImportFrom),
-    StmtGlobal(&'a StmtGlobal),
-    StmtNonlocal(&'a StmtNonlocal),
-    StmtExpr(&'a StmtExpr),
-    StmtPass(&'a StmtPass),
-    StmtBreak(&'a StmtBreak),
-    StmtContinue(&'a StmtContinue),
-    ExprBoolOp(&'a ExprBoolOp),
-    ExprNamedExpr(&'a ExprNamedExpr),
-    ExprBinOp(&'a ExprBinOp),
-    ExprUnaryOp(&'a ExprUnaryOp),
-    ExprLambda(&'a ExprLambda),
-    ExprIfExp(&'a ExprIfExp),
-    ExprDict(&'a ExprDict),
-    ExprSet(&'a ExprSet),
-    ExprListComp(&'a ExprListComp),
-    ExprSetComp(&'a ExprSetComp),
-    ExprDictComp(&'a ExprDictComp),
-    ExprGeneratorExp(&'a ExprGeneratorExp),
-    ExprAwait(&'a ExprAwait),
-    ExprYield(&'a ExprYield),
-    ExprYieldFrom(&'a ExprYieldFrom),
-    ExprCompare(&'a ExprCompare),
-    ExprCall(&'a ExprCall),
-    ExprFormattedValue(&'a ExprFormattedValue),
-    ExprJoinedStr(&'a ExprJoinedStr),
-    ExprConstant(&'a ExprConstant),
-    ExprAttribute(&'a ExprAttribute),
-    ExprSubscript(&'a ExprSubscript),
-    ExprStarred(&'a ExprStarred),
-    ExprName(&'a ExprName),
-    ExprList(&'a ExprList),
-    ExprTuple(&'a ExprTuple),
-    ExprSlice(&'a ExprSlice),
-    ExceptHandlerExceptHandler(&'a ExceptHandlerExceptHandler),
-    PatternMatchValue(&'a PatternMatchValue),
-    PatternMatchSingleton(&'a PatternMatchSingleton),
-    PatternMatchSequence(&'a PatternMatchSequence),
-    PatternMatchMapping(&'a PatternMatchMapping),
-    PatternMatchClass(&'a PatternMatchClass),
-    PatternMatchStar(&'a PatternMatchStar),
-    PatternMatchAs(&'a PatternMatchAs),
-    PatternMatchOr(&'a PatternMatchOr),
-    TypeIgnoreTypeIgnore(&'a TypeIgnoreTypeIgnore),
+    ModModule(&'a ast::ModModule),
+    ModInteractive(&'a ast::ModInteractive),
+    ModExpression(&'a ast::ModExpression),
+    ModFunctionType(&'a ast::ModFunctionType),
+    StmtFunctionDef(&'a ast::StmtFunctionDef),
+    StmtAsyncFunctionDef(&'a ast::StmtAsyncFunctionDef),
+    StmtClassDef(&'a ast::StmtClassDef),
+    StmtReturn(&'a ast::StmtReturn),
+    StmtDelete(&'a ast::StmtDelete),
+    StmtAssign(&'a ast::StmtAssign),
+    StmtAugAssign(&'a ast::StmtAugAssign),
+    StmtAnnAssign(&'a ast::StmtAnnAssign),
+    StmtFor(&'a ast::StmtFor),
+    StmtAsyncFor(&'a ast::StmtAsyncFor),
+    StmtWhile(&'a ast::StmtWhile),
+    StmtIf(&'a ast::StmtIf),
+    StmtWith(&'a ast::StmtWith),
+    StmtAsyncWith(&'a ast::StmtAsyncWith),
+    StmtMatch(&'a ast::StmtMatch),
+    StmtRaise(&'a ast::StmtRaise),
+    StmtTry(&'a ast::StmtTry),
+    StmtTryStar(&'a ast::StmtTryStar),
+    StmtAssert(&'a ast::StmtAssert),
+    StmtImport(&'a ast::StmtImport),
+    StmtImportFrom(&'a ast::StmtImportFrom),
+    StmtGlobal(&'a ast::StmtGlobal),
+    StmtNonlocal(&'a ast::StmtNonlocal),
+    StmtExpr(&'a ast::StmtExpr),
+    StmtPass(&'a ast::StmtPass),
+    StmtBreak(&'a ast::StmtBreak),
+    StmtContinue(&'a ast::StmtContinue),
+    ExprBoolOp(&'a ast::ExprBoolOp),
+    ExprNamedExpr(&'a ast::ExprNamedExpr),
+    ExprBinOp(&'a ast::ExprBinOp),
+    ExprUnaryOp(&'a ast::ExprUnaryOp),
+    ExprLambda(&'a ast::ExprLambda),
+    ExprIfExp(&'a ast::ExprIfExp),
+    ExprDict(&'a ast::ExprDict),
+    ExprSet(&'a ast::ExprSet),
+    ExprListComp(&'a ast::ExprListComp),
+    ExprSetComp(&'a ast::ExprSetComp),
+    ExprDictComp(&'a ast::ExprDictComp),
+    ExprGeneratorExp(&'a ast::ExprGeneratorExp),
+    ExprAwait(&'a ast::ExprAwait),
+    ExprYield(&'a ast::ExprYield),
+    ExprYieldFrom(&'a ast::ExprYieldFrom),
+    ExprCompare(&'a ast::ExprCompare),
+    ExprCall(&'a ast::ExprCall),
+    ExprFormattedValue(&'a ast::ExprFormattedValue),
+    ExprJoinedStr(&'a ast::ExprJoinedStr),
+    ExprConstant(&'a ast::ExprConstant),
+    ExprAttribute(&'a ast::ExprAttribute),
+    ExprSubscript(&'a ast::ExprSubscript),
+    ExprStarred(&'a ast::ExprStarred),
+    ExprName(&'a ast::ExprName),
+    ExprList(&'a ast::ExprList),
+    ExprTuple(&'a ast::ExprTuple),
+    ExprSlice(&'a ast::ExprSlice),
+    ExceptHandlerExceptHandler(&'a ast::ExceptHandlerExceptHandler),
+    PatternMatchValue(&'a ast::PatternMatchValue),
+    PatternMatchSingleton(&'a ast::PatternMatchSingleton),
+    PatternMatchSequence(&'a ast::PatternMatchSequence),
+    PatternMatchMapping(&'a ast::PatternMatchMapping),
+    PatternMatchClass(&'a ast::PatternMatchClass),
+    PatternMatchStar(&'a ast::PatternMatchStar),
+    PatternMatchAs(&'a ast::PatternMatchAs),
+    PatternMatchOr(&'a ast::PatternMatchOr),
+    TypeIgnoreTypeIgnore(&'a ast::TypeIgnoreTypeIgnore),
     Comprehension(&'a Comprehension),
     Arguments(&'a Arguments),
     Arg(&'a Arg),
@@ -4281,410 +4285,410 @@ impl AnyNodeRef<'_> {
     }
 }
 
-impl<'a> From<&'a ModModule> for AnyNodeRef<'a> {
-    fn from(node: &'a ModModule) -> Self {
+impl<'a> From<&'a ast::ModModule> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ModModule) -> Self {
         AnyNodeRef::ModModule(node)
     }
 }
 
-impl<'a> From<&'a ModInteractive> for AnyNodeRef<'a> {
-    fn from(node: &'a ModInteractive) -> Self {
+impl<'a> From<&'a ast::ModInteractive> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ModInteractive) -> Self {
         AnyNodeRef::ModInteractive(node)
     }
 }
 
-impl<'a> From<&'a ModExpression> for AnyNodeRef<'a> {
-    fn from(node: &'a ModExpression) -> Self {
+impl<'a> From<&'a ast::ModExpression> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ModExpression) -> Self {
         AnyNodeRef::ModExpression(node)
     }
 }
 
-impl<'a> From<&'a ModFunctionType> for AnyNodeRef<'a> {
-    fn from(node: &'a ModFunctionType) -> Self {
+impl<'a> From<&'a ast::ModFunctionType> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ModFunctionType) -> Self {
         AnyNodeRef::ModFunctionType(node)
     }
 }
 
-impl<'a> From<&'a StmtFunctionDef> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtFunctionDef) -> Self {
+impl<'a> From<&'a ast::StmtFunctionDef> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtFunctionDef) -> Self {
         AnyNodeRef::StmtFunctionDef(node)
     }
 }
 
-impl<'a> From<&'a StmtAsyncFunctionDef> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtAsyncFunctionDef) -> Self {
+impl<'a> From<&'a ast::StmtAsyncFunctionDef> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtAsyncFunctionDef) -> Self {
         AnyNodeRef::StmtAsyncFunctionDef(node)
     }
 }
 
-impl<'a> From<&'a StmtClassDef> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtClassDef) -> Self {
+impl<'a> From<&'a ast::StmtClassDef> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtClassDef) -> Self {
         AnyNodeRef::StmtClassDef(node)
     }
 }
 
-impl<'a> From<&'a StmtReturn> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtReturn) -> Self {
+impl<'a> From<&'a ast::StmtReturn> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtReturn) -> Self {
         AnyNodeRef::StmtReturn(node)
     }
 }
 
-impl<'a> From<&'a StmtDelete> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtDelete) -> Self {
+impl<'a> From<&'a ast::StmtDelete> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtDelete) -> Self {
         AnyNodeRef::StmtDelete(node)
     }
 }
 
-impl<'a> From<&'a StmtAssign> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtAssign) -> Self {
+impl<'a> From<&'a ast::StmtAssign> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtAssign) -> Self {
         AnyNodeRef::StmtAssign(node)
     }
 }
 
-impl<'a> From<&'a StmtAugAssign> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtAugAssign) -> Self {
+impl<'a> From<&'a ast::StmtAugAssign> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtAugAssign) -> Self {
         AnyNodeRef::StmtAugAssign(node)
     }
 }
 
-impl<'a> From<&'a StmtAnnAssign> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtAnnAssign) -> Self {
+impl<'a> From<&'a ast::StmtAnnAssign> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtAnnAssign) -> Self {
         AnyNodeRef::StmtAnnAssign(node)
     }
 }
 
-impl<'a> From<&'a StmtFor> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtFor) -> Self {
+impl<'a> From<&'a ast::StmtFor> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtFor) -> Self {
         AnyNodeRef::StmtFor(node)
     }
 }
 
-impl<'a> From<&'a StmtAsyncFor> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtAsyncFor) -> Self {
+impl<'a> From<&'a ast::StmtAsyncFor> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtAsyncFor) -> Self {
         AnyNodeRef::StmtAsyncFor(node)
     }
 }
 
-impl<'a> From<&'a StmtWhile> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtWhile) -> Self {
+impl<'a> From<&'a ast::StmtWhile> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtWhile) -> Self {
         AnyNodeRef::StmtWhile(node)
     }
 }
 
-impl<'a> From<&'a StmtIf> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtIf) -> Self {
+impl<'a> From<&'a ast::StmtIf> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtIf) -> Self {
         AnyNodeRef::StmtIf(node)
     }
 }
 
-impl<'a> From<&'a StmtWith> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtWith) -> Self {
+impl<'a> From<&'a ast::StmtWith> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtWith) -> Self {
         AnyNodeRef::StmtWith(node)
     }
 }
 
-impl<'a> From<&'a StmtAsyncWith> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtAsyncWith) -> Self {
+impl<'a> From<&'a ast::StmtAsyncWith> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtAsyncWith) -> Self {
         AnyNodeRef::StmtAsyncWith(node)
     }
 }
 
-impl<'a> From<&'a StmtMatch> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtMatch) -> Self {
+impl<'a> From<&'a ast::StmtMatch> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtMatch) -> Self {
         AnyNodeRef::StmtMatch(node)
     }
 }
 
-impl<'a> From<&'a StmtRaise> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtRaise) -> Self {
+impl<'a> From<&'a ast::StmtRaise> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtRaise) -> Self {
         AnyNodeRef::StmtRaise(node)
     }
 }
 
-impl<'a> From<&'a StmtTry> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtTry) -> Self {
+impl<'a> From<&'a ast::StmtTry> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtTry) -> Self {
         AnyNodeRef::StmtTry(node)
     }
 }
 
-impl<'a> From<&'a StmtTryStar> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtTryStar) -> Self {
+impl<'a> From<&'a ast::StmtTryStar> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtTryStar) -> Self {
         AnyNodeRef::StmtTryStar(node)
     }
 }
 
-impl<'a> From<&'a StmtAssert> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtAssert) -> Self {
+impl<'a> From<&'a ast::StmtAssert> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtAssert) -> Self {
         AnyNodeRef::StmtAssert(node)
     }
 }
 
-impl<'a> From<&'a StmtImport> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtImport) -> Self {
+impl<'a> From<&'a ast::StmtImport> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtImport) -> Self {
         AnyNodeRef::StmtImport(node)
     }
 }
 
-impl<'a> From<&'a StmtImportFrom> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtImportFrom) -> Self {
+impl<'a> From<&'a ast::StmtImportFrom> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtImportFrom) -> Self {
         AnyNodeRef::StmtImportFrom(node)
     }
 }
 
-impl<'a> From<&'a StmtGlobal> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtGlobal) -> Self {
+impl<'a> From<&'a ast::StmtGlobal> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtGlobal) -> Self {
         AnyNodeRef::StmtGlobal(node)
     }
 }
 
-impl<'a> From<&'a StmtNonlocal> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtNonlocal) -> Self {
+impl<'a> From<&'a ast::StmtNonlocal> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtNonlocal) -> Self {
         AnyNodeRef::StmtNonlocal(node)
     }
 }
 
-impl<'a> From<&'a StmtExpr> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtExpr) -> Self {
+impl<'a> From<&'a ast::StmtExpr> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtExpr) -> Self {
         AnyNodeRef::StmtExpr(node)
     }
 }
 
-impl<'a> From<&'a StmtPass> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtPass) -> Self {
+impl<'a> From<&'a ast::StmtPass> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtPass) -> Self {
         AnyNodeRef::StmtPass(node)
     }
 }
 
-impl<'a> From<&'a StmtBreak> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtBreak) -> Self {
+impl<'a> From<&'a ast::StmtBreak> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtBreak) -> Self {
         AnyNodeRef::StmtBreak(node)
     }
 }
 
-impl<'a> From<&'a StmtContinue> for AnyNodeRef<'a> {
-    fn from(node: &'a StmtContinue) -> Self {
+impl<'a> From<&'a ast::StmtContinue> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::StmtContinue) -> Self {
         AnyNodeRef::StmtContinue(node)
     }
 }
 
-impl<'a> From<&'a ExprBoolOp> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprBoolOp) -> Self {
+impl<'a> From<&'a ast::ExprBoolOp> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprBoolOp) -> Self {
         AnyNodeRef::ExprBoolOp(node)
     }
 }
 
-impl<'a> From<&'a ExprNamedExpr> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprNamedExpr) -> Self {
+impl<'a> From<&'a ast::ExprNamedExpr> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprNamedExpr) -> Self {
         AnyNodeRef::ExprNamedExpr(node)
     }
 }
 
-impl<'a> From<&'a ExprBinOp> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprBinOp) -> Self {
+impl<'a> From<&'a ast::ExprBinOp> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprBinOp) -> Self {
         AnyNodeRef::ExprBinOp(node)
     }
 }
 
-impl<'a> From<&'a ExprUnaryOp> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprUnaryOp) -> Self {
+impl<'a> From<&'a ast::ExprUnaryOp> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprUnaryOp) -> Self {
         AnyNodeRef::ExprUnaryOp(node)
     }
 }
 
-impl<'a> From<&'a ExprLambda> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprLambda) -> Self {
+impl<'a> From<&'a ast::ExprLambda> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprLambda) -> Self {
         AnyNodeRef::ExprLambda(node)
     }
 }
 
-impl<'a> From<&'a ExprIfExp> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprIfExp) -> Self {
+impl<'a> From<&'a ast::ExprIfExp> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprIfExp) -> Self {
         AnyNodeRef::ExprIfExp(node)
     }
 }
 
-impl<'a> From<&'a ExprDict> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprDict) -> Self {
+impl<'a> From<&'a ast::ExprDict> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprDict) -> Self {
         AnyNodeRef::ExprDict(node)
     }
 }
 
-impl<'a> From<&'a ExprSet> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprSet) -> Self {
+impl<'a> From<&'a ast::ExprSet> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprSet) -> Self {
         AnyNodeRef::ExprSet(node)
     }
 }
 
-impl<'a> From<&'a ExprListComp> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprListComp) -> Self {
+impl<'a> From<&'a ast::ExprListComp> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprListComp) -> Self {
         AnyNodeRef::ExprListComp(node)
     }
 }
 
-impl<'a> From<&'a ExprSetComp> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprSetComp) -> Self {
+impl<'a> From<&'a ast::ExprSetComp> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprSetComp) -> Self {
         AnyNodeRef::ExprSetComp(node)
     }
 }
 
-impl<'a> From<&'a ExprDictComp> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprDictComp) -> Self {
+impl<'a> From<&'a ast::ExprDictComp> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprDictComp) -> Self {
         AnyNodeRef::ExprDictComp(node)
     }
 }
 
-impl<'a> From<&'a ExprGeneratorExp> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprGeneratorExp) -> Self {
+impl<'a> From<&'a ast::ExprGeneratorExp> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprGeneratorExp) -> Self {
         AnyNodeRef::ExprGeneratorExp(node)
     }
 }
 
-impl<'a> From<&'a ExprAwait> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprAwait) -> Self {
+impl<'a> From<&'a ast::ExprAwait> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprAwait) -> Self {
         AnyNodeRef::ExprAwait(node)
     }
 }
 
-impl<'a> From<&'a ExprYield> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprYield) -> Self {
+impl<'a> From<&'a ast::ExprYield> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprYield) -> Self {
         AnyNodeRef::ExprYield(node)
     }
 }
 
-impl<'a> From<&'a ExprYieldFrom> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprYieldFrom) -> Self {
+impl<'a> From<&'a ast::ExprYieldFrom> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprYieldFrom) -> Self {
         AnyNodeRef::ExprYieldFrom(node)
     }
 }
 
-impl<'a> From<&'a ExprCompare> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprCompare) -> Self {
+impl<'a> From<&'a ast::ExprCompare> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprCompare) -> Self {
         AnyNodeRef::ExprCompare(node)
     }
 }
 
-impl<'a> From<&'a ExprCall> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprCall) -> Self {
+impl<'a> From<&'a ast::ExprCall> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprCall) -> Self {
         AnyNodeRef::ExprCall(node)
     }
 }
 
-impl<'a> From<&'a ExprFormattedValue> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprFormattedValue) -> Self {
+impl<'a> From<&'a ast::ExprFormattedValue> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprFormattedValue) -> Self {
         AnyNodeRef::ExprFormattedValue(node)
     }
 }
 
-impl<'a> From<&'a ExprJoinedStr> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprJoinedStr) -> Self {
+impl<'a> From<&'a ast::ExprJoinedStr> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprJoinedStr) -> Self {
         AnyNodeRef::ExprJoinedStr(node)
     }
 }
 
-impl<'a> From<&'a ExprConstant> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprConstant) -> Self {
+impl<'a> From<&'a ast::ExprConstant> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprConstant) -> Self {
         AnyNodeRef::ExprConstant(node)
     }
 }
 
-impl<'a> From<&'a ExprAttribute> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprAttribute) -> Self {
+impl<'a> From<&'a ast::ExprAttribute> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprAttribute) -> Self {
         AnyNodeRef::ExprAttribute(node)
     }
 }
 
-impl<'a> From<&'a ExprSubscript> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprSubscript) -> Self {
+impl<'a> From<&'a ast::ExprSubscript> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprSubscript) -> Self {
         AnyNodeRef::ExprSubscript(node)
     }
 }
 
-impl<'a> From<&'a ExprStarred> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprStarred) -> Self {
+impl<'a> From<&'a ast::ExprStarred> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprStarred) -> Self {
         AnyNodeRef::ExprStarred(node)
     }
 }
 
-impl<'a> From<&'a ExprName> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprName) -> Self {
+impl<'a> From<&'a ast::ExprName> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprName) -> Self {
         AnyNodeRef::ExprName(node)
     }
 }
 
-impl<'a> From<&'a ExprList> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprList) -> Self {
+impl<'a> From<&'a ast::ExprList> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprList) -> Self {
         AnyNodeRef::ExprList(node)
     }
 }
 
-impl<'a> From<&'a ExprTuple> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprTuple) -> Self {
+impl<'a> From<&'a ast::ExprTuple> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprTuple) -> Self {
         AnyNodeRef::ExprTuple(node)
     }
 }
 
-impl<'a> From<&'a ExprSlice> for AnyNodeRef<'a> {
-    fn from(node: &'a ExprSlice) -> Self {
+impl<'a> From<&'a ast::ExprSlice> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprSlice) -> Self {
         AnyNodeRef::ExprSlice(node)
     }
 }
 
-impl<'a> From<&'a ExceptHandlerExceptHandler> for AnyNodeRef<'a> {
-    fn from(node: &'a ExceptHandlerExceptHandler) -> Self {
+impl<'a> From<&'a ast::ExceptHandlerExceptHandler> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExceptHandlerExceptHandler) -> Self {
         AnyNodeRef::ExceptHandlerExceptHandler(node)
     }
 }
 
-impl<'a> From<&'a PatternMatchValue> for AnyNodeRef<'a> {
-    fn from(node: &'a PatternMatchValue) -> Self {
+impl<'a> From<&'a ast::PatternMatchValue> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::PatternMatchValue) -> Self {
         AnyNodeRef::PatternMatchValue(node)
     }
 }
 
-impl<'a> From<&'a PatternMatchSingleton> for AnyNodeRef<'a> {
-    fn from(node: &'a PatternMatchSingleton) -> Self {
+impl<'a> From<&'a ast::PatternMatchSingleton> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::PatternMatchSingleton) -> Self {
         AnyNodeRef::PatternMatchSingleton(node)
     }
 }
 
-impl<'a> From<&'a PatternMatchSequence> for AnyNodeRef<'a> {
-    fn from(node: &'a PatternMatchSequence) -> Self {
+impl<'a> From<&'a ast::PatternMatchSequence> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::PatternMatchSequence) -> Self {
         AnyNodeRef::PatternMatchSequence(node)
     }
 }
 
-impl<'a> From<&'a PatternMatchMapping> for AnyNodeRef<'a> {
-    fn from(node: &'a PatternMatchMapping) -> Self {
+impl<'a> From<&'a ast::PatternMatchMapping> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::PatternMatchMapping) -> Self {
         AnyNodeRef::PatternMatchMapping(node)
     }
 }
 
-impl<'a> From<&'a PatternMatchClass> for AnyNodeRef<'a> {
-    fn from(node: &'a PatternMatchClass) -> Self {
+impl<'a> From<&'a ast::PatternMatchClass> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::PatternMatchClass) -> Self {
         AnyNodeRef::PatternMatchClass(node)
     }
 }
 
-impl<'a> From<&'a PatternMatchStar> for AnyNodeRef<'a> {
-    fn from(node: &'a PatternMatchStar) -> Self {
+impl<'a> From<&'a ast::PatternMatchStar> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::PatternMatchStar) -> Self {
         AnyNodeRef::PatternMatchStar(node)
     }
 }
 
-impl<'a> From<&'a PatternMatchAs> for AnyNodeRef<'a> {
-    fn from(node: &'a PatternMatchAs) -> Self {
+impl<'a> From<&'a ast::PatternMatchAs> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::PatternMatchAs) -> Self {
         AnyNodeRef::PatternMatchAs(node)
     }
 }
 
-impl<'a> From<&'a PatternMatchOr> for AnyNodeRef<'a> {
-    fn from(node: &'a PatternMatchOr) -> Self {
+impl<'a> From<&'a ast::PatternMatchOr> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::PatternMatchOr) -> Self {
         AnyNodeRef::PatternMatchOr(node)
     }
 }
 
-impl<'a> From<&'a TypeIgnoreTypeIgnore> for AnyNodeRef<'a> {
-    fn from(node: &'a TypeIgnoreTypeIgnore) -> Self {
+impl<'a> From<&'a ast::TypeIgnoreTypeIgnore> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::TypeIgnoreTypeIgnore) -> Self {
         AnyNodeRef::TypeIgnoreTypeIgnore(node)
     }
 }

--- a/crates/ruff_python_ast/src/prelude.rs
+++ b/crates/ruff_python_ast/src/prelude.rs
@@ -1,3 +1,0 @@
-pub use crate::node::AstNode;
-pub use rustpython_ast::*;
-pub use rustpython_parser::*;

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -2,10 +2,9 @@
 
 pub mod preorder;
 
-use rustpython_ast::Decorator;
 use rustpython_parser::ast::{
-    self, Alias, Arg, Arguments, BoolOp, CmpOp, Comprehension, Constant, ExceptHandler, Expr,
-    ExprContext, Keyword, MatchCase, Operator, Pattern, Stmt, UnaryOp, WithItem,
+    self, Alias, Arg, Arguments, BoolOp, CmpOp, Comprehension, Constant, Decorator, ExceptHandler,
+    Expr, ExprContext, Keyword, MatchCase, Operator, Pattern, Stmt, UnaryOp, WithItem,
 };
 
 /// A trait for AST visitors. Visits all nodes in the AST recursively in evaluation-order.

--- a/crates/ruff_python_ast/src/visitor/preorder.rs
+++ b/crates/ruff_python_ast/src/visitor/preorder.rs
@@ -1,4 +1,8 @@
-use crate::prelude::*;
+use rustpython_ast::{ArgWithDefault, Mod, TypeIgnore};
+use rustpython_parser::ast::{
+    self, Alias, Arg, Arguments, BoolOp, CmpOp, Comprehension, Constant, Decorator, ExceptHandler,
+    Expr, Keyword, MatchCase, Operator, Pattern, Stmt, UnaryOp, WithItem,
+};
 
 /// Visitor that traverses all nodes recursively in pre-order.
 pub trait PreorderVisitor<'a> {
@@ -100,7 +104,7 @@ where
     V: PreorderVisitor<'a> + ?Sized,
 {
     match module {
-        Mod::Module(ModModule {
+        Mod::Module(ast::ModModule {
             body,
             range: _,
             type_ignores,
@@ -110,9 +114,9 @@ where
                 visitor.visit_type_ignore(ignore);
             }
         }
-        Mod::Interactive(ModInteractive { body, range: _ }) => visitor.visit_body(body),
-        Mod::Expression(ModExpression { body, range: _ }) => visitor.visit_expr(body),
-        Mod::FunctionType(ModFunctionType {
+        Mod::Interactive(ast::ModInteractive { body, range: _ }) => visitor.visit_body(body),
+        Mod::Expression(ast::ModExpression { body, range: _ }) => visitor.visit_expr(body),
+        Mod::FunctionType(ast::ModFunctionType {
             range: _,
             argtypes,
             returns,
@@ -140,19 +144,19 @@ where
     V: PreorderVisitor<'a> + ?Sized,
 {
     match stmt {
-        Stmt::Expr(StmtExpr {
+        Stmt::Expr(ast::StmtExpr {
             value,
             range: _range,
         }) => visitor.visit_expr(value),
 
-        Stmt::FunctionDef(StmtFunctionDef {
+        Stmt::FunctionDef(ast::StmtFunctionDef {
             args,
             body,
             decorator_list,
             returns,
             ..
         })
-        | Stmt::AsyncFunctionDef(StmtAsyncFunctionDef {
+        | Stmt::AsyncFunctionDef(ast::StmtAsyncFunctionDef {
             args,
             body,
             decorator_list,
@@ -172,7 +176,7 @@ where
             visitor.visit_body(body);
         }
 
-        Stmt::ClassDef(StmtClassDef {
+        Stmt::ClassDef(ast::StmtClassDef {
             bases,
             keywords,
             body,
@@ -194,7 +198,7 @@ where
             visitor.visit_body(body);
         }
 
-        Stmt::Return(StmtReturn {
+        Stmt::Return(ast::StmtReturn {
             value,
             range: _range,
         }) => {
@@ -203,7 +207,7 @@ where
             }
         }
 
-        Stmt::Delete(StmtDelete {
+        Stmt::Delete(ast::StmtDelete {
             targets,
             range: _range,
         }) => {
@@ -212,7 +216,7 @@ where
             }
         }
 
-        Stmt::Assign(StmtAssign {
+        Stmt::Assign(ast::StmtAssign {
             targets,
             value,
             range: _,
@@ -225,7 +229,7 @@ where
             visitor.visit_expr(value);
         }
 
-        Stmt::AugAssign(StmtAugAssign {
+        Stmt::AugAssign(ast::StmtAugAssign {
             target,
             op,
             value,
@@ -236,7 +240,7 @@ where
             visitor.visit_expr(value);
         }
 
-        Stmt::AnnAssign(StmtAnnAssign {
+        Stmt::AnnAssign(ast::StmtAnnAssign {
             target,
             annotation,
             value,
@@ -250,14 +254,14 @@ where
             }
         }
 
-        Stmt::For(StmtFor {
+        Stmt::For(ast::StmtFor {
             target,
             iter,
             body,
             orelse,
             ..
         })
-        | Stmt::AsyncFor(StmtAsyncFor {
+        | Stmt::AsyncFor(ast::StmtAsyncFor {
             target,
             iter,
             body,
@@ -270,7 +274,7 @@ where
             visitor.visit_body(orelse);
         }
 
-        Stmt::While(StmtWhile {
+        Stmt::While(ast::StmtWhile {
             test,
             body,
             orelse,
@@ -281,7 +285,7 @@ where
             visitor.visit_body(orelse);
         }
 
-        Stmt::If(StmtIf {
+        Stmt::If(ast::StmtIf {
             test,
             body,
             orelse,
@@ -292,13 +296,13 @@ where
             visitor.visit_body(orelse);
         }
 
-        Stmt::With(StmtWith {
+        Stmt::With(ast::StmtWith {
             items,
             body,
             type_comment: _,
             range: _,
         })
-        | Stmt::AsyncWith(StmtAsyncWith {
+        | Stmt::AsyncWith(ast::StmtAsyncWith {
             items,
             body,
             type_comment: _,
@@ -310,7 +314,7 @@ where
             visitor.visit_body(body);
         }
 
-        Stmt::Match(StmtMatch {
+        Stmt::Match(ast::StmtMatch {
             subject,
             cases,
             range: _range,
@@ -321,7 +325,7 @@ where
             }
         }
 
-        Stmt::Raise(StmtRaise {
+        Stmt::Raise(ast::StmtRaise {
             exc,
             cause,
             range: _range,
@@ -334,14 +338,14 @@ where
             };
         }
 
-        Stmt::Try(StmtTry {
+        Stmt::Try(ast::StmtTry {
             body,
             handlers,
             orelse,
             finalbody,
             range: _range,
         })
-        | Stmt::TryStar(StmtTryStar {
+        | Stmt::TryStar(ast::StmtTryStar {
             body,
             handlers,
             orelse,
@@ -356,7 +360,7 @@ where
             visitor.visit_body(finalbody);
         }
 
-        Stmt::Assert(StmtAssert {
+        Stmt::Assert(ast::StmtAssert {
             test,
             msg,
             range: _range,
@@ -367,7 +371,7 @@ where
             }
         }
 
-        Stmt::Import(StmtImport {
+        Stmt::Import(ast::StmtImport {
             names,
             range: _range,
         }) => {
@@ -376,7 +380,7 @@ where
             }
         }
 
-        Stmt::ImportFrom(StmtImportFrom {
+        Stmt::ImportFrom(ast::StmtImportFrom {
             range: _,
             module: _,
             names,
@@ -411,7 +415,7 @@ where
     V: PreorderVisitor<'a> + ?Sized,
 {
     match expr {
-        Expr::BoolOp(ExprBoolOp {
+        Expr::BoolOp(ast::ExprBoolOp {
             op,
             values,
             range: _range,
@@ -428,7 +432,7 @@ where
             }
         },
 
-        Expr::NamedExpr(ExprNamedExpr {
+        Expr::NamedExpr(ast::ExprNamedExpr {
             target,
             value,
             range: _range,
@@ -437,7 +441,7 @@ where
             visitor.visit_expr(value);
         }
 
-        Expr::BinOp(ExprBinOp {
+        Expr::BinOp(ast::ExprBinOp {
             left,
             op,
             right,
@@ -448,7 +452,7 @@ where
             visitor.visit_expr(right);
         }
 
-        Expr::UnaryOp(ExprUnaryOp {
+        Expr::UnaryOp(ast::ExprUnaryOp {
             op,
             operand,
             range: _range,
@@ -457,7 +461,7 @@ where
             visitor.visit_expr(operand);
         }
 
-        Expr::Lambda(ExprLambda {
+        Expr::Lambda(ast::ExprLambda {
             args,
             body,
             range: _range,
@@ -466,7 +470,7 @@ where
             visitor.visit_expr(body);
         }
 
-        Expr::IfExp(ExprIfExp {
+        Expr::IfExp(ast::ExprIfExp {
             test,
             body,
             orelse,
@@ -477,7 +481,7 @@ where
             visitor.visit_expr(orelse);
         }
 
-        Expr::Dict(ExprDict {
+        Expr::Dict(ast::ExprDict {
             keys,
             values,
             range: _range,
@@ -490,7 +494,7 @@ where
             }
         }
 
-        Expr::Set(ExprSet {
+        Expr::Set(ast::ExprSet {
             elts,
             range: _range,
         }) => {
@@ -499,7 +503,7 @@ where
             }
         }
 
-        Expr::ListComp(ExprListComp {
+        Expr::ListComp(ast::ExprListComp {
             elt,
             generators,
             range: _range,
@@ -510,7 +514,7 @@ where
             }
         }
 
-        Expr::SetComp(ExprSetComp {
+        Expr::SetComp(ast::ExprSetComp {
             elt,
             generators,
             range: _range,
@@ -521,7 +525,7 @@ where
             }
         }
 
-        Expr::DictComp(ExprDictComp {
+        Expr::DictComp(ast::ExprDictComp {
             key,
             value,
             generators,
@@ -535,7 +539,7 @@ where
             }
         }
 
-        Expr::GeneratorExp(ExprGeneratorExp {
+        Expr::GeneratorExp(ast::ExprGeneratorExp {
             elt,
             generators,
             range: _range,
@@ -546,16 +550,16 @@ where
             }
         }
 
-        Expr::Await(ExprAwait {
+        Expr::Await(ast::ExprAwait {
             value,
             range: _range,
         })
-        | Expr::YieldFrom(ExprYieldFrom {
+        | Expr::YieldFrom(ast::ExprYieldFrom {
             value,
             range: _range,
         }) => visitor.visit_expr(value),
 
-        Expr::Yield(ExprYield {
+        Expr::Yield(ast::ExprYield {
             value,
             range: _range,
         }) => {
@@ -564,7 +568,7 @@ where
             }
         }
 
-        Expr::Compare(ExprCompare {
+        Expr::Compare(ast::ExprCompare {
             left,
             ops,
             comparators,
@@ -578,7 +582,7 @@ where
             }
         }
 
-        Expr::Call(ExprCall {
+        Expr::Call(ast::ExprCall {
             func,
             args,
             keywords,
@@ -593,7 +597,7 @@ where
             }
         }
 
-        Expr::FormattedValue(ExprFormattedValue {
+        Expr::FormattedValue(ast::ExprFormattedValue {
             value, format_spec, ..
         }) => {
             visitor.visit_expr(value);
@@ -603,7 +607,7 @@ where
             }
         }
 
-        Expr::JoinedStr(ExprJoinedStr {
+        Expr::JoinedStr(ast::ExprJoinedStr {
             values,
             range: _range,
         }) => {
@@ -612,13 +616,13 @@ where
             }
         }
 
-        Expr::Constant(ExprConstant {
+        Expr::Constant(ast::ExprConstant {
             value,
             range: _,
             kind: _,
         }) => visitor.visit_constant(value),
 
-        Expr::Attribute(ExprAttribute {
+        Expr::Attribute(ast::ExprAttribute {
             value,
             attr: _,
             ctx: _,
@@ -627,7 +631,7 @@ where
             visitor.visit_expr(value);
         }
 
-        Expr::Subscript(ExprSubscript {
+        Expr::Subscript(ast::ExprSubscript {
             value,
             slice,
             ctx: _,
@@ -636,7 +640,7 @@ where
             visitor.visit_expr(value);
             visitor.visit_expr(slice);
         }
-        Expr::Starred(ExprStarred {
+        Expr::Starred(ast::ExprStarred {
             value,
             ctx: _,
             range: _range,
@@ -644,13 +648,13 @@ where
             visitor.visit_expr(value);
         }
 
-        Expr::Name(ExprName {
+        Expr::Name(ast::ExprName {
             id: _,
             ctx: _,
             range: _,
         }) => {}
 
-        Expr::List(ExprList {
+        Expr::List(ast::ExprList {
             elts,
             ctx: _,
             range: _range,
@@ -659,7 +663,7 @@ where
                 visitor.visit_expr(expr);
             }
         }
-        Expr::Tuple(ExprTuple {
+        Expr::Tuple(ast::ExprTuple {
             elts,
             ctx: _,
             range: _range,
@@ -669,7 +673,7 @@ where
             }
         }
 
-        Expr::Slice(ExprSlice {
+        Expr::Slice(ast::ExprSlice {
             lower,
             upper,
             step,
@@ -716,7 +720,7 @@ where
     V: PreorderVisitor<'a> + ?Sized,
 {
     match except_handler {
-        ExceptHandler::ExceptHandler(ExceptHandlerExceptHandler {
+        ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler {
             range: _,
             type_,
             name: _,
@@ -812,19 +816,19 @@ where
     V: PreorderVisitor<'a> + ?Sized,
 {
     match pattern {
-        Pattern::MatchValue(PatternMatchValue {
+        Pattern::MatchValue(ast::PatternMatchValue {
             value,
             range: _range,
         }) => visitor.visit_expr(value),
 
-        Pattern::MatchSingleton(PatternMatchSingleton {
+        Pattern::MatchSingleton(ast::PatternMatchSingleton {
             value,
             range: _range,
         }) => {
             visitor.visit_constant(value);
         }
 
-        Pattern::MatchSequence(PatternMatchSequence {
+        Pattern::MatchSequence(ast::PatternMatchSequence {
             patterns,
             range: _range,
         }) => {
@@ -833,7 +837,7 @@ where
             }
         }
 
-        Pattern::MatchMapping(PatternMatchMapping {
+        Pattern::MatchMapping(ast::PatternMatchMapping {
             keys,
             patterns,
             range: _,
@@ -845,7 +849,7 @@ where
             }
         }
 
-        Pattern::MatchClass(PatternMatchClass {
+        Pattern::MatchClass(ast::PatternMatchClass {
             cls,
             patterns,
             kwd_attrs: _,
@@ -864,7 +868,7 @@ where
 
         Pattern::MatchStar(_) => {}
 
-        Pattern::MatchAs(PatternMatchAs {
+        Pattern::MatchAs(ast::PatternMatchAs {
             pattern,
             range: _,
             name: _,
@@ -874,7 +878,7 @@ where
             }
         }
 
-        Pattern::MatchOr(PatternMatchOr {
+        Pattern::MatchOr(ast::PatternMatchOr {
             patterns,
             range: _range,
         }) => {
@@ -928,18 +932,20 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::{Debug, Write};
+
+    use insta::assert_snapshot;
+    use rustpython_parser::lexer::lex;
+    use rustpython_parser::{parse_tokens, Mode};
+
     use crate::node::AnyNodeRef;
     use crate::visitor::preorder::{
         walk_alias, walk_arg, walk_arguments, walk_comprehension, walk_except_handler, walk_expr,
         walk_keyword, walk_match_case, walk_module, walk_pattern, walk_stmt, walk_type_ignore,
         walk_with_item, Alias, Arg, Arguments, BoolOp, CmpOp, Comprehension, Constant,
         ExceptHandler, Expr, Keyword, MatchCase, Mod, Operator, Pattern, PreorderVisitor, Stmt,
-        String, TypeIgnore, UnaryOp, WithItem,
+        TypeIgnore, UnaryOp, WithItem,
     };
-    use insta::assert_snapshot;
-    use rustpython_parser::lexer::lex;
-    use rustpython_parser::{parse_tokens, Mode};
-    use std::fmt::{Debug, Write};
 
     #[test]
     fn function_arguments() {

--- a/crates/ruff_python_formatter/src/comments/debug.rs
+++ b/crates/ruff_python_formatter/src/comments/debug.rs
@@ -1,9 +1,12 @@
+use std::fmt::{Debug, Formatter, Write};
+
+use itertools::Itertools;
+use rustpython_parser::ast::Ranged;
+
+use ruff_formatter::SourceCode;
+
 use crate::comments::node_key::NodeRefEqualityKey;
 use crate::comments::{CommentsMap, SourceComment};
-use itertools::Itertools;
-use ruff_formatter::SourceCode;
-use ruff_python_ast::prelude::*;
-use std::fmt::{Debug, Formatter, Write};
 
 /// Prints a debug representation of [`SourceComment`] that includes the comment's text
 pub(crate) struct DebugComment<'a> {
@@ -176,13 +179,15 @@ impl Debug for DebugNodeCommentSlice<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::comments::map::MultiMap;
-    use crate::comments::{CommentLinePosition, Comments, CommentsMap, SourceComment};
     use insta::assert_debug_snapshot;
-    use ruff_formatter::SourceCode;
-    use ruff_python_ast::node::AnyNode;
     use ruff_text_size::{TextRange, TextSize};
     use rustpython_parser::ast::{StmtBreak, StmtContinue};
+
+    use ruff_formatter::SourceCode;
+    use ruff_python_ast::node::AnyNode;
+
+    use crate::comments::map::MultiMap;
+    use crate::comments::{CommentLinePosition, Comments, CommentsMap, SourceComment};
 
     #[test]
     fn debug() {

--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -1,12 +1,13 @@
+use ruff_text_size::{TextLen, TextRange, TextSize};
+use rustpython_parser::ast::Ranged;
+
+use ruff_formatter::{format_args, write, FormatError, SourceCode};
+use ruff_python_ast::node::{AnyNodeRef, AstNode};
+
 use crate::comments::SourceComment;
 use crate::context::NodeLevel;
 use crate::prelude::*;
 use crate::trivia::{lines_after, lines_before, skip_trailing_trivia};
-use ruff_formatter::{format_args, write, FormatError, SourceCode};
-use ruff_python_ast::node::AnyNodeRef;
-use ruff_python_ast::prelude::AstNode;
-use ruff_text_size::{TextLen, TextRange, TextSize};
-use rustpython_parser::ast::Ranged;
 
 /// Formats the leading comments of a node.
 pub(crate) fn leading_node_comments<T>(node: &T) -> FormatLeadingComments
@@ -69,7 +70,7 @@ where
 {
     FormatLeadingAlternateBranchComments {
         comments,
-        last_node: last_node.map(std::convert::Into::into),
+        last_node: last_node.map(Into::into),
     }
 }
 

--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -87,10 +87,12 @@
 //!
 //! It is possible to add an additional optional label to [`SourceComment`] If ever the need arises to distinguish two *dangling comments* in the formatting logic,
 
-use crate::comments::debug::{DebugComment, DebugComments};
-use crate::comments::map::MultiMap;
-use crate::comments::node_key::NodeRefEqualityKey;
-use crate::comments::visitor::CommentsVisitor;
+use std::cell::Cell;
+use std::fmt::Debug;
+use std::rc::Rc;
+
+use rustpython_parser::ast::Mod;
+
 pub(crate) use format::{
     dangling_comments, dangling_node_comments, leading_alternate_branch_comments, leading_comments,
     leading_node_comments, trailing_comments, trailing_node_comments,
@@ -98,10 +100,11 @@ pub(crate) use format::{
 use ruff_formatter::{SourceCode, SourceCodeSlice};
 use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::source_code::CommentRanges;
-use rustpython_parser::ast::Mod;
-use std::cell::Cell;
-use std::fmt::Debug;
-use std::rc::Rc;
+
+use crate::comments::debug::{DebugComment, DebugComments};
+use crate::comments::map::MultiMap;
+use crate::comments::node_key::NodeRefEqualityKey;
+use crate::comments::visitor::CommentsVisitor;
 
 mod debug;
 mod format;
@@ -404,13 +407,15 @@ struct CommentsData<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::comments::Comments;
     use insta::assert_debug_snapshot;
-    use ruff_formatter::SourceCode;
-    use ruff_python_ast::prelude::*;
-    use ruff_python_ast::source_code::{CommentRanges, CommentRangesBuilder};
+    use rustpython_parser::ast::Mod;
     use rustpython_parser::lexer::lex;
     use rustpython_parser::{parse_tokens, Mode};
+
+    use ruff_formatter::SourceCode;
+    use ruff_python_ast::source_code::{CommentRanges, CommentRangesBuilder};
+
+    use crate::comments::Comments;
 
     struct CommentsTestCase<'a> {
         module: Mod,

--- a/crates/ruff_python_formatter/src/comments/visitor.rs
+++ b/crates/ruff_python_formatter/src/comments/visitor.rs
@@ -1,17 +1,23 @@
-use crate::comments::node_key::NodeRefEqualityKey;
-use crate::comments::placement::place_comment;
-use crate::comments::{CommentLinePosition, CommentsMap, SourceComment};
+use std::iter::Peekable;
+
+use ruff_text_size::{TextRange, TextSize};
+use rustpython_parser::ast::{
+    Alias, Arg, ArgWithDefault, Arguments, Comprehension, Decorator, ExceptHandler, Expr, Keyword,
+    MatchCase, Mod, Pattern, Ranged, Stmt, WithItem,
+};
+
 use ruff_formatter::{SourceCode, SourceCodeSlice};
 use ruff_python_ast::node::AnyNodeRef;
-use ruff_python_ast::prelude::*;
 use ruff_python_ast::source_code::{CommentRanges, Locator};
 // The interface is designed to only export the members relevant for iterating nodes in
 // pre-order.
 #[allow(clippy::wildcard_imports)]
 use ruff_python_ast::visitor::preorder::*;
 use ruff_python_whitespace::is_python_whitespace;
-use ruff_text_size::TextRange;
-use std::iter::Peekable;
+
+use crate::comments::node_key::NodeRefEqualityKey;
+use crate::comments::placement::place_comment;
+use crate::comments::{CommentLinePosition, CommentsMap, SourceComment};
 
 /// Visitor extracting the comments from an AST.
 #[derive(Debug, Clone)]

--- a/crates/ruff_python_formatter/src/expression/binary_like.rs
+++ b/crates/ruff_python_formatter/src/expression/binary_like.rs
@@ -1,10 +1,12 @@
 //! This module provides helper utilities to format an expression that has a left side, an operator,
 //! and a right side (binary like).
 
+use rustpython_parser::ast::{self, Expr};
+
+use ruff_formatter::{format_args, write};
+
 use crate::expression::parentheses::Parentheses;
 use crate::prelude::*;
-use ruff_formatter::{format_args, write};
-use rustpython_parser::ast::Expr;
 
 /// Trait to implement a binary like syntax that has a left operand, an operator, and a right operand.
 pub(super) trait FormatBinaryLike<'ast> {
@@ -133,25 +135,25 @@ pub(super) trait FormatBinaryLike<'ast> {
 }
 
 fn can_break_expr(expr: &Expr) -> bool {
-    use ruff_python_ast::prelude::*;
-
     match expr {
-        Expr::Tuple(ExprTuple {
+        Expr::Tuple(ast::ExprTuple {
             elts: expressions, ..
         })
-        | Expr::List(ExprList {
+        | Expr::List(ast::ExprList {
             elts: expressions, ..
         })
-        | Expr::Set(ExprSet {
+        | Expr::Set(ast::ExprSet {
             elts: expressions, ..
         })
-        | Expr::Dict(ExprDict {
+        | Expr::Dict(ast::ExprDict {
             values: expressions,
             ..
         }) => !expressions.is_empty(),
-        Expr::Call(ExprCall { args, keywords, .. }) => !(args.is_empty() && keywords.is_empty()),
+        Expr::Call(ast::ExprCall { args, keywords, .. }) => {
+            !(args.is_empty() && keywords.is_empty())
+        }
         Expr::ListComp(_) | Expr::SetComp(_) | Expr::DictComp(_) | Expr::GeneratorExp(_) => true,
-        Expr::UnaryOp(ExprUnaryOp { operand, .. }) => match operand.as_ref() {
+        Expr::UnaryOp(ast::ExprUnaryOp { operand, .. }) => match operand.as_ref() {
             Expr::BinOp(_) => true,
             _ => can_break_expr(operand.as_ref()),
         },

--- a/crates/ruff_python_formatter/src/expression/expr_compare.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_compare.rs
@@ -8,7 +8,7 @@ use crate::FormatNodeRule;
 use ruff_formatter::{
     write, FormatError, FormatOwnedWithRule, FormatRefWithRule, FormatRuleWithOptions,
 };
-use ruff_python_ast::prelude::Expr;
+use rustpython_parser::ast::Expr;
 use rustpython_parser::ast::{CmpOp, ExprCompare};
 
 #[derive(Default)]

--- a/crates/ruff_python_formatter/src/expression/expr_dict.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_dict.rs
@@ -5,8 +5,8 @@ use crate::expression::parentheses::{
 use crate::prelude::*;
 use crate::FormatNodeRule;
 use ruff_formatter::{format_args, write};
-use ruff_python_ast::prelude::Ranged;
 use ruff_text_size::TextRange;
+use rustpython_parser::ast::Ranged;
 use rustpython_parser::ast::{Expr, ExprDict};
 
 #[derive(Default)]

--- a/crates/ruff_python_formatter/src/expression/expr_slice.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_slice.rs
@@ -8,9 +8,9 @@ use crate::{AsFormat, FormatNodeRule, PyFormatter};
 use ruff_formatter::prelude::{hard_line_break, line_suffix_boundary, space, text};
 use ruff_formatter::{write, Buffer, Format, FormatError, FormatResult};
 use ruff_python_ast::node::AstNode;
-use ruff_python_ast::prelude::{Expr, Ranged};
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::ExprSlice;
+use rustpython_parser::ast::{Expr, Ranged};
 
 #[derive(Default)]
 pub struct FormatExprSlice;

--- a/crates/ruff_python_formatter/src/expression/expr_tuple.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_tuple.rs
@@ -5,9 +5,9 @@ use crate::expression::parentheses::{
 };
 use crate::prelude::*;
 use ruff_formatter::{format_args, write, FormatRuleWithOptions};
-use ruff_python_ast::prelude::{Expr, Ranged};
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::ExprTuple;
+use rustpython_parser::ast::{Expr, Ranged};
 
 #[derive(Eq, PartialEq, Debug, Default)]
 pub enum TupleParentheses {

--- a/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
@@ -6,8 +6,8 @@ use crate::trivia::{SimpleTokenizer, TokenKind};
 use crate::{AsFormat, FormatNodeRule, PyFormatter};
 use ruff_formatter::prelude::{hard_line_break, space, text};
 use ruff_formatter::{Format, FormatContext, FormatResult};
-use ruff_python_ast::prelude::UnaryOp;
 use ruff_text_size::{TextLen, TextRange};
+use rustpython_parser::ast::UnaryOp;
 use rustpython_parser::ast::{ExprUnaryOp, Ranged};
 
 #[derive(Default)]

--- a/crates/ruff_python_formatter/src/statement/stmt_assign.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_assign.rs
@@ -4,7 +4,7 @@ use crate::{AsFormat, FormatNodeRule, PyFormatter};
 use ruff_formatter::formatter::Formatter;
 use ruff_formatter::prelude::{space, text};
 use ruff_formatter::{write, Buffer, Format, FormatResult};
-use ruff_python_ast::prelude::Expr;
+use rustpython_parser::ast::Expr;
 use rustpython_parser::ast::StmtAssign;
 
 // Note: This currently does wrap but not the black way so the types below likely need to be

--- a/crates/ruff_python_formatter/src/statement/stmt_with.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_with.rs
@@ -1,10 +1,12 @@
+use rustpython_parser::ast::StmtWith;
+
+use ruff_formatter::{write, Buffer, FormatResult};
+use ruff_python_ast::node::AstNode;
+
 use crate::builders::optional_parentheses;
 use crate::comments::trailing_comments;
 use crate::prelude::*;
 use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::{write, Buffer, FormatResult};
-use ruff_python_ast::prelude::*;
-use rustpython_parser::ast::StmtWith;
 
 #[derive(Default)]
 pub struct FormatStmtWith;

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,6 +24,9 @@ ruff_python_ast = { path = "../crates/ruff_python_ast" }
 ruff_python_formatter = { path = "../crates/ruff_python_formatter" }
 similar = { version = "2.2.1" }
 
+# Current tag: v0.0.6
+rustpython-parser = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "8078663b6c914c1cb86993e427764f7c422fc12c" , default-features = false, features = ["full-lexer", "num-bigint"] }
+
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]

--- a/fuzz/fuzz_targets/ruff_parse_simple.rs
+++ b/fuzz/fuzz_targets/ruff_parse_simple.rs
@@ -4,8 +4,9 @@
 #![no_main]
 
 use libfuzzer_sys::{fuzz_target, Corpus};
-use ruff_python_ast::prelude::{lexer, Mode, Parse, ParseError, Suite};
 use ruff_python_ast::source_code::{Generator, Locator, Stylist};
+use rustpython_parser::ast::Suite;
+use rustpython_parser::{lexer, Mode, Parse, ParseError};
 
 fn do_fuzz(case: &[u8]) -> Corpus {
     let Ok(code) = std::str::from_utf8(case) else { return Corpus::Reject; };


### PR DESCRIPTION
## Summary

Per @MichaReiser, this is causing more confusion than it is helpful.