### PR TITLE
Remove `Identifier` usages for isolating exception names

### DIFF
--- a/crates/ruff/src/rules/flake8_bandit/rules/try_except_continue.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/try_except_continue.rs
@@ -55,16 +55,14 @@ pub(crate) fn try_except_continue(
     checker: &mut Checker,
     except_handler: &ExceptHandler,
     type_: Option<&Expr>,
-    _name: Option<&str>,
     body: &[Stmt],
     check_typed_exception: bool,
 ) {
-    if body.len() == 1
-        && body[0].is_continue_stmt()
-        && (check_typed_exception || is_untyped_exception(type_, checker.semantic()))
-    {
-        checker
-            .diagnostics
-            .push(Diagnostic::new(TryExceptContinue, except_handler.range()));
+    if matches!(body, [Stmt::Continue(_)]) {
+        if check_typed_exception || is_untyped_exception(type_, checker.semantic()) {
+            checker
+                .diagnostics
+                .push(Diagnostic::new(TryExceptContinue, except_handler.range()));
+        }
     }
 }

--- a/crates/ruff/src/rules/flake8_bandit/rules/try_except_pass.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/try_except_pass.rs
@@ -51,16 +51,14 @@ pub(crate) fn try_except_pass(
     checker: &mut Checker,
     except_handler: &ExceptHandler,
     type_: Option<&Expr>,
-    _name: Option<&str>,
     body: &[Stmt],
     check_typed_exception: bool,
 ) {
-    if body.len() == 1
-        && body[0].is_pass_stmt()
-        && (check_typed_exception || is_untyped_exception(type_, checker.semantic()))
-    {
-        checker
-            .diagnostics
-            .push(Diagnostic::new(TryExceptPass, except_handler.range()));
+    if matches!(body, [Stmt::Pass(_)]) {
+        if check_typed_exception || is_untyped_exception(type_, checker.semantic()) {
+            checker
+                .diagnostics
+                .push(Diagnostic::new(TryExceptPass, except_handler.range()));
+        }
     }
 }

--- a/crates/ruff/src/rules/flake8_builtins/helpers.rs
+++ b/crates/ruff/src/rules/flake8_builtins/helpers.rs
@@ -1,44 +1,5 @@
-use ruff_text_size::TextRange;
-use rustpython_parser::ast::{ExceptHandler, Expr, Ranged, Stmt};
-
-use ruff_python_ast::identifier::{Identifier, TryIdentifier};
 use ruff_python_stdlib::builtins::BUILTINS;
 
 pub(super) fn shadows_builtin(name: &str, ignorelist: &[String]) -> bool {
     BUILTINS.contains(&name) && ignorelist.iter().all(|ignore| ignore != name)
-}
-
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub(crate) enum AnyShadowing<'a> {
-    Expression(&'a Expr),
-    Statement(&'a Stmt),
-    ExceptHandler(&'a ExceptHandler),
-}
-
-impl Identifier for AnyShadowing<'_> {
-    fn identifier(&self) -> TextRange {
-        match self {
-            AnyShadowing::Expression(expr) => expr.range(),
-            AnyShadowing::Statement(stmt) => stmt.identifier(),
-            AnyShadowing::ExceptHandler(handler) => handler.try_identifier().unwrap(),
-        }
-    }
-}
-
-impl<'a> From<&'a Stmt> for AnyShadowing<'a> {
-    fn from(value: &'a Stmt) -> Self {
-        AnyShadowing::Statement(value)
-    }
-}
-
-impl<'a> From<&'a Expr> for AnyShadowing<'a> {
-    fn from(value: &'a Expr) -> Self {
-        AnyShadowing::Expression(value)
-    }
-}
-
-impl<'a> From<&'a ExceptHandler> for AnyShadowing<'a> {
-    fn from(value: &'a ExceptHandler) -> Self {
-        AnyShadowing::ExceptHandler(value)
-    }
 }

--- a/crates/ruff/src/rules/flake8_builtins/rules/builtin_attribute_shadowing.rs
+++ b/crates/ruff/src/rules/flake8_builtins/rules/builtin_attribute_shadowing.rs
@@ -1,12 +1,12 @@
+use ruff_text_size::TextRange;
+use rustpython_parser::ast;
+
 use ruff_diagnostics::Diagnostic;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::identifier::Identifier;
-use rustpython_parser::ast;
 
 use crate::checkers::ast::Checker;
-
-use super::super::helpers::{shadows_builtin, AnyShadowing};
+use crate::rules::flake8_builtins::helpers::shadows_builtin;
 
 /// ## What it does
 /// Checks for any class attributes that use the same name as a builtin.
@@ -67,7 +67,7 @@ pub(crate) fn builtin_attribute_shadowing(
     checker: &mut Checker,
     class_def: &ast::StmtClassDef,
     name: &str,
-    shadowing: AnyShadowing,
+    range: TextRange,
 ) {
     if shadows_builtin(name, &checker.settings.flake8_builtins.builtins_ignorelist) {
         // Ignore shadowing within `TypedDict` definitions, since these are only accessible through
@@ -84,7 +84,7 @@ pub(crate) fn builtin_attribute_shadowing(
             BuiltinAttributeShadowing {
                 name: name.to_string(),
             },
-            shadowing.identifier(),
+            range,
         ));
     }
 }

