### PR TITLE
Misc. minor refactors to `incorrect-dict-iterator`

### DIFF
--- a/crates/ruff/src/rules/tryceratops/rules/reraise_no_cause.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/reraise_no_cause.rs
@@ -1,4 +1,4 @@
-use rustpython_parser::ast::Stmt;
+use rustpython_parser::ast::{Expr, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -55,10 +55,12 @@ pub(crate) fn reraise_no_cause(checker: &mut Checker, body: &[Stmt]) {
     };
 
     for (range, exc, cause) in raises {
-        if exc.map_or(false, |expr| expr.is_call_expr() && cause.is_none()) {
-            checker
-                .diagnostics
-                .push(Diagnostic::new(ReraiseNoCause, range));
+        if cause.is_none() {
+            if exc.map_or(false, Expr::is_call_expr) {
+                checker
+                    .diagnostics
+                    .push(Diagnostic::new(ReraiseNoCause, range));
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Mostly a no-op: use a single match for key-value, use identifier range rather than re-lexing, respect our `dummy-variable-rgx` setting.