### PR TITLE
Add `global` and `nonlocal` formatting

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/global.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/global.py
@@ -1,0 +1,12 @@
+def f():
+    global x, y, z
+
+
+def f():
+    # leading comment
+    global x, y, z # end-of-line comment
+    # trailing comment
+
+
+def f():
+    global analyze_featuremap_layer, analyze_featuremapcompression_layer, analyze_latencies_post, analyze_motions_layer, analyze_size_model

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/nonlocal.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/nonlocal.py
@@ -1,0 +1,12 @@
+def f():
+    nonlocal x, y, z
+
+
+def f():
+    # leading comment
+    nonlocal x, y, z # end-of-line comment
+    # trailing comment
+
+
+def f():
+    nonlocal analyze_featuremap_layer, analyze_featuremapcompression_layer, analyze_latencies_post, analyze_motions_layer, analyze_size_model

--- a/crates/ruff_python_formatter/src/statement/stmt_global.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_global.rs
@@ -1,12 +1,18 @@
-use crate::{not_yet_implemented, FormatNodeRule, PyFormatter};
-use ruff_formatter::{write, Buffer, FormatResult};
+use ruff_formatter::{format_args, write};
 use ruff_python_ast::StmtGlobal;
+
+use crate::prelude::*;
+use crate::FormatNodeRule;
 
 #[derive(Default)]
 pub struct FormatStmtGlobal;
 
 impl FormatNodeRule<StmtGlobal> for FormatStmtGlobal {
     fn fmt_fields(&self, item: &StmtGlobal, f: &mut PyFormatter) -> FormatResult<()> {
-        write!(f, [not_yet_implemented(item)])
+        write!(f, [text("global"), space()])?;
+
+        f.join_with(format_args![text(","), space()])
+            .entries(item.names.iter().formatted())
+            .finish()
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_nonlocal.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_nonlocal.rs
@@ -1,12 +1,18 @@
-use crate::{not_yet_implemented, FormatNodeRule, PyFormatter};
-use ruff_formatter::{write, Buffer, FormatResult};
+use ruff_formatter::{format_args, write};
 use ruff_python_ast::StmtNonlocal;
+
+use crate::prelude::*;
+use crate::FormatNodeRule;
 
 #[derive(Default)]
 pub struct FormatStmtNonlocal;
 
 impl FormatNodeRule<StmtNonlocal> for FormatStmtNonlocal {
     fn fmt_fields(&self, item: &StmtNonlocal, f: &mut PyFormatter) -> FormatResult<()> {
-        write!(f, [not_yet_implemented(item)])
+        write!(f, [text("nonlocal"), space()])?;
+
+        f.join_with(format_args![text(","), space()])
+            .entries(item.names.iter().formatted())
+            .finish()
     }
 }

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__global.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__global.py.snap
@@ -1,0 +1,38 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/global.py
+---
+## Input
+```py
+def f():
+    global x, y, z
+
+
+def f():
+    # leading comment
+    global x, y, z # end-of-line comment
+    # trailing comment
+
+
+def f():
+    global analyze_featuremap_layer, analyze_featuremapcompression_layer, analyze_latencies_post, analyze_motions_layer, analyze_size_model
+```
+
+## Output
+```py
+def f():
+    global x, y, z
+
+
+def f():
+    # leading comment
+    global x, y, z  # end-of-line comment
+    # trailing comment
+
+
+def f():
+    global analyze_featuremap_layer, analyze_featuremapcompression_layer, analyze_latencies_post, analyze_motions_layer, analyze_size_model
+```
+
+
+

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__nonlocal.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__nonlocal.py.snap
@@ -1,0 +1,38 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/nonlocal.py
+---
+## Input
+```py
+def f():
+    nonlocal x, y, z
+
+
+def f():
+    # leading comment
+    nonlocal x, y, z # end-of-line comment
+    # trailing comment
+
+
+def f():
+    nonlocal analyze_featuremap_layer, analyze_featuremapcompression_layer, analyze_latencies_post, analyze_motions_layer, analyze_size_model
+```
+
+## Output
+```py
+def f():
+    nonlocal x, y, z
+
+
+def f():
+    # leading comment
+    nonlocal x, y, z  # end-of-line comment
+    # trailing comment
+
+
+def f():
+    nonlocal analyze_featuremap_layer, analyze_featuremapcompression_layer, analyze_latencies_post, analyze_motions_layer, analyze_size_model
+```
+
+
+


### PR DESCRIPTION
## Summary

Adds `global` and `nonlocal` formatting, without the "deviation from black" outlined in the linked issue, which I'll do separately.

See: https://github.com/astral-sh/ruff/issues/4798.

## Test Plan

Added a fixture in the Ruff-specific directory since the Black fixtures don't seem to cover this.
