### PR TITLE
Track unresolved references in the semantic model

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -50,8 +50,8 @@ use ruff_python_ast::{cast, helpers, str, visitor};
 use ruff_python_semantic::analyze::{branch_detection, typing, visibility};
 use ruff_python_semantic::{
     Binding, BindingFlags, BindingId, BindingKind, ContextualizedDefinition, Exceptions,
-    ExecutionContext, Export, FromImport, Globals, Import, Module, ModuleKind, ResolvedRead, Scope,
-    ScopeId, ScopeKind, SemanticModel, SemanticModelFlags, StarImport, SubmoduleImport,
+    ExecutionContext, Export, FromImport, Globals, Import, Module, ModuleKind, ScopeId, ScopeKind,
+    SemanticModel, SemanticModelFlags, StarImport, SubmoduleImport,
 };
 use ruff_python_stdlib::builtins::{BUILTINS, MAGIC_GLOBALS};
 use ruff_python_stdlib::path::is_python_stub_file;
@@ -4428,55 +4428,7 @@ impl<'a> Checker<'a> {
         let Expr::Name(ast::ExprName { id, .. }) = expr else {
             return;
         };
-        match self.semantic.resolve_read(id, expr.range()) {
-            ResolvedRead::Resolved(_) | ResolvedRead::ImplicitGlobal => {
-                // Nothing to do.
-            }
-            ResolvedRead::WildcardImport => {
-                // F405
-                if self.enabled(Rule::UndefinedLocalWithImportStarUsage) {
-                    let sources: Vec<String> = self
-                        .semantic
-                        .scopes
-                        .iter()
-                        .flat_map(Scope::star_imports)
-                        .map(|StarImport { level, module }| {
-                            helpers::format_import_from(*level, *module)
-                        })
-                        .sorted()
-                        .dedup()
-                        .collect();
-                    self.diagnostics.push(Diagnostic::new(
-                        pyflakes::rules::UndefinedLocalWithImportStarUsage {
-                            name: id.to_string(),
-                            sources,
-                        },
-                        expr.range(),
-                    ));
-                }
-            }
-            ResolvedRead::NotFound | ResolvedRead::UnboundLocal(_) => {
-                // F821
-                if self.enabled(Rule::UndefinedName) {
-                    // Allow __path__.
-                    if self.path.ends_with("__init__.py") && id == "__path__" {
-                        return;
-                    }
-
-                    // Avoid flagging if `NameError` is handled.
-                    if self.semantic.exceptions().contains(Exceptions::NAME_ERROR) {
-                        return;
-                    }
-
-                    self.diagnostics.push(Diagnostic::new(
-                        pyflakes::rules::UndefinedName {
-                            name: id.to_string(),
-                        },
-                        expr.range(),
-                    ));
-                }
-            }
-        }
+        self.semantic.resolve_read(id, expr.range());
     }
 
     fn handle_node_store(&mut self, id: &'a str, expr: &Expr) {
@@ -4776,6 +4728,47 @@ impl<'a> Checker<'a> {
         }
     }
 
