### PR TITLE
`[isort]` Add `--case-sensitive` flag

### DIFF
--- a/crates/ruff/resources/test/fixtures/isort/case_sensitive.py
+++ b/crates/ruff/resources/test/fixtures/isort/case_sensitive.py
@@ -1,0 +1,6 @@
+import os
+import Pandas as pd
+import Pandas
+import Xml.etree.ElementTree as ET
+import requests
+from datetime import datetime

--- a/crates/ruff/resources/test/fixtures/isort/case_sensitive.py
+++ b/crates/ruff/resources/test/fixtures/isort/case_sensitive.py
@@ -1,6 +1,7 @@
 import os
-import Pandas as pd
 import Pandas
 import Xml.etree.ElementTree as ET
 import requests
 from datetime import datetime
+
+from module import Class, CONSTANT, function, BASIC, Apple

--- a/crates/ruff/resources/test/fixtures/isort/pyproject.toml
+++ b/crates/ruff/resources/test/fixtures/isort/pyproject.toml
@@ -6,3 +6,4 @@ lines-after-imports = 3
 lines-between-types = 2
 known-local-folder = ["ruff"]
 force-to-top = ["lib1", "lib3", "lib5", "lib3.lib4", "z"]
+case-sensitive = true

--- a/crates/ruff/resources/test/fixtures/isort/pyproject.toml
+++ b/crates/ruff/resources/test/fixtures/isort/pyproject.toml
@@ -6,4 +6,3 @@ lines-after-imports = 3
 lines-between-types = 2
 known-local-folder = ["ruff"]
 force-to-top = ["lib1", "lib3", "lib5", "lib3.lib4", "z"]
-case-sensitive = true

