### PR TITLE
Add Regression test for #5605, where formatting `x[:,]` failed.

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/slice.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/slice.py
@@ -80,3 +80,6 @@ e200 = "e"[a() :: ]
 e201 = "e"[a() :: 1]
 e202 = "e"[a() :: a()]
 e210 = "e"[a() : 1 :]
+
+# Regression test for https://github.com/astral-sh/ruff/issues/5605
+f = "f"[:,]

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__slice.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__slice.py.snap
@@ -86,6 +86,9 @@ e200 = "e"[a() :: ]
 e201 = "e"[a() :: 1]
 e202 = "e"[a() :: a()]
 e210 = "e"[a() : 1 :]
+
+# Regression test for https://github.com/astral-sh/ruff/issues/5605
+f = "f"[:,]
 ```
 
 ## Output
@@ -170,6 +173,9 @@ e200 = "e"[a() : :]
 e201 = "e"[a() :: 1]
 e202 = "e"[a() :: a()]
 e210 = "e"[a() : 1 :]
+
+# Regression test for https://github.com/astral-sh/ruff/issues/5605
+f = "f"[:,]
 ```
 
 


### PR DESCRIPTION
#5605 has been fixed, i added the failing example from the issue as a regression test.

Closes #5605