### PR TITLE
Run nightly Clippy over the Ruff repo

### DIFF
--- a/crates/ruff/src/autofix/edits.rs
+++ b/crates/ruff/src/autofix/edits.rs
@@ -317,10 +317,10 @@ mod tests {
             Some(TextSize::from(6))
         );
 
-        let contents = r#"
+        let contents = r"
 x = 1 \
   ; y = 1
-"#
+"
         .trim();
         let program = Suite::parse(contents, "<filename>")?;
         let stmt = program.first().unwrap();
@@ -349,10 +349,10 @@ x = 1 \
             TextSize::from(6)
         );
 
-        let contents = r#"
+        let contents = r"
 x = 1 \
   ; y = 1
-"#
+"
         .trim();
         let locator = Locator::new(contents);
         assert_eq!(

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -776,7 +776,7 @@ where
                     pycodestyle::rules::module_import_not_at_top_of_file(self, stmt, self.locator);
                 }
                 if self.enabled(Rule::GlobalStatement) {
-                    for name in names.iter() {
+                    for name in names {
                         if let Some(asname) = name.asname.as_ref() {
                             pylint::rules::global_statement(self, asname);
                         } else {
@@ -972,7 +972,7 @@ where
                     pycodestyle::rules::module_import_not_at_top_of_file(self, stmt, self.locator);
                 }
                 if self.enabled(Rule::GlobalStatement) {
-                    for name in names.iter() {
+                    for name in names {
                         if let Some(asname) = name.asname.as_ref() {
                             pylint::rules::global_statement(self, asname);
                         } else {
@@ -1617,7 +1617,7 @@ where
                     flake8_bandit::rules::assign_hardcoded_password_string(self, value, targets);
                 }
                 if self.enabled(Rule::GlobalStatement) {
-                    for target in targets.iter() {
+                    for target in targets {
                         if let Expr::Name(ast::ExprName { id, .. }) = target {
                             pylint::rules::global_statement(self, id);
                         }
@@ -1749,7 +1749,7 @@ where
             }
             Stmt::Delete(ast::StmtDelete { targets, range: _ }) => {
                 if self.enabled(Rule::GlobalStatement) {
-                    for target in targets.iter() {
+                    for target in targets {
                         if let Expr::Name(ast::ExprName { id, .. }) = target {
                             pylint::rules::global_statement(self, id);
                         }

--- a/crates/ruff/src/directives.rs
+++ b/crates/ruff/src/directives.rs
@@ -427,22 +427,22 @@ ghi
             NoqaMapping::from_iter([TextRange::new(TextSize::from(6), TextSize::from(28))])
         );
 
-        let contents = r#"x = \
-    1"#;
+        let contents = r"x = \
+    1";
         assert_eq!(
             noqa_mappings(contents),
             NoqaMapping::from_iter([TextRange::new(TextSize::from(0), TextSize::from(6))])
         );
 
-        let contents = r#"from foo import \
+        let contents = r"from foo import \
     bar as baz, \
-    qux as quux"#;
+    qux as quux";
         assert_eq!(
             noqa_mappings(contents),
             NoqaMapping::from_iter([TextRange::new(TextSize::from(0), TextSize::from(36))])
         );
 
-        let contents = r#"
+        let contents = r"
 # Foo
 from foo import \
     bar as baz, \
@@ -450,7 +450,7 @@ from foo import \
 x = \
     1
 y = \
-    2"#;
+    2";
         assert_eq!(
             noqa_mappings(contents),
             NoqaMapping::from_iter([

--- a/crates/ruff/src/message/azure.rs
+++ b/crates/ruff/src/message/azure.rs
@@ -51,7 +51,7 @@ mod tests {
 
     #[test]
     fn output() {
-        let mut emitter = AzureEmitter::default();
+        let mut emitter = AzureEmitter;
         let content = capture_emitter_output(&mut emitter, &create_messages());
 
         assert_snapshot!(content);

--- a/crates/ruff/src/message/github.rs
+++ b/crates/ruff/src/message/github.rs
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn output() {
-        let mut emitter = GithubEmitter::default();
+        let mut emitter = GithubEmitter;
         let content = capture_emitter_output(&mut emitter, &create_messages());
 
         assert_snapshot!(content);

--- a/crates/ruff/src/message/json.rs
+++ b/crates/ruff/src/message/json.rs
@@ -108,7 +108,7 @@ mod tests {
 
     #[test]
     fn output() {
-        let mut emitter = JsonEmitter::default();
+        let mut emitter = JsonEmitter;
         let content = capture_emitter_output(&mut emitter, &create_messages());
 
         assert_snapshot!(content);

--- a/crates/ruff/src/message/json_lines.rs
+++ b/crates/ruff/src/message/json_lines.rs
@@ -24,14 +24,14 @@ impl Emitter for JsonLinesEmitter {
 
 #[cfg(test)]
 mod tests {
-    use crate::message::json_lines::JsonLinesEmitter;
     use insta::assert_snapshot;
 
+    use crate::message::json_lines::JsonLinesEmitter;
     use crate::message::tests::{capture_emitter_output, create_messages};
 
     #[test]
     fn output() {
-        let mut emitter = JsonLinesEmitter::default();
+        let mut emitter = JsonLinesEmitter;
         let content = capture_emitter_output(&mut emitter, &create_messages());
 
         assert_snapshot!(content);

--- a/crates/ruff/src/message/junit.rs
+++ b/crates/ruff/src/message/junit.rs
@@ -93,7 +93,7 @@ mod tests {
 
     #[test]
     fn output() {
-        let mut emitter = JunitEmitter::default();
+        let mut emitter = JunitEmitter;
         let content = capture_emitter_output(&mut emitter, &create_messages());
 
         assert_snapshot!(content);

--- a/crates/ruff/src/message/pylint.rs
+++ b/crates/ruff/src/message/pylint.rs
@@ -49,7 +49,7 @@ mod tests {
 
     #[test]
     fn output() {
-        let mut emitter = PylintEmitter::default();
+        let mut emitter = PylintEmitter;
         let content = capture_emitter_output(&mut emitter, &create_messages());
 
         assert_snapshot!(content);

--- a/crates/ruff/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -350,7 +350,7 @@ fn is_wildcard_command(expr: &Expr) -> bool {
     if let Expr::List(ast::ExprList { elts, .. }) = expr {
         let mut has_star = false;
         let mut has_command = false;
-        for elt in elts.iter() {
+        for elt in elts {
             if let Some(text) = string_literal(elt) {
                 has_star |= text.contains('*');
                 has_command |= text.contains("chown")

--- a/crates/ruff/src/rules/flake8_bandit/settings.rs
+++ b/crates/ruff/src/rules/flake8_bandit/settings.rs
@@ -59,12 +59,7 @@ impl From<Options> for Settings {
                 .hardcoded_tmp_directory
                 .unwrap_or_else(default_tmp_dirs)
                 .into_iter()
-                .chain(
-                    options
-                        .hardcoded_tmp_directory_extend
-                        .unwrap_or_default()
-                        .into_iter(),
-                )
+                .chain(options.hardcoded_tmp_directory_extend.unwrap_or_default())
                 .collect(),
             check_typed_exception: options.check_typed_exception.unwrap_or(false),
         }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
@@ -351,7 +351,7 @@ pub(crate) fn reuse_of_groupby_generator(
         return;
     }
     let mut finder = GroupNameFinder::new(group_name);
-    for stmt in body.iter() {
+    for stmt in body {
         finder.visit_stmt(stmt);
     }
     for expr in finder.exprs {

--- a/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
@@ -512,7 +512,7 @@ fn pad_expression(content: String, range: TextRange, checker: &Checker) -> Strin
     // If the expression is immediately preceded by an opening brace, then
     // we need to add a space before the expression.
     let prefix = checker.locator.up_to(range.start());
-    let left_pad = matches!(prefix.chars().rev().next(), Some('{'));
+    let left_pad = matches!(prefix.chars().next_back(), Some('{'));
 
     // If the expression is immediately preceded by an opening brace, then
     // we need to add a space before the expression.

--- a/crates/ruff/src/rules/flake8_django/rules/all_with_model_form.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/all_with_model_form.rs
@@ -58,18 +58,18 @@ pub(crate) fn all_with_model_form(
     {
         return None;
     }
-    for element in body.iter() {
+    for element in body {
         let Stmt::ClassDef(ast::StmtClassDef { name, body, .. }) = element else {
             continue;
         };
         if name != "Meta" {
             continue;
         }
-        for element in body.iter() {
+        for element in body {
             let Stmt::Assign(ast::StmtAssign { targets, value, .. }) = element else {
                 continue;
             };
-            for target in targets.iter() {
+            for target in targets {
                 let Expr::Name(ast::ExprName { id, .. }) = target else {
                     continue;
                 };

--- a/crates/ruff/src/rules/flake8_django/rules/exclude_with_model_form.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/exclude_with_model_form.rs
@@ -56,18 +56,18 @@ pub(crate) fn exclude_with_model_form(
     {
         return None;
     }
-    for element in body.iter() {
+    for element in body {
         let Stmt::ClassDef(ast::StmtClassDef { name, body, .. }) = element else {
             continue;
         };
         if name != "Meta" {
             continue;
         }
-        for element in body.iter() {
+        for element in body {
             let Stmt::Assign(ast::StmtAssign { targets, .. }) = element else {
                 continue;
             };
-            for target in targets.iter() {
+            for target in targets {
                 let Expr::Name(ast::ExprName { id, .. }) = target else {
                     continue;
                 };

--- a/crates/ruff/src/rules/flake8_django/rules/model_without_dunder_str.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/model_without_dunder_str.rs
@@ -81,7 +81,7 @@ fn has_dunder_method(body: &[Stmt]) -> bool {
 }
 
 fn is_non_abstract_model(bases: &[Expr], body: &[Stmt], semantic: &SemanticModel) -> bool {
-    for base in bases.iter() {
+    for base in bases {
         if is_model_abstract(body) {
             continue;
         }
@@ -94,18 +94,18 @@ fn is_non_abstract_model(bases: &[Expr], body: &[Stmt], semantic: &SemanticModel
 
 /// Check if class is abstract, in terms of Django model inheritance.
 fn is_model_abstract(body: &[Stmt]) -> bool {
-    for element in body.iter() {
+    for element in body {
         let Stmt::ClassDef(ast::StmtClassDef { name, body, .. }) = element else {
             continue;
         };
         if name != "Meta" {
             continue;
         }
-        for element in body.iter() {
+        for element in body {
             let Stmt::Assign(ast::StmtAssign { targets, value, .. }) = element else {
                 continue;
             };
-            for target in targets.iter() {
+            for target in targets {
                 let Expr::Name(ast::ExprName { id, .. }) = target else {
                     continue;
                 };

--- a/crates/ruff/src/rules/flake8_django/rules/nullable_model_string_field.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/nullable_model_string_field.rs
@@ -53,7 +53,7 @@ impl Violation for DjangoNullableModelStringField {
 
 /// DJ001
 pub(crate) fn nullable_model_string_field(checker: &mut Checker, body: &[Stmt]) {
-    for statement in body.iter() {
+    for statement in body {
         let Stmt::Assign(ast::StmtAssign { value, .. }) = statement else {
             continue;
         };
@@ -87,7 +87,7 @@ fn is_nullable_field<'a>(checker: &'a Checker, value: &'a Expr) -> Option<&'a st
     let mut null_key = false;
     let mut blank_key = false;
     let mut unique_key = false;
-    for keyword in keywords.iter() {
+    for keyword in keywords {
         let Some(argument) = &keyword.arg else {
             continue;
         };

--- a/crates/ruff/src/rules/flake8_django/rules/unordered_body_content_in_model.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/unordered_body_content_in_model.rs
@@ -156,7 +156,7 @@ pub(crate) fn unordered_body_content_in_model(
     // Track all the element types we've seen so far.
     let mut element_types = Vec::new();
     let mut prev_element_type = None;
-    for element in body.iter() {
+    for element in body {
         let Some(element_type) = get_element_type(element, checker.semantic()) else {
             continue;
         };

--- a/crates/ruff/src/rules/flake8_gettext/settings.rs
+++ b/crates/ruff/src/rules/flake8_gettext/settings.rs
@@ -57,12 +57,7 @@ impl From<Options> for Settings {
                 .function_names
                 .unwrap_or_else(default_func_names)
                 .into_iter()
-                .chain(
-                    options
-                        .extend_function_names
-                        .unwrap_or_default()
-                        .into_iter(),
-                )
+                .chain(options.extend_function_names.unwrap_or_default())
                 .collect(),
         }
     }

--- a/crates/ruff/src/rules/flake8_quotes/rules/from_tokens.rs
+++ b/crates/ruff/src/rules/flake8_quotes/rules/from_tokens.rs
@@ -322,7 +322,7 @@ fn strings(locator: &Locator, sequence: &[TextRange], settings: &Settings) -> Ve
         string_contents.contains(good_single(quotes_settings.inline_quotes))
     });
 
-    for (range, trivia) in sequence.iter().zip(trivia.into_iter()) {
+    for (range, trivia) in sequence.iter().zip(trivia) {
         if trivia.is_multiline {
             // If our string is or contains a known good string, ignore it.
             if trivia

--- a/crates/ruff/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff/src/rules/flake8_todos/rules/todos.rs
@@ -227,9 +227,9 @@ impl Violation for MissingSpaceAfterTodoColon {
 
 static ISSUE_LINK_REGEX_SET: Lazy<RegexSet> = Lazy::new(|| {
     RegexSet::new([
-        r#"^#\s*(http|https)://.*"#, // issue link
-        r#"^#\s*\d+$"#,              // issue code - like "003"
-        r#"^#\s*[A-Z]{1,6}\-?\d+$"#, // issue code - like "TD003"
+        r"^#\s*(http|https)://.*", // issue link
+        r"^#\s*\d+$",              // issue code - like "003"
+        r"^#\s*[A-Z]{1,6}\-?\d+$", // issue code - like "TD003"
     ])
     .unwrap()
 });

--- a/crates/ruff/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/helpers.rs
@@ -38,7 +38,7 @@ pub(crate) fn runtime_evaluated(
 
 fn runtime_evaluated_base_class(base_classes: &[String], semantic: &SemanticModel) -> bool {
     if let ScopeKind::Class(ast::StmtClassDef { bases, .. }) = &semantic.scope().kind {
-        for base in bases.iter() {
+        for base in bases {
             if let Some(call_path) = semantic.resolve_call_path(base) {
                 if base_classes
                     .iter()
@@ -54,7 +54,7 @@ fn runtime_evaluated_base_class(base_classes: &[String], semantic: &SemanticMode
 
 fn runtime_evaluated_decorators(decorators: &[String], semantic: &SemanticModel) -> bool {
     if let ScopeKind::Class(ast::StmtClassDef { decorator_list, .. }) = &semantic.scope().kind {
-        for decorator in decorator_list.iter() {
+        for decorator in decorator_list {
             if let Some(call_path) = semantic.resolve_call_path(map_callable(&decorator.expression))
             {
                 if decorators

--- a/crates/ruff/src/rules/isort/order.rs
+++ b/crates/ruff/src/rules/isort/order.rs
@@ -47,7 +47,7 @@ pub(crate) fn order_imports<'a>(
             )
             .chain(
                 // Include all star imports.
-                block.import_from_star.into_iter(),
+                block.import_from_star,
             )
             .map(
                 |(

--- a/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
@@ -93,7 +93,7 @@ pub(crate) fn not_tests(
             if !matches!(&ops[..], [CmpOp::In | CmpOp::Is]) {
                 return;
             }
-            for op in ops.iter() {
+            for op in ops {
                 match op {
                     CmpOp::In => {
                         if check_not_in {

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -58,7 +58,7 @@ impl AlwaysAutofixableViolation for LRUCacheWithMaxsizeNone {
 
 /// UP033
 pub(crate) fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list: &[Decorator]) {
-    for decorator in decorator_list.iter() {
+    for decorator in decorator_list {
         let Expr::Call(ast::ExprCall {
             func,
             args,

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -56,7 +56,7 @@ impl AlwaysAutofixableViolation for LRUCacheWithoutParameters {
 
 /// UP011
 pub(crate) fn lru_cache_without_parameters(checker: &mut Checker, decorator_list: &[Decorator]) {
-    for decorator in decorator_list.iter() {
+    for decorator in decorator_list {
         let Expr::Call(ast::ExprCall {
             func,
             args,

--- a/crates/ruff/src/settings/configuration.rs
+++ b/crates/ruff/src/settings/configuration.rs
@@ -258,7 +258,7 @@ impl Configuration {
             rule_selections: config
                 .rule_selections
                 .into_iter()
-                .chain(self.rule_selections.into_iter())
+                .chain(self.rule_selections)
                 .collect(),
             allowed_confusables: self.allowed_confusables.or(config.allowed_confusables),
             builtins: self.builtins.or(config.builtins),
@@ -269,17 +269,17 @@ impl Configuration {
             extend_exclude: config
                 .extend_exclude
                 .into_iter()
-                .chain(self.extend_exclude.into_iter())
+                .chain(self.extend_exclude)
                 .collect(),
             extend_include: config
                 .extend_include
                 .into_iter()
-                .chain(self.extend_include.into_iter())
+                .chain(self.extend_include)
                 .collect(),
             extend_per_file_ignores: config
                 .extend_per_file_ignores
                 .into_iter()
-                .chain(self.extend_per_file_ignores.into_iter())
+                .chain(self.extend_per_file_ignores)
                 .collect(),
             external: self.external.or(config.external),
             fix: self.fix.or(config.fix),

--- a/crates/ruff/src/settings/options_base.rs
+++ b/crates/ruff/src/settings/options_base.rs
@@ -153,7 +153,7 @@ impl IntoIterator for OptionGroup {
 
 impl Display for OptionGroup {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        for (name, _) in self.iter() {
+        for (name, _) in self {
             writeln!(f, "{name}")?;
         }
 

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -181,13 +181,13 @@ impl Printer {
 
         match self.format {
             SerializationFormat::Json => {
-                JsonEmitter::default().emit(writer, &diagnostics.messages, &context)?;
+                JsonEmitter.emit(writer, &diagnostics.messages, &context)?;
             }
             SerializationFormat::JsonLines => {
-                JsonLinesEmitter::default().emit(writer, &diagnostics.messages, &context)?;
+                JsonLinesEmitter.emit(writer, &diagnostics.messages, &context)?;
             }
             SerializationFormat::Junit => {
-                JunitEmitter::default().emit(writer, &diagnostics.messages, &context)?;
+                JunitEmitter.emit(writer, &diagnostics.messages, &context)?;
             }
             SerializationFormat::Text => {
                 TextEmitter::default()
@@ -222,16 +222,16 @@ impl Printer {
                 self.write_summary_text(writer, diagnostics)?;
             }
             SerializationFormat::Github => {
-                GithubEmitter::default().emit(writer, &diagnostics.messages, &context)?;
+                GithubEmitter.emit(writer, &diagnostics.messages, &context)?;
             }
             SerializationFormat::Gitlab => {
                 GitlabEmitter::default().emit(writer, &diagnostics.messages, &context)?;
             }
             SerializationFormat::Pylint => {
-                PylintEmitter::default().emit(writer, &diagnostics.messages, &context)?;
+                PylintEmitter.emit(writer, &diagnostics.messages, &context)?;
             }
             SerializationFormat::Azure => {
-                AzureEmitter::default().emit(writer, &diagnostics.messages, &context)?;
+                AzureEmitter.emit(writer, &diagnostics.messages, &context)?;
             }
         }
 

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -66,7 +66,7 @@ impl Fix {
     )]
     pub fn unspecified_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         Self {
-            edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
+            edits: std::iter::once(edit).chain(rest).collect(),
             applicability: Applicability::Unspecified,
             isolation_level: IsolationLevel::default(),
         }
@@ -84,7 +84,7 @@ impl Fix {
     /// Create a new [`Fix`] with [automatic applicability](Applicability::Automatic) from multiple [`Edit`] elements.
     pub fn automatic_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         Self {
-            edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
+            edits: std::iter::once(edit).chain(rest).collect(),
             applicability: Applicability::Automatic,
             isolation_level: IsolationLevel::default(),
         }
@@ -102,7 +102,7 @@ impl Fix {
     /// Create a new [`Fix`] with [suggested applicability](Applicability::Suggested) from multiple [`Edit`] elements.
     pub fn suggested_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         Self {
-            edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
+            edits: std::iter::once(edit).chain(rest).collect(),
             applicability: Applicability::Suggested,
             isolation_level: IsolationLevel::default(),
         }
@@ -120,7 +120,7 @@ impl Fix {
     /// Create a new [`Fix`] with [manual applicability](Applicability::Manual) from multiple [`Edit`] elements.
     pub fn manual_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         Self {
-            edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
+            edits: std::iter::once(edit).chain(rest).collect(),
             applicability: Applicability::Manual,
             isolation_level: IsolationLevel::default(),
         }

--- a/crates/ruff_formatter/src/arguments.rs
+++ b/crates/ruff_formatter/src/arguments.rs
@@ -96,7 +96,7 @@ impl<Context> Copy for Arguments<'_, Context> {}
 
 impl<Context> Clone for Arguments<'_, Context> {
     fn clone(&self) -> Self {
-        Self(self.0)
+        *self
     }
 }
 

--- a/crates/ruff_macros/src/config.rs
+++ b/crates/ruff_macros/src/config.rs
@@ -19,7 +19,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
         }) => {
             let mut output = vec![];
 
-            for field in fields.named.iter() {
+            for field in &fields.named {
                 let docs: Vec<&Attribute> = field
                     .attrs
                     .iter()

--- a/crates/ruff_python_ast/src/source_code/indexer.rs
+++ b/crates/ruff_python_ast/src/source_code/indexer.rs
@@ -201,7 +201,7 @@ if True:
             ]
         );
 
-        let contents = r#"
+        let contents = r"
 x = 1; import sys
 import os
 
@@ -215,7 +215,7 @@ if True:
 
 x = 1; \
 import os
-"#
+"
         .trim();
         let lxr: Vec<LexResult> = lexer::lex(contents, Mode::Module).collect();
         let indexer = Indexer::from_tokens(lxr.as_slice(), &Locator::new(contents));

--- a/crates/ruff_python_ast/src/types.rs
+++ b/crates/ruff_python_ast/src/types.rs
@@ -28,7 +28,7 @@ impl<'a, T> AsRef<T> for RefEquality<'a, T> {
 
 impl<'a, T> Clone for RefEquality<'a, T> {
     fn clone(&self) -> Self {
-        Self(self.0)
+        *self
     }
 }
 

--- a/crates/ruff_python_formatter/generate.py
+++ b/crates/ruff_python_formatter/generate.py
@@ -136,7 +136,7 @@ for node in nodes:
             fn format(&self) -> Self::Format<'_> {{
                 FormatRefWithRule::new(
                     self,
-                    crate::{groups[group_for_node(node)]}::{to_camel_case(node)}::Format{node}::default(),
+                    crate::{groups[group_for_node(node)]}::{to_camel_case(node)}::Format{node},
                 )
             }}
         }}
@@ -149,7 +149,7 @@ for node in nodes:
             fn into_format(self) -> Self::Format {{
                 FormatOwnedWithRule::new(
                     self,
-                    crate::{groups[group_for_node(node)]}::{to_camel_case(node)}::Format{node}::default(),
+                    crate::{groups[group_for_node(node)]}::{to_camel_case(node)}::Format{node},
                 )
             }}
         }}

--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -436,7 +436,7 @@ mod tests {
 
             let comment_ranges = comment_ranges.finish();
 
-            let parsed = parse_tokens(tokens.into_iter(), Mode::Module, "test.py")
+            let parsed = parse_tokens(tokens, Mode::Module, "test.py")
                 .expect("Expect source to be valid Python");
 
             CommentsTestCase {

--- a/crates/ruff_python_formatter/src/generated.rs
+++ b/crates/ruff_python_formatter/src/generated.rs
@@ -1,4 +1,4 @@
-//! This is a generated file. Don't modify it by hand! Run `scripts/generate.py` to re-generate the file.
+//! This is a generated file. Don't modify it by hand! Run `crates/ruff_python_formatter/generate.py` to re-generate the file.
 use crate::context::PyFormatContext;
 use crate::{AsFormat, FormatNodeRule, IntoFormat};
 use ruff_formatter::formatter::Formatter;
@@ -25,7 +25,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ModModule {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::module::mod_module::FormatModModule::default())
+        FormatRefWithRule::new(self, crate::module::mod_module::FormatModModule)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ModModule {
@@ -35,7 +35,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ModModule {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::module::mod_module::FormatModModule::default())
+        FormatOwnedWithRule::new(self, crate::module::mod_module::FormatModModule)
     }
 }
 
@@ -59,10 +59,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ModInteractive {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::module::mod_interactive::FormatModInteractive::default(),
-        )
+        FormatRefWithRule::new(self, crate::module::mod_interactive::FormatModInteractive)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ModInteractive {
@@ -72,10 +69,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ModInteractive {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::module::mod_interactive::FormatModInteractive::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::module::mod_interactive::FormatModInteractive)
     }
 }
 
@@ -99,10 +93,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ModExpression {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::module::mod_expression::FormatModExpression::default(),
-        )
+        FormatRefWithRule::new(self, crate::module::mod_expression::FormatModExpression)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ModExpression {
@@ -112,10 +103,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ModExpression {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::module::mod_expression::FormatModExpression::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::module::mod_expression::FormatModExpression)
     }
 }
 
@@ -141,7 +129,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ModFunctionType {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::module::mod_function_type::FormatModFunctionType::default(),
+            crate::module::mod_function_type::FormatModFunctionType,
         )
     }
 }
@@ -154,7 +142,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ModFunctionType {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::module::mod_function_type::FormatModFunctionType::default(),
+            crate::module::mod_function_type::FormatModFunctionType,
         )
     }
 }
@@ -181,7 +169,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtFunctionDef {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::statement::stmt_function_def::FormatStmtFunctionDef::default(),
+            crate::statement::stmt_function_def::FormatStmtFunctionDef,
         )
     }
 }
@@ -194,7 +182,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtFunctionDef {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::statement::stmt_function_def::FormatStmtFunctionDef::default(),
+            crate::statement::stmt_function_def::FormatStmtFunctionDef,
         )
     }
 }
@@ -221,7 +209,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtAsyncFunctionDef {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::statement::stmt_async_function_def::FormatStmtAsyncFunctionDef::default(),
+            crate::statement::stmt_async_function_def::FormatStmtAsyncFunctionDef,
         )
     }
 }
@@ -234,7 +222,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtAsyncFunctionDef {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::statement::stmt_async_function_def::FormatStmtAsyncFunctionDef::default(),
+            crate::statement::stmt_async_function_def::FormatStmtAsyncFunctionDef,
         )
     }
 }
@@ -259,10 +247,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtClassDef {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_class_def::FormatStmtClassDef::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_class_def::FormatStmtClassDef)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtClassDef {
@@ -272,10 +257,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtClassDef {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_class_def::FormatStmtClassDef::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_class_def::FormatStmtClassDef)
     }
 }
 
@@ -299,10 +281,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtReturn {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_return::FormatStmtReturn::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_return::FormatStmtReturn)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtReturn {
@@ -312,10 +291,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtReturn {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_return::FormatStmtReturn::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_return::FormatStmtReturn)
     }
 }
 
@@ -339,10 +315,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtDelete {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_delete::FormatStmtDelete::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_delete::FormatStmtDelete)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtDelete {
@@ -352,10 +325,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtDelete {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_delete::FormatStmtDelete::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_delete::FormatStmtDelete)
     }
 }
 
@@ -379,10 +349,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtAssign {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_assign::FormatStmtAssign::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_assign::FormatStmtAssign)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtAssign {
@@ -392,10 +359,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtAssign {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_assign::FormatStmtAssign::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_assign::FormatStmtAssign)
     }
 }
 
@@ -419,10 +383,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtAugAssign {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_aug_assign::FormatStmtAugAssign::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_aug_assign::FormatStmtAugAssign)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtAugAssign {
@@ -432,10 +393,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtAugAssign {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_aug_assign::FormatStmtAugAssign::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_aug_assign::FormatStmtAugAssign)
     }
 }
 
@@ -459,10 +417,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtAnnAssign {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_ann_assign::FormatStmtAnnAssign::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_ann_assign::FormatStmtAnnAssign)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtAnnAssign {
@@ -472,10 +427,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtAnnAssign {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_ann_assign::FormatStmtAnnAssign::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_ann_assign::FormatStmtAnnAssign)
     }
 }
 
@@ -493,7 +445,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtFor {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::statement::stmt_for::FormatStmtFor::default())
+        FormatRefWithRule::new(self, crate::statement::stmt_for::FormatStmtFor)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtFor {
@@ -503,7 +455,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtFor {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::statement::stmt_for::FormatStmtFor::default())
+        FormatOwnedWithRule::new(self, crate::statement::stmt_for::FormatStmtFor)
     }
 }
 
@@ -527,10 +479,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtAsyncFor {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_async_for::FormatStmtAsyncFor::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_async_for::FormatStmtAsyncFor)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtAsyncFor {
@@ -540,10 +489,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtAsyncFor {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_async_for::FormatStmtAsyncFor::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_async_for::FormatStmtAsyncFor)
     }
 }
 
@@ -567,10 +513,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtWhile {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_while::FormatStmtWhile::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_while::FormatStmtWhile)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtWhile {
@@ -580,10 +523,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtWhile {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_while::FormatStmtWhile::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_while::FormatStmtWhile)
     }
 }
 
@@ -601,7 +541,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtIf {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::statement::stmt_if::FormatStmtIf::default())
+        FormatRefWithRule::new(self, crate::statement::stmt_if::FormatStmtIf)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtIf {
@@ -611,7 +551,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtIf {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::statement::stmt_if::FormatStmtIf::default())
+        FormatOwnedWithRule::new(self, crate::statement::stmt_if::FormatStmtIf)
     }
 }
 
@@ -635,7 +575,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtWith {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::statement::stmt_with::FormatStmtWith::default())
+        FormatRefWithRule::new(self, crate::statement::stmt_with::FormatStmtWith)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtWith {
@@ -645,7 +585,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtWith {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::statement::stmt_with::FormatStmtWith::default())
+        FormatOwnedWithRule::new(self, crate::statement::stmt_with::FormatStmtWith)
     }
 }
 
@@ -669,10 +609,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtAsyncWith {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_async_with::FormatStmtAsyncWith::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_async_with::FormatStmtAsyncWith)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtAsyncWith {
@@ -682,10 +619,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtAsyncWith {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_async_with::FormatStmtAsyncWith::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_async_with::FormatStmtAsyncWith)
     }
 }
 
@@ -709,10 +643,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtMatch {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_match::FormatStmtMatch::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_match::FormatStmtMatch)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtMatch {
@@ -722,10 +653,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtMatch {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_match::FormatStmtMatch::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_match::FormatStmtMatch)
     }
 }
 
@@ -749,10 +677,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtRaise {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_raise::FormatStmtRaise::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_raise::FormatStmtRaise)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtRaise {
@@ -762,10 +687,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtRaise {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_raise::FormatStmtRaise::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_raise::FormatStmtRaise)
     }
 }
 
@@ -783,7 +705,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtTry {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::statement::stmt_try::FormatStmtTry::default())
+        FormatRefWithRule::new(self, crate::statement::stmt_try::FormatStmtTry)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtTry {
@@ -793,7 +715,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtTry {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::statement::stmt_try::FormatStmtTry::default())
+        FormatOwnedWithRule::new(self, crate::statement::stmt_try::FormatStmtTry)
     }
 }
 
@@ -817,10 +739,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtTryStar {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_try_star::FormatStmtTryStar::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_try_star::FormatStmtTryStar)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtTryStar {
@@ -830,10 +749,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtTryStar {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_try_star::FormatStmtTryStar::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_try_star::FormatStmtTryStar)
     }
 }
 
@@ -857,10 +773,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtAssert {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_assert::FormatStmtAssert::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_assert::FormatStmtAssert)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtAssert {
@@ -870,10 +783,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtAssert {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_assert::FormatStmtAssert::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_assert::FormatStmtAssert)
     }
 }
 
@@ -897,10 +807,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtImport {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_import::FormatStmtImport::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_import::FormatStmtImport)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtImport {
@@ -910,10 +817,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtImport {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_import::FormatStmtImport::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_import::FormatStmtImport)
     }
 }
 
@@ -939,7 +843,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtImportFrom {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::statement::stmt_import_from::FormatStmtImportFrom::default(),
+            crate::statement::stmt_import_from::FormatStmtImportFrom,
         )
     }
 }
@@ -952,7 +856,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtImportFrom {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::statement::stmt_import_from::FormatStmtImportFrom::default(),
+            crate::statement::stmt_import_from::FormatStmtImportFrom,
         )
     }
 }
@@ -977,10 +881,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtGlobal {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_global::FormatStmtGlobal::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_global::FormatStmtGlobal)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtGlobal {
@@ -990,10 +891,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtGlobal {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_global::FormatStmtGlobal::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_global::FormatStmtGlobal)
     }
 }
 
@@ -1017,10 +915,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtNonlocal {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_nonlocal::FormatStmtNonlocal::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_nonlocal::FormatStmtNonlocal)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtNonlocal {
@@ -1030,10 +925,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtNonlocal {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_nonlocal::FormatStmtNonlocal::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_nonlocal::FormatStmtNonlocal)
     }
 }
 
@@ -1057,7 +949,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtExpr {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::statement::stmt_expr::FormatStmtExpr::default())
+        FormatRefWithRule::new(self, crate::statement::stmt_expr::FormatStmtExpr)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtExpr {
@@ -1067,7 +959,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtExpr {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::statement::stmt_expr::FormatStmtExpr::default())
+        FormatOwnedWithRule::new(self, crate::statement::stmt_expr::FormatStmtExpr)
     }
 }
 
@@ -1091,7 +983,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtPass {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::statement::stmt_pass::FormatStmtPass::default())
+        FormatRefWithRule::new(self, crate::statement::stmt_pass::FormatStmtPass)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtPass {
@@ -1101,7 +993,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtPass {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::statement::stmt_pass::FormatStmtPass::default())
+        FormatOwnedWithRule::new(self, crate::statement::stmt_pass::FormatStmtPass)
     }
 }
 
@@ -1125,10 +1017,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtBreak {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_break::FormatStmtBreak::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_break::FormatStmtBreak)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtBreak {
@@ -1138,10 +1027,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtBreak {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_break::FormatStmtBreak::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_break::FormatStmtBreak)
     }
 }
 
@@ -1165,10 +1051,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StmtContinue {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::statement::stmt_continue::FormatStmtContinue::default(),
-        )
+        FormatRefWithRule::new(self, crate::statement::stmt_continue::FormatStmtContinue)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtContinue {
@@ -1178,10 +1061,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StmtContinue {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::statement::stmt_continue::FormatStmtContinue::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::statement::stmt_continue::FormatStmtContinue)
     }
 }
 
@@ -1247,7 +1127,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprNamedExpr {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::expression::expr_named_expr::FormatExprNamedExpr::default(),
+            crate::expression::expr_named_expr::FormatExprNamedExpr,
         )
     }
 }
@@ -1260,7 +1140,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprNamedExpr {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::expression::expr_named_expr::FormatExprNamedExpr::default(),
+            crate::expression::expr_named_expr::FormatExprNamedExpr,
         )
     }
 }
@@ -1325,10 +1205,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprUnaryOp {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_unary_op::FormatExprUnaryOp::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_unary_op::FormatExprUnaryOp)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprUnaryOp {
@@ -1338,10 +1215,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprUnaryOp {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_unary_op::FormatExprUnaryOp::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_unary_op::FormatExprUnaryOp)
     }
 }
 
@@ -1365,10 +1239,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprLambda {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_lambda::FormatExprLambda::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_lambda::FormatExprLambda)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprLambda {
@@ -1378,10 +1249,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprLambda {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_lambda::FormatExprLambda::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_lambda::FormatExprLambda)
     }
 }
 
@@ -1405,10 +1273,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprIfExp {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_if_exp::FormatExprIfExp::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_if_exp::FormatExprIfExp)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprIfExp {
@@ -1418,10 +1283,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprIfExp {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_if_exp::FormatExprIfExp::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_if_exp::FormatExprIfExp)
     }
 }
 
@@ -1445,10 +1307,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprDict {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_dict::FormatExprDict::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_dict::FormatExprDict)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprDict {
@@ -1458,10 +1317,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprDict {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_dict::FormatExprDict::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_dict::FormatExprDict)
     }
 }
 
@@ -1479,7 +1335,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprSet {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::expression::expr_set::FormatExprSet::default())
+        FormatRefWithRule::new(self, crate::expression::expr_set::FormatExprSet)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprSet {
@@ -1489,7 +1345,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprSet {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::expression::expr_set::FormatExprSet::default())
+        FormatOwnedWithRule::new(self, crate::expression::expr_set::FormatExprSet)
     }
 }
 
@@ -1513,10 +1369,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprListComp {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_list_comp::FormatExprListComp::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_list_comp::FormatExprListComp)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprListComp {
@@ -1526,10 +1379,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprListComp {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_list_comp::FormatExprListComp::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_list_comp::FormatExprListComp)
     }
 }
 
@@ -1553,10 +1403,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprSetComp {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_set_comp::FormatExprSetComp::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_set_comp::FormatExprSetComp)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprSetComp {
@@ -1566,10 +1413,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprSetComp {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_set_comp::FormatExprSetComp::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_set_comp::FormatExprSetComp)
     }
 }
 
@@ -1593,10 +1437,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprDictComp {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_dict_comp::FormatExprDictComp::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_dict_comp::FormatExprDictComp)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprDictComp {
@@ -1606,10 +1447,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprDictComp {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_dict_comp::FormatExprDictComp::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_dict_comp::FormatExprDictComp)
     }
 }
 
@@ -1635,7 +1473,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprGeneratorExp {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::expression::expr_generator_exp::FormatExprGeneratorExp::default(),
+            crate::expression::expr_generator_exp::FormatExprGeneratorExp,
         )
     }
 }
@@ -1648,7 +1486,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprGeneratorExp {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::expression::expr_generator_exp::FormatExprGeneratorExp::default(),
+            crate::expression::expr_generator_exp::FormatExprGeneratorExp,
         )
     }
 }
@@ -1673,10 +1511,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprAwait {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_await::FormatExprAwait::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_await::FormatExprAwait)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprAwait {
@@ -1686,10 +1521,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprAwait {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_await::FormatExprAwait::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_await::FormatExprAwait)
     }
 }
 
@@ -1713,10 +1545,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprYield {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_yield::FormatExprYield::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_yield::FormatExprYield)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprYield {
@@ -1726,10 +1555,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprYield {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_yield::FormatExprYield::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_yield::FormatExprYield)
     }
 }
 
@@ -1755,7 +1581,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprYieldFrom {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::expression::expr_yield_from::FormatExprYieldFrom::default(),
+            crate::expression::expr_yield_from::FormatExprYieldFrom,
         )
     }
 }
@@ -1768,7 +1594,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprYieldFrom {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::expression::expr_yield_from::FormatExprYieldFrom::default(),
+            crate::expression::expr_yield_from::FormatExprYieldFrom,
         )
     }
 }
@@ -1833,10 +1659,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprCall {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_call::FormatExprCall::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_call::FormatExprCall)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprCall {
@@ -1846,10 +1669,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprCall {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_call::FormatExprCall::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_call::FormatExprCall)
     }
 }
 
@@ -1875,7 +1695,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprFormattedValue {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::expression::expr_formatted_value::FormatExprFormattedValue::default(),
+            crate::expression::expr_formatted_value::FormatExprFormattedValue,
         )
     }
 }
@@ -1888,7 +1708,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprFormattedValue {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::expression::expr_formatted_value::FormatExprFormattedValue::default(),
+            crate::expression::expr_formatted_value::FormatExprFormattedValue,
         )
     }
 }
@@ -1915,7 +1735,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprJoinedStr {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::expression::expr_joined_str::FormatExprJoinedStr::default(),
+            crate::expression::expr_joined_str::FormatExprJoinedStr,
         )
     }
 }
@@ -1928,7 +1748,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprJoinedStr {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::expression::expr_joined_str::FormatExprJoinedStr::default(),
+            crate::expression::expr_joined_str::FormatExprJoinedStr,
         )
     }
 }
@@ -1993,10 +1813,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprAttribute {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_attribute::FormatExprAttribute::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_attribute::FormatExprAttribute)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprAttribute {
@@ -2006,10 +1823,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprAttribute {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_attribute::FormatExprAttribute::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_attribute::FormatExprAttribute)
     }
 }
 
@@ -2033,10 +1847,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprSubscript {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_subscript::FormatExprSubscript::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_subscript::FormatExprSubscript)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprSubscript {
@@ -2046,10 +1857,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprSubscript {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_subscript::FormatExprSubscript::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_subscript::FormatExprSubscript)
     }
 }
 
@@ -2073,10 +1881,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprStarred {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_starred::FormatExprStarred::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_starred::FormatExprStarred)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprStarred {
@@ -2086,10 +1891,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprStarred {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_starred::FormatExprStarred::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_starred::FormatExprStarred)
     }
 }
 
@@ -2113,10 +1915,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprName {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_name::FormatExprName::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_name::FormatExprName)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprName {
@@ -2126,10 +1925,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprName {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_name::FormatExprName::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_name::FormatExprName)
     }
 }
 
@@ -2153,10 +1949,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprList {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_list::FormatExprList::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_list::FormatExprList)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprList {
@@ -2166,10 +1959,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprList {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_list::FormatExprList::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_list::FormatExprList)
     }
 }
 
@@ -2233,10 +2023,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprSlice {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_slice::FormatExprSlice::default(),
-        )
+        FormatRefWithRule::new(self, crate::expression::expr_slice::FormatExprSlice)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprSlice {
@@ -2246,10 +2033,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprSlice {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_slice::FormatExprSlice::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::expression::expr_slice::FormatExprSlice)
     }
 }
 
@@ -2317,7 +2101,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::PatternMatchValue {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::pattern::pattern_match_value::FormatPatternMatchValue::default(),
+            crate::pattern::pattern_match_value::FormatPatternMatchValue,
         )
     }
 }
@@ -2330,7 +2114,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::PatternMatchValue {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::pattern::pattern_match_value::FormatPatternMatchValue::default(),
+            crate::pattern::pattern_match_value::FormatPatternMatchValue,
         )
     }
 }
@@ -2357,7 +2141,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::PatternMatchSingleton {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::pattern::pattern_match_singleton::FormatPatternMatchSingleton::default(),
+            crate::pattern::pattern_match_singleton::FormatPatternMatchSingleton,
         )
     }
 }
@@ -2370,7 +2154,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::PatternMatchSingleton {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::pattern::pattern_match_singleton::FormatPatternMatchSingleton::default(),
+            crate::pattern::pattern_match_singleton::FormatPatternMatchSingleton,
         )
     }
 }
@@ -2397,7 +2181,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::PatternMatchSequence {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::pattern::pattern_match_sequence::FormatPatternMatchSequence::default(),
+            crate::pattern::pattern_match_sequence::FormatPatternMatchSequence,
         )
     }
 }
@@ -2410,7 +2194,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::PatternMatchSequence {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::pattern::pattern_match_sequence::FormatPatternMatchSequence::default(),
+            crate::pattern::pattern_match_sequence::FormatPatternMatchSequence,
         )
     }
 }
@@ -2437,7 +2221,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::PatternMatchMapping {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::pattern::pattern_match_mapping::FormatPatternMatchMapping::default(),
+            crate::pattern::pattern_match_mapping::FormatPatternMatchMapping,
         )
     }
 }
@@ -2450,7 +2234,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::PatternMatchMapping {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::pattern::pattern_match_mapping::FormatPatternMatchMapping::default(),
+            crate::pattern::pattern_match_mapping::FormatPatternMatchMapping,
         )
     }
 }
@@ -2477,7 +2261,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::PatternMatchClass {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::pattern::pattern_match_class::FormatPatternMatchClass::default(),
+            crate::pattern::pattern_match_class::FormatPatternMatchClass,
         )
     }
 }
@@ -2490,7 +2274,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::PatternMatchClass {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::pattern::pattern_match_class::FormatPatternMatchClass::default(),
+            crate::pattern::pattern_match_class::FormatPatternMatchClass,
         )
     }
 }
@@ -2517,7 +2301,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::PatternMatchStar {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::pattern::pattern_match_star::FormatPatternMatchStar::default(),
+            crate::pattern::pattern_match_star::FormatPatternMatchStar,
         )
     }
 }
