### PR TITLE
Handle parentheses when formatting slice expressions

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/slice.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/slice.py
@@ -83,3 +83,8 @@ e210 = "e"[a() : 1 :]
 
 # Regression test for https://github.com/astral-sh/ruff/issues/5605
 f = "f"[:,]
+
+# Regression test for https://github.com/astral-sh/ruff/issues/5733
+g1 = "g"[(1):(2)]
+g2 = "g"[(1):(2):(3)]
+

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__slice.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__slice.py.snap
@@ -89,6 +89,11 @@ e210 = "e"[a() : 1 :]
 
 # Regression test for https://github.com/astral-sh/ruff/issues/5605
 f = "f"[:,]
+
+# Regression test for https://github.com/astral-sh/ruff/issues/5733
+g1 = "g"[(1):(2)]
+g2 = "g"[(1):(2):(3)]
+
 ```
 
 ## Output
@@ -176,6 +181,10 @@ e210 = "e"[a() : 1 :]
 
 # Regression test for https://github.com/astral-sh/ruff/issues/5605
 f = "f"[:,]
+
+# Regression test for https://github.com/astral-sh/ruff/issues/5733
+g1 = "g"[(1):(2)]
+g2 = "g"[(1):(2):(3)]
 ```
 
 


### PR DESCRIPTION
**Summary** Fix the formatter crash with `x[(1) :: ]` and related code.

**Problem** For assigning comments in slices in subscripts, we need to find the positions of the colons to assign comments before and after the colon to the respective lower/upper/step node (or dangling in that section). Formatting `x[(1) :: ]` was broken because we were looking for a `:` after the `1` but didn't consider that there could be a `)` outside the range of the lower node, which contains just the `1` and no optional parentheses.

**Solution** Use the simple tokenizer directly and skip all closing parentheses.

**Test Plan** I added regression tests.

Closes #5733
