### PR TITLE
Add known problems to `compare-to-empty-string` documentation

### DIFF
--- a/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
+++ b/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
@@ -21,7 +21,7 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Example
 /// ```python
-/// x: str
+/// x: str = ...
 ///
 /// if x == "":
 ///     print("x is empty")
@@ -29,7 +29,7 @@ use crate::checkers::ast::Checker;
 ///
 /// Use instead:
 /// ```python
-/// x: str
+/// x: str = ...
 ///
 /// if not x:
 ///     print("x is empty")

--- a/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
+++ b/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
@@ -15,22 +15,26 @@ use crate::checkers::ast::Checker;
 /// the value can be something else Python considers falsy, such as `None` or
 /// `0` or another empty container, then the code is not equivalent.
 ///
+/// ## Known problems
+/// High false positive rate, as the check is context-insensitive and does not
+/// consider the type of the variable being compared ([#4282]).
+///
 /// ## Example
 /// ```python
-/// def foo(x):
-///     if x == "":
-///         print("x is empty")
+/// if x == "":
+///     print("x is empty")
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// def foo(x):
-///     if not x:
-///         print("x is empty")
+/// if not x:
+///     print("x is empty")
 /// ```
 ///
 /// ## References
 /// - [Python documentation: Truth Value Testing](https://docs.python.org/3/library/stdtypes.html#truth-value-testing)
+///
+/// [#4282]: https://github.com/astral-sh/ruff/issues/4282
 #[violation]
 pub struct CompareToEmptyString {
     existing: String,

--- a/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
+++ b/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
@@ -21,12 +21,16 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Example
 /// ```python
+/// x: str
+///
 /// if x == "":
 ///     print("x is empty")
 /// ```
 ///
 /// Use instead:
 /// ```python
+/// x: str
+///
 /// if not x:
 ///     print("x is empty")
 /// ```


### PR DESCRIPTION
## Summary

Add known problems to `compare-to-empty-string` documentation. Related to #5873.

Tweaked the example in the documentation to be a tad more concise and correct (that the rule is most applicable when comparing to a `str` variable).

## Test Plan

`python scripts/check_docs_formatted.py`
