### PR TITLE
Turn Linters', etc. implicit `into_iter()`s into explicit `rules()`

### DIFF
--- a/crates/ruff/src/flake8_to_ruff/plugin.rs
+++ b/crates/ruff/src/flake8_to_ruff/plugin.rs
@@ -333,7 +333,7 @@ pub(crate) fn infer_plugins_from_codes(selectors: &HashSet<RuleSelector>) -> Vec
         for selector in selectors {
             if selector
                 .into_iter()
-                .any(|rule| Linter::from(plugin).into_iter().any(|r| r == rule))
+                .any(|rule| Linter::from(plugin).rules().any(|r| r == rule))
             {
                 return true;
             }

--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -19,7 +19,7 @@ impl Rule {
     pub fn from_code(code: &str) -> Result<Self, FromCodeError> {
         let (linter, code) = Linter::parse_code(code).ok_or(FromCodeError::Unknown)?;
         let prefix: RuleCodePrefix = RuleCodePrefix::parse(&linter, code)?;
-        Ok(prefix.into_iter().next().unwrap())
+        Ok(prefix.rules().next().unwrap())
     }
 }
 

--- a/crates/ruff/src/rule_selector.rs
+++ b/crates/ruff/src/rule_selector.rs
@@ -167,7 +167,7 @@ impl IntoIterator for &RuleSelector {
                     .chain(Linter::Flake8Print.rules()),
             ),
             RuleSelector::Linter(linter) => RuleSelectorIter::Vec(linter.rules()),
-            RuleSelector::Prefix { prefix, .. } => RuleSelectorIter::Vec(prefix.into_iter()),
+            RuleSelector::Prefix { prefix, .. } => RuleSelectorIter::Vec(prefix.clone().rules()),
         }
     }
 }
@@ -346,7 +346,7 @@ mod clap_completion {
                             let prefix = p.linter().common_prefix();
                             let code = p.short_code();
 
-                            let mut rules_iter = p.into_iter();
+                            let mut rules_iter = p.rules();
                             let rule1 = rules_iter.next();
                             let rule2 = rules_iter.next();
 

--- a/crates/ruff/src/rule_selector.rs
+++ b/crates/ruff/src/rule_selector.rs
@@ -158,15 +158,15 @@ impl IntoIterator for &RuleSelector {
             }
             RuleSelector::C => RuleSelectorIter::Chain(
                 Linter::Flake8Comprehensions
-                    .into_iter()
-                    .chain(Linter::McCabe.into_iter()),
+                    .rules()
+                    .chain(Linter::McCabe.rules()),
             ),
             RuleSelector::T => RuleSelectorIter::Chain(
                 Linter::Flake8Debugger
-                    .into_iter()
-                    .chain(Linter::Flake8Print.into_iter()),
+                    .rules()
+                    .chain(Linter::Flake8Print.rules()),
             ),
-            RuleSelector::Linter(linter) => RuleSelectorIter::Vec(linter.into_iter()),
+            RuleSelector::Linter(linter) => RuleSelectorIter::Vec(linter.rules()),
             RuleSelector::Prefix { prefix, .. } => RuleSelectorIter::Vec(prefix.into_iter()),
         }
     }

--- a/crates/ruff/src/rules/flake8_type_checking/mod.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/mod.rs
@@ -327,7 +327,7 @@ mod tests {
     fn contents(contents: &str, snapshot: &str) {
         let diagnostics = test_snippet(
             contents,
-            &settings::Settings::for_rules(&Linter::Flake8TypeChecking),
+            &settings::Settings::for_rules(Linter::Flake8TypeChecking.rules()),
         );
         assert_messages!(snapshot, diagnostics);
     }

--- a/crates/ruff/src/rules/pandas_vet/mod.rs
+++ b/crates/ruff/src/rules/pandas_vet/mod.rs
@@ -354,8 +354,10 @@ mod tests {
         "PD901_fail_df_var"
     )]
     fn contents(contents: &str, snapshot: &str) {
-        let diagnostics =
-            test_snippet(contents, &settings::Settings::for_rules(&Linter::PandasVet));
+        let diagnostics = test_snippet(
+            contents,
+            &settings::Settings::for_rules(Linter::PandasVet.rules()),
+        );
         assert_messages!(snapshot, diagnostics);
     }
 

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -490,7 +490,7 @@ mod tests {
         "load_after_unbind_from_class_scope"
     )]
     fn contents(contents: &str, snapshot: &str) {
-        let diagnostics = test_snippet(contents, &Settings::for_rules(&Linter::Pyflakes));
+        let diagnostics = test_snippet(contents, &Settings::for_rules(Linter::Pyflakes.rules()));
         assert_messages!(snapshot, diagnostics);
     }
 
