### PR TITLE
Extend formatter IR to support Black's expression formatting

### DIFF
--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -1431,7 +1431,7 @@ impl<Context> std::fmt::Debug for Group<'_, Context> {
 ///
 /// # fn main() -> FormatResult<()> {
 /// use ruff_formatter::Formatted;
-/// let content = format_with(|f| {    ///
+/// let content = format_with(|f| {
 ///     let parentheses_id = f.group_id("parentheses");
 ///     group(&format_args![
 ///         if_group_breaks(&text("(")),
@@ -2006,12 +2006,7 @@ impl<Context> std::fmt::Debug for IndentIfGroupBreaks<'_, Context> {
 ///     ])
 /// });
 ///
-/// let formatted = format!(SimpleFormatContext::new(SimpleFormatOptions {
-///         line_width: LineWidth::try_from(16).unwrap(),
-///         ..SimpleFormatOptions::default()
-///     }),
-///     [content]
-/// )?;
+/// let formatted = format!(SimpleFormatContext::default(), [content])?;
 ///
 /// assert_eq!(
 ///     "a + [\n\ta, # comment\n\tb\n]",

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -7,6 +7,7 @@ mod stack;
 use crate::format_element::document::Document;
 use crate::format_element::tag::{Condition, GroupMode};
 use crate::format_element::{BestFittingMode, BestFittingVariants, LineMode, PrintMode};
