### PR TITLE
Fix find_only_token_in_range with expression parentheses

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/if.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/if.py
@@ -31,3 +31,11 @@ c2 = (
     # 8
     "b" # 9
 )
+
+# regression test: parentheses outside the expression ranges interfering with finding
+# the `if` and `else` token finding
+d1 = [
+    ("a") if # 1
+    ("b") else # 2
+    ("c")
+]

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -1215,11 +1215,15 @@ fn handle_expr_if_comment<'a>(
     CommentPlacement::Default(comment)
 }
 
-/// Looks for a token in the range that contains no other tokens.
+/// Looks for a token in the range that contains no other tokens except for parentheses outside
+/// the expression ranges
 fn find_only_token_in_range(range: TextRange, locator: &Locator, token_kind: TokenKind) -> Token {
-    let mut tokens = SimpleTokenizer::new(locator.contents(), range).skip_trivia();
+    let mut tokens = SimpleTokenizer::new(locator.contents(), range)
+        .skip_trivia()
+        .skip_while(|token| token.kind == TokenKind::RParen);
     let token = tokens.next().expect("Expected a token");
     debug_assert_eq!(token.kind(), token_kind);
+    let mut tokens = tokens.skip_while(|token| token.kind == TokenKind::LParen);
     debug_assert_eq!(tokens.next(), None);
     token
 }

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__if.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__if.py.snap
@@ -37,6 +37,14 @@ c2 = (
     # 8
     "b" # 9
 )
+
+# regression test: parentheses outside the expression ranges interfering with finding
+# the `if` and `else` token finding
+d1 = [
+    ("a") if # 1
+    ("b") else # 2
+    ("c")
+]
 ```
 
 ## Output
@@ -78,6 +86,16 @@ c2 = (
     # 8
     else "b"  # 9
 )
+
+# regression test: parentheses outside the expression ranges interfering with finding
+# the `if` and `else` token finding
+d1 = [
+    ("a")
+    # 1
+    if ("b")
+    # 2
+    else ("c")
+]
 ```
 
 


### PR DESCRIPTION
## Summary

Fix an oversight in `find_only_token_in_range` where the following code would panic due do the closing and opening parentheses being in the range we scan:
```python
d1 = [
    ("a") if # 1
    ("b") else # 2
    ("c")
]
```
Closing and opening parentheses respectively are now correctly skipped.

## Test Plan

I added a regression test