--- a/crates/ruff/src/rules/isort/mod.rs
+++ b/crates/ruff/src/rules/isort/mod.rs
@@ -313,7 +313,6 @@ mod tests {
 
     #[test_case(Path::new("add_newline_before_comments.py"))]
     #[test_case(Path::new("as_imports_comments.py"))]
-    #[test_case(Path::new("case_sensitive.py"))]
     #[test_case(Path::new("combine_as_imports.py"))]
     #[test_case(Path::new("combine_import_from.py"))]
     #[test_case(Path::new("comments.py"))]
@@ -369,6 +368,7 @@ mod tests {
         assert_messages!(snapshot, diagnostics);
         Ok(())
     }
+
 
     #[test_case(Path::new("separate_subpackage_first_and_third_party_imports.py"))]
     fn separate_modules(path: &Path) -> Result<()> {
@@ -450,6 +450,24 @@ mod tests {
                         vec![],
                         FxHashMap::default(),
                     ),
+                    ..super::settings::Settings::default()
+                },
+                src: vec![test_resource_path("fixtures/isort")],
+                ..Settings::for_rule(Rule::UnsortedImports)
+            },
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Path::new("case_sensitive.py"))]
+    fn case_sensitive(path: &Path) -> Result<()> {
+        let snapshot = format!("case_sensitive_{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("isort").join(path).as_path(),
+            &Settings {
+                isort: super::settings::Settings {
+                    case_sensitive: true,
                     ..super::settings::Settings::default()
                 },
                 src: vec![test_resource_path("fixtures/isort")],

--- a/crates/ruff/src/rules/isort/mod.rs
+++ b/crates/ruff/src/rules/isort/mod.rs
@@ -74,6 +74,7 @@ pub(crate) fn format_imports(
     combine_as_imports: bool,
     force_single_line: bool,
     force_sort_within_sections: bool,
+    case_sensitive: bool,
     force_wrap_aliases: bool,
     force_to_top: &BTreeSet<String>,
     known_modules: &KnownModules,
@@ -114,6 +115,7 @@ pub(crate) fn format_imports(
             src,
             package,
             force_sort_within_sections,
+            case_sensitive,
             force_wrap_aliases,
             force_to_top,
             known_modules,
@@ -171,6 +173,7 @@ fn format_import_block(
     src: &[PathBuf],
     package: Option<&Path>,
     force_sort_within_sections: bool,
+    case_sensitive: bool,
     force_wrap_aliases: bool,
     force_to_top: &BTreeSet<String>,
     known_modules: &KnownModules,
@@ -206,6 +209,7 @@ fn format_import_block(
         let imports = order_imports(
             import_block,
             order_by_type,
+            case_sensitive,
             relative_imports_order,
             classes,
             constants,
@@ -222,7 +226,13 @@ fn format_import_block(
                 .collect::<Vec<EitherImport>>();
             if force_sort_within_sections {
                 imports.sort_by(|import1, import2| {
-                    cmp_either_import(import1, import2, relative_imports_order, force_to_top)
+                    cmp_either_import(
+                        import1,
+                        import2,
+                        relative_imports_order,
+                        force_to_top,
+                        case_sensitive,
+                    )
                 });
             };
             imports
@@ -303,6 +313,7 @@ mod tests {
 
     #[test_case(Path::new("add_newline_before_comments.py"))]
     #[test_case(Path::new("as_imports_comments.py"))]
+    #[test_case(Path::new("case_sensitive.py"))]
     #[test_case(Path::new("combine_as_imports.py"))]
     #[test_case(Path::new("combine_import_from.py"))]
     #[test_case(Path::new("comments.py"))]

--- a/crates/ruff/src/rules/isort/order.rs
+++ b/crates/ruff/src/rules/isort/order.rs
@@ -12,6 +12,7 @@ use super::types::{AliasData, CommentSet, ImportBlock, OrderedImportBlock};
 pub(crate) fn order_imports<'a>(
     block: ImportBlock<'a>,
     order_by_type: bool,
+    case_sensitive: bool,
     relative_imports_order: RelativeImportsOrder,
     classes: &'a BTreeSet<String>,
     constants: &'a BTreeSet<String>,
@@ -83,6 +84,7 @@ pub(crate) fn order_imports<'a>(
                         import_from2,
                         relative_imports_order,
                         force_to_top,
+                        case_sensitive,
                     )
                     .then_with(|| match (aliases1.first(), aliases2.first()) {
                         (None, None) => Ordering::Equal,

--- a/crates/ruff/src/rules/isort/order.rs
+++ b/crates/ruff/src/rules/isort/order.rs
@@ -26,7 +26,7 @@ pub(crate) fn order_imports<'a>(
         block
             .import
             .into_iter()
-            .sorted_by(|(alias1, _), (alias2, _)| cmp_modules(alias1, alias2, force_to_top)),
+            .sorted_by(|(alias1, _), (alias2, _)| cmp_modules(alias1, alias2, force_to_top, case_sensitive)),
     );
 
     // Sort `Stmt::ImportFrom`.
@@ -71,6 +71,7 @@ pub(crate) fn order_imports<'a>(
                                     constants,
                                     variables,
                                     force_to_top,
+                                    case_sensitive
                                 )
                             })
                             .collect::<Vec<(AliasData, CommentSet)>>(),
@@ -98,6 +99,7 @@ pub(crate) fn order_imports<'a>(
                             constants,
                             variables,
                             force_to_top,
+                            case_sensitive
                         ),
                     })
                 },

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -127,6 +127,7 @@ pub(crate) fn organize_imports(
         settings.isort.combine_as_imports,
         settings.isort.force_single_line,
         settings.isort.force_sort_within_sections,
+        settings.isort.case_sensitive,
         settings.isort.force_wrap_aliases,
         &settings.isort.force_to_top,
         &settings.isort.known_modules,

--- a/crates/ruff/src/rules/isort/settings.rs
+++ b/crates/ruff/src/rules/isort/settings.rs
@@ -134,6 +134,15 @@ pub struct Options {
             force-to-top = ["src"]
         "#
     )]
+    /// Sort imports taking into account case sensitivity.
+    pub case_sensitive: Option<bool>,
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"
+            case-sensitive = true
+        "#
+    )]
     /// Force specific imports to the top of their appropriate section.
     pub force_to_top: Option<Vec<String>>,
     #[option(
@@ -303,6 +312,7 @@ pub struct Settings {
     pub combine_as_imports: bool,
     pub force_single_line: bool,
     pub force_sort_within_sections: bool,
+    pub case_sensitive: bool,
     pub force_wrap_aliases: bool,
     pub force_to_top: BTreeSet<String>,
     pub known_modules: KnownModules,
@@ -327,6 +337,7 @@ impl Default for Settings {
             combine_as_imports: false,
             force_single_line: false,
             force_sort_within_sections: false,
+            case_sensitive: true,
             force_wrap_aliases: false,
             force_to_top: BTreeSet::new(),
             known_modules: KnownModules::default(),
@@ -429,6 +440,7 @@ impl From<Options> for Settings {
             combine_as_imports: options.combine_as_imports.unwrap_or(false),
             force_single_line: options.force_single_line.unwrap_or(false),
             force_sort_within_sections: options.force_sort_within_sections.unwrap_or(false),
+            case_sensitive: options.case_sensitive.unwrap_or(false),
             force_wrap_aliases: options.force_wrap_aliases.unwrap_or(false),
             force_to_top: BTreeSet::from_iter(options.force_to_top.unwrap_or_default()),
             known_modules: KnownModules::new(
@@ -468,6 +480,7 @@ impl From<Settings> for Options {
             ),
             force_single_line: Some(settings.force_single_line),
             force_sort_within_sections: Some(settings.force_sort_within_sections),
+            case_sensitive: Some(settings.case_sensitive),
             force_wrap_aliases: Some(settings.force_wrap_aliases),
             force_to_top: Some(settings.force_to_top.into_iter().collect()),
             known_first_party: Some(

--- a/crates/ruff/src/rules/isort/settings.rs
+++ b/crates/ruff/src/rules/isort/settings.rs
@@ -337,7 +337,7 @@ impl Default for Settings {
             combine_as_imports: false,
             force_single_line: false,
             force_sort_within_sections: false,
-            case_sensitive: true,
+            case_sensitive: false,
             force_wrap_aliases: false,
             force_to_top: BTreeSet::new(),
             known_modules: KnownModules::default(),

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__case_sensitive.py.snap.new
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__case_sensitive.py.snap.new
@@ -1,0 +1,28 @@
+---
+source: crates/ruff/src/rules/isort/mod.rs
+assertion_line: 369
+---
+case_sensitive.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+  |
+1 | / import os
+2 | | import Pandas as pd
+3 | | import Pandas
+4 | | import Xml.etree.ElementTree as ET
+5 | | import requests
+6 | | from datetime import datetime
+  |
+  = help: Organize imports
+
+ℹ Fix
+1 1 | import os
+2   |-import Pandas as pd
+  2 |+from datetime import datetime
+  3 |+
+3 4 | import Pandas
+4   |-import Xml.etree.ElementTree as ET
+  5 |+import Pandas as pd
+5 6 | import requests
+6   |-from datetime import datetime
+  7 |+import Xml.etree.ElementTree as ET
+
+

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__case_sensitive.py.snap.new
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__case_sensitive.py.snap.new
@@ -19,10 +19,9 @@ case_sensitive.py:1:1: I001 [*] Import block is un-sorted or un-formatted
   2 |+from datetime import datetime
   3 |+
 3 4 | import Pandas
-4   |-import Xml.etree.ElementTree as ET
   5 |+import Pandas as pd
-5 6 | import requests
+4 6 | import Xml.etree.ElementTree as ET
+5 7 | import requests
 6   |-from datetime import datetime
-  7 |+import Xml.etree.ElementTree as ET
 
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__case_sensitive_case_sensitive.py.snap.new
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__case_sensitive_case_sensitive.py.snap.new
@@ -1,0 +1,29 @@
+---
+source: crates/ruff/src/rules/isort/mod.rs
+assertion_line: 477
+---
+case_sensitive.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+  |
+1 | / import os
+2 | | import Pandas
+3 | | import Xml.etree.ElementTree as ET
+4 | | import requests
+5 | | from datetime import datetime
+6 | | 
+7 | | from module import Class, CONSTANT, function, BASIC, Apple
+  |
+  = help: Organize imports
+
+ℹ Fix
+1 1 | import os
+  2 |+from datetime import datetime
+  3 |+
+2 4 | import Pandas
+3 5 | import Xml.etree.ElementTree as ET
+4 6 | import requests
+5   |-from datetime import datetime
+6   |-
+7   |-from module import Class, CONSTANT, function, BASIC, Apple
+  7 |+from module import BASIC, CONSTANT, Apple, Class, function
+
+


### PR DESCRIPTION
## Summary

Adds a `--case-sensitive` setting/flag to isort (default: `false`) which, when set to `true` sorts imports case sensitively instead of case insensitively.  

Tests and Docs can be improved, can do that if the general idea of the implementation is in order.

First `isort` edit so any and all feedback is welcomed even more than usual.

## Test Plan

Added a fixture with an assortment of imports in various cases.

## Issue links

Closes: https://github.com/astral-sh/ruff/issues/5514 
