### PR TITLE
Audit some `SemanticModel#is_builtin` usages

### DIFF
--- a/crates/ruff/src/rules/pylint/rules/property_with_parameters.rs
+++ b/crates/ruff/src/rules/pylint/rules/property_with_parameters.rs
@@ -55,7 +55,7 @@ pub(crate) fn property_with_parameters(
 ) {
     if !decorator_list
         .iter()
-        .any(|d| matches!(&d.expression, Expr::Name(ast::ExprName { id, .. }) if id == "property"))
+        .any(|decorator| matches!(&decorator.expression, Expr::Name(ast::ExprName { id, .. }) if id == "property"))
     {
         return;
     }

--- a/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
@@ -61,30 +61,31 @@ pub(crate) fn sys_exit_alias(checker: &mut Checker, func: &Expr) {
     let Expr::Name(ast::ExprName { id, .. }) = func else {
         return;
     };
-    for name in ["exit", "quit"] {
-        if id != name {
-            continue;
-        }
-        if !checker.semantic().is_builtin(name) {
-            continue;
-        }
-        let mut diagnostic = Diagnostic::new(
-            SysExitAlias {
-                name: name.to_string(),
-            },
-            func.range(),
-        );
-        if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.try_set_fix(|| {
-                let (import_edit, binding) = checker.importer.get_or_import_symbol(
-                    &ImportRequest::import("sys", "exit"),
-                    func.start(),
-                    checker.semantic(),
-                )?;
-                let reference_edit = Edit::range_replacement(binding, func.range());
-                Ok(Fix::suggested_edits(import_edit, [reference_edit]))
-            });
-        }
-        checker.diagnostics.push(diagnostic);
+
+    if !matches!(id.as_str(), "exit" | "quit") {
+        return;
     }
+
+    if !checker.semantic().is_builtin(id.as_str()) {
+        return;
+    }
+
+    let mut diagnostic = Diagnostic::new(
+        SysExitAlias {
+            name: id.to_string(),
+        },
+        func.range(),
+    );
+    if checker.patch(diagnostic.kind.rule()) {
+        diagnostic.try_set_fix(|| {
+            let (import_edit, binding) = checker.importer.get_or_import_symbol(
+                &ImportRequest::import("sys", "exit"),
+                func.start(),
+                checker.semantic(),
+            )?;
+            let reference_edit = Edit::range_replacement(binding, func.range());
+            Ok(Fix::suggested_edits(import_edit, [reference_edit]))
+        });
+    }
+    checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -86,66 +86,15 @@ pub(crate) fn native_literals(
         return;
     }
 
-    if (id == "str" || id == "bytes") && checker.semantic().is_builtin(id) {
-        let Some(arg) = args.get(0) else {
-            let mut diagnostic = Diagnostic::new(
-                NativeLiterals {
-                    literal_type: if id == "str" {
-                        LiteralType::Str
-                    } else {
-                        LiteralType::Bytes
-                    },
-                },
-                expr.range(),
-            );
-            if checker.patch(diagnostic.kind.rule()) {
-                let constant = if id == "bytes" {
-                    Constant::Bytes(vec![])
-                } else {
-                    Constant::Str(String::new())
-                };
-                let content = checker.generator().constant(&constant);
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
-                    content,
-                    expr.range(),
-                )));
-            }
-            checker.diagnostics.push(diagnostic);
-            return;
-        };
+    if !matches!(id.as_str(), "str" | "bytes") {
+        return;
+    }
 
-        // Look for `str("")`.
-        if id == "str"
-            && !matches!(
-                &arg,
-                Expr::Constant(ast::ExprConstant {
-                    value: Constant::Str(_),
-                    ..
-                }),
-            )
-        {
-            return;
-        }
+    if !checker.semantic().is_builtin(id) {
+        return;
+    }
 
-        // Look for `bytes(b"")`
-        if id == "bytes"
-            && !matches!(
-                &arg,
-                Expr::Constant(ast::ExprConstant {
-                    value: Constant::Bytes(_),
-                    ..
-                }),
-            )
-        {
-            return;
-        }
-
-        // Skip implicit string concatenations.
-        let arg_code = checker.locator.slice(arg.range());
-        if is_implicit_concatenation(arg_code) {
-            return;
-        }
-
+    let Some(arg) = args.get(0) else {
         let mut diagnostic = Diagnostic::new(
             NativeLiterals {
                 literal_type: if id == "str" {
@@ -157,11 +106,68 @@ pub(crate) fn native_literals(
             expr.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
+            let constant = if id == "bytes" {
+                Constant::Bytes(vec![])
+            } else {
+                Constant::Str(String::new())
+            };
+            let content = checker.generator().constant(&constant);
             diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
-                arg_code.to_string(),
+                content,
                 expr.range(),
             )));
         }
         checker.diagnostics.push(diagnostic);
+        return;
+    };
+
+    // Look for `str("")`.
+    if id == "str"
+        && !matches!(
+            &arg,
+            Expr::Constant(ast::ExprConstant {
+                value: Constant::Str(_),
+                ..
+            }),
+        )
+    {
+        return;
     }
+
+    // Look for `bytes(b"")`
+    if id == "bytes"
+        && !matches!(
+            &arg,
+            Expr::Constant(ast::ExprConstant {
+                value: Constant::Bytes(_),
+                ..
+            }),
+        )
+    {
+        return;
+    }
+
+    // Skip implicit string concatenations.
+    let arg_code = checker.locator.slice(arg.range());
+    if is_implicit_concatenation(arg_code) {
+        return;
+    }
+
+    let mut diagnostic = Diagnostic::new(
+        NativeLiterals {
+            literal_type: if id == "str" {
+                LiteralType::Str
+            } else {
+                LiteralType::Bytes
+            },
+        },
+        expr.range(),
+    );
+    if checker.patch(diagnostic.kind.rule()) {
+        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+            arg_code.to_string(),
+            expr.range(),
+        )));
+    }
+    checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -9,6 +9,7 @@ use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::find_keyword;
 use ruff_python_ast::source_code::Locator;
