### PR TITLE
[`pyflakes`] make F401 autofix "suggested" in `__init__.py` files

### DIFF
--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -160,7 +160,11 @@ mod tests {
     fn init() -> Result<()> {
         let diagnostics = test_path(
             Path::new("pyflakes/__init__.py"),
-            &Settings::for_rules(vec![Rule::UndefinedName, Rule::UndefinedExport]),
+            &Settings::for_rules(vec![
+                Rule::UndefinedName,
+                Rule::UndefinedExport,
+                Rule::UnusedImport,
+            ]),
         )?;
         assert_messages!(diagnostics);
         Ok(())

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__init.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__init.snap
@@ -1,4 +1,19 @@
 ---
 source: crates/ruff/src/rules/pyflakes/mod.rs
 ---
+__init__.py:1:8: F401 [*] `os` imported but unused; consider adding to `__all__` or using a redundant alias
+  |
+1 | import os
+  |        ^^ F401
+2 | 
+3 | print(__path__)
+  |
+  = help: Remove unused import: `os`
+
+ℹ Suggested fix
+1   |-import os
+2 1 | 
+3 2 | print(__path__)
+4 3 | 
+
 

--- a/crates/ruff/src/settings/options.rs
+++ b/crates/ruff/src/settings/options.rs
@@ -286,6 +286,8 @@ pub struct Options {
     /// imports will still be flagged, but with a dedicated message suggesting
     /// that the import is either added to the module's `__all__` symbol, or
     /// re-exported with a redundant alias (e.g., `import os as os`).
+    ///
+    /// This option has been **deprecated** and its effect is now the default behavior.
     pub ignore_init_module_imports: Option<bool>,
     #[option(
         default = r#"["*.py", "*.pyi", "**/pyproject.toml"]"#,

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -348,7 +348,7 @@
       }
     },
     "ignore-init-module-imports": {
-      "description": "Avoid automatically removing unused imports in `__init__.py` files. Such imports will still be flagged, but with a dedicated message suggesting that the import is either added to the module's `__all__` symbol, or re-exported with a redundant alias (e.g., `import os as os`).",
+      "description": "Avoid automatically removing unused imports in `__init__.py` files. Such imports will still be flagged, but with a dedicated message suggesting that the import is either added to the module's `__all__` symbol, or re-exported with a redundant alias (e.g., `import os as os`).\n\nThis option has been **deprecated** and its effect is now the default behavior.",
       "type": [
         "boolean",
         "null"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Make the F401 (`unused-import`) autofix "suggested", instead of "automatic".

Related:

* Closes https://github.com/astral-sh/ruff/issues/5697.

## Test Plan

- [x] Enable the `unused-import` rule in the existing pyflakes test for `__init__.py` files and validate the snapshot
