### PR TITLE
Ignore end-of-line comments when dirtying if-with-same-arms branches

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_simplify/SIM114.py
+++ b/crates/ruff/resources/test/fixtures/flake8_simplify/SIM114.py
@@ -101,3 +101,16 @@ if a:
     x = 1
 elif c:
     x = 1
+
+
+def foo():
+    a = True
+    b = False
+    if a > b:  # end-of-line
+        return 3
+    elif a == b:
+        return 3
+    elif a < b:  # end-of-line
+        return 4
+    elif b is None:
+        return 4

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
@@ -138,4 +138,30 @@ SIM114.py:62:1: SIM114 Combine `if` branches using logical `or` operator
    | |______________^ SIM114
    |
 
+SIM114.py:109:5: SIM114 Combine `if` branches using logical `or` operator
+    |
+107 |       a = True
+108 |       b = False
+109 |       if a > b:  # end-of-line
+    |  _____^
+110 | |         return 3
+111 | |     elif a == b:
+112 | |         return 3
+    | |________________^ SIM114
+113 |       elif a < b:  # end-of-line
+114 |           return 4
+    |
+
+SIM114.py:113:5: SIM114 Combine `if` branches using logical `or` operator
+    |
+111 |       elif a == b:
+112 |           return 3
+113 |       elif a < b:  # end-of-line
+    |  _____^
+114 | |         return 4
+115 | |     elif b is None:
+116 | |         return 4
+    | |________________^ SIM114
+    |
+
 


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/6025 (which contains a more thorough description of the issue). Previously, the `# noqa` here was being marked as unused, but removing it raised `SIM114`:

```python
def foo():
    a = True
    b = False
    if a > b:  # noqa: SIM114
        return 3
    elif a == b:
        return 3
```