### PR TITLE
Introduce `parenthesized` helper

### DIFF
--- a/crates/ruff_python_formatter/src/expression/expr_call.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_call.rs
@@ -1,10 +1,11 @@
 use crate::builders::PyFormatterExtensions;
 use crate::comments::{dangling_comments, Comments};
 use crate::expression::parentheses::{
-    default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
+    default_expression_needs_parentheses, parenthesized, NeedsParentheses, Parentheses,
+    Parenthesize,
 };
 use crate::{AsFormat, FormatNodeRule, PyFormatter};
-use ruff_formatter::prelude::{format_with, group, soft_block_indent, text};
+use ruff_formatter::prelude::{format_with, group, text};
 use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprCall;
 
@@ -56,7 +57,6 @@ impl FormatNodeRule<ExprCall> for FormatExprCall {
             f,
             [
                 func.format(),
-                text("("),
                 // The outer group is for things like
                 // ```python
                 // get_collection(
@@ -73,8 +73,7 @@ impl FormatNodeRule<ExprCall> for FormatExprCall {
                 // )
                 // ```
                 // TODO(konstin): Doesn't work see wrongly formatted test
-                &group(&soft_block_indent(&group(&all_args))),
-                text(")")
+                parenthesized("(", &group(&all_args), ")")
             ]
         )
     }

--- a/crates/ruff_python_formatter/src/expression/expr_dict.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_dict.rs
@@ -1,6 +1,7 @@
 use crate::comments::{dangling_node_comments, leading_comments, Comments};
 use crate::expression::parentheses::{
-    default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
+    default_expression_needs_parentheses, parenthesized, NeedsParentheses, Parentheses,
+    Parenthesize,
 };
 use crate::prelude::*;
 use crate::FormatNodeRule;
@@ -86,14 +87,7 @@ impl FormatNodeRule<ExprDict> for FormatExprDict {
             joiner.finish()
         });
 
-        write!(
-            f,
-            [group(&format_args![
-                text("{"),
-                soft_block_indent(&format_pairs),
-                text("}")
-            ])]
-        )
+        parenthesized("{", &format_pairs, "}").fmt(f)
     }
 
     fn fmt_dangling_comments(&self, _node: &ExprDict, _f: &mut PyFormatter) -> FormatResult<()> {

--- a/crates/ruff_python_formatter/src/expression/expr_list.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_list.rs
@@ -1,6 +1,7 @@
 use crate::comments::{dangling_comments, CommentLinePosition, Comments};
 use crate::expression::parentheses::{
-    default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
+    default_expression_needs_parentheses, parenthesized, NeedsParentheses, Parentheses,
+    Parenthesize,
 };
 use crate::prelude::*;
 use crate::FormatNodeRule;
@@ -54,14 +55,7 @@ impl FormatNodeRule<ExprList> for FormatExprList {
 
         let items = format_with(|f| f.join_comma_separated().nodes(elts.iter()).finish());
 
-        write!(
-            f,
-            [group(&format_args![
-                text("["),
-                soft_block_indent(&items),
-                text("]")
-            ])]
-        )
+        parenthesized("[", &items, "]").fmt(f)
     }
 
     fn fmt_dangling_comments(&self, _node: &ExprList, _f: &mut PyFormatter) -> FormatResult<()> {

--- a/crates/ruff_python_formatter/src/expression/expr_set.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_set.rs
@@ -1,12 +1,11 @@
 use crate::comments::Comments;
 use crate::expression::parentheses::{
-    default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
+    default_expression_needs_parentheses, parenthesized, NeedsParentheses, Parentheses,
+    Parenthesize,
 };
-use crate::{FormatNodeRule, FormattedIterExt, PyFormatter};
-use ruff_formatter::prelude::{
-    format_with, group, if_group_breaks, soft_block_indent, soft_line_break_or_space, text,
-};
-use ruff_formatter::{format_args, write, Buffer, FormatResult};
+use crate::prelude::*;
+use crate::FormatNodeRule;
+use ruff_formatter::format_args;
 use rustpython_parser::ast::ExprSet;
 
 #[derive(Default)]
@@ -23,14 +22,8 @@ impl FormatNodeRule<ExprSet> for FormatExprSet {
                 .entries(elts.iter().formatted())
                 .finish()
         });
-        write!(
-            f,
-            [group(&format_args![
-                text("{"),
-                soft_block_indent(&format_args![joined, if_group_breaks(&text(",")),]),
-                text("}")
-            ])]
-        )
+
+        parenthesized("{", &format_args![joined, if_group_breaks(&text(","))], "}").fmt(f)
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_tuple.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_tuple.rs
@@ -1,7 +1,8 @@
 use crate::builders::optional_parentheses;
 use crate::comments::{dangling_node_comments, Comments};
 use crate::expression::parentheses::{
-    default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
+    default_expression_needs_parentheses, parenthesized, NeedsParentheses, Parentheses,
+    Parenthesize,
 };
 use crate::prelude::*;
 use ruff_formatter::{format_args, write, FormatRuleWithOptions};
@@ -69,15 +70,8 @@ impl FormatNodeRule<ExprTuple> for FormatExprTuple {
                 )
             }
             [single] => {
-                write!(
-                    f,
-                    [group(&format_args![
-                        // A single element tuple always needs parentheses and a trailing comma
-                        &text("("),
-                        soft_block_indent(&format_args![single.format(), &text(",")]),
-                        &text(")"),
-                    ])]
-                )
+                // A single element tuple always needs parentheses and a trailing comma
+                parenthesized("(", &format_args![single.format(), &text(",")], ")").fmt(f)
             }
             // If the tuple has parentheses, we generally want to keep them. The exception are for
             // loops, see `TupleParentheses::StripInsideForLoop` doc comment.
@@ -87,15 +81,7 @@ impl FormatNodeRule<ExprTuple> for FormatExprTuple {
             elts if is_parenthesized(*range, elts, f)
                 && self.parentheses != TupleParentheses::StripInsideForLoop =>
             {
-                write!(
-                    f,
-                    [group(&format_args![
-                        // If there were previously parentheses, keep them
-                        &text("("),
-                        soft_block_indent(&ExprSequence::new(elts)),
-                        &text(")"),
-                    ])]
-                )
+                parenthesized("(", &ExprSequence::new(elts), ")").fmt(f)
             }
             elts => optional_parentheses(&ExprSequence::new(elts)).fmt(f),
         }

--- a/crates/ruff_python_formatter/src/other/arguments.rs
+++ b/crates/ruff_python_formatter/src/other/arguments.rs
@@ -10,6 +10,7 @@ use crate::comments::{
     CommentLinePosition, SourceComment,
 };
 use crate::context::NodeLevel;
+use crate::expression::parentheses::parenthesized;
 use crate::prelude::*;
 use crate::trivia::{first_non_trivia_token, SimpleTokenizer, Token, TokenKind};
 use crate::FormatNodeRule;
@@ -179,14 +180,7 @@ impl FormatNodeRule<Arguments> for FormatArguments {
                 ]
             )?;
         } else {
-            write!(
-                f,
-                [group(&format_args!(
-                    text("("),
-                    soft_block_indent(&group(&format_inner)),
-                    text(")")
-                ))]
-            )?;
+            parenthesized("(", &group(&format_inner), ")").fmt(f)?;
         }
 
         f.context_mut().set_node_level(saved_level);


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR adds a new `parenthesized` format helper for formatting parenthesized expressions. 

This doesn't seem very useful yet, but I need to apply some custom formatting to all parenthesized expressions and having a single
place to add that logic makes that easier.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test`
