### PR TITLE
Remove `TryIdentifier` trait

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -12,7 +12,7 @@ use rustpython_parser::ast::{
 use ruff_diagnostics::{Diagnostic, Fix, IsolationLevel};
 use ruff_python_ast::all::{extract_all_names, AllNamesFlags};
 use ruff_python_ast::helpers::{extract_handled_exceptions, to_module_path};
-use ruff_python_ast::identifier::{Identifier, TryIdentifier};
+use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::source_code::{Generator, Indexer, Locator, Quote, Stylist};
 use ruff_python_ast::str::trailing_quote;
 use ruff_python_ast::types::Node;
@@ -4086,7 +4086,7 @@ where
         {
             self.add_binding(
                 name,
-                pattern.try_identifier().unwrap(),
+                name.range(),
                 BindingKind::Assignment,
                 BindingFlags::empty(),
             );


### PR DESCRIPTION
## Summary

Last remaining usage here is for patterns, but we now have ranges on identifiers so it's unnecessary.