### PR TITLE
Remove empty newline in `deferred_for_loops`

### DIFF
--- a/crates/ruff/src/checkers/ast/analyze/deferred_for_loops.rs
+++ b/crates/ruff/src/checkers/ast/analyze/deferred_for_loops.rs
@@ -8,7 +8,6 @@ use crate::rules::{flake8_bugbear, perflint};
 pub(crate) fn deferred_for_loops(checker: &mut Checker) {
     while !checker.deferred.for_loops.is_empty() {
         let for_loops = std::mem::take(&mut checker.deferred.for_loops);
-
         for snapshot in for_loops {
             checker.semantic.restore(snapshot);
 


### PR DESCRIPTION
Trivial change but none of the others have this empty newline.