### PR TITLE
Gate `runtime-import-in-type-checking-block` (`TCH004`) behind enabled flag

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -5008,18 +5008,26 @@ impl<'a> Checker<'a> {
                         .collect()
                 };
 
-                flake8_type_checking::rules::runtime_import_in_type_checking_block(
-                    self,
-                    scope,
-                    &mut diagnostics,
-                );
+                if self.enabled(Rule::RuntimeImportInTypeCheckingBlock) {
+                    flake8_type_checking::rules::runtime_import_in_type_checking_block(
+                        self,
+                        scope,
+                        &mut diagnostics,
+                    );
+                }
 
-                flake8_type_checking::rules::typing_only_runtime_import(
-                    self,
-                    scope,
-                    &runtime_imports,
-                    &mut diagnostics,
-                );
+                if self.any_enabled(&[
+                    Rule::TypingOnlyFirstPartyImport,
+                    Rule::TypingOnlyThirdPartyImport,
+                    Rule::TypingOnlyStandardLibraryImport,
+                ]) {
+                    flake8_type_checking::rules::typing_only_runtime_import(
+                        self,
+                        scope,
+                        &runtime_imports,
+                        &mut diagnostics,
+                    );
+                }
             }
 
             if self.enabled(Rule::UnusedImport) {


### PR DESCRIPTION
## Summary

This rule is running whenever _any_ `TCH` rules are enabled, which is not intentional.

Closes #5787.