### PR TITLE
Allow descriptor instantiations in dataclass fields

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_raise/RSE102.py
+++ b/crates/ruff/resources/test/fixtures/flake8_raise/RSE102.py
@@ -29,6 +29,26 @@ raise TypeError(
     # Hello, world!
 )
 
+# OK
 raise AssertionError
 
+# OK
 raise AttributeError("test message")
+
+
+def return_error():
+    return ValueError("Something")
+
+
+# OK
+raise return_error()
+
+
+class Class:
+    @staticmethod
+    def error():
+        return ValueError("Something")
+
+
+# OK
+raise Class.error()

--- a/crates/ruff/resources/test/fixtures/ruff/RUF009.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF009.py
@@ -6,6 +6,7 @@ from fractions import Fraction
 from pathlib import Path
 from typing import ClassVar, NamedTuple
 
+
 def default_function() -> list[int]:
     return []
 
@@ -25,12 +26,13 @@ class A:
     fine_timedelta: datetime.timedelta = datetime.timedelta(hours=7)
     fine_tuple: tuple[int] = tuple([1])
     fine_regex: re.Pattern = re.compile(r".*")
-    fine_float: float = float('-inf')
+    fine_float: float = float("-inf")
     fine_int: int = int(12)
     fine_complex: complex = complex(1, 2)
     fine_str: str = str("foo")
     fine_bool: bool = bool("foo")
-    fine_fraction: Fraction = Fraction(1,2)
+    fine_fraction: Fraction = Fraction(1, 2)
+
 
 DEFAULT_IMMUTABLETYPE_FOR_ALL_DATACLASSES = ImmutableType(40)
 DEFAULT_A_FOR_ALL_DATACLASSES = A([1, 2, 3])
@@ -45,3 +47,25 @@ class B:
     okay_variant: A = DEFAULT_A_FOR_ALL_DATACLASSES
 
     fine_dataclass_function: list[int] = field(default_factory=list)
+
+
+class IntConversionDescriptor:
+    def __init__(self, *, default):
+        self._default = default
+
+    def __set_name__(self, owner, name):
+        self._name = "_" + name
+
+    def __get__(self, obj, type):
+        if obj is None:
+            return self._default
+
+        return getattr(obj, self._name, self._default)
+
+    def __set__(self, obj, value):
+        setattr(obj, self._name, int(value))
+
+
+@dataclass
+class InventoryItem:
+    quantity_on_hand: IntConversionDescriptor = IntConversionDescriptor(default=100)

--- a/crates/ruff/src/renamer.rs
+++ b/crates/ruff/src/renamer.rs
@@ -248,8 +248,8 @@ impl Renamer {
             | BindingKind::LoopVar
             | BindingKind::Global
             | BindingKind::Nonlocal(_)
-            | BindingKind::ClassDefinition
-            | BindingKind::FunctionDefinition
+            | BindingKind::ClassDefinition(_)
+            | BindingKind::FunctionDefinition(_)
             | BindingKind::Deletion
             | BindingKind::UnboundException(_) => {
                 Some(Edit::range_replacement(target.to_string(), binding.range))

--- a/crates/ruff/src/rules/flake8_raise/snapshots/ruff__rules__flake8_raise__tests__unnecessary-paren-on-raise-exception_RSE102.py.snap
+++ b/crates/ruff/src/rules/flake8_raise/snapshots/ruff__rules__flake8_raise__tests__unnecessary-paren-on-raise-exception_RSE102.py.snap
@@ -118,7 +118,7 @@ RSE102.py:28:16: RSE102 [*] Unnecessary parentheses on raised exception
 30 | | )
    | |_^ RSE102
 31 |   
-32 |   raise AssertionError
+32 |   # OK
    |
    = help: Remove unnecessary parentheses
 
@@ -131,7 +131,7 @@ RSE102.py:28:16: RSE102 [*] Unnecessary parentheses on raised exception
 30    |-)
    28 |+raise TypeError
 31 29 | 
-32 30 | raise AssertionError
-33 31 | 
+32 30 | # OK
+33 31 | raise AssertionError
 
 

--- a/crates/ruff/src/rules/ruff/rules/function_call_in_dataclass_default.rs
+++ b/crates/ruff/src/rules/ruff/rules/function_call_in_dataclass_default.rs
@@ -8,7 +8,7 @@ use ruff_python_semantic::analyze::typing::is_immutable_func;
 
 use crate::checkers::ast::Checker;
 use crate::rules::ruff::rules::helpers::{
-    is_class_var_annotation, is_dataclass, is_dataclass_field,
+    is_class_var_annotation, is_dataclass, is_dataclass_field, is_descriptor_class,
 };
 
 /// ## What it does
