### PR TITLE
Fix ruff_dev repeat by removing short argument

### DIFF
--- a/crates/ruff_dev/src/main.rs
+++ b/crates/ruff_dev/src/main.rs
@@ -60,7 +60,7 @@ enum Command {
         #[clap(flatten)]
         log_level_args: ruff_cli::args::LogLevelArgs,
         /// Run this many times
-        #[clap(long, short = 'n')]
+        #[clap(long)]
         repeat: usize,
     },
     /// Format a repository twice and ensure that it looks that the first and second formatting


### PR DESCRIPTION
ruff_dev repeat recently broke (i think with the cargo update?):

> thread 'main' panicked at 'Command repeat: Short option names must be unique for each argument, but '-n' is in use by both 'no_cache' and 'repeat''

This fixes this by removing the short argument.
