### PR TITLE
Add Jupyter integration to the docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -328,6 +328,20 @@ By default, Ruff will also skip any files that are omitted via `.ignore`, `.giti
 Files that are passed to `ruff` directly are always linted, regardless of the above criteria.
 For example, `ruff check /path/to/excluded/file.py` will always lint `file.py`.
 
+## Jupyter notebook discovery
+
+Jupyter notebook (`.ipynb`) files are not discovered automatically by Ruff as it's
+considered an experimental feature. For Ruff to lint such files, a user needs to
+explicitly opt-in by using the [`include`](settings.md#include) setting as follows:
+
+```toml
+[tool.ruff]
+include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
+```
+
+Or, the notebook file(s) can be passed directly to `ruff` on the command-line.
+For example, `ruff check /path/to/notebook.ipynb` will always lint `notebook.ipynb`.
+
 ## Rule selection
 
 The set of enabled rules is controlled via the [`select`](settings.md#select) and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -328,19 +328,23 @@ By default, Ruff will also skip any files that are omitted via `.ignore`, `.giti
 Files that are passed to `ruff` directly are always linted, regardless of the above criteria.
 For example, `ruff check /path/to/excluded/file.py` will always lint `file.py`.
 
-## Jupyter notebook discovery
+## Jupyter Notebook discovery
 
-Jupyter notebook (`.ipynb`) files are not discovered automatically by Ruff as it's
-considered an experimental feature. For Ruff to lint such files, a user needs to
-explicitly opt-in by using the [`include`](settings.md#include) setting as follows:
+Ruff has built-in experimental support for linting [Jupyter Notebooks](https://jupyter.org/).
+
+To opt in to linting Jupyter Notebook (`.ipynb`) files, add the `*.ipynb` pattern to your
+[`include`](settings.md#include) setting, like so:
 
 ```toml
 [tool.ruff]
 include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
 ```
 
-Or, the notebook file(s) can be passed directly to `ruff` on the command-line.
-For example, `ruff check /path/to/notebook.ipynb` will always lint `notebook.ipynb`.
+This will prompt Ruff to discover Jupyter Notebook (`.ipynb`) files in any specified
+directories, and lint them accordingly.
+
+Alternatively, pass the notebook file(s) to `ruff` on the command-line directly. For example,
+`ruff check /path/to/notebook.ipynb` will always lint `notebook.ipynb`.
 
 ## Rule selection
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -309,21 +309,23 @@ src = ["../src", "../test"]
 
 ## Does Ruff support Jupyter Notebooks?
 
-Ruff has experimental support for Jupyter Notebooks builtin. To enable it, include the
-Jupyter notebook file pattern in your [`include`](settings.md#include) option along with the existing patterns:
+Ruff has built-in experimental support for linting [Jupyter Notebooks](https://jupyter.org/).
+
+To opt in to linting Jupyter Notebook (`.ipynb`) files, add the `*.ipynb` pattern to your
+[`include`](settings.md#include) setting, like so:
 
 ```toml
 [tool.ruff]
 include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
 ```
 
-Or, you can pass in the notebook file(s) directly on the command line:
+This will prompt Ruff to discover Jupyter Notebook (`.ipynb`) files in any specified
+directories, and lint them accordingly.
 
-```console
-ruff check path/to/notebook.ipynb
-```
+Alternatively, pass the notebook file(s) to `ruff` on the command-line directly. For example,
+`ruff check /path/to/notebook.ipynb` will always lint `notebook.ipynb`.
 
-Ruff is also integrated into [nbQA](https://github.com/nbQA-dev/nbQA), a tool for running linters and
+Ruff also integrates with [nbQA](https://github.com/nbQA-dev/nbQA), a tool for running linters and
 code formatters over Jupyter Notebooks.
 
 After installing `ruff` and `nbqa`, you can run Ruff over a notebook like so:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -309,7 +309,21 @@ src = ["../src", "../test"]
 
 ## Does Ruff support Jupyter Notebooks?
 
-Ruff is integrated into [nbQA](https://github.com/nbQA-dev/nbQA), a tool for running linters and
+Ruff has experimental support for Jupyter Notebooks builtin. To enable it, include the
+Jupyter notebook file pattern in your [`include`](settings.md#include) option along with the existing patterns:
+
+```toml
+[tool.ruff]
+include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
+```
+
+Or, you can pass in the notebook file(s) directly on the command line:
+
+```console
+ruff check path/to/notebook.ipynb
+```
+
+Ruff is also integrated into [nbQA](https://github.com/nbQA-dev/nbQA), a tool for running linters and
 code formatters over Jupyter Notebooks.
 
 After installing `ruff` and `nbqa`, you can run Ruff over a notebook like so:


### PR DESCRIPTION
## Summary

Add Jupyter integration to the docs, specifically the Configuration and FAQ sections.

## Test Plan

`mkdocs serve` and check that the new sections are visible and functional.

fixes: #5396
