### PR TITLE
Move unused deletion tracking to deferred analysis

### DIFF
--- a/crates/ruff/src/renamer.rs
+++ b/crates/ruff/src/renamer.rs
@@ -245,6 +245,7 @@ impl Renamer {
             | BindingKind::NamedExprAssignment
             | BindingKind::UnpackedAssignment
             | BindingKind::Assignment
+            | BindingKind::BoundException
             | BindingKind::LoopVar
             | BindingKind::Global
             | BindingKind::Nonlocal(_)

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -2115,7 +2115,7 @@ mod tests {
         try: pass
         except Exception as fu: pass
         "#,
-            &[Rule::UnusedVariable, Rule::RedefinedWhileUnused],
+            &[Rule::RedefinedWhileUnused, Rule::UnusedVariable],
         );
     }
 


### PR DESCRIPTION
## Summary

This PR moves the "unused exception" rule out of the visitor and into a deferred check. When we can base rules solely on the semantic model, we probably should, as it greatly simplifies the `Checker` itself.
