### PR TITLE
Fix typos found by codespell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ toml = { version = "0.7.2" }
 # v1.0.1
 libcst = { git = "https://github.com/Instagram/LibCST.git", rev = "3cacca1a1029f05707e50703b49fe3dd860aa839", default-features = false }
 
-# Please tag the RustPython version everytime you update its revision here and in fuzz/Cargo.toml
+# Please tag the RustPython version every time you update its revision here and in fuzz/Cargo.toml
 # Tagging the version ensures that older ruff versions continue to build from source even when we rebase our RustPython fork.
 # Current tag: v0.0.7
 ruff_text_size = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "c174bbf1f29527edd43d432326327f16f47ab9e0" }

--- a/_typos.toml
+++ b/_typos.toml
@@ -2,7 +2,6 @@
 extend-exclude = ["resources", "snapshots"]
 
 [default.extend-words]
-trivias = "trivias"
 hel = "hel"
 whos = "whos"
 spawnve = "spawnve"

--- a/crates/ruff/src/rules/ruff/rules/unreachable.rs
+++ b/crates/ruff/src/rules/ruff/rules/unreachable.rs
@@ -693,7 +693,7 @@ impl<'stmt> BasicBlocksBuilder<'stmt> {
         }
     }
 
-    /// Select the next block from `blocks` unconditonally.
+    /// Select the next block from `blocks` unconditionally.
     fn unconditional_next_block(&self, after: Option<BlockIndex>) -> NextBlock<'static> {
         if let Some(after) = after {
             return NextBlock::Always(after);

--- a/crates/ruff_formatter/src/format_extensions.rs
+++ b/crates/ruff_formatter/src/format_extensions.rs
@@ -42,7 +42,7 @@ pub trait MemoizeFormat<Context> {
     /// # fn main() -> FormatResult<()> {
     /// let normal = MyFormat::new();
     ///
-    /// // Calls `format` for everytime the object gets formatted
+    /// // Calls `format` every time the object gets formatted
     /// assert_eq!(
     ///     "Formatted 1 times. Formatted 2 times.",
     ///     format!(SimpleFormatContext::default(), [normal, space(), normal])?.print()?.as_code()

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -701,7 +701,7 @@ struct PrinterState<'a> {
     verbatim_markers: Vec<TextRange>,
     group_modes: GroupModes,
     // Re-used queue to measure if a group fits. Optimisation to avoid re-allocating a new
-    // vec everytime a group gets measured
+    // vec every time a group gets measured
     fits_stack: Vec<StackFrame>,
     fits_queue: Vec<&'a [FormatElement]>,
 }

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/dict.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/dict.py
@@ -26,7 +26,7 @@ b
 }
 
 {
-    **a # comment before preceeding node's comma
+    **a # comment before preceding node's comma
  ,
     # before
     ** # between

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
@@ -92,7 +92,7 @@ if "Let's" "start" "with" "a" "simple" "example" "now repeat after me:" "I am co
 
 (
     # leading
-    "a" # trailing part commen
+    "a" # trailing part comment
 
     # leading part comment
 

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/skip_magic_trailing_comma.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/skip_magic_trailing_comma.py
@@ -18,5 +18,5 @@
     "fifth entry",
     "sixt entry",
     "seventh entry",
-    "eigth entry",
+    "eighth entry",
 )

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -76,7 +76,7 @@ where
     /// default implementation formats the dangling comments at the end of the node, which isn't ideal but ensures that
     /// no comments are dropped.
     ///
-    /// A node can have dangling comments if all its children are tokens or if all node childrens are optional.
+    /// A node can have dangling comments if all its children are tokens or if all node children are optional.
     fn fmt_dangling_comments(&self, node: &N, f: &mut PyFormatter) -> FormatResult<()> {
         dangling_node_comments(node).fmt(f)
     }

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__dict.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__dict.py.snap
@@ -32,7 +32,7 @@ b
 }
 
 {
-    **a # comment before preceeding node's comma
+    **a # comment before preceding node's comma
  ,
     # before
     ** # between
@@ -91,7 +91,7 @@ a = {
 }
 
 {
-    **a,  # comment before preceeding node's comma
+    **a,  # comment before preceding node's comma
     # before
     **b,  # between
 }

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -98,7 +98,7 @@ if "Let's" "start" "with" "a" "simple" "example" "now repeat after me:" "I am co
 
 (
     # leading
-    "a" # trailing part commen
+    "a" # trailing part comment
 
     # leading part comment
 
@@ -255,7 +255,7 @@ if (
 
 (
     # leading
-    "a"  # trailing part commen
+    "a"  # trailing part comment
     # leading part comment
     "b"  # trailing second part comment
     # trailing
@@ -403,7 +403,7 @@ if (
 
 (
     # leading
-    'a'  # trailing part commen
+    'a'  # trailing part comment
     # leading part comment
     'b'  # trailing second part comment
     # trailing

--- a/crates/ruff_python_formatter/tests/snapshots/format@skip_magic_trailing_comma.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@skip_magic_trailing_comma.py.snap
@@ -24,7 +24,7 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/skip_magic
     "fifth entry",
     "sixt entry",
     "seventh entry",
-    "eigth entry",
+    "eighth entry",
 )
 ```
 
@@ -54,7 +54,7 @@ magic-trailing-comma    = Respect
     "fifth entry",
     "sixt entry",
     "seventh entry",
-    "eigth entry",
+    "eighth entry",
 )
 ```
 
@@ -80,7 +80,7 @@ magic-trailing-comma    = Ignore
     "fifth entry",
     "sixt entry",
     "seventh entry",
-    "eigth entry",
+    "eighth entry",
 )
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fix typos found by [codespell](https://github.com/codespell-project/codespell).

I have left out `memoize` for now (see #5606).
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

CI tests.
<!-- How was it tested? -->
