### PR TITLE
Ignore directories when collecting files to lint

### DIFF
--- a/crates/ruff/src/resolver.rs
+++ b/crates/ruff/src/resolver.rs
@@ -329,12 +329,11 @@ pub fn python_files_in_path(
                 }
             }
 
-            let should_include = result.as_ref().map_or(true, |entry| {
+            if result.as_ref().map_or(true, |entry| {
                 // Ignore directories
                 if entry.file_type().map_or(true, |ft| ft.is_dir()) {
-                    return false;
-                }
-                if entry.depth() == 0 {
+                    false
+                } else if entry.depth() == 0 {
                     // Accept all files that are passed-in directly.
                     true
                 } else {
@@ -352,8 +351,7 @@ pub fn python_files_in_path(
                         false
                     }
                 }
-            });
-            if should_include {
+            }) {
                 files.lock().unwrap().push(result);
             }
 

--- a/crates/ruff/src/resolver.rs
+++ b/crates/ruff/src/resolver.rs
@@ -330,9 +330,13 @@ pub fn python_files_in_path(
             }
 
             if result.as_ref().map_or(true, |entry| {
+                // Ignore directories
+                if entry.file_type().map_or(true, |ft| ft.is_dir()) {
+                    return false;
+                }
                 if entry.depth() == 0 {
                     // Accept all files that are passed-in directly.
-                    entry.file_type().map_or(false, |ft| ft.is_file())
+                    true
                 } else {
                     // Otherwise, check if the file is included.
                     let path = entry.path();

--- a/crates/ruff/src/resolver.rs
+++ b/crates/ruff/src/resolver.rs
@@ -329,7 +329,7 @@ pub fn python_files_in_path(
                 }
             }
 
-            if result.as_ref().map_or(true, |entry| {
+            let should_include = result.as_ref().map_or(true, |entry| {
                 // Ignore directories
                 if entry.file_type().map_or(true, |ft| ft.is_dir()) {
                     return false;
@@ -352,7 +352,8 @@ pub fn python_files_in_path(
                         false
                     }
                 }
-            }) {
+            });
+            if should_include {
                 files.lock().unwrap().push(result);
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #5739

## Test Plan

<!-- How was it tested? -->

Manually tested:

```sh
$ tree dir
dir
├── dir.py
│   └── file.py
└── file.py

1 directory, 2 files

$ cargo run -p ruff_cli -- check dir --no-cache
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/ruff check dir --no-cache`
dir/dir.py/file.py:1:7: F821 Undefined name `a`
dir/file.py:1:7: F821 Undefined name `a`
Found 2 errors.
```

Is a unit test needed?