### PR TITLE
Preserve parentheses around left side of binary expression

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
@@ -205,3 +205,9 @@ if (
 # Unstable formatting in https://github.com/realtyem/synapse-unraid/blob/unraid_develop/synapse/handlers/presence.py
 for user_id in set(target_user_ids) - {u.user_id for u in updates}:
     updates.append(UserPresenceState.default(user_id))
+
+# Keeps parenthesized left hand sides
+(
+    log(self.price / self.strike)
+    + (self.risk_free - self.div_cont + 0.5 * (self.sigma**2)) * self.exp_time
+) / self.sigmaT

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__expression.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__expression.py.snap
@@ -274,20 +274,11 @@ last_call()
  Name
  None
  True
-@@ -24,40 +24,46 @@
- 1 >> v2
- 1 % finished
- 1 + v2 - v3 * 4 ^ 5**v6 / 7 // 8
--((1 + v2) - (v3 * 4)) ^ (((5**v6) / 7) // 8)
-+(1 + v2 - (v3 * 4)) ^ (5**v6 / 7 // 8)
- not great
- ~great
- +value
+@@ -31,33 +31,39 @@
  -1
  ~int and not v1 ^ 123 + v2 | True
--(~int) and (not ((v1 ^ (123 + v2)) | True))
+ (~int) and (not ((v1 ^ (123 + v2)) | True))
 -+(really ** -(confusing ** ~(operator**-precedence)))
-+(~int) and (not (v1 ^ (123 + v2) | True))
 ++really ** -confusing ** ~operator**-precedence
  flags & ~select.EPOLLIN and waiters.write_task is not None
 -lambda arg: None
@@ -650,13 +641,13 @@ v1 << 2
 1 >> v2
 1 % finished
 1 + v2 - v3 * 4 ^ 5**v6 / 7 // 8
-(1 + v2 - (v3 * 4)) ^ (5**v6 / 7 // 8)
+((1 + v2) - (v3 * 4)) ^ (((5**v6) / 7) // 8)
 not great
 ~great
 +value
 -1
 ~int and not v1 ^ 123 + v2 | True
-(~int) and (not (v1 ^ (123 + v2) | True))
+(~int) and (not ((v1 ^ (123 + v2)) | True))
 +really ** -confusing ** ~operator**-precedence
 flags & ~select.EPOLLIN and waiters.write_task is not None
 lambda x: True

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
@@ -211,6 +211,12 @@ if (
 # Unstable formatting in https://github.com/realtyem/synapse-unraid/blob/unraid_develop/synapse/handlers/presence.py
 for user_id in set(target_user_ids) - {u.user_id for u in updates}:
     updates.append(UserPresenceState.default(user_id))
+
+# Keeps parenthesized left hand sides
+(
+    log(self.price / self.strike)
+    + (self.risk_free - self.div_cont + 0.5 * (self.sigma**2)) * self.exp_time
+) / self.sigmaT
 ```
 
 ## Output
@@ -468,6 +474,12 @@ for user_id in set(
     target_user_ids
 ) - {NOT_IMPLEMENTED_set_value for value in NOT_IMPLEMENTED_set}:
     updates.append(UserPresenceState.default(user_id))
+
+# Keeps parenthesized left hand sides
+(
+    log(self.price / self.strike)
+    + (self.risk_free - self.div_cont + 0.5 * (self.sigma**2)) * self.exp_time
+) / self.sigmaT
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__unary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__unary.py.snap
@@ -257,8 +257,10 @@ if aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & (
     pass
 
 if (
-    not aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    not (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    )
     & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ):
     pass


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR fixes an issue where the binary expression formatting removed parentheses around the left hand side of an expression.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I added a new regression test and re-ran the ecosystem check. It brings down the `check-formatter-stability` output from a 3.4MB file down to 900KB. 

<!-- How was it tested? -->
