### PR TITLE
Add documentation to `pandas-vet` rules

### DIFF
--- a/crates/ruff/src/rules/pandas_vet/rules/assignment_to_df.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/assignment_to_df.rs
@@ -7,11 +7,9 @@ use ruff_macros::{derive_message_formats, violation};
 /// Checks for assignments to the variable `df`.
 ///
 /// ## Why is this bad?
-/// Although `df` is a common variable name for a Pandas DataFrame in short
-/// code examples, it is not a good variable name in production code. This is
-/// because `df` is not descriptive, and it is easy to forget what `df`
-/// represents. It also causes name conflict problems if you want to use
-/// multiple DataFrames in the same scope.
+/// Although `df` is a common variable name for a Pandas DataFrame, it's not a
+/// great variable name for production code, as it's non-descriptive and
+/// prone to name conflicts.
 ///
 /// Instead, use a more descriptive variable name.
 ///
@@ -26,7 +24,7 @@ use ruff_macros::{derive_message_formats, violation};
 /// ```python
 /// import pandas as pd
 ///
-/// animals_df = pd.read_csv("animals.csv")
+/// animals = pd.read_csv("animals.csv")
 /// ```
 #[violation]
 pub struct PandasDfVariableName;

--- a/crates/ruff/src/rules/pandas_vet/rules/assignment_to_df.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/assignment_to_df.rs
@@ -3,6 +3,31 @@ use rustpython_parser::ast::{self, Expr, Ranged};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 
+/// ## What it does
+/// Checks for assignments to the variable `df`.
+///
+/// ## Why is this bad?
+/// Although `df` is a common variable name for a Pandas DataFrame in short
+/// code examples, it is not a good variable name in production code. This is
+/// because `df` is not descriptive, and it is easy to forget what `df`
+/// represents. It also causes name conflict problems if you want to use
+/// multiple DataFrames in the same scope.
+///
+/// Instead, use a more descriptive variable name.
+///
+/// ## Example
+/// ```python
+/// import pandas as pd
+///
+/// df = pd.read_csv("animals.csv")
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import pandas as pd
+///
+/// animals_df = pd.read_csv("animals.csv")
+/// ```
 #[violation]
 pub struct PandasDfVariableName;
 

--- a/crates/ruff/src/rules/pandas_vet/rules/attr.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/attr.rs
@@ -8,6 +8,30 @@ use crate::checkers::ast::Checker;
 use crate::registry::Rule;
 use crate::rules::pandas_vet::helpers::{test_expression, Resolution};
 
+/// ## What it does
+/// Checks for uses of `.values` on a Pandas Series or Index.
+///
+/// ## Why is this bad?
+/// `.values` is ambiguous as it is unclear what it returns; thus, it is no
+/// longer recommended by the Pandas documentation. Instead, to return a NumPy
+/// array, use `.to_numpy()`. Or, to return a Pandas array, use `.array`.
+///
+/// ## Example
+/// ```python
+/// import pandas as pd
+///
+/// animals = pd.read_csv("animals.csv").values  # Ambiguous.
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import pandas as pd
+///
+/// animals = pd.read_csv("animals.csv").to_numpy()  # Explicit.
+/// ```
+///
+/// ## References
+/// - [Pandas documentation: Accessing the values in a Series or Index](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v0.24.0.html#accessing-the-values-in-a-series-or-index)
 #[violation]
 pub struct PandasUseOfDotValues;
 

--- a/crates/ruff/src/rules/pandas_vet/rules/attr.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/attr.rs
@@ -9,12 +9,14 @@ use crate::registry::Rule;
 use crate::rules::pandas_vet::helpers::{test_expression, Resolution};
 
 /// ## What it does
-/// Checks for uses of `.values` on a Pandas Series or Index.
+/// Checks for uses of `.values` on Pandas Series and Index objects.
 ///
 /// ## Why is this bad?
