### PR TITLE
Tweak lambda rule to use annotations rather than shadowing

### DIFF
--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -113,7 +113,11 @@ pub(crate) fn lambda_assignment(
             // See: https://github.com/astral-sh/ruff/issues/3046
             // See: https://github.com/astral-sh/ruff/issues/5421
             if (annotation.is_some() && checker.semantic().scope().kind.is_class())
-                || checker.semantic().scope().has(id)
+                || checker
+                    .semantic()
+                    .scope()
+                    .get_all(id)
+                    .any(|binding_id| checker.semantic().binding(binding_id).kind.is_annotation())
             {
                 diagnostic.set_fix(Fix::manual(Edit::range_replacement(indented, stmt.range())));
             } else {
@@ -139,9 +143,9 @@ fn extract_types(annotation: &Expr, semantic: &SemanticModel) -> Option<(Vec<Exp
     let Expr::Tuple(ast::ExprTuple { elts, .. }) = slice.as_ref() else {
         return None;
     };
-    if elts.len() != 2 {
+    let [param_types, return_type] = elts.as_slice() else {
         return None;
-    }
+    };
 
     if !semantic
         .resolve_call_path(value)
@@ -155,7 +159,7 @@ fn extract_types(annotation: &Expr, semantic: &SemanticModel) -> Option<(Vec<Exp
 
     // The first argument to `Callable` must be a list of types, parameter
     // specification, or ellipsis.
-    let args = match &elts[0] {
+    let params = match param_types {
         Expr::List(ast::ExprList { elts, .. }) => elts.clone(),
         Expr::Constant(ast::ExprConstant {
             value: Constant::Ellipsis,
@@ -165,9 +169,9 @@ fn extract_types(annotation: &Expr, semantic: &SemanticModel) -> Option<(Vec<Exp
     };
 
     // The second argument to `Callable` must be a type.
-    let return_type = elts[1].clone();
+    let return_type = return_type.clone();
 
-    Some((args, return_type))
+    Some((params, return_type))
 }
 
 fn function(


### PR DESCRIPTION
## Summary

This PR ensures that we can retain the current behavior even after we reorder the visitor a bit, by looking for annotated lambdas rather than "is the name bound to anything?", since if we visit the name before we run this rule, it'll _always_ be bound. (This check is already a bit flawed -- in truth, we should probably run this rule deferred so that we can reliably detect shadowing.)