### PR TITLE
Do not fix `NamedTuple` calls containing both a list of fields and keywords

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP014.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP014.py
@@ -8,7 +8,6 @@ MyType = NamedTuple("MyType", [("a", int), ("b", tuple[str, ...])])
 MyType = NamedTuple(
     "MyType",
     [("a", int), ("b", str), ("c", list[bool])],
-    defaults=["foo", [True]],
 )
 
 # with namespace
@@ -18,7 +17,6 @@ MyType = typing.NamedTuple("MyType", [("a", int), ("b", str)])
 MyType = NamedTuple(
     "MyType",
     [("a", int), ("b", str)],
-    defaults=[1, "bar", "baz"],
 )
 
 # invalid identifiers (OK)
@@ -29,3 +27,6 @@ MyType = typing.NamedTuple("MyType")
 
 # empty fields
 MyType = typing.NamedTuple("MyType", [])
+
+# keywords
+MyType = typing.NamedTuple("MyType", a=int, b=tuple[str, ...])

--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP014.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP014.py
@@ -4,20 +4,8 @@ import typing
 # with complex annotations
 MyType = NamedTuple("MyType", [("a", int), ("b", tuple[str, ...])])
 
-# with default values as list
-MyType = NamedTuple(
-    "MyType",
-    [("a", int), ("b", str), ("c", list[bool])],
-)
-
 # with namespace
 MyType = typing.NamedTuple("MyType", [("a", int), ("b", str)])
-
-# too many default values (OK)
-MyType = NamedTuple(
-    "MyType",
-    [("a", int), ("b", str)],
-)
 
 # invalid identifiers (OK)
 MyType = NamedTuple("MyType", [("x-y", int), ("b", tuple[str, ...])])
@@ -30,3 +18,7 @@ MyType = typing.NamedTuple("MyType", [])
 
 # keywords
 MyType = typing.NamedTuple("MyType", a=int, b=tuple[str, ...])
+
+# unfixable
+MyType = typing.NamedTuple("MyType", [("a", int)], [("b", str)])
+MyType = typing.NamedTuple("MyType", [("a", int)], b=str)

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -111,7 +111,7 @@ fn create_property_assignment_stmt(property: &str, annotation: &Expr) -> Stmt {
     .into()
 }
 
