### PR TITLE
Fix windows test warnings

### DIFF
--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -21,7 +21,9 @@ use path_absolutize::path_dedot;
 #[cfg(unix)]
 use tempfile::TempDir;
 
+#[cfg(unix)]
 use ruff_cli::args::Args;
+#[cfg(unix)]
 use ruff_cli::run;
 
 const BIN_NAME: &str = "ruff";


### PR DESCRIPTION
See https://github.com/astral-sh/ruff/actions/runs/5679922286/job/15392998698. These didn't fail CI because we run clippy on linux only.
