### PR TITLE
Add missing backtick to B034 documentation

### DIFF
--- a/crates/ruff/src/rules/flake8_bugbear/rules/re_sub_positional_args.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/re_sub_positional_args.rs
@@ -13,8 +13,8 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Why is this bad?
 /// Passing `count`, `maxsplit`, or `flags` as positional arguments to
-/// `re.sub`, re.subn`, or `re.split` can lead to confusion, as most methods in
-/// the `re` module accepts `flags` as the third positional argument, while
+/// `re.sub`, `re.subn`, or `re.split` can lead to confusion, as most methods in
+/// the `re` module accept `flags` as the third positional argument, while
 /// `re.sub`, `re.subn`, and `re.split` have different signatures.
 ///
 /// Instead, pass `count`, `maxsplit`, and `flags` as keyword arguments.


### PR DESCRIPTION
This is a great rule, but the documentation page shows some wonky formatting due to a missing backtick. Fix a typo too.

Should fix display on https://beta.ruff.rs/docs/rules/re-sub-positional-args/

<img width="1160" alt="image" src="https://github.com/astral-sh/ruff/assets/901169/44bd76ec-9eb9-4290-ba7a-7691a7ea21d4">

