### PR TITLE
Draw boundaries between various `Checker` visitation phases

### DIFF
--- a/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
@@ -1,4 +1,4 @@
-use rustpython_parser::ast::{Expr, Ranged, Stmt};
+use rustpython_parser::ast::{Expr, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -60,12 +60,7 @@ impl Violation for MixedCaseVariableInGlobalScope {
 }
 
 /// N816
-pub(crate) fn mixed_case_variable_in_global_scope(
-    checker: &mut Checker,
-    expr: &Expr,
-    stmt: &Stmt,
-    name: &str,
-) {
+pub(crate) fn mixed_case_variable_in_global_scope(checker: &mut Checker, expr: &Expr, name: &str) {
     if checker
         .settings
         .pep8_naming
@@ -75,13 +70,20 @@ pub(crate) fn mixed_case_variable_in_global_scope(
     {
         return;
     }
-    if helpers::is_mixed_case(name) && !helpers::is_named_tuple_assignment(stmt, checker.semantic())
-    {
-        checker.diagnostics.push(Diagnostic::new(
-            MixedCaseVariableInGlobalScope {
-                name: name.to_string(),
-            },
-            expr.range(),
-        ));
+
+    if !helpers::is_mixed_case(name) {
+        return;
     }
+
+    let parent = checker.semantic().stmt();
+    if helpers::is_named_tuple_assignment(parent, checker.semantic()) {
+        return;
+    }
+
+    checker.diagnostics.push(Diagnostic::new(
+        MixedCaseVariableInGlobalScope {
+            name: name.to_string(),
+        },
+        expr.range(),
+    ));
 }

--- a/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
@@ -1,4 +1,4 @@
-use rustpython_parser::ast::{Expr, Ranged, Stmt};
+use rustpython_parser::ast::{Expr, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -50,12 +50,7 @@ impl Violation for NonLowercaseVariableInFunction {
 }
 
 /// N806
-pub(crate) fn non_lowercase_variable_in_function(
-    checker: &mut Checker,
-    expr: &Expr,
-    stmt: &Stmt,
-    name: &str,
-) {
+pub(crate) fn non_lowercase_variable_in_function(checker: &mut Checker, expr: &Expr, name: &str) {
     if checker
         .settings
         .pep8_naming
@@ -66,16 +61,22 @@ pub(crate) fn non_lowercase_variable_in_function(
         return;
     }
 
-    if !str::is_lowercase(name)
-        && !helpers::is_named_tuple_assignment(stmt, checker.semantic())
-        && !helpers::is_typed_dict_assignment(stmt, checker.semantic())
-        && !helpers::is_type_var_assignment(stmt, checker.semantic())
-    {
-        checker.diagnostics.push(Diagnostic::new(
-            NonLowercaseVariableInFunction {
-                name: name.to_string(),
-            },
-            expr.range(),
-        ));
+    if str::is_lowercase(name) {
+        return;
     }
+
+    let parent = checker.semantic().stmt();
+    if helpers::is_named_tuple_assignment(parent, checker.semantic())
+        || helpers::is_typed_dict_assignment(parent, checker.semantic())
+        || helpers::is_type_var_assignment(parent, checker.semantic())
+    {
+        return;
+    }
+
+    checker.diagnostics.push(Diagnostic::new(
+        NonLowercaseVariableInFunction {
+            name: name.to_string(),
+        },
+        expr.range(),
+    ));
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/ambiguous_class_name.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/ambiguous_class_name.rs
@@ -1,4 +1,4 @@
-use ruff_text_size::TextRange;
+use rustpython_parser::ast::{Identifier, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -35,14 +35,11 @@ impl Violation for AmbiguousClassName {
 }
 
 /// E742
-pub(crate) fn ambiguous_class_name<F>(name: &str, locate: F) -> Option<Diagnostic>
-where
-    F: FnOnce() -> TextRange,
-{
+pub(crate) fn ambiguous_class_name(name: &Identifier) -> Option<Diagnostic> {
     if is_ambiguous_name(name) {
         Some(Diagnostic::new(
             AmbiguousClassName(name.to_string()),
-            locate(),
+            name.range(),
         ))
     } else {
         None

--- a/crates/ruff/src/rules/pycodestyle/rules/ambiguous_function_name.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/ambiguous_function_name.rs
@@ -1,4 +1,4 @@
-use ruff_text_size::TextRange;
+use rustpython_parser::ast::{Identifier, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -35,14 +35,11 @@ impl Violation for AmbiguousFunctionName {
 }
 
 /// E743
-pub(crate) fn ambiguous_function_name<F>(name: &str, locate: F) -> Option<Diagnostic>
-where
-    F: FnOnce() -> TextRange,
-{
+pub(crate) fn ambiguous_function_name(name: &Identifier) -> Option<Diagnostic> {
     if is_ambiguous_name(name) {
         Some(Diagnostic::new(
             AmbiguousFunctionName(name.to_string()),
-            locate(),
+            name.range(),
         ))
     } else {
         None

--- a/crates/ruff/src/rules/pyflakes/rules/break_outside_loop.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/break_outside_loop.rs
@@ -33,7 +33,6 @@ pub(crate) fn break_outside_loop<'a>(
     stmt: &'a Stmt,
     parents: &mut impl Iterator<Item = &'a Stmt>,
 ) -> Option<Diagnostic> {
-    let mut allowed: bool = false;
     let mut child = stmt;
     for parent in parents {
         match parent {
@@ -41,8 +40,7 @@ pub(crate) fn break_outside_loop<'a>(
             | Stmt::AsyncFor(ast::StmtAsyncFor { orelse, .. })
             | Stmt::While(ast::StmtWhile { orelse, .. }) => {
                 if !orelse.contains(child) {
-                    allowed = true;
-                    break;
+                    return None;
                 }
             }
             Stmt::FunctionDef(_) | Stmt::AsyncFunctionDef(_) | Stmt::ClassDef(_) => {
@@ -53,9 +51,5 @@ pub(crate) fn break_outside_loop<'a>(
         child = parent;
     }
 
-    if allowed {
-        None
-    } else {
-        Some(Diagnostic::new(BreakOutsideLoop, stmt.range()))
-    }
+    Some(Diagnostic::new(BreakOutsideLoop, stmt.range()))
 }

--- a/crates/ruff/src/rules/pyflakes/rules/continue_outside_loop.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/continue_outside_loop.rs
@@ -33,7 +33,6 @@ pub(crate) fn continue_outside_loop<'a>(
     stmt: &'a Stmt,
     parents: &mut impl Iterator<Item = &'a Stmt>,
 ) -> Option<Diagnostic> {
-    let mut allowed: bool = false;
     let mut child = stmt;
     for parent in parents {
         match parent {
@@ -41,8 +40,7 @@ pub(crate) fn continue_outside_loop<'a>(
             | Stmt::AsyncFor(ast::StmtAsyncFor { orelse, .. })
             | Stmt::While(ast::StmtWhile { orelse, .. }) => {
                 if !orelse.contains(child) {
-                    allowed = true;
-                    break;
+                    return None;
                 }
             }
             Stmt::FunctionDef(_) | Stmt::AsyncFunctionDef(_) | Stmt::ClassDef(_) => {
@@ -53,9 +51,5 @@ pub(crate) fn continue_outside_loop<'a>(
         child = parent;
     }
 
-    if allowed {
-        None
-    } else {
-        Some(Diagnostic::new(ContinueOutsideLoop, stmt.range()))
-    }
+    Some(Diagnostic::new(ContinueOutsideLoop, stmt.range()))
 }


### PR DESCRIPTION
## Summary

This PR does some non-behavior-changing refactoring of the AST checker. Specifically, it breaks the `Stmt`, `Expr`, and `ExceptHandler` visitors into four distinct, consistent phases:

1. **Phase 1: Analysis**: Run any lint rules on the node.
2. **Phase 2: Binding**: Bind any symbols declared by the node.
3. **Phase 3: Recursion**: Visit all child nodes.
4. **Phase 4: Clean-up**: Pop scopes, etc.

There are some fuzzy boundaries in the last three phases, but the most important divide is between the Phase 1 and all the others -- the goal here is (as much as possible) to disentangle all of the vanilla lint-rule calls from any other semantic analysis or model building.

Part of the motivation here is that I'm considering re-ordering some of these phases, and it was just impossible to reason about that change as long as we had miscellaneous binding-creation and scope-modification code intermingled with lint rules. However, this could also enable us to (e.g.) move the entire analysis phase elsewhere, and even with a more limited API that has read-only access to `Checker` (but can push to a diagnostics vector).
