### PR TITLE
Add filename to `noqa` warnings

### DIFF
--- a/crates/ruff/src/checkers/noqa.rs
+++ b/crates/ruff/src/checkers/noqa.rs
@@ -1,5 +1,7 @@
 //! `NoQA` enforcement and validation.
 
+use std::path::Path;
+
 use itertools::Itertools;
 use ruff_text_size::{TextLen, TextRange, TextSize};
 use rustpython_parser::ast::Ranged;
@@ -15,6 +17,7 @@ use crate::rules::ruff::rules::{UnusedCodes, UnusedNOQA};
 use crate::settings::Settings;
 
 pub(crate) fn check_noqa(
+    path: &Path,
     diagnostics: &mut Vec<Diagnostic>,
     locator: &Locator,
     comment_ranges: &[TextRange],
@@ -23,10 +26,10 @@ pub(crate) fn check_noqa(
     settings: &Settings,
 ) -> Vec<usize> {
     // Identify any codes that are globally exempted (within the current file).
-    let exemption = FileExemption::try_extract(locator.contents(), comment_ranges, locator);
+    let exemption = FileExemption::try_extract(path, locator.contents(), comment_ranges, locator);
 
     // Extract all `noqa` directives.
-    let mut noqa_directives = NoqaDirectives::from_commented_ranges(comment_ranges, locator);
+    let mut noqa_directives = NoqaDirectives::from_commented_ranges(path, comment_ranges, locator);
 
     // Indices of diagnostics that were ignored by a `noqa` directive.
     let mut ignored_diagnostics = vec![];

--- a/crates/ruff/src/checkers/noqa.rs
+++ b/crates/ruff/src/checkers/noqa.rs
@@ -17,8 +17,8 @@ use crate::rules::ruff::rules::{UnusedCodes, UnusedNOQA};
 use crate::settings::Settings;
 
 pub(crate) fn check_noqa(
-    path: &Path,
     diagnostics: &mut Vec<Diagnostic>,
+    path: &Path,
     locator: &Locator,
     comment_ranges: &[TextRange],
     noqa_line_for: &NoqaMapping,
@@ -26,10 +26,10 @@ pub(crate) fn check_noqa(
     settings: &Settings,
 ) -> Vec<usize> {
     // Identify any codes that are globally exempted (within the current file).
-    let exemption = FileExemption::try_extract(path, locator.contents(), comment_ranges, locator);
+    let exemption = FileExemption::try_extract(locator.contents(), comment_ranges, path, locator);
 
     // Extract all `noqa` directives.
-    let mut noqa_directives = NoqaDirectives::from_commented_ranges(path, comment_ranges, locator);
+    let mut noqa_directives = NoqaDirectives::from_commented_ranges(comment_ranges, path, locator);
 
     // Indices of diagnostics that were ignored by a `noqa` directive.
     let mut ignored_diagnostics = vec![];

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -213,6 +213,7 @@ pub fn check_path(
             .any(|rule_code| rule_code.lint_source().is_noqa())
     {
         let ignored = check_noqa(
+            path,
             &mut diagnostics,
             locator,
             indexer.comment_ranges(),

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -213,8 +213,8 @@ pub fn check_path(
             .any(|rule_code| rule_code.lint_source().is_noqa())
     {
         let ignored = check_noqa(
-            path,
             &mut diagnostics,
+            path,
             locator,
             indexer.comment_ranges(),
             &directives.noqa_line_for,

--- a/crates/ruff/src/noqa.rs
+++ b/crates/ruff/src/noqa.rs
@@ -959,7 +959,7 @@ mod tests {
         let contents = "x = 1";
         let noqa_line_for = NoqaMapping::default();
         let (count, output) = add_noqa_inner(
-            &path,
+            path,
             &[],
             &Locator::new(contents),
             &[],
@@ -979,7 +979,7 @@ mod tests {
         let contents = "x = 1";
         let noqa_line_for = NoqaMapping::default();
         let (count, output) = add_noqa_inner(
-            &path,
+            path,
             &diagnostics,
             &Locator::new(contents),
             &[],
@@ -1004,7 +1004,7 @@ mod tests {
         let contents = "x = 1  # noqa: E741\n";
         let noqa_line_for = NoqaMapping::default();
         let (count, output) = add_noqa_inner(
-            &path,
+            path,
             &diagnostics,
             &Locator::new(contents),
             &[TextRange::new(TextSize::from(7), TextSize::from(19))],
@@ -1029,7 +1029,7 @@ mod tests {
         let contents = "x = 1  # noqa";
         let noqa_line_for = NoqaMapping::default();
         let (count, output) = add_noqa_inner(
-            &path,
+            path,
             &diagnostics,
             &Locator::new(contents),
             &[TextRange::new(TextSize::from(7), TextSize::from(13))],

--- a/crates/ruff/src/noqa.rs
+++ b/crates/ruff/src/noqa.rs
@@ -764,6 +764,8 @@ impl FromIterator<TextRange> for NoqaMapping {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use insta::assert_debug_snapshot;
     use ruff_text_size::{TextRange, TextSize};
 

--- a/crates/ruff/src/noqa.rs
+++ b/crates/ruff/src/noqa.rs
@@ -952,9 +952,12 @@ mod tests {
 
     #[test]
     fn modification() {
+        let path = Path::new("/tmp/foo.txt");
+
         let contents = "x = 1";
         let noqa_line_for = NoqaMapping::default();
         let (count, output) = add_noqa_inner(
+            &path,
             &[],
             &Locator::new(contents),
             &[],
@@ -974,6 +977,7 @@ mod tests {
         let contents = "x = 1";
         let noqa_line_for = NoqaMapping::default();
         let (count, output) = add_noqa_inner(
+            &path,
             &diagnostics,
             &Locator::new(contents),
             &[],
@@ -998,6 +1002,7 @@ mod tests {
         let contents = "x = 1  # noqa: E741\n";
         let noqa_line_for = NoqaMapping::default();
         let (count, output) = add_noqa_inner(
+            &path,
             &diagnostics,
             &Locator::new(contents),
             &[TextRange::new(TextSize::from(7), TextSize::from(19))],
@@ -1022,6 +1027,7 @@ mod tests {
         let contents = "x = 1  # noqa";
         let noqa_line_for = NoqaMapping::default();
         let (count, output) = add_noqa_inner(
+            &path,
             &diagnostics,
             &Locator::new(contents),
             &[TextRange::new(TextSize::from(7), TextSize::from(13))],


### PR DESCRIPTION
## Summary

Before:

```
» ruff litestar tests --fix
warning: Invalid `# noqa` directive on line 19: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on line 65: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on line 74: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on line 22: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on line 66: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on line 75: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
```

After:

```
» cargo run --bin ruff ../litestar/litestar ../litestar/tests
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/ruff ../litestar/litestar ../litestar/tests`
warning: Detected debug build without --no-cache.
warning: Invalid `# noqa` directive on /Users/sobolev/Desktop/litestar/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py:19: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on /Users/sobolev/Desktop/litestar/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py:65: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on /Users/sobolev/Desktop/litestar/tests/unit/test_contrib/test_sqlalchemy/models_bigint.py:74: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on /Users/sobolev/Desktop/litestar/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py:22: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on /Users/sobolev/Desktop/litestar/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py:66: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on /Users/sobolev/Desktop/litestar/tests/unit/test_contrib/test_sqlalchemy/models_uuid.py:75: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
```

## Test Plan

I didn't find any existing tests with this warning.

Closes https://github.com/astral-sh/ruff/issues/5855
Closes https://github.com/astral-sh/ruff/issues/5729