### PR TITLE
Use permalinks in ecosystem diff references

### DIFF
--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -84,7 +84,10 @@ class Repository(NamedTuple):
     def url_for(self: Self, commit_sha: str, path: str, lnum: int | None = None) -> str:
         """Return the GitHub URL for the given commit, path, and line number, if given."""
         # Default to main branch
-        url = f"https://github.com/{self.org}/{self.repo}/blob/{commit_sha}/{path}"
+        url = (
+            f"https://github.com/{self.org}/{self.repo}"
+            f"/blob/{commit_sha}/{path}"
+        )
         if lnum:
             url += f"#L{lnum}"
         return url

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -92,7 +92,7 @@ class Repository(NamedTuple):
     async def _get_commit(self: Self, checkout_dir: Path) -> str:
         """Return the commit sha for the repository in the checkout directory."""
         git_sha_process = await create_subprocess_exec(
-            *["git", "rev-parse", "head"],
+            *["git", "rev-parse", "HEAD"],
             cwd=str(checkout_dir),
             stdout=PIPE,
         )

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -82,7 +82,9 @@ class Repository(NamedTuple):
         yield await self._get_commit(checkout_dir)
 
     def url_for(self: Self, commit_sha: str, path: str, lnum: int | None = None) -> str:
-        """Return the GitHub URL for the given commit, path, and line number, if given."""
+        """
+        Return the GitHub URL for the given commit, path, and line number, if given.
+        """
         # Default to main branch
         url = (
             f"https://github.com/{self.org}/{self.repo}"

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -86,10 +86,7 @@ class Repository(NamedTuple):
         Return the GitHub URL for the given commit, path, and line number, if given.
         """
         # Default to main branch
-        url = (
-            f"https://github.com/{self.org}/{self.repo}"
-            f"/blob/{commit_sha}/{path}"
-        )
+        url = f"https://github.com/{self.org}/{self.repo}/blob/{commit_sha}/{path}"
         if lnum:
             url += f"#L{lnum}"
         return url

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -45,11 +45,11 @@ class Repository(NamedTuple):
         """Shallow clone this repository to a temporary directory."""
         if checkout_dir.exists():
             logger.debug(f"Reusing {self.org}:{self.repo}")
-            yield Path(checkout_dir)
+            yield await self._get_commit(checkout_dir)
             return
 
         logger.debug(f"Cloning {self.org}:{self.repo}")
-        git_command = [
+        git_clone_command = [
             "git",
             "clone",
             "--config",
@@ -60,38 +60,47 @@ class Repository(NamedTuple):
             "--no-tags",
         ]
         if self.ref:
-            git_command.extend(["--branch", self.ref])
+            git_clone_command.extend(["--branch", self.ref])
 
-        git_command.extend(
+        git_clone_command.extend(
             [
                 f"https://github.com/{self.org}/{self.repo}",
                 checkout_dir,
             ],
         )
 
-        process = await create_subprocess_exec(
-            *git_command,
+        git_clone_process = await create_subprocess_exec(
+            *git_clone_command,
             env={"GIT_TERMINAL_PROMPT": "0"},
         )
 
-        status_code = await process.wait()
+        status_code = await git_clone_process.wait()
 
         logger.debug(
             f"Finished cloning {self.org}/{self.repo} with status {status_code}",
         )
+        yield await self._get_commit(checkout_dir)
 
-        yield Path(checkout_dir)
-
-    def url_for(self: Self, path: str, lnum: int | None = None) -> str:
-        """Return the GitHub URL for the given path and line number, if given."""
+    def url_for(self: Self, commit_sha: str, path: str, lnum: int | None = None) -> str:
+        """Return the GitHub URL for the given commit, path, and line number, if given."""
         # Default to main branch
-        url = (
-            f"https://github.com/{self.org}/{self.repo}"
-            f"/blob/{self.ref or 'main'}/{path}"
-        )
+        url = f"https://github.com/{self.org}/{self.repo}" f"/blob/{commit_sha}/{path}"
         if lnum:
             url += f"#L{lnum}"
         return url
+
+    async def _get_commit(self: Self, checkout_dir: Path) -> str:
+        """Return the commit sha for the repository in the checkout directory."""
+        git_sha_process = await create_subprocess_exec(
+            *["git", "rev-parse", "head"],
+            cwd=str(checkout_dir),
+            stdout=PIPE,
+        )
+        git_sha_stdout, _ = await git_sha_process.communicate()
+        assert (
+            await git_sha_process.wait() == 0
+        ), f"Failed to retrieve commit sha at {checkout_dir}"
+        return git_sha_stdout.decode().strip()
 
 
 REPOSITORIES: list[Repository] = [
@@ -169,6 +178,7 @@ class Diff(NamedTuple):
 
     removed: set[str]
     added: set[str]
+    source_sha: str
 
     def __bool__(self: Self) -> bool:
         """Return true if this diff is non-empty."""
@@ -203,13 +213,13 @@ async def compare(
         assert ":" not in repo.org
         assert ":" not in repo.repo
         checkout_dir = Path(checkout_parent).joinpath(f"{repo.org}:{repo.repo}")
-        async with repo.clone(checkout_dir) as path:
+        async with repo.clone(checkout_dir) as checkout_sha:
             try:
                 async with asyncio.TaskGroup() as tg:
                     check1 = tg.create_task(
                         check(
                             ruff=ruff1,
-                            path=path,
+                            path=checkout_dir,
                             name=f"{repo.org}/{repo.repo}",
                             select=repo.select,
                             ignore=repo.ignore,
@@ -220,7 +230,7 @@ async def compare(
                     check2 = tg.create_task(
                         check(
                             ruff=ruff2,
-                            path=path,
+                            path=checkout_dir,
                             name=f"{repo.org}/{repo.repo}",
                             select=repo.select,
                             ignore=repo.ignore,
@@ -237,7 +247,7 @@ async def compare(
                 elif line.startswith("+ "):
                     added.add(line[2:])
 
-    return Diff(removed, added)
+    return Diff(removed, added, checkout_sha)
 
 
 def read_projects_jsonl(projects_jsonl: Path) -> dict[tuple[str, str], Repository]:
@@ -379,7 +389,7 @@ async def main(
                         continue
 
                     pre, inner, path, lnum, post = match.groups()
-                    url = repo.url_for(path, int(lnum))
+                    url = repo.url_for(diff.source_sha, path, int(lnum))
                     print(f"{pre} <a href='{url}'>{inner}</a> {post}")
                 print("</pre>")
 

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -84,7 +84,7 @@ class Repository(NamedTuple):
     def url_for(self: Self, commit_sha: str, path: str, lnum: int | None = None) -> str:
         """Return the GitHub URL for the given commit, path, and line number, if given."""
         # Default to main branch
-        url = f"https://github.com/{self.org}/{self.repo}" f"/blob/{commit_sha}/{path}"
+        url = f"https://github.com/{self.org}/{self.repo}/blob/{commit_sha}/{path}"
         if lnum:
             url += f"#L{lnum}"
         return url
@@ -93,7 +93,7 @@ class Repository(NamedTuple):
         """Return the commit sha for the repository in the checkout directory."""
         git_sha_process = await create_subprocess_exec(
             *["git", "rev-parse", "HEAD"],
-            cwd=str(checkout_dir),
+            cwd=checkout_dir,
             stdout=PIPE,
         )
         git_sha_stdout, _ = await git_sha_process.communicate()


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Closes https://github.com/astral-sh/ruff/issues/5702

cc @dhruvmanila as I see you assigned yourself to the issue

## Test Plan

<!-- How was it tested? -->

Ran locally e.g.

`<a href='https://github.com/zulip/zulip/blob/fcede324202ac5bc3de0691d2d6e168d0f18c120/zproject/prod_settings_template.py#L144'>zproject/prod_settings_template.py:144:26:</a>`

Should succeed in CI as well.
