### PR TITLE
ruff rule SLOT uses URL to current Python docs

### DIFF
--- a/crates/ruff/src/rules/flake8_slots/rules/no_slots_in_namedtuple_subclass.rs
+++ b/crates/ruff/src/rules/flake8_slots/rules/no_slots_in_namedtuple_subclass.rs
@@ -46,7 +46,7 @@ use crate::rules::flake8_slots::rules::helpers::has_slots;
 /// ```
 ///
 /// ## References
-/// - [Python documentation: `__slots__`](https://docs.python.org/3.7/reference/datamodel.html#slots)
+/// - [Python documentation: `__slots__`](https://docs.python.org/3/reference/datamodel.html#slots)
 #[violation]
 pub struct NoSlotsInNamedtupleSubclass;
 

--- a/crates/ruff/src/rules/flake8_slots/rules/no_slots_in_str_subclass.rs
+++ b/crates/ruff/src/rules/flake8_slots/rules/no_slots_in_str_subclass.rs
@@ -37,7 +37,7 @@ use crate::rules::flake8_slots::rules::helpers::has_slots;
 /// ```
 ///
 /// ## References
-/// - [Python documentation: `__slots__`](https://docs.python.org/3.7/reference/datamodel.html#slots)
+/// - [Python documentation: `__slots__`](https://docs.python.org/3/reference/datamodel.html#slots)
 #[violation]
 pub struct NoSlotsInStrSubclass;
 

--- a/crates/ruff/src/rules/flake8_slots/rules/no_slots_in_tuple_subclass.rs
+++ b/crates/ruff/src/rules/flake8_slots/rules/no_slots_in_tuple_subclass.rs
@@ -38,7 +38,7 @@ use crate::rules::flake8_slots::rules::helpers::has_slots;
 /// ```
 ///
 /// ## References
-/// - [Python documentation: `__slots__`](https://docs.python.org/3.7/reference/datamodel.html#slots)
+/// - [Python documentation: `__slots__`](https://docs.python.org/3/reference/datamodel.html#slots)
 #[violation]
 pub struct NoSlotsInTupleSubclass;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Currently the URL at the bottom of the `ruff rule SLOT00x` output points to Python 3.7 docs.
Given that Python 3.7 is now end-of-life (as of yesterday), let's instead point users to the current Python docs.

## Test Plan

<!-- How was it tested? -->
