### PR TITLE
Merge clippy and clippy (wasm) jobs on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,20 +36,12 @@ jobs:
       - name: "Install Rust toolchain"
         run: |
           rustup component add clippy
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-
-  cargo-clippy-wasm:
-    name: "cargo clippy (wasm)"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: "Install Rust toolchain"
-        run: |
-          rustup component add clippy
           rustup target add wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy -p ruff_wasm --target wasm32-unknown-unknown --all-features -- -D warnings
+      - name: "Clippy"
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: "Clippy (wasm)"
+        run: cargo clippy -p ruff_wasm --target wasm32-unknown-unknown --all-features -- -D warnings
 
   cargo-test:
     strategy:

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -604,6 +604,7 @@ fn handle_trailing_end_of_line_condition_comment<'a>(
         | AnyNodeRef::StmtAsyncFor(ast::StmtAsyncFor { iter: expr, .. }) => {
             Some(AnyNodeRef::from(expr.as_ref()))
         }
+
         AnyNodeRef::StmtWith(ast::StmtWith { items, .. })
         | AnyNodeRef::StmtAsyncWith(ast::StmtAsyncWith { items, .. }) => {
             items.last().map(AnyNodeRef::from)

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -604,7 +604,6 @@ fn handle_trailing_end_of_line_condition_comment<'a>(
         | AnyNodeRef::StmtAsyncFor(ast::StmtAsyncFor { iter: expr, .. }) => {
             Some(AnyNodeRef::from(expr.as_ref()))
         }
-
         AnyNodeRef::StmtWith(ast::StmtWith { items, .. })
         | AnyNodeRef::StmtAsyncWith(ast::StmtAsyncWith { items, .. }) => {
             items.last().map(AnyNodeRef::from)


### PR DESCRIPTION
## Summary

The clippy wasm job rarely fails if regular clippy doesn't, wasm clippy still compiles a lot of native dependencies for the proc macro and we have less CI jobs overall, so i think this an improvement to our CI.

```shell
$ CARGO_TARGET_DIR=target-wasm cargo clippy -p ruff_wasm --target wasm32-unknown-unknown --all-features -j 2 -- -D warnings
$ du -sh target-wasm/*
12K	target-wasm/CACHEDIR.TAG
582M	target-wasm/debug
268M	target-wasm/wasm32-unknown-unknown
```

## Test plan

n/a