### PR TITLE
Avoid treating `Literal` members as expressions with `__future__`

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyflakes/F821_16.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F821_16.py
@@ -1,0 +1,11 @@
+"""Test case: `Literal` with `__future__` annotations."""
+
+from __future__ import annotations
+
+from typing import Literal, Final
+
+from typing_extensions import assert_type
+
+CONSTANT: Final = "ns"
+
+assert_type(CONSTANT, Literal["ns"])

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -2172,6 +2172,7 @@ where
     fn visit_expr(&mut self, expr: &'b Expr) {
         // Step 0: Pre-processing
         if !self.semantic.in_f_string()
+            && !self.semantic.in_literal()
             && !self.semantic.in_deferred_type_definition()
             && self.semantic.in_type_definition()
             && self.semantic.future_annotations()
@@ -3921,7 +3922,7 @@ where
                         Some(typing::SubscriptKind::Literal) => {
                             self.semantic.flags |= SemanticModelFlags::LITERAL;
 
-                            self.visit_type_definition(slice);
+                            self.visit_expr(slice);
                             self.visit_expr_context(ctx);
                         }
                         // Ex) Optional[int]

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -125,6 +125,7 @@ mod tests {
     #[test_case(Rule::UndefinedName, Path::new("F821_13.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_14.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_15.py"))]
+    #[test_case(Rule::UndefinedName, Path::new("F821_16.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_1.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_2.py"))]

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F821_F821_16.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F821_F821_16.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pyflakes/mod.rs
+---
+


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/6030.