### PR TITLE
Rework upstream categories so we can `all_rules()`

### DIFF
--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -38,6 +38,7 @@ mod rule_selector;
 pub mod rules;
 pub mod settings;
 pub mod source_kind;
+pub mod upstream_categories;
 
 #[cfg(any(test, fuzzing))]
 pub mod test;

--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -7,7 +7,7 @@ pub use codes::Rule;
 use ruff_macros::RuleNamespace;
 pub use rule_set::{RuleSet, RuleSetIterator};
 
-use crate::codes::{self, RuleCodePrefix};
+use crate::codes::{self};
 
 mod rule_set;
 
@@ -216,30 +216,6 @@ pub trait RuleNamespace: Sized {
     fn name(&self) -> &'static str;
 
     fn url(&self) -> Option<&'static str>;
-}
-
-/// The prefix and name for an upstream linter category.
-pub struct UpstreamCategory(pub RuleCodePrefix, pub &'static str);
-
-impl Linter {
-    pub const fn upstream_categories(&self) -> Option<&'static [UpstreamCategory]> {
-        match self {
-            Linter::Pycodestyle => Some(&[
-                UpstreamCategory(RuleCodePrefix::Pycodestyle(codes::Pycodestyle::E), "Error"),
-                UpstreamCategory(
-                    RuleCodePrefix::Pycodestyle(codes::Pycodestyle::W),
-                    "Warning",
-                ),
-            ]),
-            Linter::Pylint => Some(&[
-                UpstreamCategory(RuleCodePrefix::Pylint(codes::Pylint::C), "Convention"),
-                UpstreamCategory(RuleCodePrefix::Pylint(codes::Pylint::E), "Error"),
-                UpstreamCategory(RuleCodePrefix::Pylint(codes::Pylint::R), "Refactor"),
-                UpstreamCategory(RuleCodePrefix::Pylint(codes::Pylint::W), "Warning"),
-            ]),
-            _ => None,
-        }
-    }
 }
 
 #[derive(is_macro::Is, Copy, Clone)]

--- a/crates/ruff/src/upstream_categories.rs
+++ b/crates/ruff/src/upstream_categories.rs
@@ -1,0 +1,79 @@
+//! This module should probably not exist in this shape or form.
+use crate::codes::Rule;
+use crate::registry::Linter;
+
+#[derive(Hash, Eq, PartialEq, Copy, Clone, Debug)]
+pub struct UpstreamCategoryAndPrefix {
+    pub category: &'static str,
+    pub prefix: &'static str,
+}
+
+const PLC: UpstreamCategoryAndPrefix = UpstreamCategoryAndPrefix {
+    category: "Convention",
+    prefix: "PLC",
+};
+
+const PLE: UpstreamCategoryAndPrefix = UpstreamCategoryAndPrefix {
+    category: "Error",
+    prefix: "PLE",
+};
+
+const PLR: UpstreamCategoryAndPrefix = UpstreamCategoryAndPrefix {
+    category: "Refactor",
+    prefix: "PLR",
+};
+
+const PLW: UpstreamCategoryAndPrefix = UpstreamCategoryAndPrefix {
+    category: "Warning",
+    prefix: "PLW",
+};
+
+const E: UpstreamCategoryAndPrefix = UpstreamCategoryAndPrefix {
+    category: "Error",
+    prefix: "E",
+};
+
+const W: UpstreamCategoryAndPrefix = UpstreamCategoryAndPrefix {
+    category: "Warning",
+    prefix: "W",
+};
+
+impl Rule {
+    pub fn upstream_category(&self, linter: &Linter) -> Option<UpstreamCategoryAndPrefix> {
+        let code = linter.code_for_rule(*self).unwrap();
+        match linter {
+            Linter::Pycodestyle => {
+                if code.starts_with('E') {
+                    Some(E)
+                } else if code.starts_with('W') {
+                    Some(W)
+                } else {
+                    None
+                }
+            }
+            Linter::Pylint => {
+                if code.starts_with("PLC") {
+                    Some(PLC)
+                } else if code.starts_with("PLE") {
+                    Some(PLE)
+                } else if code.starts_with("PLR") {
+                    Some(PLR)
+                } else if code.starts_with("PLW") {
+                    Some(PLW)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+}
+impl Linter {
+    pub const fn upstream_categories(&self) -> Option<&'static [UpstreamCategoryAndPrefix]> {
+        match self {
+            Linter::Pycodestyle => Some(&[E, W]),
+            Linter::Pylint => Some(&[PLC, PLE, PLR, PLW]),
+            _ => None,
+        }
+    }
+}

--- a/crates/ruff_cli/src/commands/linter.rs
+++ b/crates/ruff_cli/src/commands/linter.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use serde::Serialize;
 use strum::IntoEnumIterator;
 
-use ruff::registry::{Linter, RuleNamespace, UpstreamCategory};
+use ruff::registry::{Linter, RuleNamespace};
 
 use crate::args::HelpFormat;
 
@@ -37,7 +37,7 @@ pub(crate) fn linter(format: HelpFormat) -> Result<()> {
                         .upstream_categories()
                         .unwrap()
                         .iter()
-                        .map(|UpstreamCategory(prefix, ..)| prefix.short_code())
+                        .map(|c| c.prefix)
                         .join("/"),
                     prefix => prefix.to_string(),
                 };
@@ -52,9 +52,9 @@ pub(crate) fn linter(format: HelpFormat) -> Result<()> {
                     name: linter_info.name(),
                     categories: linter_info.upstream_categories().map(|cats| {
                         cats.iter()
-                            .map(|UpstreamCategory(prefix, name)| LinterCategoryInfo {
-                                prefix: prefix.short_code(),
-                                name,
+                            .map(|c| LinterCategoryInfo {
+                                prefix: c.prefix,
+                                name: c.category,
                             })
                             .collect()
                     }),


### PR DESCRIPTION
## Summary

This PR reworks the `upstream_categories` mechanism that is only used for documentation purposes to make it easier to generate docs using `all_rules()`. The new implementation also relies on "tribal knowledge" about rule codes, so it's not the best implementation, but gets us forward.

Another option would be to change the rule-defining proc macros to allow configuring an optional `RuleCategory`, but that seems more heavy-handed and possibly unnecessary in the long run...

Draft since this builds on #5439.

cc @charliermarsh :)