+    /// Run any lint rules that operate over a single [`UnresolvedReference`].
+    fn check_unresolved_references(&mut self) {
+        if !self.any_enabled(&[Rule::UndefinedLocalWithImportStarUsage, Rule::UndefinedName]) {
+            return;
+        }
+
+        for reference in self.semantic.unresolved_references() {
+            if reference.wildcard_import() {
+                if self.enabled(Rule::UndefinedLocalWithImportStarUsage) {
+                    self.diagnostics.push(Diagnostic::new(
+                        pyflakes::rules::UndefinedLocalWithImportStarUsage {
+                            name: reference.name(self.locator).to_string(),
+                        },
+                        reference.range(),
+                    ));
+                }
+            } else {
+                if self.enabled(Rule::UndefinedName) {
+                    // Avoid flagging if `NameError` is handled.
+                    if reference.exceptions().contains(Exceptions::NAME_ERROR) {
+                        continue;
+                    }
+
+                    // Allow __path__.
+                    if self.path.ends_with("__init__.py") {
+                        if reference.name(self.locator) == "__path__" {
+                            continue;
+                        }
+                    }
+
+                    self.diagnostics.push(Diagnostic::new(
+                        pyflakes::rules::UndefinedName {
+                            name: reference.name(self.locator).to_string(),
+                        },
+                        reference.range(),
+                    ));
+                }
+            }
+        }
+    }
+
     /// Run any lint rules that operate over a single [`Binding`].
     fn check_bindings(&mut self) {
         if !self.any_enabled(&[
@@ -4832,6 +4825,55 @@ impl<'a> Checker<'a> {
         }
     }
 
+    /// Run any lint rules that operate over the module exports (i.e., members of `__all__`).
+    fn check_exports(&mut self) {
+        let exports: Vec<(&str, TextRange)> = self
+            .semantic
+            .global_scope()
+            .get_all("__all__")
+            .map(|binding_id| &self.semantic.bindings[binding_id])
+            .filter_map(|binding| match &binding.kind {
+                BindingKind::Export(Export { names }) => {
+                    Some(names.iter().map(|name| (*name, binding.range)))
+                }
+                _ => None,
+            })
+            .flatten()
+            .collect();
+
+        for (name, range) in exports {
+            if let Some(binding_id) = self.semantic.global_scope().get(name) {
+                // Mark anything referenced in `__all__` as used.
+                self.semantic
+                    .add_global_reference(binding_id, range, ExecutionContext::Runtime);
+            } else {
+                if self.semantic.global_scope().uses_star_imports() {
+                    // F405
+                    if self.enabled(Rule::UndefinedLocalWithImportStarUsage) {
+                        self.diagnostics.push(Diagnostic::new(
+                            pyflakes::rules::UndefinedLocalWithImportStarUsage {
+                                name: (*name).to_string(),
+                            },
+                            range,
+                        ));
+                    }
+                } else {
+                    // F822
+                    if self.enabled(Rule::UndefinedExport) {
+                        if !self.path.ends_with("__init__.py") {
+                            self.diagnostics.push(Diagnostic::new(
+                                pyflakes::rules::UndefinedExport {
+                                    name: (*name).to_string(),
+                                },
+                                range,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     fn check_deferred_scopes(&mut self) {
         if !self.any_enabled(&[
             Rule::GlobalVariableNotAssigned,
@@ -4841,35 +4883,9 @@ impl<'a> Checker<'a> {
             Rule::TypingOnlyFirstPartyImport,
             Rule::TypingOnlyStandardLibraryImport,
             Rule::TypingOnlyThirdPartyImport,
-            Rule::UndefinedExport,
-            Rule::UndefinedLocalWithImportStarUsage,
-            Rule::UndefinedLocalWithImportStarUsage,
             Rule::UnusedImport,
         ]) {
             return;
-        }
-
-        // Mark anything referenced in `__all__` as used.
-        let exports: Vec<(&str, TextRange)> = {
-            self.semantic
-                .global_scope()
-                .get_all("__all__")
-                .map(|binding_id| &self.semantic.bindings[binding_id])
-                .filter_map(|binding| match &binding.kind {
-                    BindingKind::Export(Export { names }) => {
-                        Some(names.iter().map(|name| (*name, binding.range)))
-                    }
-                    _ => None,
-                })
-                .flatten()
-                .collect()
-        };
-
-        for (name, range) in &exports {
-            if let Some(binding_id) = self.semantic.global_scope().get(name) {
-                self.semantic
-                    .add_global_reference(binding_id, *range, ExecutionContext::Runtime);
-            }
         }
 
         // Identify any valid runtime imports. If a module is imported at runtime, and
@@ -4913,43 +4929,6 @@ impl<'a> Checker<'a> {
         let mut diagnostics: Vec<Diagnostic> = vec![];
         for scope_id in self.deferred.scopes.iter().rev().copied() {
             let scope = &self.semantic.scopes[scope_id];
-
-            if scope.kind.is_module() {
-                // F822
-                if self.enabled(Rule::UndefinedExport) {
-                    if !self.path.ends_with("__init__.py") {
-                        for (name, range) in &exports {
-                            diagnostics
-                                .extend(pyflakes::rules::undefined_export(name, *range, scope));
-                        }
-                    }
-                }
-
-                // F405
-                if self.enabled(Rule::UndefinedLocalWithImportStarUsage) {
-                    let sources: Vec<String> = scope
-                        .star_imports()
-                        .map(|StarImport { level, module }| {
-                            helpers::format_import_from(*level, *module)
-                        })
-                        .sorted()
-                        .dedup()
-                        .collect();
-                    if !sources.is_empty() {
-                        for (name, range) in &exports {
-                            if !scope.has(name) {
-                                diagnostics.push(Diagnostic::new(
-                                    pyflakes::rules::UndefinedLocalWithImportStarUsage {
-                                        name: (*name).to_string(),
-                                        sources: sources.clone(),
-                                    },
-                                    *range,
-                                ));
-                            }
-                        }
-                    }
-                }
-            }
 
             // PLW0602
             if self.enabled(Rule::GlobalVariableNotAssigned) {
@@ -5220,8 +5199,8 @@ impl<'a> Checker<'a> {
 
         // Compute visibility of all definitions.
         let exports: Option<Vec<&str>> = {
-            let global_scope = self.semantic.global_scope();
-            global_scope
+            self.semantic
+                .global_scope()
                 .get_all("__all__")
                 .map(|binding_id| &self.semantic.bindings[binding_id])
                 .filter_map(|binding| match &binding.kind {
@@ -5484,14 +5463,16 @@ pub(crate) fn check_ast(
     checker.check_deferred_assignments();
     checker.check_deferred_for_loops();
 
-    // Check docstrings.
+    // Check docstrings, exports, bindings, and unresolved references.
     checker.check_definitions();
+    checker.check_exports();
+    checker.check_bindings();
+    checker.check_unresolved_references();
 
     // Reset the scope to module-level, and check all consumed scopes.
     checker.semantic.scope_id = ScopeId::global();
     checker.deferred.scopes.push(ScopeId::global());
     checker.check_deferred_scopes();
-    checker.check_bindings();
 
     checker.diagnostics
 }

--- a/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashMap;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::{NodeId, ReferenceId, Scope};
+use ruff_python_semantic::{NodeId, ResolvedReferenceId, Scope};
 
 use crate::autofix;
 use crate::checkers::ast::Checker;
@@ -180,7 +180,7 @@ struct Import<'a> {
     /// The qualified name of the import (e.g., `typing.List` for `from typing import List`).
     qualified_name: &'a str,
     /// The first reference to the imported symbol.
-    reference_id: ReferenceId,
+    reference_id: ResolvedReferenceId,
     /// The trimmed range of the import (e.g., `List` in `from typing import List`).
     range: TextRange,
     /// The range of the import's parent statement.

--- a/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashMap;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, DiagnosticKind, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::{Binding, NodeId, ReferenceId, Scope};
+use ruff_python_semantic::{Binding, NodeId, ResolvedReferenceId, Scope};
 
 use crate::autofix;
 use crate::checkers::ast::Checker;
@@ -357,7 +357,7 @@ struct Import<'a> {
     /// The qualified name of the import (e.g., `typing.List` for `from typing import List`).
     qualified_name: &'a str,
     /// The first reference to the imported symbol.
-    reference_id: ReferenceId,
+    reference_id: ResolvedReferenceId,
     /// The trimmed range of the import (e.g., `List` in `from typing import List`).
     range: TextRange,
     /// The range of the import's parent statement.

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -1026,8 +1026,8 @@ mod tests {
             &[
                 Rule::UndefinedName,
                 Rule::UndefinedName,
-                Rule::UndefinedName,
                 Rule::UnusedVariable,
+                Rule::UndefinedName,
                 Rule::UndefinedName,
             ],
         );
@@ -2115,7 +2115,7 @@ mod tests {
         try: pass
         except Exception as fu: pass
         "#,
-            &[Rule::RedefinedWhileUnused, Rule::UnusedVariable],
+            &[Rule::UnusedVariable, Rule::RedefinedWhileUnused],
         );
     }
 

--- a/crates/ruff/src/rules/pyflakes/rules/imports.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/imports.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::OneIndexed;
@@ -157,18 +155,13 @@ impl Violation for LateFutureImport {
 #[violation]
 pub struct UndefinedLocalWithImportStarUsage {
     pub(crate) name: String,
-    pub(crate) sources: Vec<String>,
 }
 
 impl Violation for UndefinedLocalWithImportStarUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let UndefinedLocalWithImportStarUsage { name, sources } = self;
-        let sources = sources
-            .iter()
-            .map(|source| format!("`{source}`"))
-            .join(", ");
-        format!("`{name}` may be undefined, or defined from star imports: {sources}")
+        let UndefinedLocalWithImportStarUsage { name } = self;
+        format!("`{name}` may be undefined, or defined from star imports")
     }
 }
 

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
@@ -1,8 +1,5 @@
-use ruff_text_size::TextRange;
-
-use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::Scope;
 
 /// ## What it does
 /// Checks for undefined names in `__all__`.
@@ -36,7 +33,7 @@ use ruff_python_semantic::Scope;
 /// - [Python documentation: `__all__`](https://docs.python.org/3/tutorial/modules.html#importing-from-a-package)
 #[violation]
 pub struct UndefinedExport {
-    name: String,
+    pub name: String,
 }
 
 impl Violation for UndefinedExport {
@@ -45,20 +42,4 @@ impl Violation for UndefinedExport {
         let UndefinedExport { name } = self;
         format!("Undefined name `{name}` in `__all__`")
     }
-}
-
-/// F822
-pub(crate) fn undefined_export(name: &str, range: TextRange, scope: &Scope) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
-    if !scope.uses_star_imports() {
-        if !scope.has(name) {
-            diagnostics.push(Diagnostic::new(
-                UndefinedExport {
-                    name: (*name).to_string(),
-                },
-                range,
-            ));
-        }
-    }
-    diagnostics
 }

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F405_F405.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F405_F405.py.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/ruff/src/rules/pyflakes/mod.rs
 ---
-F405.py:5:11: F405 `name` may be undefined, or defined from star imports: `mymodule`
+F405.py:5:11: F405 `name` may be undefined, or defined from star imports
   |
 4 | def print_name():
 5 |     print(name)
   |           ^^^^ F405
   |
 
-F405.py:11:1: F405 `a` may be undefined, or defined from star imports: `mymodule`
+F405.py:11:1: F405 `a` may be undefined, or defined from star imports
    |
  9 |     print(name)
 10 | 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__augmented_assignment_after_del.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__augmented_assignment_after_del.snap
@@ -1,14 +1,6 @@
 ---
 source: crates/ruff/src/rules/pyflakes/mod.rs
 ---
-<filename>:10:5: F821 Undefined name `x`
-   |
- 8 |     # entirely after the `del` statement. However, it should be an F821
- 9 |     # error, because the name is defined in the scope, but unbound.
-10 |     x += 1
-   |     ^ F821
-   |
-
 <filename>:10:5: F841 Local variable `x` is assigned to but never used
    |
  8 |     # entirely after the `del` statement. However, it should be an F821
@@ -17,5 +9,13 @@ source: crates/ruff/src/rules/pyflakes/mod.rs
    |     ^ F841
    |
    = help: Remove assignment to unused variable `x`
+
+<filename>:10:5: F821 Undefined name `x`
+   |
+ 8 |     # entirely after the `del` statement. However, it should be an F821
+ 9 |     # error, because the name is defined in the scope, but unbound.
+10 |     x += 1
+   |     ^ F821
+   |
 
 

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -10,7 +10,7 @@ use ruff_python_ast::source_code::Locator;
 use crate::context::ExecutionContext;
 use crate::model::SemanticModel;
 use crate::node::NodeId;
-use crate::reference::ReferenceId;
+use crate::reference::ResolvedReferenceId;
 use crate::ScopeId;
 
 #[derive(Debug, Clone)]
@@ -24,7 +24,7 @@ pub struct Binding<'a> {
     /// The statement in which the [`Binding`] was defined.
     pub source: Option<NodeId>,
     /// The references to the [`Binding`].
-    pub references: Vec<ReferenceId>,
+    pub references: Vec<ResolvedReferenceId>,
     /// The exceptions that were handled when the [`Binding`] was defined.
     pub exceptions: Exceptions,
     /// Flags for the [`Binding`].
@@ -38,7 +38,7 @@ impl<'a> Binding<'a> {
     }
 
     /// Returns an iterator over all references for the current [`Binding`].
-    pub fn references(&self) -> impl Iterator<Item = ReferenceId> + '_ {
+    pub fn references(&self) -> impl Iterator<Item = ResolvedReferenceId> + '_ {
         self.references.iter().copied()
     }
 


### PR DESCRIPTION
## Summary

As part of my continued quest to separate semantic model-building from diagnostic emission, this PR moves our unresolved-reference rules to a deferred pass. So, rather than emitting diagnostics as we encounter unresolved references, we now track those unresolved references on the semantic model (just like resolved references), and after traversal, emit the relevant rules for any unresolved references.
