### PR TITLE
`SimpleTokenizer`: Fix infinite loop when lexing empty quotes

### DIFF
--- a/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__empty_string_literal.snap
+++ b/crates/ruff_python_trivia/src/snapshots/ruff_python_trivia__tokenizer__tests__empty_string_literal.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff_python_trivia/src/tokenizer.rs
+expression: test_case.tokenize_reverse()
+---
+[
+    SimpleToken {
+        kind: Comment,
+        range: 3..16,
+    },
+    SimpleToken {
+        kind: Whitespace,
+        range: 2..3,
+    },
+    SimpleToken {
+        kind: Other,
+        range: 1..2,
+    },
+    SimpleToken {
+        kind: Bogus,
+        range: 0..1,
+    },
+]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

@konsti found another "slow" file. It turns out... it takes forever to format because I introduced an infinite loop into the `SimpleTokenizer`. 
It keeps looping forever if it sees an empty quote pair... :hankey:  

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I added a new unit test for empty quotes

<!-- How was it tested? -->
