### PR TITLE
Add more documentation to the `flake8-bandit` rules

### DIFF
--- a/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -12,9 +12,11 @@ use crate::checkers::ast::Checker;
 /// ## Why is this bad?
 /// `jinja2` templates that use `autoescape=False` are vulnerable to cross-site
 /// scripting (XSS) attacks that allow attackers to execute arbitrary
-/// JavaScript. By default, `jinja2` sets `autoescape` to `False`, so it is
-/// important to set `autoescape=True` or use the `select_autoescape` function
-/// to mitigate XSS vulnerabilities.
+/// JavaScript.
+///
+/// By default, `jinja2` sets `autoescape` to `False`, so it is important to
+/// set `autoescape=True` or use the `select_autoescape` function to mitigate
+/// XSS vulnerabilities.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -6,6 +6,33 @@ use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
 
+/// ## What it does
+/// Checks for `jinja2` templates that use `autoescape=False`.
+///
+/// ## Why is this bad?
+/// `jinja2` templates that use `autoescape=False` are vulnerable to cross-site
+/// scripting (XSS) attacks that allow attackers to execute arbitrary
+/// JavaScript. By default, `jinja2` sets `autoescape` to `False`, so it is
+/// important to set `autoescape=True` or use the `select_autoescape` function
+/// to mitigate XSS vulnerabilities.
+///
+/// ## Example
+/// ```python
+/// import jinja2
+///
+/// jinja2.Environment(loader=jinja2.FileSystemLoader("."))
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import jinja2
+///
+/// jinja2.Environment(loader=jinja2.FileSystemLoader("."), autoescape=True)
+/// ```
+///
+/// ## References
+/// - [Jinja documentation: API](https://jinja.palletsprojects.com/en/latest/api/#autoescaping)
+/// - [Common Weakness Enumeration: CWE-94](https://cwe.mitre.org/data/definitions/94.html)
 #[violation]
 pub struct Jinja2AutoescapeFalse {
     value: bool,

--- a/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
@@ -6,6 +6,24 @@ use ruff_python_ast::helpers::find_keyword;
 
 use crate::checkers::ast::Checker;
 
+/// ## What it does
+/// Checks for insecure `logging.config.listen` calls.
+///
+/// ## Why is this bad?
+/// `logging.config.listen` starts a server that listens for logging
+/// configuration requests. This is insecure as parts of the configuration are
+/// passed to the built-in `eval` function, which can be used to execute
+/// arbitrary code.
+///
+/// ## Example
+/// ```python
+/// import logging
+///
+/// logging.config.listen(9999)
+/// ```
+///
+/// ## References
+/// - [Python documentation: `logging.config.listen()`](https://docs.python.org/3/library/logging.config.html#logging.config.listen)
 #[violation]
 pub struct LoggingConfigInsecureListen;
 

--- a/crates/ruff/src/rules/flake8_bandit/rules/paramiko_calls.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/paramiko_calls.rs
@@ -11,7 +11,7 @@ use crate::checkers::ast::Checker;
 /// ## Why is this bad?
 /// `paramiko` calls allow users to execute arbitrary shell commands on a
 /// remote machine. If the inputs to these calls are not properly sanitized,
-/// this can lead to shell injection vulnerabilities.
+/// they can be vulnerable to shell injection attacks.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/flake8_bandit/rules/paramiko_calls.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/paramiko_calls.rs
@@ -5,6 +5,25 @@ use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
 
+/// ## What it does
+/// Checks for `paramiko` calls.
+///
+/// ## Why is this bad?
+/// `paramiko` calls allow users to execute arbitrary shell commands on a
+/// remote machine. If the inputs to these calls are not properly sanitized,
+/// this can lead to shell injection vulnerabilities.
+///
+/// ## Example
+/// ```python
+/// import paramiko
+///
+/// client = paramiko.SSHClient()
+/// client.exec_command("echo $HOME")
+/// ```
+///
+/// ## References
+/// - [Common Weakness Enumeration: CWE-78](https://cwe.mitre.org/data/definitions/78.html)
+/// - [Paramiko documentation: `SSHClient.exec_command()`](https://docs.paramiko.org/en/stable/api/client.html#paramiko.client.SSHClient.exec_command)
 #[violation]
 pub struct ParamikoCall;
 

--- a/crates/ruff/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -75,6 +75,31 @@ impl Violation for StartProcessWithNoShell {
     }
 }
 
+/// ## What it does
+/// Checks for the starting of a process with a partial executable path.
+///
+/// ## Why is this bad?
+/// Starting a process with a partial executable path can allow attackers to
+/// execute arbitrary executable by adjusting the `PATH` environment variable.
+/// Consider using a full path to the executable instead.
+///
+/// ## Example
+/// ```python
+/// import subprocess
+///
+/// subprocess.Popen(["ruff", "check", "file.py"])
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import subprocess
+///
+/// subprocess.Popen(["/usr/bin/ruff", "check", "file.py"])
+/// ```
+///
+/// ## References
+/// - [Python documentation: `subprocess.Popen()`](https://docs.python.org/3/library/subprocess.html#subprocess.Popen)
+/// - [Common Weakness Enumeration: CWE-78](https://cwe.mitre.org/data/definitions/78.html)
 #[violation]
 pub struct StartProcessWithPartialPath;
 
@@ -85,6 +110,29 @@ impl Violation for StartProcessWithPartialPath {
     }
 }
 
+/// ## What it does
+/// Checks for possible wildcard injections in calls to `subprocess.Popen()`.
+///
+/// ## Why is this bad?
+/// Wildcard injections can lead to unexpected behavior if unintended files are
+/// matched by the wildcard. Consider using a more specific path instead.
+///
+/// ## Example
+/// ```python
+/// import subprocess
+///
+/// subprocess.Popen(["chmod", "777", "*.py"])
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import subprocess
+///
+/// subprocess.Popen(["chmod", "777", "main.py"])
+/// ```
+///
+/// ## References
+/// - [Common Weakness Enumeration: CWE-78](https://cwe.mitre.org/data/definitions/78.html)
 #[violation]
 pub struct UnixCommandWildcardInjection;
 


### PR DESCRIPTION
## Summary

Completes the documentation for the ruleset, apart from four rules which have contradictions, so need to be thought about more regarding how to document that. Related to #2646.

## Test Plan

`python scripts/test_docs_formatted.py`