### PR TITLE
Perform lint rule analysis after subtree traversal

### DIFF
--- a/crates/ruff/src/rules/flake8_future_annotations/snapshots/ruff__rules__flake8_future_annotations__tests__fa102_no_future_import_uses_union.py.snap
+++ b/crates/ruff/src/rules/flake8_future_annotations/snapshots/ruff__rules__flake8_future_annotations__tests__fa102_no_future_import_uses_union.py.snap
@@ -1,14 +1,6 @@
 ---
 source: crates/ruff/src/rules/flake8_future_annotations/mod.rs
 ---
-no_future_import_uses_union.py:2:13: FA102 Missing `from __future__ import annotations`, but uses PEP 604 union
-  |
-1 | def main() -> None:
-2 |     a_list: list[str] | None = []
-  |             ^^^^^^^^^^^^^^^^ FA102
-3 |     a_list.append("hello")
-  |
-
 no_future_import_uses_union.py:2:13: FA102 Missing `from __future__ import annotations`, but uses PEP 585 collection
   |
 1 | def main() -> None:
@@ -17,17 +9,25 @@ no_future_import_uses_union.py:2:13: FA102 Missing `from __future__ import annot
 3 |     a_list.append("hello")
   |
 
-no_future_import_uses_union.py:6:14: FA102 Missing `from __future__ import annotations`, but uses PEP 604 union
+no_future_import_uses_union.py:2:13: FA102 Missing `from __future__ import annotations`, but uses PEP 604 union
   |
-6 | def hello(y: dict[str, int] | None) -> None:
-  |              ^^^^^^^^^^^^^^^^^^^^^ FA102
-7 |     del y
+1 | def main() -> None:
+2 |     a_list: list[str] | None = []
+  |             ^^^^^^^^^^^^^^^^ FA102
+3 |     a_list.append("hello")
   |
 
 no_future_import_uses_union.py:6:14: FA102 Missing `from __future__ import annotations`, but uses PEP 585 collection
   |
 6 | def hello(y: dict[str, int] | None) -> None:
   |              ^^^^^^^^^^^^^^ FA102
+7 |     del y
+  |
+
+no_future_import_uses_union.py:6:14: FA102 Missing `from __future__ import annotations`, but uses PEP 604 union
+  |
+6 | def hello(y: dict[str, int] | None) -> None:
+  |              ^^^^^^^^^^^^^^^^^^^^^ FA102
 7 |     del y
   |
 


### PR DESCRIPTION
## Summary

This PR modifies the order of operations in our AST checker. Previously, we ran our analysis rules first, then bound names and traversed over the subtrees. Now, after a series of refactors, we can invert the order: do the subtree traversal and model-building _first_, then run rules.

The nice thing about this change is that when we go to analyze, e.g., a function call node, we'll already have traversed any of the constituent `Expr::Name` nodes... So if we store the resolution of all names when do the traversal, we can avoid having to do any expensive work in `resolve_call_path`.

## Test Plan

Clean run of the snapshot tests, and hopefully the ecosystem checks too!
