### PR TITLE
Skip partial duplicates when applying multi-edit fixes

### DIFF
--- a/crates/ruff/src/message/diff.rs
+++ b/crates/ruff/src/message/diff.rs
@@ -38,7 +38,7 @@ impl Display for Diff<'_> {
         let mut output = String::with_capacity(self.source_code.source_text().len());
         let mut last_end = TextSize::default();
 
-        for edit in self.fix.edits().to_sorted() {
+        for edit in self.fix.edits() {
             output.push_str(
                 self.source_code
                     .slice(TextRange::new(last_end, edit.start())),

--- a/crates/ruff/src/message/diff.rs
+++ b/crates/ruff/src/message/diff.rs
@@ -38,7 +38,7 @@ impl Display for Diff<'_> {
         let mut output = String::with_capacity(self.source_code.source_text().len());
         let mut last_end = TextSize::default();
 
-        for edit in self.fix.edits().inorder() {
+        for edit in self.fix.edits().to_sorted() {
             output.push_str(
                 self.source_code
                     .slice(TextRange::new(last_end, edit.start())),

--- a/crates/ruff/src/message/diff.rs
+++ b/crates/ruff/src/message/diff.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter};
 use std::num::NonZeroUsize;
 
 use colored::{Color, ColoredString, Colorize, Styles};
-use itertools::Itertools;
+
 use ruff_text_size::{TextRange, TextSize};
 use similar::{ChangeTag, TextDiff};
 
@@ -38,12 +38,7 @@ impl Display for Diff<'_> {
         let mut output = String::with_capacity(self.source_code.source_text().len());
         let mut last_end = TextSize::default();
 
-        for edit in self
-            .fix
-            .edits()
-            .iter()
-            .sorted_unstable_by_key(|edit| edit.start())
-        {
+        for edit in self.fix.edits().inorder() {
             output.push_str(
                 self.source_code
                     .slice(TextRange::new(last_end, edit.start())),

--- a/crates/ruff/src/message/json.rs
+++ b/crates/ruff/src/message/json.rs
@@ -53,7 +53,7 @@ pub(crate) fn message_to_json_value(message: &Message) -> Value {
         json!({
             "applicability": fix.applicability(),
             "message": message.kind.suggestion.as_deref(),
-            "edits": &ExpandedEdits { edits: fix.edits(), source_code: &source_code },
+            "edits": &ExpandedEdits { edits: &fix.edits(), source_code: &source_code },
         })
     });
 

--- a/crates/ruff/src/message/json.rs
+++ b/crates/ruff/src/message/json.rs
@@ -53,7 +53,7 @@ pub(crate) fn message_to_json_value(message: &Message) -> Value {
         json!({
             "applicability": fix.applicability(),
             "message": message.kind.suggestion.as_deref(),
-            "edits": &ExpandedEdits { edits: &fix.edits(), source_code: &source_code },
+            "edits": &ExpandedEdits { edits: fix.edits(), source_code: &source_code },
         })
     });
 

--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -85,7 +85,7 @@ pub fn test_snippet(contents: &str, settings: &Settings) -> Vec<Message> {
 }
 
 thread_local! {
-    static MAX_ITERATIONS: std::cell::Cell<usize> = std::cell::Cell::new(30);
+    static MAX_ITERATIONS: std::cell::Cell<usize> = std::cell::Cell::new(8);
 }
 
 pub fn set_max_iterations(max: usize) {

--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -285,7 +285,9 @@ pub(crate) fn lint_path(
                                     .enumerate()
                                     .zip(dest_notebook.cells().iter())
                                 {
-                                    let (Cell::Code(src_code_cell), Cell::Code(dest_code_cell)) = (src_cell, dest_cell) else {
+                                    let (Cell::Code(src_code_cell), Cell::Code(dest_code_cell)) =
+                                        (src_cell, dest_cell)
+                                    else {
                                         continue;
                                     };
                                     TextDiff::from_lines(

--- a/crates/ruff_diagnostics/src/edit.rs
+++ b/crates/ruff_diagnostics/src/edit.rs
@@ -1,9 +1,9 @@
 use std::cmp::Ordering;
-use std::ops::Deref;
 
-use ruff_text_size::{TextRange, TextSize};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+use ruff_text_size::{TextRange, TextSize};
 
 /// A text edit to be applied to a source file. Inserts, deletes, or replaces
 /// content at a given location.
@@ -143,37 +143,5 @@ impl EditOperationKind {
 
     pub(crate) const fn is_replacement(self) -> bool {
         matches!(self, EditOperationKind::Replacement)
-    }
-}
-
-/// A collection of [`Edit`] elements to be applied to a source file.
-#[derive(Debug, Clone)]
-pub struct Edits<'a>(&'a [Edit]);
-
-impl<'a> Edits<'a> {
-    pub(crate) fn new(edits: &'a [Edit]) -> Self {
-        Self(edits)
-    }
-
-    /// Return the [`TextSize`] of the first [`Edit`] in the [`Fix`], as determined by the
-    /// start position of the [`Edit`].
-    pub fn min_start(&self) -> Option<TextSize> {
-        self.0.iter().map(Edit::start).min()
-    }
-
-    /// Return an iterator over the [`Edit`] elements in the [`Fix`], sorted by their start
-    /// position.
-    pub fn to_sorted(&self) -> impl IntoIterator<Item = Edit> {
-        let mut edits = self.to_vec();
-        edits.sort_by_key(Edit::start);
-        edits.into_iter()
-    }
-}
-
-impl<'a> Deref for Edits<'a> {
-    type Target = [Edit];
-
-    fn deref(&self) -> &Self::Target {
-        self.0
     }
 }

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -1,10 +1,7 @@
-use ruff_text_size::TextSize;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
-use std::ops::Deref;
 
-use crate::edit::Edit;
+use crate::edit::{Edit, Edits};
 
 /// Indicates confidence in the correctness of a suggested fix.
 #[derive(Default, Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -128,11 +125,6 @@ impl Fix {
         }
     }
 
-    /// Return the [`TextSize`] of the first [`Edit`] in the [`Fix`].
-    pub fn min_start(&self) -> Option<TextSize> {
-        self.edits.iter().map(Edit::start).min()
-    }
-
     /// Return a slice of the [`Edit`] elements in the [`Fix`].
     pub fn edits(&self) -> Edits {
         Edits::new(&self.edits)
@@ -157,45 +149,5 @@ impl Fix {
     pub fn isolate(mut self, isolation: IsolationLevel) -> Self {
         self.isolation_level = isolation;
         self
-    }
-}
-
-/// A collection of [`Edit`] elements to be applied to a source file.
-#[derive(Debug, Clone)]
-pub struct Edits<'a>(Cow<'a, [Edit]>);
-
-impl<'a> Edits<'a> {
-    fn new(edits: &'a [Edit]) -> Self {
-        Self(Cow::Borrowed(edits))
-    }
-
-    /// Return the [`TextSize`] of the first [`Edit`] in the [`Fix`], as determined by the
-    /// start position of the [`Edit`].
-    pub fn min_start(&self) -> Option<TextSize> {
-        self.0.iter().map(Edit::start).min()
-    }
-
-    /// Return an iterator over the [`Edit`] elements in the [`Fix`], sorted by their start
-    /// position.
-    pub fn inorder(&self) -> impl IntoIterator<Item = Edit> {
-        let mut edits = self.to_vec();
-        edits.sort_by_key(Edit::start);
-        edits.into_iter()
-    }
-
-    /// Filter the [`Edit`] elements in the [`Fix`] by the given predicate.
-    pub fn retain<F>(&mut self, f: F)
-    where
-        F: FnMut(&Edit) -> bool,
-    {
-        self.0.to_mut().retain(f);
-    }
-}
-
-impl<'a> Deref for Edits<'a> {
-    type Target = [Edit];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -43,7 +43,7 @@ pub enum IsolationLevel {
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Fix {
-    /// The [`Edit`] elements to be applied, sorted by [`TextSize`].
+    /// The [`Edit`] elements to be applied, sorted by [`Edit::start`] in ascending order.
     edits: Vec<Edit>,
     /// The [`Applicability`] of the fix.
     applicability: Applicability,
@@ -141,7 +141,7 @@ impl Fix {
         self.edits.first().map(Edit::start)
     }
 
-    /// Return a slice of the [`Edit`] elements in the [`Fix`], sorted by their [`TextSize`].
+    /// Return a slice of the [`Edit`] elements in the [`Fix`], sorted by [`Edit::start`] in ascending order.
     pub fn edits(&self) -> &[Edit] {
         &self.edits
     }

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -245,8 +245,8 @@ impl Workspace {
                     fix: message.fix.map(|fix| ExpandedFix {
                         message: message.kind.suggestion,
                         edits: fix
-                            .into_edits()
-                            .into_iter()
+                            .edits()
+                            .iter()
                             .map(|edit| ExpandedEdit {
                                 location: source_code.source_location(edit.start()),
                                 end_location: source_code.source_location(edit.end()),


### PR DESCRIPTION
## Summary

Right now, if we have two fixes that have an overlapping edit, but not an _identical_ set of edits, they'll conflict, causing us to do another linter traversal. Here, I've enabled the fixer to support partially overlapping edits, which (as an example) let's us greatly reduce the number of iterations required in the test suite.

The most common case here is that in which a bunch of edits need to import some symbol, and then use that symbol, but in different ways. In that case, all edits will have a common fix (to import the symbol), but deviate in some way. With this change, we can do all of those edits in one pass.

Note that the simplest way to enable this was to store sorted edits on `Fix`. We don't allow modifying the edits on `Fix` once it's constructed, so this is an easy change, and allows us to avoid a bunch of clones and traversals later on.

Closes #5800.