### PR TITLE
whitespace-before-parameters comment

### DIFF
--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
@@ -8,7 +8,7 @@ use crate::checkers::logical_lines::LogicalLinesContext;
 use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
 
 /// ## What it does
-/// Checks for extraneous whitespace immediately before an open parenthesis
+/// Checks for extraneous whitespace immediately after an open parenthesis
 /// or bracket.
 ///
 /// ## Why is this bad?

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
@@ -8,12 +8,12 @@ use crate::checkers::logical_lines::LogicalLinesContext;
 use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
 
 /// ## What it does
-/// Checks for extraneous whitespace immediately before the open parenthesis
-/// that starts the argument list of a function call
+/// Checks for extraneous whitespace immediately before an open parenthesis
+/// or bracket.
 ///
 /// ## Why is this bad?
-/// According to [PEP 8], open parentheses should not have any space before or
-/// after them.
+/// According to [PEP 8], open parentheses and brackets should not be followed
+/// by any trailing whitespace.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
@@ -7,6 +7,25 @@ use ruff_python_parser::token_kind::TokenKind;
 use crate::checkers::logical_lines::LogicalLinesContext;
 use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
 
+/// ## What it does
+/// Checks for extraneous whitespace immediately before the open parenthesis
+/// that starts the argument list of a function call
+///
+/// ## Why is this bad?
+/// According to [PEP 8], open parentheses should not have any space before or
+/// after them.
+///
+/// ## Example
+/// ```python
+/// spam (1)
+/// ```
+///
+/// Use instead:
+/// ```python
+/// spam(1)
+/// ```
+///
+/// [PEP 8]: https://peps.python.org/pep-0008/#pet-peeves
 #[violation]
 pub struct WhitespaceBeforeParameters {
     bracket: TokenKind,

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -66,6 +66,7 @@ KNOWN_FORMATTING_VIOLATIONS = [
     "useless-semicolon",
     "whitespace-after-open-bracket",
     "whitespace-before-close-bracket",
+    "whitespace-before-parameters",
     "whitespace-before-punctuation",
 ]
 


### PR DESCRIPTION
**Summary**

Updated doc comment for `whitespace_before_parameters.rs`. Online docs also benefit from this update.

**Test Plan**

Checked docs via [mkdocs](https://github.com/astral-sh/ruff/blob/389fe13c934fe73679474006412b1eded4a2cad0/CONTRIBUTING.md?plain=1#L267-L296)