### PR TITLE
Run release testing on PR, not push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
       sha:
         description: "Optionally, the full sha of the commit to be released"
         type: string
-  push:
+  pull_request:
     paths:
       # When we change pyproject.toml, we want to ensure that the maturin builds still work
       - pyproject.toml


### PR DESCRIPTION
## Summary

This job runs whenever I put up a PR to bump the version, which is really useful. But then it also runs again when I merge, and then _that_ job tends to get cancelled immediately, because I run the _actual_ release job, which triggers the cancel-concurrent-runs flow. (See, e.g., https://github.com/astral-sh/ruff/actions/runs/5534191373.)

I think it makes sense to run these on PR (when editing `pyproject.toml` and friends), but not again on merge.
