### PR TITLE
Fix `unnecessary-encode-utf8` to fix `encode` on parenthesized strings correctly

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP012.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP012.py
@@ -70,3 +70,8 @@ print("foo".encode())  # print(b"foo")
     "abc"
     "def"
 )).encode()
+
+(f"foo{bar}").encode("utf-8")
+(f"foo{bar}").encode(encoding="utf-8")
+("unicode text©").encode("utf-8")
+("unicode text©").encode(encoding="utf-8")

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -191,7 +191,7 @@ pub(crate) fn unnecessary_encode_utf8(
                         diagnostic.try_set_fix(|| {
                             remove_argument(
                                 checker.locator,
-                                func.start(),
+                                func.end(),
                                 kwarg.range(),
                                 args,
                                 kwargs,
@@ -213,7 +213,7 @@ pub(crate) fn unnecessary_encode_utf8(
                         diagnostic.try_set_fix(|| {
                             remove_argument(
                                 checker.locator,
-                                func.start(),
+                                func.end(),
                                 arg.range(),
                                 args,
                                 kwargs,
@@ -242,7 +242,7 @@ pub(crate) fn unnecessary_encode_utf8(
                         diagnostic.try_set_fix(|| {
                             remove_argument(
                                 checker.locator,
-                                func.start(),
+                                func.end(),
                                 kwarg.range(),
                                 args,
                                 kwargs,
@@ -264,7 +264,7 @@ pub(crate) fn unnecessary_encode_utf8(
                         diagnostic.try_set_fix(|| {
                             remove_argument(
                                 checker.locator,
-                                func.start(),
+                                func.end(),
                                 arg.range(),
                                 args,
                                 kwargs,

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP012.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP012.py.snap
@@ -452,6 +452,8 @@ UP012.py:69:1: UP012 [*] Unnecessary call to `encode` as UTF-8
 71 | |     "def"
 72 | | )).encode()
    | |___________^ UP012
+73 |   
+74 |   (f"foo{bar}").encode("utf-8")
    |
    = help: Rewrite as bytes literal
 
@@ -465,5 +467,82 @@ UP012.py:69:1: UP012 [*] Unnecessary call to `encode` as UTF-8
    70 |+    b"abc"
    71 |+    b"def"
    72 |+))
+73 73 | 
+74 74 | (f"foo{bar}").encode("utf-8")
+75 75 | (f"foo{bar}").encode(encoding="utf-8")
+
+UP012.py:74:1: UP012 [*] Unnecessary call to `encode` as UTF-8
+   |
+72 | )).encode()
+73 | 
+74 | (f"foo{bar}").encode("utf-8")
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP012
+75 | (f"foo{bar}").encode(encoding="utf-8")
+76 | ("unicode text©").encode("utf-8")
+   |
+   = help: Remove unnecessary encoding argument
+
+ℹ Fix
+71 71 |     "def"
+72 72 | )).encode()
+73 73 | 
+74    |-(f"foo{bar}").encode("utf-8")
+   74 |+(f"foo{bar}").encode()
+75 75 | (f"foo{bar}").encode(encoding="utf-8")
+76 76 | ("unicode text©").encode("utf-8")
+77 77 | ("unicode text©").encode(encoding="utf-8")
+
+UP012.py:75:1: UP012 [*] Unnecessary call to `encode` as UTF-8
+   |
+74 | (f"foo{bar}").encode("utf-8")
+75 | (f"foo{bar}").encode(encoding="utf-8")
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP012
+76 | ("unicode text©").encode("utf-8")
+77 | ("unicode text©").encode(encoding="utf-8")
+   |
+   = help: Remove unnecessary encoding argument
+
+ℹ Fix
+72 72 | )).encode()
+73 73 | 
+74 74 | (f"foo{bar}").encode("utf-8")
+75    |-(f"foo{bar}").encode(encoding="utf-8")
+   75 |+(f"foo{bar}").encode()
+76 76 | ("unicode text©").encode("utf-8")
+77 77 | ("unicode text©").encode(encoding="utf-8")
+
+UP012.py:76:1: UP012 [*] Unnecessary call to `encode` as UTF-8
+   |
+74 | (f"foo{bar}").encode("utf-8")
+75 | (f"foo{bar}").encode(encoding="utf-8")
+76 | ("unicode text©").encode("utf-8")
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP012
+77 | ("unicode text©").encode(encoding="utf-8")
+   |
+   = help: Remove unnecessary encoding argument
+
+ℹ Fix
+73 73 | 
+74 74 | (f"foo{bar}").encode("utf-8")
+75 75 | (f"foo{bar}").encode(encoding="utf-8")
+76    |-("unicode text©").encode("utf-8")
+   76 |+("unicode text©").encode()
+77 77 | ("unicode text©").encode(encoding="utf-8")
+
+UP012.py:77:1: UP012 [*] Unnecessary call to `encode` as UTF-8
+   |
+75 | (f"foo{bar}").encode(encoding="utf-8")
+76 | ("unicode text©").encode("utf-8")
+77 | ("unicode text©").encode(encoding="utf-8")
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP012
+   |
+   = help: Remove unnecessary encoding argument
+
+ℹ Fix
+74 74 | (f"foo{bar}").encode("utf-8")
+75 75 | (f"foo{bar}").encode(encoding="utf-8")
+76 76 | ("unicode text©").encode("utf-8")
+77    |-("unicode text©").encode(encoding="utf-8")
+   77 |+("unicode text©").encode()
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #5477

## Test Plan

<!-- How was it tested? -->

New test cases.