### PR TITLE
`[DLINT]` Add Dlint plugin and first rule DUO138

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,6 +1843,7 @@ dependencies = [
  "pyproject-toml",
  "quick-junit",
  "regex",
+ "regex-syntax",
  "result-like",
  "ruff_cache",
  "ruff_diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ path-absolutize = { version = "3.0.14" }
 proc-macro2 = { version = "1.0.51" }
 quote = { version = "1.0.23" }
 regex = { version = "1.7.1" }
+regex-syntax = {version = "0.7.3"}
 rustc-hash = { version = "1.1.0" }
 schemars = { version = "0.8.12" }
 serde = { version = "1.0.152", features = ["derive"] }

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -60,6 +60,7 @@ phf = { version = "0.11", features = ["macros"] }
 pyproject-toml = { version = "0.6.0" }
 quick-junit = { version = "0.3.2" }
 regex = { workspace = true }
+regex-syntax = { workspace = true }
 result-like = { version = "0.4.6" }
 rustc-hash = { workspace = true }
 rustpython-format = { workspace = true }

--- a/crates/ruff/resources/test/fixtures/dlint/DUO138.py
+++ b/crates/ruff/resources/test/fixtures/dlint/DUO138.py
@@ -37,10 +37,6 @@ re.search("(a+){10}b")  # DUO138
 
 re.search("(a+){10}?b")  # DUO138
 
-re.search("(a+){,10}b")  # DUO138
-
-re.search("(a+){,10}?b")  # DUO138
-
 re.search("(a+){10,}b")  # DUO138
 
 re.search("(a+){10,}?b")  # DUO138
@@ -58,10 +54,6 @@ re.search("(a+?){1,10}?b")  # DUO138
 re.search("(a+?){10}b")  # DUO138
 
 re.search("(a+?){10}?b")  # DUO138
-
-re.search("(a+?){,10}b")  # DUO138
-
-re.search("(a+?){,10}?b")  # DUO138
 
 re.search("(a+?){10,}b")  # DUO138
 
@@ -81,10 +73,6 @@ re.search("(a*){10}b")  # DUO138
 
 re.search("(a*){10}?b")  # DUO138
 
-re.search("(a*){,10}b")  # DUO138
-
-re.search("(a*){,10}?b")  # DUO138
-
 re.search("(a*){10,}b")  # DUO138
 
 re.search("(a*){10,}?b")  # DUO138
@@ -102,10 +90,6 @@ re.search("(a*?){1,10}?b")  # DUO138
 re.search("(a*?){10}b")  # DUO138
 
 re.search("(a*?){10}?b")  # DUO138
-
-re.search("(a*?){,10}b")  # DUO138
-
-re.search("(a*?){,10}?b")  # DUO138
 
 re.search("(a*?){10,}b")  # DUO138
 
@@ -125,10 +109,6 @@ re.search("(a{1,10}){10}b")  # DUO138
 
 re.search("(a{1,10}){10}?b")  # DUO138
 
-re.search("(a{1,10}){,10}b")  # DUO138
-
-re.search("(a{1,10}){,10}?b")  # DUO138
-
 re.search("(a{1,10}){10,}b")  # DUO138
 
 re.search("(a{1,10}){10,}?b")  # DUO138
@@ -146,10 +126,6 @@ re.search("(a{1,10}?){1,10}b")  # DUO138
 re.search("(a{1,10}?){10}b")  # DUO138
 
 re.search("(a{1,10}?){10}?b")  # DUO138
-
-re.search("(a{1,10}?){,10}b")  # DUO138
-
-re.search("(a{1,10}?){,10}?b")  # DUO138
 
 re.search("(a{1,10}?){10,}b")  # DUO138
 
@@ -169,10 +145,6 @@ re.search("(a{10}){1,10}?b")  # DUO138
 
 re.search("(a{10}){10}?b")  # DUO138
 
-re.search("(a{10}){,10}b")  # DUO138
-
-re.search("(a{10}){,10}?b")  # DUO138
-
 re.search("(a{10}){10,}b")  # DUO138
 
 re.search("(a{10}){10,}?b")  # DUO138
@@ -191,57 +163,9 @@ re.search("(a{10}?){1,10}?b")  # DUO138
 
 re.search("(a{10}?){10}b")  # DUO138
 
-re.search("(a{10}?){,10}b")  # DUO138
-
-re.search("(a{10}?){,10}?b")  # DUO138
-
 re.search("(a{10}?){10,}b")  # DUO138
 
 re.search("(a{10}?){10,}?b")  # DUO138
-
-re.search("(a{,10})+b")  # DUO138
-
-re.search("(a{,10})+?b")  # DUO138
-
-re.search("(a{,10})*b")  # DUO138
-
-re.search("(a{,10})*?b")  # DUO138
-
-re.search("(a{,10}){1,10}b")  # DUO138
-
-re.search("(a{,10}){1,10}?b")  # DUO138
-
-re.search("(a{,10}){10}b")  # DUO138
-
-re.search("(a{,10}){10}?b")  # DUO138
-
-re.search("(a{,10}){,10}?b")  # DUO138
-
-re.search("(a{,10}){10,}b")  # DUO138
-
-re.search("(a{,10}){10,}?b")  # DUO138
-
-re.search("(a{,10}?)+b")  # DUO138
-
-re.search("(a{,10}?)+?b")  # DUO138
-
-re.search("(a{,10}?)*b")  # DUO138
-
-re.search("(a{,10}?)*?b")  # DUO138
-
-re.search("(a{,10}?){1,10}b")  # DUO138
-
-re.search("(a{,10}?){1,10}?b")  # DUO138
-
-re.search("(a{,10}?){10}b")  # DUO138
-
-re.search("(a{,10}?){10}?b")  # DUO138
-
-re.search("(a{,10}?){,10}b")  # DUO138
-
-re.search("(a{,10}?){10,}b")  # DUO138
-
-re.search("(a{,10}?){10,}?b")  # DUO138
 
 re.search("(a{10,})+b")  # DUO138
 
@@ -258,10 +182,6 @@ re.search("(a{10,}){1,10}?b")  # DUO138
 re.search("(a{10,}){10}b")  # DUO138
 
 re.search("(a{10,}){10}?b")  # DUO138
-
-re.search("(a{10,}){,10}b")  # DUO138
-
-re.search("(a{10,}){,10}?b")  # DUO138
 
 re.search("(a{10,}){10,}?b")  # DUO138
 
@@ -280,10 +200,6 @@ re.search("(a{10,}?){1,10}?b")  # DUO138
 re.search("(a{10,}?){10}b")  # DUO138
 
 re.search("(a{10,}?){10}?b")  # DUO138
-
-re.search("(a{10,}?){,10}b")  # DUO138
-
-re.search("(a{10,}?){,10}?b")  # DUO138
 
 re.search("(a{10,}?){10,}b")  # DUO138
 

--- a/crates/ruff/resources/test/fixtures/dlint/DUO138.py
+++ b/crates/ruff/resources/test/fixtures/dlint/DUO138.py
@@ -1,0 +1,316 @@
+import re
+
+from re import compile, search, match, fullmatch, split, findall, finditer, sub, subn
+
+re.compile("(a+)+b")  # DUO138
+re.search("(a+)+b")  # DUO138
+re.match("(a+)+b")  # DUO138
+re.fullmatch("(a+)+b")  # DUO138
+re.split("(a+)+b")  # DUO138
+re.findall("(a+)+b")  # DUO138
+re.finditer("(a+)+b")  # DUO138
+re.sub("(a+)+b")  # DUO138
+re.subn("(a+)+b")  # DUO138
+
+compile("(a+)+b")  # DUO138
+search("(a+)+b")  # DUO138
+match("(a+)+b")  # DUO138
+fullmatch("(a+)+b")  # DUO138
+split("(a+)+b")  # DUO138
+findall("(a+)+b")  # DUO138
+finditer("(a+)+b")  # DUO138
+sub("(a+)+b")  # DUO138
+subn("(a+)+b")  # DUO138
+
+
+re.search("(a+)+?b")  # DUO138
+
+re.search("(a+)*b")  # DUO138
+
+re.search("(a+)*?b")  # DUO138
+
+re.search("(a+){1,10}b")  # DUO138
+
+re.search("(a+){1,10}?b")  # DUO138
+
+re.search("(a+){10}b")  # DUO138
+
+re.search("(a+){10}?b")  # DUO138
+
+re.search("(a+){,10}b")  # DUO138
+
+re.search("(a+){,10}?b")  # DUO138
+
+re.search("(a+){10,}b")  # DUO138
+
+re.search("(a+){10,}?b")  # DUO138
+
+re.search("(a+?)+b")  # DUO138
+
+re.search("(a+?)*b")  # DUO138
+
+re.search("(a+?)*?b")  # DUO138
+
+re.search("(a+?){1,10}b")  # DUO138
+
+re.search("(a+?){1,10}?b")  # DUO138
+
+re.search("(a+?){10}b")  # DUO138
+
+re.search("(a+?){10}?b")  # DUO138
+
+re.search("(a+?){,10}b")  # DUO138
+
+re.search("(a+?){,10}?b")  # DUO138
+
+re.search("(a+?){10,}b")  # DUO138
+
+re.search("(a+?){10,}?b")  # DUO138
+
+re.search("(a*)+b")  # DUO138
+
+re.search("(a*)+?b")  # DUO138
+
+re.search("(a*)*?b")  # DUO138
+
+re.search("(a*){1,10}b")  # DUO138
+
+re.search("(a*){1,10}?b")  # DUO138
+
+re.search("(a*){10}b")  # DUO138
+
+re.search("(a*){10}?b")  # DUO138
+
+re.search("(a*){,10}b")  # DUO138
+
+re.search("(a*){,10}?b")  # DUO138
+
+re.search("(a*){10,}b")  # DUO138
+
+re.search("(a*){10,}?b")  # DUO138
+
+re.search("(a*?)+b")  # DUO138
+
+re.search("(a*?)+?b")  # DUO138
+
+re.search("(a*?)*b")  # DUO138
+
+re.search("(a*?){1,10}b")  # DUO138
+
+re.search("(a*?){1,10}?b")  # DUO138
+
+re.search("(a*?){10}b")  # DUO138
+
+re.search("(a*?){10}?b")  # DUO138
+
+re.search("(a*?){,10}b")  # DUO138
+
+re.search("(a*?){,10}?b")  # DUO138
+
+re.search("(a*?){10,}b")  # DUO138
+
+re.search("(a*?){10,}?b")  # DUO138
+
+re.search("(a{1,10})+b")  # DUO138
+
+re.search("(a{1,10})+?b")  # DUO138
+
+re.search("(a{1,10})*b")  # DUO138
+
+re.search("(a{1,10})*?b")  # DUO138
+
+re.search("(a{1,10}){1,10}?b")  # DUO138
+
+re.search("(a{1,10}){10}b")  # DUO138
+
+re.search("(a{1,10}){10}?b")  # DUO138
+
+re.search("(a{1,10}){,10}b")  # DUO138
+
+re.search("(a{1,10}){,10}?b")  # DUO138
+
+re.search("(a{1,10}){10,}b")  # DUO138
+
+re.search("(a{1,10}){10,}?b")  # DUO138
+
+re.search("(a{1,10}?)+b")  # DUO138
+
+re.search("(a{1,10}?)+?b")  # DUO138
+
+re.search("(a{1,10}?)*b")  # DUO138
+
+re.search("(a{1,10}?)*?b")  # DUO138
+
+re.search("(a{1,10}?){1,10}b")  # DUO138
+
+re.search("(a{1,10}?){10}b")  # DUO138
+
+re.search("(a{1,10}?){10}?b")  # DUO138
+
+re.search("(a{1,10}?){,10}b")  # DUO138
+
+re.search("(a{1,10}?){,10}?b")  # DUO138
+
+re.search("(a{1,10}?){10,}b")  # DUO138
+
+re.search("(a{1,10}?){10,}?b")  # DUO138
+
+re.search("(a{10})+b")  # DUO138
+
+re.search("(a{10})+?b")  # DUO138
+
+re.search("(a{10})*b")  # DUO138
+
+re.search("(a{10})*?b")  # DUO138
+
+re.search("(a{10}){1,10}b")  # DUO138
+
+re.search("(a{10}){1,10}?b")  # DUO138
+
+re.search("(a{10}){10}?b")  # DUO138
+
+re.search("(a{10}){,10}b")  # DUO138
+
+re.search("(a{10}){,10}?b")  # DUO138
+
+re.search("(a{10}){10,}b")  # DUO138
+
+re.search("(a{10}){10,}?b")  # DUO138
+
+re.search("(a{10}?)+b")  # DUO138
+
+re.search("(a{10}?)+?b")  # DUO138
+
+re.search("(a{10}?)*b")  # DUO138
+
+re.search("(a{10}?)*?b")  # DUO138
+
+re.search("(a{10}?){1,10}b")  # DUO138
+
+re.search("(a{10}?){1,10}?b")  # DUO138
+
+re.search("(a{10}?){10}b")  # DUO138
+
+re.search("(a{10}?){,10}b")  # DUO138
+
+re.search("(a{10}?){,10}?b")  # DUO138
+
+re.search("(a{10}?){10,}b")  # DUO138
+
+re.search("(a{10}?){10,}?b")  # DUO138
+
+re.search("(a{,10})+b")  # DUO138
+
+re.search("(a{,10})+?b")  # DUO138
+
+re.search("(a{,10})*b")  # DUO138
+
+re.search("(a{,10})*?b")  # DUO138
+
+re.search("(a{,10}){1,10}b")  # DUO138
+
+re.search("(a{,10}){1,10}?b")  # DUO138
+
+re.search("(a{,10}){10}b")  # DUO138
+
+re.search("(a{,10}){10}?b")  # DUO138
+
+re.search("(a{,10}){,10}?b")  # DUO138
+
+re.search("(a{,10}){10,}b")  # DUO138
+
+re.search("(a{,10}){10,}?b")  # DUO138
+
+re.search("(a{,10}?)+b")  # DUO138
+
+re.search("(a{,10}?)+?b")  # DUO138
+
+re.search("(a{,10}?)*b")  # DUO138
+
+re.search("(a{,10}?)*?b")  # DUO138
+
+re.search("(a{,10}?){1,10}b")  # DUO138
+
+re.search("(a{,10}?){1,10}?b")  # DUO138
+
+re.search("(a{,10}?){10}b")  # DUO138
+
+re.search("(a{,10}?){10}?b")  # DUO138
+
+re.search("(a{,10}?){,10}b")  # DUO138
+
+re.search("(a{,10}?){10,}b")  # DUO138
+
+re.search("(a{,10}?){10,}?b")  # DUO138
+
+re.search("(a{10,})+b")  # DUO138
+
+re.search("(a{10,})+?b")  # DUO138
+
+re.search("(a{10,})*b")  # DUO138
+
+re.search("(a{10,})*?b")  # DUO138
+
+re.search("(a{10,}){1,10}b")  # DUO138
+
+re.search("(a{10,}){1,10}?b")  # DUO138
+
+re.search("(a{10,}){10}b")  # DUO138
+
+re.search("(a{10,}){10}?b")  # DUO138
+
+re.search("(a{10,}){,10}b")  # DUO138
+
+re.search("(a{10,}){,10}?b")  # DUO138
+
+re.search("(a{10,}){10,}?b")  # DUO138
+
+re.search("(a{10,}?)+b")  # DUO138
+
+re.search("(a{10,}?)+?b")  # DUO138
+
+re.search("(a{10,}?)*b")  # DUO138
+
+re.search("(a{10,}?)*?b")  # DUO138
+
+re.search("(a{10,}?){1,10}b")  # DUO138
+
+re.search("(a{10,}?){1,10}?b")  # DUO138
+
+re.search("(a{10,}?){10}b")  # DUO138
+
+re.search("(a{10,}?){10}?b")  # DUO138
+
+re.search("(a{10,}?){,10}b")  # DUO138
+
+re.search("(a{10,}?){,10}?b")  # DUO138
+
+re.search("(a{10,}?){10,}b")  # DUO138
+
+re.search("[abc]+[def]*")  # OK
+
+re.search("[abc]+([def]*)")  # OK
+
+re.search("(.|[a-c])+")  # DUO138
+
+re.search("(a|[a-c])+")  # DUO138
+
+re.search("(d|[a-c])+")  # OK
+
+re.search("([^d]|[a-c])+")  # DUO138
+
+re.search("([^b]|[a-c])+")  # DUO138
+
+re.search("([^a]|a)+")  # OK
+
+re.search("([^d]|[^b]|[a-c])+")  # DUO138
+
+
+re.search("([^abcAB]|[a-c]|[A-C])+")  # DUO138
+
+re.search("([^abcABC]|[a-c]|[A-C])+")  # OK
+
+
+re.search("([a-c]|[c-e])+")  # DUO138
+
+re.search("([a-c]|[d-e])+")  # OK

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -2937,8 +2937,8 @@ where
                 if self.enabled(Rule::DjangoLocalsInRenderFunction) {
                     flake8_django::rules::locals_in_render_function(self, func, args, keywords);
                 }
-                if self.enabled(Rule::CatastrophicReUse) {
-                    dlint::rules::catastrophic_re_use(self, expr_call);
+                if self.enabled(Rule::CatastrophicBacktrackingRegularExpression) {
+                    dlint::rules::catastrophic_backtracking_regular_expression(self, expr_call);
                 }
             }
             Expr::Dict(ast::ExprDict {

--- a/crates/ruff/src/codes.rs
+++ b/crates/ruff/src/codes.rs
@@ -824,7 +824,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8Slots, "002") => (RuleGroup::Unspecified, rules::flake8_slots::rules::NoSlotsInNamedtupleSubclass),
 
         // dlint
-        (Dlint, "138") => (RuleGroup::Unspecified, rules::dlint::rules::CatastrophicReUse),
+        (Dlint, "138") => (RuleGroup::Unspecified, rules::dlint::rules::CatastrophicBacktrackingRegularExpression),
 
         _ => return None,
     })