@@ -2530,7 +2314,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::PatternMatchStar {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::pattern::pattern_match_star::FormatPatternMatchStar::default(),
+            crate::pattern::pattern_match_star::FormatPatternMatchStar,
         )
     }
 }
@@ -2555,10 +2339,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::PatternMatchAs {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::pattern::pattern_match_as::FormatPatternMatchAs::default(),
-        )
+        FormatRefWithRule::new(self, crate::pattern::pattern_match_as::FormatPatternMatchAs)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::PatternMatchAs {
@@ -2568,10 +2349,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::PatternMatchAs {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::pattern::pattern_match_as::FormatPatternMatchAs::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::pattern::pattern_match_as::FormatPatternMatchAs)
     }
 }
 
@@ -2595,10 +2373,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::PatternMatchOr {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::pattern::pattern_match_or::FormatPatternMatchOr::default(),
-        )
+        FormatRefWithRule::new(self, crate::pattern::pattern_match_or::FormatPatternMatchOr)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::PatternMatchOr {
@@ -2608,10 +2383,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::PatternMatchOr {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::pattern::pattern_match_or::FormatPatternMatchOr::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::pattern::pattern_match_or::FormatPatternMatchOr)
     }
 }
 
@@ -2637,7 +2409,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::TypeIgnoreTypeIgnore {
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::other::type_ignore_type_ignore::FormatTypeIgnoreTypeIgnore::default(),
+            crate::other::type_ignore_type_ignore::FormatTypeIgnoreTypeIgnore,
         )
     }
 }
