### PR TITLE
Support individual codes on `# flake8: noqa` directives

### DIFF
--- a/crates/ruff/src/snapshots/ruff__noqa__tests__flake8_exemption_codes.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__flake8_exemption_codes.snap
@@ -2,6 +2,13 @@
 source: crates/ruff/src/noqa.rs
 expression: "ParsedFileExemption::try_extract(source)"
 ---
-Err(
-    UnsupportedCodes,
+Ok(
+    Some(
+        Codes(
+            [
+                "F401",
+                "F841",
+            ],
+        ),
+    ),
 )


### PR DESCRIPTION
## Summary

We now treat `# flake8: noqa: F401` as turning off F401 for the entire file. (Flake8 treats this as turning off _all rules_ for the entire file).

This deviates from Flake8, but I think it's a much more user-friendly deviation than what I introduced in #5571. See https://github.com/astral-sh/ruff/issues/5617 for an explanation.

Closes https://github.com/astral-sh/ruff/issues/5617.