### PR TITLE
Avoid PERF rules for iteration-dependent assignments

### DIFF
--- a/crates/ruff/resources/test/fixtures/perflint/PERF401.py
+++ b/crates/ruff/resources/test/fixtures/perflint/PERF401.py
@@ -30,3 +30,10 @@ def f():
     result = []
     for i in items:
         result.append(i)  # OK
+
+
+def f():
+    items = [1, 2, 3, 4]
+    result = {}
+    for i in items:
+        result[i].append(i)  # OK

--- a/crates/ruff/resources/test/fixtures/perflint/PERF402.py
+++ b/crates/ruff/resources/test/fixtures/perflint/PERF402.py
@@ -17,3 +17,10 @@ def f():
     result = []
     for i in items:
         result.append(i * i)  # OK
+
+
+def f():
+    items = [1, 2, 3, 4]
+    result = {}
+    for i in items:
+        result[i].append(i * i)  # OK


### PR DESCRIPTION
## Summary

We need to avoid raising "rewrite as a comprehension" violations in cases like:

```python
d = defaultdict(list)

for i in [1, 2, 3]:
    d[i].append(i**2)
```

Closes https://github.com/astral-sh/ruff/issues/5494.

Closes https://github.com/astral-sh/ruff/issues/5500.
