### PR TITLE
Bugfix: Remove version numbers from pypi links

### DIFF
--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -112,7 +112,7 @@ pub enum Linter {
     /// [flake8-import-conventions](https://github.com/joaopalmeiro/flake8-import-conventions)
     #[prefix = "ICN"]
     Flake8ImportConventions,
-    /// [flake8-logging-format](https://pypi.org/project/flake8-logging-format/0.9.0/)
+    /// [flake8-logging-format](https://pypi.org/project/flake8-logging-format/)
     #[prefix = "G"]
     Flake8LoggingFormat,
     /// [flake8-no-pep420](https://pypi.org/project/flake8-no-pep420/)
@@ -181,7 +181,7 @@ pub enum Linter {
     /// [Pylint](https://pypi.org/project/pylint/)
     #[prefix = "PL"]
     Pylint,
-    /// [tryceratops](https://pypi.org/project/tryceratops/1.1.0/)
+    /// [tryceratops](https://pypi.org/project/tryceratops/)
     #[prefix = "TRY"]
     Tryceratops,
     /// [flynt](https://pypi.org/project/flynt/)

--- a/crates/ruff/src/rules/flake8_logging_format/mod.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/mod.rs
@@ -1,4 +1,4 @@
-//! Rules from [flake8-logging-format](https://pypi.org/project/flake8-logging-format/0.9.0/).
+//! Rules from [flake8-logging-format](https://pypi.org/project/flake8-logging-format/).
 pub(crate) mod rules;
 pub(crate) mod violations;
 

--- a/crates/ruff/src/rules/tryceratops/mod.rs
+++ b/crates/ruff/src/rules/tryceratops/mod.rs
@@ -1,4 +1,4 @@
-//! Rules from [tryceratops](https://pypi.org/project/tryceratops/1.1.0/).
+//! Rules from [tryceratops](https://pypi.org/project/tryceratops/).
 pub(crate) mod helpers;
 pub(crate) mod rules;
 


### PR DESCRIPTION
## Summary

There are two pypi links in the documentation that link to specific version numbers of other packages. Removing these versioned links allows users to immediately view the latest version of the package and maintains consistency with the other links.

## Test Plan

N/A
