### PR TITLE
Accept noqa directives with missing hash space

### DIFF
--- a/crates/ruff/resources/test/fixtures/ruff/RUF100_3.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF100_3.py
@@ -5,11 +5,13 @@ print()  # noqa # comment
 print()  # noqa  # comment
 print()  # noqa comment
 print()  # noqa  comment
+print()  #noqa
 print(a)  # noqa
 print(a)  # noqa # comment
 print(a)  # noqa  # comment
 print(a)  # noqa comment
 print(a)  # noqa  comment
+print(a)  #noqa comment
 
 # noqa: E501, F821
 # noqa: E501, F821 # comment
@@ -23,3 +25,4 @@ print(a)  # noqa: E501, F821 # comment
 print(a)  # noqa: E501, F821  # comment
 print(a)  # noqa: E501, F821 comment
 print(a)  # noqa: E501, F821  comment
+print(a)  #noqa: E501, F821  comment

--- a/crates/ruff/resources/test/fixtures/ruff/noqa.py
+++ b/crates/ruff/resources/test/fixtures/ruff/noqa.py
@@ -21,3 +21,8 @@ def f():
 def f():
     # Only `E741` should be ignored by the `noqa`.
     I = 1  # noqa: E741.F841
+
+
+def f():
+    # These should both be ignored by the `noqa`.
+    I = 1  #noqa: E741, F841

--- a/crates/ruff/src/noqa.rs
+++ b/crates/ruff/src/noqa.rs
@@ -20,7 +20,7 @@ use crate::rule_redirects::get_redirect_target;
 
 static NOQA_LINE_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r"(?P<leading_spaces>\s*)(?P<noqa>(?i:# noqa)(?::\s?(?P<codes>(?:[A-Z]+[0-9]+)(?:[,\s]+[A-Z]+[0-9]+)*))?)(?P<trailing_spaces>\s*)",
+        r"(?P<leading_spaces>\s*)(?P<noqa>(?i:#\s*noqa)(?::\s?(?P<codes>[A-Z]+[0-9]+(?:[,\s]+[A-Z]+[0-9]+)*))?)(?P<trailing_spaces>\s*)",
     )
     .unwrap()
 });
