### PR TITLE
Use Instagram's LibCST rather than our fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 [[package]]
 name = "libcst"
 version = "0.1.0"
-source = "git+https://github.com/charliermarsh/LibCST?rev=80e4c1399f95e5beb532fdd1e209ad2dbb470438#80e4c1399f95e5beb532fdd1e209ad2dbb470438"
+source = "git+https://github.com/Instagram/LibCST.git?rev=3cacca1a1029f05707e50703b49fe3dd860aa839#3cacca1a1029f05707e50703b49fe3dd860aa839"
 dependencies = [
  "chic",
  "itertools",
@@ -1152,7 +1152,7 @@ dependencies = [
 [[package]]
 name = "libcst_derive"
 version = "0.1.0"
-source = "git+https://github.com/charliermarsh/LibCST?rev=80e4c1399f95e5beb532fdd1e209ad2dbb470438#80e4c1399f95e5beb532fdd1e209ad2dbb470438"
+source = "git+https://github.com/Instagram/LibCST.git?rev=3cacca1a1029f05707e50703b49fe3dd860aa839#3cacca1a1029f05707e50703b49fe3dd860aa839"
 dependencies = [
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ test-case = { version = "3.0.0" }
 thiserror = { version = "1.0.43" }
 toml = { version = "0.7.2" }
 
-# v0.0.1
-libcst = { git = "https://github.com/charliermarsh/LibCST", rev = "80e4c1399f95e5beb532fdd1e209ad2dbb470438" }
+# v1.0.1
+libcst = { git = "https://github.com/Instagram/LibCST.git", rev = "3cacca1a1029f05707e50703b49fe3dd860aa839", default-features = false }
 
 # Please tag the RustPython version everytime you update its revision here and in fuzz/Cargo.toml
 # Tagging the version ensures that older ruff versions continue to build from source even when we rebase our RustPython fork.


### PR DESCRIPTION
## Summary

Historically, we only used a fork to enable building without pyo3. But pyo3 is an optional feature. I may've just not understood how to accomplish this way back when.