### PR TITLE
Use `.as_ref()` in lieu of `&**`

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -411,7 +411,7 @@ where
                             stmt,
                             name,
                             decorator_list,
-                            returns.as_ref().map(|expr| &**expr),
+                            returns.as_ref().map(AsRef::as_ref),
                             args,
                             stmt.is_async_function_def_stmt(),
                         );
@@ -470,18 +470,14 @@ where
                     Rule::SuperfluousElseContinue,
                     Rule::SuperfluousElseBreak,
                 ]) {
-                    flake8_return::rules::function(
-                        self,
-                        body,
-                        returns.as_ref().map(|expr| &**expr),
-                    );
+                    flake8_return::rules::function(self, body, returns.as_ref().map(AsRef::as_ref));
                 }
                 if self.enabled(Rule::UselessReturn) {
                     pylint::rules::useless_return(
                         self,
                         stmt,
                         body,
-                        returns.as_ref().map(|expr| &**expr),
+                        returns.as_ref().map(AsRef::as_ref),
                     );
                 }
                 if self.enabled(Rule::ComplexStructure) {

--- a/crates/ruff/src/rules/flake8_annotations/helpers.rs
+++ b/crates/ruff/src/rules/flake8_annotations/helpers.rs
@@ -26,7 +26,7 @@ pub(super) fn match_function_def(
         }) => (
             name,
             args,
-            returns.as_ref().map(|expr| &**expr),
+            returns.as_ref().map(AsRef::as_ref),
             body,
             decorator_list,
         ),

--- a/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
+++ b/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
@@ -274,7 +274,7 @@ fn assignment_targets_from_expr<'a>(
             ctx: ExprContext::Store,
             value,
             range: _,
-        }) => Box::new(iter::once(&**value)),
+        }) => Box::new(iter::once(value.as_ref())),
         Expr::Name(ast::ExprName {
             ctx: ExprContext::Store,
             id,

--- a/crates/ruff_python_ast/src/all.rs
+++ b/crates/ruff_python_ast/src/all.rs
@@ -65,7 +65,7 @@ where
             }) => {
                 // Allow `tuple()` and `list()` calls.
                 if keywords.is_empty() && args.len() <= 1 {
-                    if let Expr::Name(ast::ExprName { id, .. }) = &**func {
+                    if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
                         let id = id.as_str();
                         if id == "tuple" || id == "list" {
                             if is_builtin(id) {
@@ -106,7 +106,7 @@ where
         Stmt::AugAssign(ast::StmtAugAssign { value, .. }) => Some(value),
         _ => None,
     } {
-        if let Expr::BinOp(ast::ExprBinOp { left, right, .. }) = &**value {
+        if let Expr::BinOp(ast::ExprBinOp { left, right, .. }) = value.as_ref() {
             let mut current_left = left;
             let mut current_right = right;
             loop {
@@ -119,7 +119,7 @@ where
 
                 // Process the left side, which can be a "real" value or the "rest" of the
                 // binary operation.
-                if let Expr::BinOp(ast::ExprBinOp { left, right, .. }) = &**current_left {
+                if let Expr::BinOp(ast::ExprBinOp { left, right, .. }) = current_left.as_ref() {
                     current_left = left;
                     current_right = right;
                 } else {

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -274,7 +274,7 @@ impl<'a> From<&'a ast::Pattern> for ComparablePattern<'a> {
 
 impl<'a> From<&'a Box<ast::Pattern>> for Box<ComparablePattern<'a>> {
     fn from(pattern: &'a Box<ast::Pattern>) -> Self {
-        Box::new((&**pattern).into())
+        Box::new((pattern.as_ref()).into())
     }
 }
 
@@ -362,13 +362,13 @@ impl<'a> From<&'a ast::Arguments> for ComparableArguments<'a> {
 
 impl<'a> From<&'a Box<ast::Arguments>> for ComparableArguments<'a> {
     fn from(arguments: &'a Box<ast::Arguments>) -> Self {
-        (&**arguments).into()
+        (arguments.as_ref()).into()
     }
 }
 
 impl<'a> From<&'a Box<ast::Arg>> for ComparableArg<'a> {
     fn from(arg: &'a Box<ast::Arg>) -> Self {
-        (&**arg).into()
+        (arg.as_ref()).into()
     }
 }
 
@@ -685,13 +685,13 @@ pub enum ComparableExpr<'a> {
 
 impl<'a> From<&'a Box<ast::Expr>> for Box<ComparableExpr<'a>> {
     fn from(expr: &'a Box<ast::Expr>) -> Self {
-        Box::new((&**expr).into())
+        Box::new((expr.as_ref()).into())
     }
 }
 
 impl<'a> From<&'a Box<ast::Expr>> for ComparableExpr<'a> {
     fn from(expr: &'a Box<ast::Expr>) -> Self {
-        (&**expr).into()
+        (expr.as_ref()).into()
     }
 }
 
@@ -737,7 +737,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                 body,
                 range: _range,
             }) => Self::Lambda(ExprLambda {
-                args: (&**args).into(),
+                args: (args.as_ref()).into(),
                 body: body.into(),
             }),
             ast::Expr::IfExp(ast::ExprIfExp {

--- a/crates/ruff_python_ast/src/source_code/generator.rs
+++ b/crates/ruff_python_ast/src/source_code/generator.rs
@@ -1156,7 +1156,7 @@ impl<'a> Generator<'a> {
                         range: _range,
                     })],
                     [],
-                ) = (&**args, &**keywords)
+                ) = (args.as_slice(), keywords.as_slice())
                 {
                     // Ensure that a single generator doesn't get double-parenthesized.
                     self.unparse_expr(elt, precedence::COMMA);

--- a/crates/ruff_python_semantic/src/analyze/type_inference.rs
+++ b/crates/ruff_python_semantic/src/analyze/type_inference.rs
@@ -44,8 +44,8 @@ pub enum PythonType {
 impl From<&Expr> for PythonType {
     fn from(expr: &Expr) -> Self {
         match expr {
-            Expr::NamedExpr(ast::ExprNamedExpr { value, .. }) => (&**value).into(),
-            Expr::UnaryOp(ast::ExprUnaryOp { operand, .. }) => (&**operand).into(),
+            Expr::NamedExpr(ast::ExprNamedExpr { value, .. }) => (value.as_ref()).into(),
+            Expr::UnaryOp(ast::ExprUnaryOp { operand, .. }) => (operand.as_ref()).into(),
             Expr::Dict(_) => PythonType::Dict,
             Expr::DictComp(_) => PythonType::Dict,
             Expr::Set(_) => PythonType::Set,


### PR DESCRIPTION
I find this less opaque (and often more succinct).