### PR TITLE
refactor: use find_keyword ast helper more

### DIFF
--- a/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -1,3 +1,4 @@
+use ruff_python_ast::helpers::find_keyword;
 use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
@@ -37,12 +38,7 @@ pub(crate) fn jinja2_autoescape_false(checker: &mut Checker, func: &Expr, keywor
             matches!(call_path.as_slice(), ["jinja2", "Environment"])
         })
     {
-        if let Some(keyword) = keywords.iter().find(|keyword| {
-            keyword
-                .arg
-                .as_ref()
-                .map_or(false, |arg| arg.as_str() == "autoescape")
-        }) {
+        if let Some(keyword) = find_keyword(keywords, "autoescape") {
             match &keyword.value {
                 Expr::Constant(ast::ExprConstant {
                     value: Constant::Bool(true),

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::is_const_false;
+use ruff_python_ast::helpers::{find_keyword, is_const_false};
 
 use crate::checkers::ast::Checker;
 
@@ -63,12 +63,7 @@ pub(crate) fn request_with_no_cert_validation(
             _ => None,
         })
     {
-        if let Some(keyword) = keywords.iter().find(|keyword| {
-            keyword
-                .arg
-                .as_ref()
-                .map_or(false, |arg| arg.as_str() == "verify")
-        }) {
+        if let Some(keyword) = find_keyword(keywords, "verify") {
             if is_const_false(&keyword.value) {
                 checker.diagnostics.push(Diagnostic::new(
                     RequestWithNoCertValidation {

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::is_const_none;
+use ruff_python_ast::helpers::{find_keyword, is_const_none};
 
 use crate::checkers::ast::Checker;
 
@@ -63,12 +63,7 @@ pub(crate) fn request_without_timeout(checker: &mut Checker, func: &Expr, keywor
             )
         })
     {
-        if let Some(keyword) = keywords.iter().find(|keyword| {
-            keyword
-                .arg
-                .as_ref()
-                .map_or(false, |arg| arg.as_str() == "timeout")
-        }) {
+        if let Some(keyword) = find_keyword(keywords, "timeout") {
             if is_const_none(&keyword.value) {
                 checker.diagnostics.push(Diagnostic::new(
                     RequestWithoutTimeout { implicit: false },

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
@@ -1,3 +1,4 @@
+use ruff_python_ast::helpers::find_keyword;
 use rustpython_parser::ast::{self, Expr, Keyword, Ranged, Stmt, WithItem};
 
 use ruff_diagnostics::{Diagnostic, Violation};
@@ -74,13 +75,7 @@ pub(crate) fn raises_call(checker: &mut Checker, func: &Expr, args: &[Expr], key
         }
 
         if checker.enabled(Rule::PytestRaisesTooBroad) {
-            let match_keyword = keywords.iter().find(|keyword| {
-                keyword
-                    .arg
-                    .as_ref()
-                    .map_or(false, |arg| arg.as_str() == "match")
-            });
-
+            let match_keyword = find_keyword(keywords, "match");
             if let Some(exception) = args.first() {
                 if let Some(match_keyword) = match_keyword {
                     if is_empty_or_null_string(&match_keyword.value) {


### PR DESCRIPTION
Use the ast helper function `find_keyword` where applicable

(found these while working on another feature)