### PR TITLE
Fix `SIM102` to handle indented `elif`

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_simplify/SIM102.py
+++ b/crates/ruff/resources/test/fixtures/flake8_simplify/SIM102.py
@@ -156,3 +156,12 @@ if False:
 if True:
     if a:
         pass
+
+
+# SIM102
+def f():
+    if a:
+        pass
+    elif b:
+        if c:
+            d

--- a/crates/ruff/src/rules/flake8_simplify/rules/fix_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/fix_if.rs
@@ -34,6 +34,7 @@ pub(crate) fn fix_nested_if_statements(
     locator: &Locator,
     stylist: &Stylist,
     range: TextRange,
+    is_elif: bool,
 ) -> Result<Edit> {
     // Infer the indentation of the outer block.
     let Some(outer_indent) = whitespace::indentation(locator, &range) else {
@@ -45,7 +46,6 @@ pub(crate) fn fix_nested_if_statements(
 
     // If this is an `elif`, we have to remove the `elif` keyword for now. (We'll
     // restore the `el` later on.)
-    let is_elif = contents.starts_with("elif");
     let module_text = if is_elif {
         Cow::Owned(contents.replacen("elif", "if", 1))
     } else {

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM102_SIM102.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM102_SIM102.py.snap
@@ -332,4 +332,26 @@ SIM102.py:132:5: SIM102 [*] Use a single `if` statement instead of nested `if` s
 136 135 |     print("bar")
 137 136 | 
 
+SIM102.py:165:5: SIM102 [*] Use a single `if` statement instead of nested `if` statements
+    |
+163 |       if a:
+164 |           pass
+165 |       elif b:
+    |  _____^
+166 | |         if c:
+    | |_____________^ SIM102
+167 |               d
+    |
+    = help: Combine `if` statements using `and`
+
+ℹ Suggested fix
+162 162 | def f():
+163 163 |     if a:
+164 164 |         pass
+165     |-    elif b:
+166     |-        if c:
+167     |-            d
+    165 |+    elif b and c:
+    166 |+        d
+
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

The `SIM102` auto-fix fails if `elif` is indented like this:

## Example

```python
def f():
    # SIM102
    if a:
        pass
    elif b:
        if c:
            d
```

```
> cargo run -p ruff_cli -- check --select SIM102 --fix a.py
...
error: Failed to fix nested if: Failed to extract statement from source
a.py:5:5: SIM102 Use a single `if` statement instead of nested `if` statements
Found 1 error.
```

## Test Plan

<!-- How was it tested? -->

New test