-/// `.values` is ambiguous as it is unclear what it returns; thus, it is no
-/// longer recommended by the Pandas documentation. Instead, to return a NumPy
-/// array, use `.to_numpy()`. Or, to return a Pandas array, use `.array`.
+/// The `.values` attribute is ambiguous as it's return type is unclear. As
+/// such, it is no longer recommended by the Pandas documentation.
+///
+/// Instead, use `.to_numpy()` to return a NumPy array, or `.array` to return a
+/// Pandas `ExtensionArray`.
 ///
 /// ## Example
 /// ```python
@@ -43,9 +45,10 @@ impl Violation for PandasUseOfDotValues {
 }
 
 pub(crate) fn attr(checker: &mut Checker, attr: &str, value: &Expr, attr_expr: &Expr) {
-    let rules = &checker.settings.rules;
     let violation: DiagnosticKind = match attr {
-        "values" if rules.enabled(Rule::PandasUseOfDotValues) => PandasUseOfDotValues.into(),
+        "values" if checker.settings.rules.enabled(Rule::PandasUseOfDotValues) => {
+            PandasUseOfDotValues.into()
+        }
         _ => return,
     };
 

--- a/crates/ruff/src/rules/pandas_vet/rules/call.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/call.rs
@@ -12,12 +12,11 @@ use crate::rules::pandas_vet::helpers::{test_expression, Resolution};
 /// Checks for uses of `.isnull`.
 ///
 /// ## Why is this bad?
-/// `.isna` and `.isnull` are equivalent. For consistency, use `.isna`
-/// over `.isnull`.
+/// `.isna` and `.isnull` are equivalent. For consistency, use `.isna` over
+/// `.isnull`.
 ///
-/// Further, `.isna` is a more accurate name for the method, as it
-/// checks not only for `None` values, but also for `NaN` and `NaT`
-/// values.
+/// Further, `.isna` is a more accurate name for the functionality, as it
+/// checks not only for `None` values, but also for `NaN` and `NaT` values.
 ///
 /// ## Example
 /// ```python
@@ -52,12 +51,11 @@ impl Violation for PandasUseOfDotIsNull {
 /// Checks for uses of `.notnull`.
 ///
 /// ## Why is this bad?
-/// `.notna` and `.notnull` are equivalent. For consistency, use `.notna`
-/// over `.notnull`.
+/// `.notna` and `.notnull` are equivalent. For consistency, use `.notna` over
+/// `.notnull`.
 ///
-/// Further, `.notna` is a more accurate name for the method, as it
-/// checks not only for `None` values, but also for `NaN` and `NaT`
-/// values.
+/// Further, `.notna` is a more accurate name for the functionality, as it
+/// checks not only for `None` values, but also for `NaN` and `NaT` values.
 ///
 /// ## Example
 /// ```python
@@ -92,9 +90,9 @@ impl Violation for PandasUseOfDotNotNull {
 /// Checks for uses of `.pivot` or `.unstack`.
 ///
 /// ## Why is this bad?
-/// Prefer `.pivot_table` to `.pivot` or `.unstack`, which is a more general method
-/// that can be used to implement `.pivot` and `.unstack`, and provides the same
-/// functionality.
+/// Prefer `.pivot_table` to `.pivot` or `.unstack`, which is a more general
+/// method that can be used to implement `.pivot` and `.unstack`, and
+/// provides the same functionality.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/pandas_vet/rules/call.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/call.rs
@@ -91,8 +91,8 @@ impl Violation for PandasUseOfDotNotNull {
 ///
 /// ## Why is this bad?
 /// Prefer `.pivot_table` to `.pivot` or `.unstack`, which is a more general
-/// method that can be used to implement `.pivot` and `.unstack`, and
-/// provides the same functionality.
+/// method that can be used to implement `.pivot` and `.unstack`, and provides
+/// the same functionality.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/pandas_vet/rules/call.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/call.rs
@@ -9,14 +9,15 @@ use crate::registry::Rule;
 use crate::rules::pandas_vet::helpers::{test_expression, Resolution};
 
 /// ## What it does
-/// Checks for uses of `.isnull`.
+/// Checks for uses of `.isnull` on Pandas objects.
 ///
 /// ## Why is this bad?
-/// `.isna` and `.isnull` are equivalent. For consistency, use `.isna` over
-/// `.isnull`.
+/// In the Pandas API, `.isna` and `.isnull` are equivalent. For consistency,
+/// prefer `.isna` over `.isnull`.
 ///
-/// Further, `.isna` is a more accurate name for the functionality, as it
-/// checks not only for `None` values, but also for `NaN` and `NaT` values.
+/// As a name, `.isna` more accurately reflects the behavior of the method,
+/// since these methods check for `NaN` and `NaT` values in addition to `None`
+/// values.
 ///
 /// ## Example
 /// ```python
@@ -48,14 +49,15 @@ impl Violation for PandasUseOfDotIsNull {
 }
 
 /// ## What it does
-/// Checks for uses of `.notnull`.
+/// Checks for uses of `.notnull` on Pandas objects.
 ///
 /// ## Why is this bad?
-/// `.notna` and `.notnull` are equivalent. For consistency, use `.notna` over
-/// `.notnull`.
+/// In the Pandas API, `.notna` and `.notnull` are equivalent. For consistency,
+/// prefer `.notna` over `.notnull`.
 ///
-/// Further, `.notna` is a more accurate name for the functionality, as it
-/// checks not only for `None` values, but also for `NaN` and `NaT` values.
+/// As a name, `.notna` more accurately reflects the behavior of the method,
+/// since these methods check for `NaN` and `NaT` values in addition to `None`
+/// values.
 ///
 /// ## Example
 /// ```python
@@ -87,12 +89,11 @@ impl Violation for PandasUseOfDotNotNull {
 }
 
 /// ## What it does
-/// Checks for uses of `.pivot` or `.unstack`.
+/// Checks for uses of `.pivot` or `.unstack` on Pandas objects.
 ///
 /// ## Why is this bad?
-/// Prefer `.pivot_table` to `.pivot` or `.unstack`, which is a more general
-/// method that can be used to implement `.pivot` and `.unstack`, and provides
-/// the same functionality.
+/// Prefer `.pivot_table` to `.pivot` or `.unstack`. `.pivot_table` is more general
+/// and can be used to implement the same behavior as `.pivot` and `.unstack`.
 ///
 /// ## Example
 /// ```python
@@ -138,12 +139,11 @@ impl Violation for PandasUseOfDotReadTable {
 }
 
 /// ## What it does
-/// Checks for uses of `.stack`.
+/// Checks for uses of `.stack` on Pandas objects.
 ///
 /// ## Why is this bad?
-/// Prefer `.melt` to `.stack`, which has the same functionality whilst
-/// supporting direct column renaming and avoiding a `MultiIndex`, which is
-/// generally more difficult to work with.
+/// Prefer `.melt` to `.stack`, which has the same functionality but with
+/// support for direct column renaming and no dependence on `MultiIndex`.
 ///
 /// ## Example
 /// ```python
@@ -175,20 +175,35 @@ impl Violation for PandasUseOfDotStack {
 }
 
 pub(crate) fn call(checker: &mut Checker, func: &Expr) {
-    let rules = &checker.settings.rules;
     let Expr::Attribute(ast::ExprAttribute { value, attr, .. }) = func else {
         return;
     };
     let violation: DiagnosticKind = match attr.as_str() {
-        "isnull" if rules.enabled(Rule::PandasUseOfDotIsNull) => PandasUseOfDotIsNull.into(),
-        "notnull" if rules.enabled(Rule::PandasUseOfDotNotNull) => PandasUseOfDotNotNull.into(),
-        "pivot" | "unstack" if rules.enabled(Rule::PandasUseOfDotPivotOrUnstack) => {
+        "isnull" if checker.settings.rules.enabled(Rule::PandasUseOfDotIsNull) => {
+            PandasUseOfDotIsNull.into()
+        }
+        "notnull" if checker.settings.rules.enabled(Rule::PandasUseOfDotNotNull) => {
+            PandasUseOfDotNotNull.into()
+        }
+        "pivot" | "unstack"
+            if checker
+                .settings
+                .rules
+                .enabled(Rule::PandasUseOfDotPivotOrUnstack) =>
+        {
             PandasUseOfDotPivotOrUnstack.into()
         }
-        "read_table" if rules.enabled(Rule::PandasUseOfDotReadTable) => {
+        "read_table"
+            if checker
+                .settings
+                .rules
+                .enabled(Rule::PandasUseOfDotReadTable) =>
+        {
             PandasUseOfDotReadTable.into()
         }
-        "stack" if rules.enabled(Rule::PandasUseOfDotStack) => PandasUseOfDotStack.into(),
+        "stack" if checker.settings.rules.enabled(Rule::PandasUseOfDotStack) => {
+            PandasUseOfDotStack.into()
+        }
         _ => return,
     };
 

--- a/crates/ruff/src/rules/pandas_vet/rules/call.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/call.rs
@@ -8,6 +8,36 @@ use crate::checkers::ast::Checker;
 use crate::registry::Rule;
 use crate::rules::pandas_vet::helpers::{test_expression, Resolution};
 
+/// ## What it does
+/// Checks for uses of `.isnull`.
+///
+/// ## Why is this bad?
+/// `.isna` and `.isnull` are equivalent. For consistency, use `.isna`
+/// over `.isnull`.
+///
+/// Further, `.isna` is a more accurate name for the method, as it
+/// checks not only for `None` values, but also for `NaN` and `NaT`
+/// values.
+///
+/// ## Example
+/// ```python
+/// import pandas as pd
+///
+/// animals_df = pd.read_csv("animals.csv")
+/// pd.isnull(animals_df)
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import pandas as pd
+///
+/// animals_df = pd.read_csv("animals.csv")
+/// pd.isna(animals_df)
+/// ```
+///
+/// ## References
+/// - [Pandas documentation: `isnull`](https://pandas.pydata.org/docs/reference/api/pandas.isnull.html#pandas.isnull)
+/// - [Pandas documentation: `isna`](https://pandas.pydata.org/docs/reference/api/pandas.isna.html#pandas.isna)
 #[violation]
 pub struct PandasUseOfDotIsNull;
 
@@ -18,6 +48,36 @@ impl Violation for PandasUseOfDotIsNull {
     }
 }
 
+/// ## What it does
+/// Checks for uses of `.notnull`.
+///
+/// ## Why is this bad?
+/// `.notna` and `.notnull` are equivalent. For consistency, use `.notna`
+/// over `.notnull`.
+///
+/// Further, `.notna` is a more accurate name for the method, as it
+/// checks not only for `None` values, but also for `NaN` and `NaT`
+/// values.
+///
+/// ## Example
+/// ```python
+/// import pandas as pd
+///
+/// animals_df = pd.read_csv("animals.csv")
+/// pd.notnull(animals_df)
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import pandas as pd
+///
+/// animals_df = pd.read_csv("animals.csv")
+/// pd.notna(animals_df)
+/// ```
+///
+/// ## References
+/// - [Pandas documentation: `notnull`](https://pandas.pydata.org/docs/reference/api/pandas.notnull.html#pandas.notnull)
+/// - [Pandas documentation: `notna`](https://pandas.pydata.org/docs/reference/api/pandas.notna.html#pandas.notna)
 #[violation]
 pub struct PandasUseOfDotNotNull;
 
@@ -28,6 +88,33 @@ impl Violation for PandasUseOfDotNotNull {
     }
 }
 
+/// ## What it does
+/// Checks for uses of `.pivot` or `.unstack`.
+///
+/// ## Why is this bad?
+/// Prefer `.pivot_table` to `.pivot` or `.unstack`, which is a more general method
+/// that can be used to implement `.pivot` and `.unstack`, and provides the same
+/// functionality.
+///
+/// ## Example
+/// ```python
+/// import pandas as pd
+///
+/// df = pd.read_csv("cities.csv")
+/// df.pivot(index="city", columns="year", values="population")
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import pandas as pd
+///
+/// df = pd.read_csv("cities.csv")
+/// df.pivot_table(index="city", columns="year", values="population")
+/// ```
+///
+/// ## References
+/// - [Pandas documentation: Reshaping and pivot tables](https://pandas.pydata.org/docs/user_guide/reshaping.html)
+/// - [Pandas documentation: `pivot_table`](https://pandas.pydata.org/docs/reference/api/pandas.pivot_table.html#pandas.pivot_table)
 #[violation]
 pub struct PandasUseOfDotPivotOrUnstack;
 
@@ -40,6 +127,8 @@ impl Violation for PandasUseOfDotPivotOrUnstack {
     }
 }
 
+// TODO(tjkuson): Add documentation for this rule once clarified.
+// https://github.com/astral-sh/ruff/issues/5628
 #[violation]
 pub struct PandasUseOfDotReadTable;
 
@@ -50,6 +139,33 @@ impl Violation for PandasUseOfDotReadTable {
     }
 }
 
+/// ## What it does
+/// Checks for uses of `.stack`.
+///
+/// ## Why is this bad?
+/// Prefer `.melt` to `.stack`, which has the same functionality whilst
+/// supporting direct column renaming and avoiding a `MultiIndex`, which is
+/// generally more difficult to work with.
+///
+/// ## Example
+/// ```python
+/// import pandas as pd
+///
+/// cities_df = pd.read_csv("cities.csv")
+/// cities_df.set_index("city").stack()
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import pandas as pd
+///
+/// cities_df = pd.read_csv("cities.csv")
+/// cities_df.melt(id_vars="city")
+/// ```
+///
+/// ## References
+/// - [Pandas documentation: `melt`](https://pandas.pydata.org/docs/reference/api/pandas.melt.html)
+/// - [Pandas documentation: `stack`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.stack.html)
 #[violation]
 pub struct PandasUseOfDotStack;
 

--- a/crates/ruff/src/rules/pandas_vet/rules/pd_merge.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/pd_merge.rs
@@ -21,7 +21,7 @@ use ruff_macros::{derive_message_formats, violation};
 /// cats_df = pd.read_csv("cats.csv")
 /// dogs_df = pd.read_csv("dogs.csv")
 /// rabbits_df = pd.read_csv("rabbits.csv")
-/// pets_df = pd.merge(pd.merge(cats_df, dogs_df), rabbits_df)
+/// pets_df = pd.merge(pd.merge(cats_df, dogs_df), rabbits_df)  # Hard to read.
 /// ```
 ///
 /// Use instead:

--- a/crates/ruff/src/rules/pandas_vet/rules/pd_merge.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/pd_merge.rs
@@ -4,6 +4,39 @@ use crate::checkers::ast::Checker;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 
+/// ## What it does
+/// Checks for uses of `pd.merge`.
+///
+/// ## Why is this bad?
+/// `.merge` and `pd.merge` are equivalent. For consistency, use `.merge` over
+/// `pd.merge`, which is more idiomatic.
+///
+/// Further, `pd.merge` is not a method, but a function. This means that it
+/// cannot be used in method chains, which is a common pattern in Pandas code.
+///
+/// ## Example
+/// ```python
+/// import pandas as pd
+///
+/// cats_df = pd.read_csv("cats.csv")
+/// dogs_df = pd.read_csv("dogs.csv")
+/// rabbits_df = pd.read_csv("rabbits.csv")
+/// pets_df = pd.merge(pd.merge(cats_df, dogs_df), rabbits_df)
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import pandas as pd
+///
+/// cats_df = pd.read_csv("cats.csv")
+/// dogs_df = pd.read_csv("dogs.csv")
+/// rabbits_df = pd.read_csv("rabbits.csv")
+/// pets_df = cats_df.merge(dogs_df).merge(rabbits_df)
+/// ```
+///
+/// ## References
+/// - [Pandas documentation: `merge`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.merge.html#pandas.DataFrame.merge)
+/// - [Pandas documentation: `pd.merge`](https://pandas.pydata.org/docs/reference/api/pandas.merge.html#pandas.merge)
 #[violation]
 pub struct PandasUseOfPdMerge;
 

--- a/crates/ruff/src/rules/pandas_vet/rules/pd_merge.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/pd_merge.rs
@@ -5,14 +5,17 @@ use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 
 /// ## What it does
-/// Checks for uses of `pd.merge`.
+/// Checks for uses of `pd.merge` on Pandas objects.
 ///
 /// ## Why is this bad?
-/// `.merge` and `pd.merge` are equivalent. For consistency, use `.merge` over
-/// `pd.merge`, which is more idiomatic.
+/// In Pandas, the `.merge` method (exposed on, e.g., DataFrame objects) and
+/// the `pd.merge` function (exposed on the Pandas module) are equivalent.
 ///
-/// Further, `pd.merge` is not a method, but a function. This means that it
-/// cannot be used in method chains, which is a common pattern in Pandas code.
+/// For consistency, prefer calling `.merge` on an object over calling
+/// `pd.merge` on the Pandas module, as the former is more idiomatic.
+///
+/// Further, `pd.merge` is not a method, but a function, which prohibits it
+/// from being used in method chains, a common pattern in Pandas code.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/pandas_vet/rules/subscript.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/subscript.rs
@@ -8,6 +8,34 @@ use crate::checkers::ast::Checker;
 use crate::registry::Rule;
 use crate::rules::pandas_vet::helpers::{test_expression, Resolution};
 
+/// ## What it does
+/// Checks for uses of `.ix`.
+///
+/// ## Why is this bad?
+/// `.ix` is deprecated as it is ambiguous whether it is meant to index by
+/// label or by position. Instead, use `.loc` for label-based indexing or
+/// `.iloc` for position-based indexing.
+///
+/// ## Example
+/// ```python
+/// import pandas as pd
+///
+/// students_df = pd.read_csv("students.csv")
+/// students_df.ix[0]  # 0th row or row with label 0?
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import pandas as pd
+///
+/// students_df = pd.read_csv("students.csv")
+/// students_df.iloc[0]  # 0th row
+/// ```
+///
+/// ## References
+/// - [Pandas release notes: Deprecate `.ix`](https://pandas.pydata.org/pandas-docs/version/0.20/whatsnew.html#deprecate-ix)
+/// - [Pandas documentation: `loc`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.loc.html)
+/// - [Pandas documentation: `iloc`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.iloc.html)
 #[violation]
 pub struct PandasUseOfDotIx;
 
@@ -18,6 +46,36 @@ impl Violation for PandasUseOfDotIx {
     }
 }
 
+/// ## What it does
+/// Checks for uses of `.at`.
+///
+/// ## Why is this bad?
+/// `.at` selects a single value from a DataFrame or Series based on a label
+/// index, and is slightly faster than using `.loc`. However, `.loc` is more
+/// idiomatic and versatile, as it can select multiple values at once.
+///
+/// If speed is important, consider converting the data to a NumPy array. This
+/// will provide a much greater performance gain than using `.at` over `.loc`.
+///
+/// ## Example
+/// ```python
+/// import pandas as pd
+///
+/// students_df = pd.read_csv("students.csv")
+/// students_df.at["Maria"]
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import pandas as pd
+///
+/// students_df = pd.read_csv("students.csv")
+/// students_df.loc["Maria"]
+/// ```
+///
+/// ## References
+/// - [Pandas documentation: `loc`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.loc.html)
+/// - [Pandas documentation: `at`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.at.html)
 #[violation]
 pub struct PandasUseOfDotAt;
 
@@ -28,6 +86,46 @@ impl Violation for PandasUseOfDotAt {
     }
 }
 
+/// ## What it does
+/// Checks for uses of `.iat`.
+///
+/// ## Why is this bad?
+/// `.iat` selects a single value from a DataFrame or Series based on a label
+/// index, and is slightly faster than using `.iloc`. However, `.iloc` is more
+/// idiomatic and versatile, as it can select multiple values at once.
+///
+/// If speed is important, consider converting the data to a NumPy array. This
+/// will provide a much greater performance gain than using `.iat` over
+/// `.iloc`.
+///
+/// ## Example
+/// ```python
+/// import pandas as pd
+///
+/// students_df = pd.read_csv("students.csv")
+/// students_df.iat[0]
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import pandas as pd
+///
+/// students_df = pd.read_csv("students.csv")
+/// students_df.iloc[0]
+/// ```
+///
+/// Or, using NumPy:
+/// ```python
+/// import numpy as np
+/// import pandas as pd
+///
+/// students_df = pd.read_csv("students.csv")
+/// students_df.to_numpy()[0]
+/// ```
+///
+/// ## References
+/// - [Pandas documentation: `iloc`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.iloc.html)
+/// - [Pandas documentation: `iat`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.iat.html)
 #[violation]
 pub struct PandasUseOfDotIat;
 

--- a/crates/ruff/src/rules/pandas_vet/rules/subscript.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/subscript.rs
@@ -13,8 +13,8 @@ use crate::rules::pandas_vet::helpers::{test_expression, Resolution};
 ///
 /// ## Why is this bad?
 /// `.ix` is deprecated as it is ambiguous whether it is meant to index by
-/// label or by position. Instead, use `.loc` for label-based indexing or
-/// `.iloc` for position-based indexing.
+/// label or by ordinal position. Instead, use `.loc` for label-based indexing
+/// or`.iloc` for ordinal indexing.
 ///
 /// ## Example
 /// ```python
@@ -29,7 +29,7 @@ use crate::rules::pandas_vet::helpers::{test_expression, Resolution};
 /// import pandas as pd
 ///
 /// students_df = pd.read_csv("students.csv")
-/// students_df.iloc[0]  # 0th row
+/// students_df.iloc[0]  # 0th row.
 /// ```
 ///
 /// ## References
@@ -90,9 +90,9 @@ impl Violation for PandasUseOfDotAt {
 /// Checks for uses of `.iat`.
 ///
 /// ## Why is this bad?
-/// `.iat` selects a single value from a DataFrame or Series based on a label
-/// index, and is slightly faster than using `.iloc`. However, `.iloc` is more
-/// idiomatic and versatile, as it can select multiple values at once.
+/// `.iat` selects a single value from a DataFrame or Series based on an
+/// ordinal index, and is slightly faster than using `.iloc`. However, `.iloc`
+/// is more idiomatic and versatile, as it can select multiple values at once.
 ///
 /// If speed is important, consider converting the data to a NumPy array. This
 /// will provide a much greater performance gain than using `.iat` over

--- a/crates/ruff/src/rules/pandas_vet/rules/subscript.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/subscript.rs
@@ -9,12 +9,14 @@ use crate::registry::Rule;
 use crate::rules::pandas_vet::helpers::{test_expression, Resolution};
 
 /// ## What it does
-/// Checks for uses of `.ix`.
+/// Checks for uses of `.ix` on Pandas objects.
 ///
 /// ## Why is this bad?
-/// `.ix` is deprecated as it is ambiguous whether it is meant to index by
-/// label or by ordinal position. Instead, use `.loc` for label-based indexing
-/// or`.iloc` for ordinal indexing.
+/// The `.ix` method is deprecated as its behavior is ambiguous. Specifically,
+/// it's often unclear whether `.ix` is indexing by label or by ordinal position.
+///
+/// Instead, prefer the `.loc` method for label-based indexing, and `.iloc` for
+/// ordinal indexing.
 ///
 /// ## Example
 /// ```python
@@ -47,15 +49,17 @@ impl Violation for PandasUseOfDotIx {
 }
 
 /// ## What it does
-/// Checks for uses of `.at`.
+/// Checks for uses of `.at` on Pandas objects.
 ///
 /// ## Why is this bad?
-/// `.at` selects a single value from a DataFrame or Series based on a label
-/// index, and is slightly faster than using `.loc`. However, `.loc` is more
-/// idiomatic and versatile, as it can select multiple values at once.
+/// The `.at` method selects a single value from a DataFrame or Series based on
+/// a label index, and is slightly faster than using `.loc`. However, `.loc` is
+/// more idiomatic and versatile, as it can be used to select multiple values at
+/// once.
 ///
-/// If speed is important, consider converting the data to a NumPy array. This
-/// will provide a much greater performance gain than using `.at` over `.loc`.
+/// If performance is an important consideration, convert the object to a NumPy
+/// array, which will provide a much greater performance boost than using `.at`
+/// over `.loc`.
 ///
 /// ## Example
 /// ```python
@@ -87,16 +91,17 @@ impl Violation for PandasUseOfDotAt {
 }
 
 /// ## What it does
-/// Checks for uses of `.iat`.
+/// Checks for uses of `.iat` on Pandas objects.
 ///
 /// ## Why is this bad?
-/// `.iat` selects a single value from a DataFrame or Series based on an
-/// ordinal index, and is slightly faster than using `.iloc`. However, `.iloc`
-/// is more idiomatic and versatile, as it can select multiple values at once.
+/// The `.iat` method selects a single value from a DataFrame or Series based
+/// on an ordinal index, and is slightly faster than using `.iloc`. However,
+/// `.iloc` is more idiomatic and versatile, as it can be used to select
+/// multiple values at once.
 ///
-/// If speed is important, consider converting the data to a NumPy array. This
-/// will provide a much greater performance gain than using `.iat` over
-/// `.iloc`.
+/// If performance is an important consideration, convert the object to a NumPy
+/// array, which will provide a much greater performance boost than using `.iat`
+/// over `.iloc`.
 ///
 /// ## Example
 /// ```python
@@ -141,11 +146,12 @@ pub(crate) fn subscript(checker: &mut Checker, value: &Expr, expr: &Expr) {
         return;
     };
 
-    let rules = &checker.settings.rules;
     let violation: DiagnosticKind = match attr.as_str() {
-        "ix" if rules.enabled(Rule::PandasUseOfDotIx) => PandasUseOfDotIx.into(),
-        "at" if rules.enabled(Rule::PandasUseOfDotAt) => PandasUseOfDotAt.into(),
-        "iat" if rules.enabled(Rule::PandasUseOfDotIat) => PandasUseOfDotIat.into(),
+        "ix" if checker.settings.rules.enabled(Rule::PandasUseOfDotIx) => PandasUseOfDotIx.into(),
+        "at" if checker.settings.rules.enabled(Rule::PandasUseOfDotAt) => PandasUseOfDotAt.into(),
+        "iat" if checker.settings.rules.enabled(Rule::PandasUseOfDotIat) => {
+            PandasUseOfDotIat.into()
+        }
         _ => return,
     };
 


### PR DESCRIPTION
## Summary

Completes all the documentation for the `pandas-vet` rules, except for `pandas-use-of-dot-read-table` as I am unclear of the rule's motivation (see #5628).

Related to #2646.

## Test Plan

`python scripts/check_docs_formatted.py && mkdocs serve`
