### PR TITLE
Switch from jaccard index to similarity index

### DIFF
--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -249,11 +249,11 @@ It's possible to format an entire project:
 cargo run --bin ruff_dev -- format-dev --write my_project
 ```
 
-This will format all files that `ruff check` would lint and computes the
-[Jaccard index](https://en.wikipedia.org/wiki/Jaccard_index), a measure for how close the original
-and formatted versions are. The Jaccard index is 1 if there were no changes at all, while 0 means
-every line was changed. If you run this on a black formatted projects, this tells you how similar
-the ruff formatter is to black for the given project, with our goal being as close to 1 as possible.
+This will format all files that `ruff check` would lint and computes the similarity index, the
+fraction of changed lines. The similarity index is 1 if there were no changes at all, while 0 means
+we changed every single line. If you run this on a black formatted projects, this tells you how
+similar the ruff formatter is to black for the given project, with our goal being as close to 1 as
+possible.
 
 There are three common problems with the formatter: The second formatting pass looks different than
 the first (formatter instability or lack of idempotency), we print invalid syntax (e.g. missing


### PR DESCRIPTION
## Summary

The similarity index, the fraction of unchanged lines, is easier to understand than the jaccard index, the fraction between intersection and union.

## Test Plan

I ran this on django and git a 0.945 index, meaning 5.5% of lines are currently reformatted when compared to black