@@ -2650,7 +2422,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::TypeIgnoreTypeIgnore {
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::other::type_ignore_type_ignore::FormatTypeIgnoreTypeIgnore::default(),
+            crate::other::type_ignore_type_ignore::FormatTypeIgnoreTypeIgnore,
         )
     }
 }
@@ -2675,10 +2447,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::Comprehension {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::other::comprehension::FormatComprehension::default(),
-        )
+        FormatRefWithRule::new(self, crate::other::comprehension::FormatComprehension)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::Comprehension {
@@ -2688,10 +2457,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::Comprehension {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::other::comprehension::FormatComprehension::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::other::comprehension::FormatComprehension)
     }
 }
 
@@ -2713,7 +2479,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::Arguments {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::other::arguments::FormatArguments::default())
+        FormatRefWithRule::new(self, crate::other::arguments::FormatArguments)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::Arguments {
@@ -2723,7 +2489,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::Arguments {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::other::arguments::FormatArguments::default())
+        FormatOwnedWithRule::new(self, crate::other::arguments::FormatArguments)
     }
 }
 
@@ -2737,14 +2503,14 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::Arg {
     type Format<'a> =
         FormatRefWithRule<'a, ast::Arg, crate::other::arg::FormatArg, PyFormatContext<'ast>>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::other::arg::FormatArg::default())
