### PR TITLE
Add "--select E402" to example snippet in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,8 +224,12 @@ Once you've completed the code for the rule itself, you can define tests with th
     For example, if you're adding a new rule named `E402`, you would run:
 
     ```shell
-    cargo run -p ruff_cli -- check crates/ruff/resources/test/fixtures/pycodestyle/E402.py --no-cache
+    cargo run -p ruff_cli -- check crates/ruff/resources/test/fixtures/pycodestyle/E402.py --no-cache --select E402
     ```
+
+    **Note:** In Ruff only a subset of rules are enabled by default. When testing a new rule,
+    ensure that you execute it by using `--select name_of_rule` in the command to activate the
+    desired rule.
 
 1. Add the test to the relevant `crates/ruff/src/rules/[linter]/mod.rs` file. If you're contributing
     a rule to a pre-existing set, you should be able to find a similar example to pattern-match

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,9 +227,8 @@ Once you've completed the code for the rule itself, you can define tests with th
     cargo run -p ruff_cli -- check crates/ruff/resources/test/fixtures/pycodestyle/E402.py --no-cache --select E402
     ```
 
-    **Note:** In Ruff only a subset of rules are enabled by default. When testing a new rule,
-    ensure that you execute it by using `--select name_of_rule` in the command to activate the
-    desired rule.
+    **Note:** Only a subset of rules are enabled by default. When testing a new rule, ensure that
+    you activate it by adding `--select ${rule_code}` to the command.
 
 1. Add the test to the relevant `crates/ruff/src/rules/[linter]/mod.rs` file. If you're contributing
     a rule to a pre-existing set, you should be able to find a similar example to pattern-match


### PR DESCRIPTION
## Summary
In Ruff only a subset of rules are enabled by default. This change change aims to clarify that when adding a new rule, you must explicitly use the `--select name_of_rule` command to ensure the rule gets executed.

This was talked about on Discord a while back.

## Test Plan
Checked docs via mkdocs