### PR TITLE
Consolidate `ExprYield`/`ExprYieldFrom` into `AnyExpressionYield`

### DIFF
--- a/crates/ruff_python_formatter/src/expression/expr_yield.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_yield.rs
@@ -23,10 +23,10 @@ impl<'a> AnyExpressionYield<'a> {
         matches!(self, AnyExpressionYield::YieldFrom(_))
     }
 
-    fn value(&self) -> Option<Box<Expr>> {
+    fn value(&self) -> Option<&Expr> {
         match self {
-            AnyExpressionYield::Yield(yld) => &yld.value,
-            AnyExpressionYield::YieldFrom(yld) => &Some(yld.value),
+            AnyExpressionYield::Yield(yld) => yld.value.as_deref(),
+            AnyExpressionYield::YieldFrom(yld) => Some(&yld.value),
         }
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_yield.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_yield.rs
@@ -83,7 +83,7 @@ impl<'a> From<&AnyExpressionYield<'a>> for AnyNodeRef<'a> {
 
 impl Format<PyFormatContext<'_>> for AnyExpressionYield<'_> {
     fn fmt(&self, f: &mut Formatter<PyFormatContext<'_>>) -> FormatResult<()> {
-        let expr = if self.is_yield_from() {
+        let keyword = if self.is_yield_from() {
             "yield from"
         } else {
             "yield"
@@ -93,14 +93,14 @@ impl Format<PyFormatContext<'_>> for AnyExpressionYield<'_> {
             write!(
                 f,
                 [
-                    text(expr),
+                    text(keyword),
                     space(),
                     maybe_parenthesize_expression(val, self, Parenthesize::IfRequired)
                 ]
             )?;
         } else {
             // ExprYieldFrom always has Some(value) so we should never get a bare `yield from`
-            write!(f, [&text(expr)])?;
+            write!(f, [&text(keyword)])?;
         }
         Ok(())
     }

--- a/crates/ruff_python_formatter/src/expression/expr_yield_from.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_yield_from.rs
@@ -1,48 +1,13 @@
-use crate::context::PyFormatContext;
-use crate::expression::maybe_parenthesize_expression;
-use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses, Parenthesize};
+use rustpython_ast::ExprYieldFrom;
+use ruff_formatter::{Format, FormatResult};
 use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::prelude::{space, text};
-use ruff_formatter::{write, Buffer, FormatResult};
-use ruff_python_ast::node::AnyNodeRef;
-use ruff_python_ast::ExprYieldFrom;
+use crate::expression::expr_yield::AnyExpressionYield;
 
 #[derive(Default)]
 pub struct FormatExprYieldFrom;
 
 impl FormatNodeRule<ExprYieldFrom> for FormatExprYieldFrom {
     fn fmt_fields(&self, item: &ExprYieldFrom, f: &mut PyFormatter) -> FormatResult<()> {
-        let ExprYieldFrom { range: _, value } = item;
-
-        write!(
-            f,
-            [
-                text("yield from"),
-                space(),
-                maybe_parenthesize_expression(value, item, Parenthesize::IfRequired)
-            ]
-        )?;
-
-        Ok(())
-    }
-}
-
-impl NeedsParentheses for ExprYieldFrom {
-    fn needs_parentheses(
-        &self,
-        parent: AnyNodeRef,
-        _context: &PyFormatContext,
-    ) -> OptionalParentheses {
-        // According to https://docs.python.org/3/reference/grammar.html There are two situations
-        // where we do not want to always parenthesize a yield expression:
-        //  1. Right hand side of an assignment, e.g. `x = yield y`
-        //  2. Yield statement, e.g. `def foo(): yield y`
-        // We catch situation 1 below. Situation 2 does not need to be handled here as
-        // FormatStmtExpr, does not add parenthesis
-        if parent.is_stmt_assign() || parent.is_stmt_ann_assign() || parent.is_stmt_aug_assign() {
-            OptionalParentheses::Multiline
-        } else {
-            OptionalParentheses::Always
-        }
+        AnyExpressionYield::from(item).fmt(f)
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_yield_from.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_yield_from.rs
@@ -1,7 +1,7 @@
-use rustpython_ast::ExprYieldFrom;
-use ruff_formatter::{Format, FormatResult};
-use crate::{FormatNodeRule, PyFormatter};
 use crate::expression::expr_yield::AnyExpressionYield;
+use crate::{FormatNodeRule, PyFormatter};
+use ruff_formatter::{Format, FormatResult};
+use rustpython_ast::ExprYieldFrom;
 
 #[derive(Default)]
 pub struct FormatExprYieldFrom;

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -42,10 +42,10 @@ pub(crate) mod expr_subscript;
 pub(crate) mod expr_tuple;
 pub(crate) mod expr_unary_op;
 pub(crate) mod expr_yield;
+pub(crate) mod expr_yield_from;
 pub(crate) mod number;
 pub(crate) mod parentheses;
 pub(crate) mod string;
-pub(crate) mod expr_yield_from;
 
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
 pub struct FormatExpr {
@@ -222,7 +222,9 @@ impl NeedsParentheses for Expr {
             Expr::GeneratorExp(expr) => expr.needs_parentheses(parent, context),
             Expr::Await(expr) => expr.needs_parentheses(parent, context),
             Expr::Yield(expr) => AnyExpressionYield::from(expr).needs_parentheses(parent, context),
-            Expr::YieldFrom(expr) => AnyExpressionYield::from(expr).needs_parentheses(parent, context),
+            Expr::YieldFrom(expr) => {
+                AnyExpressionYield::from(expr).needs_parentheses(parent, context)
+            }
             Expr::Compare(expr) => expr.needs_parentheses(parent, context),
             Expr::Call(expr) => expr.needs_parentheses(parent, context),
             Expr::FormattedValue(expr) => expr.needs_parentheses(parent, context),

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -9,6 +9,7 @@ use ruff_python_ast::visitor::preorder::{walk_expr, PreorderVisitor};
 
 use crate::builders::parenthesize_if_expands;
 use crate::context::NodeLevel;
+use crate::expression::expr_yield::AnyExpressionYield;
 use crate::expression::parentheses::{
     is_expression_parenthesized, optional_parentheses, parenthesized, NeedsParentheses,
     OptionalParentheses, Parentheses, Parenthesize,
@@ -41,10 +42,10 @@ pub(crate) mod expr_subscript;
 pub(crate) mod expr_tuple;
 pub(crate) mod expr_unary_op;
 pub(crate) mod expr_yield;
-pub(crate) mod expr_yield_from;
 pub(crate) mod number;
 pub(crate) mod parentheses;
 pub(crate) mod string;
+pub(crate) mod expr_yield_from;
 
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
 pub struct FormatExpr {
@@ -220,8 +221,8 @@ impl NeedsParentheses for Expr {
             Expr::DictComp(expr) => expr.needs_parentheses(parent, context),
             Expr::GeneratorExp(expr) => expr.needs_parentheses(parent, context),
             Expr::Await(expr) => expr.needs_parentheses(parent, context),
-            Expr::Yield(expr) => expr.needs_parentheses(parent, context),
-            Expr::YieldFrom(expr) => expr.needs_parentheses(parent, context),
+            Expr::Yield(expr) => AnyExpressionYield::from(expr).needs_parentheses(parent, context),
+            Expr::YieldFrom(expr) => AnyExpressionYield::from(expr).needs_parentheses(parent, context),
             Expr::Compare(expr) => expr.needs_parentheses(parent, context),
             Expr::Call(expr) => expr.needs_parentheses(parent, context),
             Expr::FormattedValue(expr) => expr.needs_parentheses(parent, context),


### PR DESCRIPTION
## Summary

Removes some duplicated logic by consolidating both `yield` expressions into one enum, as suggested by @MichaReiser in https://github.com/astral-sh/ruff/pull/5921#pullrequestreview-1541019917 

## Test Plan

Existing tests and functionality were checked to be unchanged, this is a pure refactor PR
