### PR TITLE
Update `ArgumentsParentheses` usage

### DIFF
--- a/crates/ruff_python_formatter/src/expression/expr_lambda.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_lambda.rs
@@ -27,8 +27,7 @@ impl FormatNodeRule<ExprLambda> for FormatExprLambda {
                 f,
                 [
                     space(),
-                    args.format()
-                        .with_options(ArgumentsParentheses::SkipInsideLambda),
+                    args.format().with_options(ArgumentsParentheses::Never),
                 ]
             )?;
         }

--- a/crates/ruff_python_formatter/src/other/arguments.rs
+++ b/crates/ruff_python_formatter/src/other/arguments.rs
@@ -18,11 +18,22 @@ use crate::FormatNodeRule;
 
 #[derive(Eq, PartialEq, Debug, Default)]
 pub enum ArgumentsParentheses {
+    /// By default, arguments will always preserve their surrounding parentheses.
     #[default]
-    Default,
+    Preserve,
 
-    /// Arguments should never be inside parentheses for lambda expressions.
-    SkipInsideLambda,
+    /// Handle special cases where parentheses should never be used.
+    ///
+    /// An example where parentheses are never used for arguments would be with lambda
+    /// expressions. The following is invalid syntax:
+    /// ```python
+    /// lambda (x, y, z): ...
+    /// ```
+    /// Instead the lambda here should be:
+    /// ```python
+    /// lambda x, y, z: ...
+    /// ```
+    Never,
 }
 
 #[derive(Default)]
@@ -190,7 +201,7 @@ impl FormatNodeRule<Arguments> for FormatArguments {
             + kwonlyargs.len()
             + usize::from(kwarg.is_some());
 
-        if self.parentheses == ArgumentsParentheses::SkipInsideLambda {
+        if self.parentheses == ArgumentsParentheses::Never {
             group(&format_inner).fmt(f)?;
         } else if num_arguments == 0 {
             // No arguments, format any dangling comments between `()`


### PR DESCRIPTION
## Summary

As with #5810, this PR updates the naming convention for the enum variants used for handling `Arguments`' parentheses. 

## Test Plan

Existing snapshots.
