### PR TITLE
Show `BestFitting` mode if it isn't `FirstLine`

### DIFF
--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -296,7 +296,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                         FormatElement::Line(LineMode::Hard),
                     ])?;
 
-                    if *mode != BestFittingMode::AllLines {
+                    if *mode != BestFittingMode::FirstLine {
                         write!(
                             f,
                             [


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This fixes the `Document` display implementation to show the `BestFitting` mode when it isn't `FirstLine` (which is the default)

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
