### PR TITLE
Cover Black's `is_aritmetic_like` formatting

### DIFF
--- a/crates/ruff_python_formatter/src/context.rs
+++ b/crates/ruff_python_formatter/src/context.rs
@@ -84,3 +84,13 @@ pub(crate) enum NodeLevel {
     /// Formatting nodes that are enclosed by a parenthesized (any `[]`, `{}` or `()`) expression.
     ParenthesizedExpression,
 }
+
+impl NodeLevel {
+    /// Returns `true` if the expression is in a parenthesized context.
+    pub(crate) const fn is_parenthesized(self) -> bool {
+        matches!(
+            self,
+            NodeLevel::Expression(Some(_)) | NodeLevel::ParenthesizedExpression
+        )
+    }
+}

--- a/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
@@ -1,6 +1,8 @@
 use crate::comments::{trailing_comments, trailing_node_comments};
 use crate::expression::parentheses::{
-    in_parentheses_only_group, is_expression_parenthesized, NeedsParentheses, OptionalParentheses,
+    in_parentheses_only_group, in_parentheses_only_soft_line_break,
+    in_parentheses_only_soft_line_break_or_space, is_expression_parenthesized, NeedsParentheses,
+    OptionalParentheses,
 };
 use crate::expression::Parentheses;
 use crate::prelude::*;
