### PR TITLE
Use Insiders version of `mkdocs-material`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,11 +255,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+      - name: "Add SSH key"
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.MKDOCS_INSIDERS_SSH_KEY }}
       - name: "Install Rust toolchain"
         run: rustup show
       - uses: Swatinem/rust-cache@v2
       - name: "Install dependencies"
-        run: pip install -r docs/requirements.txt
+        run: pip install -r docs/requirements-insiders.txt
       - name: "Update README File"
         run: python scripts/transform_readme.py --target mkdocs
       - name: "Generate docs"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,12 +13,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+      - name: "Add SSH key"
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.MKDOCS_INSIDERS_SSH_KEY }}
       - name: "Install Rust toolchain"
         run: rustup show
       - uses: Swatinem/rust-cache@v2
       - name: "Install dependencies"
-        run: |
-          pip install -r docs/requirements.txt
+        run: pip install -r docs/requirements-insiders.txt
       - name: "Copy README File"
         run: |
           python scripts/transform_readme.py --target mkdocs

--- a/docs/requirements-insiders.txt
+++ b/docs/requirements-insiders.txt
@@ -1,0 +1,4 @@
+PyYAML==6.0
+black==23.3.0
+mkdocs==1.4.3
+git+ssh://git@github.com/astral-sh/mkdocs-material-insiders.git

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs~=1.4.2
-mkdocs-material~=9.0.6
-PyYAML~=6.0
+PyYAML==6.0
 black==23.3.0
+mkdocs==1.4.3
+mkdocs-material==9.1.18


### PR DESCRIPTION
## Summary

This PR migrates our `mkdocs-material` version to [Insiders](https://squidfunk.github.io/mkdocs-material/insiders/), which we can access now that we're sponsors.

We can't allow public access to the Insiders version, so we instead have a private fork, which contains a deploy key that I've added as a read-only Actions secret in this repo. (That is: the deploy key only lets you read that one repo, and do nothing else.)

In general, non-Astral contributors can use the non-insiders version, and everything is expected to "work", but without the insiders features (they're intended to be ignored). See: https://squidfunk.github.io/mkdocs-material/insiders/#compatibility.
