### PR TITLE
Move `locator`, `stylist`, and friends better getters

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -100,14 +100,14 @@ pub(crate) struct Checker<'a> {
     pub(crate) settings: &'a Settings,
     /// The [`Locator`] for the current file, which enables extraction of source code from byte
     /// offsets.
-    pub(crate) locator: &'a Locator<'a>,
+    locator: &'a Locator<'a>,
     /// The [`Stylist`] for the current file, which detects the current line ending, quote, and
     /// indentation style.
-    pub(crate) stylist: &'a Stylist<'a>,
+    stylist: &'a Stylist<'a>,
     /// The [`Indexer`] for the current file, which contains the offsets of all comments and more.
-    pub(crate) indexer: &'a Indexer,
+    indexer: &'a Indexer,
     /// The [`Importer`] for the current file, which enables importing of other modules.
-    pub(crate) importer: Importer<'a>,
+    importer: Importer<'a>,
     /// The [`SemanticModel`], built up over the course of the AST traversal.
     semantic: SemanticModel<'a>,
     /// A set of deferred nodes to be processed after the current traversal (e.g., function bodies).
@@ -219,16 +219,41 @@ impl<'a> Checker<'a> {
             })
     }
 
+    /// The [`Locator`] for the current file, which enables extraction of source code from byte
+    /// offsets.
+    pub(crate) const fn locator(&self) -> &'a Locator<'a> {
+        self.locator
+    }
+
+    /// The [`Stylist`] for the current file, which detects the current line ending, quote, and
+    /// indentation style.
+    pub(crate) const fn stylist(&self) -> &'a Stylist<'a> {
+        self.stylist
+    }
+
+    /// The [`Indexer`] for the current file, which contains the offsets of all comments and more.
+    pub(crate) const fn indexer(&self) -> &'a Indexer {
+        self.indexer
+    }
+
+    /// The [`Importer`] for the current file, which enables importing of other modules.
+    pub(crate) const fn importer(&self) -> &Importer<'a> {
+        &self.importer
+    }
+
+    /// The [`SemanticModel`], built up over the course of the AST traversal.
     pub(crate) const fn semantic(&self) -> &SemanticModel<'a> {
         &self.semantic
     }
 
-    pub(crate) const fn package(&self) -> Option<&'a Path> {
-        self.package
-    }
-
+    /// The [`Path`] to the file under analysis.
     pub(crate) const fn path(&self) -> &'a Path {
         self.path
+    }
+
+    /// The [`Path`] to the package containing the current file.
+    pub(crate) const fn package(&self) -> Option<&'a Path> {
+        self.package
     }
 
     /// Returns whether the given rule should be checked.

--- a/crates/ruff/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff/src/rules/flake8_annotations/rules/definition.rs
@@ -448,11 +448,12 @@ fn check_dynamically_typed<F>(
     }) = annotation
     {
         // Quoted annotations
-        if let Ok((parsed_annotation, _)) = parse_type_annotation(string, *range, checker.locator) {
+        if let Ok((parsed_annotation, _)) = parse_type_annotation(string, *range, checker.locator())
+        {
             if type_hint_resolves_to_any(
                 &parsed_annotation,
                 checker.semantic(),
-                checker.locator,
+                checker.locator(),
                 checker.settings.target_version.minor(),
             ) {
                 diagnostics.push(Diagnostic::new(
@@ -465,7 +466,7 @@ fn check_dynamically_typed<F>(
         if type_hint_resolves_to_any(
             annotation,
             checker.semantic(),
-            checker.locator,
+            checker.locator(),
             checker.settings.target_version.minor(),
         ) {
             diagnostics.push(Diagnostic::new(
@@ -690,7 +691,7 @@ pub(crate) fn definition(
                     );
                     if checker.patch(diagnostic.kind.rule()) {
                         diagnostic.try_set_fix(|| {
-                            fixes::add_return_annotation(checker.locator, stmt, "None")
+                            fixes::add_return_annotation(checker.locator(), stmt, "None")
                                 .map(Fix::suggested)
                         });
                     }
@@ -708,7 +709,7 @@ pub(crate) fn definition(
                 if checker.patch(diagnostic.kind.rule()) {
                     if let Some(return_type) = simple_magic_return_type(name) {
                         diagnostic.try_set_fix(|| {
-                            fixes::add_return_annotation(checker.locator, stmt, return_type)
+                            fixes::add_return_annotation(checker.locator(), stmt, return_type)
                                 .map(Fix::suggested)
                         });
                     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -80,7 +80,7 @@ pub(crate) fn getattr_with_constant(
     let mut diagnostic = Diagnostic::new(GetAttrWithConstant, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
-            format!("{}.{}", checker.locator.slice(obj.range()), value),
+            format!("{}.{}", checker.locator().slice(obj.range()), value),
             expr.range(),
         )));
     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
@@ -83,7 +83,7 @@ pub(crate) fn unreliable_callable_check(
         if id == "hasattr" {
             if checker.semantic().is_builtin("callable") {
                 diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
-                    format!("callable({})", checker.locator.slice(obj.range())),
+                    format!("callable({})", checker.locator().slice(obj.range())),
                     expr.range(),
                 )));
             }

--- a/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
@@ -61,8 +61,8 @@ pub(crate) fn fix_unnecessary_generator_set(
     checker: &Checker,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Edit> {
-    let locator = checker.locator;
-    let stylist = checker.stylist;
+    let locator = checker.locator();
+    let stylist = checker.stylist();
 
     // Expr(Call(GeneratorExp)))) -> Expr(SetComp)))
     let module_text = locator.slice(expr.range());
@@ -99,8 +99,8 @@ pub(crate) fn fix_unnecessary_generator_dict(
     checker: &Checker,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Edit> {
-    let locator = checker.locator;
-    let stylist = checker.stylist;
+    let locator = checker.locator();
+    let stylist = checker.stylist();
 
     let module_text = locator.slice(expr.range());
     let mut tree = match_expression(module_text)?;
@@ -142,8 +142,8 @@ pub(crate) fn fix_unnecessary_list_comprehension_set(
     checker: &Checker,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Edit> {
-    let locator = checker.locator;
-    let stylist = checker.stylist;
+    let locator = checker.locator();
+    let stylist = checker.stylist();
     // Expr(Call(ListComp)))) ->
     // Expr(SetComp)))
     let module_text = locator.slice(expr.range());
@@ -178,8 +178,8 @@ pub(crate) fn fix_unnecessary_list_comprehension_dict(
     checker: &Checker,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Edit> {
-    let locator = checker.locator;
-    let stylist = checker.stylist;
+    let locator = checker.locator();
+    let stylist = checker.stylist();
 
     let module_text = locator.slice(expr.range());
     let mut tree = match_expression(module_text)?;
@@ -265,8 +265,8 @@ pub(crate) fn fix_unnecessary_literal_set(
     checker: &Checker,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Edit> {
-    let locator = checker.locator;
-    let stylist = checker.stylist;
+    let locator = checker.locator();
+    let stylist = checker.stylist();
 
     // Expr(Call(List|Tuple)))) -> Expr(Set)))
     let module_text = locator.slice(expr.range());
@@ -309,8 +309,8 @@ pub(crate) fn fix_unnecessary_literal_dict(
     checker: &Checker,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Edit> {
-    let locator = checker.locator;
-    let stylist = checker.stylist;
+    let locator = checker.locator();
+    let stylist = checker.stylist();
 
     // Expr(Call(List|Tuple)))) -> Expr(Dict)))
     let module_text = locator.slice(expr.range());
@@ -381,8 +381,8 @@ pub(crate) fn fix_unnecessary_collection_call(
         Dict,
     }
 
-    let locator = checker.locator;
-    let stylist = checker.stylist;
+    let locator = checker.locator();
+    let stylist = checker.stylist();
 
     // Expr(Call("list" | "tuple" | "dict")))) -> Expr(List|Tuple|Dict)
     let module_text = locator.slice(expr.range());
@@ -511,12 +511,12 @@ fn pad_expression(content: String, range: TextRange, checker: &Checker) -> Strin
 
     // If the expression is immediately preceded by an opening brace, then
     // we need to add a space before the expression.
-    let prefix = checker.locator.up_to(range.start());
+    let prefix = checker.locator().up_to(range.start());
     let left_pad = matches!(prefix.chars().next_back(), Some('{'));
 
     // If the expression is immediately preceded by an opening brace, then
     // we need to add a space before the expression.
-    let suffix = checker.locator.after(range.end());
+    let suffix = checker.locator().after(range.end());
     let right_pad = matches!(suffix.chars().next(), Some('}'));
 
     if left_pad && right_pad {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
@@ -86,8 +86,11 @@ pub(crate) fn unnecessary_call_around_sorted(
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            let edit =
-                fixes::fix_unnecessary_call_around_sorted(checker.locator, checker.stylist, expr)?;
+            let edit = fixes::fix_unnecessary_call_around_sorted(
+                checker.locator(),
+                checker.stylist(),
+                expr,
+            )?;
             if outer == "reversed" {
                 Ok(Fix::suggested(edit))
             } else {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -68,7 +68,7 @@ fn add_diagnostic(checker: &mut Checker, expr: &Expr) {
     if checker.patch(diagnostic.kind.rule()) {
         #[allow(deprecated)]
         diagnostic.try_set_fix_from_edit(|| {
-            fixes::fix_unnecessary_comprehension(checker.locator, checker.stylist, expr)
+            fixes::fix_unnecessary_comprehension(checker.locator(), checker.stylist(), expr)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_any_all.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_any_all.rs
@@ -84,7 +84,11 @@ pub(crate) fn unnecessary_comprehension_any_all(
         let mut diagnostic = Diagnostic::new(UnnecessaryComprehensionAnyAll, args[0].range());
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
-                fixes::fix_unnecessary_comprehension_any_all(checker.locator, checker.stylist, expr)
+                fixes::fix_unnecessary_comprehension_any_all(
+                    checker.locator(),
+                    checker.stylist(),
+                    expr,
+                )
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
@@ -135,8 +135,8 @@ pub(crate) fn unnecessary_double_cast_or_process(
             #[allow(deprecated)]
             diagnostic.try_set_fix_from_edit(|| {
                 fixes::fix_unnecessary_double_cast_or_process(
-                    checker.locator,
-                    checker.stylist,
+                    checker.locator(),
+                    checker.stylist(),
                     expr,
                 )
             });

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
@@ -62,7 +62,7 @@ pub(crate) fn unnecessary_generator_list(
         if checker.patch(diagnostic.kind.rule()) {
             #[allow(deprecated)]
             diagnostic.try_set_fix_from_edit(|| {
-                fixes::fix_unnecessary_generator_list(checker.locator, checker.stylist, expr)
+                fixes::fix_unnecessary_generator_list(checker.locator(), checker.stylist(), expr)
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
@@ -58,7 +58,7 @@ pub(crate) fn unnecessary_list_call(
     if checker.patch(diagnostic.kind.rule()) {
         #[allow(deprecated)]
         diagnostic.try_set_fix_from_edit(|| {
-            fixes::fix_unnecessary_list_call(checker.locator, checker.stylist, expr)
+            fixes::fix_unnecessary_list_call(checker.locator(), checker.stylist(), expr)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_dict_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_dict_call.rs
@@ -93,7 +93,11 @@ pub(crate) fn unnecessary_literal_within_dict_call(
     if checker.patch(diagnostic.kind.rule()) {
         #[allow(deprecated)]
         diagnostic.try_set_fix_from_edit(|| {
-            fixes::fix_unnecessary_literal_within_dict_call(checker.locator, checker.stylist, expr)
+            fixes::fix_unnecessary_literal_within_dict_call(
+                checker.locator(),
+                checker.stylist(),
+                expr,
+            )
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
@@ -96,7 +96,11 @@ pub(crate) fn unnecessary_literal_within_list_call(
     if checker.patch(diagnostic.kind.rule()) {
         #[allow(deprecated)]
         diagnostic.try_set_fix_from_edit(|| {
-            fixes::fix_unnecessary_literal_within_list_call(checker.locator, checker.stylist, expr)
+            fixes::fix_unnecessary_literal_within_list_call(
+                checker.locator(),
+                checker.stylist(),
+                expr,
+            )
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
@@ -97,7 +97,11 @@ pub(crate) fn unnecessary_literal_within_tuple_call(
     if checker.patch(diagnostic.kind.rule()) {
         #[allow(deprecated)]
         diagnostic.try_set_fix_from_edit(|| {
-            fixes::fix_unnecessary_literal_within_tuple_call(checker.locator, checker.stylist, expr)
+            fixes::fix_unnecessary_literal_within_tuple_call(
+                checker.locator(),
+                checker.stylist(),
+                expr,
+            )
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -163,8 +163,14 @@ pub(crate) fn unnecessary_map(
     let mut diagnostic = Diagnostic::new(UnnecessaryMap { object_type }, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            fixes::fix_unnecessary_map(checker.locator, checker.stylist, expr, parent, object_type)
-                .map(Fix::suggested)
+            fixes::fix_unnecessary_map(
+                checker.locator(),
+                checker.stylist(),
+                expr,
+                parent,
+                object_type,
+            )
+            .map(Fix::suggested)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_errmsg/rules/string_in_exception.rs
+++ b/crates/ruff/src/rules/flake8_errmsg/rules/string_in_exception.rs
@@ -188,14 +188,14 @@ pub(crate) fn string_in_exception(checker: &mut Checker, stmt: &Stmt, exc: &Expr
                                 Diagnostic::new(RawStringInException, first.range());
                             if checker.patch(diagnostic.kind.rule()) {
                                 if let Some(indentation) =
-                                    whitespace::indentation(checker.locator, stmt)
+                                    whitespace::indentation(checker.locator(), stmt)
                                 {
                                     if checker.semantic().is_available("msg") {
                                         diagnostic.set_fix(generate_fix(
                                             stmt,
                                             first,
                                             indentation,
-                                            checker.stylist,
+                                            checker.stylist(),
                                             checker.generator(),
                                         ));
                                     }
@@ -211,14 +211,14 @@ pub(crate) fn string_in_exception(checker: &mut Checker, stmt: &Stmt, exc: &Expr
                         let mut diagnostic = Diagnostic::new(FStringInException, first.range());
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(indentation) =
-                                whitespace::indentation(checker.locator, stmt)
+                                whitespace::indentation(checker.locator(), stmt)
                             {
                                 if checker.semantic().is_available("msg") {
                                     diagnostic.set_fix(generate_fix(
                                         stmt,
                                         first,
                                         indentation,
-                                        checker.stylist,
+                                        checker.stylist(),
                                         checker.generator(),
                                     ));
                                 }
@@ -238,14 +238,14 @@ pub(crate) fn string_in_exception(checker: &mut Checker, stmt: &Stmt, exc: &Expr
                                     Diagnostic::new(DotFormatInException, first.range());
                                 if checker.patch(diagnostic.kind.rule()) {
                                     if let Some(indentation) =
-                                        whitespace::indentation(checker.locator, stmt)
+                                        whitespace::indentation(checker.locator(), stmt)
                                     {
                                         if checker.semantic().is_available("msg") {
                                             diagnostic.set_fix(generate_fix(
                                                 stmt,
                                                 first,
                                                 indentation,
-                                                checker.stylist,
+                                                checker.stylist(),
                                                 checker.generator(),
                                             ));
                                         }

--- a/crates/ruff/src/rules/flake8_import_conventions/rules/unconventional_import_alias.rs
+++ b/crates/ruff/src/rules/flake8_import_conventions/rules/unconventional_import_alias.rs
@@ -64,7 +64,7 @@ pub(crate) fn unconventional_import_alias(
         return None;
     };
 
-    let name = binding.name(checker.locator);
+    let name = binding.name(checker.locator());
     if binding.is_alias() && name == expected_alias {
         return None;
     }

--- a/crates/ruff/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
@@ -86,8 +86,8 @@ pub(crate) fn duplicate_class_field_definition(
                 let edit = autofix::edits::delete_stmt(
                     stmt,
                     Some(parent),
-                    checker.locator,
-                    checker.indexer,
+                    checker.locator(),
+                    checker.indexer(),
                 );
                 diagnostic.set_fix(Fix::suggested(edit).isolate(checker.isolation(Some(parent))));
             }

--- a/crates/ruff/src/rules/flake8_pie/rules/no_unnecessary_pass.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules/no_unnecessary_pass.rs
@@ -64,10 +64,10 @@ pub(crate) fn no_unnecessary_pass(checker: &mut Checker, body: &[Stmt]) {
 
         let mut diagnostic = Diagnostic::new(UnnecessaryPass, stmt.range());
         if checker.patch(diagnostic.kind.rule()) {
-            let edit = if let Some(index) = trailing_comment_start_offset(stmt, checker.locator) {
+            let edit = if let Some(index) = trailing_comment_start_offset(stmt, checker.locator()) {
                 Edit::range_deletion(stmt.range().add_end(index))
             } else {
-                autofix::edits::delete_stmt(stmt, None, checker.locator, checker.indexer)
+                autofix::edits::delete_stmt(stmt, None, checker.locator(), checker.indexer())
             };
             diagnostic.set_fix(Fix::automatic(edit));
         }

--- a/crates/ruff/src/rules/flake8_pyi/rules/duplicate_union_member.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/duplicate_union_member.rs
@@ -54,7 +54,7 @@ pub(crate) fn duplicate_union_member<'a>(checker: &mut Checker, expr: &'a Expr) 
                     // Replace the parent with its non-duplicate child.
                     let child = if expr == left.as_ref() { right } else { left };
                     diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
-                        checker.locator.slice(child.range()).to_string(),
+                        checker.locator().slice(child.range()).to_string(),
                         parent.unwrap().range(),
                     )));
                 }

--- a/crates/ruff/src/rules/flake8_pyi/rules/ellipsis_in_non_empty_class_body.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/ellipsis_in_non_empty_class_body.rs
@@ -69,8 +69,12 @@ pub(crate) fn ellipsis_in_non_empty_class_body(
 
         let mut diagnostic = Diagnostic::new(EllipsisInNonEmptyClassBody, stmt.range());
         if checker.patch(diagnostic.kind.rule()) {
-            let edit =
-                autofix::edits::delete_stmt(stmt, Some(parent), checker.locator, checker.indexer);
+            let edit = autofix::edits::delete_stmt(
+                stmt,
+                Some(parent),
+                checker.locator(),
+                checker.indexer(),
+            );
             diagnostic.set_fix(Fix::automatic(edit).isolate(checker.isolation(Some(parent))));
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_pyi/rules/pass_in_class_body.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/pass_in_class_body.rs
@@ -35,8 +35,12 @@ pub(crate) fn pass_in_class_body(checker: &mut Checker, parent: &Stmt, body: &[S
 
         let mut diagnostic = Diagnostic::new(PassInClassBody, stmt.range());
         if checker.patch(diagnostic.kind.rule()) {
-            let edit =
-                autofix::edits::delete_stmt(stmt, Some(parent), checker.locator, checker.indexer);
+            let edit = autofix::edits::delete_stmt(
+                stmt,
+                Some(parent),
+                checker.locator(),
+                checker.indexer(),
+            );
             diagnostic.set_fix(Fix::automatic(edit).isolate(checker.isolation(Some(parent))));
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -418,7 +418,7 @@ pub(crate) fn typed_argument_simple_defaults(checker: &mut Checker, arguments: &
             if !is_valid_default_value_with_annotation(
                 default,
                 true,
-                checker.locator,
+                checker.locator(),
                 checker.semantic(),
             ) {
                 let mut diagnostic = Diagnostic::new(TypedArgumentDefaultInStub, default.range());
@@ -455,7 +455,7 @@ pub(crate) fn argument_simple_defaults(checker: &mut Checker, arguments: &Argume
             if !is_valid_default_value_with_annotation(
                 default,
                 true,
-                checker.locator,
+                checker.locator(),
                 checker.semantic(),
             ) {
                 let mut diagnostic = Diagnostic::new(ArgumentDefaultInStub, default.range());
@@ -490,7 +490,7 @@ pub(crate) fn assignment_default_in_stub(checker: &mut Checker, targets: &[Expr]
     if is_valid_default_value_without_annotation(value) {
         return;
     }
-    if is_valid_default_value_with_annotation(value, true, checker.locator, checker.semantic()) {
+    if is_valid_default_value_with_annotation(value, true, checker.locator(), checker.semantic()) {
         return;
     }
 
@@ -526,7 +526,7 @@ pub(crate) fn annotated_assignment_default_in_stub(
     if is_final_assignment(annotation, value, checker.semantic()) {
         return;
     }
-    if is_valid_default_value_with_annotation(value, true, checker.locator, checker.semantic()) {
+    if is_valid_default_value_with_annotation(value, true, checker.locator(), checker.semantic()) {
         return;
     }
 
@@ -561,7 +561,7 @@ pub(crate) fn unannotated_assignment_in_stub(
     if is_valid_default_value_without_annotation(value) {
         return;
     }
-    if !is_valid_default_value_with_annotation(value, true, checker.locator, checker.semantic()) {
+    if !is_valid_default_value_with_annotation(value, true, checker.locator(), checker.semantic()) {
         return;
     }
 
@@ -623,7 +623,7 @@ pub(crate) fn type_alias_without_annotation(checker: &mut Checker, value: &Expr,
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            let (import_edit, binding) = checker.importer.get_or_import_symbol(
+            let (import_edit, binding) = checker.importer().get_or_import_symbol(
                 &ImportRequest::import("typing", "TypeAlias"),
                 target.start(),
                 checker.semantic(),

--- a/crates/ruff/src/rules/flake8_pyi/rules/str_or_repr_defined_in_stub.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/str_or_repr_defined_in_stub.rs
@@ -96,7 +96,7 @@ pub(crate) fn str_or_repr_defined_in_stub(checker: &mut Checker, stmt: &Stmt) {
     if checker.patch(diagnostic.kind.rule()) {
         let stmt = checker.semantic().stmt();
         let parent = checker.semantic().stmt_parent();
-        let edit = delete_stmt(stmt, parent, checker.locator, checker.indexer);
+        let edit = delete_stmt(stmt, parent, checker.locator(), checker.indexer());
         diagnostic.set_fix(
             Fix::automatic(edit).isolate(checker.isolation(checker.semantic().stmt_parent())),
         );

--- a/crates/ruff/src/rules/flake8_pyi/rules/unaliased_collections_abc_set_import.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unaliased_collections_abc_set_import.rs
@@ -57,7 +57,7 @@ pub(crate) fn unaliased_collections_abc_set_import(
         return None;
     }
 
-    let name = binding.name(checker.locator);
+    let name = binding.name(checker.locator());
     if name == "AbstractSet" {
         return None;
     }

--- a/crates/ruff/src/rules/flake8_pyi/rules/unnecessary_literal_union.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unnecessary_literal_union.rs
@@ -64,7 +64,7 @@ pub(crate) fn unnecessary_literal_union<'a>(checker: &mut Checker, expr: &'a Exp
             UnnecessaryLiteralUnion {
                 members: literal_exprs
                     .into_iter()
-                    .map(|literal_expr| checker.locator.slice(literal_expr.range()).to_string())
+                    .map(|literal_expr| checker.locator().slice(literal_expr.range()).to_string())
                     .collect(),
             },
             expr.range(),

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -197,7 +197,7 @@ pub(crate) fn unittest_assertion(
                     if checker.semantic().stmt().is_expr_stmt()
                         && checker.semantic().expr_parent().is_none()
                         && !checker.semantic().scope().kind.is_lambda()
-                        && !checker.indexer.comment_ranges().intersects(expr.range())
+                        && !checker.indexer().comment_ranges().intersects(expr.range())
                     {
                         if let Ok(stmt) = unittest_assert.generate_assert(args, keywords) {
                             diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
@@ -483,11 +483,11 @@ pub(crate) fn composite_condition(
         if checker.patch(diagnostic.kind.rule()) {
             if matches!(composite, CompositionKind::Simple)
                 && msg.is_none()
-                && !checker.indexer.comment_ranges().intersects(stmt.range())
+                && !checker.indexer().comment_ranges().intersects(stmt.range())
             {
                 #[allow(deprecated)]
                 diagnostic.try_set_fix_from_edit(|| {
-                    fix_composite_condition(stmt, checker.locator, checker.stylist)
+                    fix_composite_condition(stmt, checker.locator(), checker.stylist())
                 });
             }
         }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -317,7 +317,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &D
                         if checker.patch(diagnostic.kind.rule()) {
                             diagnostic.try_set_fix(|| {
                                 remove_argument(
-                                    checker.locator,
+                                    checker.locator(),
                                     func.end(),
                                     scope_keyword.range,
                                     args,
@@ -473,7 +473,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Decorator]) {
                 let mut diagnostic =
                     Diagnostic::new(PytestUnnecessaryAsyncioMarkOnFixture, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
-                    let range = checker.locator.full_lines_range(expr.range());
+                    let range = checker.locator().full_lines_range(expr.range());
                     diagnostic.set_fix(Fix::automatic(Edit::range_deletion(range)));
                 }
                 checker.diagnostics.push(diagnostic);
@@ -485,7 +485,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Decorator]) {
                 let mut diagnostic =
                     Diagnostic::new(PytestErroneousUseFixturesOnFixture, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
-                    let line_range = checker.locator.full_lines_range(expr.range());
+                    let line_range = checker.locator().full_lines_range(expr.range());
                     diagnostic.set_fix(Fix::automatic(Edit::range_deletion(line_range)));
                 }
                 checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -141,7 +141,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                 match names_type {
                     types::ParametrizeNameType::Tuple => {
                         let name_range =
-                            get_parametrize_name_range(decorator, expr, checker.locator);
+                            get_parametrize_name_range(decorator, expr, checker.locator());
                         let mut diagnostic = Diagnostic::new(
                             PytestParametrizeNamesWrongType {
                                 expected: names_type,
@@ -172,7 +172,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                     }
                     types::ParametrizeNameType::List => {
                         let name_range =
-                            get_parametrize_name_range(decorator, expr, checker.locator);
+                            get_parametrize_name_range(decorator, expr, checker.locator());
                         let mut diagnostic = Diagnostic::new(
                             PytestParametrizeNamesWrongType {
                                 expected: names_type,

--- a/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -65,7 +65,7 @@ pub(crate) fn unnecessary_paren_on_raise_exception(checker: &mut Checker, expr: 
                 return;
             }
 
-            let range = match_parens(func.end(), checker.locator)
+            let range = match_parens(func.end(), checker.locator())
                 .expect("Expected call to include parentheses");
             let mut diagnostic = Diagnostic::new(UnnecessaryParenOnRaiseException, range);
             if checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff/src/rules/flake8_return/rules/function.rs
@@ -409,14 +409,14 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
             ) {
                 let mut diagnostic = Diagnostic::new(ImplicitReturn, stmt.range());
                 if checker.patch(diagnostic.kind.rule()) {
-                    if let Some(indent) = indentation(checker.locator, stmt) {
+                    if let Some(indent) = indentation(checker.locator(), stmt) {
                         let mut content = String::new();
-                        content.push_str(checker.stylist.line_ending().as_str());
+                        content.push_str(checker.stylist().line_ending().as_str());
                         content.push_str(indent);
                         content.push_str("return None");
                         diagnostic.set_fix(Fix::suggested(Edit::insertion(
                             content,
-                            end_of_last_statement(stmt, checker.locator),
+                            end_of_last_statement(stmt, checker.locator()),
                         )));
                     }
                 }
@@ -433,14 +433,14 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
             } else {
                 let mut diagnostic = Diagnostic::new(ImplicitReturn, stmt.range());
                 if checker.patch(diagnostic.kind.rule()) {
-                    if let Some(indent) = indentation(checker.locator, stmt) {
+                    if let Some(indent) = indentation(checker.locator(), stmt) {
                         let mut content = String::new();
-                        content.push_str(checker.stylist.line_ending().as_str());
+                        content.push_str(checker.stylist().line_ending().as_str());
                         content.push_str(indent);
                         content.push_str("return None");
                         diagnostic.set_fix(Fix::suggested(Edit::insertion(
                             content,
-                            end_of_last_statement(stmt, checker.locator),
+                            end_of_last_statement(stmt, checker.locator()),
                         )));
                     }
                 }
@@ -470,14 +470,14 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
         _ => {
             let mut diagnostic = Diagnostic::new(ImplicitReturn, stmt.range());
             if checker.patch(diagnostic.kind.rule()) {
-                if let Some(indent) = indentation(checker.locator, stmt) {
+                if let Some(indent) = indentation(checker.locator(), stmt) {
                     let mut content = String::new();
-                    content.push_str(checker.stylist.line_ending().as_str());
+                    content.push_str(checker.stylist().line_ending().as_str());
                     content.push_str(indent);
                     content.push_str("return None");
                     diagnostic.set_fix(Fix::suggested(Edit::insertion(
                         content,
-                        end_of_last_statement(stmt, checker.locator),
+                        end_of_last_statement(stmt, checker.locator()),
                     )));
                 }
             }
@@ -537,10 +537,10 @@ fn unnecessary_assign(checker: &mut Checker, stack: &Stack) {
                 // edit, since we're editing the preceding statement, so no conflicting edit would
                 // be allowed to remove that preceding statement.
                 let delete_return =
-                    edits::delete_stmt(stmt, None, checker.locator, checker.indexer);
+                    edits::delete_stmt(stmt, None, checker.locator(), checker.indexer());
 
                 // Replace the `x = 1` statement with `return 1`.
-                let content = checker.locator.slice(assign.range());
+                let content = checker.locator().slice(assign.range());
                 let equals_index = content
                     .find('=')
                     .ok_or(anyhow::anyhow!("expected '=' in assignment statement"))?;
@@ -591,7 +591,7 @@ fn superfluous_else_node(
         if child.is_return_stmt() {
             let diagnostic = Diagnostic::new(
                 SuperfluousElseReturn { branch },
-                elif_else_range(elif_else, checker.locator).unwrap_or_else(|| elif_else.range()),
+                elif_else_range(elif_else, checker.locator()).unwrap_or_else(|| elif_else.range()),
             );
             if checker.enabled(diagnostic.kind.rule()) {
                 checker.diagnostics.push(diagnostic);
@@ -600,7 +600,7 @@ fn superfluous_else_node(
         } else if child.is_break_stmt() {
             let diagnostic = Diagnostic::new(
                 SuperfluousElseBreak { branch },
-                elif_else_range(elif_else, checker.locator).unwrap_or_else(|| elif_else.range()),
+                elif_else_range(elif_else, checker.locator()).unwrap_or_else(|| elif_else.range()),
             );
             if checker.enabled(diagnostic.kind.rule()) {
                 checker.diagnostics.push(diagnostic);
@@ -609,7 +609,7 @@ fn superfluous_else_node(
         } else if child.is_raise_stmt() {
             let diagnostic = Diagnostic::new(
                 SuperfluousElseRaise { branch },
-                elif_else_range(elif_else, checker.locator).unwrap_or_else(|| elif_else.range()),
+                elif_else_range(elif_else, checker.locator()).unwrap_or_else(|| elif_else.range()),
             );
             if checker.enabled(diagnostic.kind.rule()) {
                 checker.diagnostics.push(diagnostic);
@@ -618,7 +618,7 @@ fn superfluous_else_node(
         } else if child.is_continue_stmt() {
             let diagnostic = Diagnostic::new(
                 SuperfluousElseContinue { branch },
-                elif_else_range(elif_else, checker.locator).unwrap_or_else(|| elif_else.range()),
+                elif_else_range(elif_else, checker.locator()).unwrap_or_else(|| elif_else.range()),
             );
             if checker.enabled(diagnostic.kind.rule()) {
                 checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -505,7 +505,7 @@ pub(crate) fn compare_with_tuple(checker: &mut Checker, expr: &Expr) {
         }
 
         // Avoid removing comments.
-        if has_comments(expr, checker.locator, checker.indexer) {
+        if has_comments(expr, checker.locator(), checker.indexer()) {
             continue;
         }
 

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -234,10 +234,10 @@ pub(crate) fn dict_get_with_none_default(checker: &mut Checker, expr: &Expr) {
 
     let expected = format!(
         "{}({})",
-        checker.locator.slice(func.range()),
-        checker.locator.slice(key.range())
+        checker.locator().slice(func.range()),
+        checker.locator().slice(key.range())
     );
-    let original = checker.locator.slice(expr.range()).to_string();
+    let original = checker.locator().slice(expr.range()).to_string();
 
     let mut diagnostic = Diagnostic::new(
         DictGetWithNoneDefault {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -371,7 +371,7 @@ pub(crate) fn nested_if_statements(checker: &mut Checker, stmt_if: &StmtIf, pare
 
     let colon = first_colon_range(
         TextRange::new(test.end(), first_stmt.start()),
-        checker.locator,
+        checker.locator(),
     );
 
     // Check if the parent is already emitting a larger diagnostic including this if statement
@@ -396,11 +396,11 @@ pub(crate) fn nested_if_statements(checker: &mut Checker, stmt_if: &StmtIf, pare
         // the outer and inner if statements.
         let nested_if = &body[0];
         if !checker
-            .indexer
+            .indexer()
             .comment_ranges()
             .intersects(TextRange::new(range.start(), nested_if.start()))
         {
-            match fix_if::fix_nested_if_statements(checker.locator, checker.stylist, range) {
+            match fix_if::fix_nested_if_statements(checker.locator(), checker.stylist(), range) {
                 Ok(edit) => {
                     if edit
                         .content()
@@ -508,7 +508,7 @@ pub(crate) fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
     if checker.patch(diagnostic.kind.rule()) {
         if matches!(if_return, Bool::True)
             && matches!(else_return, Bool::False)
-            && !has_comments(&range, checker.locator, checker.indexer)
+            && !has_comments(&range, checker.locator(), checker.indexer())
             && (if_test.is_compare_expr() || checker.semantic().is_builtin("bool"))
         {
             if if_test.is_compare_expr() {
@@ -650,9 +650,9 @@ pub(crate) fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt) {
     let contents = checker.generator().stmt(&ternary);
 
     // Don't flag if the resulting expression would exceed the maximum line length.
-    let line_start = checker.locator.line_start(stmt.start());
+    let line_start = checker.locator().line_start(stmt.start());
     if LineWidth::new(checker.settings.tab_size)
-        .add_str(&checker.locator.contents()[TextRange::new(line_start, stmt.start())])
+        .add_str(&checker.locator().contents()[TextRange::new(line_start, stmt.start())])
         .add_str(&contents)
         > checker.settings.line_length
     {
@@ -666,7 +666,7 @@ pub(crate) fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt) {
         stmt.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        if !has_comments(stmt, checker.locator, checker.indexer) {
+        if !has_comments(stmt, checker.locator(), checker.indexer()) {
             diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
                 contents,
                 stmt.range(),
@@ -699,11 +699,11 @@ pub(crate) fn if_with_same_arms(checker: &mut Checker, locator: &Locator, stmt_i
 
         // ...and the same comments
         let first_comments: Vec<_> = checker
-            .indexer
+            .indexer()
             .comments_in_range(current_branch.range, locator)
             .collect();
         let second_comments: Vec<_> = checker
-            .indexer
+            .indexer()
             .comments_in_range(following_branch.range, locator)
             .collect();
         if first_comments != second_comments {
@@ -952,9 +952,9 @@ pub(crate) fn use_dict_get_with_default(checker: &mut Checker, stmt_if: &StmtIf)
     let contents = checker.generator().stmt(&node5.into());
 
     // Don't flag if the resulting expression would exceed the maximum line length.
-    let line_start = checker.locator.line_start(stmt_if.start());
+    let line_start = checker.locator().line_start(stmt_if.start());
     if LineWidth::new(checker.settings.tab_size)
-        .add_str(&checker.locator.contents()[TextRange::new(line_start, stmt_if.start())])
+        .add_str(&checker.locator().contents()[TextRange::new(line_start, stmt_if.start())])
         .add_str(&contents)
         > checker.settings.line_length
     {
@@ -968,7 +968,7 @@ pub(crate) fn use_dict_get_with_default(checker: &mut Checker, stmt_if: &StmtIf)
         stmt_if.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        if !has_comments(stmt_if, checker.locator, checker.indexer) {
+        if !has_comments(stmt_if, checker.locator(), checker.indexer()) {
             diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
                 contents,
                 stmt_if.range(),

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -155,7 +155,7 @@ pub(crate) fn explicit_true_false_in_ifexpr(
     if checker.patch(diagnostic.kind.rule()) {
         if test.is_compare_expr() {
             diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
-                checker.locator.slice(test.range()).to_string(),
+                checker.locator().slice(test.range()).to_string(),
                 expr.range(),
             )));
         } else if checker.semantic().is_builtin("bool") {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -275,7 +275,7 @@ pub(crate) fn double_negation(checker: &mut Checker, expr: &Expr, op: UnaryOp, o
     if checker.patch(diagnostic.kind.rule()) {
         if checker.semantic().in_boolean_test() {
             diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
-                checker.locator.slice(operand.range()).to_string(),
+                checker.locator().slice(operand.range()).to_string(),
                 expr.range(),
             )));
         } else if checker.semantic().is_builtin("bool") {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_with.rs
@@ -118,7 +118,7 @@ pub(crate) fn multiple_with_statements(
                     .map_or(last_item.context_expr.end(), |v| v.end()),
                 body.first().expect("Expected body to be non-empty").start(),
             ),
-            checker.locator,
+            checker.locator(),
         );
 
         let mut diagnostic = Diagnostic::new(
@@ -130,13 +130,13 @@ pub(crate) fn multiple_with_statements(
         );
         if checker.patch(diagnostic.kind.rule()) {
             if !checker
-                .indexer
+                .indexer()
                 .comment_ranges()
                 .intersects(TextRange::new(with_stmt.start(), with_body[0].start()))
             {
                 match fix_with::fix_multiple_with_statements(
-                    checker.locator,
-                    checker.stylist,
+                    checker.locator(),
+                    checker.stylist(),
                     with_stmt,
                 ) {
                     Ok(edit) => {

--- a/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -88,9 +88,9 @@ fn key_in_dict(checker: &mut Checker, left: &Expr, right: &Expr, range: TextRang
     }
 
     // Slice exact content to preserve formatting.
-    let left_content = checker.locator.slice(left.range());
+    let left_content = checker.locator().slice(left.range());
     let value_content =
-        match get_value_content_for_key_in_dict(checker.locator, checker.stylist, right) {
+        match get_value_content_for_key_in_dict(checker.locator(), checker.stylist(), right) {
             Ok(value_content) => value_content,
             Err(err) => {
                 error!("Failed to get value content for key in dict: {}", err);

--- a/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -97,9 +97,9 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt) {
             );
 
             // Don't flag if the resulting expression would exceed the maximum line length.
-            let line_start = checker.locator.line_start(stmt.start());
+            let line_start = checker.locator().line_start(stmt.start());
             if LineWidth::new(checker.settings.tab_size)
-                .add_str(&checker.locator.contents()[TextRange::new(line_start, stmt.start())])
+                .add_str(&checker.locator().contents()[TextRange::new(line_start, stmt.start())])
                 .add_str(&contents)
                 > checker.settings.line_length
             {
@@ -179,9 +179,9 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt) {
             let contents = return_stmt("all", &test, loop_.target, loop_.iter, checker.generator());
 
             // Don't flag if the resulting expression would exceed the maximum line length.
-            let line_start = checker.locator.line_start(stmt.start());
+            let line_start = checker.locator().line_start(stmt.start());
             if LineWidth::new(checker.settings.tab_size)
-                .add_str(&checker.locator.contents()[TextRange::new(line_start, stmt.start())])
+                .add_str(&checker.locator().contents()[TextRange::new(line_start, stmt.start())])
                 .add_str(&contents)
                 > checker.settings.line_length
             {

--- a/crates/ruff/src/rules/flake8_simplify/rules/suppressible_exception.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/suppressible_exception.rs
@@ -117,9 +117,9 @@ pub(crate) fn suppressible_exception(
                 stmt.range(),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                if !has_comments(stmt, checker.locator, checker.indexer) {
+                if !has_comments(stmt, checker.locator(), checker.indexer()) {
                     diagnostic.try_set_fix(|| {
-                        let (import_edit, binding) = checker.importer.get_or_import_symbol(
+                        let (import_edit, binding) = checker.importer().get_or_import_symbol(
                             &ImportRequest::import("contextlib", "suppress"),
                             stmt.start(),
                             checker.semantic(),
@@ -128,7 +128,7 @@ pub(crate) fn suppressible_exception(
                             format!("with {binding}({exception})"),
                             TextRange::at(stmt.start(), "try".text_len()),
                         );
-                        let handler_line_begin = checker.locator.line_start(handler.start());
+                        let handler_line_begin = checker.locator().line_start(handler.start());
                         let remove_handler = Edit::deletion(handler_line_begin, handler.end());
                         Ok(Fix::suggested_edits(
                             import_edit,

--- a/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -174,7 +174,7 @@ pub(crate) fn yoda_conditions(
         return;
     }
 
-    if let Ok(suggestion) = reverse_comparison(expr, checker.locator, checker.stylist) {
+    if let Ok(suggestion) = reverse_comparison(expr, checker.locator(), checker.stylist()) {
         let mut diagnostic = Diagnostic::new(
             YodaConditions {
                 suggestion: Some(suggestion.to_string()),

--- a/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -60,7 +60,7 @@ pub(crate) fn empty_type_checking_block(checker: &mut Checker, stmt: &ast::StmtI
         // Delete the entire type-checking block.
         let stmt = checker.semantic().stmt();
         let parent = checker.semantic().stmt_parent();
-        let edit = autofix::edits::delete_stmt(stmt, parent, checker.locator, checker.indexer);
+        let edit = autofix::edits::delete_stmt(stmt, parent, checker.locator(), checker.indexer());
         diagnostic.set_fix(Fix::automatic(edit).isolate(checker.isolation(parent)));
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -210,13 +210,13 @@ fn fix_imports(checker: &Checker, stmt_id: NodeId, imports: &[Import]) -> Result
         qualified_names.iter().copied(),
         stmt,
         parent,
-        checker.locator,
-        checker.stylist,
-        checker.indexer,
+        checker.locator(),
+        checker.stylist(),
+        checker.indexer(),
     )?;
 
     // Step 2) Add the import to the top-level.
-    let add_import_edit = checker.importer.runtime_import_edit(
+    let add_import_edit = checker.importer().runtime_import_edit(
         &StmtImports {
             stmt,
             qualified_names,

--- a/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -434,13 +434,13 @@ fn fix_imports(checker: &Checker, stmt_id: NodeId, imports: &[Import]) -> Result
         qualified_names.iter().copied(),
         stmt,
         parent,
-        checker.locator,
-        checker.stylist,
-        checker.indexer,
+        checker.locator(),
+        checker.stylist(),
+        checker.indexer(),
     )?;
 
     // Step 2) Add the import to a `TYPE_CHECKING` block.
-    let add_import_edit = checker.importer.typing_import_edit(
+    let add_import_edit = checker.importer().typing_import_edit(
         &StmtImports {
             stmt,
             qualified_names,

--- a/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -102,7 +102,7 @@ pub(crate) fn inplace_argument(
                         && !checker.semantic().scope().kind.is_lambda()
                     {
                         if let Some(fix) = convert_inplace_argument_to_assignment(
-                            checker.locator,
+                            checker.locator(),
                             expr,
                             keyword.range(),
                             args,

--- a/crates/ruff/src/rules/perflint/rules/incorrect_dict_iterator.rs
+++ b/crates/ruff/src/rules/perflint/rules/incorrect_dict_iterator.rs
@@ -99,7 +99,7 @@ pub(crate) fn incorrect_dict_iterator(checker: &mut Checker, target: &Expr, iter
             if checker.patch(diagnostic.kind.rule()) {
                 let replace_attribute = Edit::range_replacement("values".to_string(), attr.range());
                 let replace_target = Edit::range_replacement(
-                    checker.locator.slice(value.range()).to_string(),
+                    checker.locator().slice(value.range()).to_string(),
                     target.range(),
                 );
                 diagnostic.set_fix(Fix::suggested_edits(replace_attribute, [replace_target]));
@@ -117,7 +117,7 @@ pub(crate) fn incorrect_dict_iterator(checker: &mut Checker, target: &Expr, iter
             if checker.patch(diagnostic.kind.rule()) {
                 let replace_attribute = Edit::range_replacement("keys".to_string(), attr.range());
                 let replace_target = Edit::range_replacement(
-                    checker.locator.slice(key.range()).to_string(),
+                    checker.locator().slice(key.range()).to_string(),
                     target.range(),
                 );
                 diagnostic.set_fix(Fix::suggested_edits(replace_attribute, [replace_target]));

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -79,10 +79,10 @@ pub(crate) fn lambda_assignment(
     );
 
     if checker.patch(diagnostic.kind.rule()) {
-        if !has_leading_content(stmt.start(), checker.locator)
-            && !has_trailing_content(stmt.end(), checker.locator)
+        if !has_leading_content(stmt.start(), checker.locator())
+            && !has_trailing_content(stmt.end(), checker.locator())
         {
-            let first_line = checker.locator.line(stmt.start());
+            let first_line = checker.locator().line(stmt.start());
             let indentation = leading_indentation(first_line);
             let mut indented = String::new();
             for (idx, line) in function(
@@ -99,7 +99,7 @@ pub(crate) fn lambda_assignment(
                 if idx == 0 {
                     indented.push_str(&line);
                 } else {
-                    indented.push_str(checker.stylist.line_ending().as_str());
+                    indented.push_str(checker.stylist().line_ending().as_str());
                     indented.push_str(indentation);
                     indented.push_str(&line);
                 }

--- a/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -276,7 +276,7 @@ pub(crate) fn literal_comparisons(
             .map(|(idx, op)| bad_ops.get(&idx).unwrap_or(op))
             .copied()
             .collect::<Vec<_>>();
-        let content = compare(left, &ops, comparators, checker.locator);
+        let content = compare(left, &ops, comparators, checker.locator());
         for diagnostic in &mut diagnostics {
             diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
                 content.to_string(),

--- a/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
@@ -100,7 +100,7 @@ pub(crate) fn not_tests(
                             let mut diagnostic = Diagnostic::new(NotInTest, operand.range());
                             if checker.patch(diagnostic.kind.rule()) {
                                 diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
-                                    compare(left, &[CmpOp::NotIn], comparators, checker.locator),
+                                    compare(left, &[CmpOp::NotIn], comparators, checker.locator()),
                                     expr.range(),
                                 )));
                             }
@@ -112,7 +112,7 @@ pub(crate) fn not_tests(
                             let mut diagnostic = Diagnostic::new(NotIsTest, operand.range());
                             if checker.patch(diagnostic.kind.rule()) {
                                 diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
-                                    compare(left, &[CmpOp::IsNot], comparators, checker.locator),
+                                    compare(left, &[CmpOp::IsNot], comparators, checker.locator()),
                                     expr.range(),
                                 )));
                             }

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
@@ -110,7 +110,7 @@ pub(crate) fn blank_after_summary(checker: &mut Checker, docstring: &Docstring) 
 
                 // Insert one blank line after the summary (replacing any existing lines).
                 diagnostic.set_fix(Fix::automatic(Edit::replacement(
-                    checker.stylist.line_ending().to_string(),
+                    checker.stylist().line_ending().to_string(),
                     summary_end,
                     blank_end,
                 )));

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -172,7 +172,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
     if checker.enabled(Rule::OneBlankLineBeforeClass) || checker.enabled(Rule::BlankLineBeforeClass)
     {
         let before = checker
-            .locator
+            .locator()
             .slice(TextRange::new(stmt.start(), docstring.start()));
 
         let mut blank_lines_before = 0usize;
@@ -217,7 +217,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
                 if checker.patch(diagnostic.kind.rule()) {
                     // Insert one blank line before the class.
                     diagnostic.set_fix(Fix::automatic(Edit::replacement(
-                        checker.stylist.line_ending().to_string(),
+                        checker.stylist().line_ending().to_string(),
                         blank_lines_start,
                         docstring.start() - docstring.indentation.text_len(),
                     )));
@@ -229,7 +229,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
 
     if checker.enabled(Rule::OneBlankLineAfterClass) {
         let after = checker
-            .locator
+            .locator()
             .slice(TextRange::new(docstring.end(), stmt.end()));
 
         let all_blank_after = after.universal_newlines().skip(1).all(|line| {
@@ -263,7 +263,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
             if checker.patch(diagnostic.kind.rule()) {
                 // Insert a blank line before the class (replacing any existing lines).
                 diagnostic.set_fix(Fix::automatic(Edit::replacement(
-                    checker.stylist.line_ending().to_string(),
+                    checker.stylist().line_ending().to_string(),
                     first_line_start,
                     blank_lines_end,
                 )));

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
@@ -114,7 +114,7 @@ pub(crate) fn blank_before_after_function(checker: &mut Checker, docstring: &Doc
 
     if checker.enabled(Rule::NoBlankLineBeforeFunction) {
         let before = checker
-            .locator
+            .locator()
             .slice(TextRange::new(stmt.start(), docstring.start()));
 
         let mut lines = UniversalNewlineIterator::with_offset(before, stmt.start()).rev();
@@ -150,7 +150,7 @@ pub(crate) fn blank_before_after_function(checker: &mut Checker, docstring: &Doc
 
     if checker.enabled(Rule::NoBlankLineAfterFunction) {
         let after = checker
-            .locator
+            .locator()
             .slice(TextRange::new(docstring.end(), stmt.end()));
 
         // If the docstring is only followed by blank and commented lines, abort.

--- a/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -165,15 +165,15 @@ pub(crate) fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstr
                     // If the docstring isn't on its own line, look at the statement indentation,
                     // and add the default indentation to get the "right" level.
                     if let Definition::Member(Member { stmt, .. }) = &docstring.definition {
-                        let stmt_line_start = checker.locator.line_start(stmt.start());
+                        let stmt_line_start = checker.locator().line_start(stmt.start());
                         let stmt_indentation = checker
-                            .locator
+                            .locator()
                             .slice(TextRange::new(stmt_line_start, stmt.start()));
 
                         if stmt_indentation.chars().all(char::is_whitespace) {
                             indentation.clear();
                             indentation.push_str(stmt_indentation);
-                            indentation.push_str(checker.stylist.indentation());
+                            indentation.push_str(checker.stylist().indentation());
                             fixable = true;
                         }
                     };
@@ -185,7 +185,7 @@ pub(crate) fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstr
                     // quote and text.
                     let repl = format!(
                         "{}{}{}",
-                        checker.stylist.line_ending().as_str(),
+                        checker.stylist().line_ending().as_str(),
                         indentation,
                         first_line.strip_prefix(prefix).unwrap().trim_start()
                     );

--- a/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
@@ -89,7 +89,7 @@ pub(crate) fn newline_after_last_paragraph(checker: &mut Checker, docstring: &Do
                             .sum();
                         let content = format!(
                             "{}{}",
-                            checker.stylist.line_ending().as_str(),
+                            checker.stylist().line_ending().as_str(),
                             clean_space(docstring.indentation)
                         );
                         diagnostic.set_fix(Fix::automatic(Edit::replacement(

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -1419,7 +1419,7 @@ fn blanks_and_section_underline(
                             "{}{}{}",
                             clean_space(docstring.indentation),
                             "-".repeat(context.section_name().len()),
-                            checker.stylist.line_ending().as_str()
+                            checker.stylist().line_ending().as_str()
                         );
                         diagnostic.set_fix(Fix::automatic(Edit::replacement(
                             content,
@@ -1520,7 +1520,7 @@ fn blanks_and_section_underline(
                     // Add a dashed line (of the appropriate length) under the section header.
                     let content = format!(
                         "{}{}{}",
-                        checker.stylist.line_ending().as_str(),
+                        checker.stylist().line_ending().as_str(),
                         clean_space(docstring.indentation),
                         "-".repeat(context.section_name().len()),
                     );
@@ -1576,7 +1576,7 @@ fn blanks_and_section_underline(
                 // Add a dashed line (of the appropriate length) under the section header.
                 let content = format!(
                     "{}{}{}",
-                    checker.stylist.line_ending().as_str(),
+                    checker.stylist().line_ending().as_str(),
                     clean_space(docstring.indentation),
                     "-".repeat(context.section_name().len()),
                 );
@@ -1651,7 +1651,7 @@ fn common_section(
         }
     }
 
-    let line_end = checker.stylist.line_ending().as_str();
+    let line_end = checker.stylist().line_ending().as_str();
     let last_line = context.following_lines().last();
     if last_line.map_or(true, |line| !line.trim().is_empty()) {
         if let Some(next) = next {

--- a/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -85,13 +85,13 @@ pub(crate) fn f_string_missing_placeholders(expr: &Expr, values: &[Expr], checke
         .iter()
         .any(|value| matches!(value, Expr::FormattedValue(_)))
     {
-        for (prefix_range, tok_range) in find_useless_f_strings(expr, checker.locator) {
+        for (prefix_range, tok_range) in find_useless_f_strings(expr, checker.locator()) {
             let mut diagnostic = Diagnostic::new(FStringMissingPlaceholders, tok_range);
             if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.set_fix(convert_f_string_to_regular_string(
                     prefix_range,
                     tok_range,
-                    checker.locator,
+                    checker.locator(),
                 ));
             }
             checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -134,7 +134,7 @@ pub(crate) fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values
                 if checker.enabled(Rule::MultiValueRepeatedKeyLiteral) {
                     let mut diagnostic = Diagnostic::new(
                         MultiValueRepeatedKeyLiteral {
-                            name: checker.locator.slice(key.range()).to_string(),
+                            name: checker.locator().slice(key.range()).to_string(),
                         },
                         key.range(),
                     );
@@ -153,7 +153,7 @@ pub(crate) fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values
                 if checker.enabled(Rule::MultiValueRepeatedKeyVariable) {
                     let mut diagnostic = Diagnostic::new(
                         MultiValueRepeatedKeyVariable {
-                            name: checker.locator.slice(key.range()).to_string(),
+                            name: checker.locator().slice(key.range()).to_string(),
                         },
                         key.range(),
                     );

--- a/crates/ruff/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/strings.rs
@@ -614,8 +614,8 @@ pub(crate) fn percent_format_extra_named_arguments(
             let edit = remove_unused_format_arguments_from_dict(
                 &indexes,
                 right,
-                checker.locator,
-                checker.stylist,
+                checker.locator(),
+                checker.stylist(),
             )?;
             Ok(Fix::automatic(edit))
         });
@@ -784,8 +784,8 @@ pub(crate) fn string_dot_format_extra_named_arguments(
             let edit = remove_unused_keyword_arguments_from_format_call(
                 &indexes,
                 location,
-                checker.locator,
-                checker.stylist,
+                checker.locator(),
+                checker.stylist(),
             )?;
             Ok(Fix::automatic(edit))
         });
@@ -853,8 +853,8 @@ pub(crate) fn string_dot_format_extra_positional_arguments(
                 let edit = remove_unused_positional_arguments_from_format_call(
                     &missing,
                     location,
-                    checker.locator,
-                    checker.stylist,
+                    checker.locator(),
+                    checker.stylist(),
                 )?;
                 Ok(Fix::automatic(edit))
             });

--- a/crates/ruff/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_import.rs
@@ -233,9 +233,9 @@ fn fix_imports(checker: &Checker, stmt_id: NodeId, imports: &[Import]) -> Result
             .map(|Import { qualified_name, .. }| *qualified_name),
         stmt,
         parent,
-        checker.locator,
-        checker.stylist,
-        checker.indexer,
+        checker.locator(),
+        checker.stylist(),
+        checker.indexer(),
     )?;
     Ok(Fix::automatic(edit).isolate(checker.isolation(parent)))
 }

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -204,13 +204,13 @@ fn remove_unused_variable(
                     // If the expression is complex (`x = foo()`), remove the assignment,
                     // but preserve the right-hand side.
                     let start = target.start();
-                    let end =
-                        match_token_after(start, checker.locator, |tok| tok == Tok::Equal)?.start();
+                    let end = match_token_after(start, checker.locator(), |tok| tok == Tok::Equal)?
+                        .start();
                     let edit = Edit::deletion(start, end);
                     Some(Fix::suggested(edit))
                 } else {
                     // If (e.g.) assigning to a constant (`x = 1`), delete the entire statement.
-                    let edit = delete_stmt(stmt, parent, checker.locator, checker.indexer);
+                    let edit = delete_stmt(stmt, parent, checker.locator(), checker.indexer());
                     Some(Fix::suggested(edit).isolate(checker.isolation(parent)))
                 };
             }
@@ -230,12 +230,12 @@ fn remove_unused_variable(
                 // but preserve the right-hand side.
                 let start = stmt.start();
                 let end =
-                    match_token_after(start, checker.locator, |tok| tok == Tok::Equal)?.start();
+                    match_token_after(start, checker.locator(), |tok| tok == Tok::Equal)?.start();
                 let edit = Edit::deletion(start, end);
                 Some(Fix::suggested(edit))
             } else {
                 // If (e.g.) assigning to a constant (`x = 1`), delete the entire statement.
-                let edit = delete_stmt(stmt, parent, checker.locator, checker.indexer);
+                let edit = delete_stmt(stmt, parent, checker.locator(), checker.indexer());
                 Some(Fix::suggested(edit).isolate(checker.isolation(parent)))
             };
         }
@@ -250,13 +250,13 @@ fn remove_unused_variable(
                 if optional_vars.range() == range {
                     // Find the first token before the `as` keyword.
                     let start =
-                        match_token_before(item.context_expr.start(), checker.locator, |tok| {
+                        match_token_before(item.context_expr.start(), checker.locator(), |tok| {
                             tok == Tok::As
                         })?
                         .end();
 
                     // Find the first colon, comma, or closing bracket after the `as` keyword.
-                    let end = match_token_or_closing_brace(start, checker.locator, |tok| {
+                    let end = match_token_or_closing_brace(start, checker.locator(), |tok| {
                         tok == Tok::Colon || tok == Tok::Comma
                     })?
                     .start();

--- a/crates/ruff/src/rules/pylint/rules/bad_string_format_type.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_string_format_type.rs
@@ -201,7 +201,7 @@ fn is_valid_dict(
 /// PLE1307
 pub(crate) fn bad_string_format_type(checker: &mut Checker, expr: &Expr, right: &Expr) {
     // Grab each string segment (in case there's an implicit concatenation).
-    let content = checker.locator.slice(expr.range());
+    let content = checker.locator().slice(expr.range());
     let mut strings: Vec<TextRange> = vec![];
     for (tok, range) in lexer::lex_starts_at(content, Mode::Module, expr.start()).flatten() {
         if tok.is_string() {
@@ -220,7 +220,7 @@ pub(crate) fn bad_string_format_type(checker: &mut Checker, expr: &Expr, right: 
     // Parse each string segment.
     let mut format_strings = vec![];
     for range in &strings {
-        let string = checker.locator.slice(*range);
+        let string = checker.locator().slice(*range);
         let (Some(leader), Some(trailer)) = (leading_quote(string), trailing_quote(string)) else {
             return;
         };

--- a/crates/ruff/src/rules/pylint/rules/load_before_global_declaration.rs
+++ b/crates/ruff/src/rules/pylint/rules/load_before_global_declaration.rs
@@ -58,7 +58,7 @@ pub(crate) fn load_before_global_declaration(checker: &mut Checker, name: &str, 
     if let Some(stmt) = checker.semantic().global(name) {
         if expr.start() < stmt.start() {
             #[allow(deprecated)]
-            let location = checker.locator.compute_source_location(stmt.start());
+            let location = checker.locator().compute_source_location(stmt.start());
             checker.diagnostics.push(Diagnostic::new(
                 LoadBeforeGlobalDeclaration {
                     name: name.to_string(),

--- a/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
@@ -150,7 +150,7 @@ pub(crate) fn nested_min_max(
     }) {
         let mut diagnostic = Diagnostic::new(NestedMinMax { func: min_max }, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
-            if !has_comments(expr, checker.locator, checker.indexer) {
+            if !has_comments(expr, checker.locator(), checker.indexer()) {
                 let flattened_expr = Expr::Call(ast::ExprCall {
                     func: Box::new(func.clone()),
                     args: collect_nested_args(min_max, args, checker.semantic()),

--- a/crates/ruff/src/rules/pylint/rules/repeated_equality_comparison_target.rs
+++ b/crates/ruff/src/rules/pylint/rules/repeated_equality_comparison_target.rs
@@ -88,7 +88,7 @@ pub(crate) fn repeated_equality_comparison_target(checker: &mut Checker, bool_op
                         left.as_expr(),
                         bool_op.op,
                         &comparators,
-                        checker.locator,
+                        checker.locator(),
                     ),
                 },
                 bool_op.range(),

--- a/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
@@ -78,7 +78,7 @@ pub(crate) fn sys_exit_alias(checker: &mut Checker, func: &Expr) {
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            let (import_edit, binding) = checker.importer.get_or_import_symbol(
+            let (import_edit, binding) = checker.importer().get_or_import_symbol(
                 &ImportRequest::import("sys", "exit"),
                 func.start(),
                 checker.semantic(),

--- a/crates/ruff/src/rules/pylint/rules/useless_else_on_loop.rs
+++ b/crates/ruff/src/rules/pylint/rules/useless_else_on_loop.rs
@@ -109,7 +109,7 @@ pub(crate) fn useless_else_on_loop(
     if !orelse.is_empty() && !loop_exits_early(body) {
         checker.diagnostics.push(Diagnostic::new(
             UselessElseOnLoop,
-            identifier::else_(stmt, checker.locator).unwrap(),
+            identifier::else_(stmt, checker.locator()).unwrap(),
         ));
     }
 }

--- a/crates/ruff/src/rules/pylint/rules/useless_return.rs
+++ b/crates/ruff/src/rules/pylint/rules/useless_return.rs
@@ -103,8 +103,12 @@ pub(crate) fn useless_return(
 
     let mut diagnostic = Diagnostic::new(UselessReturn, last_stmt.range());
     if checker.patch(diagnostic.kind.rule()) {
-        let edit =
-            autofix::edits::delete_stmt(last_stmt, Some(stmt), checker.locator, checker.indexer);
+        let edit = autofix::edits::delete_stmt(
+            last_stmt,
+            Some(stmt),
+            checker.locator(),
+            checker.indexer(),
+        );
         diagnostic.set_fix(Fix::automatic(edit).isolate(checker.isolation(Some(stmt))));
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -242,7 +242,7 @@ pub(crate) fn convert_named_tuple_functional_to_class(
     );
     if checker.patch(diagnostic.kind.rule()) {
         // TODO(charlie): Preserve indentation, to remove the first-column requirement.
-        if checker.locator.is_at_start_of_line(stmt.start()) {
+        if checker.locator().is_at_start_of_line(stmt.start()) {
             diagnostic.set_fix(convert_to_class(
                 stmt,
                 typename,

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -294,7 +294,7 @@ pub(crate) fn convert_typed_dict_functional_to_class(
     );
     if checker.patch(diagnostic.kind.rule()) {
         // TODO(charlie): Preserve indentation, to remove the first-column requirement.
-        if checker.locator.is_at_start_of_line(stmt.start()) {
+        if checker.locator().is_at_start_of_line(stmt.start()) {
             diagnostic.set_fix(convert_to_class(
                 stmt,
                 class_name,

--- a/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -61,7 +61,7 @@ pub(crate) fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
         let mut diagnostic = Diagnostic::new(DatetimeTimezoneUTC, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
-                let (import_edit, binding) = checker.importer.get_or_import_symbol(
+                let (import_edit, binding) = checker.importer().get_or_import_symbol(
                     &ImportRequest::import_from("datetime", "UTC"),
                     expr.start(),
                     checker.semantic(),

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
@@ -45,7 +45,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(DeprecatedCElementTree, node.range());
     if checker.patch(diagnostic.kind.rule()) {
-        let contents = checker.locator.slice(node.range());
+        let contents = checker.locator().slice(node.range());
         diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
             contents.replacen("cElementTree", "ElementTree", 1),
             node.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -567,8 +567,8 @@ pub(crate) fn deprecated_import(
         stmt,
         module,
         &members,
-        checker.locator,
-        checker.stylist,
+        checker.locator(),
+        checker.stylist(),
         checker.settings.target_version,
     );
 

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -281,8 +281,8 @@ pub(crate) fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
             {
                 // Generate the fix, if needed, which is shared between all `mock` imports.
                 let content = if checker.patch(Rule::DeprecatedMockImport) {
-                    if let Some(indent) = indentation(checker.locator, stmt) {
-                        match format_import(stmt, indent, checker.locator, checker.stylist) {
+                    if let Some(indent) = indentation(checker.locator(), stmt) {
+                        match format_import(stmt, indent, checker.locator(), checker.stylist()) {
                             Ok(content) => Some(content),
                             Err(e) => {
                                 error!("Failed to rewrite `mock` import: {e}");
@@ -333,10 +333,10 @@ pub(crate) fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
                     stmt.range(),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
-                    if let Some(indent) = indentation(checker.locator, stmt) {
+                    if let Some(indent) = indentation(checker.locator(), stmt) {
                         #[allow(deprecated)]
                         diagnostic.try_set_fix_from_edit(|| {
-                            format_import_from(stmt, indent, checker.locator, checker.stylist)
+                            format_import_from(stmt, indent, checker.locator(), checker.stylist())
                                 .map(|content| Edit::range_replacement(content, stmt.range()))
                         });
                     }

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -326,18 +326,18 @@ pub(crate) fn f_strings(
     }
 
     // Avoid refactoring strings that are implicitly concatenated.
-    if is_implicit_concatenation(checker.locator.slice(template.range())) {
+    if is_implicit_concatenation(checker.locator().slice(template.range())) {
         return;
     }
 
     // Currently, the only issue we know of is in LibCST:
     // https://github.com/Instagram/LibCST/issues/846
-    let Some(mut contents) = try_convert_to_f_string(expr, checker.locator) else {
+    let Some(mut contents) = try_convert_to_f_string(expr, checker.locator()) else {
         return;
     };
 
     // Avoid refactors that exceed the line length limit.
-    let col_offset = template.start() - checker.locator.line_start(template.start());
+    let col_offset = template.start() - checker.locator().line_start(template.start());
     if contents.lines().enumerate().any(|(idx, line)| {
         // If `template` is a multiline string, `col_offset` should only be applied to the first
         // line:
@@ -354,7 +354,7 @@ pub(crate) fn f_strings(
 
     // If necessary, add a space between any leading keyword (`return`, `yield`, `assert`, etc.)
     // and the string. For example, `return"foo"` is valid, but `returnf"foo"` is not.
-    let existing = checker.locator.slice(TextRange::up_to(expr.start()));
+    let existing = checker.locator().slice(TextRange::up_to(expr.start()));
     if existing
         .chars()
         .last()

--- a/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
@@ -180,7 +180,7 @@ pub(crate) fn format_literals(checker: &mut Checker, summary: &FormatSummary, ex
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
             Ok(Fix::suggested(Edit::range_replacement(
-                generate_call(expr, &summary.indices, checker.locator, checker.stylist)?,
+                generate_call(expr, &summary.indices, checker.locator(), checker.stylist())?,
                 expr.range(),
             )))
         });

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -91,7 +91,7 @@ pub(crate) fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list:
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.try_set_fix(|| {
-                        let (import_edit, binding) = checker.importer.get_or_import_symbol(
+                        let (import_edit, binding) = checker.importer().get_or_import_symbol(
                             &ImportRequest::import("functools", "cache"),
                             decorator.start(),
                             checker.semantic(),

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -156,7 +156,7 @@ pub(crate) fn native_literals(
             }
 
             // Skip implicit string concatenations.
-            let arg_code = checker.locator.slice(arg.range());
+            let arg_code = checker.locator().slice(arg.range());
             if is_implicit_concatenation(arg_code) {
                 return;
             }

--- a/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -161,7 +161,7 @@ fn percent_to_format(format_string: &CFormatString) -> String {
 
 /// If a tuple has one argument, remove the comma; otherwise, return it as-is.
 fn clean_params_tuple(checker: &mut Checker, right: &Expr, locator: &Locator) -> String {
-    let mut contents = checker.locator.slice(right.range()).to_string();
+    let mut contents = checker.locator().slice(right.range()).to_string();
     if let Expr::Tuple(ast::ExprTuple { elts, .. }) = &right {
         if elts.len() == 1 {
             if !locator.contains_line_break(right.range()) {
@@ -215,11 +215,11 @@ fn clean_params_dictionary(
                         seen.push(key_string);
                         if is_multi_line {
                             if indent.is_none() {
-                                indent = indentation(checker.locator, key);
+                                indent = indentation(checker.locator(), key);
                             }
                         }
 
-                        let value_string = checker.locator.slice(value.range());
+                        let value_string = checker.locator().slice(value.range());
                         arguments.push(format!("{key_string}={value_string}"));
                     } else {
                         // If there are any non-string keys, abort.
@@ -227,7 +227,7 @@ fn clean_params_dictionary(
                     }
                 }
                 None => {
-                    let value_string = checker.locator.slice(value.range());
+                    let value_string = checker.locator().slice(value.range());
                     arguments.push(format!("**{value_string}"));
                 }
             }
@@ -243,16 +243,16 @@ fn clean_params_dictionary(
             };
 
             for item in &arguments {
-                contents.push_str(checker.stylist.line_ending().as_str());
+                contents.push_str(checker.stylist().line_ending().as_str());
                 contents.push_str(indent);
                 contents.push_str(item);
                 contents.push(',');
             }
 
-            contents.push_str(checker.stylist.line_ending().as_str());
+            contents.push_str(checker.stylist().line_ending().as_str());
 
             // For the ending parentheses, go back one indent.
-            let default_indent: &str = checker.stylist.indentation();
+            let default_indent: &str = checker.stylist().indentation();
             if let Some(ident) = indent.strip_prefix(default_indent) {
                 contents.push_str(ident);
             } else {
@@ -338,7 +338,7 @@ pub(crate) fn printf_string_formatting(
     let mut strings: Vec<TextRange> = vec![];
     let mut extension = None;
     for (tok, range) in lexer::lex_starts_at(
-        checker.locator.slice(expr.range()),
+        checker.locator().slice(expr.range()),
         Mode::Module,
         expr.start(),
     )
@@ -365,7 +365,7 @@ pub(crate) fn printf_string_formatting(
     let mut num_keyword_arguments = 0;
     let mut format_strings = Vec::with_capacity(strings.len());
     for range in &strings {
-        let string = checker.locator.slice(*range);
+        let string = checker.locator().slice(*range);
         let (Some(leader), Some(trailer)) = (leading_quote(string), trailing_quote(string)) else {
             return;
         };
@@ -399,16 +399,16 @@ pub(crate) fn printf_string_formatting(
     // Parse the parameters.
     let params_string = match right {
         Expr::Constant(_) | Expr::JoinedStr(_) => {
-            format!("({})", checker.locator.slice(right.range()))
+            format!("({})", checker.locator().slice(right.range()))
         }
         Expr::Name(_) | Expr::Attribute(_) | Expr::Subscript(_) | Expr::Call(_) => {
             if num_keyword_arguments > 0 {
                 // If we have _any_ named fields, assume the right-hand side is a mapping.
-                format!("(**{})", checker.locator.slice(right.range()))
+                format!("(**{})", checker.locator().slice(right.range()))
             } else if num_positional_arguments > 1 {
                 // If we have multiple fields, but no named fields, assume the right-hand side is a
                 // tuple.
-                format!("(*{})", checker.locator.slice(right.range()))
+                format!("(*{})", checker.locator().slice(right.range()))
             } else {
                 // Otherwise, if we have a single field, we can't make any assumptions about the
                 // right-hand side. It _could_ be a tuple, but it could also be a single value,
@@ -442,12 +442,12 @@ pub(crate) fn printf_string_formatting(
             None => {
                 contents.push_str(
                     checker
-                        .locator
+                        .locator()
                         .slice(TextRange::new(expr.start(), range.start())),
                 );
             }
             Some(prev) => {
-                contents.push_str(checker.locator.slice(TextRange::new(prev, range.start())));
+                contents.push_str(checker.locator().slice(TextRange::new(prev, range.start())));
             }
         }
         // Add the string itself.
@@ -458,7 +458,7 @@ pub(crate) fn printf_string_formatting(
     if let Some(range) = extension {
         contents.push_str(
             checker
-                .locator
+                .locator()
                 .slice(TextRange::new(prev.unwrap(), range.end())),
         );
     }

--- a/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -82,7 +82,7 @@ pub(crate) fn redundant_open_modes(checker: &mut Checker, expr: &Expr) {
                                 expr,
                                 &keyword.value,
                                 mode.replacement_value(),
-                                checker.locator,
+                                checker.locator(),
                                 checker.patch(Rule::RedundantOpenModes),
                             ));
                         }
@@ -101,7 +101,7 @@ pub(crate) fn redundant_open_modes(checker: &mut Checker, expr: &Expr) {
                         expr,
                         mode_param,
                         mode.replacement_value(),
-                        checker.locator,
+                        checker.locator(),
                         checker.patch(Rule::RedundantOpenModes),
                     ));
                 }

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -121,7 +121,7 @@ pub(crate) fn replace_stdout_stderr(
         let mut diagnostic = Diagnostic::new(ReplaceStdoutStderr, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
-                generate_fix(checker.locator, func, args, keywords, stdout, stderr)
+                generate_fix(checker.locator(), func, args, keywords, stdout, stderr)
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -143,7 +143,9 @@ pub(crate) fn super_call_with_parameters(
 
     let mut diagnostic = Diagnostic::new(SuperCallWithParameters, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        if let Some(edit) = fixes::remove_super_arguments(checker.locator, checker.stylist, expr) {
+        if let Some(edit) =
+            fixes::remove_super_arguments(checker.locator(), checker.stylist(), expr)
+        {
             diagnostic.set_fix(Fix::suggested(edit));
         }
     }

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -132,9 +132,9 @@ pub(crate) fn unnecessary_builtin_import(
                 unused_imports.iter().map(String::as_str),
                 stmt,
                 parent,
-                checker.locator,
-                checker.stylist,
-                checker.indexer,
+                checker.locator(),
+                checker.stylist(),
+                checker.indexer(),
             )?;
             Ok(Fix::suggested(edit).isolate(checker.isolation(parent)))
         });

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_class_parentheses.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_class_parentheses.rs
@@ -49,7 +49,7 @@ pub(crate) fn unnecessary_class_parentheses(checker: &mut Checker, class_def: &a
     }
 
     let offset = class_def.name.end();
-    let contents = checker.locator.after(offset);
+    let contents = checker.locator().after(offset);
 
     // Find the open and closing parentheses between the class name and the colon, if they exist.
     let mut depth = 0u32;

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -175,7 +175,7 @@ pub(crate) fn unnecessary_encode_utf8(
                         expr.range(),
                     );
                     if checker.patch(Rule::UnnecessaryEncodeUTF8) {
-                        diagnostic.set_fix(replace_with_bytes_literal(checker.locator, expr));
+                        diagnostic.set_fix(replace_with_bytes_literal(checker.locator(), expr));
                     }
                     checker.diagnostics.push(diagnostic);
                 } else if let EncodingArg::Keyword(kwarg) = encoding_arg {
@@ -190,7 +190,7 @@ pub(crate) fn unnecessary_encode_utf8(
                     if checker.patch(Rule::UnnecessaryEncodeUTF8) {
                         diagnostic.try_set_fix(|| {
                             remove_argument(
-                                checker.locator,
+                                checker.locator(),
                                 func.end(),
                                 kwarg.range(),
                                 args,
@@ -212,7 +212,7 @@ pub(crate) fn unnecessary_encode_utf8(
                     if checker.patch(Rule::UnnecessaryEncodeUTF8) {
                         diagnostic.try_set_fix(|| {
                             remove_argument(
-                                checker.locator,
+                                checker.locator(),
                                 func.end(),
                                 arg.range(),
                                 args,
@@ -241,7 +241,7 @@ pub(crate) fn unnecessary_encode_utf8(
                     if checker.patch(Rule::UnnecessaryEncodeUTF8) {
                         diagnostic.try_set_fix(|| {
                             remove_argument(
-                                checker.locator,
+                                checker.locator(),
                                 func.end(),
                                 kwarg.range(),
                                 args,
@@ -263,7 +263,7 @@ pub(crate) fn unnecessary_encode_utf8(
                     if checker.patch(Rule::UnnecessaryEncodeUTF8) {
                         diagnostic.try_set_fix(|| {
                             remove_argument(
-                                checker.locator,
+                                checker.locator(),
                                 func.end(),
                                 arg.range(),
                                 args,

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -121,9 +121,9 @@ pub(crate) fn unnecessary_future_import(checker: &mut Checker, stmt: &Stmt, name
                 unused_imports.iter().map(String::as_str),
                 stmt,
                 parent,
-                checker.locator,
-                checker.stylist,
-                checker.indexer,
+                checker.locator(),
+                checker.stylist(),
+                checker.indexer(),
             )?;
             Ok(Fix::suggested(edit).isolate(checker.isolation(parent)))
         });

--- a/crates/ruff/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
@@ -67,7 +67,7 @@ pub(crate) fn unpacked_list_comprehension(checker: &mut Checker, targets: &[Expr
 
     let mut diagnostic = Diagnostic::new(UnpackedListComprehension, value.range());
     if checker.patch(diagnostic.kind.rule()) {
-        let existing = checker.locator.slice(value.range());
+        let existing = checker.locator().slice(value.range());
 
         let mut content = String::with_capacity(existing.len());
         content.push('(');

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -92,7 +92,7 @@ pub(crate) fn use_pep585_annotation(
                 ModuleMember::Member(module, member) => {
                     // Imported type, like `collections.deque`.
                     diagnostic.try_set_fix(|| {
-                        let (import_edit, binding) = checker.importer.get_or_import_symbol(
+                        let (import_edit, binding) = checker.importer().get_or_import_symbol(
                             &ImportRequest::import_from(module, member),
                             expr.start(),
                             checker.semantic(),

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -67,7 +67,7 @@ pub(crate) fn use_pep604_annotation(
             let mut diagnostic = Diagnostic::new(NonPEP604Annotation, expr.range());
             if fixable && checker.patch(diagnostic.kind.rule()) {
                 diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
-                    optional(slice, checker.locator),
+                    optional(slice, checker.locator()),
                     expr.range(),
                 )));
             }
@@ -82,14 +82,14 @@ pub(crate) fn use_pep604_annotation(
                     }
                     Expr::Tuple(ast::ExprTuple { elts, .. }) => {
                         diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
-                            union(elts, checker.locator),
+                            union(elts, checker.locator()),
                             expr.range(),
                         )));
                     }
                     _ => {
                         // Single argument.
                         diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
-                            checker.locator.slice(slice.range()).to_string(),
+                            checker.locator().slice(slice.range()).to_string(),
                             expr.range(),
                         )));
                     }

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -65,7 +65,7 @@ pub(crate) fn useless_metaclass_type(
     if checker.patch(diagnostic.kind.rule()) {
         let stmt = checker.semantic().stmt();
         let parent = checker.semantic().stmt_parent();
-        let edit = autofix::edits::delete_stmt(stmt, parent, checker.locator, checker.indexer);
+        let edit = autofix::edits::delete_stmt(stmt, parent, checker.locator(), checker.indexer());
         diagnostic.set_fix(Fix::automatic(edit).isolate(checker.isolation(parent)));
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -67,7 +67,7 @@ pub(crate) fn useless_object_inheritance(checker: &mut Checker, class_def: &ast:
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
                 let edit = remove_argument(
-                    checker.locator,
+                    checker.locator(),
                     class_def.name.end(),
                     expr.range(),
                     &class_def.bases,

--- a/crates/ruff/src/rules/pyupgrade/rules/yield_in_for_loop.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/yield_in_for_loop.rs
@@ -187,7 +187,7 @@ pub(crate) fn yield_in_for_loop(checker: &mut Checker, stmt: &Stmt) {
 
             let mut diagnostic = Diagnostic::new(YieldInForLoop, item.stmt.range());
             if checker.patch(diagnostic.kind.rule()) {
-                let contents = checker.locator.slice(item.iter.range());
+                let contents = checker.locator().slice(item.iter.range());
                 let contents = format!("yield from {contents}");
                 diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
                     contents,

--- a/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -192,7 +192,7 @@ pub(crate) fn collection_literal_concatenation(checker: &mut Checker, expr: &Exp
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        if !has_comments(expr, checker.locator, checker.indexer) {
+        if !has_comments(expr, checker.locator(), checker.indexer()) {
             // This suggestion could be unsafe if the non-literal expression in the
             // expression has overridden the `__add__` (or `__radd__`) magic methods.
             diagnostic.set_fix(Fix::suggested(Edit::range_replacement(

--- a/crates/ruff/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -120,7 +120,7 @@ pub(crate) fn explicit_f_string_type_conversion(
         let mut diagnostic = Diagnostic::new(ExplicitFStringTypeConversion, value.range());
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
-                convert_call_to_conversion_flag(expr, index, checker.locator, checker.stylist)
+                convert_call_to_conversion_flag(expr, index, checker.locator(), checker.stylist())
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
@@ -140,7 +140,7 @@ fn generate_fix(checker: &Checker, conversion_type: ConversionType, expr: &Expr)
             )))
         }
         ConversionType::Optional => {
-            let (import_edit, binding) = checker.importer.get_or_import_symbol(
+            let (import_edit, binding) = checker.importer().get_or_import_symbol(
                 &ImportRequest::import_from("typing", "Optional"),
                 expr.start(),
                 checker.semantic(),
@@ -191,11 +191,12 @@ pub(crate) fn implicit_optional(checker: &mut Checker, arguments: &Arguments) {
         }) = annotation.as_ref()
         {
             // Quoted annotation.
-            if let Ok((annotation, kind)) = parse_type_annotation(string, *range, checker.locator) {
+            if let Ok((annotation, kind)) = parse_type_annotation(string, *range, checker.locator())
+            {
                 let Some(expr) = type_hint_explicitly_allows_none(
                     &annotation,
                     checker.semantic(),
-                    checker.locator,
+                    checker.locator(),
                     checker.settings.target_version.minor(),
                 ) else {
                     continue;
@@ -216,7 +217,7 @@ pub(crate) fn implicit_optional(checker: &mut Checker, arguments: &Arguments) {
             let Some(expr) = type_hint_explicitly_allows_none(
                 annotation,
                 checker.semantic(),
-                checker.locator,
+                checker.locator(),
                 checker.settings.target_version.minor(),
             ) else {
                 continue;

--- a/crates/ruff/src/rules/ruff/rules/static_key_dict_comprehension.rs
+++ b/crates/ruff/src/rules/ruff/rules/static_key_dict_comprehension.rs
@@ -44,7 +44,7 @@ pub(crate) fn static_key_dict_comprehension(checker: &mut Checker, key: &Expr) {
     if is_constant(key) {
         checker.diagnostics.push(Diagnostic::new(
             StaticKeyDictComprehension {
-                key: checker.locator.slice(key.range()).to_string(),
+                key: checker.locator().slice(key.range()).to_string(),
             },
             key.range(),
         ));

--- a/crates/ruff/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
+++ b/crates/ruff/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
@@ -113,7 +113,7 @@ pub(crate) fn unnecessary_iterable_allocation_for_first_element(
     let Some(target) = match_iteration_target(value, checker.semantic()) else {
         return;
     };
-    let iterable = checker.locator.slice(target.range);
+    let iterable = checker.locator().slice(target.range);
     let iterable = if target.iterable {
         Cow::Borrowed(iterable)
     } else {


### PR DESCRIPTION
## Summary

Rather than exposing these as public fields, use getters, similar to `semantic()`.