### PR TITLE
Use a simple match statement for case-insensitive noqa lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,6 @@ dependencies = [
 name = "ruff"
 version = "0.0.277"
 dependencies = [
- "aho-corasick 1.0.2",
  "annotate-snippets 0.9.1",
  "anyhow",
  "bitflags 2.3.3",

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -27,7 +27,6 @@ ruff_rustpython = { path = "../ruff_rustpython" }
 ruff_text_size = { workspace = true }
 ruff_textwrap = { path = "../ruff_textwrap" }
 
-aho-corasick = { version = "1.0.2" }
 annotate-snippets = { version = "0.9.1", features = ["color"] }
 anyhow = { workspace = true }
 bitflags = { workspace = true }


### PR DESCRIPTION
## Summary

It turns out that just doing this match directly without `AhoCorasick` is much faster, like 2x (and removes one dependency, though we likely already rely on this transitively).
