### PR TITLE
Make `lint_only` aware of the source kind

### DIFF
--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -321,6 +321,7 @@ pub fn lint_only(
     package: Option<&Path>,
     settings: &Settings,
     noqa: flags::Noqa,
+    source_kind: Option<&SourceKind>,
 ) -> LinterResult<(Vec<Message>, Option<ImportMap>)> {
     // Tokenize once.
     let tokens: Vec<LexResult> = ruff_rustpython::tokenize(contents);
@@ -353,7 +354,7 @@ pub fn lint_only(
         &directives,
         settings,
         noqa,
-        None,
+        source_kind,
     );
 
     result.map(|(diagnostics, imports)| {

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -63,6 +63,7 @@ fn benchmark_linter(mut group: BenchmarkGroup<WallTime>, settings: &Settings) {
                         None,
                         settings,
                         flags::Noqa::Enabled,
+                        None,
                     );
 
                     // Assert that file contains no parse errors

--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -204,12 +204,26 @@ pub(crate) fn lint_path(
             (result, fixed)
         } else {
             // If we fail to autofix, lint the original source code.
-            let result = lint_only(&contents, path, package, &settings.lib, noqa);
+            let result = lint_only(
+                &contents,
+                path,
+                package,
+                &settings.lib,
+                noqa,
+                Some(&source_kind),
+            );
             let fixed = FxHashMap::default();
             (result, fixed)
         }
     } else {
-        let result = lint_only(&contents, path, package, &settings.lib, noqa);
+        let result = lint_only(
+            &contents,
+            path,
+            package,
+            &settings.lib,
+            noqa,
+            Some(&source_kind),
+        );
         let fixed = FxHashMap::default();
         (result, fixed)
     };
@@ -316,6 +330,7 @@ pub(crate) fn lint_stdin(
                 package,
                 settings,
                 noqa,
+                Some(&source_kind),
             );
             let fixed = FxHashMap::default();
 
@@ -333,6 +348,7 @@ pub(crate) fn lint_stdin(
             package,
             settings,
             noqa,
+            Some(&source_kind),
         );
         let fixed = FxHashMap::default();
         (result, fixed)


### PR DESCRIPTION
## Summary

Make `lint_only` aware of the source kind

fixes: #5875
