### PR TITLE
Fix resolver airflow test on windows by normalizing the paths

### DIFF
--- a/crates/ruff_python_resolver/src/lib.rs
+++ b/crates/ruff_python_resolver/src/lib.rs
@@ -15,7 +15,6 @@ mod search;
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_debug_snapshot;
     use std::fs::{create_dir_all, File};
     use std::io::{self, Write};
     use std::path::{Path, PathBuf};
@@ -127,6 +126,13 @@ mod tests {
 
     fn setup() {
         env_logger::builder().is_test(true).try_init().ok();
+    }
+
+    macro_rules! assert_debug_snapshot_normalize_paths {
+        ($value: ident) => {
+            let $value = format!("{:#?}", $value).replace('\\', "/");
+            insta::assert_display_snapshot!($value);
+        };
     }
 
     #[test]
@@ -810,7 +816,7 @@ mod tests {
             },
         );
 
-        assert_debug_snapshot!(result);
+        assert_debug_snapshot_normalize_paths!(result);
     }
 
     #[test]
@@ -831,7 +837,7 @@ mod tests {
             },
         );
 
-        assert_debug_snapshot!(result);
+        assert_debug_snapshot_normalize_paths!(result);
     }
 
     #[test]
@@ -852,7 +858,7 @@ mod tests {
             },
         );
 
-        assert_debug_snapshot!(result);
+        assert_debug_snapshot_normalize_paths!(result);
     }
 
     #[test]
@@ -873,7 +879,7 @@ mod tests {
             },
         );
 
-        assert_debug_snapshot!(result);
+        assert_debug_snapshot_normalize_paths!(result);
     }
 
     #[test]
@@ -894,7 +900,7 @@ mod tests {
             },
         );
 
-        assert_debug_snapshot!(result);
+        assert_debug_snapshot_normalize_paths!(result);
     }
 
     #[test]
@@ -915,7 +921,7 @@ mod tests {
             },
         );
 
-        assert_debug_snapshot!(result);
+        assert_debug_snapshot_normalize_paths!(result);
     }
 
     #[test]
@@ -936,6 +942,6 @@ mod tests {
             },
         );
 
-        assert_debug_snapshot!(result);
+        assert_debug_snapshot_normalize_paths!(result);
     }
 }

--- a/crates/ruff_python_resolver/src/lib.rs
+++ b/crates/ruff_python_resolver/src/lib.rs
@@ -129,11 +129,13 @@ mod tests {
     }
 
     macro_rules! assert_debug_snapshot_normalize_paths {
-        ($value: ident) => {
+        ($value: ident) => {{
             // The debug representation for the backslash are two backslashes (escaping)
-            let $value = format!("{:#?}", $value).replace("\\\\", "/");
+            let $value = std::format!("{:#?}", $value).replace("\\\\", "/");
+            // `insta::assert_snapshot` uses the debug representation of the string, which would
+            // be a single line containing `\n`
             insta::assert_display_snapshot!($value);
-        };
+        }};
     }
 
     #[test]

--- a/crates/ruff_python_resolver/src/lib.rs
+++ b/crates/ruff_python_resolver/src/lib.rs
@@ -130,7 +130,8 @@ mod tests {
 
     macro_rules! assert_debug_snapshot_normalize_paths {
         ($value: ident) => {
-            let $value = format!("{:#?}", $value).replace('\\', "/");
+            // The debug representation for the backslash are two backslashes (escaping)
+            let $value = format!("{:#?}", $value).replace("\\\\", "/");
             insta::assert_display_snapshot!($value);
         };
     }


### PR DESCRIPTION
## Summary

The airflow windows tests were failing because `/` was saved but windows uses `\`, so now the tests normalize the backwards slash to a forward slash

## Test Plan

linux fixtures showed no failures, CI should check windows

