### PR TITLE
Use Ruff's import resolver to power import sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,6 +1908,7 @@ dependencies = [
  "ruff_python_codegen",
  "ruff_python_index",
  "ruff_python_parser",
+ "ruff_python_resolver",
  "ruff_python_semantic",
  "ruff_python_stdlib",
  "ruff_python_trivia",

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -22,10 +22,11 @@ ruff_macros = { path = "../ruff_macros" }
 ruff_python_ast = { path = "../ruff_python_ast", features = ["serde"] }
 ruff_python_codegen = { path = "../ruff_python_codegen" }
 ruff_python_index = { path = "../ruff_python_index" }
+ruff_python_parser = { path = "../ruff_python_parser" }
+ruff_python_resolver = { path = "../ruff_python_resolver" }
 ruff_python_semantic = { path = "../ruff_python_semantic" }
 ruff_python_stdlib = { path = "../ruff_python_stdlib" }
 ruff_python_trivia = { path = "../ruff_python_trivia" }
-ruff_python_parser = { path = "../ruff_python_parser" }
 ruff_source_file = { path = "../ruff_source_file" }
 ruff_text_size = { workspace = true }
 

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -70,8 +70,6 @@ mod deferred;
 pub(crate) struct Checker<'a> {
     /// The [`Path`] to the file under analysis.
     path: &'a Path,
-    /// The [`Path`] to the package containing the current file.
-    package: Option<&'a Path>,
     /// The module representation of the current file (e.g., `foo.bar`).
     module_path: Option<&'a [String]>,
     /// Whether the current file is a stub (`.pyi`) file.
