### PR TITLE
Use tabbed interface for docs

### DIFF
--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -12,6 +12,7 @@ theme:
     - toc.follow
     - navigation.path
     - navigation.top
+    - navigation.tabs
     - content.code.copy
   palette:
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
Use tabbed interface for docs.

| Current | Tabbed Interface |
|--------|--------|
| <img width="1642" alt="Screenshot 2023-07-16 at 15 01 55" src="https://github.com/astral-sh/ruff/assets/67177269/15a2a1f7-2902-492b-a280-deb829879943"> | <img width="1641" alt="Screenshot 2023-07-16 at 15 00 59" src="https://github.com/astral-sh/ruff/assets/67177269/4a05c237-f1d5-4e63-bc7e-d734b5f0f893"> |

Or, we could use an additional TOC on the right side of the page.

<img width="1644" alt="Screenshot 2023-07-16 at 15 00 02" src="https://github.com/astral-sh/ruff/assets/67177269/2e6293cf-bdc5-4e22-b10a-6c3fca9620a1">

Examples:
* https://docs.pydantic.dev/latest/
* https://squidfunk.github.io/mkdocs-material/getting-started/
