### PR TITLE
Fix the example for blank-line-before-class (D211)

### DIFF
--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -128,13 +128,13 @@ impl AlwaysAutofixableViolation for OneBlankLineAfterClass {
 /// ## Example
 /// ```python
 /// class PhotoMetadata:
+///
 ///     """Metadata about a photo."""
 /// ```
 ///
 /// Use instead:
 /// ```python
 /// class PhotoMetadata:
-///
 ///     """Metadata about a photo."""
 /// ```
 ///


### PR DESCRIPTION
The example for [D211](https://beta.ruff.rs/docs/rules/blank-line-before-class/) is currently identical to the example for [D203](https://beta.ruff.rs/docs/rules/one-blank-line-before-class/). It should be the opposite, with the incorrect case having a blank line before the class docstring and the correct case having no blank line.

