### PR TITLE
[`pep8-naming`]: New config option `extend-ignore-names`

### DIFF
--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1424,6 +1424,16 @@
             "type": "string"
           }
         },
+        "extend-ignore-names": {
+          "description": "Additional names (or patterns) to ignore when considering `pep8-naming` violations, in addition to those included in `ignore-names`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "ignore-names": {
           "description": "A list of names (or patterns) to ignore when considering `pep8-naming` violations.",
           "type": [


### PR DESCRIPTION
## Summary

This PR adds a new config option for `pep8-naming` plugin called `extend-ignore-names` which is used to extend the default values in `ignore-names` option.

resolves: #6050
