### PR TITLE
Update from `join_with` example to `join_comma_separated`

### DIFF
--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -80,15 +80,15 @@ If it doesn't, we get something like
 ```
 
 For a list of expression, you don't need to format it manually but can use the `JoinBuilder` util,
-accessible through `.join_with`. Finish will write to the formatter internally.
+accessible through `.join_comma_separated`. Finish will write to the formatter internally.
 
 ```rust
-f.join_with(&format_args!(text(","), soft_line_break_or_space()))
-    .entries(self.elts.iter().formatted())
-    .finish()?;
-// Here we need a trailing comma on the last entry of an expanded group since we have more
-// than one element
-write!(f, [if_group_breaks(&text(","))])
+f.join_comma_separated(item.end())
+    .nodes(elts.iter())
+    .finish()
+// Here we have a builder that separates each element by a `,` and a [`soft_line_break_or_space`].
+// It emits a trailing `,` that is only shown if the enclosing group expands. It forces the enclosing
+// group to expand if the last item has a trailing `comma` and the magical comma option is enabled.
 ```
 
 If you need avoid second mutable borrows with a builder, you can use `format_with(|f| { ... })` as


### PR DESCRIPTION
## Summary

Originally `join_with` was used in the formatters README.md. Now it uses

```rs
f.join_comma_separated(item.end())
    .nodes(elts.iter())
    .finish()
```

## Test Plan

None