--- a/crates/ruff/src/codes.rs
+++ b/crates/ruff/src/codes.rs
@@ -823,6 +823,9 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8Slots, "001") => (RuleGroup::Unspecified, rules::flake8_slots::rules::NoSlotsInTupleSubclass),
         (Flake8Slots, "002") => (RuleGroup::Unspecified, rules::flake8_slots::rules::NoSlotsInNamedtupleSubclass),
 
+        // dlint
+        (Dlint, "138") => (RuleGroup::Unspecified, rules::dlint::rules::CatastrophicReUse),
+
         _ => return None,
     })
 }

--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -196,6 +196,9 @@ pub enum Linter {
     /// [Perflint](https://pypi.org/project/perflint/)
     #[prefix = "PERF"]
     Perflint,
+    /// [Dlint](https://pypi.org/project/dlint/)
+    #[prefix = "DUO"]
+    Dlint,
     /// Ruff-specific rules
     #[prefix = "RUF"]
     Ruff,

--- a/crates/ruff/src/rules/dlint/mod.rs
+++ b/crates/ruff/src/rules/dlint/mod.rs
@@ -13,7 +13,7 @@ mod tests {
     use crate::settings::Settings;
     use crate::test::test_path;
 
-    #[test_case(Rule::CatastrophicReUse, Path::new("DUO138.py"))]
+    #[test_case(Rule::CatastrophicBacktrackingRegularExpression, Path::new("DUO138.py"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/ruff/src/rules/dlint/mod.rs
+++ b/crates/ruff/src/rules/dlint/mod.rs
@@ -1,0 +1,26 @@
+//! Rules from [dlint](https://pypi.org/project/dlint/).
+pub(crate) mod rules;
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use anyhow::Result;
+    use test_case::test_case;
+
+    use crate::assert_messages;
+    use crate::registry::Rule;
+    use crate::settings::Settings;
+    use crate::test::test_path;
+
+    #[test_case(Rule::CatastrophicReUse, Path::new("DUO138.py"))]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("dlint").join(path).as_path(),
+            &Settings::for_rule(rule_code),
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+}

--- a/crates/ruff/src/rules/dlint/rules/catastrophic_backtracking_regular_expression.rs
+++ b/crates/ruff/src/rules/dlint/rules/catastrophic_backtracking_regular_expression.rs
@@ -42,7 +42,7 @@ pub struct CatastrophicBacktrackingRegularExpression;
 impl Violation for CatastrophicBacktrackingRegularExpression {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Potentially dangerous regex expression can lead to catastrophic backtracking")
+        format!("Regular expression can lead to catastrophic backtracking")
     }
 }
 

