### PR TITLE
Fix RustPython rev to main branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc#1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc"
+source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=4d03b9b5b212fc869e4cfda151414438186a7779#4d03b9b5b212fc869e4cfda151414438186a7779"
 dependencies = [
  "schemars",
  "serde",
@@ -2334,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.2.0"
-source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc#1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc"
+source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=4d03b9b5b212fc869e4cfda151414438186a7779#4d03b9b5b212fc869e4cfda151414438186a7779"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "rustpython-format"
 version = "0.2.0"
-source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc#1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc"
+source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=4d03b9b5b212fc869e4cfda151414438186a7779#4d03b9b5b212fc869e4cfda151414438186a7779"
 dependencies = [
  "bitflags 2.3.3",
  "itertools",
@@ -2357,7 +2357,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.2.0"
-source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc#1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc"
+source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=4d03b9b5b212fc869e4cfda151414438186a7779#4d03b9b5b212fc869e4cfda151414438186a7779"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -2369,7 +2369,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.2.0"
-source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc#1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc"
+source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=4d03b9b5b212fc869e4cfda151414438186a7779#4d03b9b5b212fc869e4cfda151414438186a7779"
 dependencies = [
  "anyhow",
  "is-macro",
@@ -2392,7 +2392,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser-core"
 version = "0.2.0"
-source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc#1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc"
+source = "git+https://github.com/astral-sh/RustPython-Parser.git?rev=4d03b9b5b212fc869e4cfda151414438186a7779#4d03b9b5b212fc869e4cfda151414438186a7779"
 dependencies = [
  "is-macro",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,11 +52,11 @@ wsl = { version = "0.1.0" }
 # v1.0.1
 libcst = { git = "https://github.com/Instagram/LibCST.git", rev = "3cacca1a1029f05707e50703b49fe3dd860aa839", default-features = false }
 
-ruff_text_size = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc" }
-rustpython-ast = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc" , default-features = false, features = ["num-bigint"]}
-rustpython-format = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc", default-features = false, features = ["num-bigint"] }
-rustpython-literal = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc", default-features = false }
-rustpython-parser = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc" , default-features = false, features = ["full-lexer", "num-bigint"] }
+ruff_text_size = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "4d03b9b5b212fc869e4cfda151414438186a7779" }
+rustpython-ast = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "4d03b9b5b212fc869e4cfda151414438186a7779" , default-features = false, features = ["num-bigint"]}
+rustpython-format = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "4d03b9b5b212fc869e4cfda151414438186a7779", default-features = false, features = ["num-bigint"] }
+rustpython-literal = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "4d03b9b5b212fc869e4cfda151414438186a7779", default-features = false }
+rustpython-parser = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "4d03b9b5b212fc869e4cfda151414438186a7779" , default-features = false, features = ["full-lexer", "num-bigint"] }
 
 [profile.release]
 lto = "fat"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ ruff_python_ast = { path = "../crates/ruff_python_ast" }
 ruff_python_formatter = { path = "../crates/ruff_python_formatter" }
 similar = { version = "2.2.1" }
 
-rustpython-parser = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "1c08c5984d31be9af9e2cd10dfe8e3d32d6eb0bc" , default-features = false, features = ["full-lexer", "num-bigint"] }
+rustpython-parser = { git = "https://github.com/astral-sh/RustPython-Parser.git", rev = "4d03b9b5b212fc869e4cfda151414438186a7779" , default-features = false, features = ["full-lexer", "num-bigint"] }
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
**Summary** I accidentally merged earlier while the RustPython parser rev was still pointing to the feature branch instead of to the merged main. This make the rev point to the RustPython parser repo main again