### PR TITLE
Move `pandas-df-variable-name` (`PD901`) to the nursery

### DIFF
--- a/crates/ruff/src/codes.rs
+++ b/crates/ruff/src/codes.rs
@@ -587,7 +587,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (PandasVet, "012") => (RuleGroup::Unspecified, rules::pandas_vet::rules::PandasUseOfDotReadTable),
         (PandasVet, "013") => (RuleGroup::Unspecified, rules::pandas_vet::rules::PandasUseOfDotStack),
         (PandasVet, "015") => (RuleGroup::Unspecified, rules::pandas_vet::rules::PandasUseOfPdMerge),
-        (PandasVet, "901") => (RuleGroup::Unspecified, rules::pandas_vet::rules::PandasDfVariableName),
+        (PandasVet, "901") => (RuleGroup::Nursery, rules::pandas_vet::rules::PandasDfVariableName),
 
         // flake8-errmsg
         (Flake8ErrMsg, "101") => (RuleGroup::Unspecified, rules::flake8_errmsg::rules::RawStringInException),


### PR DESCRIPTION
Closes #3330.