### PR TITLE
Avoid triggering `unnecessary-map` (`C417`) for late-bound lambdas

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_comprehensions/C417.py
+++ b/crates/ruff/resources/test/fixtures/flake8_comprehensions/C417.py
@@ -32,5 +32,8 @@ def func(arg1: int, arg2: int = 4):
 # Non-error: `func` is not a lambda.
 list(map(func, nums))
 
-# False positive: need to preserve the late-binding of `x`.
-callbacks = map(lambda x: lambda: x, range(4))
+# False positive: need to preserve the late-binding of `x` in the inner lambda.
+map(lambda x: lambda: x, range(4))
+
+# Error: the `x` is overridden by the inner lambda.
+map(lambda x: lambda x: x, range(4))

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C417_C417.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C417_C417.py.snap
@@ -260,19 +260,19 @@ C417.py:21:1: C417 Unnecessary `map` usage (rewrite using a generator expression
    |
    = help: Replace `map` with a generator expression
 
-C417.py:36:13: C417 [*] Unnecessary `map` usage (rewrite using a generator expression)
+C417.py:39:1: C417 [*] Unnecessary `map` usage (rewrite using a generator expression)
    |
-35 | # False positive: need to preserve the late-binding of `x`.
-36 | callbacks = map(lambda x: lambda: x, range(4))
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C417
+38 | # Error: the `x` is overridden by the inner lambda.
+39 | map(lambda x: lambda x: x, range(4))
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C417
    |
    = help: Replace `map` with a generator expression
 
 ℹ Suggested fix
-33 33 | list(map(func, nums))
-34 34 | 
-35 35 | # False positive: need to preserve the late-binding of `x`.
-36    |-callbacks = map(lambda x: lambda: x, range(4))
-   36 |+callbacks = (lambda: x for x in range(4))
+36 36 | map(lambda x: lambda: x, range(4))
+37 37 | 
+38 38 | # Error: the `x` is overridden by the inner lambda.
+39    |-map(lambda x: lambda x: x, range(4))
+   39 |+(lambda x: x for x in range(4))
 
 


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/5502.