### PR TITLE
Use `find_keyword` helper function in more places

### DIFF
--- a/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
@@ -2,6 +2,7 @@ use rustpython_parser::ast::{Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::helpers::find_keyword;
 
 use crate::checkers::ast::Checker;
 
@@ -28,12 +29,7 @@ pub(crate) fn logging_config_insecure_listen(
             matches!(call_path.as_slice(), ["logging", "config", "listen"])
         })
     {
-        if keywords.iter().any(|keyword| {
-            keyword
-                .arg
-                .as_ref()
-                .map_or(false, |arg| arg.as_str() == "verify")
-        }) {
+        if find_keyword(keywords, "verify").is_some() {
             return;
         }
 

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
@@ -3,6 +3,7 @@ use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::helpers::find_keyword;
 
 use crate::checkers::ast::Checker;
 
@@ -50,12 +51,7 @@ pub(crate) fn snmp_insecure_version(checker: &mut Checker, func: &Expr, keywords
             matches!(call_path.as_slice(), ["pysnmp", "hlapi", "CommunityData"])
         })
     {
-        if let Some(keyword) = keywords.iter().find(|keyword| {
-            keyword
-                .arg
-                .as_ref()
-                .map_or(false, |arg| arg.as_str() == "mpModel")
-        }) {
+        if let Some(keyword) = find_keyword(keywords, "mpModel") {
             if let Expr::Constant(ast::ExprConstant {
                 value: Constant::Int(value),
                 ..

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -4,6 +4,7 @@ use rustpython_parser::ast::{self, Expr, Ranged, WithItem};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::helpers::find_keyword;
 
 use crate::checkers::ast::Checker;
 
@@ -115,9 +116,7 @@ pub(crate) fn assert_raises_exception(checker: &mut Checker, items: &[WithItem])
             .map_or(false, |call_path| {
                 matches!(call_path.as_slice(), ["pytest", "raises"])
             })
-            && !keywords
-                .iter()
-                .any(|keyword| keyword.arg.as_ref().map_or(false, |arg| arg == "match"))
+            && find_keyword(keywords, "match").is_none()
         {
             AssertionKind::PytestRaises
         } else {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
@@ -2,6 +2,7 @@ use rustpython_parser::ast::{Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::helpers::find_keyword;
 
 use crate::checkers::ast::Checker;
 
@@ -48,12 +49,7 @@ pub(crate) fn no_explicit_stacklevel(checker: &mut Checker, func: &Expr, keyword
         return;
     }
 
-    if keywords.iter().any(|keyword| {
-        keyword
-            .arg
-            .as_ref()
-            .map_or(false, |arg| arg.as_str() == "stacklevel")
-    }) {
+    if find_keyword(keywords, "stacklevel").is_some() {
         return;
     }
 

--- a/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{self, Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::is_const_none;
+use ruff_python_ast::helpers::{find_keyword, is_const_none};
 use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
@@ -51,9 +51,7 @@ pub(crate) fn zip_without_explicit_strict(
     if let Expr::Name(ast::ExprName { id, .. }) = func {
         if id == "zip"
             && checker.semantic().is_builtin("zip")
-            && !kwargs
-                .iter()
-                .any(|keyword| keyword.arg.as_ref().map_or(false, |name| name == "strict"))
+            && find_keyword(kwargs, "strict").is_none()
             && !args
                 .iter()
                 .any(|arg| is_infinite_iterator(arg, checker.semantic()))

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -8,7 +8,7 @@ use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::collect_call_path;
-use ruff_python_ast::helpers::includes_arg_name;
+use ruff_python_ast::helpers::{find_keyword, includes_arg_name};
 use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
@@ -306,11 +306,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &D
             }
 
             if checker.enabled(Rule::PytestExtraneousScopeFunction) {
-                let scope_keyword = keywords
-                    .iter()
-                    .find(|kw| kw.arg.as_ref().map_or(false, |arg| arg == "scope"));
-
-                if let Some(scope_keyword) = scope_keyword {
+                if let Some(scope_keyword) = find_keyword(keywords, "scope") {
                     if keyword_is_literal(scope_keyword, "function") {
                         let mut diagnostic =
                             Diagnostic::new(PytestExtraneousScopeFunction, scope_keyword.range());


### PR DESCRIPTION
## Summary

Use the `find_keyword` helper function instead of reimplementing it.

Follows on from #5983 by doing a different search.

## Test Plan

`cargo test`
