### PR TITLE
Print files that are slow to format

### DIFF
--- a/crates/ruff_dev/src/format_dev.rs
+++ b/crates/ruff_dev/src/format_dev.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context};
 use clap::{CommandFactory, FromArgMatches};
 use ignore::DirEntry;
 use indicatif::ProgressBar;
-use log::{error, warn};
+
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use ruff::resolver::python_files_in_path;
 use ruff::settings::types::{FilePattern, FilePatternSet};
@@ -532,6 +532,7 @@ Formatted twice:
             CheckFileError::IoError(error) => {
                 writeln!(f, "Error reading {}: {}", file.display(), error)?;
             }
+            #[cfg(not(debug_assertions))]
             CheckFileError::Slow(duration) => {
                 writeln!(
                     f,
@@ -569,6 +570,7 @@ enum CheckFileError {
     Panic { message: String },
 
     /// Formatting a file took too long
+    #[cfg(not(debug_assertions))]
     Slow(Duration),
 }
 
@@ -581,8 +583,9 @@ impl CheckFileError {
             | CheckFileError::SyntaxErrorInOutput { .. }
             | CheckFileError::FormatError(_)
             | CheckFileError::PrintError(_)
-            | CheckFileError::Panic { .. }
-            | CheckFileError::Slow(_) => false,
+            | CheckFileError::Panic { .. } => false,
+            #[cfg(not(debug_assertions))]
+            CheckFileError::Slow(_) => false,
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR extends `cargo dev format` to print files that take "long" to format in release builds. I picked a rather random number of 50ms as long, we can fine tune this later. 

Why release mode only? It otherwise gets pretty noisy and debug performance isn't very meaningful. 

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Run it in release, it reported one file that takes 53ms
<!-- How was it tested? -->
