### PR TITLE
Avoid line break before `for` in comprehension if outer expression expands

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/dict_comp.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/dict_comp.py
@@ -75,3 +75,14 @@
     ) in this_is_a_very_long_variable_which_will_cause_a_trailing_comma_which_breaks_the_comprehension  # Trailing
 }  # Trailing
 # Trailing
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/5911
+selected_choices = {
+    k: str(v) for v in value if str(v) not in self.choices.field.empty_values
+}
+
+selected_choices = {
+    k: str(v)
+    for vvvvvvvvvvvvvvvvvvvvvvv in value if str(v) not in self.choices.field.empty_values
+}

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/list_comp.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/list_comp.py
@@ -43,3 +43,13 @@
     if
     gggggggggggggggggggggggggggggggggggggggggggg
 ]
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/5911
+selected_choices = [
+    str(v) for v in value if str(v) not in self.choices.field.empty_values
+]
+
+selected_choices = [
+    str(v)
+    for vvvvvvvvvvvvvvvvvvvvvvv in value if str(v) not in self.choices.field.empty_values
+]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/set_comp.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/set_comp.py
@@ -43,3 +43,13 @@
     if
     gggggggggggggggggggggggggggggggggggggggggggg
 }
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/5911
+selected_choices = {
+    str(v) for v in value if str(v) not in self.choices.field.empty_values
+}
+
+selected_choices = {
+    str(v)
+    for vvvvvvvvvvvvvvvvvvvvvvv in value if str(v) not in self.choices.field.empty_values
+}

--- a/crates/ruff_python_formatter/src/expression/expr_dict_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_dict_comp.rs
@@ -31,14 +31,14 @@ impl FormatNodeRule<ExprDictComp> for FormatExprDictComp {
             f,
             [parenthesized(
                 "{",
-                &format_args!(
+                &group(&format_args!(
                     group(&key.format()),
                     text(":"),
                     space(),
                     value.format(),
                     soft_line_break_or_space(),
                     group(&joined)
-                ),
+                )),
                 "}"
             )]
         )

--- a/crates/ruff_python_formatter/src/expression/expr_list_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_list_comp.rs
@@ -28,11 +28,11 @@ impl FormatNodeRule<ExprListComp> for FormatExprListComp {
             f,
             [parenthesized(
                 "[",
-                &format_args!(
+                &group(&format_args![
                     group(&elt.format()),
                     soft_line_break_or_space(),
                     group(&joined)
-                ),
+                ]),
                 "]"
             )]
         )

--- a/crates/ruff_python_formatter/src/expression/expr_set_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_set_comp.rs
@@ -28,11 +28,11 @@ impl FormatNodeRule<ExprSetComp> for FormatExprSetComp {
             f,
             [parenthesized(
                 "{",
-                &format_args!(
+                &group(&format_args!(
                     group(&elt.format()),
                     soft_line_break_or_space(),
                     group(&joined)
-                ),
+                )),
                 "}"
             )]
         )

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
@@ -278,16 +278,14 @@ aaaaaaaaaaaaaa + {
     eeeeeee,
 }
 aaaaaaaaaaaaaa + [
-    a
-    for x in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    a for x in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 ]
 (
     aaaaaaaaaaaaaa
     + (a for x in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
 )
 aaaaaaaaaaaaaa + {
-    a
-    for x in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    a for x in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 }
 
 # Wraps it in parentheses if it needs to break both left and right

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__dict_comp.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__dict_comp.py.snap
@@ -80,7 +80,19 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression
         a,  # Trailing
     ) in this_is_a_very_long_variable_which_will_cause_a_trailing_comma_which_breaks_the_comprehension  # Trailing
 }  # Trailing
-# Trailing```
+# Trailing
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/5911
+selected_choices = {
+    k: str(v) for v in value if str(v) not in self.choices.field.empty_values
+}
+
+selected_choices = {
+    k: str(v)
+    for vvvvvvvvvvvvvvvvvvvvvvv in value if str(v) not in self.choices.field.empty_values
+}
+```
 
 ## Output
 ```py
@@ -217,6 +229,18 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression
     ) in this_is_a_very_long_variable_which_will_cause_a_trailing_comma_which_breaks_the_comprehension  # Trailing
 }  # Trailing
 # Trailing
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/5911
+selected_choices = {
+    k: str(v) for v in value if str(v) not in self.choices.field.empty_values
+}
+
+selected_choices = {
+    k: str(v)
+    for vvvvvvvvvvvvvvvvvvvvvvv in value
+    if str(v) not in self.choices.field.empty_values
+}
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__list_comp.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__list_comp.py.snap
@@ -49,6 +49,16 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression
     if
     gggggggggggggggggggggggggggggggggggggggggggg
 ]
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/5911
+selected_choices = [
+    str(v) for v in value if str(v) not in self.choices.field.empty_values
+]
+
+selected_choices = [
+    str(v)
+    for vvvvvvvvvvvvvvvvvvvvvvv in value if str(v) not in self.choices.field.empty_values
+]
 ```
 
 ## Output
@@ -100,6 +110,17 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression
     < gggggggggggggggggggggggggggggggggggggggggggggg
     < hhhhhhhhhhhhhhhhhhhhhhhhhh
     if gggggggggggggggggggggggggggggggggggggggggggg
+]
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/5911
+selected_choices = [
+    str(v) for v in value if str(v) not in self.choices.field.empty_values
+]
+
+selected_choices = [
+    str(v)
+    for vvvvvvvvvvvvvvvvvvvvvvv in value
+    if str(v) not in self.choices.field.empty_values
 ]
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__set_comp.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__set_comp.py.snap
@@ -49,6 +49,16 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression
     if
     gggggggggggggggggggggggggggggggggggggggggggg
 }
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/5911
+selected_choices = {
+    str(v) for v in value if str(v) not in self.choices.field.empty_values
+}
+
+selected_choices = {
+    str(v)
+    for vvvvvvvvvvvvvvvvvvvvvvv in value if str(v) not in self.choices.field.empty_values
+}
 ```
 
 ## Output
@@ -100,6 +110,17 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression
     < gggggggggggggggggggggggggggggggggggggggggggggg
     < hhhhhhhhhhhhhhhhhhhhhhhhhh
     if gggggggggggggggggggggggggggggggggggggggggggg
+}
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/5911
+selected_choices = {
+    str(v) for v in value if str(v) not in self.choices.field.empty_values
+}
+
+selected_choices = {
+    str(v)
+    for vvvvvvvvvvvvvvvvvvvvvvv in value
+    if str(v) not in self.choices.field.empty_values
 }
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #5911

Wrap the comprehension expression body (without the parentheses) in a group to avoid that the soft line break before the `for` expands if the whole expression doesn't fit. 

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I added new regression tests 

Django similarity index:  0.983 ->  0.984
<!-- How was it tested? -->
