### PR TITLE
Fix formatting lambda with empty arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=db04fd415774032e1e2ceb03bcbf5305e0d22c8c#db04fd415774032e1e2ceb03bcbf5305e0d22c8c"
+source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc#1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc"
 dependencies = [
  "schemars",
  "serde",
@@ -2334,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.2.0"
-source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=db04fd415774032e1e2ceb03bcbf5305e0d22c8c#db04fd415774032e1e2ceb03bcbf5305e0d22c8c"
+source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc#1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "rustpython-format"
 version = "0.2.0"
-source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=db04fd415774032e1e2ceb03bcbf5305e0d22c8c#db04fd415774032e1e2ceb03bcbf5305e0d22c8c"
+source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc#1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc"
 dependencies = [
  "bitflags 2.3.3",
  "itertools",
@@ -2357,7 +2357,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.2.0"
-source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=db04fd415774032e1e2ceb03bcbf5305e0d22c8c#db04fd415774032e1e2ceb03bcbf5305e0d22c8c"
+source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc#1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -2369,7 +2369,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.2.0"
-source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=db04fd415774032e1e2ceb03bcbf5305e0d22c8c#db04fd415774032e1e2ceb03bcbf5305e0d22c8c"
+source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc#1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc"
 dependencies = [
  "anyhow",
  "is-macro",
@@ -2392,7 +2392,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser-core"
 version = "0.2.0"
-source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=db04fd415774032e1e2ceb03bcbf5305e0d22c8c#db04fd415774032e1e2ceb03bcbf5305e0d22c8c"
+source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc#1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc"
 dependencies = [
  "is-macro",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,11 +52,11 @@ wsl = { version = "0.1.0" }
 # v1.0.1
 libcst = { git = "https://github.com/Instagram/LibCST.git", rev = "3cacca1a1029f05707e50703b49fe3dd860aa839", default-features = false }
 
-ruff_text_size = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "db04fd415774032e1e2ceb03bcbf5305e0d22c8c" }
-rustpython-ast = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "db04fd415774032e1e2ceb03bcbf5305e0d22c8c" , default-features = false, features = ["num-bigint"]}
-rustpython-format = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "db04fd415774032e1e2ceb03bcbf5305e0d22c8c", default-features = false, features = ["num-bigint"] }
-rustpython-literal = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "db04fd415774032e1e2ceb03bcbf5305e0d22c8c", default-features = false }
-rustpython-parser = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "db04fd415774032e1e2ceb03bcbf5305e0d22c8c" , default-features = false, features = ["full-lexer", "num-bigint"] }
+ruff_text_size = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc" }
+rustpython-ast = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc" , default-features = false, features = ["num-bigint"]}
+rustpython-format = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc", default-features = false, features = ["num-bigint"] }
+rustpython-literal = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc", default-features = false }
+rustpython-parser = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc" , default-features = false, features = ["full-lexer", "num-bigint"] }
 
 [profile.release]
 lto = "fat"

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
@@ -61,3 +61,8 @@ a = (
     lambda  # Dangling
            : 1
 )
+
+# Regression test: lambda empty arguments ranges were too long, leading to unstable
+# formatting
+(lambda:(#
+),)

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
@@ -66,7 +66,13 @@ z)  # Trailing
 a = (
     lambda  # Dangling
            : 1
-)```
+)
+
+# Regression test: lambda empty arguments ranges were too long, leading to unstable
+# formatting
+(lambda:(#
+),)
+```
 
 ## Output
 ```py
@@ -129,6 +135,13 @@ lambda x: lambda y: lambda z: (
 
 a = (
     lambda: 1  # Dangling
+)
+
+# Regression test: lambda empty arguments ranges were too long, leading to unstable
+# formatting
+(
+    lambda: (  #
+    ),
 )
 ```
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ ruff_python_ast = { path = "../crates/ruff_python_ast" }
 ruff_python_formatter = { path = "../crates/ruff_python_formatter" }
 similar = { version = "2.2.1" }
 
-rustpython-parser = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "db04fd415774032e1e2ceb03bcbf5305e0d22c8c" , default-features = false, features = ["full-lexer", "num-bigint"] }
+rustpython-parser = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc" , default-features = false, features = ["full-lexer", "num-bigint"] }
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
**Summary** Fix implemented in https://github.com/astral-sh/RustPython-Parser/pull/35: Previously, empty lambda arguments (e.g. `lambda: 1`) would get the range of the entire expression, which leads to incorrect comment placement. Now empty lambda arguments get an empty range between the `lambda` and the `:` tokens.

**Test Plan** Added a regression test.

149 instances of unstable formatting remaining.

```
$ cargo run --bin ruff_dev --release -- format-dev --stability-check --error-file formatter-ecosystem-errors.txt --multi-project target/checkouts > formatter-ecosystem-progress.txt
$ rg "Unstable formatting" target/formatter-ecosystem-errors.txt | wc -l
149
```
