### PR TITLE
Create snake_case file if linter is Pylint

### DIFF
--- a/scripts/add_rule.py
+++ b/scripts/add_rule.py
@@ -20,11 +20,12 @@ from _utils import ROOT_DIR, dir_name, get_indent, pascal_case, snake_case
 def main(*, name: str, prefix: str, code: str, linter: str) -> None:
     """Generate boilerplate for a new rule."""
     # Create a test fixture.
+    filestem = f"{prefix}{code}" if linter != "pylint" else snake_case(name)
     with (
         ROOT_DIR
         / "crates/ruff/resources/test/fixtures"
         / dir_name(linter)
-        / f"{prefix}{code}.py"
+        / f"{filestem}.py"
     ).open(
         "a",
     ):
@@ -45,7 +46,6 @@ def main(*, name: str, prefix: str, code: str, linter: str) -> None:
                 line.strip() == "fn rules(rule_code: Rule, path: &Path) -> Result<()> {"
             ):
                 indent = get_indent(line)
-                filestem = f"{prefix}{code}" if linter != "pylint" else snake_case(name)
                 lines.append(
                     f'{indent}#[test_case(Rule::{name}, Path::new("{filestem}.py"))]',
                 )


### PR DESCRIPTION
## Summary

The `add_rule.py` script would create a test case that pointed to a file that didn't exist when the linter is set to `"pylint"`. This PR fixes that.

## Test Plan

`python scripts/add_rule.py --name DoTheThing --prefix PL --code C0999 --linter pylint`
