### PR TITLE
Formatter: Better f-string dummy

### DIFF
--- a/crates/ruff_python_formatter/src/expression/expr_joined_str.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_joined_str.rs
@@ -1,6 +1,6 @@
 use crate::context::PyFormatContext;
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
-use crate::{not_yet_implemented, FormatNodeRule, PyFormatter};
+use crate::{not_yet_implemented_custom_text, FormatNodeRule, PyFormatter};
 use ruff_formatter::{write, Buffer, FormatResult};
 use ruff_python_ast::node::AnyNodeRef;
 use rustpython_parser::ast::ExprJoinedStr;
@@ -9,8 +9,13 @@ use rustpython_parser::ast::ExprJoinedStr;
 pub struct FormatExprJoinedStr;
 
 impl FormatNodeRule<ExprJoinedStr> for FormatExprJoinedStr {
-    fn fmt_fields(&self, item: &ExprJoinedStr, f: &mut PyFormatter) -> FormatResult<()> {
-        write!(f, [not_yet_implemented(item)])
+    fn fmt_fields(&self, _item: &ExprJoinedStr, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(
+            f,
+            [not_yet_implemented_custom_text(
+                r#"f"NOT_YET_IMPLEMENTED_ExprJoinedStr""#
+            )]
+        )
     }
 }
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@miscellaneous__debug_visitor.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@miscellaneous__debug_visitor.py.snap
@@ -44,7 +44,7 @@ class DebugVisitor(Visitor[T]):
 ```diff
 --- Black
 +++ Ruff
-@@ -3,24 +3,24 @@
+@@ -3,24 +3,29 @@
      tree_depth: int = 0
  
      def visit_default(self, node: LN) -> Iterator[T]:
@@ -53,7 +53,7 @@ class DebugVisitor(Visitor[T]):
          if isinstance(node, Node):
              _type = type_repr(node.type)
 -            out(f'{indent}{_type}', fg='yellow')
-+            out(NOT_YET_IMPLEMENTED_ExprJoinedStr, fg="yellow")
++            out(f"NOT_YET_IMPLEMENTED_ExprJoinedStr", fg="yellow")
              self.tree_depth += 1
              for child in node.children:
 -                yield from self.visit(child)
@@ -61,18 +61,23 @@ class DebugVisitor(Visitor[T]):
  
              self.tree_depth -= 1
 -            out(f'{indent}/{_type}', fg='yellow', bold=False)
-+            out(NOT_YET_IMPLEMENTED_ExprJoinedStr, fg="yellow", bold=False)
++            out(f"NOT_YET_IMPLEMENTED_ExprJoinedStr", fg="yellow", bold=False)
          else:
              _type = token.tok_name.get(node.type, str(node.type))
 -            out(f'{indent}{_type}', fg='blue', nl=False)
-+            out(NOT_YET_IMPLEMENTED_ExprJoinedStr, fg="blue", nl=False)
++            out(f"NOT_YET_IMPLEMENTED_ExprJoinedStr", fg="blue", nl=False)
              if node.prefix:
                  # We don't have to handle prefixes for `Node` objects since
                  # that delegates to the first child anyway.
 -                out(f' {node.prefix!r}', fg='green', bold=False, nl=False)
 -            out(f' {node.value!r}', fg='blue', bold=False)
-+                out(NOT_YET_IMPLEMENTED_ExprJoinedStr, fg="green", bold=False, nl=False)
-+            out(NOT_YET_IMPLEMENTED_ExprJoinedStr, fg="blue", bold=False)
++                out(
++                    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
++                    fg="green",
++                    bold=False,
++                    nl=False,
++                )
++            out(f"NOT_YET_IMPLEMENTED_ExprJoinedStr", fg="blue", bold=False)
  
      @classmethod
      def show(cls, code: str) -> None:
@@ -89,21 +94,26 @@ class DebugVisitor(Visitor[T]):
         indent = " " * (2 * self.tree_depth)
         if isinstance(node, Node):
             _type = type_repr(node.type)
-            out(NOT_YET_IMPLEMENTED_ExprJoinedStr, fg="yellow")
+            out(f"NOT_YET_IMPLEMENTED_ExprJoinedStr", fg="yellow")
             self.tree_depth += 1
             for child in node.children:
                 NOT_YET_IMPLEMENTED_ExprYieldFrom
 
             self.tree_depth -= 1
-            out(NOT_YET_IMPLEMENTED_ExprJoinedStr, fg="yellow", bold=False)
+            out(f"NOT_YET_IMPLEMENTED_ExprJoinedStr", fg="yellow", bold=False)
         else:
             _type = token.tok_name.get(node.type, str(node.type))
-            out(NOT_YET_IMPLEMENTED_ExprJoinedStr, fg="blue", nl=False)
+            out(f"NOT_YET_IMPLEMENTED_ExprJoinedStr", fg="blue", nl=False)
             if node.prefix:
                 # We don't have to handle prefixes for `Node` objects since
                 # that delegates to the first child anyway.
-                out(NOT_YET_IMPLEMENTED_ExprJoinedStr, fg="green", bold=False, nl=False)
-            out(NOT_YET_IMPLEMENTED_ExprJoinedStr, fg="blue", bold=False)
+                out(
+                    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
+                    fg="green",
+                    bold=False,
+                    nl=False,
+                )
+            out(f"NOT_YET_IMPLEMENTED_ExprJoinedStr", fg="blue", bold=False)
 
     @classmethod
     def show(cls, code: str) -> None:

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@miscellaneous__docstring_preview_no_string_normalization.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@miscellaneous__docstring_preview_no_string_normalization.py.snap
@@ -27,7 +27,7 @@ def do_not_touch_this_prefix3():
  
  def do_not_touch_this_prefix2():
 -    FR'There was a bug where docstring prefixes would be normalized even with -S.'
-+    NOT_YET_IMPLEMENTED_ExprJoinedStr
++    f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  
  
  def do_not_touch_this_prefix3():
@@ -43,7 +43,7 @@ def do_not_touch_this_prefix():
 
 
 def do_not_touch_this_prefix2():
-    NOT_YET_IMPLEMENTED_ExprJoinedStr
+    f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 
 
 def do_not_touch_this_prefix3():

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@miscellaneous__long_strings_flag_disabled.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@miscellaneous__long_strings_flag_disabled.py.snap
@@ -309,10 +309,10 @@ long_unmergable_string_with_pragma = (
  )
  
 -fstring = f"f-strings definitely make things more {difficult} than they need to be for {{black}}. But boy they sure are handy. The problem is that some lines will need to have the 'f' whereas others do not. This {line}, for example, needs one."
-+fstring = NOT_YET_IMPLEMENTED_ExprJoinedStr
++fstring = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  
 -fstring_with_no_fexprs = f"Some regular string that needs to get split certainly but is NOT an fstring by any means whatsoever."
-+fstring_with_no_fexprs = NOT_YET_IMPLEMENTED_ExprJoinedStr
++fstring_with_no_fexprs = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  
  comment_string = "Long lines with inline comments should have their comments appended to the reformatted string's enclosing right parentheses."  # This comment gets thrown to the top.
  
@@ -366,7 +366,7 @@ long_unmergable_string_with_pragma = (
  
  
 -x = f"This is a {{really}} long string that needs to be split without a doubt (i.e. most definitely). In short, this {string} that can't possibly be {{expected}} to fit all together on one line. In {fact} it may even take up three or more lines... like four or five... but probably just four."
-+x = NOT_YET_IMPLEMENTED_ExprJoinedStr
++x = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  
  long_unmergable_string_with_pragma = (
      "This is a really long string that can't be merged because it has a likely pragma at the end"  # type: ignore
@@ -520,9 +520,9 @@ old_fmt_string3 = (
     )
 )
 
-fstring = NOT_YET_IMPLEMENTED_ExprJoinedStr
+fstring = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 
-fstring_with_no_fexprs = NOT_YET_IMPLEMENTED_ExprJoinedStr
+fstring_with_no_fexprs = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 
 comment_string = "Long lines with inline comments should have their comments appended to the reformatted string's enclosing right parentheses."  # This comment gets thrown to the top.
 
@@ -639,7 +639,7 @@ def foo():
     NOT_YET_IMPLEMENTED_ExprYield
 
 
-x = NOT_YET_IMPLEMENTED_ExprJoinedStr
+x = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 
 long_unmergable_string_with_pragma = (
     "This is a really long string that can't be merged because it has a likely pragma at the end"  # type: ignore

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@miscellaneous__string_quotes.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@miscellaneous__string_quotes.py.snap
@@ -77,10 +77,10 @@ f"\"{a}\"{'hello' * b}\"{c}\""
 -f"""This is a triple-quoted {f}-string"""
 -f'MOAR {" ".join([])}'
 -f"MOAR {' '.join([])}"
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  r"raw string ftw"
 -r"Date d\'expiration:(.*)"
 +r"Date d'expiration:(.*)"
@@ -89,7 +89,7 @@ f"\"{a}\"{'hello' * b}\"{c}\""
 -rf"{yay}"
 -"\nThe \"quick\"\nbrown fox\njumps over\nthe 'lazy' dog.\n"
 +r'Not-so-tricky "quote'
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 +"\n\
 +The \"quick\"\n\
 +brown fox\n\
@@ -107,10 +107,10 @@ f"\"{a}\"{'hello' * b}\"{c}\""
 -f"{{y * \" \"}} '{z}'"
 -f'\'{z}\' {y * " "}'
 -f"{y * x} '{z}'"
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  "'{z}' {y * \" \"}"
  "{y * x} '{z}'"
  
@@ -118,8 +118,8 @@ f"\"{a}\"{'hello' * b}\"{c}\""
  # expressions. xref: https://github.com/psf/black/issues/2348
 -f"\"{b}\"{' ' * (long-len(b)+1)}: \"{sts}\",\n"
 -f"\"{a}\"{'hello' * b}\"{c}\""
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 ```
 
 ## Ruff Output
@@ -142,15 +142,15 @@ f"\"{a}\"{'hello' * b}\"{c}\""
 """Here's a " """
 """Just a normal triple
 quote"""
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 r"raw string ftw"
 r"Date d'expiration:(.*)"
 r'Tricky "quote'
 r'Not-so-tricky "quote'
-NOT_YET_IMPLEMENTED_ExprJoinedStr
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 "\n\
 The \"quick\"\n\
 brown fox\n\
@@ -171,17 +171,17 @@ re.compile(r'[\\"]')
 '\\""'
 "\\''"
 "Lots of \\\\\\\\'quotes'"
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 "'{z}' {y * \" \"}"
 "{y * x} '{z}'"
 
 # We must bail out if changing the quotes would introduce backslashes in f-string
 # expressions. xref: https://github.com/psf/black/issues/2348
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 ```
 
 ## Black Output

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_generic.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_generic.py.snap
@@ -124,13 +124,13 @@ with match() as match:
  match = a
  with match() as match:
 -    match = f"{match}"
-+    match = NOT_YET_IMPLEMENTED_ExprJoinedStr
++    match = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  
  re.match()
  match = a
  with match() as match:
 -    match = f"{match}"
-+    match = NOT_YET_IMPLEMENTED_ExprJoinedStr
++    match = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  
  
  def get_grammars(target_versions: Set[TargetVersion]) -> List[Grammar]:
@@ -157,7 +157,7 @@ with match() as match:
      match = a
      with match() as match:
 -        match = f"{match}"
-+        match = NOT_YET_IMPLEMENTED_ExprJoinedStr
++        match = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  
      def test_patma_139(self):
          x = False
@@ -192,13 +192,13 @@ with match() as match:
  match = a
  with match() as match:
 -    match = f"{match}"
-+    match = NOT_YET_IMPLEMENTED_ExprJoinedStr
++    match = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  
  re.match()
  match = a
  with match() as match:
 -    match = f"{match}"
-+    match = NOT_YET_IMPLEMENTED_ExprJoinedStr
++    match = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 ```
 
 ## Ruff Output