+        FormatRefWithRule::new(self, crate::other::arg::FormatArg)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::Arg {
     type Format =
         FormatOwnedWithRule<ast::Arg, crate::other::arg::FormatArg, PyFormatContext<'ast>>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::other::arg::FormatArg::default())
+        FormatOwnedWithRule::new(self, crate::other::arg::FormatArg)
     }
 }
 
@@ -2768,10 +2534,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ArgWithDefault {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::other::arg_with_default::FormatArgWithDefault::default(),
-        )
+        FormatRefWithRule::new(self, crate::other::arg_with_default::FormatArgWithDefault)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ArgWithDefault {
@@ -2781,10 +2544,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ArgWithDefault {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::other::arg_with_default::FormatArgWithDefault::default(),
-        )
+        FormatOwnedWithRule::new(self, crate::other::arg_with_default::FormatArgWithDefault)
     }
 }
 
@@ -2802,7 +2562,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::Keyword {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::other::keyword::FormatKeyword::default())
+        FormatRefWithRule::new(self, crate::other::keyword::FormatKeyword)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::Keyword {
@@ -2812,7 +2572,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::Keyword {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::other::keyword::FormatKeyword::default())
+        FormatOwnedWithRule::new(self, crate::other::keyword::FormatKeyword)
     }
 }
 
