### PR TITLE
Fix invalid printer IR error

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
@@ -108,3 +108,13 @@ test_particular = [
     '1.0000000000000000000000000000000000000000000010000' #...
     '0000000000000000000000000000000000000000025',
 ]
+
+# Parenthesized string continuation with messed up indentation
+{
+    "key": (
+        [],
+    'a'
+        'b'
+    'c'
+    )
+}

--- a/crates/ruff_python_formatter/src/builders.rs
+++ b/crates/ruff_python_formatter/src/builders.rs
@@ -242,23 +242,25 @@ impl<'fmt, 'ast, 'buf> JoinCommaSeparatedBuilder<'fmt, 'ast, 'buf> {
     }
 
     pub(crate) fn finish(&mut self) -> FormatResult<()> {
-        if let Some(last_end) = self.last_end.take() {
-            if_group_breaks(&text(",")).fmt(self.fmt)?;
+        self.result.and_then(|_| {
+            if let Some(last_end) = self.last_end.take() {
+                if_group_breaks(&text(",")).fmt(self.fmt)?;
 
-            if self.fmt.options().magic_trailing_comma().is_respect()
-                && matches!(
-                    first_non_trivia_token(last_end, self.fmt.context().contents()),
-                    Some(Token {
-                        kind: TokenKind::Comma,
-                        ..
-                    })
-                )
-            {
-                expand_parent().fmt(self.fmt)?;
+                if self.fmt.options().magic_trailing_comma().is_respect()
+                    && matches!(
+                        first_non_trivia_token(last_end, self.fmt.context().contents()),
+                        Some(Token {
+                            kind: TokenKind::Comma,
+                            ..
+                        })
+                    )
+                {
+                    expand_parent().fmt(self.fmt)?;
+                }
             }
-        }
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -114,6 +114,16 @@ test_particular = [
     '1.0000000000000000000000000000000000000000000010000' #...
     '0000000000000000000000000000000000000000025',
 ]
+
+# Parenthesized string continuation with messed up indentation
+{
+    "key": (
+        [],
+    'a'
+        'b'
+    'c'
+    )
+}
 ```
 
 ## Outputs
@@ -259,6 +269,9 @@ test_particular = [
     "1.0000000000000000000000000000000000000000000010000"  # ...
     "0000000000000000000000000000000000000000025",
 ]
+
+# Parenthesized string continuation with messed up indentation
+{"key": ([], "a" "b" "c")}
 ```
 
 
@@ -404,6 +417,9 @@ test_particular = [
     '1.0000000000000000000000000000000000000000000010000'  # ...
     '0000000000000000000000000000000000000000025',
 ]
+
+# Parenthesized string continuation with messed up indentation
+{'key': ([], 'a' 'b' 'c')}
 ```
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR fixes an issue where formatting the following expression statement resulted in a `FormatError::InvalidDocument`:

```python
{
    "key": (
        [],
    'a'
        'b'
    'c'
    )
}
```

The root cause for the invalid document was that the new `JoinCommaSeparatedBuilder` always returned `Ok(())` even if the
formatting of an item failed. The fix requires consuming `self.result` and only writing the trailing comma if `result` is `Ok`. 

The fix revealed an error with the implicit string continuation formatting where it returned a `FormatError::SyntaxError` for the above example. 
The cause of this is that we call into the RustPython lexer and start lexing from the start of the string. However, the lexer doesn't know that 
the string is parenthesized. I opted for the fix to ignore any indentation errors because we know that the program lexed without errors once (or we wouldn't have an AST). 


<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I added a new test to the continuation fixture test.

<!-- How was it tested? -->
