### PR TITLE
Fix `SimpleTokenizer`'s backward lexing of `# `

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2197,6 +2197,7 @@ dependencies = [
  "insta",
  "memchr",
  "ruff_text_size",
+ "smallvec",
  "unic-ucd-ident",
 ]
 

--- a/crates/ruff/src/rules/pyflakes/fixes.rs
+++ b/crates/ruff/src/rules/pyflakes/fixes.rs
@@ -95,8 +95,11 @@ pub(crate) fn remove_exception_handler_assignment(
     locator: &Locator,
 ) -> Result<Edit> {
     // Lex backwards, to the token just before the `as`.
-    let mut tokenizer =
-        SimpleTokenizer::up_to(bound_exception.range.start(), locator.contents()).skip_trivia();
+    let mut tokenizer = SimpleTokenizer::up_to_without_back_comment(
+        bound_exception.range.start(),
+        locator.contents(),
+    )
+    .skip_trivia();
 
     // Eat the `as` token.
     let preceding = tokenizer

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -8,8 +8,7 @@ use ruff_python_ast::node::{AnyNodeRef, AstNode};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::whitespace;
 use ruff_python_trivia::{
-    first_non_trivia_token_rev, PythonWhitespace, SimpleToken, SimpleTokenKind, SimpleTokenizer,
-    UniversalNewlines,
+    PythonWhitespace, SimpleToken, SimpleTokenKind, SimpleTokenizer, UniversalNewlines,
 };
 
 use crate::comments::visitor::{CommentPlacement, DecoratedComment};
@@ -1060,7 +1059,9 @@ fn handle_slice_comments<'a>(
 
     // Check for `foo[ # comment`, but only if they are on the same line
     let after_lbracket = matches!(
-        first_non_trivia_token_rev(comment.slice().start(), locator.contents()),
+        SimpleTokenizer::up_to_without_back_comment(comment.slice().start(), locator.contents())
+            .skip_trivia()
+            .next_back(),
         Some(SimpleToken {
             kind: SimpleTokenKind::LBracket,
             ..

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -279,30 +279,23 @@ if True:
     #[test]
     fn quick_test() {
         let src = r#"
-with (
-    [
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "bbbbbbbbbb",
-        "cccccccccccccccccccccccccccccccccccccccccc",
-        dddddddddddddddddddddddddddddddd,
-    ] as example1,
-    aaaaaaaaaaaaaaaaaaaaaaaaaa
-    + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    + cccccccccccccccccccccccccccc
-    + ddddddddddddddddd as example2,
-    CtxManager2() as example2,
-    CtxManager2() as example2,
-    CtxManager2() as example2,
-):
-    ...
+(
+    # leading
+    "a" # trailing part comment
 
-with [
-    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "bbbbbbbbbb",
-    "cccccccccccccccccccccccccccccccccccccccccc",
-    dddddddddddddddddddddddddddddddd,
-] as example1, aaaaaaaaaaaaaaaaaaaaaaaaaa * bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb * cccccccccccccccccccccccccccc + ddddddddddddddddd as example2, CtxManager222222222222222() as example2:
-    ...
+    # leading part comment
+
+    "b" # trailing second part comment
+    # trailing
+)
+
+(
+    # leading
+    "a"  # trailing part comment
+    # leading part comment
+    "b"  # trailing second part comment
+    # trailing
+)
 
 "#;
         // Tokenize once

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -279,23 +279,30 @@ if True:
     #[test]
     fn quick_test() {
         let src = r#"
-(
-    # leading
-    "a" # trailing part comment
+with (
+    [
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "bbbbbbbbbb",
+        "cccccccccccccccccccccccccccccccccccccccccc",
+        dddddddddddddddddddddddddddddddd,
+    ] as example1,
+    aaaaaaaaaaaaaaaaaaaaaaaaaa
+    + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    + cccccccccccccccccccccccccccc
+    + ddddddddddddddddd as example2,
+    CtxManager2() as example2,
+    CtxManager2() as example2,
+    CtxManager2() as example2,
+):
+    ...
 
-    # leading part comment
-
-    "b" # trailing second part comment
-    # trailing
-)
-
-(
-    # leading
-    "a"  # trailing part comment
-    # leading part comment
-    "b"  # trailing second part comment
-    # trailing
-)
+with [
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "bbbbbbbbbb",
+    "cccccccccccccccccccccccccccccccccccccccccc",
+    dddddddddddddddddddddddddddddddd,
+] as example1, aaaaaaaaaaaaaaaaaaaaaaaaaa * bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb * cccccccccccccccccccccccccccc + ddddddddddddddddd as example2, CtxManager222222222222222() as example2:
+    ...
 
 "#;
         // Tokenize once

--- a/crates/ruff_python_trivia/Cargo.toml
+++ b/crates/ruff_python_trivia/Cargo.toml
@@ -16,6 +16,7 @@ license = { workspace = true }
 ruff_text_size = { workspace = true }
 
 memchr = { workspace = true }
+smallvec = { workspace = true }
 unic-ucd-ident = "0.9.0"
 
 [dev-dependencies]

--- a/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__comment_containing_single_quoted_string.snap
+++ b/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__comment_containing_single_quoted_string.snap
@@ -1,0 +1,78 @@
+---
+source: crates/ruff_python_trivia/src/tokenizer.rs
+expression: test_case.tokenize_reverse()
+---
+[
+    SimpleToken {
+        kind: Comment,
+        range: 17..43,
+    },
+    SimpleToken {
+        kind: Whitespace,
+        range: 16..17,
+    },
+    SimpleToken {
+        kind: Other,
+        range: 15..16,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 14..15,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 13..14,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 12..13,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 11..12,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 10..11,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 9..10,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 8..9,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 7..8,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 6..7,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 5..6,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 4..5,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 3..4,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 2..3,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 1..2,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 0..1,
+    },
+]

--- a/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__comment_containing_triple_quoted_string.snap
+++ b/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__comment_containing_triple_quoted_string.snap
@@ -1,0 +1,94 @@
+---
+source: crates/ruff_python_trivia/src/tokenizer.rs
+expression: test_case.tokenize_reverse()
+---
+[
+    SimpleToken {
+        kind: Comment,
+        range: 21..51,
+    },
+    SimpleToken {
+        kind: Whitespace,
+        range: 20..21,
+    },
+    SimpleToken {
+        kind: Other,
+        range: 19..20,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 18..19,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 17..18,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 16..17,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 15..16,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 14..15,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 13..14,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 12..13,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 11..12,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 10..11,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 9..10,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 8..9,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 7..8,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 6..7,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 5..6,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 4..5,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 3..4,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 2..3,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 1..2,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 0..1,
+    },
+]

--- a/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__single_quoted_multiline_string_containing_comment.snap
+++ b/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__single_quoted_multiline_string_containing_comment.snap
@@ -1,0 +1,314 @@
+---
+source: crates/ruff_python_trivia/src/tokenizer.rs
+expression: test_case.tokenize_reverse()
+---
+[
+    SimpleToken {
+        kind: Other,
+        range: 76..77,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 75..76,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 74..75,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 73..74,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 72..73,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 71..72,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 70..71,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 69..70,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 68..69,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 67..68,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 66..67,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 65..66,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 64..65,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 63..64,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 62..63,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 61..62,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 60..61,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 59..60,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 58..59,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 57..58,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 56..57,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 55..56,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 54..55,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 53..54,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 52..53,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 51..52,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 50..51,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 49..50,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 48..49,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 47..48,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 46..47,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 45..46,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 44..45,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 43..44,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 42..43,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 41..42,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 40..41,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 39..40,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 38..39,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 37..38,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 36..37,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 35..36,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 34..35,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 33..34,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 32..33,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 31..32,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 30..31,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 29..30,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 28..29,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 27..28,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 26..27,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 25..26,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 24..25,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 23..24,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 22..23,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 21..22,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 20..21,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 19..20,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 18..19,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 17..18,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 16..17,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 15..16,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 14..15,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 13..14,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 12..13,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 11..12,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 10..11,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 9..10,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 8..9,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 7..8,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 6..7,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 5..6,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 4..5,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 3..4,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 2..3,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 1..2,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 0..1,
+    },
+]

--- a/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__single_quoted_multiline_string_implicit_concatenation.snap
+++ b/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__single_quoted_multiline_string_implicit_concatenation.snap
@@ -1,0 +1,322 @@
+---
+source: crates/ruff_python_trivia/src/tokenizer.rs
+expression: test_case.tokenize_reverse()
+---
+[
+    SimpleToken {
+        kind: Other,
+        range: 78..79,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 77..78,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 76..77,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 75..76,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 74..75,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 73..74,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 72..73,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 71..72,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 70..71,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 69..70,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 68..69,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 67..68,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 66..67,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 65..66,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 64..65,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 63..64,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 62..63,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 61..62,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 60..61,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 59..60,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 58..59,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 57..58,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 56..57,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 55..56,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 54..55,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 53..54,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 52..53,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 51..52,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 50..51,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 49..50,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 48..49,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 47..48,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 46..47,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 45..46,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 44..45,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 43..44,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 42..43,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 41..42,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 40..41,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 39..40,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 38..39,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 37..38,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 36..37,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 35..36,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 34..35,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 33..34,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 32..33,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 31..32,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 30..31,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 29..30,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 28..29,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 27..28,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 26..27,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 25..26,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 24..25,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 23..24,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 22..23,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 21..22,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 20..21,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 19..20,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 18..19,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 17..18,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 16..17,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 15..16,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 14..15,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 13..14,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 12..13,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 11..12,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 10..11,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 9..10,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 8..9,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 7..8,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 6..7,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 5..6,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 4..5,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 3..4,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 2..3,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 1..2,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 0..1,
+    },
+]

--- a/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__string_followed_by_multiple_comments.snap
+++ b/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__string_followed_by_multiple_comments.snap
@@ -1,0 +1,222 @@
+---
+source: crates/ruff_python_trivia/src/tokenizer.rs
+expression: test_case.tokenize_reverse()
+---
+[
+    SimpleToken {
+        kind: Comment,
+        range: 53..72,
+    },
+    SimpleToken {
+        kind: Whitespace,
+        range: 52..53,
+    },
+    SimpleToken {
+        kind: Other,
+        range: 51..52,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 50..51,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 49..50,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 48..49,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 47..48,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 46..47,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 45..46,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 44..45,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 43..44,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 42..43,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 41..42,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 40..41,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 39..40,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 38..39,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 37..38,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 36..37,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 35..36,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 34..35,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 33..34,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 32..33,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 31..32,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 30..31,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 29..30,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 28..29,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 27..28,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 26..27,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 25..26,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 24..25,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 23..24,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 22..23,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 21..22,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 20..21,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 19..20,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 18..19,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 17..18,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 16..17,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 15..16,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 14..15,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 13..14,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 12..13,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 11..12,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 10..11,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 9..10,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 8..9,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 7..8,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 6..7,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 5..6,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 4..5,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 3..4,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 2..3,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 1..2,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 0..1,
+    },
+]

--- a/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__string_with_double_escaped_backslash.snap
+++ b/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__string_with_double_escaped_backslash.snap
@@ -1,0 +1,66 @@
+---
+source: crates/ruff_python_trivia/src/tokenizer.rs
+expression: test_case.tokenize_reverse()
+---
+[
+    SimpleToken {
+        kind: Comment,
+        range: 14..27,
+    },
+    SimpleToken {
+        kind: Whitespace,
+        range: 13..14,
+    },
+    SimpleToken {
+        kind: Other,
+        range: 12..13,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 11..12,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 10..11,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 9..10,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 8..9,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 7..8,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 6..7,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 5..6,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 4..5,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 3..4,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 2..3,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 1..2,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 0..1,
+    },
+]

--- a/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__string_with_escaped_quote.snap
+++ b/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__string_with_escaped_quote.snap
@@ -1,0 +1,150 @@
+---
+source: crates/ruff_python_trivia/src/tokenizer.rs
+expression: test_case.tokenize_reverse()
+---
+[
+    SimpleToken {
+        kind: Comment,
+        range: 35..54,
+    },
+    SimpleToken {
+        kind: Whitespace,
+        range: 34..35,
+    },
+    SimpleToken {
+        kind: Other,
+        range: 33..34,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 32..33,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 31..32,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 30..31,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 29..30,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 28..29,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 27..28,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 26..27,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 25..26,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 24..25,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 23..24,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 22..23,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 21..22,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 20..21,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 19..20,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 18..19,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 17..18,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 16..17,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 15..16,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 14..15,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 13..14,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 12..13,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 11..12,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 10..11,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 9..10,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 8..9,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 7..8,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 6..7,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 5..6,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 4..5,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 3..4,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 2..3,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 1..2,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 0..1,
+    },
+]

--- a/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__triple_quoted_multiline_string_containing_comment.snap
+++ b/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__triple_quoted_multiline_string_containing_comment.snap
@@ -1,0 +1,326 @@
+---
+source: crates/ruff_python_trivia/src/tokenizer.rs
+expression: test_case.tokenize_reverse()
+---
+[
+    SimpleToken {
+        kind: Other,
+        range: 79..80,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 78..79,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 77..78,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 76..77,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 75..76,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 74..75,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 73..74,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 72..73,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 71..72,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 70..71,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 69..70,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 68..69,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 67..68,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 66..67,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 65..66,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 64..65,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 63..64,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 62..63,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 61..62,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 60..61,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 59..60,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 58..59,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 57..58,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 56..57,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 55..56,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 54..55,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 53..54,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 52..53,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 51..52,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 50..51,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 49..50,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 48..49,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 47..48,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 46..47,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 45..46,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 44..45,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 43..44,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 42..43,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 41..42,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 40..41,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 39..40,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 38..39,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 37..38,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 36..37,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 35..36,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 34..35,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 33..34,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 32..33,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 31..32,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 30..31,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 29..30,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 28..29,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 27..28,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 26..27,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 25..26,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 24..25,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 23..24,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 22..23,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 21..22,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 20..21,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 19..20,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 18..19,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 17..18,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 16..17,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 15..16,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 14..15,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 13..14,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 12..13,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 11..12,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 10..11,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 9..10,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 8..9,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 7..8,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 6..7,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 5..6,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 4..5,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 3..4,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 2..3,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 1..2,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 0..1,
+    },
+]

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -625,6 +625,10 @@ fn is_string_terminated(kind: StringKind, cursor: &mut Cursor) -> bool {
                 return false;
             }
             '\\' => {
+                // Skip over escaped quotes that match this strings quotes or double escaped backslashes
+                if cursor.eat_char(quote_char) || cursor.eat_char('\\') {
+                    continue;
+                }
                 // Eat over line continuation
                 cursor.eat_char('\r');
                 cursor.eat_char('\n');
@@ -919,6 +923,20 @@ mod tests {
     fn string_followed_by_multiple_comments() {
         let test_case =
             tokenize(r#"'a string # containing a hash " # and another hash ' # finally a comment"#);
+
+        assert_debug_snapshot!(test_case.tokenize_reverse());
+    }
+
+    #[test]
+    fn string_with_escaped_quote() {
+        let test_case = tokenize(r#"'a string \' # containing a hash ' # finally a comment"#);
+
+        assert_debug_snapshot!(test_case.tokenize_reverse());
+    }
+
+    #[test]
+    fn string_with_double_escaped_backslash() {
+        let test_case = tokenize(r#"'a string \\' # a comment '"#);
 
         assert_debug_snapshot!(test_case.tokenize_reverse());
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR fixes the `SimpleTokenizer`s backward lexing to handle `#` tokens inside multiline strings correctly. 

```python
'a multiline\
string containing a # token'

'''a multiline
string containing a # token'''
```

For both these cases, `#` is not the start of a comment. Instead, it's just a regular hash inside of the multiline string. 

However, the following is a comment

```python
'a string' # comment 'with quotes'
```

Unfortunately, there's no easy way to detect whether `# token'` is a comment or part of a string when lexing backward because it's impossible to tell if two quotes form a pair when looking backward:

```python
# It looks like the ''' in the comment match the opening ''' on the first line
'''
a # comment '''

# But let's zoom out... are they matching pairs?

a + '''
some multiline text
'''
a # comment '''
```

The way this is solved in this PR is that we lex out all strings and comments if we encounter any `#` that is followed by a quote. This should be rare because:

* Comments are rare; comments containing quotes are even rarer. 
* Strings are common, but they rarely contain hashes

Also, backward lexing is strongly discouraged, and you should prefer `up_to_no_back_comment`, which skips over the expensive comments handling until it reaches a new line (and the whole purpose of the lexer is only to lex very few tokens). 

For most cases, lexing the "whole" source should be fast because we only lex over a very limited range. This is not true for `up_to`, which we used in `lines_before`. That's why I went ahead and rewrote `lines_before` and `lines_after` to **not** use the `SimpleTokenizer` anymore. They don't care about trivia, meaning we can get away with a trivial `Cursor` based implementation.



## Test Plan

I added new snapshot tests
<!-- How was it tested? -->
