### PR TITLE
Allow parentheses for function calls for `RSE102`

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_raise/RSE102.py
+++ b/crates/ruff/resources/test/fixtures/flake8_raise/RSE102.py
@@ -32,3 +32,9 @@ raise TypeError(
 raise AssertionError
 
 raise AttributeError("test message")
+
+
+def return_error():
+    return ValueError("Something")
+
+raise return_error()

--- a/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -52,6 +52,18 @@ pub(crate) fn unnecessary_paren_on_raise_exception(checker: &mut Checker, expr: 
         range: _,
     }) = expr
     {
+        let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() else {
+            return;
+        };
+
+        let scope = checker.semantic().scope();
+        if let Some(binding_id) = scope.get(id) {
+            let binding = checker.semantic().binding(binding_id);
+            if binding.kind.is_function_definition() {
+                return;
+            }
+        }
+
         if args.is_empty() && keywords.is_empty() {
             let range = match_parens(func.end(), checker.locator)
                 .expect("Expected call to include parentheses");


### PR DESCRIPTION
## Summary

Edit RSE102 to allow empty parentheses if the call is a function that raises an error (and not e.g. a Class instantiation) so that we allow scenarios like:

```python
def return_error():
    return ValueError("Something")

raise return_error()
```

and we don't break the code during autofix into:

```python
def return_error():
    return ValueError("Something")

raise return_error
```

## Test Plan

Added an extra case to the existing fixture

## Issue link:

Closes: https://github.com/astral-sh/ruff/issues/5416 
