### PR TITLE
Fix `cargo test -p ruff`

### DIFF
--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -26,7 +26,7 @@ ruff_python_semantic = { path = "../ruff_python_semantic" }
 ruff_python_stdlib = { path = "../ruff_python_stdlib" }
 ruff_python_trivia = { path = "../ruff_python_trivia" }
 ruff_python_parser = { path = "../ruff_python_parser" }
-ruff_source_file = { path = "../ruff_source_file" }
+ruff_source_file = { path = "../ruff_source_file", features = ["serde"] }
 ruff_text_size = { workspace = true }
 
 annotate-snippets = { version = "0.9.1", features = ["color"] }


### PR DESCRIPTION
Previously, this would fail with "the trait bound `SourceLocation: Serialize` is not satisfied".