### PR TITLE
Add `tkinter` import convention

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_import_conventions/defaults.py
+++ b/crates/ruff/resources/test/fixtures/flake8_import_conventions/defaults.py
@@ -5,15 +5,18 @@ import matplotlib.pyplot  # unconventional
 import numpy  # unconventional
 import pandas  # unconventional
 import seaborn  # unconventional
+import tkinter  # unconventional
 
 import altair as altr  # unconventional
 import matplotlib.pyplot as plot  # unconventional
 import numpy as nmp  # unconventional
 import pandas as pdas  # unconventional
 import seaborn as sbrn  # unconventional
+import tkinter as tkr  # unconventional
 
 import altair as alt  # conventional
 import matplotlib.pyplot as plt  # conventional
 import numpy as np  # conventional
 import pandas as pd  # conventional
 import seaborn as sns  # conventional
+import tkinter as tk  # conventional

--- a/crates/ruff/src/rules/flake8_import_conventions/settings.rs
+++ b/crates/ruff/src/rules/flake8_import_conventions/settings.rs
@@ -13,6 +13,7 @@ const CONVENTIONAL_ALIASES: &[(&str, &str)] = &[
     ("pandas", "pd"),
     ("seaborn", "sns"),
     ("tensorflow", "tf"),
+    ("tkinter", "tk"),
     ("holoviews", "hv"),
     ("panel", "pn"),
     ("plotly.express", "px"),
@@ -31,7 +32,7 @@ const CONVENTIONAL_ALIASES: &[(&str, &str)] = &[
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Options {
     #[option(
-        default = r#"{"altair": "alt", "matplotlib": "mpl", "matplotlib.pyplot": "plt", "numpy": "np", "pandas": "pd", "seaborn": "sns", "tensorflow": "tf", "holoviews": "hv", "panel": "pn", "plotly.express": "px", "polars": "pl", "pyarrow": "pa"}"#,
+        default = r#"{"altair": "alt", "matplotlib": "mpl", "matplotlib.pyplot": "plt", "numpy": "np", "pandas": "pd", "seaborn": "sns", "tensorflow": "tf", "tkinter":  "tk", "holoviews": "hv", "panel": "pn", "plotly.express": "px", "polars": "pl", "pyarrow": "pa"}"#,
         value_type = "dict[str, str]",
         example = r#"
             [tool.ruff.flake8-import-conventions.aliases]

--- a/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__defaults.snap
+++ b/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__defaults.snap
@@ -40,6 +40,7 @@ defaults.py:6:8: ICN001 `pandas` should be imported as `pd`
 6 | import pandas  # unconventional
   |        ^^^^^^ ICN001
 7 | import seaborn  # unconventional
+8 | import tkinter  # unconventional
   |
   = help: Alias `pandas` to `pd`
 
@@ -49,62 +50,83 @@ defaults.py:7:8: ICN001 `seaborn` should be imported as `sns`
 6 | import pandas  # unconventional
 7 | import seaborn  # unconventional
   |        ^^^^^^^ ICN001
-8 | 
-9 | import altair as altr  # unconventional
+8 | import tkinter  # unconventional
   |
   = help: Alias `seaborn` to `sns`
 
-defaults.py:9:18: ICN001 `altair` should be imported as `alt`
+defaults.py:8:8: ICN001 `tkinter` should be imported as `tk`
    |
+ 6 | import pandas  # unconventional
  7 | import seaborn  # unconventional
- 8 | 
- 9 | import altair as altr  # unconventional
+ 8 | import tkinter  # unconventional
+   |        ^^^^^^^ ICN001
+ 9 | 
+10 | import altair as altr  # unconventional
+   |
+   = help: Alias `tkinter` to `tk`
+
+defaults.py:10:18: ICN001 `altair` should be imported as `alt`
+   |
+ 8 | import tkinter  # unconventional
+ 9 | 
+10 | import altair as altr  # unconventional
    |                  ^^^^ ICN001
-10 | import matplotlib.pyplot as plot  # unconventional
-11 | import numpy as nmp  # unconventional
+11 | import matplotlib.pyplot as plot  # unconventional
+12 | import numpy as nmp  # unconventional
    |
    = help: Alias `altair` to `alt`
 
-defaults.py:10:29: ICN001 `matplotlib.pyplot` should be imported as `plt`
+defaults.py:11:29: ICN001 `matplotlib.pyplot` should be imported as `plt`
    |
- 9 | import altair as altr  # unconventional
-10 | import matplotlib.pyplot as plot  # unconventional
+10 | import altair as altr  # unconventional
+11 | import matplotlib.pyplot as plot  # unconventional
    |                             ^^^^ ICN001
-11 | import numpy as nmp  # unconventional
-12 | import pandas as pdas  # unconventional
+12 | import numpy as nmp  # unconventional
+13 | import pandas as pdas  # unconventional
    |
    = help: Alias `matplotlib.pyplot` to `plt`
 
-defaults.py:11:17: ICN001 `numpy` should be imported as `np`
+defaults.py:12:17: ICN001 `numpy` should be imported as `np`
    |
- 9 | import altair as altr  # unconventional
-10 | import matplotlib.pyplot as plot  # unconventional
-11 | import numpy as nmp  # unconventional
+10 | import altair as altr  # unconventional
+11 | import matplotlib.pyplot as plot  # unconventional
+12 | import numpy as nmp  # unconventional
    |                 ^^^ ICN001
-12 | import pandas as pdas  # unconventional
-13 | import seaborn as sbrn  # unconventional
+13 | import pandas as pdas  # unconventional
+14 | import seaborn as sbrn  # unconventional
    |
    = help: Alias `numpy` to `np`
 
-defaults.py:12:18: ICN001 `pandas` should be imported as `pd`
+defaults.py:13:18: ICN001 `pandas` should be imported as `pd`
    |
-10 | import matplotlib.pyplot as plot  # unconventional
-11 | import numpy as nmp  # unconventional
-12 | import pandas as pdas  # unconventional
+11 | import matplotlib.pyplot as plot  # unconventional
+12 | import numpy as nmp  # unconventional
+13 | import pandas as pdas  # unconventional
    |                  ^^^^ ICN001
-13 | import seaborn as sbrn  # unconventional
+14 | import seaborn as sbrn  # unconventional
+15 | import tkinter as tkr  # unconventional
    |
    = help: Alias `pandas` to `pd`
 
-defaults.py:13:19: ICN001 `seaborn` should be imported as `sns`
+defaults.py:14:19: ICN001 `seaborn` should be imported as `sns`
    |
-11 | import numpy as nmp  # unconventional
-12 | import pandas as pdas  # unconventional
-13 | import seaborn as sbrn  # unconventional
+12 | import numpy as nmp  # unconventional
+13 | import pandas as pdas  # unconventional
+14 | import seaborn as sbrn  # unconventional
    |                   ^^^^ ICN001
-14 | 
-15 | import altair as alt  # conventional
+15 | import tkinter as tkr  # unconventional
    |
    = help: Alias `seaborn` to `sns`
+
+defaults.py:15:19: ICN001 `tkinter` should be imported as `tk`
+   |
+13 | import pandas as pdas  # unconventional
+14 | import seaborn as sbrn  # unconventional
+15 | import tkinter as tkr  # unconventional
+   |                   ^^^ ICN001
+16 | 
+17 | import altair as alt  # conventional
+   |
+   = help: Alias `tkinter` to `tk`
 
 


### PR DESCRIPTION
## Summary

Adds `import tkinter as tk` to the list of default import conventions.

Closes #5620.

## Test Plan

Added `tkinter` to test fixture.

`cargo test`
