### PR TITLE
Fix Black compatible snapshot deletion

### DIFF
--- a/crates/ruff_python_formatter/tests/fixtures.rs
+++ b/crates/ruff_python_formatter/tests/fixtures.rs
@@ -32,18 +32,20 @@ fn black_compatibility() {
             // already perfectly captures the expected output.
             // The following code mimics insta's logic generating the snapshot name for a test.
             let workspace_path = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-            let snapshot_name = insta::_function_name!()
-                .strip_prefix(&format!("{}::", module_path!()))
-                .unwrap();
-            let module_path = module_path!().replace("::", "__");
+
+            let mut components = input_path.components().rev();
+            let file_name = components.next().unwrap();
+            let test_suite = components.next().unwrap();
+
+            let snapshot_name = format!(
+                "black_compatibility@{}__{}.snap",
+                test_suite.as_os_str().to_string_lossy(),
+                file_name.as_os_str().to_string_lossy()
+            );
 
             let snapshot_path = Path::new(&workspace_path)
-                .join("src/snapshots")
-                .join(format!(
-                    "{module_path}__{}.snap",
-                    snapshot_name.replace(&['/', '\\'][..], "__")
-                ));
-
+                .join("tests/snapshots")
+                .join(snapshot_name);
             if snapshot_path.exists() && snapshot_path.is_file() {
                 // SAFETY: This is a convenience feature. That's why we don't want to abort
                 // when deleting a no longer needed snapshot fails.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR fixes the deletion of black compatibility test snapshots when Ruff and Black produce the same output. 

The functionality broke after my refactor to use insta's glob feature.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I changed the `FormatString` implementation to emit a hardcoded string. This created a few new snapshot files. 
I then reverted the change and re-ran the tests. The created snapshots were automatically deleted

<!-- How was it tested? -->
