### PR TITLE
Fix version number in playground

### DIFF
--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -9,6 +9,8 @@ pub use ruff_python_ast::source_code::round_trip;
 pub use rule_selector::RuleSelector;
 pub use rules::pycodestyle::rules::IOError;
 
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 mod autofix;
 mod checkers;
 mod codes;

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -21,8 +21,6 @@ use ruff::settings::{defaults, flags, Settings};
 use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::{Indexer, Locator, SourceLocation, Stylist};
 
-const VERSION: &str = env!("CARGO_PKG_VERSION");
-
 #[wasm_bindgen(typescript_custom_section)]
 const TYPES: &'static str = r#"
 export interface Diagnostic {
@@ -87,7 +85,7 @@ pub fn run() {
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 pub fn currentVersion() -> JsValue {
-    JsValue::from(VERSION)
+    JsValue::from(ruff::VERSION)
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
## Summary

`v0.0.275` in the top-right was showing `v0.0.0` at all times.

## Test Plan

![Screen Shot 2023-06-26 at 11 31 16 AM](https://github.com/astral-sh/ruff/assets/1309177/e6cd0e19-6a5f-4b46-a060-54f492524737)