--- a/crates/ruff/src/rules/flake8_builtins/rules/builtin_variable_shadowing.rs
+++ b/crates/ruff/src/rules/flake8_builtins/rules/builtin_variable_shadowing.rs
@@ -1,11 +1,11 @@
+use ruff_text_size::TextRange;
+
 use ruff_diagnostics::Diagnostic;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::identifier::Identifier;
 
 use crate::checkers::ast::Checker;
-
-use super::super::helpers::{shadows_builtin, AnyShadowing};
+use crate::rules::flake8_builtins::helpers::shadows_builtin;
 
 /// ## What it does
 /// Checks for variable (and function) assignments that use the same name
@@ -59,17 +59,13 @@ impl Violation for BuiltinVariableShadowing {
 }
 
 /// A001
-pub(crate) fn builtin_variable_shadowing(
-    checker: &mut Checker,
-    name: &str,
-    shadowing: AnyShadowing,
-) {
+pub(crate) fn builtin_variable_shadowing(checker: &mut Checker, name: &str, range: TextRange) {
     if shadows_builtin(name, &checker.settings.flake8_builtins.builtins_ignorelist) {
         checker.diagnostics.push(Diagnostic::new(
             BuiltinVariableShadowing {
                 name: name.to_string(),
             },
-            shadowing.identifier(),
+            range,
         ));
     }
 }

--- a/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A001_A001.py.snap
+++ b/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A001_A001.py.snap
@@ -1,28 +1,28 @@
 ---
 source: crates/ruff/src/rules/flake8_builtins/mod.rs
 ---
-A001.py:1:1: A001 Variable `sum` is shadowing a Python builtin
+A001.py:1:16: A001 Variable `sum` is shadowing a Python builtin
   |
 1 | import some as sum
-  | ^^^^^^^^^^^^^^^^^^ A001
+  |                ^^^ A001
 2 | from some import other as int
 3 | from directory import new as dir
   |
 
-A001.py:2:1: A001 Variable `int` is shadowing a Python builtin
+A001.py:2:27: A001 Variable `int` is shadowing a Python builtin
   |
 1 | import some as sum
 2 | from some import other as int
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A001
+  |                           ^^^ A001
 3 | from directory import new as dir
   |
 
-A001.py:3:1: A001 Variable `dir` is shadowing a Python builtin
+A001.py:3:30: A001 Variable `dir` is shadowing a Python builtin
   |
 1 | import some as sum
 2 | from some import other as int
 3 | from directory import new as dir
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A001
+  |                              ^^^ A001
 4 | 
 5 | print = 1
   |

--- a/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A001_A001.py_builtins_ignorelist.snap
+++ b/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A001_A001.py_builtins_ignorelist.snap
@@ -1,19 +1,19 @@
 ---
 source: crates/ruff/src/rules/flake8_builtins/mod.rs
 ---
-A001.py:1:1: A001 Variable `sum` is shadowing a Python builtin
+A001.py:1:16: A001 Variable `sum` is shadowing a Python builtin
   |
 1 | import some as sum
-  | ^^^^^^^^^^^^^^^^^^ A001
+  |                ^^^ A001
 2 | from some import other as int
 3 | from directory import new as dir
   |
 
-A001.py:2:1: A001 Variable `int` is shadowing a Python builtin
+A001.py:2:27: A001 Variable `int` is shadowing a Python builtin
   |
 1 | import some as sum
 2 | from some import other as int
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A001
+  |                           ^^^ A001
 3 | from directory import new as dir
   |
 

--- a/crates/ruff_python_ast/src/identifier.rs
+++ b/crates/ruff_python_ast/src/identifier.rs
@@ -138,22 +138,6 @@ impl TryIdentifier for Pattern {
     }
 }
 
-impl TryIdentifier for ExceptHandler {
-    /// Return the [`TextRange`] of a named exception in an [`ExceptHandler`].
-    ///
-    /// For example, return the range of `e` in:
-    /// ```python
-    /// try:
-    ///     ...
-    /// except ValueError as e:
-    ///     ...
-    /// ```
-    fn try_identifier(&self) -> Option<TextRange> {
-        let ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler { name, .. }) = self;
-        name.as_ref().map(Ranged::range)
-    }
-}
-
 /// Return the [`TextRange`] of the `except` token in an [`ExceptHandler`].
 pub fn except(handler: &ExceptHandler, locator: &Locator) -> TextRange {
     IdentifierTokenizer::new(locator.contents(), handler.range())


### PR DESCRIPTION
## Summary

The motivating change here is to remove `let range = except_handler.try_identifier().unwrap();` and instead just do `name.range()`, since exception names now have ranges attached to them by the parse. This also required some refactors (which are improvements) to the built-in attribute shadowing rules, since at least one invocation relied on passing in the exception handler and calling `.try_identifier()`. Now that we have easy access to identifiers, we can remove the whole `AnyShadowing` abstraction.