### PR TITLE
Extend PEP 604 rewrites to support some quoted annotations

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -2152,8 +2152,7 @@ where
                     Rule::FutureRewritableTypeAnnotation,
                     Rule::NonPEP604Annotation,
                 ]) {
-                    if let Some(operator) = typing::to_pep604_operator(value, slice, &self.semantic)
-                    {
+                    if let Some(operator) = typing::to_pep604_operator(value, &self.semantic) {
                         if self.enabled(Rule::FutureRewritableTypeAnnotation) {
                             if !self.is_stub
                                 && self.settings.target_version < PythonVersion::Py310

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -2152,7 +2152,8 @@ where
                     Rule::FutureRewritableTypeAnnotation,
                     Rule::NonPEP604Annotation,
                 ]) {
-                    if let Some(operator) = typing::to_pep604_operator(value, &self.semantic) {
+                    if let Some(operator) = typing::to_pep604_operator(value, slice, &self.semantic)
+                    {
                         if self.enabled(Rule::FutureRewritableTypeAnnotation) {
                             if !self.is_stub
                                 && self.settings.target_version < PythonVersion::Py310

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -1,6 +1,6 @@
 use itertools::Either::{Left, Right};
 use itertools::Itertools;
-use rustpython_parser::ast::{self, Expr, Ranged};
+use rustpython_parser::ast::{self, Constant, Expr, Ranged};
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -57,9 +57,30 @@ pub(crate) fn use_pep604_annotation(
     slice: &Expr,
     operator: Pep604Operator,
 ) {
+    // If the slice is a forward reference (e.g., `Optional["Foo"]`), it can only be rewritten
+    // if we're in a typing-only context.
+    //
+    // This, for example, is invalid, as Python will evaluate `"Foo" | None` at runtime in order to
+    // populate the function's `__annotations__`:
+    // ```python
+    // def f(x: "Foo" | None): ...
+    // ```
+    //
+    // This, however, is valid:
+    // ```python
+    // def f():
+    //     x: "Foo" | None
+    // ```
+    if quoted_annotation(slice) {
+        if checker.semantic().execution_context().is_runtime() {
+            return;
+        }
+    }
+
     // Avoid fixing forward references, or types not in an annotation.
     let fixable = checker.semantic().in_type_definition()
         && !checker.semantic().in_complex_string_type_definition();
+
     match operator {
         Pep604Operator::Optional => {
             let mut diagnostic = Diagnostic::new(NonPEP604Annotation, expr.range());
@@ -95,6 +116,18 @@ pub(crate) fn use_pep604_annotation(
             }
             checker.diagnostics.push(diagnostic);
         }
+    }
+}
+
+/// Returns `true` if any argument in the slice is a forward reference (i.e., a quoted annotation).
+fn quoted_annotation(slice: &Expr) -> bool {
+    match slice {
+        Expr::Constant(ast::ExprConstant {
+            value: Constant::Str(_),
+            ..
+        }) => true,
+        Expr::Tuple(ast::ExprTuple { elts, .. }) => elts.iter().any(quoted_annotation),
+        _ => false,
     }
 }
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP007.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP007.py.snap
@@ -276,4 +276,20 @@ UP007.py:60:8: UP007 [*] Use `X | Y` for type annotations
    60 |+    x: str | int
 61 61 |     x: Union["str", "int"]
 
+UP007.py:61:8: UP007 [*] Use `X | Y` for type annotations
+   |
+59 |     x = Union["str", "int"]
+60 |     x: Union[str, int]
+61 |     x: Union["str", "int"]
+   |        ^^^^^^^^^^^^^^^^^^^ UP007
+   |
+   = help: Convert to `X | Y`
+
+ℹ Suggested fix
+58 58 |     x = Union[str, int]
+59 59 |     x = Union["str", "int"]
+60 60 |     x: Union[str, int]
+61    |-    x: Union["str", "int"]
+   61 |+    x: "str" | "int"
+
 

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -122,29 +122,7 @@ pub enum Pep604Operator {
 }
 
 /// Return the PEP 604 operator variant to which the given subscript [`Expr`] corresponds, if any.
-pub fn to_pep604_operator(
-    value: &Expr,
-    slice: &Expr,
-    semantic: &SemanticModel,
-) -> Option<Pep604Operator> {
-    /// Returns `true` if any argument in the slice is a string.
-    fn any_arg_is_str(slice: &Expr) -> bool {
-        match slice {
-            Expr::Constant(ast::ExprConstant {
-                value: Constant::Str(_),
-                ..
-            }) => true,
-            Expr::Tuple(ast::ExprTuple { elts, .. }) => elts.iter().any(any_arg_is_str),
-            _ => false,
-        }
-    }
-
-    // If any of the _arguments_ are forward references, we can't use PEP 604.
-    // Ex) `Union["str", "int"]` can't be converted to `"str" | "int"`.
-    if any_arg_is_str(slice) {
-        return None;
-    }
-
+pub fn to_pep604_operator(value: &Expr, semantic: &SemanticModel) -> Option<Pep604Operator> {
     semantic
         .resolve_call_path(value)
         .as_ref()


### PR DESCRIPTION
## Summary

Python doesn't allow `"Foo" | None` if the annotation will be evaluated at runtime (see the comments in the PR, or the semantic model documentation for more on what this means and when it is true), but it _does_ allow it if the annotation is typing-only.

This, for example, is invalid, as Python will evaluate `"Foo" | None` at runtime in order to
populate the function's `__annotations__`:

```python
def f(x: "Foo" | None): ...
```

This, however, is valid:

```python
def f():
    x: "Foo" | None
```

As is this:

```python
from __future__ import annotations

def f(x: "Foo" | None): ...
```

Closes #5706.
