### PR TITLE
tuple constants are for optimisations, not source

### DIFF
--- a/crates/ruff_python_formatter/src/expression/expr_constant.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_constant.rs
@@ -36,7 +36,7 @@ impl FormatNodeRule<ExprConstant> for FormatExprConstant {
                 not_yet_implemented_custom_text(r#"b"NOT_YET_IMPLEMENTED_BYTE_STRING""#).fmt(f)
             }
             Constant::Tuple(_) => {
-                not_yet_implemented_custom_text("(NOT_YET_IMPLEMENTED_TUPLE,)").fmt(f)
+                unreachable!("Tuple constants are only found in optimised bytecode")
             }
         }
     }


### PR DESCRIPTION
my reading of https://docs.python.org/3/library/ast.html#ast.unparse and
https://discuss.python.org/t/ast-constant-value-tuple-s-and-frozenset-s/22578 is that tuple constants cannot come from parsing python source, they are only for optimised bytecode