@@ -111,7 +109,6 @@ impl<'a> Checker<'a> {
         noqa_line_for: &'a NoqaMapping,
         noqa: flags::Noqa,
         path: &'a Path,
-        package: Option<&'a Path>,
         module: Module<'a>,
         locator: &'a Locator,
         stylist: &'a Stylist,
@@ -123,7 +120,6 @@ impl<'a> Checker<'a> {
             noqa_line_for,
             noqa,
             path,
-            package,
             module_path: module.path(),
             is_stub: is_python_stub_file(path),
             locator,
@@ -235,11 +231,6 @@ impl<'a> Checker<'a> {
     /// The [`Path`] to the file under analysis.
     pub(crate) const fn path(&self) -> &'a Path {
         self.path
-    }
-
-    /// The [`Path`] to the package containing the current file.
-    pub(crate) const fn package(&self) -> Option<&'a Path> {
-        self.package
     }
 
     /// Returns whether the given rule should be checked.
@@ -1854,7 +1845,6 @@ pub(crate) fn check_ast(
         noqa_line_for,
         noqa,
         path,
-        package,
         module,
         locator,
         stylist,

--- a/crates/ruff/src/checkers/imports.rs
+++ b/crates/ruff/src/checkers/imports.rs
@@ -103,9 +103,9 @@ pub(crate) fn check_imports(
     if settings.rules.enabled(Rule::UnsortedImports) {
         for block in &blocks {
             if !block.imports.is_empty() {
-                if let Some(diagnostic) = isort::rules::organize_imports(
-                    block, locator, stylist, indexer, settings, package,
-                ) {
+                if let Some(diagnostic) =
+                    isort::rules::organize_imports(block, locator, stylist, indexer, settings, path)
+                {
                     diagnostics.push(diagnostic);
                 }
             }

--- a/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -250,8 +250,8 @@ pub(crate) fn typing_only_runtime_import(
             let import_type = match categorize(
                 qualified_name,
                 Some(level),
+                checker.path(),
                 &checker.settings.src,
-                checker.package(),
                 &checker.settings.isort.known_modules,
                 checker.settings.target_version,
             ) {

--- a/crates/ruff/src/rules/isort/mod.rs
+++ b/crates/ruff/src/rules/isort/mod.rs
@@ -70,8 +70,8 @@ pub(crate) fn format_imports(
     line_length: LineLength,
     indentation_width: LineWidth,
     stylist: &Stylist,
+    path: &Path,
     src: &[PathBuf],
-    package: Option<&Path>,
     combine_as_imports: bool,
     force_single_line: bool,
     force_sort_within_sections: bool,
@@ -113,8 +113,8 @@ pub(crate) fn format_imports(
             line_length,
             indentation_width,
             stylist,
+            path,
             src,
-            package,
             force_sort_within_sections,
             case_sensitive,
             force_wrap_aliases,
@@ -171,8 +171,8 @@ fn format_import_block(
     line_length: LineLength,
     indentation_width: LineWidth,
     stylist: &Stylist,
+    path: &Path,
     src: &[PathBuf],
-    package: Option<&Path>,
     force_sort_within_sections: bool,
     case_sensitive: bool,
     force_wrap_aliases: bool,
@@ -190,7 +190,7 @@ fn format_import_block(
     section_order: &[ImportSection],
 ) -> String {
     // Categorize by type (e.g., first-party vs. third-party).
-    let mut block_by_type = categorize_imports(block, src, package, known_modules, target_version);
+    let mut block_by_type = categorize_imports(block, path, src, known_modules, target_version);
 
     let mut output = String::new();
 

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -1,8 +1,7 @@
-use std::path::Path;
-
 use itertools::{EitherOrBoth, Itertools};
 use ruff_text_size::TextRange;
 use rustpython_ast::{Ranged, Stmt};
+use std::path::Path;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -86,7 +85,7 @@ pub(crate) fn organize_imports(
     stylist: &Stylist,
     indexer: &Indexer,
     settings: &Settings,
-    package: Option<&Path>,
+    path: &Path,
 ) -> Option<Diagnostic> {
     let indentation = locator.slice(extract_indentation_range(&block.imports, locator));
     let indentation = leading_indentation(indentation);
@@ -121,8 +120,8 @@ pub(crate) fn organize_imports(
         settings.line_length,
         LineWidth::new(settings.tab_size).add_str(indentation),
         stylist,
+        path,
         &settings.src,
-        package,
         settings.isort.combine_as_imports,
         settings.isort.force_single_line,
         settings.isort.force_sort_within_sections,

--- a/crates/ruff_python_resolver/src/config.rs
+++ b/crates/ruff_python_resolver/src/config.rs
@@ -1,18 +1,19 @@
 use std::path::PathBuf;
 
-pub(crate) struct Config {
+#[derive(Debug, Default)]
+pub struct Config {
     /// Path to use for typeshed definitions.
-    pub(crate) typeshed_path: Option<PathBuf>,
+    pub typeshed_path: Option<PathBuf>,
 
     /// Path to custom typings (stub) modules.
-    pub(crate) stub_path: Option<PathBuf>,
+    pub stub_path: Option<PathBuf>,
 
     /// Path to a directory containing one or more virtual environment
     /// directories. This is used in conjunction with the "venv" name in
     /// the config file to identify the python environment used for resolving
     /// third-party modules.
-    pub(crate) venv_path: Option<PathBuf>,
+    pub venv_path: Option<PathBuf>,
 
     /// Default venv environment.
-    pub(crate) venv: Option<PathBuf>,
+    pub venv: Option<PathBuf>,
 }

--- a/crates/ruff_python_resolver/src/execution_environment.rs
+++ b/crates/ruff_python_resolver/src/execution_environment.rs
@@ -4,16 +4,16 @@ use crate::python_platform::PythonPlatform;
 use crate::python_version::PythonVersion;
 
 #[derive(Debug)]
-pub(crate) struct ExecutionEnvironment {
+pub struct ExecutionEnvironment {
     /// The root directory of the execution environment.
-    pub(crate) root: PathBuf,
+    pub root: PathBuf,
 
     /// The Python version of the execution environment.
-    pub(crate) python_version: PythonVersion,
+    pub python_version: PythonVersion,
 
     /// The Python platform of the execution environment.
-    pub(crate) python_platform: PythonPlatform,
+    pub python_platform: PythonPlatform,
 
     /// The extra search paths of the execution environment.
-    pub(crate) extra_paths: Vec<PathBuf>,
+    pub extra_paths: Vec<PathBuf>,
 }

--- a/crates/ruff_python_resolver/src/host.rs
+++ b/crates/ruff_python_resolver/src/host.rs
@@ -6,7 +6,7 @@ use crate::python_platform::PythonPlatform;
 use crate::python_version::PythonVersion;
 
 /// A trait to expose the host environment to the resolver.
-pub(crate) trait Host {
+pub trait Host {
     /// The search paths to use when resolving Python modules.
     fn python_search_paths(&self) -> Vec<PathBuf>;
 
@@ -18,12 +18,13 @@ pub(crate) trait Host {
 }
 
 /// A host that exposes a fixed set of search paths.
-pub(crate) struct StaticHost {
+#[derive(Debug, Default)]
+pub struct StaticHost {
     search_paths: Vec<PathBuf>,
 }
 
 impl StaticHost {
-    pub(crate) fn new(search_paths: Vec<PathBuf>) -> Self {
+    pub fn new(search_paths: Vec<PathBuf>) -> Self {
         Self { search_paths }
     }
 }

--- a/crates/ruff_python_resolver/src/import_result.rs
+++ b/crates/ruff_python_resolver/src/import_result.rs
@@ -7,12 +7,12 @@ use crate::py_typed::PyTypedInfo;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(clippy::struct_excessive_bools)]
-pub(crate) struct ImportResult {
+pub struct ImportResult {
     /// Whether the import name was relative (e.g., ".foo").
     pub(crate) is_relative: bool,
 
     /// Whether the import was resolved to a file or module.
-    pub(crate) is_import_found: bool,
+    pub is_import_found: bool,
 
     /// The path was partially resolved, but the specific submodule
     /// defining the import was not found. For example, `foo.bar` was
@@ -32,7 +32,7 @@ pub(crate) struct ImportResult {
     pub(crate) is_stub_package: bool,
 
     /// The import resolved to a built-in, local, or third-party module.
-    pub(crate) import_type: ImportType,
+    pub import_type: ImportType,
 
     /// A vector of resolved absolute paths for each file in the module
     /// name. Typically includes a sequence of `__init__.py` files, followed
@@ -114,7 +114,7 @@ impl ImportResult {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ImportType {
+pub enum ImportType {
     BuiltIn,
     ThirdParty,
     Local,

--- a/crates/ruff_python_resolver/src/lib.rs
+++ b/crates/ruff_python_resolver/src/lib.rs
@@ -1,5 +1,14 @@
 #![allow(dead_code)]
 
+pub use config::*;
+pub use execution_environment::*;
+pub use host::*;
+pub use import_result::*;
+pub use module_descriptor::*;
+pub use python_platform::*;
+pub use python_version::*;
+pub use resolver::*;
+
 mod config;
 mod execution_environment;
 mod host;

--- a/crates/ruff_python_resolver/src/module_descriptor.rs
+++ b/crates/ruff_python_resolver/src/module_descriptor.rs
@@ -1,8 +1,8 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ImportModuleDescriptor {
-    pub(crate) leading_dots: usize,
-    pub(crate) name_parts: Vec<String>,
-    pub(crate) imported_symbols: Vec<String>,
+pub struct ImportModuleDescriptor {
+    pub leading_dots: usize,
+    pub name_parts: Vec<String>,
+    pub imported_symbols: Vec<String>,
 }
 
 impl ImportModuleDescriptor {

--- a/crates/ruff_python_resolver/src/python_platform.rs
+++ b/crates/ruff_python_resolver/src/python_platform.rs
@@ -1,6 +1,6 @@
 /// Enum to represent a Python platform.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(crate) enum PythonPlatform {
+pub enum PythonPlatform {
     Darwin,
     Linux,
     Windows,

--- a/crates/ruff_python_resolver/src/python_version.rs
+++ b/crates/ruff_python_resolver/src/python_version.rs
@@ -1,6 +1,6 @@
 /// Enum to represent a Python version.
 #[derive(Debug, Copy, Clone)]
-pub(crate) enum PythonVersion {
+pub enum PythonVersion {
     Py37,
     Py38,
     Py39,


### PR DESCRIPTION
## Summary

Work-in-progress PR to migrate our import sorting categorizer over to Ruff's import resolver. Previously, the import categorization logic just looked at the first part of an import (e.g., `import foo.bar`, take `foo`) and tried to find either a `foo` directory or a `foo.py` file. This often worked, but (e.g.) doesn't properly handle namespace packages, and improperly categorizes projects with structures like:

```py
bar/
   bar/
     __init__.py
```

## Test Plan

I tested over a bunch of repos and verified that sorting is as-before:

- **Airflow** (able to remove their `known-first-party` and `known-third-party` classifications while retaining parity with the existing sort)
- **Zulip**
- **FastAPI**
- **Pydantic** (able to remove `known-third-party`)
- **Poetry**

This PR also passes all existing import-sorting tests in Ruff.

This needs more testing in the wild though. For example, it dramatically changed Dagster's sorting, I think because Dagster is implicitly relying on the above behavior to treat Dagster as first-party in various contexts. I'd need to come up with a solution for Dagster specifically prior to merging.
