### PR TITLE
Pass `FormatContext` to `NeedsParentheses`

### DIFF
--- a/crates/ruff_python_formatter/src/builders.rs
+++ b/crates/ruff_python_formatter/src/builders.rs
@@ -94,7 +94,7 @@ impl<'fmt, 'ast, 'buf> JoinNodesBuilder<'fmt, 'ast, 'buf> {
 
         self.result = self.result.and_then(|_| {
             if let Some(last_end) = self.last_end.replace(node.end()) {
-                let source = self.fmt.context().contents();
+                let source = self.fmt.context().source();
                 let count_lines = |offset| {
                     // It's necessary to skip any trailing line comment because RustPython doesn't include trailing comments
                     // in the node's range
@@ -262,7 +262,7 @@ impl<'fmt, 'ast, 'buf> JoinCommaSeparatedBuilder<'fmt, 'ast, 'buf> {
             if let Some(last_end) = self.end_of_last_entry.take() {
                 let magic_trailing_comma = self.fmt.options().magic_trailing_comma().is_respect()
                     && matches!(
-                        first_non_trivia_token(last_end, self.fmt.context().contents()),
+                        first_non_trivia_token(last_end, self.fmt.context().source()),
                         Some(Token {
                             kind: TokenKind::Comma,
                             ..

--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -43,7 +43,7 @@ impl Format<PyFormatContext<'_>> for FormatLeadingComments<'_> {
         {
             let slice = comment.slice();
 
-            let lines_after_comment = lines_after(slice.end(), f.context().contents());
+            let lines_after_comment = lines_after(slice.end(), f.context().source());
             write!(
                 f,
                 [format_comment(comment), empty_lines(lines_after_comment)]
@@ -84,16 +84,16 @@ impl Format<PyFormatContext<'_>> for FormatLeadingAlternateBranchComments<'_> {
         if let Some(first_leading) = self.comments.first() {
             // Leading comments only preserves the lines after the comment but not before.
             // Insert the necessary lines.
-            if lines_before(first_leading.slice().start(), f.context().contents()) > 1 {
+            if lines_before(first_leading.slice().start(), f.context().source()) > 1 {
                 write!(f, [empty_line()])?;
             }
 
             write!(f, [leading_comments(self.comments)])?;
         } else if let Some(last_preceding) = self.last_node {
-            let full_end = skip_trailing_trivia(last_preceding.end(), f.context().contents());
+            let full_end = skip_trailing_trivia(last_preceding.end(), f.context().source());
             // The leading comments formatting ensures that it preserves the right amount of lines after
             // We need to take care of this ourselves, if there's no leading `else` comment.
-            if lines_after(full_end, f.context().contents()) > 1 {
+            if lines_after(full_end, f.context().source()) > 1 {
                 write!(f, [empty_line()])?;
             }
         }
@@ -140,7 +140,7 @@ impl Format<PyFormatContext<'_>> for FormatTrailingComments<'_> {
             has_trailing_own_line_comment |= trailing.line_position().is_own_line();
 
             if has_trailing_own_line_comment {
-                let lines_before_comment = lines_before(slice.start(), f.context().contents());
+                let lines_before_comment = lines_before(slice.start(), f.context().source());
 
                 // A trailing comment at the end of a body or list
                 // ```python
@@ -217,7 +217,7 @@ impl Format<PyFormatContext<'_>> for FormatDanglingComments<'_> {
                 f,
                 [
                     format_comment(comment),
-                    empty_lines(lines_after(comment.slice().end(), f.context().contents()))
+                    empty_lines(lines_after(comment.slice().end(), f.context().source()))
                 ]
             )?;
 
@@ -245,7 +245,7 @@ struct FormatComment<'a> {
 impl Format<PyFormatContext<'_>> for FormatComment<'_> {
     fn fmt(&self, f: &mut Formatter<PyFormatContext<'_>>) -> FormatResult<()> {
         let slice = self.comment.slice();
-        let comment_text = slice.text(SourceCode::new(f.context().contents()));
+        let comment_text = slice.text(SourceCode::new(f.context().source()));
 
         let trimmed = comment_text.trim_end();
         let trailing_whitespace_len = comment_text.text_len() - trimmed.text_len();

--- a/crates/ruff_python_formatter/src/context.rs
+++ b/crates/ruff_python_formatter/src/context.rs
@@ -22,7 +22,7 @@ impl<'a> PyFormatContext<'a> {
         }
     }
 
-    pub(crate) fn contents(&self) -> &'a str {
+    pub(crate) fn source(&self) -> &'a str {
         self.contents
     }
 

--- a/crates/ruff_python_formatter/src/expression/expr_attribute.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_attribute.rs
@@ -97,14 +97,13 @@ impl NeedsParentheses for ExprAttribute {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        if has_breaking_comments_attribute_chain(self, comments) {
+        if has_breaking_comments_attribute_chain(self, context.comments()) {
             return Parentheses::Always;
         }
 
-        match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
+        match default_expression_needs_parentheses(self.into(), parenthesize, context) {
             Parentheses::Optional => Parentheses::Never,
             parentheses => parentheses,
         }

--- a/crates/ruff_python_formatter/src/expression/expr_await.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_await.rs
@@ -1,4 +1,4 @@
-use crate::comments::Comments;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -21,9 +21,8 @@ impl NeedsParentheses for ExprAwait {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        default_expression_needs_parentheses(self.into(), parenthesize, source, comments)
+        default_expression_needs_parentheses(self.into(), parenthesize, context)
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
@@ -1,4 +1,4 @@
-use crate::comments::{trailing_comments, trailing_node_comments, Comments};
+use crate::comments::{trailing_comments, trailing_node_comments};
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, in_parentheses_only_group, is_expression_parenthesized,
     NeedsParentheses, Parenthesize,
@@ -33,7 +33,7 @@ impl FormatNodeRule<ExprBinOp> for FormatExprBinOp {
         let comments = f.context().comments().clone();
 
         let format_inner = format_with(|f: &mut PyFormatter| {
-            let source = f.context().contents();
+            let source = f.context().source();
             let binary_chain: SmallVec<[&ExprBinOp; 4]> = iter::successors(Some(item), |parent| {
                 parent.left.as_bin_op_expr().and_then(|bin_expression| {
                     if is_expression_parenthesized(bin_expression.as_any_node_ref(), source) {
@@ -176,9 +176,8 @@ impl NeedsParentheses for ExprBinOp {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        default_expression_needs_parentheses(self.into(), parenthesize, source, comments)
+        default_expression_needs_parentheses(self.into(), parenthesize, context)
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_bool_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bool_op.rs
@@ -1,4 +1,4 @@
-use crate::comments::{leading_comments, Comments};
+use crate::comments::leading_comments;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, in_parentheses_only_group, NeedsParentheses, Parentheses,
     Parenthesize,
@@ -71,10 +71,9 @@ impl NeedsParentheses for ExprBoolOp {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        default_expression_needs_parentheses(self.into(), parenthesize, source, comments)
+        default_expression_needs_parentheses(self.into(), parenthesize, context)
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_call.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_call.rs
@@ -1,5 +1,6 @@
 use crate::builders::PyFormatterExtensions;
-use crate::comments::{dangling_comments, Comments};
+use crate::comments::dangling_comments;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, parenthesized, NeedsParentheses, Parentheses,
     Parenthesize,
@@ -88,10 +89,9 @@ impl NeedsParentheses for ExprCall {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
+        match default_expression_needs_parentheses(self.into(), parenthesize, context) {
             Parentheses::Optional => Parentheses::Never,
             parentheses => parentheses,
         }

--- a/crates/ruff_python_formatter/src/expression/expr_compare.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_compare.rs
@@ -1,4 +1,4 @@
-use crate::comments::{leading_comments, Comments};
+use crate::comments::leading_comments;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, in_parentheses_only_group, NeedsParentheses, Parentheses,
     Parenthesize,
@@ -70,10 +70,9 @@ impl NeedsParentheses for ExprCompare {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        default_expression_needs_parentheses(self.into(), parenthesize, source, comments)
+        default_expression_needs_parentheses(self.into(), parenthesize, context)
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_constant.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_constant.rs
@@ -1,4 +1,3 @@
-use crate::comments::Comments;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -63,10 +62,9 @@ impl NeedsParentheses for ExprConstant {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
+        match default_expression_needs_parentheses(self.into(), parenthesize, context) {
             Parentheses::Optional if self.value.is_str() && parenthesize.is_if_breaks() => {
                 // Custom handling that only adds parentheses for implicit concatenated strings.
                 if parenthesize.is_if_breaks() {

--- a/crates/ruff_python_formatter/src/expression/expr_dict.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_dict.rs
@@ -1,4 +1,4 @@
-use crate::comments::{dangling_node_comments, leading_comments, Comments};
+use crate::comments::{dangling_node_comments, leading_comments};
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, parenthesized, NeedsParentheses, Parentheses,
     Parenthesize,
@@ -100,10 +100,9 @@ impl NeedsParentheses for ExprDict {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
+        match default_expression_needs_parentheses(self.into(), parenthesize, context) {
             Parentheses::Optional => Parentheses::Never,
             parentheses => parentheses,
         }

--- a/crates/ruff_python_formatter/src/expression/expr_dict_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_dict_comp.rs
@@ -1,4 +1,4 @@
-use crate::comments::Comments;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -24,10 +24,9 @@ impl NeedsParentheses for ExprDictComp {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
+        match default_expression_needs_parentheses(self.into(), parenthesize, context) {
             Parentheses::Optional => Parentheses::Never,
             parentheses => parentheses,
         }

--- a/crates/ruff_python_formatter/src/expression/expr_formatted_value.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_formatted_value.rs
@@ -1,4 +1,4 @@
-use crate::comments::Comments;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -19,9 +19,8 @@ impl NeedsParentheses for ExprFormattedValue {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        default_expression_needs_parentheses(self.into(), parenthesize, source, comments)
+        default_expression_needs_parentheses(self.into(), parenthesize, context)
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_generator_exp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_generator_exp.rs
@@ -1,4 +1,4 @@
-use crate::comments::Comments;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -24,10 +24,9 @@ impl NeedsParentheses for ExprGeneratorExp {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
+        match default_expression_needs_parentheses(self.into(), parenthesize, context) {
             Parentheses::Optional => Parentheses::Never,
             parentheses => parentheses,
         }

--- a/crates/ruff_python_formatter/src/expression/expr_if_exp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_if_exp.rs
@@ -1,4 +1,4 @@
-use crate::comments::{leading_comments, Comments};
+use crate::comments::leading_comments;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, in_parentheses_only_group, NeedsParentheses, Parentheses,
     Parenthesize,
@@ -47,9 +47,8 @@ impl NeedsParentheses for ExprIfExp {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        default_expression_needs_parentheses(self.into(), parenthesize, source, comments)
+        default_expression_needs_parentheses(self.into(), parenthesize, context)
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_joined_str.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_joined_str.rs
@@ -1,4 +1,4 @@
-use crate::comments::Comments;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -19,9 +19,8 @@ impl NeedsParentheses for ExprJoinedStr {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        default_expression_needs_parentheses(self.into(), parenthesize, source, comments)
+        default_expression_needs_parentheses(self.into(), parenthesize, context)
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_lambda.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_lambda.rs
@@ -1,4 +1,4 @@
-use crate::comments::Comments;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -19,9 +19,8 @@ impl NeedsParentheses for ExprLambda {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        default_expression_needs_parentheses(self.into(), parenthesize, source, comments)
+        default_expression_needs_parentheses(self.into(), parenthesize, context)
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_list.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_list.rs
@@ -1,4 +1,4 @@
-use crate::comments::{dangling_comments, CommentLinePosition, Comments};
+use crate::comments::{dangling_comments, CommentLinePosition};
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, parenthesized, NeedsParentheses, Parentheses,
     Parenthesize,
@@ -68,10 +68,9 @@ impl NeedsParentheses for ExprList {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
+        match default_expression_needs_parentheses(self.into(), parenthesize, context) {
             Parentheses::Optional => Parentheses::Never,
             parentheses => parentheses,
         }

--- a/crates/ruff_python_formatter/src/expression/expr_list_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_list_comp.rs
@@ -1,4 +1,4 @@
-use crate::comments::Comments;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, parenthesized, NeedsParentheses, Parentheses,
     Parenthesize,
@@ -45,10 +45,9 @@ impl NeedsParentheses for ExprListComp {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
+        match default_expression_needs_parentheses(self.into(), parenthesize, context) {
             Parentheses::Optional => Parentheses::Never,
             parentheses => parentheses,
         }

--- a/crates/ruff_python_formatter/src/expression/expr_name.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_name.rs
@@ -1,4 +1,3 @@
-use crate::comments::Comments;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -30,10 +29,9 @@ impl NeedsParentheses for ExprName {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        default_expression_needs_parentheses(self.into(), parenthesize, source, comments)
+        default_expression_needs_parentheses(self.into(), parenthesize, context)
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
@@ -1,4 +1,4 @@
-use crate::comments::Comments;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -34,10 +34,9 @@ impl NeedsParentheses for ExprNamedExpr {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
+        match default_expression_needs_parentheses(self.into(), parenthesize, context) {
             // Unlike tuples, named expression parentheses are not part of the range even when
             // mandatory. See [PEP 572](https://peps.python.org/pep-0572/) for details.
             Parentheses::Optional => Parentheses::Always,

--- a/crates/ruff_python_formatter/src/expression/expr_set.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_set.rs
@@ -1,4 +1,3 @@
-use crate::comments::Comments;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, parenthesized, NeedsParentheses, Parentheses,
     Parenthesize,
@@ -31,10 +30,9 @@ impl NeedsParentheses for ExprSet {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
+        match default_expression_needs_parentheses(self.into(), parenthesize, context) {
             Parentheses::Optional => Parentheses::Never,
             parentheses => parentheses,
         }

--- a/crates/ruff_python_formatter/src/expression/expr_set_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_set_comp.rs
@@ -1,4 +1,4 @@
-use crate::comments::Comments;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -24,10 +24,9 @@ impl NeedsParentheses for ExprSetComp {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
+        match default_expression_needs_parentheses(self.into(), parenthesize, context) {
             Parentheses::Optional => Parentheses::Never,
             parentheses => parentheses,
         }

--- a/crates/ruff_python_formatter/src/expression/expr_slice.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_slice.rs
@@ -1,4 +1,5 @@
-use crate::comments::{dangling_comments, Comments, SourceComment};
+use crate::comments::{dangling_comments, SourceComment};
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -27,8 +28,7 @@ impl FormatNodeRule<ExprSlice> for FormatExprSlice {
             step,
         } = item;
 
-        let (first_colon, second_colon) =
-            find_colons(f.context().contents(), *range, lower, upper)?;
+        let (first_colon, second_colon) = find_colons(f.context().source(), *range, lower, upper)?;
 
         // Handle comment placement
         // In placements.rs, we marked comment for None nodes a dangling and associated all others
@@ -263,9 +263,8 @@ impl NeedsParentheses for ExprSlice {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        default_expression_needs_parentheses(self.into(), parenthesize, source, comments)
+        default_expression_needs_parentheses(self.into(), parenthesize, context)
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_starred.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_starred.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::ExprStarred;
 
 use ruff_formatter::write;
 
-use crate::comments::Comments;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -34,9 +34,8 @@ impl NeedsParentheses for ExprStarred {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        default_expression_needs_parentheses(self.into(), parenthesize, source, comments)
+        default_expression_needs_parentheses(self.into(), parenthesize, context)
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_subscript.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_subscript.rs
@@ -3,8 +3,9 @@ use rustpython_parser::ast::ExprSubscript;
 use ruff_formatter::{format_args, write};
 use ruff_python_ast::node::AstNode;
 
-use crate::comments::{trailing_comments, Comments};
+use crate::comments::trailing_comments;
 use crate::context::NodeLevel;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -66,10 +67,9 @@ impl NeedsParentheses for ExprSubscript {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
+        match default_expression_needs_parentheses(self.into(), parenthesize, context) {
             Parentheses::Optional => Parentheses::Never,
             parentheses => parentheses,
         }

--- a/crates/ruff_python_formatter/src/expression/expr_tuple.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_tuple.rs
@@ -1,5 +1,5 @@
 use crate::builders::optional_parentheses;
-use crate::comments::{dangling_comments, CommentLinePosition, Comments};
+use crate::comments::{dangling_comments, CommentLinePosition};
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, parenthesized, NeedsParentheses, Parentheses,
     Parenthesize,
@@ -131,10 +131,9 @@ impl NeedsParentheses for ExprTuple {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
+        match default_expression_needs_parentheses(self.into(), parenthesize, context) {
             Parentheses::Optional => Parentheses::Never,
             parentheses => parentheses,
         }
@@ -148,7 +147,7 @@ fn is_parenthesized(
     f: &mut Formatter<PyFormatContext<'_>>,
 ) -> bool {
     let parentheses = '(';
-    let first_char = &f.context().contents()[usize::from(tuple_range.start())..]
+    let first_char = &f.context().source()[usize::from(tuple_range.start())..]
         .chars()
         .next();
     let Some(first_char) = first_char else {

--- a/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
@@ -1,4 +1,5 @@
-use crate::comments::{trailing_comments, Comments};
+use crate::comments::trailing_comments;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -70,13 +71,12 @@ impl NeedsParentheses for ExprUnaryOp {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        match default_expression_needs_parentheses(self.into(), parenthesize, source, comments) {
+        match default_expression_needs_parentheses(self.into(), parenthesize, context) {
             Parentheses::Optional => {
                 // We preserve the parentheses of the operand. It should not be necessary to break this expression.
-                if is_operand_parenthesized(self, source) {
+                if is_operand_parenthesized(self, context.source()) {
                     Parentheses::Never
                 } else {
                     Parentheses::Optional

--- a/crates/ruff_python_formatter/src/expression/expr_yield.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_yield.rs
@@ -1,4 +1,4 @@
-use crate::comments::Comments;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -19,9 +19,8 @@ impl NeedsParentheses for ExprYield {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        default_expression_needs_parentheses(self.into(), parenthesize, source, comments)
+        default_expression_needs_parentheses(self.into(), parenthesize, context)
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_yield_from.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_yield_from.rs
@@ -1,4 +1,4 @@
-use crate::comments::Comments;
+use crate::context::PyFormatContext;
 use crate::expression::parentheses::{
     default_expression_needs_parentheses, NeedsParentheses, Parentheses, Parenthesize,
 };
@@ -19,9 +19,8 @@ impl NeedsParentheses for ExprYieldFrom {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses {
-        default_expression_needs_parentheses(self.into(), parenthesize, source, comments)
+        default_expression_needs_parentheses(self.into(), parenthesize, context)
     }
 }

--- a/crates/ruff_python_formatter/src/expression/parentheses.rs
+++ b/crates/ruff_python_formatter/src/expression/parentheses.rs
@@ -1,4 +1,3 @@
-use crate::comments::Comments;
 use crate::context::NodeLevel;
 use crate::prelude::*;
 use crate::trivia::{first_non_trivia_token, first_non_trivia_token_rev, Token, TokenKind};
@@ -11,16 +10,14 @@ pub(crate) trait NeedsParentheses {
     fn needs_parentheses(
         &self,
         parenthesize: Parenthesize,
-        source: &str,
-        comments: &Comments,
+        context: &PyFormatContext,
     ) -> Parentheses;
 }
 
 pub(super) fn default_expression_needs_parentheses(
     node: AnyNodeRef,
     parenthesize: Parenthesize,
-    source: &str,
-    comments: &Comments,
+    context: &PyFormatContext,
 ) -> Parentheses {
     debug_assert!(
         node.is_expression(),
@@ -34,13 +31,13 @@ pub(super) fn default_expression_needs_parentheses(
         Parentheses::Never
     }
     // `Optional` or `Preserve` and expression has parentheses in source code.
-    else if !parenthesize.is_if_breaks() && is_expression_parenthesized(node, source) {
+    else if !parenthesize.is_if_breaks() && is_expression_parenthesized(node, context.source()) {
         Parentheses::Always
     }
     // `Optional` or `IfBreaks`: Add parentheses if the expression doesn't fit on a line but enforce
     // parentheses if the expression has leading comments
     else if !parenthesize.is_preserve() {
-        if comments.has_leading_comments(node) {
+        if context.comments().has_leading_comments(node) {
             Parentheses::Always
         } else {
             Parentheses::Optional

--- a/crates/ruff_python_formatter/src/other/arguments.rs
+++ b/crates/ruff_python_formatter/src/other/arguments.rs
@@ -36,7 +36,7 @@ impl FormatNodeRule<Arguments> for FormatArguments {
 
         let comments = f.context().comments().clone();
         let dangling = comments.dangling_comments(item);
-        let (slash, star) = find_argument_separators(f.context().contents(), item);
+        let (slash, star) = find_argument_separators(f.context().source(), item);
 
         let format_inner = format_with(|f: &mut PyFormatter| {
             let separator = format_with(|f| write!(f, [text(","), soft_line_break_or_space()]));
@@ -142,7 +142,7 @@ impl FormatNodeRule<Arguments> for FormatArguments {
                 let maybe_comma_token = if ends_with_pos_only_argument_separator {
                     // `def a(b, c, /): ... `
                     let mut tokens =
-                        SimpleTokenizer::starts_at(last_node.end(), f.context().contents())
+                        SimpleTokenizer::starts_at(last_node.end(), f.context().source())
                             .skip_trivia();
 
                     let comma = tokens.next();
@@ -153,7 +153,7 @@ impl FormatNodeRule<Arguments> for FormatArguments {
 
                     tokens.next()
                 } else {
-                    first_non_trivia_token(last_node.end(), f.context().contents())
+                    first_non_trivia_token(last_node.end(), f.context().source())
                 };
 
                 if maybe_comma_token.map_or(false, |token| token.kind() == TokenKind::Comma) {

--- a/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
@@ -79,7 +79,7 @@ impl Format<PyFormatContext<'_>> for FormatInheritanceClause<'_> {
             ..
         } = self.class_definition;
 
-        let source = f.context().contents();
+        let source = f.context().source();
 
         let mut joiner = f.join_comma_separated();
 

--- a/crates/ruff_python_formatter/src/statement/stmt_expr.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_expr.rs
@@ -13,7 +13,7 @@ impl FormatNodeRule<StmtExpr> for FormatStmtExpr {
 
         if let Some(constant) = value.as_constant_expr() {
             if constant.value.is_str()
-                && !is_expression_parenthesized(value.as_ref().into(), f.context().contents())
+                && !is_expression_parenthesized(value.as_ref().into(), f.context().source())
             {
                 return constant.format().with_options(StringLayout::Flat).fmt(f);
             }

--- a/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
@@ -56,9 +56,9 @@ impl FormatRule<AnyFunctionDefinition<'_>, PyFormatContext<'_>> for FormatAnyFun
                 // while maintaining the right amount of empty lines between the comment
                 // and the last decorator.
                 let decorator_end =
-                    skip_trailing_trivia(last_decorator.end(), f.context().contents());
+                    skip_trailing_trivia(last_decorator.end(), f.context().source());
 
-                let leading_line = if lines_after(decorator_end, f.context().contents()) <= 1 {
+                let leading_line = if lines_after(decorator_end, f.context().source()) <= 1 {
                     hard_line_break()
                 } else {
                     empty_line()

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -43,7 +43,7 @@ impl FormatRule<Suite, PyFormatContext<'_>> for FormatSuite {
         };
 
         let comments = f.context().comments().clone();
-        let source = f.context().contents();
+        let source = f.context().source();
 
         let saved_level = f.context().node_level();
         f.context_mut().set_node_level(node_level);


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I started working on this because I assumed that I would need access to options inside of `NeedsParantheses` but it then turned out that I won't. 
Anyway, it kind of felt nice to pass fewer arguments. So I'm gonna put this out here to get your feedback if you prefer this over passing individual fiels. 

Oh, I sneeked in another change. I renamed `context.contents` to `source`. `contents` is too generic and doesn't tell you anything. 

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

It compiles
