### PR TITLE
Remove some allocations in argument detection

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -72,7 +72,7 @@ pub(crate) struct Checker<'a> {
     deferred: Deferred<'a>,
     pub(crate) diagnostics: Vec<Diagnostic>,
     // Check-specific state.
-    pub(crate) flake8_bugbear_seen: Vec<&'a Expr>,
+    pub(crate) flake8_bugbear_seen: Vec<&'a ast::ExprName>,
 }
 
 impl<'a> Checker<'a> {

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
@@ -1,30 +1,27 @@
-use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged};
+use rustpython_parser::ast::{Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::SimpleCallArgs;
+use ruff_python_ast::helpers::{is_const_none, SimpleCallArgs};
 
 use crate::checkers::ast::Checker;
 
 #[violation]
 pub struct RequestWithoutTimeout {
-    pub timeout: Option<String>,
+    implicit: bool,
 }
 
 impl Violation for RequestWithoutTimeout {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let RequestWithoutTimeout { timeout } = self;
-        match timeout {
-            Some(value) => {
-                format!("Probable use of requests call with timeout set to `{value}`")
-            }
-            None => format!("Probable use of requests call without timeout"),
+        let RequestWithoutTimeout { implicit } = self;
+        if *implicit {
+            format!("Probable use of requests call without timeout")
+        } else {
+            format!("Probable use of requests call with timeout set to `None`")
         }
     }
 }
-
-const HTTP_VERBS: [&str; 7] = ["get", "options", "head", "post", "put", "patch", "delete"];
 
 /// S113
 pub(crate) fn request_without_timeout(
@@ -37,30 +34,26 @@ pub(crate) fn request_without_timeout(
         .semantic()
         .resolve_call_path(func)
         .map_or(false, |call_path| {
-            HTTP_VERBS
-                .iter()
-                .any(|func_name| call_path.as_slice() == ["requests", func_name])
+            matches!(
+                call_path.as_slice(),
+                [
+                    "requests",
+                    "get" | "options" | "head" | "post" | "put" | "patch" | "delete"
+                ]
+            )
         })
     {
         let call_args = SimpleCallArgs::new(args, keywords);
-        if let Some(timeout_arg) = call_args.keyword_argument("timeout") {
-            if let Some(timeout) = match timeout_arg {
-                Expr::Constant(ast::ExprConstant {
-                    value: value @ Constant::None,
-                    ..
-                }) => Some(checker.generator().constant(value)),
-                _ => None,
-            } {
+        if let Some(timeout) = call_args.keyword_argument("timeout") {
+            if is_const_none(timeout) {
                 checker.diagnostics.push(Diagnostic::new(
-                    RequestWithoutTimeout {
-                        timeout: Some(timeout),
-                    },
-                    timeout_arg.range(),
+                    RequestWithoutTimeout { implicit: false },
+                    timeout.range(),
                 ));
             }
         } else {
             checker.diagnostics.push(Diagnostic::new(
-                RequestWithoutTimeout { timeout: None },
+                RequestWithoutTimeout { implicit: true },
                 func.range(),
             ));
         }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -9,7 +9,7 @@ use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::collect_call_path;
-use ruff_python_ast::helpers::collect_arg_names;
+use ruff_python_ast::helpers::includes_arg_name;
 use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::visitor;
@@ -455,7 +455,7 @@ fn check_fixture_decorator_name(checker: &mut Checker, decorator: &Decorator) {
 
 /// PT021
 fn check_fixture_addfinalizer(checker: &mut Checker, args: &Arguments, body: &[Stmt]) {
-    if !collect_arg_names(args).contains(&"request") {
+    if !includes_arg_name("request", args) {
         return;
     }
 


### PR DESCRIPTION
## Summary

Drive-by PR to remove some allocations around argument name matching.