### PR TITLE
Add documentation to the `flynt` rules

### DIFF
--- a/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -9,6 +9,24 @@ use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 use crate::rules::flynt::helpers;
 
+/// ## What it does
+/// Checks for `str#join` calls that can be replaced with f-strings.
+///
+/// ## Why is this bad?
+/// f-strings are more readable and generally preferred over `str#join` calls.
+///
+/// ## Example
+/// ```python
+/// " ".join((foo, bar))
+/// ```
+///
+/// Use instead:
+/// ```python
+/// f"{foo} {bar}"
+/// ```
+///
+/// ## References
+/// - [Python documentation: f-strings](https://docs.python.org/3/reference/lexical_analysis.html#f-strings)
 #[violation]
 pub struct StaticJoinToFString {
     expr: String,


### PR DESCRIPTION
## Summary

Completes the documentation for the one and only (current) rule in the `flynt` ruleset. Related to #2646.

## Test Plan

`python scripts/test_docs_formatted.py`