--- a/crates/ruff/src/rules/dlint/rules/catastrophic_re_use.rs
+++ b/crates/ruff/src/rules/dlint/rules/catastrophic_re_use.rs
@@ -1,0 +1,46 @@
+use ruff_diagnostics::Violation;
+use rustpython_parser::ast::ExprCall;
+
+use ruff_macros::{derive_message_formats, violation};
+
+use crate::checkers::ast::Checker;
+
+/// ## What it does
+/// Checks for regular expressions that can, under certain inputs, lead to catastrophic
+/// backtracking in the Python `re` module.
+///
+/// ## Why is this bad?
+/// Catastrophic backtracking will often lead to denial-of-service. Catastrophic cases may take
+/// days, weeks, or years to complete which may leave your service degraded or unusable.
+///
+/// ## Example
+/// ```python
+/// import re
+///
+/// subject = 'a' * 64
+/// re.search(r'(.|[abc])+z', subject)  # Boom
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import re
+///
+/// subject = 'a' * 64
+/// re.search(r'.+z', subject)
+/// ```
+///
+/// ## References
+/// - [Runaway Regular Expressions: Catastrophic Backtracking](https://www.regular-expressions.info/catastrophic.html)
+/// - [Preventing Regular Expression Denial of Service (ReDoS)](https://www.regular-expressions.info/redos.html)
+#[violation]
+pub struct CatastrophicReUse;
+
+impl Violation for CatastrophicReUse {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Potentially dangerous regex expression can lead to catastrophic backtracking")
+    }
+}
+
+/// DUO138
+pub(crate) fn catastrophic_re_use(checker: &mut Checker, call: &ExprCall) {}

--- a/crates/ruff/src/rules/dlint/rules/catastrophic_re_use.rs
+++ b/crates/ruff/src/rules/dlint/rules/catastrophic_re_use.rs
@@ -1,9 +1,8 @@
-use regex_syntax::hir::{Hir, HirKind, Literal};
+use regex_syntax::hir::{Hir, HirKind};
 use regex_syntax::ParserBuilder;
 use ruff_diagnostics::{Diagnostic, Violation};
 use rustpython_parser::ast;
 use rustpython_parser::ast::{Constant, Expr, ExprCall, Ranged};
-use std::collections::HashSet;
 
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::CallPath;

--- a/crates/ruff/src/rules/dlint/rules/mod.rs
+++ b/crates/ruff/src/rules/dlint/rules/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) use catastrophic_re_use::*;
+
+mod catastrophic_re_use;

--- a/crates/ruff/src/rules/dlint/rules/mod.rs
+++ b/crates/ruff/src/rules/dlint/rules/mod.rs
@@ -1,3 +1,3 @@
-pub(crate) use catastrophic_re_use::*;
+pub(crate) use catastrophic_backtracking_regular_expression::*;
 
-mod catastrophic_re_use;
+mod catastrophic_backtracking_regular_expression;

