### PR TITLE
Parenthesize with statements

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
@@ -40,9 +40,6 @@ with (a,):  # magic trailing comma
 with (a):  # should remove brackets
     ...
 
-# TODO: black doesn't wrap this, but maybe we want to anyway?
-# if we do want to wrap, do we prefer to wrap the entire WithItem or to let the
-# WithItem allow the `aa + bb` content expression to be wrapped
 with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as c:
     ...
 
@@ -52,3 +49,62 @@ with (name_2 for name_0 in name_4):
     pass
 with (a, *b):
     pass
+
+with (
+    # leading comment
+    a) as b: ...
+
+with (
+    # leading comment
+    a as b
+): ...
+
+
+with (a # trailing same line comment
+    # trailing own line comment
+    ) as b: ...
+
+with (
+    a # trailing same line comment
+    # trailing own line comment
+    as b
+): ...
+
+
+with (a # trailing same line comment
+    # trailing own line comment
+) as b: ...
+
+with (
+    (a
+    # trailing own line comment
+    )
+    as # trailing as same line comment
+    b # trailing b same line comment
+): ...
+
+with (
+    [
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "bbbbbbbbbb",
+        "cccccccccccccccccccccccccccccccccccccccccc",
+        dddddddddddddddddddddddddddddddd,
+    ] as example1,
+    aaaaaaaaaaaaaaaaaaaaaaaaaa
+    + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    + cccccccccccccccccccccccccccc
+    + ddddddddddddddddd as example2,
+    CtxManager2() as example2,
+    CtxManager2() as example2,
+    CtxManager2() as example2,
+):
+    ...
+
+
+with [
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "bbbbbbbbbb",
+    "cccccccccccccccccccccccccccccccccccccccccc",
+    dddddddddddddddddddddddddddddddd,
+] as example1, aaaaaaaaaaaaaaaaaaaaaaaaaa * bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb * cccccccccccccccccccccccccccc + ddddddddddddddddd as example2, CtxManager222222222222222() as example2:
+    ...

