### PR TITLE
Enable attribute lookups via semantic model

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_raise/RSE102.py
+++ b/crates/ruff/resources/test/fixtures/flake8_raise/RSE102.py
@@ -29,6 +29,26 @@ raise TypeError(
     # Hello, world!
 )
 
+# OK
 raise AssertionError
 
+# OK
 raise AttributeError("test message")
+
+
+def return_error():
+    return ValueError("Something")
+
+
+# OK
+raise return_error()
+
+
+class Class:
+    @staticmethod
+    def error():
+        return ValueError("Something")
+
+
+# OK
+raise Class.error()

--- a/crates/ruff/src/renamer.rs
+++ b/crates/ruff/src/renamer.rs
@@ -248,8 +248,8 @@ impl Renamer {
             | BindingKind::LoopVar
             | BindingKind::Global
             | BindingKind::Nonlocal(_)
-            | BindingKind::ClassDefinition
-            | BindingKind::FunctionDefinition
+            | BindingKind::ClassDefinition(_)
+            | BindingKind::FunctionDefinition(_)
             | BindingKind::Deletion
             | BindingKind::UnboundException(_) => {
                 Some(Edit::range_replacement(target.to_string(), binding.range))

--- a/crates/ruff/src/rules/flake8_raise/snapshots/ruff__rules__flake8_raise__tests__unnecessary-paren-on-raise-exception_RSE102.py.snap
+++ b/crates/ruff/src/rules/flake8_raise/snapshots/ruff__rules__flake8_raise__tests__unnecessary-paren-on-raise-exception_RSE102.py.snap
@@ -118,7 +118,7 @@ RSE102.py:28:16: RSE102 [*] Unnecessary parentheses on raised exception
 30 | | )
    | |_^ RSE102
 31 |   
-32 |   raise AssertionError
+32 |   # OK
    |
    = help: Remove unnecessary parentheses
 
@@ -131,7 +131,7 @@ RSE102.py:28:16: RSE102 [*] Unnecessary parentheses on raised exception
 30    |-)
    28 |+raise TypeError
 31 29 | 
-32 30 | raise AssertionError
-33 31 | 
+32 30 | # OK
+33 31 | raise AssertionError
 
 

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -126,11 +126,11 @@ impl<'a> Binding<'a> {
         }
         matches!(
             existing.kind,
-            BindingKind::ClassDefinition
-                | BindingKind::FunctionDefinition
-                | BindingKind::Import(..)
-                | BindingKind::FromImport(..)
-                | BindingKind::SubmoduleImport(..)
+            BindingKind::ClassDefinition(_)
+                | BindingKind::FunctionDefinition(_)
+                | BindingKind::Import(_)
+                | BindingKind::FromImport(_)
+                | BindingKind::SubmoduleImport(_)
         )
     }
 
@@ -372,14 +372,14 @@ pub enum BindingKind<'a> {
     /// class Foo:
     ///     ...
     /// ```
-    ClassDefinition,
+    ClassDefinition(ScopeId),
 
     /// A binding for a function, like `foo` in:
     /// ```python
     /// def foo():
     ///     ...
     /// ```
-    FunctionDefinition,
+    FunctionDefinition(ScopeId),
 
     /// A binding for an `__all__` export, like `__all__` in:
     /// ```python


### PR DESCRIPTION
## Summary

This PR enables us to resolve attribute accesses within files, at least for static and class methods. For example, we can now detect that this is a function access (and avoid a false-positive):

```python
class Class:
    @staticmethod
    def error():
        return ValueError("Something")


# OK
raise Class.error()
```

Closes #5487.

Closes #5416.