@@ -207,12 +207,12 @@ with match() as match:
 re.match()
 match = a
 with match() as match:
-    match = NOT_YET_IMPLEMENTED_ExprJoinedStr
+    match = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 
 re.match()
 match = a
 with match() as match:
-    match = NOT_YET_IMPLEMENTED_ExprJoinedStr
+    match = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 
 
 def get_grammars(target_versions: Set[TargetVersion]) -> List[Grammar]:
@@ -245,7 +245,7 @@ def get_grammars(target_versions: Set[TargetVersion]) -> List[Grammar]:
     re.match()
     match = a
     with match() as match:
-        match = NOT_YET_IMPLEMENTED_ExprJoinedStr
+        match = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 
     def test_patma_139(self):
         x = False
@@ -297,12 +297,12 @@ def lib2to3_parse(src_txt: str, target_versions: Iterable[TargetVersion] = ()) -
 re.match()
 match = a
 with match() as match:
-    match = NOT_YET_IMPLEMENTED_ExprJoinedStr
+    match = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 
 re.match()
 match = a
 with match() as match:
-    match = NOT_YET_IMPLEMENTED_ExprJoinedStr
+    match = f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 ```
 
 ## Black Output

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__docstring_preview.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__docstring_preview.py.snap
@@ -71,7 +71,7 @@ def single_quote_docstring_over_line_limit2():
  
  def docstring_almost_at_line_limit_with_prefix():
 -    f"""long docstring................................................................"""
-+    NOT_YET_IMPLEMENTED_ExprJoinedStr
++    f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  
  
  def mulitline_docstring_almost_at_line_limit():
@@ -83,7 +83,7 @@ def single_quote_docstring_over_line_limit2():
 -
 -    ..................................................................................
 -    """
-+    NOT_YET_IMPLEMENTED_ExprJoinedStr
++    f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  
  
  def docstring_at_line_limit():
@@ -92,7 +92,7 @@ def single_quote_docstring_over_line_limit2():
  
  def docstring_at_line_limit_with_prefix():
 -    f"""long docstring..............................................................."""
-+    NOT_YET_IMPLEMENTED_ExprJoinedStr
++    f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  
  
  def multiline_docstring_at_line_limit():
@@ -103,7 +103,7 @@ def single_quote_docstring_over_line_limit2():
 -    f"""first line----------------------------------------------------------------------
 -
 -    second line----------------------------------------------------------------------"""
-+    NOT_YET_IMPLEMENTED_ExprJoinedStr
++    f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  
  
  def single_quote_docstring_over_line_limit():
@@ -118,7 +118,7 @@ def docstring_almost_at_line_limit():
 
 
 def docstring_almost_at_line_limit_with_prefix():
-    NOT_YET_IMPLEMENTED_ExprJoinedStr
+    f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 
 
 def mulitline_docstring_almost_at_line_limit():
@@ -129,7 +129,7 @@ def mulitline_docstring_almost_at_line_limit():
 
 
 def mulitline_docstring_almost_at_line_limit_with_prefix():
-    NOT_YET_IMPLEMENTED_ExprJoinedStr
+    f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 
 
 def docstring_at_line_limit():
@@ -137,7 +137,7 @@ def docstring_at_line_limit():
 
 
 def docstring_at_line_limit_with_prefix():
-    NOT_YET_IMPLEMENTED_ExprJoinedStr
+    f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 
 
 def multiline_docstring_at_line_limit():
@@ -147,7 +147,7 @@ def multiline_docstring_at_line_limit():
 
 
 def multiline_docstring_at_line_limit_with_prefix():
-    NOT_YET_IMPLEMENTED_ExprJoinedStr
+    f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 
 
 def single_quote_docstring_over_line_limit():

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__fmtonoff.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__fmtonoff.py.snap
@@ -207,7 +207,7 @@ d={'a':1,
 +from third_party import X, Y, Z
  # fmt: on
 -f"trigger 3.6 mode"
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  # Comment 1
  
  # Comment 2
@@ -407,7 +407,7 @@ from library import some_connection, some_decorator
 # fmt: off
 from third_party import X, Y, Z
 # fmt: on
-NOT_YET_IMPLEMENTED_ExprJoinedStr
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 # Comment 1
 
 # Comment 2

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__fstring.py.snap
@@ -35,31 +35,31 @@ but none started with prefix {parentdir_prefix}"
 -f'Hello \'{tricky + "example"}\''
 -f"Tried directories {str(rootdirs)} \
 -but none started with prefix {parentdir_prefix}"
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 ```
 
 ## Ruff Output
 
 ```py
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
-NOT_YET_IMPLEMENTED_ExprJoinedStr
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 ```
 
 ## Black Output

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__function.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__function.py.snap
@@ -113,7 +113,7 @@ def __await__(): return (yield)
  from library import some_connection, some_decorator
 -
 -f"trigger 3.6 mode"
