### PR TITLE
Only run pyproject.toml lint rules when enabled

### DIFF
--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -252,6 +252,7 @@ pub enum LintSource {
     Imports,
     Noqa,
     Filesystem,
+    PyprojectToml,
 }
 
 impl Rule {
@@ -259,6 +260,7 @@ impl Rule {
     /// physical lines).
     pub const fn lint_source(&self) -> LintSource {
         match self {
+            Rule::InvalidPyprojectToml => LintSource::PyprojectToml,
             Rule::UnusedNOQA => LintSource::Noqa,
             Rule::BlanketNOQA
             | Rule::BlanketTypeIgnore

--- a/crates/ruff/src/rules/ruff/mod.rs
+++ b/crates/ruff/src/rules/ruff/mod.rs
@@ -203,7 +203,10 @@ mod tests {
             .join("pyproject.toml");
         let contents = fs::read_to_string(path)?;
         let source_file = SourceFileBuilder::new("pyproject.toml", contents).finish();
-        let messages = lint_pyproject_toml(source_file)?;
+        let messages = lint_pyproject_toml(
+            source_file,
+            &settings::Settings::for_rule(Rule::InvalidPyprojectToml),
+        )?;
         assert_messages!(snapshot, messages);
         Ok(())
     }


### PR DESCRIPTION
## Summary

I was testing some changes on Airflow, and I realized that we _always_ run the `pyproject.toml` validation rules, even if they're not enabled. This PR gates them behind the appropriate enablement flags.

## Test Plan

- Ran: `cargo run -p ruff_cli -- check ../airflow -n`. Verified that no RUF200 violations were raised.
- Run: `cargo run -p ruff_cli -- check ../airflow -n --select RUF200`. Verified that two RUF200 violations were raised.
