### PR TITLE
Expand `RUF015` to include all expression types

### DIFF
--- a/crates/ruff/resources/test/fixtures/ruff/RUF015.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF015.py
@@ -34,11 +34,23 @@ list(x)[::]
 [i for i in x][::2]
 [i for i in x][::]
 
-# OK (doesn't mirror the underlying list)
+# RUF015 (doesn't mirror the underlying list)
 [i + 1 for i in x][0]
 [i for i in x if i > 5][0]
 [(i, i + 1) for i in x][0]
 
-# OK (multiple generators)
+# RUF015 (multiple generators)
 y = range(10)
 [i + j for i in x for j in y][0]
+
+# RUF015
+list(range(10))[0]
+list(x.y)[0]
+list(x["y"])[0]
+
+# RUF015 (multi-line)
+revision_heads_map_ast = [
+    a
+    for a in revision_heads_map_ast_obj.body
+    if isinstance(a, ast.Assign) and a.targets[0].id == "REVISION_HEADS_MAP"
+][0]

--- a/crates/ruff/src/rules/ruff/rules/invalid_index_type.rs
+++ b/crates/ruff/src/rules/ruff/rules/invalid_index_type.rs
@@ -49,7 +49,7 @@ impl Violation for InvalidIndexType {
     }
 }
 