@@ -498,7 +498,7 @@ mod tests {
     /// Note that all tests marked with `#[ignore]` should be considered TODOs.
     fn flakes(contents: &str, expected: &[Rule]) {
         let contents = dedent(contents);
-        let settings = Settings::for_rules(&Linter::Pyflakes);
+        let settings = Settings::for_rules(Linter::Pyflakes.rules());
         let tokens: Vec<LexResult> = ruff_rustpython::tokenize(&contents);
         let locator = Locator::new(&contents);
         let stylist = Stylist::from_tokens(&tokens, &locator);

--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -102,7 +102,7 @@ pub(crate) fn generate() -> String {
                 ));
                 table_out.push('\n');
                 table_out.push('\n');
-                generate_table(&mut table_out, prefix, &linter);
+                generate_table(&mut table_out, prefix.clone().rules(), &linter);
             }
         } else {
             generate_table(&mut table_out, linter.rules(), &linter);

--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -105,7 +105,7 @@ pub(crate) fn generate() -> String {
                 generate_table(&mut table_out, prefix, &linter);
             }
         } else {
-            generate_table(&mut table_out, &linter, &linter);
+            generate_table(&mut table_out, linter.rules(), &linter);
         }
     }
 

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -139,30 +139,13 @@ pub(crate) fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
         }
 
         output.extend(quote! {
-            impl IntoIterator for &#linter {
-                type Item = Rule;
-                type IntoIter = ::std::vec::IntoIter<Self::Item>;
-
-                fn into_iter(self) -> Self::IntoIter {
+            impl #linter {
+                pub fn rules(self) -> ::std::vec::IntoIter<Rule> {
                     match self { #prefix_into_iter_match_arms }
                 }
             }
         });
     }
-
-    output.extend(quote! {
-        impl IntoIterator for &RuleCodePrefix {
-            type Item = Rule;
-            type IntoIter = ::std::vec::IntoIter<Self::Item>;
-
-            fn into_iter(self) -> Self::IntoIter {
-                match self {
-                    #(RuleCodePrefix::#linter_idents(prefix) => prefix.into_iter(),)*
-                }
-            }
-        }
-    });
-
     output.extend(quote! {
         impl RuleCodePrefix {
             pub fn parse(linter: &Linter, code: &str) -> Result<Self, crate::registry::FromCodeError> {
@@ -171,6 +154,12 @@ pub(crate) fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
                 Ok(match linter {
                     #(Linter::#linter_idents => RuleCodePrefix::#linter_idents(#linter_idents::from_str(code).map_err(|_| crate::registry::FromCodeError::Unknown)?),)*
                 })
+            }
+
+            pub fn rules(self) -> ::std::vec::IntoIter<Rule> {
+                match self {
+                    #(RuleCodePrefix::#linter_idents(prefix) => prefix.clone().rules(),)*
+                }
             }
         }
     });


### PR DESCRIPTION
## Summary

As discussed on ~IRC~ Discord, this will make it easier for e.g. the docs generation stuff to get all rules for a linter (using `all_rules()`) instead of just non-nursery ones, and it also makes it more Explicit Is Better Than Implicit to iterate over linter rules.

Grepping for `Item = Rule` reveals some remaining implicit `IntoIterator`s that I didn't feel were necessarily in scope for this (and honestly, iterating over a `RuleSet` makes sense).