### PR TITLE
Skip BOM when determining Locator's line starts

### DIFF
--- a/crates/ruff/resources/test/fixtures/isort/bom_sorted.py
+++ b/crates/ruff/resources/test/fixtures/isort/bom_sorted.py
@@ -1,0 +1,2 @@
+﻿import bar
+import foo

--- a/crates/ruff/resources/test/fixtures/isort/bom_unsorted.py
+++ b/crates/ruff/resources/test/fixtures/isort/bom_unsorted.py
@@ -1,0 +1,2 @@
+﻿import foo
+import bar

--- a/crates/ruff/src/rules/isort/mod.rs
+++ b/crates/ruff/src/rules/isort/mod.rs
@@ -314,6 +314,8 @@ mod tests {
 
     #[test_case(Path::new("add_newline_before_comments.py"))]
     #[test_case(Path::new("as_imports_comments.py"))]
+    #[test_case(Path::new("bom_sorted.py"))]
+    #[test_case(Path::new("bom_unsorted.py"))]
     #[test_case(Path::new("combine_as_imports.py"))]
     #[test_case(Path::new("combine_import_from.py"))]
     #[test_case(Path::new("comments.py"))]

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -61,7 +61,6 @@ fn extract_range(body: &[&Stmt]) -> TextRange {
 
 fn extract_indentation_range(body: &[&Stmt], locator: &Locator) -> TextRange {
     let location = body.first().unwrap().start();
-
     TextRange::new(locator.line_start(location), location)
 }
 

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -61,6 +61,7 @@ fn extract_range(body: &[&Stmt]) -> TextRange {
 
 fn extract_indentation_range(body: &[&Stmt], locator: &Locator) -> TextRange {
     let location = body.first().unwrap().start();
+
     TextRange::new(locator.line_start(location), location)
 }
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__bom_sorted.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__bom_sorted.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/isort/mod.rs
+---
+

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__bom_unsorted.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__bom_unsorted.py.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ruff/src/rules/isort/mod.rs
+---
+bom_unsorted.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+  |
+1 |   ﻿import foo
+  |  _^
+2 | | import bar
+  |
+  = help: Organize imports
+
+ℹ Fix
+1   |-﻿import foo
+2   |-import bar
+  1 |+﻿import bar
+  2 |+import foo
+
+

--- a/crates/ruff_source_file/src/locator.rs
+++ b/crates/ruff_source_file/src/locator.rs
@@ -76,7 +76,11 @@ impl<'a> Locator<'a> {
         if let Some(index) = memrchr2(b'\n', b'\r', bytes) {
             // SAFETY: Safe because `index < offset`
             TextSize::try_from(index).unwrap().add(TextSize::from(1))
+        } else if self.contents.starts_with('\u{feff}') {
+            // Skip the BOM.
+            '\u{feff}'.text_len()
         } else {
+            // Start of file.
             TextSize::default()
         }
     }


### PR DESCRIPTION
## Summary

If a file has a BOM, the import sorter _always_ reports the imports as unsorted. The acute issue is that we detect that the line has leading content (before the imports), which we always consider a violation. Rather than fixing that one site, this PR instead makes `.line_start` BOM-aware.

Fixes https://github.com/astral-sh/ruff/issues/6155.
