### PR TITLE
Remove leading and trailing space length from `Directive`

### DIFF
--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_all.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_all.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/ruff/src/noqa.rs
-expression: "Directive::extract(range, &locator)"
+expression: "Directive::try_extract(range, &locator)"
 ---
 Some(
     All(
         All {
-            leading_space_len: 0,
-            noqa_range: 0..6,
-            trailing_space_len: 0,
+            range: 0..6,
         },
     ),
 )

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_all_case_insensitive.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_all_case_insensitive.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/ruff/src/noqa.rs
-expression: "Directive::extract(range, &locator)"
+expression: "Directive::try_extract(range, &locator)"
 ---
 Some(
     All(
         All {
-            leading_space_len: 0,
-            noqa_range: 0..6,
-            trailing_space_len: 0,
+            range: 0..6,
         },
     ),
 )

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_code.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_code.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/ruff/src/noqa.rs
-expression: "Directive::extract(range, &locator)"
+expression: "Directive::try_extract(range, &locator)"
 ---
 Some(
     Codes(
         Codes {
-            leading_space_len: 0,
-            noqa_range: 0..12,
-            trailing_space_len: 0,
+            range: 0..12,
             codes: [
                 "F401",
             ],

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_code_case_insensitive.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_code_case_insensitive.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/ruff/src/noqa.rs
-expression: "Directive::extract(range, &locator)"
+expression: "Directive::try_extract(range, &locator)"
 ---
 Some(
     Codes(
         Codes {
-            leading_space_len: 0,
-            noqa_range: 0..12,
-            trailing_space_len: 0,
+            range: 0..12,
             codes: [
                 "F401",
             ],

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_codes.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_codes.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/ruff/src/noqa.rs
-expression: "Directive::extract(range, &locator)"
+expression: "Directive::try_extract(range, &locator)"
 ---
 Some(
     Codes(
         Codes {
-            leading_space_len: 0,
-            noqa_range: 0..18,
-            trailing_space_len: 0,
+            range: 0..18,
             codes: [
                 "F401",
                 "F841",

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_codes_case_insensitive.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_codes_case_insensitive.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/ruff/src/noqa.rs
-expression: "Directive::extract(range, &locator)"
+expression: "Directive::try_extract(range, &locator)"
 ---
 Some(
     Codes(
         Codes {
-            leading_space_len: 0,
-            noqa_range: 0..18,
-            trailing_space_len: 0,
+            range: 0..18,
             codes: [
                 "F401",
                 "F841",

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_leading_space.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_leading_space.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/ruff/src/noqa.rs
-expression: "Directive::extract(range, &locator)"
+expression: "Directive::try_extract(range, &locator)"
 ---
 Some(
     Codes(
         Codes {
-            leading_space_len: 3,
-            noqa_range: 4..16,
-            trailing_space_len: 0,
+            range: 4..16,
             codes: [
                 "F401",
             ],

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_trailing_space.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_trailing_space.snap
@@ -1,13 +1,11 @@
 ---
 source: crates/ruff/src/noqa.rs
-expression: "Directive::extract(range, &locator)"
+expression: "Directive::try_extract(range, &locator)"
 ---
 Some(
     Codes(
         Codes {
-            leading_space_len: 0,
-            noqa_range: 0..12,
-            trailing_space_len: 3,
+            range: 0..12,
             codes: [
                 "F401",
             ],


### PR DESCRIPTION
## Summary

We only need this in one place (when removing the directive), and it simplifies a lot of details to just compute it there.