-+NOT_YET_IMPLEMENTED_ExprJoinedStr
++f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
  
  
  def func_no_args():
@@ -188,7 +188,7 @@ import sys
 from third_party import X, Y, Z
 
 from library import some_connection, some_decorator
-NOT_YET_IMPLEMENTED_ExprJoinedStr
+f"NOT_YET_IMPLEMENTED_ExprJoinedStr"
 
 
 def func_no_args():

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__remove_newline_after_code_block_open.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__remove_newline_after_code_block_open.py.snap
@@ -125,18 +125,18 @@ with open("/path/to/file.txt", mode="r") as read_file:
  
  for i in range(5):
 -    print(f"{i}) The line above me should be removed!")
-+    print(NOT_YET_IMPLEMENTED_ExprJoinedStr)
++    print(f"NOT_YET_IMPLEMENTED_ExprJoinedStr")
  
  
  for i in range(5):
 -    print(f"{i}) The lines above me should be removed!")
-+    print(NOT_YET_IMPLEMENTED_ExprJoinedStr)
++    print(f"NOT_YET_IMPLEMENTED_ExprJoinedStr")
  
  
  for i in range(5):
      for j in range(7):
 -        print(f"{i}) The lines above me should be removed!")
-+        print(NOT_YET_IMPLEMENTED_ExprJoinedStr)
++        print(f"NOT_YET_IMPLEMENTED_ExprJoinedStr")
  
  
  if random.randint(0, 3) == 0:
@@ -174,16 +174,16 @@ class Foo:
 
 
 for i in range(5):
-    print(NOT_YET_IMPLEMENTED_ExprJoinedStr)
+    print(f"NOT_YET_IMPLEMENTED_ExprJoinedStr")
 
 
 for i in range(5):
-    print(NOT_YET_IMPLEMENTED_ExprJoinedStr)
+    print(f"NOT_YET_IMPLEMENTED_ExprJoinedStr")
 
 
 for i in range(5):
     for j in range(7):
-        print(NOT_YET_IMPLEMENTED_ExprJoinedStr)
+        print(f"NOT_YET_IMPLEMENTED_ExprJoinedStr")
 
 
 if random.randint(0, 3) == 0:

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__remove_parens.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__remove_parens.py.snap
@@ -74,7 +74,7 @@ def example8():
 -                data = (
 -                    f"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 -                ).encode()
-+                data = (NOT_YET_IMPLEMENTED_ExprJoinedStr).encode()
++                data = (f"NOT_YET_IMPLEMENTED_ExprJoinedStr").encode()
          except Exception as e:
              pass
  
@@ -151,7 +151,7 @@ async def show_status():
     while True:
         try:
             if report_host:
-                data = (NOT_YET_IMPLEMENTED_ExprJoinedStr).encode()
+                data = (f"NOT_YET_IMPLEMENTED_ExprJoinedStr").encode()
         except Exception as e:
             pass
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__string_prefixes.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__string_prefixes.py.snap
@@ -38,7 +38,7 @@ def docstring_multiline():
  name = "Łukasz"
 -(f"hello {name}", f"hello {name}")
 -(b"", b"")
-+(NOT_YET_IMPLEMENTED_ExprJoinedStr, NOT_YET_IMPLEMENTED_ExprJoinedStr)
++(f"NOT_YET_IMPLEMENTED_ExprJoinedStr", f"NOT_YET_IMPLEMENTED_ExprJoinedStr")
 +(b"NOT_YET_IMPLEMENTED_BYTE_STRING", b"NOT_YET_IMPLEMENTED_BYTE_STRING")
  ("", "")
  (r"", R"")
@@ -46,14 +46,14 @@ def docstring_multiline():
 -(rf"", rf"", Rf"", Rf"", rf"", rf"", Rf"", Rf"")
 -(rb"", rb"", Rb"", Rb"", rb"", rb"", Rb"", Rb"")
 +(
-+    NOT_YET_IMPLEMENTED_ExprJoinedStr,
-+    NOT_YET_IMPLEMENTED_ExprJoinedStr,
-+    NOT_YET_IMPLEMENTED_ExprJoinedStr,
-+    NOT_YET_IMPLEMENTED_ExprJoinedStr,
-+    NOT_YET_IMPLEMENTED_ExprJoinedStr,
-+    NOT_YET_IMPLEMENTED_ExprJoinedStr,
-+    NOT_YET_IMPLEMENTED_ExprJoinedStr,
-+    NOT_YET_IMPLEMENTED_ExprJoinedStr,
++    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
++    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
++    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
++    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
++    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
++    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
++    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
++    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
 +)
 +(
 +    b"NOT_YET_IMPLEMENTED_BYTE_STRING",
@@ -76,20 +76,20 @@ def docstring_multiline():
 #!/usr/bin/env python3
 
 name = "Łukasz"
-(NOT_YET_IMPLEMENTED_ExprJoinedStr, NOT_YET_IMPLEMENTED_ExprJoinedStr)
+(f"NOT_YET_IMPLEMENTED_ExprJoinedStr", f"NOT_YET_IMPLEMENTED_ExprJoinedStr")
 (b"NOT_YET_IMPLEMENTED_BYTE_STRING", b"NOT_YET_IMPLEMENTED_BYTE_STRING")
 ("", "")
 (r"", R"")
 
 (
-    NOT_YET_IMPLEMENTED_ExprJoinedStr,
-    NOT_YET_IMPLEMENTED_ExprJoinedStr,
-    NOT_YET_IMPLEMENTED_ExprJoinedStr,
-    NOT_YET_IMPLEMENTED_ExprJoinedStr,
-    NOT_YET_IMPLEMENTED_ExprJoinedStr,
-    NOT_YET_IMPLEMENTED_ExprJoinedStr,
-    NOT_YET_IMPLEMENTED_ExprJoinedStr,
-    NOT_YET_IMPLEMENTED_ExprJoinedStr,
+    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
+    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
+    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
+    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
+    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
+    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
+    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
+    f"NOT_YET_IMPLEMENTED_ExprJoinedStr",
 )
 (
     b"NOT_YET_IMPLEMENTED_BYTE_STRING",


### PR DESCRIPTION
## Summary

The previous dummy was causing instabilities since it turned a string into a variable.

E.g.
```python
            script_header_dict[
                "slurm_partition_line"
            ] = f"#SBATCH --partition {resources.queue_name}"
```
has an instability as
```python
-            script_header_dict["slurm_partition_line"] = (
-                NOT_YET_IMPLEMENTED_ExprJoinedStr
-            )
+            script_header_dict[
+                "slurm_partition_line"
+            ] = NOT_YET_IMPLEMENTED_ExprJoinedStr
```

## Test Plan

The instability is gone, otherwise it's still a dummy