@@ -2826,14 +2586,14 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::Alias {
     type Format<'a> =
         FormatRefWithRule<'a, ast::Alias, crate::other::alias::FormatAlias, PyFormatContext<'ast>>;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::other::alias::FormatAlias::default())
+        FormatRefWithRule::new(self, crate::other::alias::FormatAlias)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::Alias {
     type Format =
         FormatOwnedWithRule<ast::Alias, crate::other::alias::FormatAlias, PyFormatContext<'ast>>;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::other::alias::FormatAlias::default())
+        FormatOwnedWithRule::new(self, crate::other::alias::FormatAlias)
     }
 }
 
@@ -2855,7 +2615,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::WithItem {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::other::with_item::FormatWithItem::default())
+        FormatRefWithRule::new(self, crate::other::with_item::FormatWithItem)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::WithItem {
@@ -2865,7 +2625,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::WithItem {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::other::with_item::FormatWithItem::default())
+        FormatOwnedWithRule::new(self, crate::other::with_item::FormatWithItem)
     }
 }
 
@@ -2887,7 +2647,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::MatchCase {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::other::match_case::FormatMatchCase::default())
+        FormatRefWithRule::new(self, crate::other::match_case::FormatMatchCase)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::MatchCase {
@@ -2897,7 +2657,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::MatchCase {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::other::match_case::FormatMatchCase::default())
+        FormatOwnedWithRule::new(self, crate::other::match_case::FormatMatchCase)
     }
 }
 
