### PR TITLE
Restore `redefined-while-unused` violations in classes

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyflakes/F811_26.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F811_26.py
@@ -1,0 +1,6 @@
+class Class:
+    def func(self):
+        pass
+
+    def func(self):
+        pass

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -4964,11 +4964,6 @@ impl<'a> Checker<'a> {
                 }
             }
 
-            // Imports in classes are public members.
-            if scope.kind.is_class() {
-                continue;
-            }
-
             // F402
             if self.enabled(Rule::ImportShadowedByLoopVar) {
                 for (name, binding_id) in scope.bindings() {
@@ -5099,6 +5094,11 @@ impl<'a> Checker<'a> {
                         diagnostics.push(diagnostic);
                     }
                 }
+            }
+
+            // Imports in classes are public members.
+            if scope.kind.is_class() {
+                continue;
             }
 
             if enforce_typing_imports {

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -108,6 +108,7 @@ mod tests {
     #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_23.py"))]
     #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_24.py"))]
     #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_25.py"))]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_26.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_0.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_1.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_2.py"))]

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F811_F811_26.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F811_F811_26.py.snap
@@ -1,0 +1,13 @@
+---
+source: crates/ruff/src/rules/pyflakes/mod.rs
+---
+F811_26.py:5:9: F811 Redefinition of unused `func` from line 2
+  |
+3 |         pass
+4 | 
+5 |     def func(self):
+  |         ^^^^ F811
+6 |         pass
+  |
+
+


### PR DESCRIPTION
## Summary

This is a regression from a recent refactor whereby we moved these checks to a deferred pass.

Closes https://github.com/astral-sh/ruff/issues/5918.

