### PR TITLE
Consider Jupyter index for code frames (`--show-source`)

### DIFF
--- a/crates/ruff/src/message/grouped.rs
+++ b/crates/ruff/src/message/grouped.rs
@@ -149,7 +149,14 @@ impl Display for DisplayGroupedMessage<'_> {
         if self.show_source {
             use std::fmt::Write;
             let mut padded = PadAdapter::new(f);
-            writeln!(padded, "{}", MessageCodeFrame { message })?;
+            writeln!(
+                padded,
+                "{}",
+                MessageCodeFrame {
+                    message,
+                    jupyter_index: self.jupyter_index
+                }
+            )?;
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

Consider Jupyter index for code frames (`--show-source`).

This solves two problems as mentioned in the linked issue:

> Omit any contents from adjoining cells

If the Jupyter index is present, we'll use that to check if the surrounding
lines belong to the same cell as the content line. If not, we'll skip that line
until we either reach the one which does or we reach the content line.

> code frame line number

If the Jupyter index is present, we'll use that to get the actual start line in
corresponding to the computed start index.

## Test Plan

`cargo run --bin ruff -- check --no-cache --isolated --select=ALL --show-source /path/to/notebook.ipynb`

fixes: #5395
