### PR TITLE
Include file permissions in key for cached files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,6 +2002,7 @@ dependencies = [
  "ruff",
  "ruff_cache",
  "ruff_diagnostics",
+ "ruff_macros",
  "ruff_python_ast",
  "ruff_python_formatter",
  "ruff_python_stdlib",

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -30,6 +30,7 @@ ruff_python_ast = { path = "../ruff_python_ast" }
 ruff_python_formatter = { path = "../ruff_python_formatter" }
 ruff_text_size = { workspace = true }
 ruff_textwrap = { path = "../ruff_textwrap" }
+ruff_macros = { path = "../ruff_macros" }
 
 annotate-snippets = { version = "0.9.1", features = ["color"] }
 anyhow = { workspace = true }

--- a/crates/ruff_cli/resources/test/fixtures/cache_mutable/source.py
+++ b/crates/ruff_cli/resources/test/fixtures/cache_mutable/source.py
@@ -1,4 +1,3 @@
-# NOTE: sync with cache::invalidation test
 a = 1
 
 __all__ = list(["a", "b"])

--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -517,6 +517,9 @@ mod tests {
         let cache = test_cache.open();
 
         // Write the same contents to the source file (updating the modified time)
+        // We must sleep for a millisecond or this can happen too fast on some systems resulting in a modified time collision.
+        // Once `std::fs::File.set_modified` is stable we can use that instead.
+        std::thread::sleep(std::time::Duration::from_millis(1));
         test_cache.write_source_file("source.py", source);
 
         let got_diagnostics = test_cache

--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -517,9 +517,9 @@ mod tests {
         let cache = test_cache.open();
 
         // Write the same contents to the source file (updating the modified time)
-        // We must sleep for a millisecond or this can happen too fast on some systems resulting in a modified time collision.
+        // We must sleep for a little or this can happen too fast on some systems resulting in a modified time collision.
         // Once `std::fs::File.set_modified` is stable we can use that instead.
-        std::thread::sleep(std::time::Duration::from_millis(1));
+        std::thread::sleep(std::time::Duration::from_millis(10));
         test_cache.write_source_file("source.py", source);
 
         let got_diagnostics = test_cache

--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -532,8 +532,8 @@ mod tests {
             "Cache should not be used, the file should be treated as new and added to the cache"
         );
 
-        assert!(
-            expected_diagnostics == got_diagnostics,
+        assert_eq!(
+            expected_diagnostics, got_diagnostics,
             "The diagnostics should not change"
         );
     }
@@ -590,8 +590,8 @@ mod tests {
             "Cache should not be used, the file should be treated as new and added to the cache"
         );
 
-        assert!(
-            expected_diagnostics == got_diagnostics,
+        assert_eq!(
+            expected_diagnostics, got_diagnostics,
             "The diagnostics should not change"
         );
     }

--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -9,9 +9,7 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 use colored::Colorize;
 use filetime::FileTime;
-use log::{debug, error};
 use log::{debug, error, warn};
-use ruff_text_size::TextSize;
 use ruff_text_size::{TextRange, TextSize};
 use rustc_hash::FxHashMap;
 use similar::TextDiff;
@@ -19,7 +17,6 @@ use similar::TextDiff;
 use std::os::unix::fs::PermissionsExt;
 
 use crate::cache::Cache;
-use ruff::fs;
 use ruff::jupyter::Notebook;
 use ruff::linter::{lint_fix, lint_only, FixTable, FixerResult, LinterResult};
 use ruff::logging::DisplayParseError;


### PR DESCRIPTION
Reimplements https://github.com/astral-sh/ruff/pull/3104
Closes https://github.com/astral-sh/ruff/issues/5726

Note that we will generate the hash for a cache key twice in normal operation. Once to check for the cached item and again to update the cache. We could optimize this by generating the hash once in `diagnostics::lint_file` and passing the `u64` into `get` and `update`. We'd probably want to wrap it in a `CacheKeyHash` enum for type safety.

## Test plan

Unit tests for Windows and Unix.

Manual test with case from issue

```
❯ touch fake.py
❯ chmod +x fake.py
❯ ./target/debug/ruff --select EXE fake.py
fake.py:1:1: EXE002 The file is executable but no shebang is present
Found 1 error.
❯ chmod -x fake.py
❯ ./target/debug/ruff --select EXE fake.py
```