### PR TITLE
Ignore some common builtin overrides on standard library subclasses

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_builtins/A003.py
+++ b/crates/ruff/resources/test/fixtures/flake8_builtins/A003.py
@@ -17,3 +17,25 @@ from typing import TypedDict
 
 class MyClass(TypedDict):
     id: int
+
+
+from threading import Event
+
+
+class CustomEvent(Event):
+    def set(self) -> None:
+        ...
+
+    def str(self) -> None:
+        ...
+
+
+from logging import Filter, LogRecord
+
+
+class CustomFilter(Filter):
+    def filter(self, record: LogRecord) -> bool:
+        ...
+
+    def str(self) -> None:
+        ...

--- a/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A003_A003.py.snap
+++ b/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A003_A003.py.snap
@@ -38,4 +38,22 @@ A003.py:11:9: A003 Class attribute `str` is shadowing a Python builtin
 12 |         pass
    |
 
+A003.py:29:9: A003 Class attribute `str` is shadowing a Python builtin
+   |
+27 |         ...
+28 | 
+29 |     def str(self) -> None:
+   |         ^^^ A003
+30 |         ...
+   |
+
+A003.py:40:9: A003 Class attribute `str` is shadowing a Python builtin
+   |
+38 |         ...
+39 | 
+40 |     def str(self) -> None:
+   |         ^^^ A003
+41 |         ...
+   |
+
 

--- a/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A003_A003.py_builtins_ignorelist.snap
+++ b/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A003_A003.py_builtins_ignorelist.snap
@@ -19,4 +19,22 @@ A003.py:11:9: A003 Class attribute `str` is shadowing a Python builtin
 12 |         pass
    |
 
+A003.py:29:9: A003 Class attribute `str` is shadowing a Python builtin
+   |
+27 |         ...
+28 | 
+29 |     def str(self) -> None:
+   |         ^^^ A003
+30 |         ...
+   |
+
+A003.py:40:9: A003 Class attribute `str` is shadowing a Python builtin
+   |
+38 |         ...
+39 | 
+40 |     def str(self) -> None:
+   |         ^^^ A003
+41 |         ...
+   |
+
 


### PR DESCRIPTION
## Summary

If a user subclasses `threading.Event`, e.g. with:

```python
from threading import Event


class CustomEvent(Event):
    def set(self) -> None:
        ...
```

They no control over the method name (`set`). This PR allows `threading.Event#set` and `logging.Filter#filter` overrides, and avoids flagging A003 in such cases. Ideally, we'd avoid flagging all overridden methods, but... that's a lot more difficult, and this is at least _better_ than what we do now.

Closes https://github.com/astral-sh/ruff/issues/6057.

Closes https://github.com/astral-sh/ruff/issues/5956.
