### PR TITLE
Allow `respect_gitignore` when not in a git repo

### DIFF
--- a/crates/ruff/src/resolver.rs
+++ b/crates/ruff/src/resolver.rs
@@ -262,6 +262,7 @@ pub fn python_files_in_path(
         builder.add(path);
     }
     builder.standard_filters(pyproject_config.settings.lib.respect_gitignore);
+    builder.require_git(false);
     builder.hidden(false);
     let walker = builder.build_parallel();
 


### PR DESCRIPTION
## Summary

Allow `respect_gitignore` even when not in a git repo

## Test Plan

Within the Ruff repository:

1. Renamed `.git` to `.hello-world`
2. Added `test.py` in root folder
3. Added `test.py` to `.gitignore`
4. Ran `cargo run --bin ruff -- check --no-cache --isolated --show-files .` with
   and without `--respect-gitignore` flag

fixes: #5930
