### PR TITLE
Upgrade cargo insta

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,10 +53,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: "Install Rust toolchain"
         run: rustup show
-      - uses: Swatinem/rust-cache@v2
-      # cargo insta 1.30.0 fails for some reason (https://github.com/mitsuhiko/insta/issues/392)
-      - run: cargo install cargo-insta@=1.29.0
+      - name: "Install cargo insta"
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-insta
       - run: pip install black[d]==23.1.0
+      - uses: Swatinem/rust-cache@v2
       - name: "Run tests (Ubuntu)"
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: cargo insta test --all --all-features --unreferenced reject

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.30.0"
+version = "1.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28491f7753051e5704d4d0ae7860d45fae3238d7d235bc4289dcd45c48d3cec3"
+checksum = "a0770b0a3d4c70567f0d58331f3088b0e4c4f56c9b8d764efe654b4a5d46de3a"
 dependencies = [
  "console",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ filetime = { version = "0.2.20" }
 glob = { version = "0.3.1" }
 globset = { version = "0.4.10" }
 ignore = { version = "0.4.20" }
-insta = { version = "1.30.0" }
+insta = { version = "1.31.0" }
 is-macro = { version = "0.2.2" }
 itertools = { version = "0.10.5" }
 log = { version = "0.4.17" }

--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -26,6 +26,12 @@ use crate::settings::{flags, Settings};
 use crate::source_kind::SourceKind;
 
 #[cfg(not(fuzzing))]
+#[test]
+pub(crate) fn intentionally_failing() {
+    assert_eq!(true, false);
+}
+
+#[cfg(not(fuzzing))]
 pub(crate) fn read_jupyter_notebook(path: &Path) -> Result<Notebook> {
     let path = test_resource_path("fixtures/jupyter").join(path);
     Notebook::read(&path).map_err(|err| {

--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -26,12 +26,6 @@ use crate::settings::{flags, Settings};
 use crate::source_kind::SourceKind;
 
 #[cfg(not(fuzzing))]
-#[test]
-pub(crate) fn intentionally_failing() {
-    assert_eq!(true, false);
-}
-
-#[cfg(not(fuzzing))]
 pub(crate) fn read_jupyter_notebook(path: &Path) -> Result<Notebook> {
     let path = test_resource_path("fixtures/jupyter").join(path);
     Notebook::read(&path).map_err(|err| {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR upgrades insta and cargo-insta in the CI pipeline, now that the [exit code bug](https://github.com/mitsuhiko/insta/issues/392) is fixed.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

The CI job fails as expected on [a failing test](https://github.com/astral-sh/ruff/actions/runs/5592408847/jobs/10224860467?pr=5872).

<!-- How was it tested? -->
