### PR TITLE
Ignore precedence when identifying explicit concatenations

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_implicit_str_concat/ISC.py
+++ b/crates/ruff/resources/test/fixtures/flake8_implicit_str_concat/ISC.py
@@ -59,3 +59,13 @@ _ = "abc" + "def" + foo
 _ = foo + bar + "abc"
 _ = "abc" + foo + bar
 _ = foo + "abc" + bar
+
+_ = (
+  a + f"abc" +
+  "def"
+)
+
+_ = (
+  f"abc" +
+  "def" + a
+)

--- a/crates/ruff/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff/src/checkers/ast/analyze/expression.rs
@@ -12,10 +12,10 @@ use crate::registry::Rule;
 use crate::rules::{
     flake8_2020, flake8_async, flake8_bandit, flake8_boolean_trap, flake8_bugbear, flake8_builtins,
     flake8_comprehensions, flake8_datetimez, flake8_debugger, flake8_django,
-    flake8_future_annotations, flake8_gettext, flake8_implicit_str_concat, flake8_logging_format,
-    flake8_pie, flake8_print, flake8_pyi, flake8_pytest_style, flake8_self, flake8_simplify,
-    flake8_tidy_imports, flake8_use_pathlib, flynt, numpy, pandas_vet, pep8_naming, pycodestyle,
-    pyflakes, pygrep_hooks, pylint, pyupgrade, ruff,
+    flake8_future_annotations, flake8_gettext, flake8_logging_format, flake8_pie, flake8_print,
+    flake8_pyi, flake8_pytest_style, flake8_self, flake8_simplify, flake8_tidy_imports,
+    flake8_use_pathlib, flynt, numpy, pandas_vet, pep8_naming, pycodestyle, pyflakes, pygrep_hooks,
+    pylint, pyupgrade, ruff,
 };
 use crate::settings::types::PythonVersion;
 
@@ -1055,13 +1055,6 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
         Expr::BinOp(ast::ExprBinOp {
             op: Operator::Add, ..
         }) => {
-            if checker.enabled(Rule::ExplicitStringConcatenation) {
-                if let Some(diagnostic) =
-                    flake8_implicit_str_concat::rules::explicit(expr, checker.locator)
-                {
-                    checker.diagnostics.push(diagnostic);
-                }
-            }
             if checker.enabled(Rule::CollectionLiteralConcatenation) {
                 ruff::rules::collection_literal_concatenation(checker, expr);
             }

--- a/crates/ruff/src/checkers/tokens.rs
+++ b/crates/ruff/src/checkers/tokens.rs
@@ -119,8 +119,8 @@ pub(crate) fn check_tokens(
     }
 
     if settings.rules.any_enabled(&[
-        Rule::SingleLineImplicitStringConcatenation,
         Rule::MultiLineImplicitStringConcatenation,
+        Rule::SingleLineImplicitStringConcatenation,
     ]) {
         flake8_implicit_str_concat::rules::implicit(
             &mut diagnostics,
@@ -128,6 +128,10 @@ pub(crate) fn check_tokens(
             &settings.flake8_implicit_str_concat,
             locator,
         );
+    }
+
+    if settings.rules.enabled(Rule::ExplicitStringConcatenation) {
+        flake8_implicit_str_concat::rules::explicit(&mut diagnostics, tokens);
     }
 
     if settings.rules.any_enabled(&[

--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -258,6 +258,7 @@ impl Rule {
             | Rule::BlanketNOQA
             | Rule::BlanketTypeIgnore
             | Rule::CommentedOutCode
+            | Rule::ExplicitStringConcatenation
             | Rule::ExtraneousParentheses
             | Rule::InvalidCharacterBackspace
             | Rule::InvalidCharacterEsc

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__ISC003_ISC.py.snap
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__ISC003_ISC.py.snap
@@ -31,4 +31,24 @@ ISC.py:19:3: ISC003 Explicitly concatenated string should be implicitly concaten
 21 |   )
    |
 
+ISC.py:64:7: ISC003 Explicitly concatenated string should be implicitly concatenated
+   |
+63 |   _ = (
+64 |     a + f"abc" +
+   |  _______^
+65 | |   "def"
+   | |_______^ ISC003
+66 |   )
+   |
+
+ISC.py:69:3: ISC003 Explicitly concatenated string should be implicitly concatenated
+   |
+68 |   _ = (
+69 |     f"abc" +
+   |  ___^
+70 | |   "def" + a
+   | |_______^ ISC003
+71 |   )
+   |
+
 

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__multiline_ISC003_ISC.py.snap
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__multiline_ISC003_ISC.py.snap
@@ -31,4 +31,24 @@ ISC.py:19:3: ISC003 Explicitly concatenated string should be implicitly concaten
 21 |   )
    |
 
+ISC.py:64:7: ISC003 Explicitly concatenated string should be implicitly concatenated
+   |
+63 |   _ = (
+64 |     a + f"abc" +
+   |  _______^
+65 | |   "def"
+   | |_______^ ISC003
+66 |   )
+   |
+
+ISC.py:69:3: ISC003 Explicitly concatenated string should be implicitly concatenated
+   |
+68 |   _ = (
+69 |     f"abc" +
+   |  ___^
+70 | |   "def" + a
+   | |_______^ ISC003
+71 |   )
+   |
+
 


### PR DESCRIPTION
This is the other piece of https://github.com/astral-sh/ruff/issues/5332.