+use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
 use crate::registry::Rule;
@@ -36,7 +37,7 @@ use crate::registry::Rule;
 /// - [Python documentation: `open`](https://docs.python.org/3/library/functions.html#open)
 #[violation]
 pub struct RedundantOpenModes {
-    pub replacement: Option<String>,
+    replacement: Option<String>,
 }
 
 impl AlwaysAutofixableViolation for RedundantOpenModes {
@@ -62,10 +63,78 @@ impl AlwaysAutofixableViolation for RedundantOpenModes {
     }
 }
 
+/// UP015
+pub(crate) fn redundant_open_modes(checker: &mut Checker, expr: &Expr) {
+    let Some((mode_param, keywords)) = match_open(expr, checker.semantic()) else {
+        return;
+    };
+    match mode_param {
+        None => {
+            if !keywords.is_empty() {
+                if let Some(keyword) = find_keyword(keywords, MODE_KEYWORD_ARGUMENT) {
+                    if let Expr::Constant(ast::ExprConstant {
+                        value: Constant::Str(mode_param_value),
+                        ..
+                    }) = &keyword.value
+                    {
+                        if let Ok(mode) = OpenMode::from_str(mode_param_value.as_str()) {
+                            checker.diagnostics.push(create_check(
+                                expr,
+                                &keyword.value,
+                                mode.replacement_value(),
+                                checker.locator,
+                                checker.patch(Rule::RedundantOpenModes),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        Some(mode_param) => {
+            if let Expr::Constant(ast::ExprConstant {
+                value: Constant::Str(value),
+                ..
+            }) = &mode_param
+            {
+                if let Ok(mode) = OpenMode::from_str(value.as_str()) {
+                    checker.diagnostics.push(create_check(
+                        expr,
+                        mode_param,
+                        mode.replacement_value(),
+                        checker.locator,
+                        checker.patch(Rule::RedundantOpenModes),
+                    ));
+                }
+            }
+        }
+    }
+}
+
 const OPEN_FUNC_NAME: &str = "open";
 const MODE_KEYWORD_ARGUMENT: &str = "mode";
 
-#[derive(Copy, Clone)]
+fn match_open<'a>(
+    expr: &'a Expr,
+    model: &SemanticModel,
+) -> Option<(Option<&'a Expr>, &'a [Keyword])> {
+    let ast::ExprCall {
+        func,
+        args,
+        keywords,
+        range: _,
+    } = expr.as_call_expr()?;
+
+    let ast::ExprName { id, .. } = func.as_name_expr()?;
+
+    if id.as_str() == OPEN_FUNC_NAME && model.is_builtin(id) {
+        // Return the "open mode" parameter and keywords.
+        Some((args.get(1), keywords))
+    } else {
+        None
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
 enum OpenMode {
     U,
     Ur,
@@ -105,22 +174,6 @@ impl OpenMode {
             Self::Wt => Some("\"w\""),
         }
     }
-}
-
-fn match_open(expr: &Expr) -> (Option<&Expr>, Vec<Keyword>) {
-    if let Expr::Call(ast::ExprCall {
-        func,
-        args,
-        keywords,
-        range: _,
-    }) = expr
-    {
-        if matches!(func.as_ref(), Expr::Name(ast::ExprName {id, ..}) if id == OPEN_FUNC_NAME) {
-            // Return the "open mode" parameter and keywords.
-            return (args.get(1), keywords.clone());
-        }
-    }
-    (None, vec![])
 }
 
 fn create_check(
@@ -188,49 +241,5 @@ fn create_remove_param_fix(locator: &Locator, expr: &Expr, mode_param: &Expr) ->
         _ => Err(anyhow::anyhow!(
             "Failed to locate start and end parentheses"
         )),
-    }
-}
-
-/// UP015
-pub(crate) fn redundant_open_modes(checker: &mut Checker, expr: &Expr) {
-    // If `open` has been rebound, skip this check entirely.
-    if !checker.semantic().is_builtin(OPEN_FUNC_NAME) {
-        return;
-    }
-    let (mode_param, keywords): (Option<&Expr>, Vec<Keyword>) = match_open(expr);
-    if mode_param.is_none() && !keywords.is_empty() {
-        if let Some(keyword) = find_keyword(&keywords, MODE_KEYWORD_ARGUMENT) {
-            if let Expr::Constant(ast::ExprConstant {
-                value: Constant::Str(mode_param_value),
-                ..
-            }) = &keyword.value
-            {
-                if let Ok(mode) = OpenMode::from_str(mode_param_value.as_str()) {
-                    checker.diagnostics.push(create_check(
-                        expr,
-                        &keyword.value,
-                        mode.replacement_value(),
-                        checker.locator,
-                        checker.patch(Rule::RedundantOpenModes),
-                    ));
-                }
-            }
-        }
-    } else if let Some(mode_param) = mode_param {
-        if let Expr::Constant(ast::ExprConstant {
-            value: Constant::Str(mode_param_value),
-            ..
-        }) = &mode_param
-        {
-            if let Ok(mode) = OpenMode::from_str(mode_param_value.as_str()) {
-                checker.diagnostics.push(create_check(
-                    expr,
-                    mode_param,
-                    mode.replacement_value(),
-                    checker.locator,
-                    checker.patch(Rule::RedundantOpenModes),
-                ));
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary

Non-behavior-changing refactors to delay some `.is_builtin` calls in a few older rules. Cheaper pre-conditions should always be checked first.
