### PR TITLE
playground: Persist source and panel

### DIFF
--- a/playground/src/Editor/SecondaryPanel.tsx
+++ b/playground/src/Editor/SecondaryPanel.tsx
@@ -1,7 +1,12 @@
 import Editor from "@monaco-editor/react";
 import { Theme } from "./theme";
 
-export type SecondaryTool = "Format" | "AST" | "Tokens" | "FIR";
+export enum SecondaryTool {
+  "Format" = "Format",
+  "AST" = "AST",
+  "Tokens" = "Tokens",
+  "FIR" = "FIR",
+}
 
 export type SecondaryPanelResult =
   | null

--- a/playground/src/Editor/SecondarySideBar.tsx
+++ b/playground/src/Editor/SecondarySideBar.tsx
@@ -15,32 +15,32 @@ export default function SecondarySideBar({
     <SideBar position="right">
       <SideBarEntry
         title="Format (alpha)"
-        selected={selected === "Format"}
-        onClick={() => onSelected("Format")}
+        selected={selected === SecondaryTool.Format}
+        onClick={() => onSelected(SecondaryTool.Format)}
       >
         <FormatIcon />
       </SideBarEntry>
 
       <SideBarEntry
         title="AST"
-        selected={selected === "AST"}
-        onClick={() => onSelected("AST")}
+        selected={selected === SecondaryTool.AST}
+        onClick={() => onSelected(SecondaryTool.AST)}
       >
         <StructureIcon />
       </SideBarEntry>
 
       <SideBarEntry
         title="Tokens"
-        selected={selected === "Tokens"}
-        onClick={() => onSelected("Tokens")}
+        selected={selected === SecondaryTool.Tokens}
+        onClick={() => onSelected(SecondaryTool.Tokens)}
       >
         <TokensIcon />
       </SideBarEntry>
 
       <SideBarEntry
         title="Formatter IR"
-        selected={selected === "FIR"}
-        onClick={() => onSelected("FIR")}
+        selected={selected === SecondaryTool.FIR}
+        onClick={() => onSelected(SecondaryTool.FIR)}
       >
         FIR
       </SideBarEntry>

--- a/playground/src/Editor/settings.ts
+++ b/playground/src/Editor/settings.ts
@@ -39,10 +39,33 @@ export function restore(): [string, string] | null {
     window.location.hash.slice(1),
   );
 
-  if (value != null) {
+  if (value == null) {
+    return restoreLocal();
+  } else {
     const [settingsSource, pythonSource] = value.split("$$$");
     return [settingsSource.replaceAll("$$$$$$", "$$$"), pythonSource];
-  } else {
-    return null;
   }
+}
+
+function restoreLocal(): [string, string] | null {
+  const source = localStorage.getItem("source");
+
+  if (source == null) {
+    return null;
+  } else {
+    return JSON.parse(source);
+  }
+}
+
+export function persistLocal({
+  settingsSource,
+  pythonSource,
+}: {
+  settingsSource: string;
+  pythonSource: string;
+}) {
+  localStorage.setItem(
+    "source",
+    JSON.stringify([settingsSource, pythonSource]),
+  );
 }

--- a/playground/src/index.css
+++ b/playground/src/index.css
@@ -29,8 +29,8 @@ html,
 @font-face {
   font-family: "Alliance Text";
   src:
-    url("../public/fonts/Alliance-TextRegular.woff2") format("woff2"),
-    url("../public/fonts/Alliance-TextRegular.woff") format("woff");
+    url("../fonts/Alliance-TextRegular.woff2") format("woff2"),
+    url("../fonts/Alliance-TextRegular.woff") format("woff");
   font-weight: normal;
   font-style: normal;
   font-display: block;
@@ -39,8 +39,8 @@ html,
 @font-face {
   font-family: "Alliance Text";
   src:
-    url("../public/fonts/Alliance-TextMedium.woff2") format("woff2"),
-    url("../public/fonts/Alliance-TextMedium.woff") format("woff");
+    url("../fonts/Alliance-TextMedium.woff2") format("woff2"),
+    url("../fonts/Alliance-TextMedium.woff") format("woff");
   font-weight: 500;
   font-style: normal;
   font-display: block;
@@ -49,8 +49,8 @@ html,
 @font-face {
   font-family: "Alliance Platt";
   src:
-    url("../public/fonts/Alliance-PlattMedium.woff2") format("woff2"),
-    url("../public/fonts/Alliance-PlattMedium.woff") format("woff");
+    url("../fonts/Alliance-PlattMedium.woff2") format("woff2"),
+    url("../fonts/Alliance-PlattMedium.woff") format("woff");
   font-weight: 500;
   font-style: normal;
   font-display: block;
@@ -59,8 +59,8 @@ html,
 @font-face {
   font-family: "Alliance Platt";
   src:
-    url("../public/fonts/Alliance-PlattRegular.woff2") format("woff2"),
-    url("../public/fonts/Alliance-PlattRegular.woff") format("woff");
+    url("../fonts/Alliance-PlattRegular.woff2") format("woff2"),
+    url("../fonts/Alliance-PlattRegular.woff") format("woff");
   font-weight: normal;
   font-style: normal;
   font-display: block;


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR extends the playground to remember the open panel and last entered source code by:

* Storing the open secondary panel in the URL. This has the advantage that someone opening the playground sees the same as the user who shared the play. 
* Storing the source and settings in the local storage and load it when opening an *empty* playground (not a shared playground). There's one caveat to this. Reloading a playground that you opened from an URL will always restore the source from the URL, regardless if you made local changes. 


I decided not to store the open panel in the local storage for now because it complicates things and I mainly want to keep the same panel open when hitting refresh (or when vite decides to reload the page because of a new wasm file). 

## Test Plan

My screen recording is broken :cry: ... 

* I tested loading the playground with an empty local storage -> Shows default code
* Reloading with an open panel preserves the panel
* Reloading preserves the code
* Loading a link loads the code from the link