-/// Create a list of property assignments from the `NamedTuple` positional arguments.
+/// Create a list of property assignments from the `NamedTuple` fields argument.
 fn create_properties_from_fields_arg(fields: &Expr) -> Result<Vec<Stmt>> {
     let Expr::List(ast::ExprList { elts, .. }) = &fields else {
         bail!("Expected argument to be `Expr::List`");

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP014.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP014.py.snap
@@ -23,37 +23,6 @@ UP014.py:5:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class s
 7 9 | # with default values as list
 8 10 | MyType = NamedTuple(
 
-UP014.py:8:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class syntax
-   |
- 7 |   # with default values as list
- 8 | / MyType = NamedTuple(
- 9 | |     "MyType",
-10 | |     [("a", int), ("b", str), ("c", list[bool])],
-11 | |     defaults=["foo", [True]],
-12 | | )
-   | |_^ UP014
-13 |   
-14 |   # with namespace
-   |
-   = help: Convert `MyType` to class syntax
-
-ℹ Suggested fix
-5  5  | MyType = NamedTuple("MyType", [("a", int), ("b", tuple[str, ...])])
-6  6  | 
-7  7  | # with default values as list
-8     |-MyType = NamedTuple(
-9     |-    "MyType",
-10    |-    [("a", int), ("b", str), ("c", list[bool])],
-11    |-    defaults=["foo", [True]],
-12    |-)
-   8  |+class MyType(NamedTuple):
-   9  |+    a: int
-   10 |+    b: str = "foo"
-   11 |+    c: list[bool] = [True]
-13 12 | 
-14 13 | # with namespace
-15 14 | MyType = typing.NamedTuple("MyType", [("a", int), ("b", str)])
-
 UP014.py:15:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class syntax
    |
 14 | # with namespace

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP014.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP014.py.snap
@@ -7,7 +7,7 @@ UP014.py:5:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class s
 5 | MyType = NamedTuple("MyType", [("a", int), ("b", tuple[str, ...])])
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP014
 6 | 
-7 | # with default values as list
+7 | # with namespace
   |
   = help: Convert `MyType` to class syntax
 
@@ -20,66 +20,93 @@ UP014.py:5:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class s
   6 |+    a: int
   7 |+    b: tuple[str, ...]
 6 8 | 
-7 9 | # with default values as list
-8 10 | MyType = NamedTuple(
+7 9 | # with namespace
+8 10 | MyType = typing.NamedTuple("MyType", [("a", int), ("b", str)])
 
-UP014.py:15:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class syntax
+UP014.py:8:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class syntax
    |
-14 | # with namespace
-15 | MyType = typing.NamedTuple("MyType", [("a", int), ("b", str)])
+ 7 | # with namespace
+ 8 | MyType = typing.NamedTuple("MyType", [("a", int), ("b", str)])
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP014
-16 | 
-17 | # too many default values (OK)
+ 9 | 
+10 | # invalid identifiers (OK)
    |
    = help: Convert `MyType` to class syntax
 
 ℹ Suggested fix
-12 12 | )
-13 13 | 
-14 14 | # with namespace
-15    |-MyType = typing.NamedTuple("MyType", [("a", int), ("b", str)])
-   15 |+class MyType(typing.NamedTuple):
-   16 |+    a: int
-   17 |+    b: str
-16 18 | 
-17 19 | # too many default values (OK)
-18 20 | MyType = NamedTuple(
+5  5  | MyType = NamedTuple("MyType", [("a", int), ("b", tuple[str, ...])])
+6  6  | 
+7  7  | # with namespace
+8     |-MyType = typing.NamedTuple("MyType", [("a", int), ("b", str)])
+   8  |+class MyType(typing.NamedTuple):
+   9  |+    a: int
+   10 |+    b: str
+9  11 | 
+10 12 | # invalid identifiers (OK)
+11 13 | MyType = NamedTuple("MyType", [("x-y", int), ("b", tuple[str, ...])])
 
-UP014.py:28:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class syntax
+UP014.py:14:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class syntax
    |
-27 | # no fields
-28 | MyType = typing.NamedTuple("MyType")
+13 | # no fields
+14 | MyType = typing.NamedTuple("MyType")
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP014
-29 | 
-30 | # empty fields
+15 | 
+16 | # empty fields
    |
    = help: Convert `MyType` to class syntax
 
 ℹ Suggested fix
-25 25 | MyType = NamedTuple("MyType", [("x-y", int), ("b", tuple[str, ...])])
-26 26 | 
-27 27 | # no fields
-28    |-MyType = typing.NamedTuple("MyType")
-   28 |+class MyType(typing.NamedTuple):
-   29 |+    pass
-29 30 | 
-30 31 | # empty fields
-31 32 | MyType = typing.NamedTuple("MyType", [])
+11 11 | MyType = NamedTuple("MyType", [("x-y", int), ("b", tuple[str, ...])])
+12 12 | 
+13 13 | # no fields
+14    |-MyType = typing.NamedTuple("MyType")
+   14 |+class MyType(typing.NamedTuple):
+   15 |+    pass
+15 16 | 
+16 17 | # empty fields
+17 18 | MyType = typing.NamedTuple("MyType", [])
 
-UP014.py:31:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class syntax
+UP014.py:17:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class syntax
    |
-30 | # empty fields
-31 | MyType = typing.NamedTuple("MyType", [])
+16 | # empty fields
+17 | MyType = typing.NamedTuple("MyType", [])
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP014
+18 | 
+19 | # keywords
    |
    = help: Convert `MyType` to class syntax
 
 ℹ Suggested fix
-28 28 | MyType = typing.NamedTuple("MyType")
-29 29 | 
-30 30 | # empty fields
-31    |-MyType = typing.NamedTuple("MyType", [])
-   31 |+class MyType(typing.NamedTuple):
-   32 |+    pass
+14 14 | MyType = typing.NamedTuple("MyType")
+15 15 | 
+16 16 | # empty fields
+17    |-MyType = typing.NamedTuple("MyType", [])
+   17 |+class MyType(typing.NamedTuple):
+   18 |+    pass
+18 19 | 
+19 20 | # keywords
+20 21 | MyType = typing.NamedTuple("MyType", a=int, b=tuple[str, ...])
+
+UP014.py:20:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class syntax
+   |
+19 | # keywords
+20 | MyType = typing.NamedTuple("MyType", a=int, b=tuple[str, ...])
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP014
+21 | 
+22 | # unfixable
+   |
+   = help: Convert `MyType` to class syntax
+
+ℹ Suggested fix
+17 17 | MyType = typing.NamedTuple("MyType", [])
+18 18 | 
+19 19 | # keywords
+20    |-MyType = typing.NamedTuple("MyType", a=int, b=tuple[str, ...])
+   20 |+class MyType(typing.NamedTuple):
+   21 |+    a: int
+   22 |+    b: tuple[str, ...]
+21 23 | 
+22 24 | # unfixable
+23 25 | MyType = typing.NamedTuple("MyType", [("a", int)], [("b", str)])
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #5794

## Test Plan

<!-- How was it tested? -->

Existing tests