### PR TITLE
Format StmtAugAssign

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/ann_assign.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/ann_assign.py
@@ -1,0 +1,5 @@
+tree_depth += 1
+
+greeting += "This is very long, formal greeting for whomever is name here. Dear %s, it will break the line" % len(
+    name
+)

--- a/crates/ruff_python_formatter/src/statement/stmt_aug_assign.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_aug_assign.rs
@@ -1,4 +1,6 @@
-use crate::{not_yet_implemented, FormatNodeRule, PyFormatter};
+use crate::expression::parentheses::Parenthesize;
+use crate::{AsFormat, FormatNodeRule, PyFormatter};
+use ruff_formatter::prelude::{space, text};
 use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtAugAssign;
 
@@ -7,6 +9,22 @@ pub struct FormatStmtAugAssign;
 
 impl FormatNodeRule<StmtAugAssign> for FormatStmtAugAssign {
     fn fmt_fields(&self, item: &StmtAugAssign, f: &mut PyFormatter) -> FormatResult<()> {
-        write!(f, [not_yet_implemented(item)])
+        let StmtAugAssign {
+            target,
+            op,
+            value,
+            range: _,
+        } = item;
+        write!(
+            f,
+            [
+                target.format(),
+                space(),
+                op.format(),
+                text("="),
+                space(),
+                value.format().with_options(Parenthesize::IfBreaks)
+            ]
+        )
     }
 }

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@miscellaneous__debug_visitor.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@miscellaneous__debug_visitor.py.snap
@@ -56,16 +56,14 @@ class DebugVisitor(Visitor[T]):
          if isinstance(node, Node):
              _type = type_repr(node.type)
 -            out(f'{indent}{_type}', fg='yellow')
--            self.tree_depth += 1
 +            out(NOT_YET_IMPLEMENTED_ExprJoinedStr, fg="yellow")
-+            NOT_YET_IMPLEMENTED_StmtAugAssign
+             self.tree_depth += 1
              for child in node.children:
 -                yield from self.visit(child)
 +                NOT_YET_IMPLEMENTED_ExprYieldFrom
  
--            self.tree_depth -= 1
+             self.tree_depth -= 1
 -            out(f'{indent}/{_type}', fg='yellow', bold=False)
-+            NOT_YET_IMPLEMENTED_StmtAugAssign
 +            out(NOT_YET_IMPLEMENTED_ExprJoinedStr, fg="yellow", bold=False)
          else:
              _type = token.tok_name.get(node.type, str(node.type))
@@ -102,11 +100,11 @@ class DebugVisitor(Visitor[T]):
         if isinstance(node, Node):
             _type = type_repr(node.type)
             out(NOT_YET_IMPLEMENTED_ExprJoinedStr, fg="yellow")
-            NOT_YET_IMPLEMENTED_StmtAugAssign
+            self.tree_depth += 1
             for child in node.children:
                 NOT_YET_IMPLEMENTED_ExprYieldFrom
 
-            NOT_YET_IMPLEMENTED_StmtAugAssign
+            self.tree_depth -= 1
             out(NOT_YET_IMPLEMENTED_ExprJoinedStr, fg="yellow", bold=False)
         else:
             _type = token.tok_name.get(node.type, str(node.type))

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@miscellaneous__long_strings_flag_disabled.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@miscellaneous__long_strings_flag_disabled.py.snap
@@ -304,14 +304,6 @@ long_unmergable_string_with_pragma = (
 ```diff
 --- Black
 +++ Ruff
-@@ -1,6 +1,6 @@
- x = "This is a really long string that can't possibly be expected to fit all together on one line. In fact it may even take up three or more lines... like four or five... but probably just three."
- 
--x += "This is a really long string that can't possibly be expected to fit all together on one line. In fact it may even take up three or more lines... like four or five... but probably just three."
-+NOT_YET_IMPLEMENTED_StmtAugAssign
- 
- y = "Short string"
- 
 @@ -70,8 +70,8 @@
  bad_split3 = (
      "What if we have inline comments on "  # First Comment
@@ -471,7 +463,7 @@ long_unmergable_string_with_pragma = (
 ```py
 x = "This is a really long string that can't possibly be expected to fit all together on one line. In fact it may even take up three or more lines... like four or five... but probably just three."
 
-NOT_YET_IMPLEMENTED_StmtAugAssign
+x += "This is a really long string that can't possibly be expected to fit all together on one line. In fact it may even take up three or more lines... like four or five... but probably just three."
 
 y = "Short string"
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_generic.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_generic.py.snap
@@ -187,15 +187,6 @@ with match() as match:
  
      # At least one of the above branches must have been taken, because every Python
      # version has exactly one of the two 'ASYNC_*' flags
-@@ -91,7 +83,7 @@
- def lib2to3_parse(src_txt: str, target_versions: Iterable[TargetVersion] = ()) -> Node:
-     """Given a string with source, return the lib2to3 Node."""
-     if not src_txt.endswith("\n"):
--        src_txt += "\n"
-+        NOT_YET_IMPLEMENTED_StmtAugAssign
- 
-     grammars = get_grammars(set(target_versions))
- 
 @@ -99,9 +91,9 @@
  re.match()
  match = a
@@ -298,7 +289,7 @@ def get_grammars(target_versions: Set[TargetVersion]) -> List[Grammar]:
 def lib2to3_parse(src_txt: str, target_versions: Iterable[TargetVersion] = ()) -> Node:
     """Given a string with source, return the lib2to3 Node."""
     if not src_txt.endswith("\n"):
-        NOT_YET_IMPLEMENTED_StmtAugAssign
+        src_txt += "\n"
 
     grammars = get_grammars(set(target_versions))
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__ann_assign.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__ann_assign.py.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/ann_assign.py
+---
+## Input
+```py
+tree_depth += 1
+
+greeting += "This is very long, formal greeting for whomever is name here. Dear %s, it will break the line" % len(
+    name
+)
+```
+
+## Output
+```py
+tree_depth += 1
+
+greeting += (
+    "This is very long, formal greeting for whomever is name here. Dear %s, it will break the line"
+    % len(name)
+)
+```
+
+
+


### PR DESCRIPTION
## Summary

Format statements such as `tree_depth += 1`. This is a statement that does not allow any line breaks, the only thing to be mindful of is to parenthesize the assigned expression

Jaccard index on django: 0.915 -> 0.918

## Test Plan

black tests, and two new tests, a basic one and one that ensures that the child gets parentheses. I ran the django stability check.