### PR TITLE
ecosystem: Run `git` command with no human interaction flag

### DIFF
--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -69,7 +69,10 @@ class Repository(NamedTuple):
             ],
         )
 
-        process = await create_subprocess_exec(*git_command)
+        process = await create_subprocess_exec(
+            *git_command,
+            env={"GIT_TERMINAL_PROMPT": "0"},
+        )
 
         status_code = await process.wait()
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR runs the `git clone` command with the `GIT_TERMINAL_PROMPT` environment variable set to `0`. Setting the variable to `0` ensures that git fails instead of doing any interactive prompts. 

I'm adding this because the ecosystem check continued to ask me for my GitHub credentials for seamingly no longer existing repositories. This didn't just happen once, but for many repositories.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Ran the ecossytem checkout locally. Git no longer asks for the credentials. 
