### PR TITLE
Read black options in format_dev script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ schemastore
 .venv*
 # Formatter debugging (crates/ruff_python_formatter/README.md)
 scratch.py
+scratch.pyi
 # Created by `perf` (CONTRIBUTING.md)
 perf.data
 perf.data.old

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,7 @@ schemastore
 # `maturin develop` and ecosystem_all_check.sh
 .venv*
 # Formatter debugging (crates/ruff_python_formatter/README.md)
-scratch.py
-scratch.pyi
+scratch.*
 # Created by `perf` (CONTRIBUTING.md)
 perf.data
 perf.data.old

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c785eefb63ebd0e33416dfcb8d6da0bf27ce752843a45632a67bf10d4d4b5c4"
+
+[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1987,6 +1993,7 @@ dependencies = [
  "clap",
  "ignore",
  "indicatif",
+ "indoc",
  "itertools",
  "libcst",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2004,11 +2004,13 @@ dependencies = [
  "rustpython-format",
  "rustpython-parser",
  "schemars",
+ "serde",
  "serde_json",
  "similar",
  "strum",
  "strum_macros",
  "tempfile",
+ "toml",
 ]
 
 [[package]]
@@ -2783,9 +2785,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebafdf5ad1220cb59e7d17cf4d2c72015297b75b19a10472f99b89225089240"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2804,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.11"
+version = "0.19.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
+checksum = "5f8751d9c1b03c6500c387e96f81f815a4f8e72d142d2d4a9ffa6fedd51ddee7"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -3339,9 +3341,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
 dependencies = [
  "memchr",
 ]

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -40,3 +40,6 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 tempfile = "3.6.0"
 toml = { version = "0.7.6", features = ["parse"] }
+
+[dev-dependencies]
+indoc = "2.0.3"

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -39,7 +39,7 @@ similar = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 tempfile = "3.6.0"
-toml = { version = "0.7.6", features = ["parse"] }
+toml = { workspace = true, features = ["parse"] }
 
 [dev-dependencies]
 indoc = "2.0.3"

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -28,13 +28,15 @@ libcst = { workspace = true }
 log = { workspace = true }
 once_cell = { workspace = true }
 pretty_assertions = { version = "1.3.0" }
-regex = { workspace = true }
 rayon = "1.7.0"
+regex = { workspace = true }
 rustpython-format = { workspace = true }
 rustpython-parser = { workspace = true }
 schemars = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 similar = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 tempfile = "3.6.0"
+toml = { version = "0.7.6", features = ["parse"] }

--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -271,7 +271,7 @@ It is also possible large number of repositories using ruff. This dataset is lar
 only do this occasionally:
 
 ```shell
-curl https://raw.githubusercontent.com/akx/ruff-usage-aggregate/master/data/known-github-tomls.jsonl > github_search.jsonl
+curl https://raw.githubusercontent.com/akx/ruff-usage-aggregate/master/data/known-github-tomls-clean.jsonl> github_search.jsonl
 python scripts/check_ecosystem.py --checkouts target/checkouts --projects github_search.jsonl -v $(which true) $(which true)
 cargo run --bin ruff_dev -- format-dev --stability-check --multi-project target/checkouts
 ```


### PR DESCRIPTION
## Summary

Comparing repos with black requires that we use the settings as black, notably line length and magic trailing comma behaviour. Excludes and preserving quotes (vs. a preference for either quote style) is not yet implemented because they weren't needed for the test projects.

In the other two commits i fixed the output when the progress bar is hidden (this way is recommonded in the indicatif docs), added a `scratch.pyi` file to gitignore because black formats stub files differently and also updated the ecosystem readme with the projects json without forks. 

## Test Plan

I added a `line-length` vs `line_length` test. Otherwise only my personal usage atm, a PR to integrate the script into the CI to check some projects will follow.
