### PR TITLE
Ignore `Enum`-and-`str` subclasses for slots enforcement

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_slots/SLOT000.py
+++ b/crates/ruff/resources/test/fixtures/flake8_slots/SLOT000.py
@@ -4,3 +4,10 @@ class Bad(str):  # SLOT000
 
 class Good(str):  # Ok
     __slots__ = ["foo"]
+
+
+from enum import Enum
+
+
+class Fine(str, Enum):  # Ok
+    __slots__ = ["foo"]


### PR DESCRIPTION
## Summary

Matches the behavior of the upstream plugin.

Closes #5748.