### PR TITLE
Remove multithreading from check multiproject

### DIFF
--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -279,15 +279,30 @@ if True:
     #[test]
     fn quick_test() {
         let src = r#"
-[
-    a
-    for [
-        xxxxxxxxxxxxxxxxxxx,
-        bbbbbbbbbbbbbbbbbbbbbbb,
-        ccccccccccccccccc,
-        dddddddddddddddddddd,
-    ] in [eeeeeeeeeeeeeeee, fffffffffff, ggggggggggg]
-]
+with (
+    [
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "bbbbbbbbbb",
+        "cccccccccccccccccccccccccccccccccccccccccc",
+        dddddddddddddddddddddddddddddddd,
+    ] as example1,
+    aaaaaaaaaaaaaaaaaaaaaaaaaa
+    + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    + cccccccccccccccccccccccccccc
+    + ddddddddddddddddd as example2,
+    CtxManager2() as example2,
+    CtxManager2() as example2,
+    CtxManager2() as example2,
+):
+    ...
+
+with [
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "bbbbbbbbbb",
+    "cccccccccccccccccccccccccccccccccccccccccc",
+    dddddddddddddddddddddddddddddddd,
+] as example1, aaaaaaaaaaaaaaaaaaaaaaaaaa * bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb * cccccccccccccccccccccccccccc + ddddddddddddddddd as example2, CtxManager222222222222222() as example2:
+    ...
 
 "#;
         // Tokenize once

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -279,30 +279,15 @@ if True:
     #[test]
     fn quick_test() {
         let src = r#"
-with (
-    [
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "bbbbbbbbbb",
-        "cccccccccccccccccccccccccccccccccccccccccc",
-        dddddddddddddddddddddddddddddddd,
-    ] as example1,
-    aaaaaaaaaaaaaaaaaaaaaaaaaa
-    + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    + cccccccccccccccccccccccccccc
-    + ddddddddddddddddd as example2,
-    CtxManager2() as example2,
-    CtxManager2() as example2,
-    CtxManager2() as example2,
-):
-    ...
-
-with [
-    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "bbbbbbbbbb",
-    "cccccccccccccccccccccccccccccccccccccccccc",
-    dddddddddddddddddddddddddddddddd,
-] as example1, aaaaaaaaaaaaaaaaaaaaaaaaaa * bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb * cccccccccccccccccccccccccccc + ddddddddddddddddd as example2, CtxManager222222222222222() as example2:
-    ...
+[
+    a
+    for [
+        xxxxxxxxxxxxxxxxxxx,
+        bbbbbbbbbbbbbbbbbbbbbbb,
+        ccccccccccccccccc,
+        dddddddddddddddddddd,
+    ] in [eeeeeeeeeeeeeeee, fffffffffff, ggggggggggg]
+]
 
 "#;
         // Tokenize once


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR removes the multithreading from the multiproject check because we already use a `par_iter` to iterate over the files. 

This doesn't give us as good parallelism because the discovery of the project files now runs single threaded but it's still pretty good
and it significantly simplies the code (and fixes the misterious stack overflow).

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

[Screencast from 2023-07-19 16-30-42.webm](https://github.com/astral-sh/ruff/assets/1203881/be7b95fb-af85-4dc5-b111-5513271a5958)


The whole check completes in about 90s

![image](https://github.com/astral-sh/ruff/assets/1203881/bf8da147-9f05-41dd-9dec-1e20a769bc76)


<!-- How was it tested? -->
