### PR TITLE
Fix autofix capabilities in playground

### DIFF
--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -18,7 +18,6 @@ use ruff::rules::{
 use ruff::settings::configuration::Configuration;
 use ruff::settings::options::Options;
 use ruff::settings::{defaults, flags, Settings};
-use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::{Indexer, Locator, SourceLocation, Stylist};
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -37,7 +36,7 @@ export interface Diagnostic {
     fix: {
         message: string | null;
         edits: {
-            content: string;
+            content: string | null;
             location: {
                 row: number;
                 column: number;
@@ -52,18 +51,25 @@ export interface Diagnostic {
 "#;
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
-pub struct ExpandedFix {
-    message: Option<String>,
-    edits: Vec<Edit>,
-}
-
-#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
 pub struct ExpandedMessage {
     pub code: String,
     pub message: String,
     pub location: SourceLocation,
     pub end_location: SourceLocation,
     pub fix: Option<ExpandedFix>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
+pub struct ExpandedFix {
+    message: Option<String>,
+    edits: Vec<ExpandedEdit>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
+struct ExpandedEdit {
+    location: SourceLocation,
+    end_location: SourceLocation,
+    content: Option<String>,
 }
 
 #[wasm_bindgen(start)]
@@ -220,7 +226,15 @@ pub fn check(contents: &str, options: JsValue) -> Result<JsValue, JsValue> {
                 end_location,
                 fix: message.fix.map(|fix| ExpandedFix {
                     message: message.kind.suggestion,
-                    edits: fix.into_edits(),
+                    edits: fix
+                        .into_edits()
+                        .into_iter()
+                        .map(|edit| ExpandedEdit {
+                            location: source_code.source_location(edit.start()),
+                            end_location: source_code.source_location(edit.end()),
+                            content: edit.content().map(ToString::to_string),
+                        })
+                        .collect(),
                 }),
             }
         })

--- a/playground/src/Editor/SourceEditor.tsx
+++ b/playground/src/Editor/SourceEditor.tsx
@@ -54,7 +54,7 @@ export default function SourceEditor({
         provideCodeActions: function (model, position) {
           const actions = diagnostics
             .filter((check) => position.startLineNumber === check.location.row)
-            .filter((check) => check.fix)
+            .filter(({ fix }) => fix)
             .map((check) => ({
               title: check.fix
                 ? check.fix.message
@@ -71,11 +71,11 @@ export default function SourceEditor({
                       edit: {
                         range: {
                           startLineNumber: edit.location.row,
-                          startColumn: edit.location.column + 1,
+                          startColumn: edit.location.column,
                           endLineNumber: edit.end_location.row,
-                          endColumn: edit.end_location.column + 1,
+                          endColumn: edit.end_location.column,
                         },
-                        text: edit.content,
+                        text: edit.content || "",
                       },
                     })),
                   }


### PR DESCRIPTION
## Summary

These had just bitrotted over time -- we were no longer passing along the row-and-column indices, etc.

## Test Plan

![Screen Shot 2023-06-26 at 12 03 41 PM](https://github.com/astral-sh/ruff/assets/1309177/6791330d-010b-45d3-91ef-531d4745193f)
