### PR TITLE
types.rs: fnmatch url should point to current Python docs

### DIFF
--- a/crates/ruff/src/settings/types.rs
+++ b/crates/ruff/src/settings/types.rs
@@ -269,6 +269,6 @@ impl Deref for Version {
 /// luckily this not relevant since identifiers don't contains slashes.
 ///
 /// For reference pep8-naming uses
-/// [`fnmatch`](https://docs.python.org/3.11/library/fnmatch.html) for
+/// [`fnmatch`](https://docs.python.org/3/library/fnmatch.html) for
 /// pattern matching.
 pub type IdentifierPattern = glob::Pattern;


### PR DESCRIPTION
Like #5412
```diff
- /// [`fnmatch`](https://docs.python.org/3.11/library/fnmatch.html) for
+ /// [`fnmatch`](https://docs.python.org/3/library/fnmatch.html) for
```

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
