### PR TITLE
Avoid raising `UP032` if `format` call arguments contain multiline expressions

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP032_0.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP032_0.py
@@ -132,6 +132,14 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     ]
 )
 
+"{a}".format(
+    a=[
+        1,
+        2,
+        3,
+    ]
+)
+
 async def c():
     return "{}".format(await 3)
 

--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP032_0.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP032_0.py
@@ -124,6 +124,14 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     111111
 )
 
+"{}".format(
+    [
+        1,
+        2,
+        3,
+    ]
+)
+
 async def c():
     return "{}".format(await 3)
 

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -70,6 +70,9 @@ impl<'a> FormatSummaryValues<'a> {
                 if contains_invalids(locator.slice(arg.range())) {
                     return None;
                 }
+                if locator.contains_line_break(arg.range()) {
+                    return None;
+                }
                 extracted_args.push(arg);
             }
             for keyword in keywords {

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -67,10 +67,9 @@ impl<'a> FormatSummaryValues<'a> {
         let mut extracted_kwargs: FxHashMap<&str, &Expr> = FxHashMap::default();
         if let Expr::Call(ast::ExprCall { args, keywords, .. }) = expr {
             for arg in args {
-                if contains_invalids(locator.slice(arg.range())) {
-                    return None;
-                }
-                if locator.contains_line_break(arg.range()) {
+                if contains_invalids(locator.slice(arg.range()))
+                    || locator.contains_line_break(arg.range())
+                {
                     return None;
                 }
                 extracted_args.push(arg);
@@ -82,7 +81,9 @@ impl<'a> FormatSummaryValues<'a> {
                     range: _,
                 } = keyword;
                 if let Some(key) = arg {
-                    if contains_invalids(locator.slice(value.range())) {
+                    if contains_invalids(locator.slice(value.range()))
+                        || locator.contains_line_break(value.range())
+                    {
                         return None;
                     }
                     extracted_kwargs.insert(key, value);

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP032_0.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP032_0.py.snap
@@ -655,54 +655,54 @@ UP032_0.py:69:85: UP032 [*] Use f-string instead of `format` call
 75 73 | ###
 76 74 | # Non-errors
 
-UP032_0.py:136:11: UP032 [*] Use f-string instead of `format` call
+UP032_0.py:144:11: UP032 [*] Use f-string instead of `format` call
     |
-135 | def d(osname, version, release):
-136 |     return"{}-{}.{}".format(osname, version, release)
+143 | def d(osname, version, release):
+144 |     return"{}-{}.{}".format(osname, version, release)
     |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP032
     |
     = help: Convert to f-string
 
 ℹ Suggested fix
-133 133 | 
-134 134 | 
-135 135 | def d(osname, version, release):
-136     |-    return"{}-{}.{}".format(osname, version, release)
-    136 |+    return f"{osname}-{version}.{release}"
-137 137 | 
-138 138 | 
-139 139 | def e():
+141 141 | 
+142 142 | 
+143 143 | def d(osname, version, release):
+144     |-    return"{}-{}.{}".format(osname, version, release)
+    144 |+    return f"{osname}-{version}.{release}"
+145 145 | 
+146 146 | 
+147 147 | def e():
 
-UP032_0.py:140:10: UP032 [*] Use f-string instead of `format` call
+UP032_0.py:148:10: UP032 [*] Use f-string instead of `format` call
     |
-139 | def e():
-140 |     yield"{}".format(1)
+147 | def e():
+148 |     yield"{}".format(1)
     |          ^^^^^^^^^^^^^^ UP032
     |
     = help: Convert to f-string
 
 ℹ Suggested fix
-137 137 | 
-138 138 | 
-139 139 | def e():
-140     |-    yield"{}".format(1)
-    140 |+    yield f"{1}"
-141 141 | 
-142 142 | 
-143 143 | assert"{}".format(1)
+145 145 | 
+146 146 | 
+147 147 | def e():
+148     |-    yield"{}".format(1)
+    148 |+    yield f"{1}"
+149 149 | 
+150 150 | 
+151 151 | assert"{}".format(1)
 
-UP032_0.py:143:7: UP032 [*] Use f-string instead of `format` call
+UP032_0.py:151:7: UP032 [*] Use f-string instead of `format` call
     |
-143 | assert"{}".format(1)
+151 | assert"{}".format(1)
     |       ^^^^^^^^^^^^^^ UP032
     |
     = help: Convert to f-string
 
 ℹ Suggested fix
-140 140 |     yield"{}".format(1)
-141 141 | 
-142 142 | 
-143     |-assert"{}".format(1)
-    143 |+assert f"{1}"
+148 148 |     yield"{}".format(1)
+149 149 | 
+150 150 | 
+151     |-assert"{}".format(1)
+    151 |+assert f"{1}"
 
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP032_0.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP032_0.py.snap
@@ -655,54 +655,54 @@ UP032_0.py:69:85: UP032 [*] Use f-string instead of `format` call
 75 73 | ###
 76 74 | # Non-errors
 
-UP032_0.py:144:11: UP032 [*] Use f-string instead of `format` call
+UP032_0.py:152:11: UP032 [*] Use f-string instead of `format` call
     |
-143 | def d(osname, version, release):
-144 |     return"{}-{}.{}".format(osname, version, release)
+151 | def d(osname, version, release):
+152 |     return"{}-{}.{}".format(osname, version, release)
     |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP032
     |
     = help: Convert to f-string
 
 ℹ Suggested fix
-141 141 | 
-142 142 | 
-143 143 | def d(osname, version, release):
-144     |-    return"{}-{}.{}".format(osname, version, release)
-    144 |+    return f"{osname}-{version}.{release}"
-145 145 | 
-146 146 | 
-147 147 | def e():
+149 149 | 
+150 150 | 
+151 151 | def d(osname, version, release):
+152     |-    return"{}-{}.{}".format(osname, version, release)
+    152 |+    return f"{osname}-{version}.{release}"
+153 153 | 
+154 154 | 
+155 155 | def e():
 
-UP032_0.py:148:10: UP032 [*] Use f-string instead of `format` call
+UP032_0.py:156:10: UP032 [*] Use f-string instead of `format` call
     |
-147 | def e():
-148 |     yield"{}".format(1)
+155 | def e():
+156 |     yield"{}".format(1)
     |          ^^^^^^^^^^^^^^ UP032
     |
     = help: Convert to f-string
 
 ℹ Suggested fix
-145 145 | 
-146 146 | 
-147 147 | def e():
-148     |-    yield"{}".format(1)
-    148 |+    yield f"{1}"
-149 149 | 
-150 150 | 
-151 151 | assert"{}".format(1)
+153 153 | 
+154 154 | 
+155 155 | def e():
+156     |-    yield"{}".format(1)
+    156 |+    yield f"{1}"
+157 157 | 
+158 158 | 
+159 159 | assert"{}".format(1)
 
-UP032_0.py:151:7: UP032 [*] Use f-string instead of `format` call
+UP032_0.py:159:7: UP032 [*] Use f-string instead of `format` call
     |
-151 | assert"{}".format(1)
+159 | assert"{}".format(1)
     |       ^^^^^^^^^^^^^^ UP032
     |
     = help: Convert to f-string
 
 ℹ Suggested fix
-148 148 |     yield"{}".format(1)
-149 149 | 
-150 150 | 
-151     |-assert"{}".format(1)
-    151 |+assert f"{1}"
+156 156 |     yield"{}".format(1)
+157 157 | 
+158 158 | 
+159     |-assert"{}".format(1)
+    159 |+assert f"{1}"
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fix a regression introduced by https://github.com/astral-sh/ruff/pull/5638. A multiline expression can't be safely inserted into a format field.

### Example

```
> cat a.py
"{}".format(
    [
        1,
        2,
        3,
    ]
)

> cargo run -p ruff_cli -- check a.py --no-cache --select UP032 --fix
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/ruff check a.py --no-cache --select UP032 --fix`
error: Autofix introduced a syntax error in `a.py` with rule codes UP032: EOL while scanning string literal at byte offset 5
---
f"{[
        1,
        2,
        3,
    ]}"

---
a.py:1:1: UP032 Use f-string instead of `format` call
Found 1 error.
```


## Test Plan

<!-- How was it tested? -->


New test cases