-/// RUF015
+/// RUF016
 pub(crate) fn invalid_index_type(checker: &mut Checker, expr: &ExprSubscript) {
     let ExprSubscript {
         value,

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF015_RUF015.py.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF015_RUF015.py.snap
@@ -335,4 +335,172 @@ RUF015.py:19:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
 21 21 | # OK (not indexing (solely) the first element)
 22 22 | list(x)
 
+RUF015.py:38:1: RUF015 [*] Prefer `next(iter(i + 1 for i in x))` over `list(i + 1 for i in x)[0]`
+   |
+37 | # RUF015 (doesn't mirror the underlying list)
+38 | [i + 1 for i in x][0]
+   | ^^^^^^^^^^^^^^^^^^^^^ RUF015
+39 | [i for i in x if i > 5][0]
+40 | [(i, i + 1) for i in x][0]
+   |
+   = help: Replace with `next(iter(i + 1 for i in x))`
+
+ℹ Suggested fix
+35 35 | [i for i in x][::]
+36 36 | 
+37 37 | # RUF015 (doesn't mirror the underlying list)
+38    |-[i + 1 for i in x][0]
+   38 |+next(iter(i + 1 for i in x))
+39 39 | [i for i in x if i > 5][0]
+40 40 | [(i, i + 1) for i in x][0]
+41 41 | 
+
+RUF015.py:39:1: RUF015 [*] Prefer `next(iter(i for i in x if i > 5))` over `list(i for i in x if i > 5)[0]`
+   |
+37 | # RUF015 (doesn't mirror the underlying list)
+38 | [i + 1 for i in x][0]
+39 | [i for i in x if i > 5][0]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF015
+40 | [(i, i + 1) for i in x][0]
+   |
+   = help: Replace with `next(iter(i for i in x if i > 5))`
+
+ℹ Suggested fix
+36 36 | 
+37 37 | # RUF015 (doesn't mirror the underlying list)
+38 38 | [i + 1 for i in x][0]
+39    |-[i for i in x if i > 5][0]
+   39 |+next(iter(i for i in x if i > 5))
+40 40 | [(i, i + 1) for i in x][0]
+41 41 | 
+42 42 | # RUF015 (multiple generators)
+
+RUF015.py:40:1: RUF015 [*] Prefer `next(iter((i, i + 1) for i in x))` over `list((i, i + 1) for i in x)[0]`
+   |
+38 | [i + 1 for i in x][0]
+39 | [i for i in x if i > 5][0]
+40 | [(i, i + 1) for i in x][0]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF015
+41 | 
+42 | # RUF015 (multiple generators)
+   |
+   = help: Replace with `next(iter((i, i + 1) for i in x))`
+
+ℹ Suggested fix
+37 37 | # RUF015 (doesn't mirror the underlying list)
+38 38 | [i + 1 for i in x][0]
+39 39 | [i for i in x if i > 5][0]
+40    |-[(i, i + 1) for i in x][0]
+   40 |+next(iter((i, i + 1) for i in x))
+41 41 | 
+42 42 | # RUF015 (multiple generators)
+43 43 | y = range(10)
+
+RUF015.py:44:1: RUF015 [*] Prefer `next(iter(i + j for i in x for j in y))` over `list(i + j for i in x for j in y)[0]`
+   |
+42 | # RUF015 (multiple generators)
+43 | y = range(10)
+44 | [i + j for i in x for j in y][0]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF015
+45 | 
+46 | # RUF015
+   |
+   = help: Replace with `next(iter(i + j for i in x for j in y))`
+
+ℹ Suggested fix
+41 41 | 
+42 42 | # RUF015 (multiple generators)
+43 43 | y = range(10)
+44    |-[i + j for i in x for j in y][0]
+   44 |+next(iter(i + j for i in x for j in y))
+45 45 | 
+46 46 | # RUF015
+47 47 | list(range(10))[0]
+
+RUF015.py:47:1: RUF015 [*] Prefer `next(iter(range(10)))` over `list(range(10))[0]`
+   |
+46 | # RUF015
+47 | list(range(10))[0]
+   | ^^^^^^^^^^^^^^^^^^ RUF015
+48 | list(x.y)[0]
+49 | list(x["y"])[0]
+   |
+   = help: Replace with `next(iter(range(10)))`
+
+ℹ Suggested fix
+44 44 | [i + j for i in x for j in y][0]
+45 45 | 
+46 46 | # RUF015
+47    |-list(range(10))[0]
+   47 |+next(iter(range(10)))
+48 48 | list(x.y)[0]
+49 49 | list(x["y"])[0]
+50 50 | 
+
+RUF015.py:48:1: RUF015 [*] Prefer `next(iter(x.y))` over `list(x.y)[0]`
+   |
+46 | # RUF015
+47 | list(range(10))[0]
+48 | list(x.y)[0]
+   | ^^^^^^^^^^^^ RUF015
+49 | list(x["y"])[0]
+   |
+   = help: Replace with `next(iter(x.y))`
+
+ℹ Suggested fix
+45 45 | 
+46 46 | # RUF015
+47 47 | list(range(10))[0]
+48    |-list(x.y)[0]
+   48 |+next(iter(x.y))
+49 49 | list(x["y"])[0]
+50 50 | 
+51 51 | # RUF015 (multi-line)
+
+RUF015.py:49:1: RUF015 [*] Prefer `next(iter(x["y"]))` over `list(x["y"])[0]`
+   |
+47 | list(range(10))[0]
+48 | list(x.y)[0]
+49 | list(x["y"])[0]
+   | ^^^^^^^^^^^^^^^ RUF015
+50 | 
+51 | # RUF015 (multi-line)
+   |
+   = help: Replace with `next(iter(x["y"]))`
+
+ℹ Suggested fix
+46 46 | # RUF015
+47 47 | list(range(10))[0]
+48 48 | list(x.y)[0]
+49    |-list(x["y"])[0]
+   49 |+next(iter(x["y"]))
+50 50 | 
+51 51 | # RUF015 (multi-line)
+52 52 | revision_heads_map_ast = [
+
+RUF015.py:52:26: RUF015 [*] Prefer `next(iter(...))` over `list(...)[0]`
+   |
+51 |   # RUF015 (multi-line)
+52 |   revision_heads_map_ast = [
+   |  __________________________^
+53 | |     a
+54 | |     for a in revision_heads_map_ast_obj.body
+55 | |     if isinstance(a, ast.Assign) and a.targets[0].id == "REVISION_HEADS_MAP"
+56 | | ][0]
+   | |____^ RUF015
+   |
+   = help: Replace with `next(iter(...))`
+
+ℹ Suggested fix
+49 49 | list(x["y"])[0]
+50 50 | 
+51 51 | # RUF015 (multi-line)
+52    |-revision_heads_map_ast = [
+   52 |+revision_heads_map_ast = next(iter(
+53 53 |     a
+54 54 |     for a in revision_heads_map_ast_obj.body
+55 55 |     if isinstance(a, ast.Assign) and a.targets[0].id == "REVISION_HEADS_MAP"
+56    |-][0]
+   56 |+))
+
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF015_RUF015.py.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF015_RUF015.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/ruff/mod.rs
 ---
-RUF015.py:4:1: RUF015 [*] Prefer `next(iter(x))` over `list(x)[0]`
+RUF015.py:4:1: RUF015 [*] Prefer `next(iter(x))` over single element slice
   |
 3 | # RUF015
 4 | list(x)[0]
@@ -21,7 +21,7 @@ RUF015.py:4:1: RUF015 [*] Prefer `next(iter(x))` over `list(x)[0]`
 6 6 | list(x)[:1:1]
 7 7 | list(x)[:1:2]
 
-RUF015.py:5:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
+RUF015.py:5:1: RUF015 [*] Prefer `[next(iter(x))]` over single element slice
   |
 3 | # RUF015
 4 | list(x)[0]
@@ -42,7 +42,7 @@ RUF015.py:5:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
 7 7 | list(x)[:1:2]
 8 8 | tuple(x)[0]
 
-RUF015.py:6:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
+RUF015.py:6:1: RUF015 [*] Prefer `[next(iter(x))]` over single element slice
   |
 4 | list(x)[0]
 5 | list(x)[:1]
@@ -63,7 +63,7 @@ RUF015.py:6:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
 8 8 | tuple(x)[0]
 9 9 | tuple(x)[:1]
 
-RUF015.py:7:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
+RUF015.py:7:1: RUF015 [*] Prefer `[next(iter(x))]` over single element slice
   |
 5 | list(x)[:1]
 6 | list(x)[:1:1]
@@ -84,7 +84,7 @@ RUF015.py:7:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
 9 9 | tuple(x)[:1]
 10 10 | tuple(x)[:1:1]
 
-RUF015.py:8:1: RUF015 [*] Prefer `next(iter(x))` over `list(x)[0]`
+RUF015.py:8:1: RUF015 [*] Prefer `next(iter(x))` over single element slice
    |
  6 | list(x)[:1:1]
  7 | list(x)[:1:2]
@@ -105,7 +105,7 @@ RUF015.py:8:1: RUF015 [*] Prefer `next(iter(x))` over `list(x)[0]`
 10 10 | tuple(x)[:1:1]
 11 11 | tuple(x)[:1:2]
 
-RUF015.py:9:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
+RUF015.py:9:1: RUF015 [*] Prefer `[next(iter(x))]` over single element slice
    |
  7 | list(x)[:1:2]
  8 | tuple(x)[0]
@@ -126,7 +126,7 @@ RUF015.py:9:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
 11 11 | tuple(x)[:1:2]
 12 12 | list(i for i in x)[0]
 
-RUF015.py:10:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
+RUF015.py:10:1: RUF015 [*] Prefer `[next(iter(x))]` over single element slice
    |
  8 | tuple(x)[0]
  9 | tuple(x)[:1]
@@ -147,7 +147,7 @@ RUF015.py:10:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
 12 12 | list(i for i in x)[0]
 13 13 | list(i for i in x)[:1]
 
-RUF015.py:11:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
+RUF015.py:11:1: RUF015 [*] Prefer `[next(iter(x))]` over single element slice
    |
  9 | tuple(x)[:1]
 10 | tuple(x)[:1:1]
@@ -168,7 +168,7 @@ RUF015.py:11:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
 13 13 | list(i for i in x)[:1]
 14 14 | list(i for i in x)[:1:1]
 
-RUF015.py:12:1: RUF015 [*] Prefer `next(iter(x))` over `list(x)[0]`
+RUF015.py:12:1: RUF015 [*] Prefer `next(iter(x))` over single element slice
    |
 10 | tuple(x)[:1:1]
 11 | tuple(x)[:1:2]
@@ -189,7 +189,7 @@ RUF015.py:12:1: RUF015 [*] Prefer `next(iter(x))` over `list(x)[0]`
 14 14 | list(i for i in x)[:1:1]
 15 15 | list(i for i in x)[:1:2]
 
-RUF015.py:13:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
+RUF015.py:13:1: RUF015 [*] Prefer `[next(iter(x))]` over single element slice
    |
 11 | tuple(x)[:1:2]
 12 | list(i for i in x)[0]
@@ -210,7 +210,7 @@ RUF015.py:13:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
 15 15 | list(i for i in x)[:1:2]
 16 16 | [i for i in x][0]
 
-RUF015.py:14:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
+RUF015.py:14:1: RUF015 [*] Prefer `[next(iter(x))]` over single element slice
    |
 12 | list(i for i in x)[0]
 13 | list(i for i in x)[:1]
@@ -231,7 +231,7 @@ RUF015.py:14:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
 16 16 | [i for i in x][0]
 17 17 | [i for i in x][:1]
 
-RUF015.py:15:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
+RUF015.py:15:1: RUF015 [*] Prefer `[next(iter(x))]` over single element slice
    |
 13 | list(i for i in x)[:1]
 14 | list(i for i in x)[:1:1]
@@ -252,7 +252,7 @@ RUF015.py:15:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
 17 17 | [i for i in x][:1]
 18 18 | [i for i in x][:1:1]
 
-RUF015.py:16:1: RUF015 [*] Prefer `next(iter(x))` over `list(x)[0]`
+RUF015.py:16:1: RUF015 [*] Prefer `next(iter(x))` over single element slice
    |
 14 | list(i for i in x)[:1:1]
 15 | list(i for i in x)[:1:2]
@@ -273,7 +273,7 @@ RUF015.py:16:1: RUF015 [*] Prefer `next(iter(x))` over `list(x)[0]`
 18 18 | [i for i in x][:1:1]
 19 19 | [i for i in x][:1:2]
 
-RUF015.py:17:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
+RUF015.py:17:1: RUF015 [*] Prefer `[next(iter(x))]` over single element slice
    |
 15 | list(i for i in x)[:1:2]
 16 | [i for i in x][0]
@@ -294,7 +294,7 @@ RUF015.py:17:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
 19 19 | [i for i in x][:1:2]
 20 20 | 
 
-RUF015.py:18:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
+RUF015.py:18:1: RUF015 [*] Prefer `[next(iter(x))]` over single element slice
    |
 16 | [i for i in x][0]
 17 | [i for i in x][:1]
@@ -314,7 +314,7 @@ RUF015.py:18:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
 20 20 | 
 21 21 | # OK (not indexing (solely) the first element)
 
-RUF015.py:19:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
+RUF015.py:19:1: RUF015 [*] Prefer `[next(iter(x))]` over single element slice
    |
 17 | [i for i in x][:1]
 18 | [i for i in x][:1:1]
@@ -335,7 +335,7 @@ RUF015.py:19:1: RUF015 [*] Prefer `[next(iter(x))]` over `list(x)[:1]`
 21 21 | # OK (not indexing (solely) the first element)
 22 22 | list(x)
 
-RUF015.py:38:1: RUF015 [*] Prefer `next(iter(i + 1 for i in x))` over `list(i + 1 for i in x)[0]`
+RUF015.py:38:1: RUF015 [*] Prefer `next(i + 1 for i in x)` over single element slice
    |
 37 | # RUF015 (doesn't mirror the underlying list)
 38 | [i + 1 for i in x][0]
@@ -343,19 +343,19 @@ RUF015.py:38:1: RUF015 [*] Prefer `next(iter(i + 1 for i in x))` over `list(i + 
 39 | [i for i in x if i > 5][0]
 40 | [(i, i + 1) for i in x][0]
    |
-   = help: Replace with `next(iter(i + 1 for i in x))`
+   = help: Replace with `next(i + 1 for i in x)`
 
 ℹ Suggested fix
 35 35 | [i for i in x][::]
 36 36 | 
 37 37 | # RUF015 (doesn't mirror the underlying list)
 38    |-[i + 1 for i in x][0]
-   38 |+next(iter(i + 1 for i in x))
+   38 |+next(i + 1 for i in x)
 39 39 | [i for i in x if i > 5][0]
 40 40 | [(i, i + 1) for i in x][0]
 41 41 | 
 
-RUF015.py:39:1: RUF015 [*] Prefer `next(iter(i for i in x if i > 5))` over `list(i for i in x if i > 5)[0]`
+RUF015.py:39:1: RUF015 [*] Prefer `next(i for i in x if i > 5)` over single element slice
    |
 37 | # RUF015 (doesn't mirror the underlying list)
 38 | [i + 1 for i in x][0]
@@ -363,19 +363,19 @@ RUF015.py:39:1: RUF015 [*] Prefer `next(iter(i for i in x if i > 5))` over `list
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF015
 40 | [(i, i + 1) for i in x][0]
    |
-   = help: Replace with `next(iter(i for i in x if i > 5))`
+   = help: Replace with `next(i for i in x if i > 5)`
 
 ℹ Suggested fix
 36 36 | 
 37 37 | # RUF015 (doesn't mirror the underlying list)
 38 38 | [i + 1 for i in x][0]
 39    |-[i for i in x if i > 5][0]
-   39 |+next(iter(i for i in x if i > 5))
+   39 |+next(i for i in x if i > 5)
 40 40 | [(i, i + 1) for i in x][0]
 41 41 | 
 42 42 | # RUF015 (multiple generators)
 
-RUF015.py:40:1: RUF015 [*] Prefer `next(iter((i, i + 1) for i in x))` over `list((i, i + 1) for i in x)[0]`
+RUF015.py:40:1: RUF015 [*] Prefer `next((i, i + 1) for i in x)` over single element slice
    |
 38 | [i + 1 for i in x][0]
 39 | [i for i in x if i > 5][0]
@@ -384,19 +384,19 @@ RUF015.py:40:1: RUF015 [*] Prefer `next(iter((i, i + 1) for i in x))` over `list
 41 | 
 42 | # RUF015 (multiple generators)
    |
-   = help: Replace with `next(iter((i, i + 1) for i in x))`
+   = help: Replace with `next((i, i + 1) for i in x)`
 
 ℹ Suggested fix
 37 37 | # RUF015 (doesn't mirror the underlying list)
 38 38 | [i + 1 for i in x][0]
 39 39 | [i for i in x if i > 5][0]
 40    |-[(i, i + 1) for i in x][0]
-   40 |+next(iter((i, i + 1) for i in x))
+   40 |+next((i, i + 1) for i in x)
 41 41 | 
 42 42 | # RUF015 (multiple generators)
 43 43 | y = range(10)
 
-RUF015.py:44:1: RUF015 [*] Prefer `next(iter(i + j for i in x for j in y))` over `list(i + j for i in x for j in y)[0]`
+RUF015.py:44:1: RUF015 [*] Prefer `next(i + j for i in x for j in y)` over single element slice
    |
 42 | # RUF015 (multiple generators)
 43 | y = range(10)
@@ -405,19 +405,19 @@ RUF015.py:44:1: RUF015 [*] Prefer `next(iter(i + j for i in x for j in y))` over
 45 | 
 46 | # RUF015
    |
-   = help: Replace with `next(iter(i + j for i in x for j in y))`
+   = help: Replace with `next(i + j for i in x for j in y)`
 
 ℹ Suggested fix
 41 41 | 
 42 42 | # RUF015 (multiple generators)
 43 43 | y = range(10)
 44    |-[i + j for i in x for j in y][0]
-   44 |+next(iter(i + j for i in x for j in y))
+   44 |+next(i + j for i in x for j in y)
 45 45 | 
 46 46 | # RUF015
 47 47 | list(range(10))[0]
 
-RUF015.py:47:1: RUF015 [*] Prefer `next(iter(range(10)))` over `list(range(10))[0]`
+RUF015.py:47:1: RUF015 [*] Prefer `next(iter(range(10)))` over single element slice
    |
 46 | # RUF015
 47 | list(range(10))[0]
@@ -437,7 +437,7 @@ RUF015.py:47:1: RUF015 [*] Prefer `next(iter(range(10)))` over `list(range(10))[
 49 49 | list(x["y"])[0]
 50 50 | 
 
-RUF015.py:48:1: RUF015 [*] Prefer `next(iter(x.y))` over `list(x.y)[0]`
+RUF015.py:48:1: RUF015 [*] Prefer `next(iter(x.y))` over single element slice
    |
 46 | # RUF015
 47 | list(range(10))[0]
@@ -457,7 +457,7 @@ RUF015.py:48:1: RUF015 [*] Prefer `next(iter(x.y))` over `list(x.y)[0]`
 50 50 | 
 51 51 | # RUF015 (multi-line)
 
-RUF015.py:49:1: RUF015 [*] Prefer `next(iter(x["y"]))` over `list(x["y"])[0]`
+RUF015.py:49:1: RUF015 [*] Prefer `next(iter(x["y"]))` over single element slice
    |
 47 | list(range(10))[0]
 48 | list(x.y)[0]
@@ -478,7 +478,7 @@ RUF015.py:49:1: RUF015 [*] Prefer `next(iter(x["y"]))` over `list(x["y"])[0]`
 51 51 | # RUF015 (multi-line)
 52 52 | revision_heads_map_ast = [
 
-RUF015.py:52:26: RUF015 [*] Prefer `next(iter(...))` over `list(...)[0]`
+RUF015.py:52:26: RUF015 [*] Prefer `next(...)` over single element slice
    |
 51 |   # RUF015 (multi-line)
 52 |   revision_heads_map_ast = [
@@ -489,18 +489,18 @@ RUF015.py:52:26: RUF015 [*] Prefer `next(iter(...))` over `list(...)[0]`
 56 | | ][0]
    | |____^ RUF015
    |
-   = help: Replace with `next(iter(...))`
+   = help: Replace with `next(...)`
 
 ℹ Suggested fix
 49 49 | list(x["y"])[0]
 50 50 | 
 51 51 | # RUF015 (multi-line)
 52    |-revision_heads_map_ast = [
-   52 |+revision_heads_map_ast = next(iter(
+   52 |+revision_heads_map_ast = next(
 53 53 |     a
 54 54 |     for a in revision_heads_map_ast_obj.body
 55 55 |     if isinstance(a, ast.Assign) and a.targets[0].id == "REVISION_HEADS_MAP"
 56    |-][0]
-   56 |+))
+   56 |+)
 
 


### PR DESCRIPTION
## Summary

We now allow RUF015 to fix cases like:

```python
list(range(10))[0]
list(x.y)[0]
list(x["y"])[0]
```

Further, we fix generators like:

```python
[i + 1 for i in x][0]
```

By rewriting to `next(iter(i + 1 for i in x))`.

I've retained the special-case that rewrites `[i for i in x][0]` to `next(iter(x))`.

Closes https://github.com/astral-sh/ruff/issues/5764.
