### PR TITLE
Exclude docstrings from PYI053

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_pyi/PYI053.py
+++ b/crates/ruff/resources/test/fixtures/flake8_pyi/PYI053.py
@@ -36,3 +36,11 @@ bar: str = "51 character stringgggggggggggggggggggggggggggggggg"
 baz: bytes = b"50 character byte stringgggggggggggggggggggggggggg"
 
 qux: bytes = b"51 character byte stringggggggggggggggggggggggggggg\xff"
+
+
+class Demo:
+    """Docstrings are excluded from this rule. Some padding."""
+
+
+def func() -> None:
+    """Docstrings are excluded from this rule. Some padding."""

--- a/crates/ruff/resources/test/fixtures/flake8_pyi/PYI053.pyi
+++ b/crates/ruff/resources/test/fixtures/flake8_pyi/PYI053.pyi
@@ -28,3 +28,9 @@ bar: str = "51 character stringgggggggggggggggggggggggggggggggg"  # Error: PYI05
 baz: bytes = b"50 character byte stringgggggggggggggggggggggggggg"  # OK
 
 qux: bytes = b"51 character byte stringggggggggggggggggggggggggggg\xff"  # Error: PYI053
+
+class Demo:
+    """Docstrings are excluded from this rule. Some padding."""  # OK
+
+def func() -> None:
+    """Docstrings are excluded from this rule. Some padding."""  # OK

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -11,7 +11,7 @@ use rustpython_parser::ast::{
 
 use ruff_diagnostics::{Diagnostic, Fix, IsolationLevel};
 use ruff_python_ast::all::{extract_all_names, AllNamesFlags};
-use ruff_python_ast::helpers::{extract_handled_exceptions, is_docstring_stmt, to_module_path};
+use ruff_python_ast::helpers::{extract_handled_exceptions, to_module_path};
 use ruff_python_ast::identifier::{Identifier, TryIdentifier};
 use ruff_python_ast::source_code::{Generator, Indexer, Locator, Quote, Stylist};
 use ruff_python_ast::str::trailing_quote;
@@ -3270,10 +3270,7 @@ where
                 if self.enabled(Rule::UnicodeKindPrefix) {
                     pyupgrade::rules::unicode_kind_prefix(self, expr, kind.as_deref());
                 }
-                if self.is_stub
-                    && self.enabled(Rule::StringOrBytesTooLong)
-                    && !is_docstring_stmt(self.semantic.stmt())
-                {
+                if self.is_stub && self.enabled(Rule::StringOrBytesTooLong) {
                     flake8_pyi::rules::string_or_bytes_too_long(self, expr);
                 }
             }

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -11,7 +11,7 @@ use rustpython_parser::ast::{
 
 use ruff_diagnostics::{Diagnostic, Fix, IsolationLevel};
 use ruff_python_ast::all::{extract_all_names, AllNamesFlags};
-use ruff_python_ast::helpers::{extract_handled_exceptions, to_module_path};
+use ruff_python_ast::helpers::{extract_handled_exceptions, is_docstring_stmt, to_module_path};
 use ruff_python_ast::identifier::{Identifier, TryIdentifier};
 use ruff_python_ast::source_code::{Generator, Indexer, Locator, Quote, Stylist};
 use ruff_python_ast::str::trailing_quote;
@@ -3270,7 +3270,10 @@ where
                 if self.enabled(Rule::UnicodeKindPrefix) {
                     pyupgrade::rules::unicode_kind_prefix(self, expr, kind.as_deref());
                 }
-                if self.is_stub && self.enabled(Rule::StringOrBytesTooLong) {
+                if self.is_stub
+                    && self.enabled(Rule::StringOrBytesTooLong)
+                    && !is_docstring_stmt(self.semantic.stmt())
+                {
                     flake8_pyi::rules::string_or_bytes_too_long(self, expr);
                 }
             }

--- a/crates/ruff/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
@@ -2,6 +2,7 @@ use rustpython_parser::ast::{self, Constant, Expr, Ranged};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::helpers::is_docstring_stmt;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -41,6 +42,11 @@ impl AlwaysAutofixableViolation for StringOrBytesTooLong {
 
 /// PYI053
 pub(crate) fn string_or_bytes_too_long(checker: &mut Checker, expr: &Expr) {
+    // Ignore docstrings.
+    if is_docstring_stmt(checker.semantic().stmt()) {
+        return;
+    }
+
     let length = match expr {
         Expr::Constant(ast::ExprConstant {
             value: Constant::Str(s),

--- a/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI053_PYI053.pyi.snap
+++ b/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI053_PYI053.pyi.snap
@@ -89,6 +89,8 @@ PYI053.pyi:30:14: PYI053 [*] String and bytes literals longer than 50 characters
 29 | 
 30 | qux: bytes = b"51 character byte stringggggggggggggggggggggggggggg\xff"  # Error: PYI053
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI053
+31 | 
+32 | class Demo:
    |
    = help: Replace with `...`
 
@@ -98,5 +100,8 @@ PYI053.pyi:30:14: PYI053 [*] String and bytes literals longer than 50 characters
 29 29 | 
 30    |-qux: bytes = b"51 character byte stringggggggggggggggggggggggggggg\xff"  # Error: PYI053
    30 |+qux: bytes = ...  # Error: PYI053
+31 31 | 
+32 32 | class Demo:
+33 33 |   """Docstrings are excluded from this rule. Some more padding."""  # OK
 
 

--- a/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI053_PYI053.pyi.snap
+++ b/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI053_PYI053.pyi.snap
@@ -102,6 +102,6 @@ PYI053.pyi:30:14: PYI053 [*] String and bytes literals longer than 50 characters
    30 |+qux: bytes = ...  # Error: PYI053
 31 31 | 
 32 32 | class Demo:
-33 33 |   """Docstrings are excluded from this rule. Some more padding."""  # OK
+33 33 |     """Docstrings are excluded from this rule. Some padding."""  # OK
 
 


### PR DESCRIPTION
## Summary

The `Y053` rule of `flake8-pyi` ignores docstrings, it only triggers on other string literals.

The separate `Y021/PYI021` rule exists to disallow docstrings.

## Test Plan

Added some `# OK` test cases to `PYI053.py(i)` files.
