### PR TITLE
check-formatter-stability: Remove newlines and add `--error-file`

### DIFF
--- a/crates/ruff_dev/src/check_formatter_stability.rs
+++ b/crates/ruff_dev/src/check_formatter_stability.rs
@@ -73,6 +73,12 @@ pub(crate) fn main(args: &Args) -> anyhow::Result<ExitCode> {
         #[allow(clippy::print_stdout)]
         {
             print!("{}", result.display(args.format));
+            println!(
+                "Found {} stability errors in {} files in {:.2}s",
+                result.diagnostics.len(),
+                result.file_count,
+                result.duration.as_secs_f32(),
+            );
         }
 
         result.is_success()
@@ -171,8 +177,10 @@ fn check_multi_project(args: &Args) -> bool {
 
     #[allow(clippy::print_stdout)]
     {
-        println!("{total_errors} stability errors in {total_files} files");
-        println!("Finished in {}s", duration.as_secs_f32());
+        println!(
+            "{total_errors} stability errors in {total_files} files in {}s",
+            duration.as_secs_f32()
+        );
     }
 
     all_success

--- a/crates/ruff_dev/src/check_formatter_stability.rs
+++ b/crates/ruff_dev/src/check_formatter_stability.rs
@@ -135,13 +135,16 @@ fn check_multi_project(args: &Args) -> bool {
                     Message::Finished { path, result } => {
                         total_errors += result.diagnostics.len();
                         total_files += result.file_count;
+
                         writeln!(
                             stdout,
-                            "Finished {}\n{}\n",
+                            "Finished {} with {} files in {:.2}s",
                             path.display(),
-                            result.display(args.format)
+                            result.file_count,
+                            result.duration.as_secs_f32(),
                         )
                         .unwrap();
+                        write!(stdout, "{}", result.display(args.format)).unwrap();
                         all_success = all_success && result.is_success();
                     }
                     Message::Failed { path, error } => {
@@ -295,23 +298,11 @@ struct DisplayCheckRepoResult<'a> {
 }
 
 impl Display for DisplayCheckRepoResult<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let CheckRepoResult {
-            duration,
-            file_count,
-            diagnostics,
-        } = self.result;
-
-        for diagnostic in diagnostics {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        for diagnostic in &self.result.diagnostics {
             write!(f, "{}", diagnostic.display(self.format))?;
         }
-
-        writeln!(
-            f,
-            "Formatting {} files twice took {:.2}s",
-            file_count,
-            duration.as_secs_f32()
-        )
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

This makes the output of `check-formatter-stability` more concise by removing extraneous newlines. It also adds a `--error-file` option to that script that allows creating a file with just the errors (without the status messages) to share with others.

## Test Plan

I ran it over CPython and looked at the output. I then added the `--error-file` option and looked at the contents of the file