@@ -2919,7 +2679,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::Decorator {
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::other::decorator::FormatDecorator::default())
+        FormatRefWithRule::new(self, crate::other::decorator::FormatDecorator)
     }
 }
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::Decorator {
@@ -2929,6 +2689,6 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::Decorator {
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::other::decorator::FormatDecorator::default())
+        FormatOwnedWithRule::new(self, crate::other::decorator::FormatDecorator)
     }
 }

--- a/crates/ruff_python_formatter/src/module/mod.rs
+++ b/crates/ruff_python_formatter/src/module/mod.rs
@@ -26,7 +26,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for Mod {
     type Format<'a> = FormatRefWithRule<'a, Mod, FormatMod, PyFormatContext<'ast>>;
 
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, FormatMod::default())
+        FormatRefWithRule::new(self, FormatMod)
     }
 }
 
@@ -34,6 +34,6 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for Mod {
     type Format = FormatOwnedWithRule<Mod, FormatMod, PyFormatContext<'ast>>;
 
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, FormatMod::default())
+        FormatOwnedWithRule::new(self, FormatMod)
     }
 }

--- a/crates/ruff_python_formatter/src/statement/mod.rs
+++ b/crates/ruff_python_formatter/src/statement/mod.rs
@@ -72,7 +72,7 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for Stmt {
     type Format<'a> = FormatRefWithRule<'a, Stmt, FormatStmt, PyFormatContext<'ast>>;
 
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, FormatStmt::default())
+        FormatRefWithRule::new(self, FormatStmt)
     }
 }
 
@@ -80,6 +80,6 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for Stmt {
     type Format = FormatOwnedWithRule<Stmt, FormatStmt, PyFormatContext<'ast>>;
 
     fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, FormatStmt::default())
+        FormatOwnedWithRule::new(self, FormatStmt)
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
@@ -124,7 +124,7 @@ impl<'def, 'ast> AsFormat<PyFormatContext<'ast>> for AnyFunctionDefinition<'def>
     > where Self: 'a;
 
     fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, FormatAnyFunctionDef::default())
+        FormatRefWithRule::new(self, FormatAnyFunctionDef)
     }
 }
 


### PR DESCRIPTION
## Summary

This is the result of running `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings` and fixing all violations. Just wanted to see if there were any interesting new checks on nightly :eyes: