### PR TITLE
Fix typo in PYI056 docs

### DIFF
--- a/crates/ruff/src/rules/flake8_pyi/rules/unsupported_method_call_on_all.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unsupported_method_call_on_all.rs
@@ -23,7 +23,7 @@ use crate::checkers::ast::Checker;
 /// Use instead:
 /// ```python
 /// __all__ = ["A"]
-/// __all__ += "B"
+/// __all__ += ["B"]
 /// ```
 #[violation]
 pub struct UnsupportedMethodCallOnAll {


### PR DESCRIPTION
The current "use instead" code would correctly be rejected by any type checker worth its salt ;)