@@ -526,6 +526,9 @@ mod tests {
         assert!(NOQA_LINE_REGEX.is_match("# noqa"));
         assert!(NOQA_LINE_REGEX.is_match("# NoQA"));
 
+        assert!(NOQA_LINE_REGEX.is_match("#noqa"));
+        assert!(NOQA_LINE_REGEX.is_match("#NoQA"));
+
         assert!(NOQA_LINE_REGEX.is_match("# noqa: F401"));
         assert!(NOQA_LINE_REGEX.is_match("# NoQA: F401"));
         assert!(NOQA_LINE_REGEX.is_match("# noqa: F401, E501"));
@@ -533,6 +536,10 @@ mod tests {
         assert!(NOQA_LINE_REGEX.is_match("# noqa:F401"));
         assert!(NOQA_LINE_REGEX.is_match("# NoQA:F401"));
         assert!(NOQA_LINE_REGEX.is_match("# noqa:F401, E501"));
+
+        assert!(NOQA_LINE_REGEX.is_match("#noqa:F401"));
+        assert!(NOQA_LINE_REGEX.is_match("#NoQA:F401"));
+        assert!(NOQA_LINE_REGEX.is_match("#noqa:F401, E501"));
     }
 
     #[test]

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__noqa.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__noqa.snap
@@ -16,5 +16,8 @@ noqa.py:23:5: F841 [*] Local variable `I` is assigned to but never used
 22 22 |     # Only `E741` should be ignored by the `noqa`.
 23    |-    I = 1  # noqa: E741.F841
    23 |+    pass  # noqa: E741.F841
+24 24 | 
+25 25 | 
+26 26 | def f():
 
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_3.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_3.snap
@@ -94,7 +94,7 @@ RUF100_3.py:5:10: RUF100 [*] Unused blanket `noqa` directive
   5 |+print()  # comment
 6 6 | print()  # noqa comment
 7 7 | print()  # noqa  comment
-8 8 | print(a)  # noqa
+8 8 | print()  #noqa
 
 RUF100_3.py:6:10: RUF100 [*] Unused blanket `noqa` directive
   |
@@ -103,7 +103,7 @@ RUF100_3.py:6:10: RUF100 [*] Unused blanket `noqa` directive
 6 | print()  # noqa comment
   |          ^^^^^^ RUF100
 7 | print()  # noqa  comment
-8 | print(a)  # noqa
+8 | print()  #noqa
   |
   = help: Remove unused `noqa` directive
 
@@ -114,8 +114,8 @@ RUF100_3.py:6:10: RUF100 [*] Unused blanket `noqa` directive
 6   |-print()  # noqa comment
   6 |+print()  # comment
 7 7 | print()  # noqa  comment
-8 8 | print(a)  # noqa
-9 9 | print(a)  # noqa # comment
+8 8 | print()  #noqa
+9 9 | print(a)  # noqa
 
 RUF100_3.py:7:10: RUF100 [*] Unused blanket `noqa` directive
   |
@@ -123,8 +123,8 @@ RUF100_3.py:7:10: RUF100 [*] Unused blanket `noqa` directive
 6 | print()  # noqa comment
 7 | print()  # noqa  comment
   |          ^^^^^^ RUF100
-8 | print(a)  # noqa
-9 | print(a)  # noqa # comment
+8 | print()  #noqa
+9 | print(a)  # noqa
   |
   = help: Remove unused `noqa` directive
 
@@ -134,249 +134,291 @@ RUF100_3.py:7:10: RUF100 [*] Unused blanket `noqa` directive
 6 6 | print()  # noqa comment
 7   |-print()  # noqa  comment
   7 |+print()  # comment
-8 8 | print(a)  # noqa
-9 9 | print(a)  # noqa # comment
-10 10 | print(a)  # noqa  # comment
+8 8 | print()  #noqa
+9 9 | print(a)  # noqa
+10 10 | print(a)  # noqa # comment
 
-RUF100_3.py:14:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
+RUF100_3.py:8:10: RUF100 [*] Unused blanket `noqa` directive
    |
-12 | print(a)  # noqa  comment
-13 | 
-14 | # noqa: E501, F821
+ 6 | print()  # noqa comment
+ 7 | print()  # noqa  comment
+ 8 | print()  #noqa
+   |          ^^^^^ RUF100
+ 9 | print(a)  # noqa
+10 | print(a)  # noqa # comment
+   |
+   = help: Remove unused `noqa` directive
+
+ℹ Suggested fix
+5 5 | print()  # noqa  # comment
+6 6 | print()  # noqa comment
+7 7 | print()  # noqa  comment
+8   |-print()  #noqa
+  8 |+print()
+9 9 | print(a)  # noqa
+10 10 | print(a)  # noqa # comment
+11 11 | print(a)  # noqa  # comment
+
+RUF100_3.py:16:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
+   |
+14 | print(a)  #noqa comment
+15 | 
+16 | # noqa: E501, F821
    | ^^^^^^^^^^^^^^^^^^ RUF100
-15 | # noqa: E501, F821 # comment
-16 | print()  # noqa: E501, F821
+17 | # noqa: E501, F821 # comment
+18 | print()  # noqa: E501, F821
    |
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-11 11 | print(a)  # noqa comment
-12 12 | print(a)  # noqa  comment
-13 13 | 
-14    |-# noqa: E501, F821
-15 14 | # noqa: E501, F821 # comment
-16 15 | print()  # noqa: E501, F821
-17 16 | print()  # noqa: E501, F821 # comment
+13 13 | print(a)  # noqa  comment
+14 14 | print(a)  #noqa comment
+15 15 | 
+16    |-# noqa: E501, F821
+17 16 | # noqa: E501, F821 # comment
+18 17 | print()  # noqa: E501, F821
+19 18 | print()  # noqa: E501, F821 # comment
 
-RUF100_3.py:15:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
+RUF100_3.py:17:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
-14 | # noqa: E501, F821
-15 | # noqa: E501, F821 # comment
+16 | # noqa: E501, F821
+17 | # noqa: E501, F821 # comment
    | ^^^^^^^^^^^^^^^^^^ RUF100
-16 | print()  # noqa: E501, F821
-17 | print()  # noqa: E501, F821 # comment
+18 | print()  # noqa: E501, F821
+19 | print()  # noqa: E501, F821 # comment
    |
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-12 12 | print(a)  # noqa  comment
-13 13 | 
-14 14 | # noqa: E501, F821
-15    |-# noqa: E501, F821 # comment
-   15 |+# comment
-16 16 | print()  # noqa: E501, F821
-17 17 | print()  # noqa: E501, F821 # comment
-18 18 | print()  # noqa: E501, F821  # comment
-
-RUF100_3.py:16:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
-   |
-14 | # noqa: E501, F821
-15 | # noqa: E501, F821 # comment
-16 | print()  # noqa: E501, F821
-   |          ^^^^^^^^^^^^^^^^^^ RUF100
-17 | print()  # noqa: E501, F821 # comment
-18 | print()  # noqa: E501, F821  # comment
-   |
-   = help: Remove unused `noqa` directive
-
-ℹ Suggested fix
-13 13 | 
-14 14 | # noqa: E501, F821
-15 15 | # noqa: E501, F821 # comment
-16    |-print()  # noqa: E501, F821
-   16 |+print()
-17 17 | print()  # noqa: E501, F821 # comment
-18 18 | print()  # noqa: E501, F821  # comment
-19 19 | print()  # noqa: E501, F821 comment
-
-RUF100_3.py:17:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
-   |
-15 | # noqa: E501, F821 # comment
-16 | print()  # noqa: E501, F821
-17 | print()  # noqa: E501, F821 # comment
-   |          ^^^^^^^^^^^^^^^^^^ RUF100
-18 | print()  # noqa: E501, F821  # comment
-19 | print()  # noqa: E501, F821 comment
-   |
-   = help: Remove unused `noqa` directive
-
-ℹ Suggested fix
-14 14 | # noqa: E501, F821
-15 15 | # noqa: E501, F821 # comment
-16 16 | print()  # noqa: E501, F821
-17    |-print()  # noqa: E501, F821 # comment
-   17 |+print()  # comment
-18 18 | print()  # noqa: E501, F821  # comment
-19 19 | print()  # noqa: E501, F821 comment
-20 20 | print()  # noqa: E501, F821  comment
+14 14 | print(a)  #noqa comment
+15 15 | 
+16 16 | # noqa: E501, F821
+17    |-# noqa: E501, F821 # comment
+   17 |+# comment
+18 18 | print()  # noqa: E501, F821
+19 19 | print()  # noqa: E501, F821 # comment
+20 20 | print()  # noqa: E501, F821  # comment
 
 RUF100_3.py:18:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
-16 | print()  # noqa: E501, F821
-17 | print()  # noqa: E501, F821 # comment
-18 | print()  # noqa: E501, F821  # comment
+16 | # noqa: E501, F821
+17 | # noqa: E501, F821 # comment
+18 | print()  # noqa: E501, F821
    |          ^^^^^^^^^^^^^^^^^^ RUF100
-19 | print()  # noqa: E501, F821 comment
-20 | print()  # noqa: E501, F821  comment
+19 | print()  # noqa: E501, F821 # comment
+20 | print()  # noqa: E501, F821  # comment
    |
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-15 15 | # noqa: E501, F821 # comment
-16 16 | print()  # noqa: E501, F821
-17 17 | print()  # noqa: E501, F821 # comment
-18    |-print()  # noqa: E501, F821  # comment
-   18 |+print()  # comment
-19 19 | print()  # noqa: E501, F821 comment
-20 20 | print()  # noqa: E501, F821  comment
-21 21 | print(a)  # noqa: E501, F821
+15 15 | 
+16 16 | # noqa: E501, F821
+17 17 | # noqa: E501, F821 # comment
+18    |-print()  # noqa: E501, F821
+   18 |+print()
+19 19 | print()  # noqa: E501, F821 # comment
+20 20 | print()  # noqa: E501, F821  # comment
+21 21 | print()  # noqa: E501, F821 comment
 
 RUF100_3.py:19:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
-17 | print()  # noqa: E501, F821 # comment
-18 | print()  # noqa: E501, F821  # comment
-19 | print()  # noqa: E501, F821 comment
+17 | # noqa: E501, F821 # comment
+18 | print()  # noqa: E501, F821
+19 | print()  # noqa: E501, F821 # comment
    |          ^^^^^^^^^^^^^^^^^^ RUF100
-20 | print()  # noqa: E501, F821  comment
-21 | print(a)  # noqa: E501, F821
+20 | print()  # noqa: E501, F821  # comment
+21 | print()  # noqa: E501, F821 comment
    |
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-16 16 | print()  # noqa: E501, F821
-17 17 | print()  # noqa: E501, F821 # comment
-18 18 | print()  # noqa: E501, F821  # comment
-19    |-print()  # noqa: E501, F821 comment
+16 16 | # noqa: E501, F821
+17 17 | # noqa: E501, F821 # comment
+18 18 | print()  # noqa: E501, F821
+19    |-print()  # noqa: E501, F821 # comment
    19 |+print()  # comment
-20 20 | print()  # noqa: E501, F821  comment
-21 21 | print(a)  # noqa: E501, F821
-22 22 | print(a)  # noqa: E501, F821 # comment
+20 20 | print()  # noqa: E501, F821  # comment
+21 21 | print()  # noqa: E501, F821 comment
+22 22 | print()  # noqa: E501, F821  comment
 
 RUF100_3.py:20:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
-18 | print()  # noqa: E501, F821  # comment
-19 | print()  # noqa: E501, F821 comment
-20 | print()  # noqa: E501, F821  comment
+18 | print()  # noqa: E501, F821
+19 | print()  # noqa: E501, F821 # comment
+20 | print()  # noqa: E501, F821  # comment
    |          ^^^^^^^^^^^^^^^^^^ RUF100
-21 | print(a)  # noqa: E501, F821
-22 | print(a)  # noqa: E501, F821 # comment
+21 | print()  # noqa: E501, F821 comment
+22 | print()  # noqa: E501, F821  comment
    |
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-17 17 | print()  # noqa: E501, F821 # comment
-18 18 | print()  # noqa: E501, F821  # comment
-19 19 | print()  # noqa: E501, F821 comment
-20    |-print()  # noqa: E501, F821  comment
+17 17 | # noqa: E501, F821 # comment
+18 18 | print()  # noqa: E501, F821
+19 19 | print()  # noqa: E501, F821 # comment
+20    |-print()  # noqa: E501, F821  # comment
    20 |+print()  # comment
-21 21 | print(a)  # noqa: E501, F821
-22 22 | print(a)  # noqa: E501, F821 # comment
-23 23 | print(a)  # noqa: E501, F821  # comment
+21 21 | print()  # noqa: E501, F821 comment
+22 22 | print()  # noqa: E501, F821  comment
+23 23 | print(a)  # noqa: E501, F821
 
-RUF100_3.py:21:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
+RUF100_3.py:21:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
-19 | print()  # noqa: E501, F821 comment
-20 | print()  # noqa: E501, F821  comment
-21 | print(a)  # noqa: E501, F821
-   |           ^^^^^^^^^^^^^^^^^^ RUF100
-22 | print(a)  # noqa: E501, F821 # comment
-23 | print(a)  # noqa: E501, F821  # comment
-   |
-   = help: Remove unused `noqa` directive
-
-ℹ Suggested fix
-18 18 | print()  # noqa: E501, F821  # comment
-19 19 | print()  # noqa: E501, F821 comment
-20 20 | print()  # noqa: E501, F821  comment
-21    |-print(a)  # noqa: E501, F821
-   21 |+print(a)  # noqa: F821
-22 22 | print(a)  # noqa: E501, F821 # comment
-23 23 | print(a)  # noqa: E501, F821  # comment
-24 24 | print(a)  # noqa: E501, F821 comment
-
-RUF100_3.py:22:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
-   |
-20 | print()  # noqa: E501, F821  comment
-21 | print(a)  # noqa: E501, F821
-22 | print(a)  # noqa: E501, F821 # comment
-   |           ^^^^^^^^^^^^^^^^^^ RUF100
-23 | print(a)  # noqa: E501, F821  # comment
-24 | print(a)  # noqa: E501, F821 comment
+19 | print()  # noqa: E501, F821 # comment
+20 | print()  # noqa: E501, F821  # comment
+21 | print()  # noqa: E501, F821 comment
+   |          ^^^^^^^^^^^^^^^^^^ RUF100
+22 | print()  # noqa: E501, F821  comment
+23 | print(a)  # noqa: E501, F821
    |
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-19 19 | print()  # noqa: E501, F821 comment
-20 20 | print()  # noqa: E501, F821  comment
-21 21 | print(a)  # noqa: E501, F821
-22    |-print(a)  # noqa: E501, F821 # comment
-   22 |+print(a)  # noqa: F821 # comment
-23 23 | print(a)  # noqa: E501, F821  # comment
-24 24 | print(a)  # noqa: E501, F821 comment
-25 25 | print(a)  # noqa: E501, F821  comment
+18 18 | print()  # noqa: E501, F821
+19 19 | print()  # noqa: E501, F821 # comment
+20 20 | print()  # noqa: E501, F821  # comment
+21    |-print()  # noqa: E501, F821 comment
+   21 |+print()  # comment
+22 22 | print()  # noqa: E501, F821  comment
+23 23 | print(a)  # noqa: E501, F821
+24 24 | print(a)  # noqa: E501, F821 # comment
+
+RUF100_3.py:22:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
+   |
+20 | print()  # noqa: E501, F821  # comment
+21 | print()  # noqa: E501, F821 comment
+22 | print()  # noqa: E501, F821  comment
+   |          ^^^^^^^^^^^^^^^^^^ RUF100
+23 | print(a)  # noqa: E501, F821
+24 | print(a)  # noqa: E501, F821 # comment
+   |
+   = help: Remove unused `noqa` directive
+
+ℹ Suggested fix
+19 19 | print()  # noqa: E501, F821 # comment
+20 20 | print()  # noqa: E501, F821  # comment
+21 21 | print()  # noqa: E501, F821 comment
+22    |-print()  # noqa: E501, F821  comment
+   22 |+print()  # comment
+23 23 | print(a)  # noqa: E501, F821
+24 24 | print(a)  # noqa: E501, F821 # comment
+25 25 | print(a)  # noqa: E501, F821  # comment
 
 RUF100_3.py:23:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
-21 | print(a)  # noqa: E501, F821
-22 | print(a)  # noqa: E501, F821 # comment
-23 | print(a)  # noqa: E501, F821  # comment
+21 | print()  # noqa: E501, F821 comment
+22 | print()  # noqa: E501, F821  comment
+23 | print(a)  # noqa: E501, F821
    |           ^^^^^^^^^^^^^^^^^^ RUF100
-24 | print(a)  # noqa: E501, F821 comment
-25 | print(a)  # noqa: E501, F821  comment
+24 | print(a)  # noqa: E501, F821 # comment
+25 | print(a)  # noqa: E501, F821  # comment
    |
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-20 20 | print()  # noqa: E501, F821  comment
-21 21 | print(a)  # noqa: E501, F821
-22 22 | print(a)  # noqa: E501, F821 # comment
-23    |-print(a)  # noqa: E501, F821  # comment
-   23 |+print(a)  # noqa: F821  # comment
-24 24 | print(a)  # noqa: E501, F821 comment
-25 25 | print(a)  # noqa: E501, F821  comment
+20 20 | print()  # noqa: E501, F821  # comment
+21 21 | print()  # noqa: E501, F821 comment
+22 22 | print()  # noqa: E501, F821  comment
+23    |-print(a)  # noqa: E501, F821
+   23 |+print(a)  # noqa: F821
+24 24 | print(a)  # noqa: E501, F821 # comment
+25 25 | print(a)  # noqa: E501, F821  # comment
+26 26 | print(a)  # noqa: E501, F821 comment
 
 RUF100_3.py:24:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
-22 | print(a)  # noqa: E501, F821 # comment
-23 | print(a)  # noqa: E501, F821  # comment
-24 | print(a)  # noqa: E501, F821 comment
+22 | print()  # noqa: E501, F821  comment
+23 | print(a)  # noqa: E501, F821
+24 | print(a)  # noqa: E501, F821 # comment
    |           ^^^^^^^^^^^^^^^^^^ RUF100
-25 | print(a)  # noqa: E501, F821  comment
+25 | print(a)  # noqa: E501, F821  # comment
+26 | print(a)  # noqa: E501, F821 comment
    |
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-21 21 | print(a)  # noqa: E501, F821
-22 22 | print(a)  # noqa: E501, F821 # comment
-23 23 | print(a)  # noqa: E501, F821  # comment
-24    |-print(a)  # noqa: E501, F821 comment
-   24 |+print(a)  # noqa: F821 comment
-25 25 | print(a)  # noqa: E501, F821  comment
+21 21 | print()  # noqa: E501, F821 comment
+22 22 | print()  # noqa: E501, F821  comment
+23 23 | print(a)  # noqa: E501, F821
+24    |-print(a)  # noqa: E501, F821 # comment
+   24 |+print(a)  # noqa: F821 # comment
+25 25 | print(a)  # noqa: E501, F821  # comment
+26 26 | print(a)  # noqa: E501, F821 comment
+27 27 | print(a)  # noqa: E501, F821  comment
 
 RUF100_3.py:25:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
-23 | print(a)  # noqa: E501, F821  # comment
-24 | print(a)  # noqa: E501, F821 comment
-25 | print(a)  # noqa: E501, F821  comment
+23 | print(a)  # noqa: E501, F821
+24 | print(a)  # noqa: E501, F821 # comment
+25 | print(a)  # noqa: E501, F821  # comment
    |           ^^^^^^^^^^^^^^^^^^ RUF100
+26 | print(a)  # noqa: E501, F821 comment
+27 | print(a)  # noqa: E501, F821  comment
    |
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-22 22 | print(a)  # noqa: E501, F821 # comment
-23 23 | print(a)  # noqa: E501, F821  # comment
-24 24 | print(a)  # noqa: E501, F821 comment
-25    |-print(a)  # noqa: E501, F821  comment
-   25 |+print(a)  # noqa: F821  comment
+22 22 | print()  # noqa: E501, F821  comment
+23 23 | print(a)  # noqa: E501, F821
+24 24 | print(a)  # noqa: E501, F821 # comment
+25    |-print(a)  # noqa: E501, F821  # comment
+   25 |+print(a)  # noqa: F821  # comment
+26 26 | print(a)  # noqa: E501, F821 comment
+27 27 | print(a)  # noqa: E501, F821  comment
+28 28 | print(a)  #noqa: E501, F821  comment
+
+RUF100_3.py:26:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
+   |
+24 | print(a)  # noqa: E501, F821 # comment
+25 | print(a)  # noqa: E501, F821  # comment
+26 | print(a)  # noqa: E501, F821 comment
+   |           ^^^^^^^^^^^^^^^^^^ RUF100
+27 | print(a)  # noqa: E501, F821  comment
+28 | print(a)  #noqa: E501, F821  comment
+   |
+   = help: Remove unused `noqa` directive
+
+ℹ Suggested fix
+23 23 | print(a)  # noqa: E501, F821
+24 24 | print(a)  # noqa: E501, F821 # comment
+25 25 | print(a)  # noqa: E501, F821  # comment
+26    |-print(a)  # noqa: E501, F821 comment
+   26 |+print(a)  # noqa: F821 comment
+27 27 | print(a)  # noqa: E501, F821  comment
+28 28 | print(a)  #noqa: E501, F821  comment
+
+RUF100_3.py:27:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
+   |
+25 | print(a)  # noqa: E501, F821  # comment
+26 | print(a)  # noqa: E501, F821 comment
+27 | print(a)  # noqa: E501, F821  comment
+   |           ^^^^^^^^^^^^^^^^^^ RUF100
+28 | print(a)  #noqa: E501, F821  comment
+   |
+   = help: Remove unused `noqa` directive
+
+ℹ Suggested fix
+24 24 | print(a)  # noqa: E501, F821 # comment
+25 25 | print(a)  # noqa: E501, F821  # comment
+26 26 | print(a)  # noqa: E501, F821 comment
+27    |-print(a)  # noqa: E501, F821  comment
+   27 |+print(a)  # noqa: F821  comment
+28 28 | print(a)  #noqa: E501, F821  comment
+
+RUF100_3.py:28:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
+   |
+26 | print(a)  # noqa: E501, F821 comment
+27 | print(a)  # noqa: E501, F821  comment
+28 | print(a)  #noqa: E501, F821  comment
+   |           ^^^^^^^^^^^^^^^^^ RUF100
+   |
+   = help: Remove unused `noqa` directive
+
+ℹ Suggested fix
+25 25 | print(a)  # noqa: E501, F821  # comment
+26 26 | print(a)  # noqa: E501, F821 comment
+27 27 | print(a)  # noqa: E501, F821  comment
+28    |-print(a)  #noqa: E501, F821  comment
+   28 |+print(a)  # noqa: F821  comment
 
 


### PR DESCRIPTION
## Summary

We now respect, e.g., `#noqa: F401`.

Closes #5177.
