### PR TITLE
Close unclosed code block in documentation

### DIFF
--- a/crates/ruff/src/rules/pylint/rules/bad_str_strip_call.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_str_strip_call.rs
@@ -37,6 +37,7 @@ use crate::settings::types::PythonVersion;
 /// ```python
 /// # Evaluates to "foo".
 /// "bar foo baz".removeprefix("bar ").removesuffix(" baz")
+/// ```
 ///
 /// ## Options
 /// - `target-version`


### PR DESCRIPTION
## Summary

Closes an unclosed code block such that the rule documentation renders properly.

## Test Plan

`mkdocs serve -f mkdocs.generated.yml`
