### PR TITLE
Use a boxed slice for `Export` struct

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -4562,7 +4562,9 @@ impl<'a> Checker<'a> {
             self.add_binding(
                 id,
                 expr.range(),
-                BindingKind::Export(Export { names }),
+                BindingKind::Export(Export {
+                    names: names.into_boxed_slice(),
+                }),
                 BindingFlags::empty(),
             );
             return;
@@ -4571,7 +4573,7 @@ impl<'a> Checker<'a> {
         if self
             .semantic
             .expr_ancestors()
-            .any(|expr| matches!(expr, Expr::NamedExpr(_)))
+            .any(|expr| expr.is_named_expr_expr())
         {
             self.add_binding(
                 id,

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -283,7 +283,7 @@ impl<'a> FromIterator<Binding<'a>> for Bindings<'a> {
 #[derive(Debug, Clone)]
 pub struct Export<'a> {
     /// The names of the bindings exported via `__all__`.
-    pub names: Vec<&'a str>,
+    pub names: Box<[&'a str]>,
 }
 
 /// A binding for an `import`, keyed on the name to which the import is bound.


### PR DESCRIPTION
## Summary

The vector of names here is immutable -- we never push to it after initialization. Boxing reduces the size of the variant from 32 bytes to 24 bytes. (See: https://nnethercote.github.io/perf-book/type-sizes.html#boxed-slices.) It doesn't make a difference here, since it's not the largest variant, but it still seems like a prudent change (and I was considering adding another field to this variant, though I may no longer do so).
