### PR TITLE
Avoid removing raw strings in comparison fixes

### DIFF
--- a/crates/ruff/resources/test/fixtures/pycodestyle/E713.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/E713.py
@@ -36,3 +36,4 @@ if (True) == TrueElement or x == TrueElement:
 assert (not foo) in bar
 assert {"x": not foo} in bar
 assert [42, not foo] in bar
+assert not (re.search(r"^.:\\Users\\[^\\]*\\Downloads\\.*") is None)

--- a/crates/ruff/resources/test/fixtures/pycodestyle/E714.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/E714.py
@@ -36,3 +36,4 @@ if (True) == TrueElement or x == TrueElement:
 assert (not foo) in bar
 assert {"x": not foo} in bar
 assert [42, not foo] in bar
+assert not (re.search(r"^.:\\Users\\[^\\]*\\Downloads\\.*") is None)

--- a/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -276,7 +276,7 @@ pub(crate) fn literal_comparisons(
             .map(|(idx, op)| bad_ops.get(&idx).unwrap_or(op))
             .copied()
             .collect::<Vec<_>>();
-        let content = compare(left, &ops, comparators, checker.generator());
+        let content = compare(left, &ops, comparators, checker.locator);
         for diagnostic in &mut diagnostics {
             diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
                 content.to_string(),

--- a/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
@@ -100,12 +100,7 @@ pub(crate) fn not_tests(
                             let mut diagnostic = Diagnostic::new(NotInTest, operand.range());
                             if checker.patch(diagnostic.kind.rule()) {
                                 diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
-                                    compare(
-                                        left,
-                                        &[CmpOp::NotIn],
-                                        comparators,
-                                        checker.generator(),
-                                    ),
+                                    compare(left, &[CmpOp::NotIn], comparators, checker.locator),
                                     expr.range(),
                                 )));
                             }
@@ -117,12 +112,7 @@ pub(crate) fn not_tests(
                             let mut diagnostic = Diagnostic::new(NotIsTest, operand.range());
                             if checker.patch(diagnostic.kind.rule()) {
                                 diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
-                                    compare(
-                                        left,
-                                        &[CmpOp::IsNot],
-                                        comparators,
-                                        checker.generator(),
-                                    ),
+                                    compare(left, &[CmpOp::IsNot], comparators, checker.locator),
                                     expr.range(),
                                 )));
                             }

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E714_E714.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E714_E714.py.snap
@@ -39,4 +39,20 @@ E714.py:5:8: E714 [*] Test for object identity should be `is not`
 7 7 | 
 8 8 | #: Okay
 
+E714.py:39:13: E714 [*] Test for object identity should be `is not`
+   |
+37 | assert {"x": not foo} in bar
+38 | assert [42, not foo] in bar
+39 | assert not (re.search(r"^.:\\Users\\[^\\]*\\Downloads\\.*") is None)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E714
+   |
+   = help: Convert to `is not`
+
+ℹ Fix
+36 36 | assert (not foo) in bar
+37 37 | assert {"x": not foo} in bar
+38 38 | assert [42, not foo] in bar
+39    |-assert not (re.search(r"^.:\\Users\\[^\\]*\\Downloads\\.*") is None)
+   39 |+assert re.search(r"^.:\\Users\\[^\\]*\\Downloads\\.*") is not None
+
 


### PR DESCRIPTION
## Summary

Use `Locator`-based verbatim fix rather than a `Generator`-based fix, which loses trivia (and raw strings).

Closes https://github.com/astral-sh/ruff/issues/4130.
