### PR TITLE
Remove `Directive::None` variant

### DIFF
--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_all.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_all.snap
@@ -2,10 +2,12 @@
 source: crates/ruff/src/noqa.rs
 expression: "Directive::extract(range, &locator)"
 ---
-All(
-    All {
-        leading_space_len: 0,
-        noqa_range: 0..6,
-        trailing_space_len: 0,
-    },
+Some(
+    All(
+        All {
+            leading_space_len: 0,
+            noqa_range: 0..6,
+            trailing_space_len: 0,
+        },
+    ),
 )

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_all_case_insensitive.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_all_case_insensitive.snap
@@ -2,10 +2,12 @@
 source: crates/ruff/src/noqa.rs
 expression: "Directive::extract(range, &locator)"
 ---
-All(
-    All {
-        leading_space_len: 0,
-        noqa_range: 0..6,
-        trailing_space_len: 0,
-    },
+Some(
+    All(
+        All {
+            leading_space_len: 0,
+            noqa_range: 0..6,
+            trailing_space_len: 0,
+        },
+    ),
 )

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_code.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_code.snap
@@ -2,13 +2,15 @@
 source: crates/ruff/src/noqa.rs
 expression: "Directive::extract(range, &locator)"
 ---
-Codes(
-    Codes {
-        leading_space_len: 0,
-        noqa_range: 0..12,
-        trailing_space_len: 0,
-        codes: [
-            "F401",
-        ],
-    },
+Some(
+    Codes(
+        Codes {
+            leading_space_len: 0,
+            noqa_range: 0..12,
+            trailing_space_len: 0,
+            codes: [
+                "F401",
+            ],
+        },
+    ),
 )

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_code_case_insensitive.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_code_case_insensitive.snap
@@ -2,13 +2,15 @@
 source: crates/ruff/src/noqa.rs
 expression: "Directive::extract(range, &locator)"
 ---
-Codes(
-    Codes {
-        leading_space_len: 0,
-        noqa_range: 0..12,
-        trailing_space_len: 0,
-        codes: [
-            "F401",
-        ],
-    },
+Some(
+    Codes(
+        Codes {
+            leading_space_len: 0,
+            noqa_range: 0..12,
+            trailing_space_len: 0,
+            codes: [
+                "F401",
+            ],
+        },
+    ),
 )

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_codes.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_codes.snap
@@ -2,14 +2,16 @@
 source: crates/ruff/src/noqa.rs
 expression: "Directive::extract(range, &locator)"
 ---
-Codes(
-    Codes {
-        leading_space_len: 0,
-        noqa_range: 0..18,
-        trailing_space_len: 0,
-        codes: [
-            "F401",
-            "F841",
-        ],
-    },
+Some(
+    Codes(
+        Codes {
+            leading_space_len: 0,
+            noqa_range: 0..18,
+            trailing_space_len: 0,
+            codes: [
+                "F401",
+                "F841",
+            ],
+        },
+    ),
 )

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_codes_case_insensitive.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_codes_case_insensitive.snap
@@ -2,14 +2,16 @@
 source: crates/ruff/src/noqa.rs
 expression: "Directive::extract(range, &locator)"
 ---
-Codes(
-    Codes {
-        leading_space_len: 0,
-        noqa_range: 0..18,
-        trailing_space_len: 0,
-        codes: [
-            "F401",
-            "F841",
-        ],
-    },
+Some(
+    Codes(
+        Codes {
+            leading_space_len: 0,
+            noqa_range: 0..18,
+            trailing_space_len: 0,
+            codes: [
+                "F401",
+                "F841",
+            ],
+        },
+    ),
 )

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_leading_space.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_leading_space.snap
@@ -2,13 +2,15 @@
 source: crates/ruff/src/noqa.rs
 expression: "Directive::extract(range, &locator)"
 ---
-Codes(
-    Codes {
-        leading_space_len: 3,
-        noqa_range: 4..16,
-        trailing_space_len: 0,
-        codes: [
-            "F401",
-        ],
-    },
+Some(
+    Codes(
+        Codes {
+            leading_space_len: 3,
+            noqa_range: 4..16,
+            trailing_space_len: 0,
+            codes: [
+                "F401",
+            ],
+        },
+    ),
 )

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_trailing_space.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_trailing_space.snap
@@ -2,13 +2,15 @@
 source: crates/ruff/src/noqa.rs
 expression: "Directive::extract(range, &locator)"
 ---
-Codes(
-    Codes {
-        leading_space_len: 0,
-        noqa_range: 0..12,
-        trailing_space_len: 3,
-        codes: [
-            "F401",
-        ],
-    },
+Some(
+    Codes(
+        Codes {
+            leading_space_len: 0,
+            noqa_range: 0..12,
+            trailing_space_len: 3,
+            codes: [
+                "F401",
+            ],
+        },
+    ),
 )


### PR DESCRIPTION
## Summary

This is creating some weird, impossible states. Make impossible states unrepresentable!