### PR TITLE
Avoid allocations in `SimpleCallArgs`

### DIFF
--- a/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
@@ -4,7 +4,7 @@ use rustpython_parser::ast::{self, Constant, Expr, Keyword, Operator, Ranged};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::CallPath;
-use ruff_python_ast::helpers::SimpleCallArgs;
+use ruff_python_ast::helpers::CallArguments;
 use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
@@ -61,7 +61,7 @@ pub(crate) fn bad_file_permissions(
             matches!(call_path.as_slice(), ["os", "chmod"])
         })
     {
-        let call_args = SimpleCallArgs::new(args, keywords);
+        let call_args = CallArguments::new(args, keywords);
         if let Some(mode_arg) = call_args.argument("mode", 1) {
             if let Some(int_value) = int_value(mode_arg, checker.semantic()) {
                 if (int_value & WRITE_WORLD > 0) || (int_value & EXECUTE_GROUP > 0) {

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::SimpleCallArgs;
+use ruff_python_ast::helpers::CallArguments;
 
 use crate::checkers::ast::Checker;
 
@@ -36,8 +36,7 @@ impl Violation for SnmpWeakCryptography {
     #[derive_message_formats]
     fn message(&self) -> String {
         format!(
-            "You should not use SNMPv3 without encryption. `noAuthNoPriv` & `authNoPriv` is \
-             insecure."
+            "You should not use SNMPv3 without encryption. `noAuthNoPriv` & `authNoPriv` is insecure."
         )
     }
 }
@@ -56,8 +55,7 @@ pub(crate) fn snmp_weak_cryptography(
             matches!(call_path.as_slice(), ["pysnmp", "hlapi", "UsmUserData"])
         })
     {
-        let call_args = SimpleCallArgs::new(args, keywords);
-        if call_args.len() < 3 {
+        if CallArguments::new(args, keywords).len() < 3 {
             checker
                 .diagnostics
                 .push(Diagnostic::new(SnmpWeakCryptography, func.range()));

--- a/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{self, Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::SimpleCallArgs;
+use ruff_python_ast::helpers::CallArguments;
 
 use crate::checkers::ast::Checker;
 
@@ -73,7 +73,7 @@ pub(crate) fn unsafe_yaml_load(
             matches!(call_path.as_slice(), ["yaml", "load"])
         })
     {
-        let call_args = SimpleCallArgs::new(args, keywords);
+        let call_args = CallArguments::new(args, keywords);
         if let Some(loader_arg) = call_args.argument("Loader", 1) {
             if !checker
                 .semantic()

--- a/crates/ruff/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -2,7 +2,7 @@ use ruff_text_size::{TextRange, TextSize};
 use rustpython_parser::ast::{self, Constant, Expr, Keyword, Operator, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
-use ruff_python_ast::helpers::{find_keyword, SimpleCallArgs};
+use ruff_python_ast::helpers::{find_keyword, CallArguments};
 use ruff_python_semantic::analyze::logging;
 use ruff_python_stdlib::logging::LoggingLevel;
 
@@ -164,7 +164,7 @@ pub(crate) fn logging_call(
 
     if let Expr::Attribute(ast::ExprAttribute { value, attr, .. }) = func {
         if let Some(logging_call_type) = LoggingCallType::from_attribute(attr.as_str()) {
-            let call_args = SimpleCallArgs::new(args, keywords);
+            let call_args = CallArguments::new(args, keywords);
             let level_call_range = TextRange::new(value.end() + TextSize::from(1), func.end());
 
             // G001 - G004

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fail.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fail.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::SimpleCallArgs;
+use ruff_python_ast::helpers::CallArguments;
 
 use crate::checkers::ast::Checker;
 
@@ -58,7 +58,7 @@ impl Violation for PytestFailWithoutMessage {
 
 pub(crate) fn fail_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords: &[Keyword]) {
     if is_pytest_fail(func, checker.semantic()) {
-        let call_args = SimpleCallArgs::new(args, keywords);
+        let call_args = CallArguments::new(args, keywords);
 
         // Allow either `pytest.fail(reason="...")` (introduced in pytest 7.0) or
         // `pytest.fail(msg="...")` (deprecated in pytest 7.0)

--- a/crates/ruff/src/rules/pylint/rules/logging.rs
+++ b/crates/ruff/src/rules/pylint/rules/logging.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::SimpleCallArgs;
+use ruff_python_ast::helpers::CallArguments;
 use ruff_python_semantic::analyze::logging;
 use ruff_python_stdlib::logging::LoggingLevel;
 
@@ -102,10 +102,6 @@ pub(crate) fn logging_call(
         return;
     }
 
-    if !logging::is_logger_candidate(func, checker.semantic(), &checker.settings.logger_objects) {
-        return;
-    }
-
     let Expr::Attribute(ast::ExprAttribute { attr, .. }) = func else {
         return;
     };
@@ -114,7 +110,7 @@ pub(crate) fn logging_call(
         return;
     }
 
-    let call_args = SimpleCallArgs::new(args, keywords);
+    let call_args = CallArguments::new(args, keywords);
     let Some(Expr::Constant(ast::ExprConstant {
         value: Constant::Str(value),
         ..
@@ -122,6 +118,10 @@ pub(crate) fn logging_call(
     else {
         return;
     };
+
+    if !logging::is_logger_candidate(func, checker.semantic(), &checker.settings.logger_objects) {
+        return;
+    }
 
     let Ok(summary) = CFormatSummary::try_from(value.as_str()) else {
         return;


### PR DESCRIPTION
## Summary

My intuition is that it's faster to do these checks as-needed rather than allocation new hash maps and vectors for the arguments. (We typically only query once anyway.)