### PR TITLE
Playground: Fix escaped quotes handling

### DIFF
--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -270,7 +270,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
 
                         if text.contains('"') {
                             f.write_element(FormatElement::DynamicText {
-                                text: text.replace('"', "\\\"").into(),
+                                text: text.replace('"', r#"\""#).into(),
                             })
                         } else {
                             f.write_element(element.clone())

--- a/playground/src/Editor/setupMonaco.tsx
+++ b/playground/src/Editor/setupMonaco.tsx
@@ -596,6 +596,7 @@ function defineRustPythonAstLanguage(monaco: Monaco) {
       ],
       string: [
         [/[^\\"]+/, "string"],
+        [/\\[\\"]/, "string.escape"],
         [/"/, { token: "string.quote", bracket: "@close", next: "@pop" }],
       ],
     },
@@ -650,6 +651,7 @@ function defineRustPythonTokensLanguage(monaco: Monaco) {
       ],
       string: [
         [/[^\\"]+/, "string"],
+        [/\\[\\"]/, "string.escape"],
         [/"/, { token: "string.quote", bracket: "@close", next: "@pop" }],
       ],
     },
@@ -695,6 +697,7 @@ function defineFirLanguage(monaco: Monaco) {
       ],
       string: [
         [/[^\\"]+/, "string"],
+        [/\\[\\"]/, "string.escape"],
         [/"/, { token: "string.quote", bracket: "@close", next: "@pop" }],
       ],
     },


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Using quotes inside of strings currently breaks the code highlighting in the playground.

![image](https://github.com/astral-sh/ruff/assets/1203881/0eec17d9-471d-4b4a-a49c-ec48812ed45c)
![image](https://github.com/astral-sh/ruff/assets/1203881/2631e3d9-c152-4b41-903e-d278a0598941)
![image](https://github.com/astral-sh/ruff/assets/1203881/5ddac56a-06cb-4016-8ec8-aa75873b19be)



This PR escapes `"` when printing the formatter IR and adds support for string escape sequences to all grammars in the playground.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

![image](https://github.com/astral-sh/ruff/assets/1203881/6943a45a-1826-49d5-b401-aab080d69c46)
![image](https://github.com/astral-sh/ruff/assets/1203881/f7b10863-cd93-495f-a1bf-d609f098ce87)
![image](https://github.com/astral-sh/ruff/assets/1203881/a487449b-b6e8-4d18-979f-d386ecfb4346)

