### PR TITLE
[`flake8-bugbear`] Add autofix for B006

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_B008.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_B008.py
@@ -79,6 +79,9 @@ def multiline_arg_wrong(value={
 }):
     ...
 
+def single_line_func_wrong(value = {}): ...
+
+
 def and_this(value=set()):
     ...
 

--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_B008.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_B008.py
@@ -67,11 +67,17 @@ def this_is_wrong(value=[1, 2, 3]):
 def this_is_also_wrong(value={}):
     ...
 
+
 class Foo:
     @staticmethod
     def this_is_also_wrong_and_more_indented(value={}):
         pass
 
+
+def multiline_arg_wrong(value={
+
+}):
+    ...
 
 def and_this(value=set()):
     ...

--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_B008.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_B008.py
@@ -67,6 +67,11 @@ def this_is_wrong(value=[1, 2, 3]):
 def this_is_also_wrong(value={}):
     ...
 
+class Foo:
+    @staticmethod
+    def this_is_also_wrong_and_more_indented(value={}):
+        pass
+
 
 def and_this(value=set()):
     ...

--- a/crates/ruff/src/checkers/ast/analyze/parameters.rs
+++ b/crates/ruff/src/checkers/ast/analyze/parameters.rs
@@ -6,9 +6,6 @@ use crate::rules::{flake8_bugbear, flake8_pyi, ruff};
 
 /// Run lint rules over a [`Parameters`] syntax node.
 pub(crate) fn parameters(parameters: &Parameters, checker: &mut Checker) {
-    if checker.enabled(Rule::MutableArgumentDefault) {
-        flake8_bugbear::rules::mutable_argument_default(checker, parameters);
-    }
     if checker.enabled(Rule::FunctionCallInDefaultArgument) {
         flake8_bugbear::rules::function_call_in_argument_default(checker, parameters);
     }

--- a/crates/ruff/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff/src/checkers/ast/analyze/statement.rs
@@ -204,6 +204,9 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             if checker.enabled(Rule::CachedInstanceMethod) {
                 flake8_bugbear::rules::cached_instance_method(checker, decorator_list);
             }
+            if checker.enabled(Rule::MutableArgumentDefault) {
+                flake8_bugbear::rules::mutable_argument_default(checker, parameters, body);
+            }
             if checker.any_enabled(&[
                 Rule::UnnecessaryReturnNone,
                 Rule::ImplicitReturnValue,

--- a/crates/ruff/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff/src/checkers/ast/analyze/statement.rs
@@ -77,7 +77,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             parameters,
             body,
             type_params,
-            range: _,
+            range,
         }) => {
             if checker.enabled(Rule::DjangoNonLeadingReceiverDecorator) {
                 flake8_django::rules::non_leading_receiver_decorator(checker, decorator_list);
@@ -205,7 +205,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 flake8_bugbear::rules::cached_instance_method(checker, decorator_list);
             }
             if checker.enabled(Rule::MutableArgumentDefault) {
-                flake8_bugbear::rules::mutable_argument_default(checker, parameters, body);
+                flake8_bugbear::rules::mutable_argument_default(checker, parameters, body, *range);
             }
             if checker.any_enabled(&[
                 Rule::UnnecessaryReturnNone,

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -3,7 +3,9 @@ use ruff_python_ast::{ParameterWithDefault, Parameters, Ranged, Stmt};
 use crate::registry::AsRule;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::docstrings::leading_space;
 use ruff_python_semantic::analyze::typing::{is_immutable_annotation, is_mutable_expr};
+use ruff_text_size::TextRange;
 
 use crate::checkers::ast::Checker;
 
@@ -56,7 +58,6 @@ impl AlwaysAutofixableViolation for MutableArgumentDefault {
         format!("Do not use mutable data structures for argument defaults")
     }
     fn autofix_title(&self) -> String {
-        // TODO: Fix message
         format!("Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`")
     }
 }
@@ -67,7 +68,6 @@ pub(crate) fn mutable_argument_default(
     parameters: &Parameters,
     body: &[Stmt],
 ) {
-    let mut invalid_defaults = vec![];
     // Scan in reverse order to right-align zip().
     for ParameterWithDefault {
         parameter,
@@ -89,24 +89,30 @@ pub(crate) fn mutable_argument_default(
                 .as_ref()
                 .is_some_and(|expr| is_immutable_annotation(expr, checker.semantic()))
         {
-            invalid_defaults.push((parameter, default));
             let mut diagnostic = Diagnostic::new(MutableArgumentDefault, default.range());
+
             if checker.patch(diagnostic.kind.rule()) {
+                // Set the default arg value to None
                 let arg_edit = Edit::range_replacement("None".to_string(), default.range());
+
+                // Add conditional check to set the default arg to its original value if still None
                 let mut check_lines = String::new();
+                let indentation = checker.locator().slice(TextRange::new(
+                    checker.locator().line_start(body[0].start()),
+                    body[0].start(),
+                ));
+                let indentation = leading_space(indentation);
                 check_lines.push_str(format!("if {} is None:\n", parameter.name.as_str()).as_str());
-                let indent = checker.stylist().indentation();
-                check_lines.push_str(indent);
-                check_lines.push_str(indent);
                 check_lines.push_str(
                     format!(
-                        "{} = {}\n",
+                        "{}    {} = {}\n{}",
+                        indentation,
                         parameter.name.as_str(),
-                        checker.generator().expr(default)
+                        checker.generator().expr(default),
+                        indentation
                     )
                     .as_str(),
                 );
-                check_lines.push_str(indent);
                 let check_edit = Edit::insertion(check_lines, body[0].start());
 
                 diagnostic.set_fix(Fix::automatic_edits(arg_edit, [check_edit]));

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -102,6 +102,8 @@ pub(crate) fn mutable_argument_default(
                     body[0].start(),
                 ));
                 let indentation = leading_space(indentation);
+                // body[0].start() starts at correct indentation so we do need to add indentation
+                // before pushing the if statement
                 check_lines.push_str(format!("if {} is None:\n", parameter.name.as_str()).as_str());
                 check_lines.push_str(indentation);
                 check_lines.push_str(checker.stylist().indentation());

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -5,6 +5,7 @@ use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::docstrings::leading_space;
 use ruff_python_semantic::analyze::typing::{is_immutable_annotation, is_mutable_expr};
+use ruff_python_trivia::indentation_at_offset;
 use ruff_text_size::TextRange;
 
 use crate::checkers::ast::Checker;
@@ -57,10 +58,12 @@ impl Violation for MutableArgumentDefault {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Do not use mutable data structures for argument defaults")
+        format!("Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`")
     }
     fn autofix_title(&self) -> Option<String> {
-        Some(format!("Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`"))
+        Some(format!(
+            "Do not use mutable data structures for argument defaults"
+        ))
     }
 }
 
@@ -104,10 +107,8 @@ pub(crate) fn mutable_argument_default(
 
                 // Add conditional check to set the default arg to its original value if still None
                 let mut check_lines = String::new();
-                let indentation = checker.locator().slice(TextRange::new(
-                    checker.locator().line_start(body[0].start()),
-                    body[0].start(),
-                ));
+                let indentation =
+                    indentation_at_offset(body[0].start(), checker.locator()).unwrap_or_default();
                 let indentation = leading_space(indentation);
                 // body[0].start() starts at correct indentation so we do need to add indentation
                 // before pushing the if statement

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -1,14 +1,13 @@
-use ruff_python_ast::{ParameterWithDefault, Parameters, Ranged, Stmt};
-
-use crate::registry::AsRule;
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::docstrings::leading_space;
+use ruff_python_ast::{ParameterWithDefault, Parameters, Ranged, Stmt};
 use ruff_python_semantic::analyze::typing::{is_immutable_annotation, is_mutable_expr};
 use ruff_python_trivia::indentation_at_offset;
 use ruff_text_size::TextRange;
 
 use crate::checkers::ast::Checker;
+use crate::registry::AsRule;
 
 /// ## What it does
 /// Checks for uses of mutable objects as function argument defaults.
@@ -99,8 +98,8 @@ pub(crate) fn mutable_argument_default(
             if checker.patch(diagnostic.kind.rule())
                 // Do not try to fix if the function is only one line.
                 && checker
-                    .locator()
-                    .contains_line_break(TextRange::new(parameters.range().end(), body[0].start()))
+                .locator()
+                .contains_line_break(TextRange::new(parameters.range().end(), body[0].start()))
             {
                 // Set the default arg value to None
                 let arg_edit = Edit::range_replacement("None".to_string(), default.range());

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -103,16 +103,18 @@ pub(crate) fn mutable_argument_default(
                 ));
                 let indentation = leading_space(indentation);
                 check_lines.push_str(format!("if {} is None:\n", parameter.name.as_str()).as_str());
+                check_lines.push_str(indentation);
+                check_lines.push_str(checker.stylist().indentation());
                 check_lines.push_str(
                     format!(
-                        "{}    {} = {}\n{}",
-                        indentation,
+                        "{} = {}",
                         parameter.name.as_str(),
                         checker.generator().expr(default),
-                        indentation
                     )
                     .as_str(),
                 );
+                check_lines.push_str(&*checker.stylist().line_ending());
+                check_lines.push_str(indentation);
                 let check_edit = Edit::insertion(check_lines, body[0].start());
 
                 diagnostic.set_fix(Fix::automatic_edits(arg_edit, [check_edit]));

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -113,7 +113,7 @@ pub(crate) fn mutable_argument_default(
                     )
                     .as_str(),
                 );
-                check_lines.push_str(&*checker.stylist().line_ending());
+                check_lines.push_str(&checker.stylist().line_ending());
                 check_lines.push_str(indentation);
                 let check_edit = Edit::insertion(check_lines, body[0].start());
 

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -60,11 +60,11 @@ impl Violation for MutableArgumentDefault {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`")
+        format!("Do not use mutable data structures for argument defaults")
     }
     fn autofix_title(&self) -> Option<String> {
         Some(format!(
-            "Do not use mutable data structures for argument defaults"
+            "Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`"
         ))
     }
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -117,9 +117,9 @@ pub(crate) fn mutable_argument_default(
                 check_lines.push_str(indentation);
                 let check_edit = Edit::insertion(check_lines, body[0].start());
 
-                diagnostic.set_fix(Fix::automatic_edits(arg_edit, [check_edit]));
-                checker.diagnostics.push(diagnostic);
+                diagnostic.set_fix(Fix::manual_edits(arg_edit, [check_edit]));
             }
+            checker.diagnostics.push(diagnostic);
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -1,7 +1,7 @@
 use ruff_python_ast::{ParameterWithDefault, Parameters, Ranged, Stmt};
 
 use crate::registry::AsRule;
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::docstrings::leading_space;
 use ruff_python_semantic::analyze::typing::{is_immutable_annotation, is_mutable_expr};
@@ -52,13 +52,15 @@ use crate::checkers::ast::Checker;
 #[violation]
 pub struct MutableArgumentDefault;
 
-impl AlwaysAutofixableViolation for MutableArgumentDefault {
+impl Violation for MutableArgumentDefault {
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("Do not use mutable data structures for argument defaults")
     }
-    fn autofix_title(&self) -> String {
-        format!("Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`")
+    fn autofix_title(&self) -> Option<String> {
+        Some(format!("Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`"))
     }
 }
 
@@ -91,7 +93,12 @@ pub(crate) fn mutable_argument_default(
         {
             let mut diagnostic = Diagnostic::new(MutableArgumentDefault, default.range());
 
-            if checker.patch(diagnostic.kind.rule()) {
+            if checker.patch(diagnostic.kind.rule())
+                // Do not try to fix if the function is only one line.
+                && checker
+                    .locator()
+                    .contains_line_break(TextRange::new(parameters.range().end(), body[0].start()))
+            {
                 // Set the default arg value to None
                 let arg_edit = Edit::range_replacement("None".to_string(), default.range());
 

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
@@ -9,7 +9,7 @@ B006_B008.py:63:25: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 60 60 | # Flag mutable literals/comprehensions
 61 61 | 
 62 62 | 
@@ -29,7 +29,7 @@ B006_B008.py:67:30: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 64 64 |     ...
 65 65 | 
 66 66 | 
@@ -51,7 +51,7 @@ B006_B008.py:72:52: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 69 69 | 
 70 70 | class Foo:
 71 71 |     @staticmethod
@@ -71,7 +71,7 @@ B006_B008.py:76:20: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 73 73 |         pass
 74 74 | 
 75 75 | 
@@ -91,7 +91,7 @@ B006_B008.py:80:20: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 77 77 |     ...
 78 78 | 
 79 79 | 
@@ -111,7 +111,7 @@ B006_B008.py:84:32: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 81 81 |     ...
 82 82 | 
 83 83 | 
@@ -131,7 +131,7 @@ B006_B008.py:88:26: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 85 85 |     ...
 86 86 | 
 87 87 | 
@@ -152,7 +152,7 @@ B006_B008.py:93:46: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 90 90 | 
 91 91 | 
 92 92 | # N.B. we're also flagging the function call in the comprehension
@@ -172,7 +172,7 @@ B006_B008.py:97:46: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 94  94  |     pass
 95  95  | 
 96  96  | 
@@ -192,7 +192,7 @@ B006_B008.py:101:45: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 98  98  |     pass
 99  99  | 
 100 100 | 
@@ -212,7 +212,7 @@ B006_B008.py:105:33: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 102 102 |     pass
 103 103 | 
 104 104 | 
@@ -234,7 +234,7 @@ B006_B008.py:226:20: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 223 223 | 
 224 224 | # B006 and B008
 225 225 | # We should handle arbitrary nesting of these B008.
@@ -256,7 +256,7 @@ B006_B008.py:263:27: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 260 260 | 
 261 261 | 
 262 262 | def mutable_annotations(
@@ -281,7 +281,7 @@ B006_B008.py:264:35: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 261 261 | 
 262 262 | def mutable_annotations(
 263 263 |     a: list[int] | None = [],
@@ -305,7 +305,7 @@ B006_B008.py:265:62: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 262 262 | def mutable_annotations(
 263 263 |     a: list[int] | None = [],
 264 264 |     b: Optional[Dict[int, int]] = {},
@@ -328,7 +328,7 @@ B006_B008.py:266:80: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-ℹ Fix
+ℹ Possible fix
 263 263 |     a: list[int] | None = [],
 264 264 |     b: Optional[Dict[int, int]] = {},
 265 265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
@@ -1,123 +1,342 @@
 ---
 source: crates/ruff/src/rules/flake8_bugbear/mod.rs
 ---
-B006_B008.py:63:25: B006 Do not use mutable data structures for argument defaults
+B006_B008.py:63:25: B006 [*] Do not use mutable data structures for argument defaults
    |
 63 | def this_is_wrong(value=[1, 2, 3]):
    |                         ^^^^^^^^^ B006
 64 |     ...
    |
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-B006_B008.py:67:30: B006 Do not use mutable data structures for argument defaults
+ℹ Fix
+60 60 | # Flag mutable literals/comprehensions
+61 61 | 
+62 62 | 
+63    |-def this_is_wrong(value=[1, 2, 3]):
+   63 |+def this_is_wrong(value=None):
+   64 |+    if value is None:
+   65 |+        value = [1, 2, 3]
+64 66 |     ...
+65 67 | 
+66 68 | 
+
+B006_B008.py:67:30: B006 [*] Do not use mutable data structures for argument defaults
    |
 67 | def this_is_also_wrong(value={}):
    |                              ^^ B006
 68 |     ...
    |
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-B006_B008.py:71:20: B006 Do not use mutable data structures for argument defaults
+ℹ Fix
+64 64 |     ...
+65 65 | 
+66 66 | 
+67    |-def this_is_also_wrong(value={}):
+   67 |+def this_is_also_wrong(value=None):
+   68 |+    if value is None:
+   69 |+        value = {}
+68 70 |     ...
+69 71 | 
+70 72 | class Foo:
+
+B006_B008.py:72:52: B006 [*] Do not use mutable data structures for argument defaults
    |
-71 | def and_this(value=set()):
+70 | class Foo:
+71 |     @staticmethod
+72 |     def this_is_also_wrong_and_more_indented(value={}):
+   |                                                    ^^ B006
+73 |         pass
+   |
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+
+ℹ Fix
+69 69 | 
+70 70 | class Foo:
+71 71 |     @staticmethod
+72    |-    def this_is_also_wrong_and_more_indented(value={}):
+   72 |+    def this_is_also_wrong_and_more_indented(value=None):
+   73 |+        if value is None:
+   74 |+            value = {}
+73 75 |         pass
+74 76 | 
+75 77 | 
+
+B006_B008.py:76:20: B006 [*] Do not use mutable data structures for argument defaults
+   |
+76 | def and_this(value=set()):
    |                    ^^^^^ B006
-72 |     ...
+77 |     ...
    |
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-B006_B008.py:75:20: B006 Do not use mutable data structures for argument defaults
+ℹ Fix
+73 73 |         pass
+74 74 | 
+75 75 | 
+76    |-def and_this(value=set()):
+   76 |+def and_this(value=None):
+   77 |+    if value is None:
+   78 |+        value = set()
+77 79 |     ...
+78 80 | 
+79 81 | 
+
+B006_B008.py:80:20: B006 [*] Do not use mutable data structures for argument defaults
    |
-75 | def this_too(value=collections.OrderedDict()):
+80 | def this_too(value=collections.OrderedDict()):
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ B006
-76 |     ...
+81 |     ...
    |
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-B006_B008.py:79:32: B006 Do not use mutable data structures for argument defaults
+ℹ Fix
+77 77 |     ...
+78 78 | 
+79 79 | 
+80    |-def this_too(value=collections.OrderedDict()):
+   80 |+def this_too(value=None):
+   81 |+    if value is None:
+   82 |+        value = collections.OrderedDict()
+81 83 |     ...
+82 84 | 
+83 85 | 
+
+B006_B008.py:84:32: B006 [*] Do not use mutable data structures for argument defaults
    |
-79 | async def async_this_too(value=collections.defaultdict()):
+84 | async def async_this_too(value=collections.defaultdict()):
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^ B006
-80 |     ...
+85 |     ...
    |
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-B006_B008.py:83:26: B006 Do not use mutable data structures for argument defaults
+ℹ Fix
+81 81 |     ...
+82 82 | 
+83 83 | 
+84    |-async def async_this_too(value=collections.defaultdict()):
+   84 |+async def async_this_too(value=None):
+   85 |+    if value is None:
+   86 |+        value = collections.defaultdict()
+85 87 |     ...
+86 88 | 
+87 89 | 
+
+B006_B008.py:88:26: B006 [*] Do not use mutable data structures for argument defaults
    |
-83 | def dont_forget_me(value=collections.deque()):
+88 | def dont_forget_me(value=collections.deque()):
    |                          ^^^^^^^^^^^^^^^^^^^ B006
-84 |     ...
+89 |     ...
    |
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-B006_B008.py:88:46: B006 Do not use mutable data structures for argument defaults
+ℹ Fix
+85 85 |     ...
+86 86 | 
+87 87 | 
+88    |-def dont_forget_me(value=collections.deque()):
+   88 |+def dont_forget_me(value=None):
+   89 |+    if value is None:
+   90 |+        value = collections.deque()
+89 91 |     ...
+90 92 | 
+91 93 | 
+
+B006_B008.py:93:46: B006 [*] Do not use mutable data structures for argument defaults
    |
-87 | # N.B. we're also flagging the function call in the comprehension
-88 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
+92 | # N.B. we're also flagging the function call in the comprehension
+93 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^ B006
-89 |     pass
+94 |     pass
    |
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-B006_B008.py:92:46: B006 Do not use mutable data structures for argument defaults
+ℹ Fix
+90 90 | 
+91 91 | 
+92 92 | # N.B. we're also flagging the function call in the comprehension
+93    |-def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
+   93 |+def list_comprehension_also_not_okay(default=None):
+   94 |+    if default is None:
+   95 |+        default = [i ** 2 for i in range(3)]
+94 96 |     pass
+95 97 | 
+96 98 | 
+
+B006_B008.py:97:46: B006 [*] Do not use mutable data structures for argument defaults
    |
-92 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
+97 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ B006
-93 |     pass
+98 |     pass
    |
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-B006_B008.py:96:45: B006 Do not use mutable data structures for argument defaults
-   |
-96 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^ B006
-97 |     pass
-   |
+ℹ Fix
+94  94  |     pass
+95  95  | 
+96  96  | 
+97      |-def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
+    97  |+def dict_comprehension_also_not_okay(default=None):
+    98  |+    if default is None:
+    99  |+        default = {i: i ** 2 for i in range(3)}
+98  100 |     pass
+99  101 | 
+100 102 | 
 
-B006_B008.py:100:33: B006 Do not use mutable data structures for argument defaults
+B006_B008.py:101:45: B006 [*] Do not use mutable data structures for argument defaults
     |
-100 | def kwonlyargs_mutable(*, value=[]):
+101 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
+    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^ B006
+102 |     pass
+    |
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+
+ℹ Fix
+98  98  |     pass
+99  99  | 
+100 100 | 
+101     |-def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
+    101 |+def set_comprehension_also_not_okay(default=None):
+    102 |+    if default is None:
+    103 |+        default = {i ** 2 for i in range(3)}
+102 104 |     pass
+103 105 | 
+104 106 | 
+
+B006_B008.py:105:33: B006 [*] Do not use mutable data structures for argument defaults
+    |
+105 | def kwonlyargs_mutable(*, value=[]):
     |                                 ^^ B006
-101 |     ...
+106 |     ...
     |
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-B006_B008.py:221:20: B006 Do not use mutable data structures for argument defaults
+ℹ Fix
+102 102 |     pass
+103 103 | 
+104 104 | 
+105     |-def kwonlyargs_mutable(*, value=[]):
+    105 |+def kwonlyargs_mutable(*, value=None):
+    106 |+    if value is None:
+    107 |+        value = []
+106 108 |     ...
+107 109 | 
+108 110 | 
+
+B006_B008.py:226:20: B006 [*] Do not use mutable data structures for argument defaults
     |
-219 | # B006 and B008
-220 | # We should handle arbitrary nesting of these B008.
-221 | def nested_combo(a=[float(3), dt.datetime.now()]):
+224 | # B006 and B008
+225 | # We should handle arbitrary nesting of these B008.
+226 | def nested_combo(a=[float(3), dt.datetime.now()]):
     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B006
-222 |     pass
+227 |     pass
     |
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-B006_B008.py:258:27: B006 Do not use mutable data structures for argument defaults
+ℹ Fix
+223 223 | 
+224 224 | # B006 and B008
+225 225 | # We should handle arbitrary nesting of these B008.
+226     |-def nested_combo(a=[float(3), dt.datetime.now()]):
+    226 |+def nested_combo(a=None):
+    227 |+    if a is None:
+    228 |+        a = [float(3), dt.datetime.now()]
+227 229 |     pass
+228 230 | 
+229 231 | 
+
+B006_B008.py:263:27: B006 [*] Do not use mutable data structures for argument defaults
     |
-257 | def mutable_annotations(
-258 |     a: list[int] | None = [],
+262 | def mutable_annotations(
+263 |     a: list[int] | None = [],
     |                           ^^ B006
-259 |     b: Optional[Dict[int, int]] = {},
-260 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+264 |     b: Optional[Dict[int, int]] = {},
+265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-B006_B008.py:259:35: B006 Do not use mutable data structures for argument defaults
+ℹ Fix
+260 260 | 
+261 261 | 
+262 262 | def mutable_annotations(
+263     |-    a: list[int] | None = [],
+    263 |+    a: list[int] | None = None,
+264 264 |     b: Optional[Dict[int, int]] = {},
+265 265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+266 266 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+267 267 | ):
+    268 |+    if a is None:
+    269 |+        a = []
+268 270 |     pass
+
+B006_B008.py:264:35: B006 [*] Do not use mutable data structures for argument defaults
     |
-257 | def mutable_annotations(
-258 |     a: list[int] | None = [],
-259 |     b: Optional[Dict[int, int]] = {},
+262 | def mutable_annotations(
+263 |     a: list[int] | None = [],
+264 |     b: Optional[Dict[int, int]] = {},
     |                                   ^^ B006
-260 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-261 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+266 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-B006_B008.py:260:62: B006 Do not use mutable data structures for argument defaults
+ℹ Fix
+261 261 | 
+262 262 | def mutable_annotations(
+263 263 |     a: list[int] | None = [],
+264     |-    b: Optional[Dict[int, int]] = {},
+    264 |+    b: Optional[Dict[int, int]] = None,
+265 265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+266 266 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+267 267 | ):
+    268 |+    if b is None:
+    269 |+        b = {}
+268 270 |     pass
+
+B006_B008.py:265:62: B006 [*] Do not use mutable data structures for argument defaults
     |
-258 |     a: list[int] | None = [],
-259 |     b: Optional[Dict[int, int]] = {},
-260 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+263 |     a: list[int] | None = [],
+264 |     b: Optional[Dict[int, int]] = {},
+265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |                                                              ^^^^^ B006
-261 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-262 | ):
+266 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+267 | ):
     |
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-B006_B008.py:261:80: B006 Do not use mutable data structures for argument defaults
+ℹ Fix
+262 262 | def mutable_annotations(
+263 263 |     a: list[int] | None = [],
+264 264 |     b: Optional[Dict[int, int]] = {},
+265     |-    c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+    265 |+    c: Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
+266 266 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+267 267 | ):
+    268 |+    if c is None:
+    269 |+        c = set()
+268 270 |     pass
+
+B006_B008.py:266:80: B006 [*] Do not use mutable data structures for argument defaults
     |
-259 |     b: Optional[Dict[int, int]] = {},
-260 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-261 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+264 |     b: Optional[Dict[int, int]] = {},
+265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+266 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |                                                                                ^^^^^ B006
-262 | ):
-263 |     pass
+267 | ):
+268 |     pass
     |
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+
+ℹ Fix
+263 263 |     a: list[int] | None = [],
+264 264 |     b: Optional[Dict[int, int]] = {},
+265 265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+266     |-    d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+    266 |+    d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
+267 267 | ):
+    268 |+    if d is None:
+    269 |+        d = set()
+268 270 |     pass
 
 

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/ruff/src/rules/flake8_bugbear/mod.rs
 ---
-B006_B008.py:63:25: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:63:25: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
    |
 63 | def this_is_wrong(value=[1, 2, 3]):
    |                         ^^^^^^^^^ B006
 64 |     ...
    |
-   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+   = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 60 60 | # Flag mutable literals/comprehensions
@@ -21,13 +21,13 @@ B006_B008.py:63:25: B006 [*] Do not use mutable data structures for argument def
 65 67 | 
 66 68 | 
 
-B006_B008.py:67:30: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:67:30: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
    |
 67 | def this_is_also_wrong(value={}):
    |                              ^^ B006
 68 |     ...
    |
-   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+   = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 64 64 |     ...
@@ -41,7 +41,7 @@ B006_B008.py:67:30: B006 [*] Do not use mutable data structures for argument def
 69 71 | 
 70 72 | 
 
-B006_B008.py:73:52: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:73:52: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
    |
 71 | class Foo:
 72 |     @staticmethod
@@ -49,7 +49,7 @@ B006_B008.py:73:52: B006 [*] Do not use mutable data structures for argument def
    |                                                    ^^ B006
 74 |         pass
    |
-   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+   = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 70 70 | 
@@ -63,7 +63,7 @@ B006_B008.py:73:52: B006 [*] Do not use mutable data structures for argument def
 75 77 | 
 76 78 | 
 
-B006_B008.py:77:31: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:77:31: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
    |
 77 |   def multiline_arg_wrong(value={
    |  _______________________________^
@@ -72,7 +72,7 @@ B006_B008.py:77:31: B006 [*] Do not use mutable data structures for argument def
    | |_^ B006
 80 |       ...
    |
-   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+   = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 74 74 |         pass
@@ -88,22 +88,22 @@ B006_B008.py:77:31: B006 [*] Do not use mutable data structures for argument def
 81 81 | 
 82 82 | def single_line_func_wrong(value = {}): ...
 
-B006_B008.py:82:36: B006 Do not use mutable data structures for argument defaults
+B006_B008.py:82:36: B006 Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
    |
 80 |     ...
 81 | 
 82 | def single_line_func_wrong(value = {}): ...
    |                                    ^^ B006
    |
-   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+   = help: Do not use mutable data structures for argument defaults
 
-B006_B008.py:85:20: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:85:20: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
    |
 85 | def and_this(value=set()):
    |                    ^^^^^ B006
 86 |     ...
    |
-   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+   = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 82 82 | def single_line_func_wrong(value = {}): ...
@@ -117,13 +117,13 @@ B006_B008.py:85:20: B006 [*] Do not use mutable data structures for argument def
 87 89 | 
 88 90 | 
 
-B006_B008.py:89:20: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:89:20: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
    |
 89 | def this_too(value=collections.OrderedDict()):
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ B006
 90 |     ...
    |
-   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+   = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 86 86 |     ...
@@ -137,13 +137,13 @@ B006_B008.py:89:20: B006 [*] Do not use mutable data structures for argument def
 91 93 | 
 92 94 | 
 
-B006_B008.py:93:32: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:93:32: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
    |
 93 | async def async_this_too(value=collections.defaultdict()):
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^ B006
 94 |     ...
    |
-   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+   = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 90 90 |     ...
@@ -157,13 +157,13 @@ B006_B008.py:93:32: B006 [*] Do not use mutable data structures for argument def
 95 97 | 
 96 98 | 
 
-B006_B008.py:97:26: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:97:26: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
    |
 97 | def dont_forget_me(value=collections.deque()):
    |                          ^^^^^^^^^^^^^^^^^^^ B006
 98 |     ...
    |
-   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+   = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 94  94  |     ...
@@ -177,14 +177,14 @@ B006_B008.py:97:26: B006 [*] Do not use mutable data structures for argument def
 99  101 | 
 100 102 | 
 
-B006_B008.py:102:46: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:102:46: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
     |
 101 | # N.B. we're also flagging the function call in the comprehension
 102 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
     |                                              ^^^^^^^^^^^^^^^^^^^^^^^^ B006
 103 |     pass
     |
-    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+    = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 99  99  | 
@@ -198,13 +198,13 @@ B006_B008.py:102:46: B006 [*] Do not use mutable data structures for argument de
 104 106 | 
 105 107 | 
 
-B006_B008.py:106:46: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:106:46: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
     |
 106 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
     |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ B006
 107 |     pass
     |
-    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+    = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 103 103 |     pass
@@ -218,13 +218,13 @@ B006_B008.py:106:46: B006 [*] Do not use mutable data structures for argument de
 108 110 | 
 109 111 | 
 
-B006_B008.py:110:45: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:110:45: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
     |
 110 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
     |                                             ^^^^^^^^^^^^^^^^^^^^^^^^ B006
 111 |     pass
     |
-    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+    = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 107 107 |     pass
@@ -238,13 +238,13 @@ B006_B008.py:110:45: B006 [*] Do not use mutable data structures for argument de
 112 114 | 
 113 115 | 
 
-B006_B008.py:114:33: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:114:33: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
     |
 114 | def kwonlyargs_mutable(*, value=[]):
     |                                 ^^ B006
 115 |     ...
     |
-    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+    = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 111 111 |     pass
@@ -258,7 +258,7 @@ B006_B008.py:114:33: B006 [*] Do not use mutable data structures for argument de
 116 118 | 
 117 119 | 
 
-B006_B008.py:235:20: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:235:20: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
     |
 233 | # B006 and B008
 234 | # We should handle arbitrary nesting of these B008.
@@ -266,7 +266,7 @@ B006_B008.py:235:20: B006 [*] Do not use mutable data structures for argument de
     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B006
 236 |     pass
     |
-    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+    = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 232 232 | 
@@ -280,7 +280,7 @@ B006_B008.py:235:20: B006 [*] Do not use mutable data structures for argument de
 237 239 | 
 238 240 | 
 
-B006_B008.py:272:27: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:272:27: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
     |
 271 | def mutable_annotations(
 272 |     a: list[int] | None = [],
@@ -288,7 +288,7 @@ B006_B008.py:272:27: B006 [*] Do not use mutable data structures for argument de
 273 |     b: Optional[Dict[int, int]] = {},
 274 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
-    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+    = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 269 269 | 
@@ -304,7 +304,7 @@ B006_B008.py:272:27: B006 [*] Do not use mutable data structures for argument de
     278 |+        a = []
 277 279 |     pass
 
-B006_B008.py:273:35: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:273:35: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
     |
 271 | def mutable_annotations(
 272 |     a: list[int] | None = [],
@@ -313,7 +313,7 @@ B006_B008.py:273:35: B006 [*] Do not use mutable data structures for argument de
 274 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
 275 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
-    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+    = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 270 270 | 
@@ -328,7 +328,7 @@ B006_B008.py:273:35: B006 [*] Do not use mutable data structures for argument de
     278 |+        b = {}
 277 279 |     pass
 
-B006_B008.py:274:62: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:274:62: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
     |
 272 |     a: list[int] | None = [],
 273 |     b: Optional[Dict[int, int]] = {},
@@ -337,7 +337,7 @@ B006_B008.py:274:62: B006 [*] Do not use mutable data structures for argument de
 275 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
 276 | ):
     |
-    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+    = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 271 271 | def mutable_annotations(
@@ -351,7 +351,7 @@ B006_B008.py:274:62: B006 [*] Do not use mutable data structures for argument de
     278 |+        c = set()
 277 279 |     pass
 
-B006_B008.py:275:80: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:275:80: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
     |
 273 |     b: Optional[Dict[int, int]] = {},
 274 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
@@ -360,7 +360,7 @@ B006_B008.py:275:80: B006 [*] Do not use mutable data structures for argument de
 276 | ):
 277 |     pass
     |
-    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+    = help: Do not use mutable data structures for argument defaults
 
 ℹ Possible fix
 272 272 |     a: list[int] | None = [],

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/ruff/src/rules/flake8_bugbear/mod.rs
 ---
-B006_B008.py:63:25: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:63:25: B006 [*] Do not use mutable data structures for argument defaults
    |
 63 | def this_is_wrong(value=[1, 2, 3]):
    |                         ^^^^^^^^^ B006
 64 |     ...
    |
-   = help: Do not use mutable data structures for argument defaults
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 60 60 | # Flag mutable literals/comprehensions
@@ -21,13 +21,13 @@ B006_B008.py:63:25: B006 [*] Replace mutable data structure with `None` in argum
 65 67 | 
 66 68 | 
 
-B006_B008.py:67:30: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:67:30: B006 [*] Do not use mutable data structures for argument defaults
    |
 67 | def this_is_also_wrong(value={}):
    |                              ^^ B006
 68 |     ...
    |
-   = help: Do not use mutable data structures for argument defaults
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 64 64 |     ...
@@ -41,7 +41,7 @@ B006_B008.py:67:30: B006 [*] Replace mutable data structure with `None` in argum
 69 71 | 
 70 72 | 
 
-B006_B008.py:73:52: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:73:52: B006 [*] Do not use mutable data structures for argument defaults
    |
 71 | class Foo:
 72 |     @staticmethod
@@ -49,7 +49,7 @@ B006_B008.py:73:52: B006 [*] Replace mutable data structure with `None` in argum
    |                                                    ^^ B006
 74 |         pass
    |
-   = help: Do not use mutable data structures for argument defaults
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 70 70 | 
@@ -63,7 +63,7 @@ B006_B008.py:73:52: B006 [*] Replace mutable data structure with `None` in argum
 75 77 | 
 76 78 | 
 
-B006_B008.py:77:31: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:77:31: B006 [*] Do not use mutable data structures for argument defaults
    |
 77 |   def multiline_arg_wrong(value={
    |  _______________________________^
@@ -72,7 +72,7 @@ B006_B008.py:77:31: B006 [*] Replace mutable data structure with `None` in argum
    | |_^ B006
 80 |       ...
    |
-   = help: Do not use mutable data structures for argument defaults
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 74 74 |         pass
@@ -88,22 +88,22 @@ B006_B008.py:77:31: B006 [*] Replace mutable data structure with `None` in argum
 81 81 | 
 82 82 | def single_line_func_wrong(value = {}): ...
 
-B006_B008.py:82:36: B006 Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:82:36: B006 Do not use mutable data structures for argument defaults
    |
 80 |     ...
 81 | 
 82 | def single_line_func_wrong(value = {}): ...
    |                                    ^^ B006
    |
-   = help: Do not use mutable data structures for argument defaults
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
-B006_B008.py:85:20: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:85:20: B006 [*] Do not use mutable data structures for argument defaults
    |
 85 | def and_this(value=set()):
    |                    ^^^^^ B006
 86 |     ...
    |
-   = help: Do not use mutable data structures for argument defaults
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 82 82 | def single_line_func_wrong(value = {}): ...
@@ -117,13 +117,13 @@ B006_B008.py:85:20: B006 [*] Replace mutable data structure with `None` in argum
 87 89 | 
 88 90 | 
 
-B006_B008.py:89:20: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:89:20: B006 [*] Do not use mutable data structures for argument defaults
    |
 89 | def this_too(value=collections.OrderedDict()):
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ B006
 90 |     ...
    |
-   = help: Do not use mutable data structures for argument defaults
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 86 86 |     ...
@@ -137,13 +137,13 @@ B006_B008.py:89:20: B006 [*] Replace mutable data structure with `None` in argum
 91 93 | 
 92 94 | 
 
-B006_B008.py:93:32: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:93:32: B006 [*] Do not use mutable data structures for argument defaults
    |
 93 | async def async_this_too(value=collections.defaultdict()):
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^ B006
 94 |     ...
    |
-   = help: Do not use mutable data structures for argument defaults
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 90 90 |     ...
@@ -157,13 +157,13 @@ B006_B008.py:93:32: B006 [*] Replace mutable data structure with `None` in argum
 95 97 | 
 96 98 | 
 
-B006_B008.py:97:26: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:97:26: B006 [*] Do not use mutable data structures for argument defaults
    |
 97 | def dont_forget_me(value=collections.deque()):
    |                          ^^^^^^^^^^^^^^^^^^^ B006
 98 |     ...
    |
-   = help: Do not use mutable data structures for argument defaults
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 94  94  |     ...
@@ -177,14 +177,14 @@ B006_B008.py:97:26: B006 [*] Replace mutable data structure with `None` in argum
 99  101 | 
 100 102 | 
 
-B006_B008.py:102:46: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:102:46: B006 [*] Do not use mutable data structures for argument defaults
     |
 101 | # N.B. we're also flagging the function call in the comprehension
 102 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
     |                                              ^^^^^^^^^^^^^^^^^^^^^^^^ B006
 103 |     pass
     |
-    = help: Do not use mutable data structures for argument defaults
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 99  99  | 
@@ -198,13 +198,13 @@ B006_B008.py:102:46: B006 [*] Replace mutable data structure with `None` in argu
 104 106 | 
 105 107 | 
 
-B006_B008.py:106:46: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:106:46: B006 [*] Do not use mutable data structures for argument defaults
     |
 106 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
     |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ B006
 107 |     pass
     |
-    = help: Do not use mutable data structures for argument defaults
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 103 103 |     pass
@@ -218,13 +218,13 @@ B006_B008.py:106:46: B006 [*] Replace mutable data structure with `None` in argu
 108 110 | 
 109 111 | 
 
-B006_B008.py:110:45: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:110:45: B006 [*] Do not use mutable data structures for argument defaults
     |
 110 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
     |                                             ^^^^^^^^^^^^^^^^^^^^^^^^ B006
 111 |     pass
     |
-    = help: Do not use mutable data structures for argument defaults
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 107 107 |     pass
@@ -238,13 +238,13 @@ B006_B008.py:110:45: B006 [*] Replace mutable data structure with `None` in argu
 112 114 | 
 113 115 | 
 
-B006_B008.py:114:33: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:114:33: B006 [*] Do not use mutable data structures for argument defaults
     |
 114 | def kwonlyargs_mutable(*, value=[]):
     |                                 ^^ B006
 115 |     ...
     |
-    = help: Do not use mutable data structures for argument defaults
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 111 111 |     pass
@@ -258,7 +258,7 @@ B006_B008.py:114:33: B006 [*] Replace mutable data structure with `None` in argu
 116 118 | 
 117 119 | 
 
-B006_B008.py:235:20: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:235:20: B006 [*] Do not use mutable data structures for argument defaults
     |
 233 | # B006 and B008
 234 | # We should handle arbitrary nesting of these B008.
@@ -266,7 +266,7 @@ B006_B008.py:235:20: B006 [*] Replace mutable data structure with `None` in argu
     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B006
 236 |     pass
     |
-    = help: Do not use mutable data structures for argument defaults
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 232 232 | 
@@ -280,7 +280,7 @@ B006_B008.py:235:20: B006 [*] Replace mutable data structure with `None` in argu
 237 239 | 
 238 240 | 
 
-B006_B008.py:272:27: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:272:27: B006 [*] Do not use mutable data structures for argument defaults
     |
 271 | def mutable_annotations(
 272 |     a: list[int] | None = [],
@@ -288,7 +288,7 @@ B006_B008.py:272:27: B006 [*] Replace mutable data structure with `None` in argu
 273 |     b: Optional[Dict[int, int]] = {},
 274 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
-    = help: Do not use mutable data structures for argument defaults
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 269 269 | 
@@ -304,7 +304,7 @@ B006_B008.py:272:27: B006 [*] Replace mutable data structure with `None` in argu
     278 |+        a = []
 277 279 |     pass
 
-B006_B008.py:273:35: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:273:35: B006 [*] Do not use mutable data structures for argument defaults
     |
 271 | def mutable_annotations(
 272 |     a: list[int] | None = [],
@@ -313,7 +313,7 @@ B006_B008.py:273:35: B006 [*] Replace mutable data structure with `None` in argu
 274 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
 275 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
-    = help: Do not use mutable data structures for argument defaults
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 270 270 | 
@@ -328,7 +328,7 @@ B006_B008.py:273:35: B006 [*] Replace mutable data structure with `None` in argu
     278 |+        b = {}
 277 279 |     pass
 
-B006_B008.py:274:62: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:274:62: B006 [*] Do not use mutable data structures for argument defaults
     |
 272 |     a: list[int] | None = [],
 273 |     b: Optional[Dict[int, int]] = {},
@@ -337,7 +337,7 @@ B006_B008.py:274:62: B006 [*] Replace mutable data structure with `None` in argu
 275 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
 276 | ):
     |
-    = help: Do not use mutable data structures for argument defaults
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 271 271 | def mutable_annotations(
@@ -351,7 +351,7 @@ B006_B008.py:274:62: B006 [*] Replace mutable data structure with `None` in argu
     278 |+        c = set()
 277 279 |     pass
 
-B006_B008.py:275:80: B006 [*] Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:275:80: B006 [*] Do not use mutable data structures for argument defaults
     |
 273 |     b: Optional[Dict[int, int]] = {},
 274 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
@@ -360,7 +360,7 @@ B006_B008.py:275:80: B006 [*] Replace mutable data structure with `None` in argu
 276 | ):
 277 |     pass
     |
-    = help: Do not use mutable data structures for argument defaults
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
 272 272 |     a: list[int] | None = [],

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
@@ -39,304 +39,331 @@ B006_B008.py:67:30: B006 [*] Do not use mutable data structures for argument def
    69 |+        value = {}
 68 70 |     ...
 69 71 | 
-70 72 | class Foo:
+70 72 | 
 
-B006_B008.py:72:52: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:73:52: B006 [*] Do not use mutable data structures for argument defaults
    |
-70 | class Foo:
-71 |     @staticmethod
-72 |     def this_is_also_wrong_and_more_indented(value={}):
+71 | class Foo:
+72 |     @staticmethod
+73 |     def this_is_also_wrong_and_more_indented(value={}):
    |                                                    ^^ B006
-73 |         pass
+74 |         pass
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-69 69 | 
-70 70 | class Foo:
-71 71 |     @staticmethod
-72    |-    def this_is_also_wrong_and_more_indented(value={}):
-   72 |+    def this_is_also_wrong_and_more_indented(value=None):
-   73 |+        if value is None:
-   74 |+            value = {}
-73 75 |         pass
-74 76 | 
+70 70 | 
+71 71 | class Foo:
+72 72 |     @staticmethod
+73    |-    def this_is_also_wrong_and_more_indented(value={}):
+   73 |+    def this_is_also_wrong_and_more_indented(value=None):
+   74 |+        if value is None:
+   75 |+            value = {}
+74 76 |         pass
 75 77 | 
+76 78 | 
 
-B006_B008.py:76:20: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:77:31: B006 [*] Do not use mutable data structures for argument defaults
    |
-76 | def and_this(value=set()):
-   |                    ^^^^^ B006
-77 |     ...
+77 |   def multiline_arg_wrong(value={
+   |  _______________________________^
+78 | | 
+79 | | }):
+   | |_^ B006
+80 |       ...
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-73 73 |         pass
-74 74 | 
+74 74 |         pass
 75 75 | 
-76    |-def and_this(value=set()):
-   76 |+def and_this(value=None):
-   77 |+    if value is None:
-   78 |+        value = set()
-77 79 |     ...
-78 80 | 
-79 81 | 
+76 76 | 
+77    |-def multiline_arg_wrong(value={
+78    |-
+79    |-}):
+   77 |+def multiline_arg_wrong(value=None):
+   78 |+    if value is None:
+   79 |+        value = {}
+80 80 |     ...
+81 81 | 
+82 82 | def and_this(value=set()):
 
-B006_B008.py:80:20: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:82:20: B006 [*] Do not use mutable data structures for argument defaults
    |
-80 | def this_too(value=collections.OrderedDict()):
+80 |     ...
+81 | 
+82 | def and_this(value=set()):
+   |                    ^^^^^ B006
+83 |     ...
+   |
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+
+ℹ Possible fix
+79 79 | }):
+80 80 |     ...
+81 81 | 
+82    |-def and_this(value=set()):
+   82 |+def and_this(value=None):
+   83 |+    if value is None:
+   84 |+        value = set()
+83 85 |     ...
+84 86 | 
+85 87 | 
+
+B006_B008.py:86:20: B006 [*] Do not use mutable data structures for argument defaults
+   |
+86 | def this_too(value=collections.OrderedDict()):
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ B006
-81 |     ...
+87 |     ...
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-77 77 |     ...
-78 78 | 
-79 79 | 
-80    |-def this_too(value=collections.OrderedDict()):
-   80 |+def this_too(value=None):
-   81 |+    if value is None:
-   82 |+        value = collections.OrderedDict()
-81 83 |     ...
-82 84 | 
-83 85 | 
+83 83 |     ...
+84 84 | 
+85 85 | 
+86    |-def this_too(value=collections.OrderedDict()):
+   86 |+def this_too(value=None):
+   87 |+    if value is None:
+   88 |+        value = collections.OrderedDict()
+87 89 |     ...
+88 90 | 
+89 91 | 
 
-B006_B008.py:84:32: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:90:32: B006 [*] Do not use mutable data structures for argument defaults
    |
-84 | async def async_this_too(value=collections.defaultdict()):
+90 | async def async_this_too(value=collections.defaultdict()):
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^ B006
-85 |     ...
+91 |     ...
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-81 81 |     ...
-82 82 | 
-83 83 | 
-84    |-async def async_this_too(value=collections.defaultdict()):
-   84 |+async def async_this_too(value=None):
-   85 |+    if value is None:
-   86 |+        value = collections.defaultdict()
-85 87 |     ...
-86 88 | 
-87 89 | 
+87 87 |     ...
+88 88 | 
+89 89 | 
+90    |-async def async_this_too(value=collections.defaultdict()):
+   90 |+async def async_this_too(value=None):
+   91 |+    if value is None:
+   92 |+        value = collections.defaultdict()
+91 93 |     ...
+92 94 | 
+93 95 | 
 
-B006_B008.py:88:26: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:94:26: B006 [*] Do not use mutable data structures for argument defaults
    |
-88 | def dont_forget_me(value=collections.deque()):
+94 | def dont_forget_me(value=collections.deque()):
    |                          ^^^^^^^^^^^^^^^^^^^ B006
-89 |     ...
+95 |     ...
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-85 85 |     ...
-86 86 | 
-87 87 | 
-88    |-def dont_forget_me(value=collections.deque()):
-   88 |+def dont_forget_me(value=None):
-   89 |+    if value is None:
-   90 |+        value = collections.deque()
-89 91 |     ...
-90 92 | 
-91 93 | 
-
-B006_B008.py:93:46: B006 [*] Do not use mutable data structures for argument defaults
-   |
-92 | # N.B. we're also flagging the function call in the comprehension
-93 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^ B006
-94 |     pass
-   |
-   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
-
-ℹ Possible fix
-90 90 | 
-91 91 | 
-92 92 | # N.B. we're also flagging the function call in the comprehension
-93    |-def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
-   93 |+def list_comprehension_also_not_okay(default=None):
-   94 |+    if default is None:
-   95 |+        default = [i ** 2 for i in range(3)]
-94 96 |     pass
-95 97 | 
+91 91 |     ...
+92 92 | 
+93 93 | 
+94    |-def dont_forget_me(value=collections.deque()):
+   94 |+def dont_forget_me(value=None):
+   95 |+    if value is None:
+   96 |+        value = collections.deque()
+95 97 |     ...
 96 98 | 
+97 99 | 
 
-B006_B008.py:97:46: B006 [*] Do not use mutable data structures for argument defaults
-   |
-97 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ B006
-98 |     pass
-   |
-   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:99:46: B006 [*] Do not use mutable data structures for argument defaults
+    |
+ 98 | # N.B. we're also flagging the function call in the comprehension
+ 99 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
+    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^ B006
+100 |     pass
+    |
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-94  94  |     pass
-95  95  | 
 96  96  | 
-97      |-def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
-    97  |+def dict_comprehension_also_not_okay(default=None):
-    98  |+    if default is None:
-    99  |+        default = {i: i ** 2 for i in range(3)}
-98  100 |     pass
-99  101 | 
-100 102 | 
+97  97  | 
+98  98  | # N.B. we're also flagging the function call in the comprehension
+99      |-def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
+    99  |+def list_comprehension_also_not_okay(default=None):
+    100 |+    if default is None:
+    101 |+        default = [i ** 2 for i in range(3)]
+100 102 |     pass
+101 103 | 
+102 104 | 
 
-B006_B008.py:101:45: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:103:46: B006 [*] Do not use mutable data structures for argument defaults
     |
-101 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
+103 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
+    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ B006
+104 |     pass
+    |
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+
+ℹ Possible fix
+100 100 |     pass
+101 101 | 
+102 102 | 
+103     |-def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
+    103 |+def dict_comprehension_also_not_okay(default=None):
+    104 |+    if default is None:
+    105 |+        default = {i: i ** 2 for i in range(3)}
+104 106 |     pass
+105 107 | 
+106 108 | 
+
+B006_B008.py:107:45: B006 [*] Do not use mutable data structures for argument defaults
+    |
+107 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
     |                                             ^^^^^^^^^^^^^^^^^^^^^^^^ B006
-102 |     pass
+108 |     pass
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-98  98  |     pass
-99  99  | 
-100 100 | 
-101     |-def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
-    101 |+def set_comprehension_also_not_okay(default=None):
-    102 |+    if default is None:
-    103 |+        default = {i ** 2 for i in range(3)}
-102 104 |     pass
-103 105 | 
-104 106 | 
+104 104 |     pass
+105 105 | 
+106 106 | 
+107     |-def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
+    107 |+def set_comprehension_also_not_okay(default=None):
+    108 |+    if default is None:
+    109 |+        default = {i ** 2 for i in range(3)}
+108 110 |     pass
+109 111 | 
+110 112 | 
 
-B006_B008.py:105:33: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:111:33: B006 [*] Do not use mutable data structures for argument defaults
     |
-105 | def kwonlyargs_mutable(*, value=[]):
+111 | def kwonlyargs_mutable(*, value=[]):
     |                                 ^^ B006
-106 |     ...
+112 |     ...
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-102 102 |     pass
-103 103 | 
-104 104 | 
-105     |-def kwonlyargs_mutable(*, value=[]):
-    105 |+def kwonlyargs_mutable(*, value=None):
-    106 |+    if value is None:
-    107 |+        value = []
-106 108 |     ...
-107 109 | 
-108 110 | 
+108 108 |     pass
+109 109 | 
+110 110 | 
+111     |-def kwonlyargs_mutable(*, value=[]):
+    111 |+def kwonlyargs_mutable(*, value=None):
+    112 |+    if value is None:
+    113 |+        value = []
+112 114 |     ...
+113 115 | 
+114 116 | 
 
-B006_B008.py:226:20: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:232:20: B006 [*] Do not use mutable data structures for argument defaults
     |
-224 | # B006 and B008
-225 | # We should handle arbitrary nesting of these B008.
-226 | def nested_combo(a=[float(3), dt.datetime.now()]):
+230 | # B006 and B008
+231 | # We should handle arbitrary nesting of these B008.
+232 | def nested_combo(a=[float(3), dt.datetime.now()]):
     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B006
-227 |     pass
+233 |     pass
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-223 223 | 
-224 224 | # B006 and B008
-225 225 | # We should handle arbitrary nesting of these B008.
-226     |-def nested_combo(a=[float(3), dt.datetime.now()]):
-    226 |+def nested_combo(a=None):
-    227 |+    if a is None:
-    228 |+        a = [float(3), dt.datetime.now()]
-227 229 |     pass
-228 230 | 
-229 231 | 
+229 229 | 
+230 230 | # B006 and B008
+231 231 | # We should handle arbitrary nesting of these B008.
+232     |-def nested_combo(a=[float(3), dt.datetime.now()]):
+    232 |+def nested_combo(a=None):
+    233 |+    if a is None:
+    234 |+        a = [float(3), dt.datetime.now()]
+233 235 |     pass
+234 236 | 
+235 237 | 
 
-B006_B008.py:263:27: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:269:27: B006 [*] Do not use mutable data structures for argument defaults
     |
-262 | def mutable_annotations(
-263 |     a: list[int] | None = [],
+268 | def mutable_annotations(
+269 |     a: list[int] | None = [],
     |                           ^^ B006
-264 |     b: Optional[Dict[int, int]] = {},
-265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+270 |     b: Optional[Dict[int, int]] = {},
+271 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-260 260 | 
-261 261 | 
-262 262 | def mutable_annotations(
-263     |-    a: list[int] | None = [],
-    263 |+    a: list[int] | None = None,
-264 264 |     b: Optional[Dict[int, int]] = {},
-265 265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-266 266 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-267 267 | ):
-    268 |+    if a is None:
-    269 |+        a = []
-268 270 |     pass
+266 266 | 
+267 267 | 
+268 268 | def mutable_annotations(
+269     |-    a: list[int] | None = [],
+    269 |+    a: list[int] | None = None,
+270 270 |     b: Optional[Dict[int, int]] = {},
+271 271 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+272 272 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+273 273 | ):
+    274 |+    if a is None:
+    275 |+        a = []
+274 276 |     pass
 
-B006_B008.py:264:35: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:270:35: B006 [*] Do not use mutable data structures for argument defaults
     |
-262 | def mutable_annotations(
-263 |     a: list[int] | None = [],
-264 |     b: Optional[Dict[int, int]] = {},
+268 | def mutable_annotations(
+269 |     a: list[int] | None = [],
+270 |     b: Optional[Dict[int, int]] = {},
     |                                   ^^ B006
-265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-266 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+271 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+272 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-261 261 | 
-262 262 | def mutable_annotations(
-263 263 |     a: list[int] | None = [],
-264     |-    b: Optional[Dict[int, int]] = {},
-    264 |+    b: Optional[Dict[int, int]] = None,
-265 265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-266 266 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-267 267 | ):
-    268 |+    if b is None:
-    269 |+        b = {}
-268 270 |     pass
+267 267 | 
+268 268 | def mutable_annotations(
+269 269 |     a: list[int] | None = [],
+270     |-    b: Optional[Dict[int, int]] = {},
+    270 |+    b: Optional[Dict[int, int]] = None,
+271 271 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+272 272 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+273 273 | ):
+    274 |+    if b is None:
+    275 |+        b = {}
+274 276 |     pass
 
-B006_B008.py:265:62: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:271:62: B006 [*] Do not use mutable data structures for argument defaults
     |
-263 |     a: list[int] | None = [],
-264 |     b: Optional[Dict[int, int]] = {},
-265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+269 |     a: list[int] | None = [],
+270 |     b: Optional[Dict[int, int]] = {},
+271 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |                                                              ^^^^^ B006
-266 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-267 | ):
+272 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+273 | ):
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-262 262 | def mutable_annotations(
-263 263 |     a: list[int] | None = [],
-264 264 |     b: Optional[Dict[int, int]] = {},
-265     |-    c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-    265 |+    c: Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
-266 266 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-267 267 | ):
-    268 |+    if c is None:
-    269 |+        c = set()
-268 270 |     pass
+268 268 | def mutable_annotations(
+269 269 |     a: list[int] | None = [],
+270 270 |     b: Optional[Dict[int, int]] = {},
+271     |-    c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+    271 |+    c: Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
+272 272 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+273 273 | ):
+    274 |+    if c is None:
+    275 |+        c = set()
+274 276 |     pass
 
-B006_B008.py:266:80: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:272:80: B006 [*] Do not use mutable data structures for argument defaults
     |
-264 |     b: Optional[Dict[int, int]] = {},
-265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-266 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+270 |     b: Optional[Dict[int, int]] = {},
+271 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+272 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |                                                                                ^^^^^ B006
-267 | ):
-268 |     pass
+273 | ):
+274 |     pass
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-263 263 |     a: list[int] | None = [],
-264 264 |     b: Optional[Dict[int, int]] = {},
-265 265 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-266     |-    d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-    266 |+    d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
-267 267 | ):
-    268 |+    if d is None:
-    269 |+        d = set()
-268 270 |     pass
+269 269 |     a: list[int] | None = [],
+270 270 |     b: Optional[Dict[int, int]] = {},
+271 271 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+272     |-    d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+    272 |+    d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
+273 273 | ):
+    274 |+    if d is None:
+    275 |+        d = set()
+274 276 |     pass
 
 

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
@@ -86,284 +86,291 @@ B006_B008.py:77:31: B006 [*] Do not use mutable data structures for argument def
    79 |+        value = {}
 80 80 |     ...
 81 81 | 
-82 82 | def and_this(value=set()):
+82 82 | def single_line_func_wrong(value = {}): ...
 
-B006_B008.py:82:20: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:82:36: B006 Do not use mutable data structures for argument defaults
    |
 80 |     ...
 81 | 
-82 | def and_this(value=set()):
+82 | def single_line_func_wrong(value = {}): ...
+   |                                    ^^ B006
+   |
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+
+B006_B008.py:85:20: B006 [*] Do not use mutable data structures for argument defaults
+   |
+85 | def and_this(value=set()):
    |                    ^^^^^ B006
-83 |     ...
+86 |     ...
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-79 79 | }):
-80 80 |     ...
-81 81 | 
-82    |-def and_this(value=set()):
-   82 |+def and_this(value=None):
-   83 |+    if value is None:
-   84 |+        value = set()
-83 85 |     ...
-84 86 | 
-85 87 | 
-
-B006_B008.py:86:20: B006 [*] Do not use mutable data structures for argument defaults
-   |
-86 | def this_too(value=collections.OrderedDict()):
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ B006
-87 |     ...
-   |
-   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
-
-ℹ Possible fix
-83 83 |     ...
+82 82 | def single_line_func_wrong(value = {}): ...
+83 83 | 
 84 84 | 
-85 85 | 
-86    |-def this_too(value=collections.OrderedDict()):
-   86 |+def this_too(value=None):
-   87 |+    if value is None:
-   88 |+        value = collections.OrderedDict()
-87 89 |     ...
+85    |-def and_this(value=set()):
+   85 |+def and_this(value=None):
+   86 |+    if value is None:
+   87 |+        value = set()
+86 88 |     ...
+87 89 | 
 88 90 | 
-89 91 | 
 
-B006_B008.py:90:32: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:89:20: B006 [*] Do not use mutable data structures for argument defaults
    |
-90 | async def async_this_too(value=collections.defaultdict()):
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^ B006
-91 |     ...
+89 | def this_too(value=collections.OrderedDict()):
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ B006
+90 |     ...
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-87 87 |     ...
+86 86 |     ...
+87 87 | 
 88 88 | 
-89 89 | 
-90    |-async def async_this_too(value=collections.defaultdict()):
-   90 |+async def async_this_too(value=None):
-   91 |+    if value is None:
-   92 |+        value = collections.defaultdict()
-91 93 |     ...
+89    |-def this_too(value=collections.OrderedDict()):
+   89 |+def this_too(value=None):
+   90 |+    if value is None:
+   91 |+        value = collections.OrderedDict()
+90 92 |     ...
+91 93 | 
 92 94 | 
-93 95 | 
 
-B006_B008.py:94:26: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:93:32: B006 [*] Do not use mutable data structures for argument defaults
    |
-94 | def dont_forget_me(value=collections.deque()):
-   |                          ^^^^^^^^^^^^^^^^^^^ B006
-95 |     ...
+93 | async def async_this_too(value=collections.defaultdict()):
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^ B006
+94 |     ...
    |
    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-91 91 |     ...
+90 90 |     ...
+91 91 | 
 92 92 | 
-93 93 | 
-94    |-def dont_forget_me(value=collections.deque()):
-   94 |+def dont_forget_me(value=None):
-   95 |+    if value is None:
-   96 |+        value = collections.deque()
-95 97 |     ...
+93    |-async def async_this_too(value=collections.defaultdict()):
+   93 |+async def async_this_too(value=None):
+   94 |+    if value is None:
+   95 |+        value = collections.defaultdict()
+94 96 |     ...
+95 97 | 
 96 98 | 
-97 99 | 
 
-B006_B008.py:99:46: B006 [*] Do not use mutable data structures for argument defaults
-    |
- 98 | # N.B. we're also flagging the function call in the comprehension
- 99 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
-    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^ B006
-100 |     pass
-    |
-    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+B006_B008.py:97:26: B006 [*] Do not use mutable data structures for argument defaults
+   |
+97 | def dont_forget_me(value=collections.deque()):
+   |                          ^^^^^^^^^^^^^^^^^^^ B006
+98 |     ...
+   |
+   = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
+94  94  |     ...
+95  95  | 
 96  96  | 
-97  97  | 
-98  98  | # N.B. we're also flagging the function call in the comprehension
-99      |-def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
-    99  |+def list_comprehension_also_not_okay(default=None):
-    100 |+    if default is None:
-    101 |+        default = [i ** 2 for i in range(3)]
-100 102 |     pass
-101 103 | 
-102 104 | 
+97      |-def dont_forget_me(value=collections.deque()):
+    97  |+def dont_forget_me(value=None):
+    98  |+    if value is None:
+    99  |+        value = collections.deque()
+98  100 |     ...
+99  101 | 
+100 102 | 
 
-B006_B008.py:103:46: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:102:46: B006 [*] Do not use mutable data structures for argument defaults
     |
-103 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
-    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ B006
-104 |     pass
+101 | # N.B. we're also flagging the function call in the comprehension
+102 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
+    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^ B006
+103 |     pass
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-100 100 |     pass
-101 101 | 
-102 102 | 
-103     |-def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
-    103 |+def dict_comprehension_also_not_okay(default=None):
-    104 |+    if default is None:
-    105 |+        default = {i: i ** 2 for i in range(3)}
-104 106 |     pass
+99  99  | 
+100 100 | 
+101 101 | # N.B. we're also flagging the function call in the comprehension
+102     |-def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
+    102 |+def list_comprehension_also_not_okay(default=None):
+    103 |+    if default is None:
+    104 |+        default = [i ** 2 for i in range(3)]
+103 105 |     pass
+104 106 | 
 105 107 | 
-106 108 | 
 
-B006_B008.py:107:45: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:106:46: B006 [*] Do not use mutable data structures for argument defaults
     |
-107 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
-    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^ B006
-108 |     pass
+106 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
+    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ B006
+107 |     pass
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-104 104 |     pass
+103 103 |     pass
+104 104 | 
 105 105 | 
-106 106 | 
-107     |-def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
-    107 |+def set_comprehension_also_not_okay(default=None):
-    108 |+    if default is None:
-    109 |+        default = {i ** 2 for i in range(3)}
-108 110 |     pass
+106     |-def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
+    106 |+def dict_comprehension_also_not_okay(default=None):
+    107 |+    if default is None:
+    108 |+        default = {i: i ** 2 for i in range(3)}
+107 109 |     pass
+108 110 | 
 109 111 | 
-110 112 | 
 
-B006_B008.py:111:33: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:110:45: B006 [*] Do not use mutable data structures for argument defaults
     |
-111 | def kwonlyargs_mutable(*, value=[]):
-    |                                 ^^ B006
-112 |     ...
+110 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
+    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^ B006
+111 |     pass
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-108 108 |     pass
+107 107 |     pass
+108 108 | 
 109 109 | 
-110 110 | 
-111     |-def kwonlyargs_mutable(*, value=[]):
-    111 |+def kwonlyargs_mutable(*, value=None):
-    112 |+    if value is None:
-    113 |+        value = []
-112 114 |     ...
+110     |-def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
+    110 |+def set_comprehension_also_not_okay(default=None):
+    111 |+    if default is None:
+    112 |+        default = {i ** 2 for i in range(3)}
+111 113 |     pass
+112 114 | 
 113 115 | 
-114 116 | 
 
-B006_B008.py:232:20: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:114:33: B006 [*] Do not use mutable data structures for argument defaults
     |
-230 | # B006 and B008
-231 | # We should handle arbitrary nesting of these B008.
-232 | def nested_combo(a=[float(3), dt.datetime.now()]):
+114 | def kwonlyargs_mutable(*, value=[]):
+    |                                 ^^ B006
+115 |     ...
+    |
+    = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
+
+ℹ Possible fix
+111 111 |     pass
+112 112 | 
+113 113 | 
+114     |-def kwonlyargs_mutable(*, value=[]):
+    114 |+def kwonlyargs_mutable(*, value=None):
+    115 |+    if value is None:
+    116 |+        value = []
+115 117 |     ...
+116 118 | 
+117 119 | 
+
+B006_B008.py:235:20: B006 [*] Do not use mutable data structures for argument defaults
+    |
+233 | # B006 and B008
+234 | # We should handle arbitrary nesting of these B008.
+235 | def nested_combo(a=[float(3), dt.datetime.now()]):
     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B006
-233 |     pass
+236 |     pass
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-229 229 | 
-230 230 | # B006 and B008
-231 231 | # We should handle arbitrary nesting of these B008.
-232     |-def nested_combo(a=[float(3), dt.datetime.now()]):
-    232 |+def nested_combo(a=None):
-    233 |+    if a is None:
-    234 |+        a = [float(3), dt.datetime.now()]
-233 235 |     pass
-234 236 | 
-235 237 | 
+232 232 | 
+233 233 | # B006 and B008
+234 234 | # We should handle arbitrary nesting of these B008.
+235     |-def nested_combo(a=[float(3), dt.datetime.now()]):
+    235 |+def nested_combo(a=None):
+    236 |+    if a is None:
+    237 |+        a = [float(3), dt.datetime.now()]
+236 238 |     pass
+237 239 | 
+238 240 | 
 
-B006_B008.py:269:27: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:272:27: B006 [*] Do not use mutable data structures for argument defaults
     |
-268 | def mutable_annotations(
-269 |     a: list[int] | None = [],
+271 | def mutable_annotations(
+272 |     a: list[int] | None = [],
     |                           ^^ B006
-270 |     b: Optional[Dict[int, int]] = {},
-271 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+273 |     b: Optional[Dict[int, int]] = {},
+274 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-266 266 | 
-267 267 | 
-268 268 | def mutable_annotations(
-269     |-    a: list[int] | None = [],
-    269 |+    a: list[int] | None = None,
-270 270 |     b: Optional[Dict[int, int]] = {},
-271 271 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-272 272 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-273 273 | ):
-    274 |+    if a is None:
-    275 |+        a = []
-274 276 |     pass
+269 269 | 
+270 270 | 
+271 271 | def mutable_annotations(
+272     |-    a: list[int] | None = [],
+    272 |+    a: list[int] | None = None,
+273 273 |     b: Optional[Dict[int, int]] = {},
+274 274 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+275 275 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+276 276 | ):
+    277 |+    if a is None:
+    278 |+        a = []
+277 279 |     pass
 
-B006_B008.py:270:35: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:273:35: B006 [*] Do not use mutable data structures for argument defaults
     |
-268 | def mutable_annotations(
-269 |     a: list[int] | None = [],
-270 |     b: Optional[Dict[int, int]] = {},
+271 | def mutable_annotations(
+272 |     a: list[int] | None = [],
+273 |     b: Optional[Dict[int, int]] = {},
     |                                   ^^ B006
-271 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-272 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+274 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+275 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-267 267 | 
-268 268 | def mutable_annotations(
-269 269 |     a: list[int] | None = [],
-270     |-    b: Optional[Dict[int, int]] = {},
-    270 |+    b: Optional[Dict[int, int]] = None,
-271 271 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-272 272 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-273 273 | ):
-    274 |+    if b is None:
-    275 |+        b = {}
-274 276 |     pass
+270 270 | 
+271 271 | def mutable_annotations(
+272 272 |     a: list[int] | None = [],
+273     |-    b: Optional[Dict[int, int]] = {},
+    273 |+    b: Optional[Dict[int, int]] = None,
+274 274 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+275 275 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+276 276 | ):
+    277 |+    if b is None:
+    278 |+        b = {}
+277 279 |     pass
 
-B006_B008.py:271:62: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:274:62: B006 [*] Do not use mutable data structures for argument defaults
     |
-269 |     a: list[int] | None = [],
-270 |     b: Optional[Dict[int, int]] = {},
-271 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+272 |     a: list[int] | None = [],
+273 |     b: Optional[Dict[int, int]] = {},
+274 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |                                                              ^^^^^ B006
-272 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-273 | ):
+275 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+276 | ):
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-268 268 | def mutable_annotations(
-269 269 |     a: list[int] | None = [],
-270 270 |     b: Optional[Dict[int, int]] = {},
-271     |-    c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-    271 |+    c: Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
-272 272 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-273 273 | ):
-    274 |+    if c is None:
-    275 |+        c = set()
-274 276 |     pass
+271 271 | def mutable_annotations(
+272 272 |     a: list[int] | None = [],
+273 273 |     b: Optional[Dict[int, int]] = {},
+274     |-    c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+    274 |+    c: Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
+275 275 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+276 276 | ):
+    277 |+    if c is None:
+    278 |+        c = set()
+277 279 |     pass
 
-B006_B008.py:272:80: B006 [*] Do not use mutable data structures for argument defaults
+B006_B008.py:275:80: B006 [*] Do not use mutable data structures for argument defaults
     |
-270 |     b: Optional[Dict[int, int]] = {},
-271 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-272 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+273 |     b: Optional[Dict[int, int]] = {},
+274 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+275 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |                                                                                ^^^^^ B006
-273 | ):
-274 |     pass
+276 | ):
+277 |     pass
     |
     = help: Replace mutable data structure with `None` in argument default and replace it with data structure inside the function if still `None`
 
 ℹ Possible fix
-269 269 |     a: list[int] | None = [],
-270 270 |     b: Optional[Dict[int, int]] = {},
-271 271 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-272     |-    d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-    272 |+    d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
-273 273 | ):
-    274 |+    if d is None:
-    275 |+        d = set()
-274 276 |     pass
+272 272 |     a: list[int] | None = [],
+273 273 |     b: Optional[Dict[int, int]] = {},
+274 274 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+275     |-    d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+    275 |+    d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
+276 276 | ):
+    277 |+    if d is None:
+    278 |+        d = set()
+277 279 |     pass
 
 

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B008_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B008_B006_B008.py.snap
@@ -1,83 +1,83 @@
 ---
 source: crates/ruff/src/rules/flake8_bugbear/mod.rs
 ---
-B006_B008.py:93:61: B008 Do not perform function call `range` in argument defaults
-   |
-92 | # N.B. we're also flagging the function call in the comprehension
-93 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
-   |                                                             ^^^^^^^^ B008
-94 |     pass
-   |
-
-B006_B008.py:97:64: B008 Do not perform function call `range` in argument defaults
-   |
-97 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
-   |                                                                ^^^^^^^^ B008
-98 |     pass
-   |
-
-B006_B008.py:101:60: B008 Do not perform function call `range` in argument defaults
+B006_B008.py:99:61: B008 Do not perform function call `range` in argument defaults
     |
-101 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
+ 98 | # N.B. we're also flagging the function call in the comprehension
+ 99 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
+    |                                                             ^^^^^^^^ B008
+100 |     pass
+    |
+
+B006_B008.py:103:64: B008 Do not perform function call `range` in argument defaults
+    |
+103 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
+    |                                                                ^^^^^^^^ B008
+104 |     pass
+    |
+
+B006_B008.py:107:60: B008 Do not perform function call `range` in argument defaults
+    |
+107 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
     |                                                            ^^^^^^^^ B008
-102 |     pass
+108 |     pass
     |
 
-B006_B008.py:117:39: B008 Do not perform function call `time.time` in argument defaults
+B006_B008.py:123:39: B008 Do not perform function call `time.time` in argument defaults
     |
-115 | # B008
-116 | # Flag function calls as default args (including if they are part of a sub-expression)
-117 | def in_fact_all_calls_are_wrong(value=time.time()):
+121 | # B008
+122 | # Flag function calls as default args (including if they are part of a sub-expression)
+123 | def in_fact_all_calls_are_wrong(value=time.time()):
     |                                       ^^^^^^^^^^^ B008
-118 |     ...
+124 |     ...
     |
 
-B006_B008.py:121:12: B008 Do not perform function call `dt.datetime.now` in argument defaults
+B006_B008.py:127:12: B008 Do not perform function call `dt.datetime.now` in argument defaults
     |
-121 | def f(when=dt.datetime.now() + dt.timedelta(days=7)):
+127 | def f(when=dt.datetime.now() + dt.timedelta(days=7)):
     |            ^^^^^^^^^^^^^^^^^ B008
-122 |     pass
+128 |     pass
     |
 
-B006_B008.py:125:30: B008 Do not perform function call in argument defaults
+B006_B008.py:131:30: B008 Do not perform function call in argument defaults
     |
-125 | def can_even_catch_lambdas(a=(lambda x: x)()):
+131 | def can_even_catch_lambdas(a=(lambda x: x)()):
     |                              ^^^^^^^^^^^^^^^ B008
-126 |     ...
+132 |     ...
     |
 
-B006_B008.py:226:31: B008 Do not perform function call `dt.datetime.now` in argument defaults
+B006_B008.py:232:31: B008 Do not perform function call `dt.datetime.now` in argument defaults
     |
-224 | # B006 and B008
-225 | # We should handle arbitrary nesting of these B008.
-226 | def nested_combo(a=[float(3), dt.datetime.now()]):
+230 | # B006 and B008
+231 | # We should handle arbitrary nesting of these B008.
+232 | def nested_combo(a=[float(3), dt.datetime.now()]):
     |                               ^^^^^^^^^^^^^^^^^ B008
-227 |     pass
-    |
-
-B006_B008.py:232:22: B008 Do not perform function call `map` in argument defaults
-    |
-230 | # Don't flag nested B006 since we can't guarantee that
-231 | # it isn't made mutable by the outer operation.
-232 | def no_nested_b006(a=map(lambda s: s.upper(), ["a", "b", "c"])):
-    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B008
 233 |     pass
     |
 
-B006_B008.py:237:19: B008 Do not perform function call `random.randint` in argument defaults
+B006_B008.py:238:22: B008 Do not perform function call `map` in argument defaults
     |
-236 | # B008-ception.
-237 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
-    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B008
-238 |     pass
+236 | # Don't flag nested B006 since we can't guarantee that
+237 | # it isn't made mutable by the outer operation.
+238 | def no_nested_b006(a=map(lambda s: s.upper(), ["a", "b", "c"])):
+    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B008
+239 |     pass
     |
 
-B006_B008.py:237:37: B008 Do not perform function call `dt.datetime.now` in argument defaults
+B006_B008.py:243:19: B008 Do not perform function call `random.randint` in argument defaults
     |
-236 | # B008-ception.
-237 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
+242 | # B008-ception.
+243 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
+    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B008
+244 |     pass
+    |
+
+B006_B008.py:243:37: B008 Do not perform function call `dt.datetime.now` in argument defaults
+    |
+242 | # B008-ception.
+243 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
     |                                     ^^^^^^^^^^^^^^^^^ B008
-238 |     pass
+244 |     pass
     |
 
 

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B008_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B008_B006_B008.py.snap
@@ -1,83 +1,83 @@
 ---
 source: crates/ruff/src/rules/flake8_bugbear/mod.rs
 ---
-B006_B008.py:99:61: B008 Do not perform function call `range` in argument defaults
+B006_B008.py:102:61: B008 Do not perform function call `range` in argument defaults
     |
- 98 | # N.B. we're also flagging the function call in the comprehension
- 99 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
+101 | # N.B. we're also flagging the function call in the comprehension
+102 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
     |                                                             ^^^^^^^^ B008
-100 |     pass
+103 |     pass
     |
 
-B006_B008.py:103:64: B008 Do not perform function call `range` in argument defaults
+B006_B008.py:106:64: B008 Do not perform function call `range` in argument defaults
     |
-103 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
+106 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
     |                                                                ^^^^^^^^ B008
-104 |     pass
+107 |     pass
     |
 
-B006_B008.py:107:60: B008 Do not perform function call `range` in argument defaults
+B006_B008.py:110:60: B008 Do not perform function call `range` in argument defaults
     |
-107 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
+110 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
     |                                                            ^^^^^^^^ B008
-108 |     pass
+111 |     pass
     |
 
-B006_B008.py:123:39: B008 Do not perform function call `time.time` in argument defaults
+B006_B008.py:126:39: B008 Do not perform function call `time.time` in argument defaults
     |
-121 | # B008
-122 | # Flag function calls as default args (including if they are part of a sub-expression)
-123 | def in_fact_all_calls_are_wrong(value=time.time()):
+124 | # B008
+125 | # Flag function calls as default args (including if they are part of a sub-expression)
+126 | def in_fact_all_calls_are_wrong(value=time.time()):
     |                                       ^^^^^^^^^^^ B008
-124 |     ...
+127 |     ...
     |
 
-B006_B008.py:127:12: B008 Do not perform function call `dt.datetime.now` in argument defaults
+B006_B008.py:130:12: B008 Do not perform function call `dt.datetime.now` in argument defaults
     |
-127 | def f(when=dt.datetime.now() + dt.timedelta(days=7)):
+130 | def f(when=dt.datetime.now() + dt.timedelta(days=7)):
     |            ^^^^^^^^^^^^^^^^^ B008
-128 |     pass
+131 |     pass
     |
 
-B006_B008.py:131:30: B008 Do not perform function call in argument defaults
+B006_B008.py:134:30: B008 Do not perform function call in argument defaults
     |
-131 | def can_even_catch_lambdas(a=(lambda x: x)()):
+134 | def can_even_catch_lambdas(a=(lambda x: x)()):
     |                              ^^^^^^^^^^^^^^^ B008
-132 |     ...
+135 |     ...
     |
 
-B006_B008.py:232:31: B008 Do not perform function call `dt.datetime.now` in argument defaults
+B006_B008.py:235:31: B008 Do not perform function call `dt.datetime.now` in argument defaults
     |
-230 | # B006 and B008
-231 | # We should handle arbitrary nesting of these B008.
-232 | def nested_combo(a=[float(3), dt.datetime.now()]):
+233 | # B006 and B008
+234 | # We should handle arbitrary nesting of these B008.
+235 | def nested_combo(a=[float(3), dt.datetime.now()]):
     |                               ^^^^^^^^^^^^^^^^^ B008
-233 |     pass
+236 |     pass
     |
 
-B006_B008.py:238:22: B008 Do not perform function call `map` in argument defaults
+B006_B008.py:241:22: B008 Do not perform function call `map` in argument defaults
     |
-236 | # Don't flag nested B006 since we can't guarantee that
-237 | # it isn't made mutable by the outer operation.
-238 | def no_nested_b006(a=map(lambda s: s.upper(), ["a", "b", "c"])):
+239 | # Don't flag nested B006 since we can't guarantee that
+240 | # it isn't made mutable by the outer operation.
+241 | def no_nested_b006(a=map(lambda s: s.upper(), ["a", "b", "c"])):
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B008
-239 |     pass
+242 |     pass
     |
 
-B006_B008.py:243:19: B008 Do not perform function call `random.randint` in argument defaults
+B006_B008.py:246:19: B008 Do not perform function call `random.randint` in argument defaults
     |
-242 | # B008-ception.
-243 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
+245 | # B008-ception.
+246 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B008
-244 |     pass
+247 |     pass
     |
 
-B006_B008.py:243:37: B008 Do not perform function call `dt.datetime.now` in argument defaults
+B006_B008.py:246:37: B008 Do not perform function call `dt.datetime.now` in argument defaults
     |
-242 | # B008-ception.
-243 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
+245 | # B008-ception.
+246 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
     |                                     ^^^^^^^^^^^^^^^^^ B008
-244 |     pass
+247 |     pass
     |
 
 

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B008_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B008_B006_B008.py.snap
@@ -1,83 +1,83 @@
 ---
 source: crates/ruff/src/rules/flake8_bugbear/mod.rs
 ---
-B006_B008.py:88:61: B008 Do not perform function call `range` in argument defaults
+B006_B008.py:93:61: B008 Do not perform function call `range` in argument defaults
    |
-87 | # N.B. we're also flagging the function call in the comprehension
-88 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
+92 | # N.B. we're also flagging the function call in the comprehension
+93 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
    |                                                             ^^^^^^^^ B008
-89 |     pass
+94 |     pass
    |
 
-B006_B008.py:92:64: B008 Do not perform function call `range` in argument defaults
+B006_B008.py:97:64: B008 Do not perform function call `range` in argument defaults
    |
-92 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
+97 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
    |                                                                ^^^^^^^^ B008
-93 |     pass
+98 |     pass
    |
 
-B006_B008.py:96:60: B008 Do not perform function call `range` in argument defaults
-   |
-96 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
-   |                                                            ^^^^^^^^ B008
-97 |     pass
-   |
-
-B006_B008.py:112:39: B008 Do not perform function call `time.time` in argument defaults
+B006_B008.py:101:60: B008 Do not perform function call `range` in argument defaults
     |
-110 | # B008
-111 | # Flag function calls as default args (including if they are part of a sub-expression)
-112 | def in_fact_all_calls_are_wrong(value=time.time()):
+101 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
+    |                                                            ^^^^^^^^ B008
+102 |     pass
+    |
+
+B006_B008.py:117:39: B008 Do not perform function call `time.time` in argument defaults
+    |
+115 | # B008
+116 | # Flag function calls as default args (including if they are part of a sub-expression)
+117 | def in_fact_all_calls_are_wrong(value=time.time()):
     |                                       ^^^^^^^^^^^ B008
-113 |     ...
+118 |     ...
     |
 
-B006_B008.py:116:12: B008 Do not perform function call `dt.datetime.now` in argument defaults
+B006_B008.py:121:12: B008 Do not perform function call `dt.datetime.now` in argument defaults
     |
-116 | def f(when=dt.datetime.now() + dt.timedelta(days=7)):
+121 | def f(when=dt.datetime.now() + dt.timedelta(days=7)):
     |            ^^^^^^^^^^^^^^^^^ B008
-117 |     pass
+122 |     pass
     |
 
-B006_B008.py:120:30: B008 Do not perform function call in argument defaults
+B006_B008.py:125:30: B008 Do not perform function call in argument defaults
     |
-120 | def can_even_catch_lambdas(a=(lambda x: x)()):
+125 | def can_even_catch_lambdas(a=(lambda x: x)()):
     |                              ^^^^^^^^^^^^^^^ B008
-121 |     ...
+126 |     ...
     |
 
-B006_B008.py:221:31: B008 Do not perform function call `dt.datetime.now` in argument defaults
+B006_B008.py:226:31: B008 Do not perform function call `dt.datetime.now` in argument defaults
     |
-219 | # B006 and B008
-220 | # We should handle arbitrary nesting of these B008.
-221 | def nested_combo(a=[float(3), dt.datetime.now()]):
+224 | # B006 and B008
+225 | # We should handle arbitrary nesting of these B008.
+226 | def nested_combo(a=[float(3), dt.datetime.now()]):
     |                               ^^^^^^^^^^^^^^^^^ B008
-222 |     pass
+227 |     pass
     |
 
-B006_B008.py:227:22: B008 Do not perform function call `map` in argument defaults
+B006_B008.py:232:22: B008 Do not perform function call `map` in argument defaults
     |
-225 | # Don't flag nested B006 since we can't guarantee that
-226 | # it isn't made mutable by the outer operation.
-227 | def no_nested_b006(a=map(lambda s: s.upper(), ["a", "b", "c"])):
+230 | # Don't flag nested B006 since we can't guarantee that
+231 | # it isn't made mutable by the outer operation.
+232 | def no_nested_b006(a=map(lambda s: s.upper(), ["a", "b", "c"])):
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B008
-228 |     pass
+233 |     pass
     |
 
-B006_B008.py:232:19: B008 Do not perform function call `random.randint` in argument defaults
+B006_B008.py:237:19: B008 Do not perform function call `random.randint` in argument defaults
     |
-231 | # B008-ception.
-232 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
+236 | # B008-ception.
+237 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B008
-233 |     pass
+238 |     pass
     |
 
-B006_B008.py:232:37: B008 Do not perform function call `dt.datetime.now` in argument defaults
+B006_B008.py:237:37: B008 Do not perform function call `dt.datetime.now` in argument defaults
     |
-231 | # B008-ception.
-232 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
+236 | # B008-ception.
+237 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
     |                                     ^^^^^^^^^^^^^^^^^ B008
-233 |     pass
+238 |     pass
     |
 
 


### PR DESCRIPTION
## Summary

Reopening of https://github.com/astral-sh/ruff/pull/4880 

One open TODO as described in: https://github.com/astral-sh/ruff/pull/4880#discussion_r1265110215 

FYI @charliermarsh seeing as you commented you wanted to do final review and merge. @konstin @dhruvmanila @MichaReiser as previous reviewers.

# Old Description
## Summary

Adds an autofix for B006 turning mutable argument defaults into None and setting their original value back in the function body if still `None` at runtime like so:
```python
def before(x=[]):
    pass
    
def after(x=None):
    if x is None:
        x = []
    pass
```

## Test Plan

Added an extra test case to existing fixture with more indentation. Checked results for all old examples.

NOTE: Also adapted the jupyter notebook test as this checked for B006 as well.

## Issue link

Closes: https://github.com/charliermarsh/ruff/issues/4693