--- a/crates/ruff_python_formatter/src/builders.rs
+++ b/crates/ruff_python_formatter/src/builders.rs
@@ -228,9 +228,22 @@ impl<'fmt, 'ast, 'buf> JoinCommaSeparatedBuilder<'fmt, 'ast, 'buf> {
     where
         T: Ranged,
     {
+        self.entry_with_line_separator(node, content, soft_line_break_or_space())
+    }
+
+    pub(crate) fn entry_with_line_separator<N, Separator>(
+        &mut self,
+        node: &N,
+        content: &dyn Format<PyFormatContext<'ast>>,
+        separator: Separator,
+    ) -> &mut Self
+    where
+        N: Ranged,
+        Separator: Format<PyFormatContext<'ast>>,
+    {
         self.result = self.result.and_then(|_| {
             if self.end_of_last_entry.is_some() {
-                write!(self.fmt, [text(","), soft_line_break_or_space()])?;
+                write!(self.fmt, [text(","), separator])?;
             }
 
             self.end_of_last_entry = Some(node.end());

--- a/crates/ruff_python_formatter/src/expression/expr_await.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_await.rs
@@ -15,24 +15,27 @@ impl FormatNodeRule<ExprAwait> for FormatExprAwait {
     fn fmt_fields(&self, item: &ExprAwait, f: &mut PyFormatter) -> FormatResult<()> {
         let ExprAwait { range: _, value } = item;
 
-        let format_value = format_with(|f: &mut PyFormatter| {
-            if f.context().node_level().is_parenthesized() {
-                value.format().fmt(f)
-            } else {
-                maybe_parenthesize_expression(value, item, Parenthesize::Optional).fmt(f)
-            }
-        });
-
-        write!(f, [text("await"), space(), format_value])
+        write!(
+            f,
+            [
+                text("await"),
+                space(),
+                maybe_parenthesize_expression(value, item, Parenthesize::IfRequired)
+            ]
+        )
     }
 }
 
 impl NeedsParentheses for ExprAwait {
     fn needs_parentheses(
         &self,
-        _parent: AnyNodeRef,
+        parent: AnyNodeRef,
         _context: &PyFormatContext,
     ) -> OptionalParentheses {
-        OptionalParentheses::Multiline
+        if parent.is_expr_await() {
+            OptionalParentheses::Always
+        } else {
+            OptionalParentheses::Multiline
+        }
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
@@ -176,9 +176,13 @@ impl FormatRule<Operator, PyFormatContext<'_>> for FormatOperator {
 impl NeedsParentheses for ExprBinOp {
     fn needs_parentheses(
         &self,
-        _parent: AnyNodeRef,
+        parent: AnyNodeRef,
         _context: &PyFormatContext,
     ) -> OptionalParentheses {
-        OptionalParentheses::Multiline
+        if parent.is_expr_await() && !self.op.is_pow() {
+            OptionalParentheses::Always
+        } else {
+            OptionalParentheses::Multiline
+        }
     }
 }

--- a/crates/ruff_python_formatter/src/expression/parentheses.rs
+++ b/crates/ruff_python_formatter/src/expression/parentheses.rs
@@ -19,6 +19,12 @@ pub(crate) enum OptionalParentheses {
     Never,
 }
 
+impl OptionalParentheses {
+    pub(crate) const fn is_always(self) -> bool {
+        matches!(self, OptionalParentheses::Always)
+    }
+}
+
 pub(crate) trait NeedsParentheses {
     /// Determines if this object needs optional parentheses or if it is safe to omit the parentheses.
     fn needs_parentheses(
@@ -36,6 +42,17 @@ pub(crate) enum Parenthesize {
 
     /// Parenthesizes the expression only if it doesn't fit on a line.
     IfBreaks,
+
+    /// Only adds parentheses if absolutely necessary:
+    /// * The expression is not enclosed by another parenthesized expression and it expands over multiple lines
+    /// * The expression has leading or trailing comments. Adding parentheses is desired to prevent the comments from wandering.
+    IfRequired,
+}
+
+impl Parenthesize {
+    pub(crate) const fn is_optional(self) -> bool {
+        matches!(self, Parenthesize::Optional)
+    }
 }
 
 /// Whether it is necessary to add parentheses around an expression.

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -280,15 +280,30 @@ if True:
     #[test]
     fn quick_test() {
         let src = r#"
-if a * [
-    bbbbbbbbbbbbbbbbbbbbbb,
-    cccccccccccccccccccccccccccccdddddddddddddddddddddddddd,
-] + a * e * [
-    ffff,
-    gggg,
-    hhhhhhhhhhhhhh,
-] * c:
-    pass
+with (
+    [
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "bbbbbbbbbb",
+        "cccccccccccccccccccccccccccccccccccccccccc",
+        dddddddddddddddddddddddddddddddd,
+    ] as example1,
+    aaaaaaaaaaaaaaaaaaaaaaaaaa
+    + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    + cccccccccccccccccccccccccccc
+    + ddddddddddddddddd as example2,
+    CtxManager2() as example2,
+    CtxManager2() as example2,
+    CtxManager2() as example2,
+):
+    ...
+
+with [
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "bbbbbbbbbb",
+    "cccccccccccccccccccccccccccccccccccccccccc",
+    dddddddddddddddddddddddddddddddd,
+] as example1, aaaaaaaaaaaaaaaaaaaaaaaaaa * bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb * cccccccccccccccccccccccccccc + ddddddddddddddddd as example2, CtxManager222222222222222() as example2:
+    ...
 
 "#;
         // Tokenize once

--- a/crates/ruff_python_formatter/src/other/with_item.rs
+++ b/crates/ruff_python_formatter/src/other/with_item.rs
@@ -1,9 +1,12 @@
+use rustpython_parser::ast::WithItem;
+
+use ruff_formatter::{write, Buffer, FormatResult};
+
+use crate::comments::trailing_comments;
 use crate::expression::maybe_parenthesize_expression;
 use crate::expression::parentheses::Parenthesize;
 use crate::prelude::*;
 use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::{write, Buffer, FormatResult};
-use rustpython_parser::ast::WithItem;
 
 #[derive(Default)]
 pub struct FormatWithItem;
@@ -16,20 +19,27 @@ impl FormatNodeRule<WithItem> for FormatWithItem {
             optional_vars,
         } = item;
 
-        let inner = format_with(|f| {
+        let comments = f.context().comments().clone();
+        let trailing_as_comments = comments.dangling_comments(item);
+
+        maybe_parenthesize_expression(context_expr, item, Parenthesize::IfRequired).fmt(f)?;
+
+        if let Some(optional_vars) = optional_vars {
             write!(
                 f,
-                [maybe_parenthesize_expression(
-                    context_expr,
-                    item,
-                    Parenthesize::IfBreaks
-                )]
+                [
+                    space(),
+                    text("as"),
+                    trailing_comments(trailing_as_comments),
+                    space(),
+                    optional_vars.format(),
+                ]
             )?;
-            if let Some(optional_vars) = optional_vars {
-                write!(f, [space(), text("as"), space(), optional_vars.format()])?;
-            }
-            Ok(())
-        });
-        write!(f, [group(&inner)])
+        }
+        Ok(())
+    }
+
+    fn fmt_dangling_comments(&self, _node: &WithItem, _f: &mut PyFormatter) -> FormatResult<()> {
+        Ok(())
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_with.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_with.rs
@@ -1,11 +1,15 @@
-use ruff_formatter::{write, Buffer, FormatResult};
-use ruff_python_ast::node::AnyNodeRef;
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{Ranged, StmtAsyncWith, StmtWith, Suite, WithItem};
 
-use crate::builders::parenthesize_if_expands;
+use ruff_formatter::{format_args, write, FormatError};
+use ruff_python_ast::node::AnyNodeRef;
+
 use crate::comments::trailing_comments;
+use crate::expression::parentheses::{
+    in_parentheses_only_soft_line_break_or_space, optional_parentheses,
+};
 use crate::prelude::*;
+use crate::trivia::{SimpleTokenizer, TokenKind};
 use crate::FormatNodeRule;
 
 pub(super) enum AnyStatementWith<'a> {
@@ -68,27 +72,72 @@ impl Format<PyFormatContext<'_>> for AnyStatementWith<'_> {
         let comments = f.context().comments().clone();
         let dangling_comments = comments.dangling_comments(self);
 
-        let joined_items = format_with(|f| {
-            f.join_comma_separated(self.body().first().unwrap().start())
-                .nodes(self.items().iter())
-                .finish()
-        });
+        write!(
+            f,
+            [
+                self.is_async()
+                    .then_some(format_args![text("async"), space()]),
+                text("with"),
+                space()
+            ]
+        )?;
 
-        if self.is_async() {
-            write!(f, [text("async"), space()])?;
+        if are_with_items_parenthesized(self, f.context())? {
+            optional_parentheses(&format_with(|f| {
+                let mut joiner = f.join_comma_separated(self.body().first().unwrap().start());
+
+                for item in self.items() {
+                    joiner.entry_with_line_separator(
+                        item,
+                        &item.format(),
+                        in_parentheses_only_soft_line_break_or_space(),
+                    );
+                }
+                joiner.finish()
+            }))
+            .fmt(f)?;
+        } else {
+            f.join_with(format_args![text(","), space()])
+                .entries(self.items().iter().formatted())
+                .finish()?;
         }
 
         write!(
             f,
             [
-                text("with"),
-                space(),
-                group(&parenthesize_if_expands(&joined_items)),
                 text(":"),
                 trailing_comments(dangling_comments),
                 block_indent(&self.body().format())
             ]
         )
+    }
+}
+
+fn are_with_items_parenthesized(
+    with: &AnyStatementWith,
+    context: &PyFormatContext,
+) -> FormatResult<bool> {
+    let first_with_item = with.items().first().ok_or(FormatError::SyntaxError)?;
+    let before_first_with_item = TextRange::new(with.start(), first_with_item.start());
+
+    let mut tokenizer = SimpleTokenizer::new(context.source(), before_first_with_item)
+        .skip_trivia()
+        .skip_while(|t| t.kind() == TokenKind::Async);
+
+    let with_keyword = tokenizer.next().ok_or(FormatError::SyntaxError)?;
+
+    debug_assert_eq!(
+        with_keyword.kind(),
+        TokenKind::With,
+        "Expected with keyword but at {with_keyword:?}"
+    );
+
+    match tokenizer.next() {
+        Some(left_paren) => {
+            debug_assert_eq!(left_paren.kind(), TokenKind::LParen);
+            Ok(true)
+        }
+        None => Ok(false),
     }
 }
 

--- a/crates/ruff_python_formatter/src/trivia.rs
+++ b/crates/ruff_python_formatter/src/trivia.rs
@@ -193,8 +193,17 @@ pub(crate) enum TokenKind {
     /// `in`
     In,
 
+    /// `as`
+    As,
+
     /// `match`
     Match,
+
+    /// `with`
+    With,
+
+    /// `async`
+    Async,
 
     /// Any other non trivia token.
     Other,
@@ -272,10 +281,13 @@ impl<'a> SimpleTokenizer<'a> {
     fn to_keyword_or_other(&self, range: TextRange) -> TokenKind {
         let source = &self.source[range];
         match source {
-            "if" => TokenKind::If,
+            "as" => TokenKind::As,
+            "async" => TokenKind::Async,
             "else" => TokenKind::Else,
+            "if" => TokenKind::If,
             "in" => TokenKind::In,
             "match" => TokenKind::Match, // Match is a soft keyword that depends on the context but we can always lex it as a keyword and leave it to the caller (parser) to decide if it should be handled as an identifier or keyword.
+            "with" => TokenKind::With,
             // ...,
             _ => TokenKind::Other, // Potentially an identifier, but only if it isn't a string prefix. We can ignore this for now https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals
         }

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__remove_await_parens.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__remove_await_parens.py.snap
@@ -93,23 +93,7 @@ async def main():
 ```diff
 --- Black
 +++ Ruff
-@@ -8,28 +8,33 @@
- 
- # Remove brackets for short coroutine/task
- async def main():
--    await asyncio.sleep(1)
-+    await (asyncio.sleep(1))
- 
- 
- async def main():
--    await asyncio.sleep(1)
-+    await (asyncio.sleep(1))
- 
- 
- async def main():
--    await asyncio.sleep(1)
-+    await (asyncio.sleep(1))
- 
+@@ -21,7 +21,10 @@
  
  # Check comments
  async def main():
@@ -121,48 +105,21 @@ async def main():
  
  
  async def main():
--    await asyncio.sleep(1)  # Hello
-+    await (
-+        asyncio.sleep(1)  # Hello
-+    )
- 
- 
- async def main():
--    await asyncio.sleep(1)  # Hello
-+    await (asyncio.sleep(1))  # Hello
- 
- 
- # Long lines
-@@ -60,7 +65,7 @@
- 
- # Cr@zY Br@ck3Tz
- async def main():
--    await black(1)
-+    await (black(1))
- 
- 
- # Keep brackets around non power operations and nested awaits
-@@ -78,16 +83,16 @@
+@@ -78,7 +81,7 @@
  
  
  async def main():
 -    await (yield x)
-+    await (NOT_YET_IMPLEMENTED_ExprYield)
++    await NOT_YET_IMPLEMENTED_ExprYield
  
  
  async def main():
--    await (await asyncio.sleep(1))
-+    await (await (asyncio.sleep(1)))
- 
- 
- async def main():
--    await (await (await (await (await asyncio.sleep(1)))))
-+    await (await (await (await (await (asyncio.sleep(1))))))
+@@ -90,4 +93,4 @@
  
  
  async def main():
 -    await (yield)
-+    await (NOT_YET_IMPLEMENTED_ExprYield)
++    await NOT_YET_IMPLEMENTED_ExprYield
 ```
 
 ## Ruff Output
@@ -178,15 +135,15 @@ async def main():
 
 # Remove brackets for short coroutine/task
 async def main():
-    await (asyncio.sleep(1))
+    await asyncio.sleep(1)
 
 
 async def main():
-    await (asyncio.sleep(1))
+    await asyncio.sleep(1)
 
 
 async def main():
-    await (asyncio.sleep(1))
+    await asyncio.sleep(1)
 
 
 # Check comments
@@ -198,13 +155,11 @@ async def main():
 
 
 async def main():
-    await (
-        asyncio.sleep(1)  # Hello
-    )
+    await asyncio.sleep(1)  # Hello
 
 
 async def main():
-    await (asyncio.sleep(1))  # Hello
+    await asyncio.sleep(1)  # Hello
 
 
 # Long lines
@@ -235,7 +190,7 @@ async def main():
 
 # Cr@zY Br@ck3Tz
 async def main():
-    await (black(1))
+    await black(1)
 
 
 # Keep brackets around non power operations and nested awaits
@@ -253,19 +208,19 @@ async def main():
 
 
 async def main():
-    await (NOT_YET_IMPLEMENTED_ExprYield)
+    await NOT_YET_IMPLEMENTED_ExprYield
 
 
 async def main():
-    await (await (asyncio.sleep(1)))
+    await (await asyncio.sleep(1))
 
 
 async def main():
-    await (await (await (await (await (asyncio.sleep(1))))))
+    await (await (await (await (await asyncio.sleep(1)))))
 
 
 async def main():
-    await (NOT_YET_IMPLEMENTED_ExprYield)
+    await NOT_YET_IMPLEMENTED_ExprYield
 ```
 
 ## Black Output

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
@@ -46,9 +46,6 @@ with (a,):  # magic trailing comma
 with (a):  # should remove brackets
     ...
 
-# TODO: black doesn't wrap this, but maybe we want to anyway?
-# if we do want to wrap, do we prefer to wrap the entire WithItem or to let the
-# WithItem allow the `aa + bb` content expression to be wrapped
 with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as c:
     ...
 
@@ -58,14 +55,70 @@ with (name_2 for name_0 in name_4):
     pass
 with (a, *b):
     pass
+
+with (
+    # leading comment
+    a) as b: ...
+
+with (
+    # leading comment
+    a as b
+): ...
+
+
+with (a # trailing same line comment
+    # trailing own line comment
+    ) as b: ...
+
+with (
+    a # trailing same line comment
+    # trailing own line comment
+    as b
+): ...
+
+
+with (a # trailing same line comment
+    # trailing own line comment
+) as b: ...
+
+with (
+    (a
+    # trailing own line comment
+    )
+    as # trailing as same line comment
+    b # trailing b same line comment
+): ...
+
+with (
+    [
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "bbbbbbbbbb",
+        "cccccccccccccccccccccccccccccccccccccccccc",
+        dddddddddddddddddddddddddddddddd,
+    ] as example1,
+    aaaaaaaaaaaaaaaaaaaaaaaaaa
+    + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    + cccccccccccccccccccccccccccc
+    + ddddddddddddddddd as example2,
+    CtxManager2() as example2,
+    CtxManager2() as example2,
+    CtxManager2() as example2,
+):
+    ...
+
+
+with [
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "bbbbbbbbbb",
+    "cccccccccccccccccccccccccccccccccccccccccc",
+    dddddddddddddddddddddddddddddddd,
+] as example1, aaaaaaaaaaaaaaaaaaaaaaaaaa * bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb * cccccccccccccccccccccccccccc + ddddddddddddddddd as example2, CtxManager222222222222222() as example2:
+    ...
 ```
 
 ## Output
 ```py
-with (
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
-):
+with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
     ...
     # trailing
 
@@ -105,12 +158,7 @@ with (
 with a:  # should remove brackets
     ...
 
-# TODO: black doesn't wrap this, but maybe we want to anyway?
-# if we do want to wrap, do we prefer to wrap the entire WithItem or to let the
-# WithItem allow the `aa + bb` content expression to be wrapped
-with (
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as c
-):
+with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as c:
     ...
 
 
@@ -119,6 +167,72 @@ with (NOT_YET_IMPLEMENTED_generator_key for NOT_YET_IMPLEMENTED_generator_key in
     pass
 with (a, *b):
     pass
+
+with (
+    # leading comment
+    a
+) as b:
+    ...
+
+with (
+    # leading comment
+    a as b
+):
+    ...
+
+
+with (
+    a  # trailing same line comment
+    # trailing own line comment
+) as b:
+    ...
+
+with (
+    a  # trailing same line comment
+    # trailing own line comment
+) as b:
+    ...
+
+
+with (
+    a  # trailing same line comment
+    # trailing own line comment
+) as b:
+    ...
+
+with (
+    (
+        a
+        # trailing own line comment
+    ) as b  # trailing as same line comment  # trailing b same line comment
+):
+    ...
+
+with (
+    [
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "bbbbbbbbbb",
+        "cccccccccccccccccccccccccccccccccccccccccc",
+        dddddddddddddddddddddddddddddddd,
+    ] as example1,
+    aaaaaaaaaaaaaaaaaaaaaaaaaa
+    + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    + cccccccccccccccccccccccccccc
+    + ddddddddddddddddd as example2,
+    CtxManager2() as example2,
+    CtxManager2() as example2,
+    CtxManager2() as example2,
+):
+    ...
+
+
+with [
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "bbbbbbbbbb",
+    "cccccccccccccccccccccccccccccccccccccccccc",
+    dddddddddddddddddddddddddddddddd,
+] as example1, aaaaaaaaaaaaaaaaaaaaaaaaaa * bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb * cccccccccccccccccccccccccccc + ddddddddddddddddd as example2, CtxManager222222222222222() as example2:
+    ...
 ```
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR improves the parentheses handling for with items to get closer to black's formatting. 

### Case 1:

```python
# Black / Input
with (
    [
        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
        "bbbbbbbbbb",
        "cccccccccccccccccccccccccccccccccccccccccc",
        dddddddddddddddddddddddddddddddd,
    ] as example1,
    aaaaaaaaaaaaaaaaaaaaaaaaaa
    + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
    + cccccccccccccccccccccccccccc
    + ddddddddddddddddd as example2,
    CtxManager2() as example2,
    CtxManager2() as example2,
    CtxManager2() as example2,
):
    ...

# Before
with (
    [
        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
        "bbbbbbbbbb",
        "cccccccccccccccccccccccccccccccccccccccccc",
        dddddddddddddddddddddddddddddddd,
    ] as example1,
    (
        aaaaaaaaaaaaaaaaaaaaaaaaaa
        + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
        + cccccccccccccccccccccccccccc
        + ddddddddddddddddd
    ) as example2,
    CtxManager2() as example2,
    CtxManager2() as example2,
    CtxManager2() as example2,
):
    ...
```

Notice how Ruff wraps the binary expression in an extra set of parentheses


### Case 2:
Black does not expand the with-items if the with has no parentheses:

```python
# Black / Input
with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as c:
    ...

# Before
with (
    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as c
):
    ...
```

Or 

```python
# Black / Input
with [
    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
    "bbbbbbbbbb",
    "cccccccccccccccccccccccccccccccccccccccccc",
    dddddddddddddddddddddddddddddddd,
] as example1, aaaaaaaaaaaaaaaaaaaaaaaaaa * bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb * cccccccccccccccccccccccccccc + ddddddddddddddddd as example2, CtxManager222222222222222() as example2:
    ...

# Before (Same as Case 1)
with (
    [
        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
        "bbbbbbbbbb",
        "cccccccccccccccccccccccccccccccccccccccccc",
        dddddddddddddddddddddddddddddddd,
    ] as example1,
    (
        aaaaaaaaaaaaaaaaaaaaaaaaaa
        * bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
        * cccccccccccccccccccccccccccc
        + ddddddddddddddddd
    ) as example2,
    CtxManager222222222222222() as example2,
):
    ...

```
## Test Plan

I added new snapshot tests

Improves the django similarity index from 0.973 to 0.977
