### PR TITLE
Avoid returning first-match for rule prefixes

### DIFF
--- a/crates/ruff_cli/src/commands/rule.rs
+++ b/crates/ruff_cli/src/commands/rule.rs
@@ -31,7 +31,6 @@ pub(crate) fn rule(rule: Rule, format: HelpFormat) -> Result<()> {
             output.push('\n');
             output.push('\n');
 
-            let (linter, _) = Linter::parse_code(&rule.noqa_code().to_string()).unwrap();
             output.push_str(&format!("Derived from the **{}** linter.", linter.name()));
             output.push('\n');
             output.push('\n');


### PR DESCRIPTION
Closes #5495, but there's a TODO here to improve this further. The current `from_code` implementation feels really indirect.