@@ -98,6 +98,7 @@ pub(crate) fn function_call_in_dataclass_default(
                 if !is_class_var_annotation(annotation, checker.semantic())
                     && !is_immutable_func(func, checker.semantic(), &extend_immutable_calls)
                     && !is_dataclass_field(func, checker.semantic())
+                    && !is_descriptor_class(func, checker.semantic())
                 {
                     checker.diagnostics.push(Diagnostic::new(
                         FunctionCallInDataclassDefaultArgument {

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF009_RUF009.py.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF009_RUF009.py.snap
@@ -1,44 +1,44 @@
 ---
 source: crates/ruff/src/rules/ruff/mod.rs
 ---
-RUF009.py:19:41: RUF009 Do not perform function call `default_function` in dataclass defaults
+RUF009.py:20:41: RUF009 Do not perform function call `default_function` in dataclass defaults
    |
-17 | @dataclass()
-18 | class A:
-19 |     hidden_mutable_default: list[int] = default_function()
+18 | @dataclass()
+19 | class A:
+20 |     hidden_mutable_default: list[int] = default_function()
    |                                         ^^^^^^^^^^^^^^^^^^ RUF009
-20 |     class_variable: typing.ClassVar[list[int]] = default_function()
-21 |     another_class_var: ClassVar[list[int]] = default_function()
+21 |     class_variable: typing.ClassVar[list[int]] = default_function()
+22 |     another_class_var: ClassVar[list[int]] = default_function()
    |
 
-RUF009.py:41:41: RUF009 Do not perform function call `default_function` in dataclass defaults
+RUF009.py:43:41: RUF009 Do not perform function call `default_function` in dataclass defaults
    |
-39 | @dataclass
-40 | class B:
-41 |     hidden_mutable_default: list[int] = default_function()
+41 | @dataclass
+42 | class B:
+43 |     hidden_mutable_default: list[int] = default_function()
    |                                         ^^^^^^^^^^^^^^^^^^ RUF009
-42 |     another_dataclass: A = A()
-43 |     not_optimal: ImmutableType = ImmutableType(20)
+44 |     another_dataclass: A = A()
+45 |     not_optimal: ImmutableType = ImmutableType(20)
    |
 
-RUF009.py:42:28: RUF009 Do not perform function call `A` in dataclass defaults
+RUF009.py:44:28: RUF009 Do not perform function call `A` in dataclass defaults
    |
-40 | class B:
-41 |     hidden_mutable_default: list[int] = default_function()
-42 |     another_dataclass: A = A()
+42 | class B:
+43 |     hidden_mutable_default: list[int] = default_function()
+44 |     another_dataclass: A = A()
    |                            ^^^ RUF009
-43 |     not_optimal: ImmutableType = ImmutableType(20)
-44 |     good_variant: ImmutableType = DEFAULT_IMMUTABLETYPE_FOR_ALL_DATACLASSES
+45 |     not_optimal: ImmutableType = ImmutableType(20)
+46 |     good_variant: ImmutableType = DEFAULT_IMMUTABLETYPE_FOR_ALL_DATACLASSES
    |
 
-RUF009.py:43:34: RUF009 Do not perform function call `ImmutableType` in dataclass defaults
+RUF009.py:45:34: RUF009 Do not perform function call `ImmutableType` in dataclass defaults
    |
-41 |     hidden_mutable_default: list[int] = default_function()
-42 |     another_dataclass: A = A()
-43 |     not_optimal: ImmutableType = ImmutableType(20)
+43 |     hidden_mutable_default: list[int] = default_function()
+44 |     another_dataclass: A = A()
+45 |     not_optimal: ImmutableType = ImmutableType(20)
    |                                  ^^^^^^^^^^^^^^^^^ RUF009
-44 |     good_variant: ImmutableType = DEFAULT_IMMUTABLETYPE_FOR_ALL_DATACLASSES
-45 |     okay_variant: A = DEFAULT_A_FOR_ALL_DATACLASSES
+46 |     good_variant: ImmutableType = DEFAULT_IMMUTABLETYPE_FOR_ALL_DATACLASSES
+47 |     okay_variant: A = DEFAULT_A_FOR_ALL_DATACLASSES
    |
 
 

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -126,11 +126,11 @@ impl<'a> Binding<'a> {
         }
         matches!(
             existing.kind,
-            BindingKind::ClassDefinition
-                | BindingKind::FunctionDefinition
-                | BindingKind::Import(..)
-                | BindingKind::FromImport(..)
-                | BindingKind::SubmoduleImport(..)
+            BindingKind::ClassDefinition(_)
+                | BindingKind::FunctionDefinition(_)
+                | BindingKind::Import(_)
+                | BindingKind::FromImport(_)
+                | BindingKind::SubmoduleImport(_)
         )
     }
 
@@ -372,14 +372,14 @@ pub enum BindingKind<'a> {
     /// class Foo:
     ///     ...
     /// ```
-    ClassDefinition,
+    ClassDefinition(ScopeId),
 
     /// A binding for a function, like `foo` in:
     /// ```python
     /// def foo():
     ///     ...
     /// ```
-    FunctionDefinition,
+    FunctionDefinition(ScopeId),
 
     /// A binding for an `__all__` export, like `__all__` in:
     /// ```python


### PR DESCRIPTION
## Summary

Per the Python documentation, dataclasses are allowed to instantiate descriptors, like so:

```python
class IntConversionDescriptor:
  def __init__(self, *, default):
    self._default = default

  def __set_name__(self, owner, name):
    self._name = "_" + name

  def __get__(self, obj, type):
    if obj is None:
      return self._default

    return getattr(obj, self._name, self._default)

  def __set__(self, obj, value):
    setattr(obj, self._name, int(value))

@dataclass
class InventoryItem:
  quantity_on_hand: IntConversionDescriptor = IntConversionDescriptor(default=100)
```

Closes https://github.com/astral-sh/ruff/issues/4451.