@@ -64,9 +66,9 @@ impl FormatNodeRule<ExprBinOp> for FormatExprBinOp {
                 let needs_space = !is_simple_power_expression(current);
 
                 let before_operator_space = if needs_space {
-                    soft_line_break_or_space()
+                    in_parentheses_only_soft_line_break_or_space()
                 } else {
-                    soft_line_break()
+                    in_parentheses_only_soft_line_break()
                 };
 
                 write!(

--- a/crates/ruff_python_formatter/src/expression/expr_bool_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bool_op.rs
@@ -1,6 +1,7 @@
 use crate::comments::leading_comments;
 use crate::expression::parentheses::{
-    in_parentheses_only_group, NeedsParentheses, OptionalParentheses, Parentheses,
+    in_parentheses_only_group, in_parentheses_only_soft_line_break_or_space, NeedsParentheses,
+    OptionalParentheses, Parentheses,
 };
 use crate::prelude::*;
 use ruff_formatter::{write, FormatOwnedWithRule, FormatRefWithRule, FormatRuleWithOptions};
@@ -42,7 +43,7 @@ impl FormatNodeRule<ExprBoolOp> for FormatExprBoolOp {
                 let leading_value_comments = comments.leading_comments(value);
                 // Format the expressions leading comments **before** the operator
                 if leading_value_comments.is_empty() {
-                    write!(f, [soft_line_break_or_space()])?;
+                    write!(f, [in_parentheses_only_soft_line_break_or_space()])?;
                 } else {
                     write!(
                         f,

--- a/crates/ruff_python_formatter/src/expression/expr_compare.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_compare.rs
@@ -1,6 +1,7 @@
 use crate::comments::leading_comments;
 use crate::expression::parentheses::{
-    in_parentheses_only_group, NeedsParentheses, OptionalParentheses, Parentheses,
+    in_parentheses_only_group, in_parentheses_only_soft_line_break_or_space, NeedsParentheses,
+    OptionalParentheses, Parentheses,
 };
 use crate::prelude::*;
 use crate::FormatNodeRule;
@@ -41,7 +42,7 @@ impl FormatNodeRule<ExprCompare> for FormatExprCompare {
             for (operator, comparator) in ops.iter().zip(comparators) {
                 let leading_comparator_comments = comments.leading_comments(comparator);
                 if leading_comparator_comments.is_empty() {
-                    write!(f, [soft_line_break_or_space()])?;
+                    write!(f, [in_parentheses_only_soft_line_break_or_space()])?;
                 } else {
                     // Format the expressions leading comments **before** the operator
                     write!(

--- a/crates/ruff_python_formatter/src/expression/expr_if_exp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_if_exp.rs
@@ -1,6 +1,7 @@
 use crate::comments::leading_comments;
 use crate::expression::parentheses::{
-    in_parentheses_only_group, NeedsParentheses, OptionalParentheses,
+    in_parentheses_only_group, in_parentheses_only_soft_line_break_or_space, NeedsParentheses,
+    OptionalParentheses,
 };
 use crate::prelude::*;
 use crate::FormatNodeRule;
@@ -28,12 +29,12 @@ impl FormatNodeRule<ExprIfExp> for FormatExprIfExp {
             f,
             [in_parentheses_only_group(&format_args![
                 body.format(),
-                soft_line_break_or_space(),
+                in_parentheses_only_soft_line_break_or_space(),
                 leading_comments(comments.leading_comments(test.as_ref())),
                 text("if"),
                 space(),
                 test.format(),
-                soft_line_break_or_space(),
+                in_parentheses_only_soft_line_break_or_space(),
                 leading_comments(comments.leading_comments(orelse.as_ref())),
                 text("else"),
                 space(),

--- a/crates/ruff_python_formatter/src/expression/expr_subscript.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_subscript.rs
@@ -7,9 +7,7 @@ use crate::comments::trailing_comments;
 use crate::context::NodeLevel;
 use crate::context::PyFormatContext;
 use crate::expression::expr_tuple::TupleParentheses;
-use crate::expression::parentheses::{
-    in_parentheses_only_group, NeedsParentheses, OptionalParentheses,
-};
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 use crate::FormatNodeRule;
 
@@ -64,7 +62,7 @@ impl FormatNodeRule<ExprSubscript> for FormatExprSubscript {
 
         write!(
             f,
-            [in_parentheses_only_group(&format_args![
+            [group(&format_args![
                 text("["),
                 trailing_comments(dangling_comments),
                 soft_block_indent(&format_slice),

--- a/crates/ruff_python_formatter/src/expression/string.rs
+++ b/crates/ruff_python_formatter/src/expression/string.rs
@@ -10,7 +10,9 @@ use ruff_formatter::{format_args, write, FormatError};
 use ruff_python_ast::str::is_implicit_concatenation;
 
 use crate::comments::{leading_comments, trailing_comments};
-use crate::expression::parentheses::in_parentheses_only_group;
+use crate::expression::parentheses::{
+    in_parentheses_only_group, in_parentheses_only_soft_line_break_or_space,
+};
 use crate::prelude::*;
 use crate::QuoteStyle;
 
@@ -64,7 +66,7 @@ impl Format<PyFormatContext<'_>> for FormatStringContinuation<'_> {
         // because this is a black preview style.
         let lexer = lex_starts_at(string_content, Mode::Expression, string_range.start());
 
-        let mut joiner = f.join_with(soft_line_break_or_space());
+        let mut joiner = f.join_with(in_parentheses_only_soft_line_break_or_space());
 
         for token in lexer {
             let (token, token_range) = match token {

--- a/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
@@ -1,9 +1,9 @@
 use crate::comments::trailing_comments;
 
-use crate::expression::parentheses::Parentheses;
+use crate::expression::parentheses::{parenthesized, Parentheses};
 use crate::prelude::*;
 use crate::trivia::{SimpleTokenizer, TokenKind};
-use ruff_formatter::{format_args, write};
+use ruff_formatter::write;
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{Ranged, StmtClassDef};
 
@@ -32,16 +32,14 @@ impl FormatNodeRule<StmtClassDef> for FormatStmtClassDef {
         write!(f, [text("class"), space(), name.format()])?;
 
         if !(bases.is_empty() && keywords.is_empty()) {
-            write!(
-                f,
-                [group(&format_args![
-                    text("("),
-                    soft_block_indent(&FormatInheritanceClause {
-                        class_definition: item
-                    }),
-                    text(")")
-                ])]
-            )?;
+            parenthesized(
+                "(",
+                &FormatInheritanceClause {
+                    class_definition: item,
+                },
+                ")",
+            )
+            .fmt(f)?;
         }
 
         let comments = f.context().comments().clone();

--- a/crates/ruff_python_formatter/src/statement/stmt_expr.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_expr.rs
@@ -1,4 +1,5 @@
-use rustpython_parser::ast::StmtExpr;
+use rustpython_parser::ast;
+use rustpython_parser::ast::{Expr, Operator, StmtExpr};
 
 use crate::expression::maybe_parenthesize_expression;
 use crate::expression::parentheses::Parenthesize;
@@ -12,6 +13,25 @@ impl FormatNodeRule<StmtExpr> for FormatStmtExpr {
     fn fmt_fields(&self, item: &StmtExpr, f: &mut PyFormatter) -> FormatResult<()> {
         let StmtExpr { value, .. } = item;
 
-        maybe_parenthesize_expression(value, item, Parenthesize::Optional).fmt(f)
+        if is_arithmetic_like(value) {
+            maybe_parenthesize_expression(value, item, Parenthesize::Optional).fmt(f)
+        } else {
+            value.format().fmt(f)
+        }
     }
+}
+
+const fn is_arithmetic_like(expression: &Expr) -> bool {
+    matches!(
+        expression,
+        Expr::BinOp(ast::ExprBinOp {
+            op: Operator::BitOr
+                | Operator::BitXor
+                | Operator::LShift
+                | Operator::RShift
+                | Operator::Add
+                | Operator::Sub,
+            ..
+        })
+    )
 }

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__remove_await_parens.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__remove_await_parens.py.snap
@@ -114,8 +114,8 @@ async def main():
  # Check comments
  async def main():
 -    await asyncio.sleep(1)  # Hello
-+    (
-+        await # Hello
++    await (
++        # Hello
 +        asyncio.sleep(1)
 +    )
  
@@ -191,8 +191,8 @@ async def main():
 
 # Check comments
 async def main():
-    (
-        await # Hello
+    await (
+        # Hello
         asyncio.sleep(1)
     )
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__compare.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__compare.py.snap
@@ -93,22 +93,12 @@ a not in b
 
 a < b > c == d
 
-(
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    < bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    > ccccccccccccccccccccccccccccc
-    == ddddddddddddddddddddd
-)
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa < bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb > ccccccccccccccccccccccccccccc == ddddddddddddddddddddd
 
-(
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    < [
-        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
-        ff,
-    ]
-    < [ccccccccccccccccccccccccccccc, dddd]
-    < ddddddddddddddddddddddddddddddddddddddddddd
-)
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa < [
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    ff,
+] < [ccccccccccccccccccccccccccccc, dddd] < ddddddddddddddddddddddddddddddddddddddddddd
 
 return 1 == 2 and (
     name,

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -203,20 +203,7 @@ String \"\"\"
 
 "Let's" "start" "with" "a" "simple" "example"
 
-(
-    "Let's"
-    "start"
-    "with"
-    "a"
-    "simple"
-    "example"
-    "now repeat after me:"
-    "I am confident"
-    "I am confident"
-    "I am confident"
-    "I am confident"
-    "I am confident"
-)
+"Let's" "start" "with" "a" "simple" "example" "now repeat after me:" "I am confident" "I am confident" "I am confident" "I am confident" "I am confident"
 
 (
     "Let's"
@@ -364,20 +351,7 @@ String \"\"\"
 
 "Let's" 'start' 'with' 'a' 'simple' 'example'
 
-(
-    "Let's"
-    'start'
-    'with'
-    'a'
-    'simple'
-    'example'
-    'now repeat after me:'
-    'I am confident'
-    'I am confident'
-    'I am confident'
-    'I am confident'
-    'I am confident'
-)
+"Let's" 'start' 'with' 'a' 'simple' 'example' 'now repeat after me:' 'I am confident' 'I am confident' 'I am confident' 'I am confident' 'I am confident'
 
 (
     "Let's"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Black only wrapps some *arithmetic* like expressions in parentheses on the expression but keeps all other statements single lines. 

This PR implements this behavior by introducing new `in_parentheses_only_*` helpers for line breaks. We don't really need the
`in_parentheses_only_group` anymore but it is a nice optimisation that prevents that the Printer must measure if a group fits if it doesn't contain a single soft line break.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

You can see how `+` expressions continue to expand, while comparision expressions and strings remain flat. 

The similarity index for the django project remains unchanged.
