### PR TITLE
call-datetime-without-tzinfo comment

### DIFF
--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
@@ -21,12 +21,14 @@ use super::helpers;
 /// ## Example
 /// ```python
 /// import datetime
+///
 /// datetime.datetime(2000, 1, 1, 0, 0, 0)
 /// ```
 ///
 /// Use instead:
 /// ```python
 /// import datetime
+///
 /// datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=datetime.UTC)
 /// ```
 #[violation]

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
@@ -10,13 +10,13 @@ use crate::checkers::ast::Checker;
 use super::helpers;
 
 /// ## What it does
-/// Checks for use of a datetime without use of the `tzinfo` argument
+/// Checks for `datetime` instantiations that lack a `tzinfo` argument.
 ///
 /// ## Why is this bad?
-/// Naive timestamps lack explicit information about time zone or daylight
-/// saving time rules.  This amibiguity can make naive datetimes difficult to
-/// interpret.  Providing timezone information allows easier reference and
-/// comparison of timestamps.
+/// `datetime` objects are "naive" by default, in that they do not include
+/// timezone information. By providing a `tzinfo`, a `datetime` can be made
+/// timezone "aware". "Naive" objects are easy to understand, but ignore some
+/// aspects of reality, which can lead to subtle bugs.
 ///
 /// ## Example
 /// ```python
@@ -27,7 +27,7 @@ use super::helpers;
 /// Use instead:
 /// ```python
 /// import datetime
-/// datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+/// datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=datetime.UTC)
 /// ```
 #[violation]
 pub struct CallDatetimeWithoutTzinfo;

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
@@ -9,6 +9,26 @@ use crate::checkers::ast::Checker;
 
 use super::helpers;
 
+/// ## What it does
+/// Checks for use of a datetime without use of the `tzinfo` argument
+///
+/// ## Why is this bad?
+/// Naive timestamps lack explicit information about time zone or daylight
+/// saving time rules.  This amibiguity can make naive datetimes difficult to
+/// interpret.  Providing timezone information allows easier reference and
+/// comparison of timestamps.
+///
+/// ## Example
+/// ```python
+/// import datetime
+/// datetime.datetime(2000, 1, 1, 0, 0, 0)
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import datetime
+/// datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+/// ```
 #[violation]
 pub struct CallDatetimeWithoutTzinfo;
 

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -32,6 +32,7 @@ KNOWN_FORMATTING_VIOLATIONS = [
     "bad-quotes-docstring",
     "bad-quotes-inline-string",
     "bad-quotes-multiline-string",
+    "call-datetime-without-tzinfo",
     "explicit-string-concatenation",
     "indent-with-spaces",
     "indentation-with-invalid-multiple",

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -32,7 +32,6 @@ KNOWN_FORMATTING_VIOLATIONS = [
     "bad-quotes-docstring",
     "bad-quotes-inline-string",
     "bad-quotes-multiline-string",
-    "call-datetime-without-tzinfo",
     "explicit-string-concatenation",
     "indent-with-spaces",
     "indentation-with-invalid-multiple",


### PR DESCRIPTION
## Summary

Updated doc comment for `call_datetime_without_tzinfo.rs`. Online docs also benefit from this update.

## Test Plan

Checked docs via [mkdocs](https://github.com/astral-sh/ruff/blob/389fe13c934fe73679474006412b1eded4a2cad0/CONTRIBUTING.md?plain=1#L267-L296)
