### PR TITLE
Respect indent when measuring with `MeasureMode::AllLines`

### DIFF
--- a/crates/ruff_python_formatter/src/expression/expr_attribute.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_attribute.rs
@@ -75,7 +75,7 @@ impl FormatNodeRule<ExprAttribute> for FormatExprAttribute {
 impl NeedsParentheses for ExprAttribute {
     fn needs_parentheses(
         &self,
-        parent: AnyNodeRef,
+        _parent: AnyNodeRef,
         context: &PyFormatContext,
     ) -> OptionalParentheses {
         // Checks if there are any own line comments in an attribute chain (a.b.c).
@@ -88,7 +88,7 @@ impl NeedsParentheses for ExprAttribute {
         {
             OptionalParentheses::Always
         } else {
-            self.value.needs_parentheses(parent, context)
+            self.value.needs_parentheses(self.into(), context)
         }
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_call.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_call.rs
@@ -119,10 +119,10 @@ impl FormatNodeRule<ExprCall> for FormatExprCall {
 impl NeedsParentheses for ExprCall {
     fn needs_parentheses(
         &self,
-        parent: AnyNodeRef,
+        _parent: AnyNodeRef,
         context: &PyFormatContext,
     ) -> OptionalParentheses {
-        self.func.needs_parentheses(parent, context)
+        self.func.needs_parentheses(self.into(), context)
     }
 }
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__composition.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__composition.py.snap
@@ -203,18 +203,41 @@ class C:
                          print(i)
          xxxxxxxxxxxxxxxx = Yyyy2YyyyyYyyyyy(
              push_manager=context.request.resource_manager,
-@@ -120,9 +120,7 @@
-             key7: value7,
-             key8: value8,
-             key9: value9,
+@@ -110,19 +110,20 @@
+             value, is_going_to_be="too long to fit in a single line", srsly=True
+         ), "Not what we expected"
+ 
+-        assert {
+-            key1: value1,
+-            key2: value2,
+-            key3: value3,
+-            key4: value4,
+-            key5: value5,
+-            key6: value6,
+-            key7: value7,
+-            key8: value8,
+-            key9: value9,
 -        } == expected, (
 -            "Not what we expected and the message is too long to fit in one line"
 -        )
-+        } == expected, "Not what we expected and the message is too long to fit in one line"
++        assert (
++            {
++                key1: value1,
++                key2: value2,
++                key3: value3,
++                key4: value4,
++                key5: value5,
++                key6: value6,
++                key7: value7,
++                key8: value8,
++                key9: value9,
++            }
++            == expected
++        ), "Not what we expected and the message is too long to fit in one line"
  
          assert expected(
              value, is_going_to_be="too long to fit in a single line", srsly=True
-@@ -153,7 +151,8 @@
+@@ -153,7 +154,8 @@
              " because it's too long"
          )
  
@@ -224,7 +247,7 @@ class C:
          %3d           0 LOAD_FAST                1 (x)
                        2 LOAD_CONST               1 (1)
                        4 COMPARE_OP               2 (==)
-@@ -161,8 +160,8 @@
+@@ -161,8 +163,8 @@
                        8 STORE_ATTR               0 (x)
                       10 LOAD_CONST               0 (None)
                       12 RETURN_VALUE
@@ -352,17 +375,20 @@ class C:
             value, is_going_to_be="too long to fit in a single line", srsly=True
         ), "Not what we expected"
 
-        assert {
-            key1: value1,
-            key2: value2,
-            key3: value3,
-            key4: value4,
-            key5: value5,
-            key6: value6,
-            key7: value7,
-            key8: value8,
-            key9: value9,
-        } == expected, "Not what we expected and the message is too long to fit in one line"
+        assert (
+            {
+                key1: value1,
+                key2: value2,
+                key3: value3,
+                key4: value4,
+                key5: value5,
+                key6: value6,
+                key7: value7,
+                key8: value8,
+                key9: value9,
+            }
+            == expected
+        ), "Not what we expected and the message is too long to fit in one line"
 
         assert expected(
             value, is_going_to_be="too long to fit in a single line", srsly=True

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__composition_no_trailing_comma.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__composition_no_trailing_comma.py.snap
@@ -203,18 +203,41 @@ class C:
                          print(i)
          xxxxxxxxxxxxxxxx = Yyyy2YyyyyYyyyyy(
              push_manager=context.request.resource_manager,
-@@ -120,9 +120,7 @@
-             key7: value7,
-             key8: value8,
-             key9: value9,
+@@ -110,19 +110,20 @@
+             value, is_going_to_be="too long to fit in a single line", srsly=True
+         ), "Not what we expected"
+ 
+-        assert {
+-            key1: value1,
+-            key2: value2,
+-            key3: value3,
+-            key4: value4,
+-            key5: value5,
+-            key6: value6,
+-            key7: value7,
+-            key8: value8,
+-            key9: value9,
 -        } == expected, (
 -            "Not what we expected and the message is too long to fit in one line"
 -        )
-+        } == expected, "Not what we expected and the message is too long to fit in one line"
++        assert (
++            {
++                key1: value1,
++                key2: value2,
++                key3: value3,
++                key4: value4,
++                key5: value5,
++                key6: value6,
++                key7: value7,
++                key8: value8,
++                key9: value9,
++            }
++            == expected
++        ), "Not what we expected and the message is too long to fit in one line"
  
          assert expected(
              value, is_going_to_be="too long to fit in a single line", srsly=True
-@@ -153,7 +151,8 @@
+@@ -153,7 +154,8 @@
              " because it's too long"
          )
  
@@ -224,7 +247,7 @@ class C:
          %3d           0 LOAD_FAST                1 (x)
                        2 LOAD_CONST               1 (1)
                        4 COMPARE_OP               2 (==)
-@@ -161,8 +160,8 @@
+@@ -161,8 +163,8 @@
                        8 STORE_ATTR               0 (x)
                       10 LOAD_CONST               0 (None)
                       12 RETURN_VALUE
@@ -352,17 +375,20 @@ class C:
             value, is_going_to_be="too long to fit in a single line", srsly=True
         ), "Not what we expected"
 
-        assert {
-            key1: value1,
-            key2: value2,
-            key3: value3,
-            key4: value4,
-            key5: value5,
-            key6: value6,
-            key7: value7,
-            key8: value8,
-            key9: value9,
-        } == expected, "Not what we expected and the message is too long to fit in one line"
+        assert (
+            {
+                key1: value1,
+                key2: value2,
+                key3: value3,
+                key4: value4,
+                key5: value5,
+                key6: value6,
+                key7: value7,
+                key8: value8,
+                key9: value9,
+            }
+            == expected
+        ), "Not what we expected and the message is too long to fit in one line"
 
         assert expected(
             value, is_going_to_be="too long to fit in a single line", srsly=True


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR contains two smaller Printer improvements:

1. The printer didn't queue an indent after a newline when measuring if all lines fits. This means, it measured the lines after the first line without any indent. 
2. Remove the unused `pending_space` state variable

This PR contains another small bugfix where `ExprCall` and `ExprAttribute` passed the wrong parent in `NeedsParentheses` (their parent instead of self)

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

See updated snapshot. The assert now breaks because the content doesn't fit when also considering the indentation (Yes, this is a regression to black's formatting but this needs special formatting rather than relying on a Printer bug)

<!-- How was it tested? -->
