### PR TITLE
Avoid checking `EXE001` and `EXE002` on WSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,6 +1899,7 @@ dependencies = [
  "typed-arena",
  "unicode-width",
  "unicode_names2",
+ "wsl",
 ]
 
 [[package]]
@@ -3344,6 +3345,12 @@ checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wsl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ syn = { version = "2.0.15" }
 test-case = { version = "3.0.0" }
 thiserror = { version = "1.0.43" }
 toml = { version = "0.7.2" }
+wsl = { version = "0.1.0" }
 
 # v1.0.1
 libcst = { git = "https://github.com/Instagram/LibCST.git", rev = "3cacca1a1029f05707e50703b49fe3dd860aa839", default-features = false }

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -78,6 +78,7 @@ toml = { workspace = true }
 typed-arena = { version = "2.0.2" }
 unicode-width = { version = "0.1.10" }
 unicode_names2 = { version = "0.6.0", git = "https://github.com/youknowone/unicode_names2.git", rev = "4ce16aa85cbcdd9cc830410f1a72ef9a235f2fde" }
+wsl = { version = "0.1.0" }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
@@ -2,6 +2,8 @@
 
 use std::path::Path;
 
+use wsl;
+
 use ruff_text_size::TextRange;
 
 use ruff_diagnostics::{Diagnostic, Violation};
@@ -42,6 +44,9 @@ impl Violation for ShebangMissingExecutableFile {
 /// EXE002
 #[cfg(target_family = "unix")]
 pub(crate) fn shebang_missing(filepath: &Path) -> Option<Diagnostic> {
+    if wsl::is_wsl() {
+        return None;
+    }
     if let Ok(true) = is_executable(filepath) {
         let diagnostic = Diagnostic::new(ShebangMissingExecutableFile, TextRange::default());
         return Some(diagnostic);

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
@@ -44,6 +44,8 @@ impl Violation for ShebangMissingExecutableFile {
 /// EXE002
 #[cfg(target_family = "unix")]
 pub(crate) fn shebang_missing(filepath: &Path) -> Option<Diagnostic> {
+    // WSL supports Windows file systems, which do not have executable bits.
+    // Instead, everything is executable. Therefore, we skip this rule on WSL.
     if wsl::is_wsl() {
         return None;
     }

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -2,6 +2,8 @@
 
 use std::path::Path;
 
+use wsl;
+
 use ruff_text_size::{TextLen, TextRange, TextSize};
 
 use ruff_diagnostics::{Diagnostic, Violation};
@@ -48,6 +50,9 @@ pub(crate) fn shebang_not_executable(
     range: TextRange,
     shebang: &ShebangDirective,
 ) -> Option<Diagnostic> {
+    if wsl::is_wsl() {
+        return None;
+    }
     let ShebangDirective { offset, contents } = shebang;
 
     if let Ok(false) = is_executable(filepath) {

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -50,6 +50,8 @@ pub(crate) fn shebang_not_executable(
     range: TextRange,
     shebang: &ShebangDirective,
 ) -> Option<Diagnostic> {
+    // WSL supports Windows file systems, which do not have executable bits.
+    // Instead, everything is executable. Therefore, we skip this rule on WSL.
     if wsl::is_wsl() {
         return None;
     }


### PR DESCRIPTION
## Summary

Do not raise `EXE001` and `EXE002` if WSL is detected. Uses the [`wsl`](https://crates.io/crates/wsl) crate.

Closes #5445.

## Test Plan

`cargo test`

I don't use Windows, so was unable to test on a WSL environment. It would be good if someone who runs Windows could check the functionality.