+use crate::prelude::tag;
 use crate::prelude::tag::{DedentMode, Tag, TagKind, VerbatimKind};
 use crate::printer::call_stack::{
     CallStack, FitsCallStack, PrintCallStack, PrintElementArgs, StackFrame,
@@ -143,40 +144,26 @@ impl<'a> Printer<'a> {
             }
 
             FormatElement::Tag(StartGroup(group)) => {
-                let group_mode = match group.mode() {
-                    GroupMode::Expand | GroupMode::Propagated => PrintMode::Expanded,
-                    GroupMode::Flat => {
-                        match args.mode() {
-                            PrintMode::Flat if self.state.measured_group_fits => {
-                                // A parent group has already verified that this group fits on a single line
-                                // Thus, just continue in flat mode
-                                PrintMode::Flat
-                            }
-                            // The printer is either in expanded mode or it's necessary to re-measure if the group fits
-                            // because the printer printed a line break
-                            _ => {
-                                self.state.measured_group_fits = true;
-
-                                // Measure to see if the group fits up on a single line. If that's the case,
-                                // print the group in "flat" mode, otherwise continue in expanded mode
-                                stack.push(TagKind::Group, args.with_print_mode(PrintMode::Flat));
-                                let fits = self.fits(queue, stack)?;
-                                stack.pop(TagKind::Group)?;
-
-                                if fits {
-                                    PrintMode::Flat
-                                } else {
-                                    PrintMode::Expanded
-                                }
-                            }
-                        }
-                    }
-                };
-
-                stack.push(TagKind::Group, args.with_print_mode(group_mode));
+                let print_mode =
+                    self.print_group(TagKind::Group, group.mode(), args, queue, stack)?;
 
                 if let Some(id) = group.id() {
-                    self.state.group_modes.insert_print_mode(id, group_mode);
+                    self.state.group_modes.insert_print_mode(id, print_mode);
+                }
+            }
+
+            FormatElement::Tag(StartConditionalGroup(group)) => {
+                let condition = group.condition();
+                let expected_mode = match condition.group_id {
+                    None => args.mode(),
+                    Some(id) => self.state.group_modes.unwrap_print_mode(id, element),
+                };
+
+                if expected_mode == condition.mode {
+                    self.print_group(TagKind::ConditionalGroup, group.mode(), args, queue, stack)?;
+                } else {
+                    // Condition isn't met, render as normal content
+                    stack.push(TagKind::ConditionalGroup, args);
                 }
             }
 
@@ -244,6 +231,29 @@ impl<'a> Printer<'a> {
                 stack.push(TagKind::Verbatim, args);
             }
 
+            FormatElement::Tag(StartFitsExpanded(tag::FitsExpanded { condition, .. })) => {
+                let condition_met = match condition {
+                    Some(condition) => {
+                        let group_mode = match condition.group_id {
+                            Some(group_id) => {
+                                self.state.group_modes.unwrap_print_mode(group_id, element)
+                            }
+                            None => args.mode(),
+                        };
+
+                        condition.mode == group_mode
+                    }
+                    None => true,
+                };
+
+                if condition_met {
+                    // We measured the inner groups all in expanded. It now is necessary to measure if the inner groups fit as well.
+                    self.state.measured_group_fits = false;
+                }
+
+                stack.push(TagKind::FitsExpanded, args);
+            }
+
             FormatElement::Tag(tag @ (StartLabelled(_) | StartEntry)) => {
                 stack.push(tag.kind(), args);
             }
@@ -252,11 +262,13 @@ impl<'a> Printer<'a> {
                 tag @ (EndLabelled
                 | EndEntry
                 | EndGroup
+                | EndConditionalGroup
                 | EndIndent
                 | EndDedent
                 | EndAlign
                 | EndConditionalContent
                 | EndIndentIfGroupBreaks
+                | EndFitsExpanded
                 | EndVerbatim
                 | EndLineSuffix
                 | EndFill),
@@ -273,6 +285,49 @@ impl<'a> Printer<'a> {
         let result = measure.fits(&mut AllPredicate);
         measure.finish();
         result
+    }
+
+    fn print_group(
+        &mut self,
+        kind: TagKind,
+        mode: GroupMode,
+        args: PrintElementArgs,
+        queue: &mut PrintQueue<'a>,
+        stack: &mut PrintCallStack,
+    ) -> PrintResult<PrintMode> {
+        let group_mode = match mode {
+            GroupMode::Expand | GroupMode::Propagated => PrintMode::Expanded,
+            GroupMode::Flat => {
+                match args.mode() {
+                    PrintMode::Flat if self.state.measured_group_fits => {
+                        // A parent group has already verified that this group fits on a single line
+                        // Thus, just continue in flat mode
+                        PrintMode::Flat
+                    }
+                    // The printer is either in expanded mode or it's necessary to re-measure if the group fits
+                    // because the printer printed a line break
+                    _ => {
+                        self.state.measured_group_fits = true;
+
+                        // Measure to see if the group fits up on a single line. If that's the case,
+                        // print the group in "flat" mode, otherwise continue in expanded mode
+                        stack.push(kind, args.with_print_mode(PrintMode::Flat));
+                        let fits = self.fits(queue, stack)?;
+                        stack.pop(kind)?;
+
+                        if fits {
+                            PrintMode::Flat
+                        } else {
+                            PrintMode::Expanded
+                        }
+                    }
+                }
+            }
+        };
+
+        stack.push(kind, args.with_print_mode(group_mode));
+
+        Ok(group_mode)
     }
 
     fn print_text(&mut self, text: &str, source_range: Option<TextRange>) {
@@ -1050,22 +1105,24 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
             }
 
             FormatElement::Tag(StartGroup(group)) => {
-                if self.must_be_flat && !group.mode().is_flat() {
-                    return Ok(Fits::No);
-                }
+                return self.fits_group(TagKind::Group, group.mode(), group.id(), args);
+            }
 
-                // Continue printing groups in expanded mode if measuring a `fits_expanded` element
-                let print_mode = if !group.mode().is_flat() {
-                    PrintMode::Expanded
-                } else {
-                    args.mode()
+            FormatElement::Tag(StartConditionalGroup(group)) => {
+                let condition = group.condition();
+
+                let print_mode = match condition.group_id {
+                    None => args.mode(),
+                    Some(group_id) => self
+                        .group_modes()
+                        .get_print_mode(group_id)
+                        .unwrap_or_else(|| args.mode()),
                 };
 
-                self.stack
-                    .push(TagKind::Group, args.with_print_mode(print_mode));
-
-                if let Some(id) = group.id() {
-                    self.group_modes_mut().insert_print_mode(id, print_mode);
+                if condition.mode == print_mode {
+                    return self.fits_group(TagKind::ConditionalGroup, group.mode(), None, args);
+                } else {
+                    self.stack.push(TagKind::ConditionalGroup, args);
                 }
             }
 
@@ -1113,6 +1170,42 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                 return invalid_end_tag(TagKind::LineSuffix, self.stack.top_kind());
             }
 
+            FormatElement::Tag(StartFitsExpanded(tag::FitsExpanded {
+                condition,
+                propagate_expand,
+            })) => {
+                let condition_met = match condition {
+                    Some(condition) => {
+                        let group_mode = match condition.group_id {
+                            Some(group_id) => self
+                                .group_modes()
+                                .get_print_mode(group_id)
+                                .unwrap_or_else(|| args.mode()),
+                            None => args.mode(),
+                        };
+
+                        condition.mode == group_mode
+                    }
+                    None => true,
+                };
+
+                if condition_met {
+                    // Measure in fully expanded mode.
+                    self.stack.push(
+                        TagKind::FitsExpanded,
+                        args.with_print_mode(PrintMode::Expanded)
+                            .with_measure_mode(MeasureMode::AllLines),
+                    )
+                } else {
+                    if propagate_expand.get() && args.mode().is_flat() {
+                        return Ok(Fits::No);
+                    }
+
+                    // As usual
+                    self.stack.push(TagKind::FitsExpanded, args)
+                }
+            }
+
             FormatElement::Tag(
                 tag @ (StartFill | StartVerbatim(_) | StartLabelled(_) | StartEntry),
             ) => {
@@ -1125,14 +1218,44 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                 | EndLabelled
                 | EndEntry
                 | EndGroup
+                | EndConditionalGroup
                 | EndIndentIfGroupBreaks
                 | EndConditionalContent
                 | EndAlign
                 | EndDedent
-                | EndIndent),
+                | EndIndent
+                | EndFitsExpanded),
             ) => {
                 self.stack.pop(tag.kind())?;
             }
+        }
+
+        Ok(Fits::Maybe)
+    }
+
+    fn fits_group(
+        &mut self,
+        kind: TagKind,
+        mode: GroupMode,
+        id: Option<GroupId>,
+        args: PrintElementArgs,
+    ) -> PrintResult<Fits> {
+        if self.must_be_flat && !mode.is_flat() {
+            return Ok(Fits::No);
+        }
+
+        // Continue printing groups in expanded mode if measuring a `best_fitting` element where
+        // a group expands.
+        let print_mode = if !mode.is_flat() {
+            PrintMode::Expanded
+        } else {
+            args.mode()
+        };
+
+        self.stack.push(kind, args.with_print_mode(print_mode));
+
+        if let Some(id) = id {
+            self.group_modes_mut().insert_print_mode(id, print_mode);
         }
 
         Ok(Fits::Maybe)

--- a/crates/ruff_python_formatter/src/comments/debug.rs
+++ b/crates/ruff_python_formatter/src/comments/debug.rs
@@ -29,10 +29,8 @@ impl Debug for DebugComment<'_> {
 
         strut
             .field("text", &self.comment.slice.text(self.source_code))
-            .field("position", &self.comment.line_position);
-
-        #[cfg(debug_assertions)]
-        strut.field("formatted", &self.comment.formatted.get());
+            .field("position", &self.comment.line_position)
+            .field("formatted", &self.comment.formatted.get());
 
         strut.finish()
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR makes two extensions to support Black's expression formatting. 

### `ConditionalGroup`

The first extension adds a new `ConditionalGroup` IR element. The semantic is the same as for `Group`, except that it has a condition controlling whether the enclosing content should be grouped or not. Another way to think about this is: Only group this content if some condition is true, but the condition only gets evaluated when printing the IR. 

This is necessary to support Black's formatting for expressions where the enclosing parentheses are optional, for example Black only adds parentheses around the condition of an `if` statement if the expression, after breaking any lists, dicts, etc., does not fit on a line:

```python
# We want 
if a + [ 
	b,
	c
]: 
	pass

# Rather than
if a
	+ [b, c]
: 
	pass
```

which is invalid syntax. Meaning we only want to break after left-parens (`(`, `[`, `{`), but not before operators. 

However, we do want to break **before** operators when the whole expression does not fit:

```python
# We want
if (
	a
	+ [b, c]
): pass

# rather than
if (
	a + [
		b, 
		c
	]
): pass
```

If the whole expression does not fit. You can see, how this is the opposite of when not adding the parentheses. 

The way this extension solves this problem is to *remove* the binary expression groups (gate them with a condition) when the whole expression fits, but *keep* them when the whole expression expands. 

Another way to think about the new IR is that this is the same as the following, but as custom IR to avoid interning `content`.

```
if_group_breaks(group(content), parentheses_group_id)),
if_group_fits_on_line(content, parentheses_group_id)
```

### `FitsExpanded`

The way we implement the adding of the optional parentheses is by wrapping the whole `if` condition by a group. However, this creates a problem if an inner parenthesized expression expands, because this would automatically expand all enclosing groups, including the group that adds the optional parentheses. But we don't want the optional parentheses if a parenthesized expression expands. 

The way this PR solves this problem is by introducing a new `FitsExpanded` IR that, similar to best fitting, acts as an expands boundary. Meaning, it won't expand the enclosing parentheses `group` if any of its content expands (a parenthesized expression). Other than best fitting, it also has a different `fits` definition. The content inside a `FitsExpanded` doesn't get measured in the "all flat" mode, instead, it gets measured assuming all its inner content will expand (what's the least space that is required, rather than what is the most space that it requires). 

`FitsExpanded` also supports an optional `Condition` to control when this changed semantic applies or not. This is necessary because we want to keep the list expression together, if possible, when we break before an operator

```python
# We want
if (
	a
	+ [b, c]
): pass

# Instead of 
if (
	a + [
		b, 
		c
	]
): pass
```

## Test Plan

I added a few doctests and use the new IR in the next IR to format expressions.


### Reference

This behavior mimics Blacks [`can_omit_invisible_parentheses`](https://github.com/psf/black/blob/d1248ca9beaf0ba526d265f4108836d89cf551b7/src/black/lines.py#L881-L963) and [transformer selection](https://github.com/psf/black/blob/d1248ca9beaf0ba526d265f4108836d89cf551b7/src/black/linegen.py#L601-L604). 

Ruff does not test whether a parenthesized expression is at the start or end of line. This is done inside of the printer (expanding after an opening parentheses always has the consequence that the expression now is at the end of the line)