### PR TITLE
Fix `StmtAnnAssign` formatting by mirroring `StmtAssign`

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/ann_assign.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/ann_assign.py
@@ -1,3 +1,6 @@
-# Regression test: Don't forget the parentheses when breaking
+# Regression test: Don't forget the parentheses in the value when breaking
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: int = a + 1 * a
 
+# Regression test: Don't forget the parentheses in the annotation when breaking
+class DefaultRunner():
+    task_runner_cls: TaskRunnerProtocol | typing.Callable[[], typing.Any] = DefaultTaskRunner

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/ann_assign.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/ann_assign.py
@@ -1,5 +1,3 @@
-tree_depth += 1
+# Regression test: Don't forget the parentheses when breaking
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: int = a + 1 * a
 
-greeting += "This is very long, formal greeting for whomever is name here. Dear %s, it will break the line" % len(
-    name
-)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/ann_assign.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/ann_assign.py
@@ -1,6 +1,7 @@
 # Regression test: Don't forget the parentheses in the value when breaking
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: int = a + 1 * a
 
+
 # Regression test: Don't forget the parentheses in the annotation when breaking
-class DefaultRunner():
+class DefaultRunner:
     task_runner_cls: TaskRunnerProtocol | typing.Callable[[], typing.Any] = DefaultTaskRunner

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/aug_assign.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/aug_assign.py
@@ -1,0 +1,5 @@
+tree_depth += 1
+
+greeting += "This is very long, formal greeting for whomever is name here. Dear %s, it will break the line" % len(
+    name
+)

--- a/crates/ruff_python_formatter/src/statement/stmt_ann_assign.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_ann_assign.rs
@@ -20,7 +20,12 @@ impl FormatNodeRule<StmtAnnAssign> for FormatStmtAnnAssign {
 
         write!(
             f,
-            [target.format(), text(":"), space(), annotation.format()]
+            [
+                target.format(),
+                text(":"),
+                space(),
+                maybe_parenthesize_expression(annotation, item, Parenthesize::IfBreaks)
+            ]
         )?;
 
         if let Some(value) = value {

--- a/crates/ruff_python_formatter/src/statement/stmt_ann_assign.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_ann_assign.rs
@@ -1,3 +1,5 @@
+use crate::expression::maybe_parenthesize_expression;
+use crate::expression::parentheses::Parenthesize;
 use crate::prelude::*;
 use crate::FormatNodeRule;
 use ruff_formatter::write;
@@ -22,7 +24,15 @@ impl FormatNodeRule<StmtAnnAssign> for FormatStmtAnnAssign {
         )?;
 
         if let Some(value) = value {
-            write!(f, [space(), text("="), space(), value.format()])?;
+            write!(
+                f,
+                [
+                    space(),
+                    text("="),
+                    space(),
+                    maybe_parenthesize_expression(value, item, Parenthesize::IfBreaks)
+                ]
+            )?;
         }
 
         Ok(())

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__ann_assign.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__ann_assign.py.snap
@@ -4,17 +4,27 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/
 ---
 ## Input
 ```py
-# Regression test: Don't forget the parentheses when breaking
+# Regression test: Don't forget the parentheses in the value when breaking
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: int = a + 1 * a
 
+# Regression test: Don't forget the parentheses in the annotation when breaking
+class DefaultRunner():
+    task_runner_cls: TaskRunnerProtocol | typing.Callable[[], typing.Any] = DefaultTaskRunner
 ```
 
 ## Output
 ```py
-# Regression test: Don't forget the parentheses when breaking
+# Regression test: Don't forget the parentheses in the value when breaking
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: int = (
     a + 1 * a
 )
+
+
+# Regression test: Don't forget the parentheses in the annotation when breaking
+class DefaultRunner:
+    task_runner_cls: (
+        TaskRunnerProtocol | typing.Callable[[], typing.Any]
+    ) = DefaultTaskRunner
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__ann_assign.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__ann_assign.py.snap
@@ -7,6 +7,7 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/
 # Regression test: Don't forget the parentheses in the value when breaking
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: int = a + 1 * a
 
+
 # Regression test: Don't forget the parentheses in the annotation when breaking
 class DefaultRunner:
     task_runner_cls: TaskRunnerProtocol | typing.Callable[[], typing.Any] = DefaultTaskRunner

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__ann_assign.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__ann_assign.py.snap
@@ -8,7 +8,7 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: int = a + 1 * a
 
 # Regression test: Don't forget the parentheses in the annotation when breaking
-class DefaultRunner():
+class DefaultRunner:
     task_runner_cls: TaskRunnerProtocol | typing.Callable[[], typing.Any] = DefaultTaskRunner
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__ann_assign.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__ann_assign.py.snap
@@ -4,20 +4,16 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/
 ---
 ## Input
 ```py
-tree_depth += 1
+# Regression test: Don't forget the parentheses when breaking
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: int = a + 1 * a
 
-greeting += "This is very long, formal greeting for whomever is name here. Dear %s, it will break the line" % len(
-    name
-)
 ```
 
 ## Output
 ```py
-tree_depth += 1
-
-greeting += (
-    "This is very long, formal greeting for whomever is name here. Dear %s, it will break the line"
-    % len(name)
+# Regression test: Don't forget the parentheses when breaking
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: int = (
+    a + 1 * a
 )
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__aug_assign.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__aug_assign.py.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/aug_assign.py
+---
+## Input
+```py
+tree_depth += 1
+
+greeting += "This is very long, formal greeting for whomever is name here. Dear %s, it will break the line" % len(
+    name
+)
+```
+
+## Output
+```py
+tree_depth += 1
+
+greeting += (
+    "This is very long, formal greeting for whomever is name here. Dear %s, it will break the line"
+    % len(name)
+)
+```
+
+
+


### PR DESCRIPTION
## Summary

`StmtAnnAssign` would not insert parentheses when breaking the same way `StmtAssign` does, causing unstable formatting and likely some syntax errors.

## Test Plan

I added two regression tests, one for the value and one for the annotation.