--- a/crates/ruff/src/rules/dlint/snapshots/ruff__rules__dlint__tests__DUO138_DUO138.py.snap.new
+++ b/crates/ruff/src/rules/dlint/snapshots/ruff__rules__dlint__tests__DUO138_DUO138.py.snap.new
@@ -1,0 +1,749 @@
+---
+source: crates/ruff/src/rules/dlint/mod.rs
+assertion_line: 23
+---
+DUO138.py:5:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+  |
+3 | from re import compile, search, match, fullmatch, split, findall, finditer, sub, subn
+4 | 
+5 | re.compile("(a+)+b")  # DUO138
+  | ^^^^^^^^^^ DUO138
+6 | re.search("(a+)+b")  # DUO138
+7 | re.match("(a+)+b")  # DUO138
+  |
+
+DUO138.py:6:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+  |
+5 | re.compile("(a+)+b")  # DUO138
+6 | re.search("(a+)+b")  # DUO138
+  | ^^^^^^^^^ DUO138
+7 | re.match("(a+)+b")  # DUO138
+8 | re.fullmatch("(a+)+b")  # DUO138
+  |
+
+DUO138.py:7:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+  |
+5 | re.compile("(a+)+b")  # DUO138
+6 | re.search("(a+)+b")  # DUO138
+7 | re.match("(a+)+b")  # DUO138
+  | ^^^^^^^^ DUO138
+8 | re.fullmatch("(a+)+b")  # DUO138
+9 | re.split("(a+)+b")  # DUO138
+  |
+
+DUO138.py:8:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+ 6 | re.search("(a+)+b")  # DUO138
+ 7 | re.match("(a+)+b")  # DUO138
+ 8 | re.fullmatch("(a+)+b")  # DUO138
+   | ^^^^^^^^^^^^ DUO138
+ 9 | re.split("(a+)+b")  # DUO138
+10 | re.findall("(a+)+b")  # DUO138
+   |
+
+DUO138.py:9:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+ 7 | re.match("(a+)+b")  # DUO138
+ 8 | re.fullmatch("(a+)+b")  # DUO138
+ 9 | re.split("(a+)+b")  # DUO138
+   | ^^^^^^^^ DUO138
+10 | re.findall("(a+)+b")  # DUO138
+11 | re.finditer("(a+)+b")  # DUO138
+   |
+
+DUO138.py:10:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+ 8 | re.fullmatch("(a+)+b")  # DUO138
+ 9 | re.split("(a+)+b")  # DUO138
+10 | re.findall("(a+)+b")  # DUO138
+   | ^^^^^^^^^^ DUO138
+11 | re.finditer("(a+)+b")  # DUO138
+12 | re.sub("(a+)+b")  # DUO138
+   |
+
+DUO138.py:11:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+ 9 | re.split("(a+)+b")  # DUO138
+10 | re.findall("(a+)+b")  # DUO138
+11 | re.finditer("(a+)+b")  # DUO138
+   | ^^^^^^^^^^^ DUO138
+12 | re.sub("(a+)+b")  # DUO138
+13 | re.subn("(a+)+b")  # DUO138
+   |
+
+DUO138.py:12:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+10 | re.findall("(a+)+b")  # DUO138
+11 | re.finditer("(a+)+b")  # DUO138
+12 | re.sub("(a+)+b")  # DUO138
+   | ^^^^^^ DUO138
+13 | re.subn("(a+)+b")  # DUO138
+   |
+
+DUO138.py:13:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+11 | re.finditer("(a+)+b")  # DUO138
+12 | re.sub("(a+)+b")  # DUO138
+13 | re.subn("(a+)+b")  # DUO138
+   | ^^^^^^^ DUO138
+14 | 
+15 | compile("(a+)+b")  # DUO138
+   |
+
+DUO138.py:15:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+13 | re.subn("(a+)+b")  # DUO138
+14 | 
+15 | compile("(a+)+b")  # DUO138
+   | ^^^^^^^ DUO138
+16 | search("(a+)+b")  # DUO138
+17 | match("(a+)+b")  # DUO138
+   |
+
+DUO138.py:16:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+15 | compile("(a+)+b")  # DUO138
+16 | search("(a+)+b")  # DUO138
+   | ^^^^^^ DUO138
+17 | match("(a+)+b")  # DUO138
+18 | fullmatch("(a+)+b")  # DUO138
+   |
+
+DUO138.py:17:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+15 | compile("(a+)+b")  # DUO138
+16 | search("(a+)+b")  # DUO138
+17 | match("(a+)+b")  # DUO138
+   | ^^^^^ DUO138
+18 | fullmatch("(a+)+b")  # DUO138
+19 | split("(a+)+b")  # DUO138
+   |
+
+DUO138.py:18:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+16 | search("(a+)+b")  # DUO138
+17 | match("(a+)+b")  # DUO138
+18 | fullmatch("(a+)+b")  # DUO138
+   | ^^^^^^^^^ DUO138
+19 | split("(a+)+b")  # DUO138
+20 | findall("(a+)+b")  # DUO138
+   |
+
+DUO138.py:19:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+17 | match("(a+)+b")  # DUO138
+18 | fullmatch("(a+)+b")  # DUO138
+19 | split("(a+)+b")  # DUO138
+   | ^^^^^ DUO138
+20 | findall("(a+)+b")  # DUO138
+21 | finditer("(a+)+b")  # DUO138
+   |
+
+DUO138.py:20:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+18 | fullmatch("(a+)+b")  # DUO138
+19 | split("(a+)+b")  # DUO138
+20 | findall("(a+)+b")  # DUO138
+   | ^^^^^^^ DUO138
+21 | finditer("(a+)+b")  # DUO138
+22 | sub("(a+)+b")  # DUO138
+   |
+
+DUO138.py:21:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+19 | split("(a+)+b")  # DUO138
+20 | findall("(a+)+b")  # DUO138
+21 | finditer("(a+)+b")  # DUO138
+   | ^^^^^^^^ DUO138
+22 | sub("(a+)+b")  # DUO138
+23 | subn("(a+)+b")  # DUO138
+   |
+
+DUO138.py:22:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+20 | findall("(a+)+b")  # DUO138
+21 | finditer("(a+)+b")  # DUO138
+22 | sub("(a+)+b")  # DUO138
+   | ^^^ DUO138
+23 | subn("(a+)+b")  # DUO138
+   |
+
+DUO138.py:23:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+21 | finditer("(a+)+b")  # DUO138
+22 | sub("(a+)+b")  # DUO138
+23 | subn("(a+)+b")  # DUO138
+   | ^^^^ DUO138
+   |
+
+DUO138.py:28:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+26 | re.search("(a+)+?b")  # DUO138
+27 | 
+28 | re.search("(a+)*b")  # DUO138
+   | ^^^^^^^^^ DUO138
+29 | 
+30 | re.search("(a+)*?b")  # DUO138
+   |
+
+DUO138.py:32:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+30 | re.search("(a+)*?b")  # DUO138
+31 | 
+32 | re.search("(a+){1,10}b")  # DUO138
+   | ^^^^^^^^^ DUO138
+33 | 
+34 | re.search("(a+){1,10}?b")  # DUO138
+   |
+
+DUO138.py:36:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+34 | re.search("(a+){1,10}?b")  # DUO138
+35 | 
+36 | re.search("(a+){10}b")  # DUO138
+   | ^^^^^^^^^ DUO138
+37 | 
+38 | re.search("(a+){10}?b")  # DUO138
+   |
+
+DUO138.py:40:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+38 | re.search("(a+){10}?b")  # DUO138
+39 | 
+40 | re.search("(a+){10,}b")  # DUO138
+   | ^^^^^^^^^ DUO138
+41 | 
+42 | re.search("(a+){10,}?b")  # DUO138
+   |
+
+DUO138.py:44:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+42 | re.search("(a+){10,}?b")  # DUO138
+43 | 
+44 | re.search("(a+?)+b")  # DUO138
+   | ^^^^^^^^^ DUO138
+45 | 
+46 | re.search("(a+?)*b")  # DUO138
+   |
+
+DUO138.py:46:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+44 | re.search("(a+?)+b")  # DUO138
+45 | 
+46 | re.search("(a+?)*b")  # DUO138
+   | ^^^^^^^^^ DUO138
+47 | 
+48 | re.search("(a+?)*?b")  # DUO138
+   |
+
+DUO138.py:50:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+48 | re.search("(a+?)*?b")  # DUO138
+49 | 
+50 | re.search("(a+?){1,10}b")  # DUO138
+   | ^^^^^^^^^ DUO138
+51 | 
+52 | re.search("(a+?){1,10}?b")  # DUO138
+   |
+
+DUO138.py:54:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+52 | re.search("(a+?){1,10}?b")  # DUO138
+53 | 
+54 | re.search("(a+?){10}b")  # DUO138
+   | ^^^^^^^^^ DUO138
+55 | 
+56 | re.search("(a+?){10}?b")  # DUO138
+   |
+
+DUO138.py:58:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+56 | re.search("(a+?){10}?b")  # DUO138
+57 | 
+58 | re.search("(a+?){10,}b")  # DUO138
+   | ^^^^^^^^^ DUO138
+59 | 
+60 | re.search("(a+?){10,}?b")  # DUO138
+   |
+
+DUO138.py:62:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+60 | re.search("(a+?){10,}?b")  # DUO138
+61 | 
+62 | re.search("(a*)+b")  # DUO138
+   | ^^^^^^^^^ DUO138
+63 | 
+64 | re.search("(a*)+?b")  # DUO138
+   |
+
+DUO138.py:68:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+66 | re.search("(a*)*?b")  # DUO138
+67 | 
+68 | re.search("(a*){1,10}b")  # DUO138
+   | ^^^^^^^^^ DUO138
+69 | 
+70 | re.search("(a*){1,10}?b")  # DUO138
+   |
+
+DUO138.py:72:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+70 | re.search("(a*){1,10}?b")  # DUO138
+71 | 
+72 | re.search("(a*){10}b")  # DUO138
+   | ^^^^^^^^^ DUO138
+73 | 
+74 | re.search("(a*){10}?b")  # DUO138
+   |
+
+DUO138.py:76:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+74 | re.search("(a*){10}?b")  # DUO138
+75 | 
+76 | re.search("(a*){10,}b")  # DUO138
+   | ^^^^^^^^^ DUO138
+77 | 
+78 | re.search("(a*){10,}?b")  # DUO138
+   |
+
+DUO138.py:80:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+78 | re.search("(a*){10,}?b")  # DUO138
+79 | 
+80 | re.search("(a*?)+b")  # DUO138
+   | ^^^^^^^^^ DUO138
+81 | 
+82 | re.search("(a*?)+?b")  # DUO138
+   |
+
+DUO138.py:84:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+82 | re.search("(a*?)+?b")  # DUO138
+83 | 
+84 | re.search("(a*?)*b")  # DUO138
+   | ^^^^^^^^^ DUO138
+85 | 
+86 | re.search("(a*?){1,10}b")  # DUO138
+   |
+
+DUO138.py:86:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+84 | re.search("(a*?)*b")  # DUO138
+85 | 
+86 | re.search("(a*?){1,10}b")  # DUO138
+   | ^^^^^^^^^ DUO138
+87 | 
+88 | re.search("(a*?){1,10}?b")  # DUO138
+   |
+
+DUO138.py:90:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+88 | re.search("(a*?){1,10}?b")  # DUO138
+89 | 
+90 | re.search("(a*?){10}b")  # DUO138
+   | ^^^^^^^^^ DUO138
+91 | 
+92 | re.search("(a*?){10}?b")  # DUO138
+   |
+
+DUO138.py:94:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+92 | re.search("(a*?){10}?b")  # DUO138
+93 | 
+94 | re.search("(a*?){10,}b")  # DUO138
+   | ^^^^^^^^^ DUO138
+95 | 
+96 | re.search("(a*?){10,}?b")  # DUO138
+   |
+
+DUO138.py:98:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+ 96 | re.search("(a*?){10,}?b")  # DUO138
+ 97 | 
+ 98 | re.search("(a{1,10})+b")  # DUO138
+    | ^^^^^^^^^ DUO138
+ 99 | 
+100 | re.search("(a{1,10})+?b")  # DUO138
+    |
+
+DUO138.py:102:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+100 | re.search("(a{1,10})+?b")  # DUO138
+101 | 
+102 | re.search("(a{1,10})*b")  # DUO138
+    | ^^^^^^^^^ DUO138
+103 | 
+104 | re.search("(a{1,10})*?b")  # DUO138
+    |
+
+DUO138.py:108:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+106 | re.search("(a{1,10}){1,10}?b")  # DUO138
+107 | 
+108 | re.search("(a{1,10}){10}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+109 | 
+110 | re.search("(a{1,10}){10}?b")  # DUO138
+    |
+
+DUO138.py:112:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+110 | re.search("(a{1,10}){10}?b")  # DUO138
+111 | 
+112 | re.search("(a{1,10}){10,}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+113 | 
+114 | re.search("(a{1,10}){10,}?b")  # DUO138
+    |
+
+DUO138.py:116:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+114 | re.search("(a{1,10}){10,}?b")  # DUO138
+115 | 
+116 | re.search("(a{1,10}?)+b")  # DUO138
+    | ^^^^^^^^^ DUO138
+117 | 
+118 | re.search("(a{1,10}?)+?b")  # DUO138
+    |
+
+DUO138.py:120:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+118 | re.search("(a{1,10}?)+?b")  # DUO138
+119 | 
+120 | re.search("(a{1,10}?)*b")  # DUO138
+    | ^^^^^^^^^ DUO138
+121 | 
+122 | re.search("(a{1,10}?)*?b")  # DUO138
+    |
+
+DUO138.py:124:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+122 | re.search("(a{1,10}?)*?b")  # DUO138
+123 | 
+124 | re.search("(a{1,10}?){1,10}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+125 | 
+126 | re.search("(a{1,10}?){10}b")  # DUO138
+    |
+
+DUO138.py:126:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+124 | re.search("(a{1,10}?){1,10}b")  # DUO138
+125 | 
+126 | re.search("(a{1,10}?){10}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+127 | 
+128 | re.search("(a{1,10}?){10}?b")  # DUO138
+    |
+
+DUO138.py:130:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+128 | re.search("(a{1,10}?){10}?b")  # DUO138
+129 | 
+130 | re.search("(a{1,10}?){10,}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+131 | 
+132 | re.search("(a{1,10}?){10,}?b")  # DUO138
+    |
+
+DUO138.py:134:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+132 | re.search("(a{1,10}?){10,}?b")  # DUO138
+133 | 
+134 | re.search("(a{10})+b")  # DUO138
+    | ^^^^^^^^^ DUO138
+135 | 
+136 | re.search("(a{10})+?b")  # DUO138
+    |
+
+DUO138.py:138:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+136 | re.search("(a{10})+?b")  # DUO138
+137 | 
+138 | re.search("(a{10})*b")  # DUO138
+    | ^^^^^^^^^ DUO138
+139 | 
+140 | re.search("(a{10})*?b")  # DUO138
+    |
+
+DUO138.py:142:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+140 | re.search("(a{10})*?b")  # DUO138
+141 | 
+142 | re.search("(a{10}){1,10}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+143 | 
+144 | re.search("(a{10}){1,10}?b")  # DUO138
+    |
+
+DUO138.py:148:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+146 | re.search("(a{10}){10}?b")  # DUO138
+147 | 
+148 | re.search("(a{10}){10,}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+149 | 
+150 | re.search("(a{10}){10,}?b")  # DUO138
+    |
+
+DUO138.py:152:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+150 | re.search("(a{10}){10,}?b")  # DUO138
+151 | 
+152 | re.search("(a{10}?)+b")  # DUO138
+    | ^^^^^^^^^ DUO138
+153 | 
+154 | re.search("(a{10}?)+?b")  # DUO138
+    |
+
+DUO138.py:156:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+154 | re.search("(a{10}?)+?b")  # DUO138
+155 | 
+156 | re.search("(a{10}?)*b")  # DUO138
+    | ^^^^^^^^^ DUO138
+157 | 
+158 | re.search("(a{10}?)*?b")  # DUO138
+    |
+
+DUO138.py:160:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+158 | re.search("(a{10}?)*?b")  # DUO138
+159 | 
+160 | re.search("(a{10}?){1,10}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+161 | 
+162 | re.search("(a{10}?){1,10}?b")  # DUO138
+    |
+
+DUO138.py:164:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+162 | re.search("(a{10}?){1,10}?b")  # DUO138
+163 | 
+164 | re.search("(a{10}?){10}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+165 | 
+166 | re.search("(a{10}?){10,}b")  # DUO138
+    |
+
+DUO138.py:166:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+164 | re.search("(a{10}?){10}b")  # DUO138
+165 | 
+166 | re.search("(a{10}?){10,}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+167 | 
+168 | re.search("(a{10}?){10,}?b")  # DUO138
+    |
+
+DUO138.py:170:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+168 | re.search("(a{10}?){10,}?b")  # DUO138
+169 | 
+170 | re.search("(a{10,})+b")  # DUO138
+    | ^^^^^^^^^ DUO138
+171 | 
+172 | re.search("(a{10,})+?b")  # DUO138
+    |
+
+DUO138.py:174:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+172 | re.search("(a{10,})+?b")  # DUO138
+173 | 
+174 | re.search("(a{10,})*b")  # DUO138
+    | ^^^^^^^^^ DUO138
+175 | 
+176 | re.search("(a{10,})*?b")  # DUO138
+    |
+
+DUO138.py:178:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+176 | re.search("(a{10,})*?b")  # DUO138
+177 | 
+178 | re.search("(a{10,}){1,10}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+179 | 
+180 | re.search("(a{10,}){1,10}?b")  # DUO138
+    |
+
+DUO138.py:182:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+180 | re.search("(a{10,}){1,10}?b")  # DUO138
+181 | 
+182 | re.search("(a{10,}){10}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+183 | 
+184 | re.search("(a{10,}){10}?b")  # DUO138
+    |
+
+DUO138.py:188:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+186 | re.search("(a{10,}){10,}?b")  # DUO138
+187 | 
+188 | re.search("(a{10,}?)+b")  # DUO138
+    | ^^^^^^^^^ DUO138
+189 | 
+190 | re.search("(a{10,}?)+?b")  # DUO138
+    |
+
+DUO138.py:192:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+190 | re.search("(a{10,}?)+?b")  # DUO138
+191 | 
+192 | re.search("(a{10,}?)*b")  # DUO138
+    | ^^^^^^^^^ DUO138
+193 | 
+194 | re.search("(a{10,}?)*?b")  # DUO138
+    |
+
+DUO138.py:196:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+194 | re.search("(a{10,}?)*?b")  # DUO138
+195 | 
+196 | re.search("(a{10,}?){1,10}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+197 | 
+198 | re.search("(a{10,}?){1,10}?b")  # DUO138
+    |
+
+DUO138.py:200:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+198 | re.search("(a{10,}?){1,10}?b")  # DUO138
+199 | 
+200 | re.search("(a{10,}?){10}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+201 | 
+202 | re.search("(a{10,}?){10}?b")  # DUO138
+    |
+
+DUO138.py:204:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+202 | re.search("(a{10,}?){10}?b")  # DUO138
+203 | 
+204 | re.search("(a{10,}?){10,}b")  # DUO138
+    | ^^^^^^^^^ DUO138
+205 | 
+206 | re.search("[abc]+[def]*")  # OK
+    |
+
+DUO138.py:206:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+204 | re.search("(a{10,}?){10,}b")  # DUO138
+205 | 
+206 | re.search("[abc]+[def]*")  # OK
+    | ^^^^^^^^^ DUO138
+207 | 
+208 | re.search("[abc]+([def]*)")  # OK
+    |
+
+DUO138.py:208:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+206 | re.search("[abc]+[def]*")  # OK
+207 | 
+208 | re.search("[abc]+([def]*)")  # OK
+    | ^^^^^^^^^ DUO138
+209 | 
+210 | re.search("(.|[a-c])+")  # DUO138
+    |
+
+DUO138.py:210:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+208 | re.search("[abc]+([def]*)")  # OK
+209 | 
+210 | re.search("(.|[a-c])+")  # DUO138
+    | ^^^^^^^^^ DUO138
+211 | 
+212 | re.search("(a|[a-c])+")  # DUO138
+    |
+
+DUO138.py:212:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+210 | re.search("(.|[a-c])+")  # DUO138
+211 | 
+212 | re.search("(a|[a-c])+")  # DUO138
+    | ^^^^^^^^^ DUO138
+213 | 
+214 | re.search("(d|[a-c])+")  # OK
+    |
+
+DUO138.py:214:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+212 | re.search("(a|[a-c])+")  # DUO138
+213 | 
+214 | re.search("(d|[a-c])+")  # OK
+    | ^^^^^^^^^ DUO138
+215 | 
+216 | re.search("([^d]|[a-c])+")  # DUO138
+    |
+
+DUO138.py:216:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+214 | re.search("(d|[a-c])+")  # OK
+215 | 
+216 | re.search("([^d]|[a-c])+")  # DUO138
+    | ^^^^^^^^^ DUO138
+217 | 
+218 | re.search("([^b]|[a-c])+")  # DUO138
+    |
+
+DUO138.py:218:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+216 | re.search("([^d]|[a-c])+")  # DUO138
+217 | 
+218 | re.search("([^b]|[a-c])+")  # DUO138
+    | ^^^^^^^^^ DUO138
+219 | 
+220 | re.search("([^a]|a)+")  # OK
+    |
+
+DUO138.py:220:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+218 | re.search("([^b]|[a-c])+")  # DUO138
+219 | 
+220 | re.search("([^a]|a)+")  # OK
+    | ^^^^^^^^^ DUO138
+221 | 
+222 | re.search("([^d]|[^b]|[a-c])+")  # DUO138
+    |
+
+DUO138.py:222:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+220 | re.search("([^a]|a)+")  # OK
+221 | 
+222 | re.search("([^d]|[^b]|[a-c])+")  # DUO138
+    | ^^^^^^^^^ DUO138
+    |
+
+DUO138.py:225:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+225 | re.search("([^abcAB]|[a-c]|[A-C])+")  # DUO138
+    | ^^^^^^^^^ DUO138
+226 | 
+227 | re.search("([^abcABC]|[a-c]|[A-C])+")  # OK
+    |
+
+DUO138.py:227:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+225 | re.search("([^abcAB]|[a-c]|[A-C])+")  # DUO138
+226 | 
+227 | re.search("([^abcABC]|[a-c]|[A-C])+")  # OK
+    | ^^^^^^^^^ DUO138
+    |
+
+DUO138.py:230:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+230 | re.search("([a-c]|[c-e])+")  # DUO138
+    | ^^^^^^^^^ DUO138
+231 | 
+232 | re.search("([a-c]|[d-e])+")  # OK
+    |
+
+DUO138.py:232:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+230 | re.search("([a-c]|[c-e])+")  # DUO138
+231 | 
+232 | re.search("([a-c]|[d-e])+")  # OK
+    | ^^^^^^^^^ DUO138
+    |
+
+

--- a/crates/ruff/src/rules/dlint/snapshots/ruff__rules__dlint__tests__DUO138_DUO138.py.snap.new
+++ b/crates/ruff/src/rules/dlint/snapshots/ruff__rules__dlint__tests__DUO138_DUO138.py.snap.new
@@ -176,6 +176,14 @@ DUO138.py:23:1: DUO138 Potentially dangerous regex expression can lead to catast
    | ^^^^ DUO138
    |
 
+DUO138.py:26:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+26 | re.search("(a+)+?b")  # DUO138
+   | ^^^^^^^^^ DUO138
+27 | 
+28 | re.search("(a+)*b")  # DUO138
+   |
+
 DUO138.py:28:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
    |
 26 | re.search("(a+)+?b")  # DUO138
@@ -184,6 +192,16 @@ DUO138.py:28:1: DUO138 Potentially dangerous regex expression can lead to catast
    | ^^^^^^^^^ DUO138
 29 | 
 30 | re.search("(a+)*?b")  # DUO138
+   |
+
+DUO138.py:30:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+28 | re.search("(a+)*b")  # DUO138
+29 | 
+30 | re.search("(a+)*?b")  # DUO138
+   | ^^^^^^^^^ DUO138
+31 | 
+32 | re.search("(a+){1,10}b")  # DUO138
    |
 
 DUO138.py:32:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
@@ -196,6 +214,16 @@ DUO138.py:32:1: DUO138 Potentially dangerous regex expression can lead to catast
 34 | re.search("(a+){1,10}?b")  # DUO138
    |
 
+DUO138.py:34:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+32 | re.search("(a+){1,10}b")  # DUO138
+33 | 
+34 | re.search("(a+){1,10}?b")  # DUO138
+   | ^^^^^^^^^ DUO138
+35 | 
+36 | re.search("(a+){10}b")  # DUO138
+   |
+
 DUO138.py:36:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
    |
 34 | re.search("(a+){1,10}?b")  # DUO138
@@ -204,6 +232,16 @@ DUO138.py:36:1: DUO138 Potentially dangerous regex expression can lead to catast
    | ^^^^^^^^^ DUO138
 37 | 
 38 | re.search("(a+){10}?b")  # DUO138
+   |
+
+DUO138.py:38:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+36 | re.search("(a+){10}b")  # DUO138
+37 | 
+38 | re.search("(a+){10}?b")  # DUO138
+   | ^^^^^^^^^ DUO138
+39 | 
+40 | re.search("(a+){10,}b")  # DUO138
    |
 
 DUO138.py:40:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
@@ -216,54 +254,14 @@ DUO138.py:40:1: DUO138 Potentially dangerous regex expression can lead to catast
 42 | re.search("(a+){10,}?b")  # DUO138
    |
 
-DUO138.py:44:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+DUO138.py:42:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
    |
+40 | re.search("(a+){10,}b")  # DUO138
+41 | 
 42 | re.search("(a+){10,}?b")  # DUO138
+   | ^^^^^^^^^ DUO138
 43 | 
 44 | re.search("(a+?)+b")  # DUO138
-   | ^^^^^^^^^ DUO138
-45 | 
-46 | re.search("(a+?)*b")  # DUO138
-   |
-
-DUO138.py:46:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-   |
-44 | re.search("(a+?)+b")  # DUO138
-45 | 
-46 | re.search("(a+?)*b")  # DUO138
-   | ^^^^^^^^^ DUO138
-47 | 
-48 | re.search("(a+?)*?b")  # DUO138
-   |
-
-DUO138.py:50:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-   |
-48 | re.search("(a+?)*?b")  # DUO138
-49 | 
-50 | re.search("(a+?){1,10}b")  # DUO138
-   | ^^^^^^^^^ DUO138
-51 | 
-52 | re.search("(a+?){1,10}?b")  # DUO138
-   |
-
-DUO138.py:54:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-   |
-52 | re.search("(a+?){1,10}?b")  # DUO138
-53 | 
-54 | re.search("(a+?){10}b")  # DUO138
-   | ^^^^^^^^^ DUO138
-55 | 
-56 | re.search("(a+?){10}?b")  # DUO138
-   |
-
-DUO138.py:58:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-   |
-56 | re.search("(a+?){10}?b")  # DUO138
-57 | 
-58 | re.search("(a+?){10,}b")  # DUO138
-   | ^^^^^^^^^ DUO138
-59 | 
-60 | re.search("(a+?){10,}?b")  # DUO138
    |
 
 DUO138.py:62:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
@@ -276,6 +274,26 @@ DUO138.py:62:1: DUO138 Potentially dangerous regex expression can lead to catast
 64 | re.search("(a*)+?b")  # DUO138
    |
 
+DUO138.py:64:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+62 | re.search("(a*)+b")  # DUO138
+63 | 
+64 | re.search("(a*)+?b")  # DUO138
+   | ^^^^^^^^^ DUO138
+65 | 
+66 | re.search("(a*)*?b")  # DUO138
+   |
+
+DUO138.py:66:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+64 | re.search("(a*)+?b")  # DUO138
+65 | 
+66 | re.search("(a*)*?b")  # DUO138
+   | ^^^^^^^^^ DUO138
+67 | 
+68 | re.search("(a*){1,10}b")  # DUO138
+   |
+
 DUO138.py:68:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
    |
 66 | re.search("(a*)*?b")  # DUO138
@@ -284,6 +302,16 @@ DUO138.py:68:1: DUO138 Potentially dangerous regex expression can lead to catast
    | ^^^^^^^^^ DUO138
 69 | 
 70 | re.search("(a*){1,10}?b")  # DUO138
+   |
+
+DUO138.py:70:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+68 | re.search("(a*){1,10}b")  # DUO138
+69 | 
+70 | re.search("(a*){1,10}?b")  # DUO138
+   | ^^^^^^^^^ DUO138
+71 | 
+72 | re.search("(a*){10}b")  # DUO138
    |
 
 DUO138.py:72:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
@@ -296,6 +324,16 @@ DUO138.py:72:1: DUO138 Potentially dangerous regex expression can lead to catast
 74 | re.search("(a*){10}?b")  # DUO138
    |
 
+DUO138.py:74:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+   |
+72 | re.search("(a*){10}b")  # DUO138
+73 | 
+74 | re.search("(a*){10}?b")  # DUO138
+   | ^^^^^^^^^ DUO138
+75 | 
+76 | re.search("(a*){10,}b")  # DUO138
+   |
+
 DUO138.py:76:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
    |
 74 | re.search("(a*){10}?b")  # DUO138
@@ -306,235 +344,15 @@ DUO138.py:76:1: DUO138 Potentially dangerous regex expression can lead to catast
 78 | re.search("(a*){10,}?b")  # DUO138
    |
 
-DUO138.py:80:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+DUO138.py:78:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
    |
+76 | re.search("(a*){10,}b")  # DUO138
+77 | 
 78 | re.search("(a*){10,}?b")  # DUO138
+   | ^^^^^^^^^ DUO138
 79 | 
 80 | re.search("(a*?)+b")  # DUO138
-   | ^^^^^^^^^ DUO138
-81 | 
-82 | re.search("(a*?)+?b")  # DUO138
    |
-
-DUO138.py:84:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-   |
-82 | re.search("(a*?)+?b")  # DUO138
-83 | 
-84 | re.search("(a*?)*b")  # DUO138
-   | ^^^^^^^^^ DUO138
-85 | 
-86 | re.search("(a*?){1,10}b")  # DUO138
-   |
-
-DUO138.py:86:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-   |
-84 | re.search("(a*?)*b")  # DUO138
-85 | 
-86 | re.search("(a*?){1,10}b")  # DUO138
-   | ^^^^^^^^^ DUO138
-87 | 
-88 | re.search("(a*?){1,10}?b")  # DUO138
-   |
-
-DUO138.py:90:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-   |
-88 | re.search("(a*?){1,10}?b")  # DUO138
-89 | 
-90 | re.search("(a*?){10}b")  # DUO138
-   | ^^^^^^^^^ DUO138
-91 | 
-92 | re.search("(a*?){10}?b")  # DUO138
-   |
-
-DUO138.py:94:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-   |
-92 | re.search("(a*?){10}?b")  # DUO138
-93 | 
-94 | re.search("(a*?){10,}b")  # DUO138
-   | ^^^^^^^^^ DUO138
-95 | 
-96 | re.search("(a*?){10,}?b")  # DUO138
-   |
-
-DUO138.py:98:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
- 96 | re.search("(a*?){10,}?b")  # DUO138
- 97 | 
- 98 | re.search("(a{1,10})+b")  # DUO138
-    | ^^^^^^^^^ DUO138
- 99 | 
-100 | re.search("(a{1,10})+?b")  # DUO138
-    |
-
-DUO138.py:102:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-100 | re.search("(a{1,10})+?b")  # DUO138
-101 | 
-102 | re.search("(a{1,10})*b")  # DUO138
-    | ^^^^^^^^^ DUO138
-103 | 
-104 | re.search("(a{1,10})*?b")  # DUO138
-    |
-
-DUO138.py:108:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-106 | re.search("(a{1,10}){1,10}?b")  # DUO138
-107 | 
-108 | re.search("(a{1,10}){10}b")  # DUO138
-    | ^^^^^^^^^ DUO138
-109 | 
-110 | re.search("(a{1,10}){10}?b")  # DUO138
-    |
-
-DUO138.py:112:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-110 | re.search("(a{1,10}){10}?b")  # DUO138
-111 | 
-112 | re.search("(a{1,10}){10,}b")  # DUO138
-    | ^^^^^^^^^ DUO138
-113 | 
-114 | re.search("(a{1,10}){10,}?b")  # DUO138
-    |
-
-DUO138.py:116:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-114 | re.search("(a{1,10}){10,}?b")  # DUO138
-115 | 
-116 | re.search("(a{1,10}?)+b")  # DUO138
-    | ^^^^^^^^^ DUO138
-117 | 
-118 | re.search("(a{1,10}?)+?b")  # DUO138
-    |
-
-DUO138.py:120:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-118 | re.search("(a{1,10}?)+?b")  # DUO138
-119 | 
-120 | re.search("(a{1,10}?)*b")  # DUO138
-    | ^^^^^^^^^ DUO138
-121 | 
-122 | re.search("(a{1,10}?)*?b")  # DUO138
-    |
-
-DUO138.py:124:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-122 | re.search("(a{1,10}?)*?b")  # DUO138
-123 | 
-124 | re.search("(a{1,10}?){1,10}b")  # DUO138
-    | ^^^^^^^^^ DUO138
-125 | 
-126 | re.search("(a{1,10}?){10}b")  # DUO138
-    |
-
-DUO138.py:126:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-124 | re.search("(a{1,10}?){1,10}b")  # DUO138
-125 | 
-126 | re.search("(a{1,10}?){10}b")  # DUO138
-    | ^^^^^^^^^ DUO138
-127 | 
-128 | re.search("(a{1,10}?){10}?b")  # DUO138
-    |
-
-DUO138.py:130:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-128 | re.search("(a{1,10}?){10}?b")  # DUO138
-129 | 
-130 | re.search("(a{1,10}?){10,}b")  # DUO138
-    | ^^^^^^^^^ DUO138
-131 | 
-132 | re.search("(a{1,10}?){10,}?b")  # DUO138
-    |
-
-DUO138.py:134:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-132 | re.search("(a{1,10}?){10,}?b")  # DUO138
-133 | 
-134 | re.search("(a{10})+b")  # DUO138
-    | ^^^^^^^^^ DUO138
-135 | 
-136 | re.search("(a{10})+?b")  # DUO138
-    |
-
-DUO138.py:138:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-136 | re.search("(a{10})+?b")  # DUO138
-137 | 
-138 | re.search("(a{10})*b")  # DUO138
-    | ^^^^^^^^^ DUO138
-139 | 
-140 | re.search("(a{10})*?b")  # DUO138
-    |
-
-DUO138.py:142:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-140 | re.search("(a{10})*?b")  # DUO138
-141 | 
-142 | re.search("(a{10}){1,10}b")  # DUO138
-    | ^^^^^^^^^ DUO138
-143 | 
-144 | re.search("(a{10}){1,10}?b")  # DUO138
-    |
-
-DUO138.py:148:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-146 | re.search("(a{10}){10}?b")  # DUO138
-147 | 
-148 | re.search("(a{10}){10,}b")  # DUO138
-    | ^^^^^^^^^ DUO138
-149 | 
-150 | re.search("(a{10}){10,}?b")  # DUO138
-    |
-
-DUO138.py:152:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-150 | re.search("(a{10}){10,}?b")  # DUO138
-151 | 
-152 | re.search("(a{10}?)+b")  # DUO138
-    | ^^^^^^^^^ DUO138
-153 | 
-154 | re.search("(a{10}?)+?b")  # DUO138
-    |
-
-DUO138.py:156:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-154 | re.search("(a{10}?)+?b")  # DUO138
-155 | 
-156 | re.search("(a{10}?)*b")  # DUO138
-    | ^^^^^^^^^ DUO138
-157 | 
-158 | re.search("(a{10}?)*?b")  # DUO138
-    |
-
-DUO138.py:160:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-158 | re.search("(a{10}?)*?b")  # DUO138
-159 | 
-160 | re.search("(a{10}?){1,10}b")  # DUO138
-    | ^^^^^^^^^ DUO138
-161 | 
-162 | re.search("(a{10}?){1,10}?b")  # DUO138
-    |
-
-DUO138.py:164:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-162 | re.search("(a{10}?){1,10}?b")  # DUO138
-163 | 
-164 | re.search("(a{10}?){10}b")  # DUO138
-    | ^^^^^^^^^ DUO138
-165 | 
-166 | re.search("(a{10}?){10,}b")  # DUO138
-    |
-
-DUO138.py:166:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-164 | re.search("(a{10}?){10}b")  # DUO138
-165 | 
-166 | re.search("(a{10}?){10,}b")  # DUO138
-    | ^^^^^^^^^ DUO138
-167 | 
-168 | re.search("(a{10}?){10,}?b")  # DUO138
-    |
 
 DUO138.py:170:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
     |
@@ -544,6 +362,16 @@ DUO138.py:170:1: DUO138 Potentially dangerous regex expression can lead to catas
     | ^^^^^^^^^ DUO138
 171 | 
 172 | re.search("(a{10,})+?b")  # DUO138
+    |
+
+DUO138.py:172:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+170 | re.search("(a{10,})+b")  # DUO138
+171 | 
+172 | re.search("(a{10,})+?b")  # DUO138
+    | ^^^^^^^^^ DUO138
+173 | 
+174 | re.search("(a{10,})*b")  # DUO138
     |
 
 DUO138.py:174:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
@@ -556,6 +384,16 @@ DUO138.py:174:1: DUO138 Potentially dangerous regex expression can lead to catas
 176 | re.search("(a{10,})*?b")  # DUO138
     |
 
+DUO138.py:176:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+174 | re.search("(a{10,})*b")  # DUO138
+175 | 
+176 | re.search("(a{10,})*?b")  # DUO138
+    | ^^^^^^^^^ DUO138
+177 | 
+178 | re.search("(a{10,}){1,10}b")  # DUO138
+    |
+
 DUO138.py:178:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
     |
 176 | re.search("(a{10,})*?b")  # DUO138
@@ -564,6 +402,16 @@ DUO138.py:178:1: DUO138 Potentially dangerous regex expression can lead to catas
     | ^^^^^^^^^ DUO138
 179 | 
 180 | re.search("(a{10,}){1,10}?b")  # DUO138
+    |
+
+DUO138.py:180:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+178 | re.search("(a{10,}){1,10}b")  # DUO138
+179 | 
+180 | re.search("(a{10,}){1,10}?b")  # DUO138
+    | ^^^^^^^^^ DUO138
+181 | 
+182 | re.search("(a{10,}){10}b")  # DUO138
     |
 
 DUO138.py:182:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
@@ -576,174 +424,24 @@ DUO138.py:182:1: DUO138 Potentially dangerous regex expression can lead to catas
 184 | re.search("(a{10,}){10}?b")  # DUO138
     |
 
-DUO138.py:188:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+DUO138.py:184:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
     |
+182 | re.search("(a{10,}){10}b")  # DUO138
+183 | 
+184 | re.search("(a{10,}){10}?b")  # DUO138
+    | ^^^^^^^^^ DUO138
+185 | 
 186 | re.search("(a{10,}){10,}?b")  # DUO138
+    |
+
+DUO138.py:186:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
+    |
+184 | re.search("(a{10,}){10}?b")  # DUO138
+185 | 
+186 | re.search("(a{10,}){10,}?b")  # DUO138
+    | ^^^^^^^^^ DUO138
 187 | 
 188 | re.search("(a{10,}?)+b")  # DUO138
-    | ^^^^^^^^^ DUO138
-189 | 
-190 | re.search("(a{10,}?)+?b")  # DUO138
-    |
-
-DUO138.py:192:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-190 | re.search("(a{10,}?)+?b")  # DUO138
-191 | 
-192 | re.search("(a{10,}?)*b")  # DUO138
-    | ^^^^^^^^^ DUO138
-193 | 
-194 | re.search("(a{10,}?)*?b")  # DUO138
-    |
-
-DUO138.py:196:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-194 | re.search("(a{10,}?)*?b")  # DUO138
-195 | 
-196 | re.search("(a{10,}?){1,10}b")  # DUO138
-    | ^^^^^^^^^ DUO138
-197 | 
-198 | re.search("(a{10,}?){1,10}?b")  # DUO138
-    |
-
-DUO138.py:200:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-198 | re.search("(a{10,}?){1,10}?b")  # DUO138
-199 | 
-200 | re.search("(a{10,}?){10}b")  # DUO138
-    | ^^^^^^^^^ DUO138
-201 | 
-202 | re.search("(a{10,}?){10}?b")  # DUO138
-    |
-
-DUO138.py:204:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-202 | re.search("(a{10,}?){10}?b")  # DUO138
-203 | 
-204 | re.search("(a{10,}?){10,}b")  # DUO138
-    | ^^^^^^^^^ DUO138
-205 | 
-206 | re.search("[abc]+[def]*")  # OK
-    |
-
-DUO138.py:206:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-204 | re.search("(a{10,}?){10,}b")  # DUO138
-205 | 
-206 | re.search("[abc]+[def]*")  # OK
-    | ^^^^^^^^^ DUO138
-207 | 
-208 | re.search("[abc]+([def]*)")  # OK
-    |
-
-DUO138.py:208:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-206 | re.search("[abc]+[def]*")  # OK
-207 | 
-208 | re.search("[abc]+([def]*)")  # OK
-    | ^^^^^^^^^ DUO138
-209 | 
-210 | re.search("(.|[a-c])+")  # DUO138
-    |
-
-DUO138.py:210:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-208 | re.search("[abc]+([def]*)")  # OK
-209 | 
-210 | re.search("(.|[a-c])+")  # DUO138
-    | ^^^^^^^^^ DUO138
-211 | 
-212 | re.search("(a|[a-c])+")  # DUO138
-    |
-
-DUO138.py:212:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-210 | re.search("(.|[a-c])+")  # DUO138
-211 | 
-212 | re.search("(a|[a-c])+")  # DUO138
-    | ^^^^^^^^^ DUO138
-213 | 
-214 | re.search("(d|[a-c])+")  # OK
-    |
-
-DUO138.py:214:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-212 | re.search("(a|[a-c])+")  # DUO138
-213 | 
-214 | re.search("(d|[a-c])+")  # OK
-    | ^^^^^^^^^ DUO138
-215 | 
-216 | re.search("([^d]|[a-c])+")  # DUO138
-    |
-
-DUO138.py:216:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-214 | re.search("(d|[a-c])+")  # OK
-215 | 
-216 | re.search("([^d]|[a-c])+")  # DUO138
-    | ^^^^^^^^^ DUO138
-217 | 
-218 | re.search("([^b]|[a-c])+")  # DUO138
-    |
-
-DUO138.py:218:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-216 | re.search("([^d]|[a-c])+")  # DUO138
-217 | 
-218 | re.search("([^b]|[a-c])+")  # DUO138
-    | ^^^^^^^^^ DUO138
-219 | 
-220 | re.search("([^a]|a)+")  # OK
-    |
-
-DUO138.py:220:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-218 | re.search("([^b]|[a-c])+")  # DUO138
-219 | 
-220 | re.search("([^a]|a)+")  # OK
-    | ^^^^^^^^^ DUO138
-221 | 
-222 | re.search("([^d]|[^b]|[a-c])+")  # DUO138
-    |
-
-DUO138.py:222:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-220 | re.search("([^a]|a)+")  # OK
-221 | 
-222 | re.search("([^d]|[^b]|[a-c])+")  # DUO138
-    | ^^^^^^^^^ DUO138
-    |
-
-DUO138.py:225:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-225 | re.search("([^abcAB]|[a-c]|[A-C])+")  # DUO138
-    | ^^^^^^^^^ DUO138
-226 | 
-227 | re.search("([^abcABC]|[a-c]|[A-C])+")  # OK
-    |
-
-DUO138.py:227:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-225 | re.search("([^abcAB]|[a-c]|[A-C])+")  # DUO138
-226 | 
-227 | re.search("([^abcABC]|[a-c]|[A-C])+")  # OK
-    | ^^^^^^^^^ DUO138
-    |
-
-DUO138.py:230:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-230 | re.search("([a-c]|[c-e])+")  # DUO138
-    | ^^^^^^^^^ DUO138
-231 | 
-232 | re.search("([a-c]|[d-e])+")  # OK
-    |
-
-DUO138.py:232:1: DUO138 Potentially dangerous regex expression can lead to catastrophic backtracking
-    |
-230 | re.search("([a-c]|[c-e])+")  # DUO138
-231 | 
-232 | re.search("([a-c]|[d-e])+")  # OK
-    | ^^^^^^^^^ DUO138
     |
 
 

--- a/crates/ruff/src/rules/mod.rs
+++ b/crates/ruff/src/rules/mod.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::useless_format)]
 pub mod airflow;
+pub mod dlint;
 pub mod eradicate;
 pub mod flake8_2020;
 pub mod flake8_annotations;

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,6 +30,7 @@ Ruff also re-implements some of the most popular Flake8 plugins and related code
 natively, including:
 
 - [autoflake](https://pypi.org/project/autoflake/)
+- [dlint](https://pypi.org/project/dlint/)
 - [eradicate](https://pypi.org/project/eradicate/)
 - [flake8-2020](https://pypi.org/project/flake8-2020/)
 - [flake8-annotations](https://pypi.org/project/flake8-annotations/)


### PR DESCRIPTION
## Summary

Adds Dlint plugin port and a first rule `DUO138` `catastrophic_backtracking_regular_expression` which checks for regex statements which can potentially lead to catastrophic backtracking and hence are vulnerable to ReDoS attacks. 

Upstream implementation uses `sre.parse`. We do not have this so we use the `regex_syntax` crate. We cannot directly copy the logic from dlint due to this so we have to find our own implementation

TODOs:

- [x] Implement unbounded repetition within repetition logic for catastrophic backtracking in `detect_redos()`
- [ ] Implement alternation with overlap logic for catastrophic backtracking in `detect_redos()`

## Test Plan

Fixture added with many examples of catastrophic backtracking

## Issue links

Refers: https://github.com/astral-sh/ruff/issues/4479 
