### PR TITLE
Try statements have a body: Fix formatter instability

### DIFF
--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -4281,6 +4281,8 @@ impl AnyNodeRef<'_> {
                 | AnyNodeRef::StmtFunctionDef(_)
                 | AnyNodeRef::StmtAsyncFunctionDef(_)
                 | AnyNodeRef::StmtClassDef(_)
+                | AnyNodeRef::StmtTry(_)
+                | AnyNodeRef::StmtTryStar(_)
         )
     }
 }

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/try.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/try.py
@@ -89,3 +89,13 @@ else:
 # before finally
 finally:
     ...
+
+# try and try star are statements with body
+# Minimized from https://github.com/python/cpython/blob/99b00efd5edfd5b26bf9e2a35cbfc96277fdcbb1/Lib/getpass.py#L68-L91
+try:
+    try:
+        pass
+    finally:
+        print(1)  # issue7208
+except A:
+    pass


### PR DESCRIPTION
## Summary

The following code was previously leading to unstable formatting:
```python
try:
    try:
        pass
    finally:
        print(1)  # issue7208
except A:
    pass
```
The comment would be formatted as a trailing comment of `try` which is unstable as an end-of-line comment gets two extra whitespaces.

This was originally found in https://github.com/python/cpython/blob/99b00efd5edfd5b26bf9e2a35cbfc96277fdcbb1/Lib/getpass.py#L68-L91

## Test Plan

I added a regression test
