### PR TITLE
Only run jobs if relevant files changed

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -2,6 +2,14 @@ name: Benchmark
 
 on:
   pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain'
+      - 'crates/**'
+      - '!crates/ruff_dev'
+      - '!crates/ruff_shrinking'
+
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,41 @@ env:
   PYTHON_VERSION: "3.11" # to build abi3 wheels
 
 jobs:
+  determine_changes:
+    name: "Determine changes"
+    runs-on: ubuntu-latest
+    outputs:
+      linter: ${{ steps.linter.outputs.any_changed }}
+      formatter: ${{ steps.formatter.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: tj-actions/changed-files@v37
+        id: linter
+        with:
+          files: |
+            Cargo.toml
+            Cargo.lock
+            crates/**
+            !crates/ruff_python_formatter/**
+            !crates/ruff_formatter/**
+            !crates/ruff_dev/**
+            !crates/ruff_shrinking/**
+
+      - uses: tj-actions/changed-files@v37
+        id: formatter
+        with:
+          files: |
+            Cargo.toml
+            Cargo.lock
+            crates/ruff_python_formatter/**
+            crates/ruff_formatter/**
+            crates/ruff_python_trivia/**
+            crates/ruff_python_ast/**
+
+
   cargo-fmt:
     name: "cargo fmt"
     runs-on: ubuntu-latest
@@ -137,9 +172,11 @@ jobs:
   ecosystem:
     name: "ecosystem"
     runs-on: ubuntu-latest
-    needs: cargo-test
+    needs:
+      - cargo-test
+      - determine_changes
     # Only runs on pull requests, since that is the only we way we can find the base version for comparison.
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && needs.determine_changes.outputs.linter == 'true'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -287,6 +324,8 @@ jobs:
   check-formatter-stability:
     name: "Check formatter stability"
     runs-on: ubuntu-latest
+    needs: determine_changes
+    if: needs.determine_changes.outputs.formatter == 'true'
     steps:
       - uses: actions/checkout@v3
       - name: "Install Rust toolchain"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Only run the benchmark, ecosystem, and formatter stability checks when relevant files changed:

* ecosystem: Any rust code, excluding the formatter and dev tools
* formatter stability: Any change to `ruff_python_formatter`, `ruff_formatter`, `ruff_python_ast` or `ruff_python_trivia` or the dependencies
* benchmark: Any rust code change, excluding dev tools

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

* [No code changes](https://github.com/astral-sh/ruff/actions/runs/5609118168?pr=5908)
	* skips formatter stability check
	* Benchmark didn't trigger (I can't link a non existing job :sweat_smile: ) 
	* skips ecosystem check
* [Linter changes](https://github.com/astral-sh/ruff/actions/runs/5609443499?pr=5908)
	* skips formatter stability check
	* runs [Benchmark](https://github.com/astral-sh/ruff/actions/runs/5609443502/jobs/10263167796?pr=5908)
	* runs ecosystem check
* [Formatter change](https://github.com/astral-sh/ruff/actions/runs/5609289445?pr=5908)
	* runs formatter stability check
	* runs [Benchmark](https://github.com/astral-sh/ruff/actions/runs/5609289411?pr=5908)
	* skips ecosystem check
