### PR TITLE
Format `ModExpression`

### DIFF
--- a/crates/ruff_python_formatter/src/module/mod_expression.rs
+++ b/crates/ruff_python_formatter/src/module/mod_expression.rs
@@ -1,5 +1,5 @@
-use crate::{not_yet_implemented, FormatNodeRule, PyFormatter};
-use ruff_formatter::{write, Buffer, FormatResult};
+use crate::{AsFormat, FormatNodeRule, PyFormatter};
+use ruff_formatter::{Format, FormatResult};
 use rustpython_parser::ast::ModExpression;
 
 #[derive(Default)]
@@ -7,6 +7,7 @@ pub struct FormatModExpression;
 
 impl FormatNodeRule<ModExpression> for FormatModExpression {
     fn fmt_fields(&self, item: &ModExpression, f: &mut PyFormatter) -> FormatResult<()> {
-        write!(f, [not_yet_implemented(item)])
+        let ModExpression { body, range: _ } = item;
+        body.format().fmt(f)
     }
 }


### PR DESCRIPTION
## Summary

We don't use `ModExpression` anywhere but it's part of the AST, removes one `not_implemented_yet` and is a trivial 2-liner, so i implemented formatting for `ModExpression`.

## Test Plan

None, this kind of node does not occur in file input. Otherwise all the tests for expressions