### PR TITLE
Use CompactStr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +426,20 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2050,6 +2073,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "compact_str",
  "dirs 5.0.1",
  "fern",
  "glob",
@@ -2278,6 +2302,7 @@ name = "ruff_python_ast"
 version = "0.0.0"
 dependencies = [
  "bitflags 2.3.3",
+ "compact_str",
  "insta",
  "is-macro",
  "memchr",
@@ -2349,6 +2374,7 @@ name = "ruff_python_literal"
 version = "0.0.0"
 dependencies = [
  "bitflags 2.3.3",
+ "compact_str",
  "hexf-parse",
  "is-macro",
  "itertools",
@@ -2364,6 +2390,7 @@ name = "ruff_python_parser"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "compact_str",
  "insta",
  "is-macro",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ bitflags = { version = "2.3.1" }
 chrono = { version = "0.4.23", default-features = false, features = ["clock"] }
 clap = { version = "4.1.8", features = ["derive"] }
 colored = { version = "2.0.0" }
+compact_str = "0.7.1"
 filetime = { version = "0.2.20" }
 glob = { version = "0.3.1" }
 globset = { version = "0.4.10" }

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -36,6 +36,7 @@ bitflags = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "string"], optional = true }
 colored = { workspace = true }
+compact_str = { workspace = true }
 dirs = { version = "5.0.0" }
 fern = { version = "0.6.1" }
 glob = { workspace = true }

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -839,7 +839,7 @@ where
                 range: _,
             }) => {
                 if let Expr::Name(ast::ExprName { id, ctx, range: _ }) = func.as_ref() {
-                    if id == "locals" && ctx.is_load() {
+                    if id.as_str() == "locals" && ctx.is_load() {
                         let scope = self.semantic.scope_mut();
                         scope.set_uses_locals();
                     }
@@ -1651,21 +1651,21 @@ impl<'a> Checker<'a> {
             && match parent {
                 Stmt::Assign(ast::StmtAssign { targets, .. }) => {
                     if let Some(Expr::Name(ast::ExprName { id, .. })) = targets.first() {
-                        id == "__all__"
+                        id.as_str() == "__all__"
                     } else {
                         false
                     }
                 }
                 Stmt::AugAssign(ast::StmtAugAssign { target, .. }) => {
                     if let Expr::Name(ast::ExprName { id, .. }) = target.as_ref() {
-                        id == "__all__"
+                        id.as_str() == "__all__"
                     } else {
                         false
                     }
                 }
                 Stmt::AnnAssign(ast::StmtAnnAssign { target, .. }) => {
                     if let Expr::Name(ast::ExprName { id, .. }) = target.as_ref() {
-                        id == "__all__"
+                        id.as_str() == "__all__"
                     } else {
                         false
                     }

--- a/crates/ruff/src/checkers/imports.rs
+++ b/crates/ruff/src/checkers/imports.rs
@@ -47,7 +47,7 @@ fn extract_import_map(path: &Path, package: Option<&Path>, blocks: &[&Block]) ->
             }) => {
                 let level = level.map_or(0, |level| level.to_usize());
                 let module = if let Some(module) = module {
-                    let module: &String = module.as_ref();
+                    let module = module.as_ref();
                     if level == 0 {
                         Cow::Borrowed(module)
                     } else {

--- a/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -71,7 +71,7 @@ pub(crate) fn jinja2_autoescape_false(checker: &mut Checker, call: &ast::ExprCal
                 }) => (),
                 Expr::Call(ast::ExprCall { func, .. }) => {
                     if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
-                        if id != "select_autoescape" {
+                        if id.as_str() != "select_autoescape" {
                             checker.diagnostics.push(Diagnostic::new(
                                 Jinja2AutoescapeFalse { value: true },
                                 keyword.range(),

--- a/crates/ruff/src/rules/flake8_blind_except/rules/blind_except.rs
+++ b/crates/ruff/src/rules/flake8_blind_except/rules/blind_except.rs
@@ -76,7 +76,7 @@ pub(crate) fn blind_except(
         if let Stmt::Raise(ast::StmtRaise { exc, .. }) = stmt {
             if let Some(exc) = exc {
                 if let Expr::Name(ast::ExprName { id, .. }) = exc.as_ref() {
-                    name.is_some_and(|name| id == name)
+                    name.is_some_and(|name| id.as_str() == name)
                 } else {
                     false
                 }

--- a/crates/ruff/src/rules/flake8_boolean_trap/rules/check_positional_boolean_in_def.rs
+++ b/crates/ruff/src/rules/flake8_boolean_trap/rules/check_positional_boolean_in_def.rs
@@ -110,11 +110,11 @@ pub(crate) fn check_positional_boolean_in_def(
 
         // check for both bool (python class) and 'bool' (string annotation)
         let hint = match expr.as_ref() {
-            Expr::Name(name) => &name.id == "bool",
+            Expr::Name(name) => name.id.as_str() == "bool",
             Expr::Constant(ast::ExprConstant {
                 value: Constant::Str(value),
                 ..
-            }) => value == "bool",
+            }) => *value == "bool",
             _ => false,
         };
         if !hint {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assignment_to_os_environ.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assignment_to_os_environ.rs
@@ -62,7 +62,7 @@ pub(crate) fn assignment_to_os_environ(checker: &mut Checker, targets: &[Expr]) 
     let Expr::Name(ast::ExprName { id, .. }) = value.as_ref() else {
         return;
     };
-    if id != "os" {
+    if id.as_str() != "os" {
         return;
     }
     checker

--- a/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -84,7 +84,7 @@ pub(crate) fn cached_instance_method(checker: &mut Checker, decorator_list: &[De
         // TODO(charlie): This should take into account `classmethod-decorators` and
         // `staticmethod-decorators`.
         if let Expr::Name(ast::ExprName { id, .. }) = &decorator.expression {
-            if id == "classmethod" || id == "staticmethod" {
+            if id.as_str() == "classmethod" || id.as_str() == "staticmethod" {
                 return;
             }
         }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
@@ -149,7 +149,7 @@ impl<'a> Visitor<'a> for SuspiciousVariablesVisitor<'a> {
                     Expr::Attribute(ast::ExprAttribute { value, attr, .. }) => {
                         if attr == "reduce" {
                             if let Expr::Name(ast::ExprName { id, .. }) = value.as_ref() {
-                                if id == "functools" {
+                                if id.as_str() == "functools" {
                                     for arg in args {
                                         if arg.is_lambda_expr() {
                                             self.safe_functions.push(arg);

--- a/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -57,7 +57,7 @@ pub(crate) fn getattr_with_constant(
     let Expr::Name(ast::ExprName { id, .. }) = func else {
         return;
     };
-    if id != "getattr" {
+    if id.as_str() != "getattr" {
         return;
     }
     let [obj, arg] = args else {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
@@ -87,7 +87,7 @@ pub(crate) fn raise_without_from_inside_except(
                 if let Some(name) = name {
                     if exc
                         .as_name_expr()
-                        .is_some_and(|ast::ExprName { id, .. }| name == id)
+                        .is_some_and(|ast::ExprName { id, .. }| name == id.as_str())
                     {
                         continue;
                     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
@@ -82,7 +82,7 @@ impl<'a> GroupNameFinder<'a> {
 
     fn name_matches(&self, expr: &Expr) -> bool {
         if let Expr::Name(ast::ExprName { id, .. }) = expr {
-            id == self.group_name
+            id.as_str() == self.group_name
         } else {
             false
         }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -52,7 +52,7 @@ fn assignment(obj: &Expr, name: &str, value: &Expr, generator: Generator) -> Str
     let stmt = Stmt::Assign(ast::StmtAssign {
         targets: vec![Expr::Attribute(ast::ExprAttribute {
             value: Box::new(obj.clone()),
-            attr: Identifier::new(name.to_string(), TextRange::default()),
+            attr: Identifier::new(name, TextRange::default()),
             ctx: ExprContext::Store,
             range: TextRange::default(),
         })],
@@ -72,7 +72,7 @@ pub(crate) fn setattr_with_constant(
     let Expr::Name(ast::ExprName { id, .. }) = func else {
         return;
     };
-    if id != "setattr" {
+    if id.as_str() != "setattr" {
         return;
     }
     let [obj, name, value] = args else {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unintentional_type_annotation.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unintentional_type_annotation.rs
@@ -53,7 +53,7 @@ pub(crate) fn unintentional_type_annotation(
         }
         Expr::Attribute(ast::ExprAttribute { value, .. }) => {
             if let Expr::Name(ast::ExprName { id, .. }) = value.as_ref() {
-                if id != "self" {
+                if id.as_str() != "self" {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(UnintentionalTypeAnnotation, stmt.range()));

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
@@ -74,13 +74,13 @@ pub(crate) fn unreliable_callable_check(
     else {
         return;
     };
-    if string != "__call__" {
+    if *string != "__call__" {
         return;
     }
 
     let mut diagnostic = Diagnostic::new(UnreliableCallableCheck, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        if id == "hasattr" {
+        if id.as_str() == "hasattr" {
             if checker.semantic().is_builtin("callable") {
                 diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
                     format!("callable({})", checker.locator().slice(obj.range())),

--- a/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -42,7 +42,7 @@ impl Violation for ZipWithoutExplicitStrict {
 /// B905
 pub(crate) fn zip_without_explicit_strict(checker: &mut Checker, call: &ast::ExprCall) {
     if let Expr::Name(ast::ExprName { id, .. }) = call.func.as_ref() {
-        if id == "zip"
+        if id.as_str() == "zip"
             && checker.semantic().is_builtin("zip")
             && call.arguments.find_keyword("strict").is_none()
             && !call

--- a/crates/ruff/src/rules/flake8_django/rules/all_with_model_form.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/all_with_model_form.rs
@@ -76,7 +76,7 @@ pub(crate) fn all_with_model_form(
                 let Expr::Name(ast::ExprName { id, .. }) = target else {
                     continue;
                 };
-                if id != "fields" {
+                if id.as_str() != "fields" {
                     continue;
                 }
                 let Expr::Constant(ast::ExprConstant { value, .. }) = value.as_ref() else {
@@ -84,7 +84,7 @@ pub(crate) fn all_with_model_form(
                 };
                 match value {
                     Constant::Str(s) => {
-                        if s == "__all__" {
+                        if *s == "__all__" {
                             return Some(Diagnostic::new(DjangoAllWithModelForm, element.range()));
                         }
                     }

--- a/crates/ruff/src/rules/flake8_django/rules/exclude_with_model_form.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/exclude_with_model_form.rs
@@ -74,7 +74,7 @@ pub(crate) fn exclude_with_model_form(
                 let Expr::Name(ast::ExprName { id, .. }) = target else {
                     continue;
                 };
-                if id == "exclude" {
+                if id.as_str() == "exclude" {
                     return Some(Diagnostic::new(DjangoExcludeWithModelForm, target.range()));
                 }
             }

--- a/crates/ruff/src/rules/flake8_django/rules/model_without_dunder_str.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/model_without_dunder_str.rs
@@ -116,7 +116,7 @@ fn is_model_abstract(body: &[Stmt]) -> bool {
                 let Expr::Name(ast::ExprName { id, .. }) = target else {
                     continue;
                 };
-                if id != "abstract" {
+                if id.as_str() != "abstract" {
                     continue;
                 }
                 if !is_const_true(value) {

--- a/crates/ruff/src/rules/flake8_django/rules/unordered_body_content_in_model.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/unordered_body_content_in_model.rs
@@ -117,7 +117,7 @@ fn get_element_type(element: &Stmt, semantic: &SemanticModel) -> Option<ContentT
             let Expr::Name(ast::ExprName { id, .. }) = expr else {
                 return None;
             };
-            if id == "objects" {
+            if id.as_str() == "objects" {
                 Some(ContentType::ManagerDeclaration)
             } else {
                 None

--- a/crates/ruff/src/rules/flake8_gettext/mod.rs
+++ b/crates/ruff/src/rules/flake8_gettext/mod.rs
@@ -7,7 +7,9 @@ pub mod settings;
 /// Returns true if the [`Expr`] is an internationalization function call.
 pub(crate) fn is_gettext_func_call(func: &Expr, functions_names: &[String]) -> bool {
     if let Expr::Name(ast::ExprName { id, .. }) = func {
-        functions_names.contains(id)
+        functions_names
+            .iter()
+            .any(|item| item.as_str() == id.as_str())
     } else {
         false
     }

--- a/crates/ruff/src/rules/flake8_pie/rules/multiple_starts_ends_with.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules/multiple_starts_ends_with.rs
@@ -163,7 +163,7 @@ pub(crate) fn multiple_starts_ends_with(checker: &mut Checker, expr: &Expr) {
                 });
                 let node2 = Expr::Attribute(ast::ExprAttribute {
                     value: Box::new(node1),
-                    attr: Identifier::new(attr_name.to_string(), TextRange::default()),
+                    attr: Identifier::new(attr_name, TextRange::default()),
                     ctx: ExprContext::Load,
                     range: TextRange::default(),
                 });

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -50,7 +50,7 @@ pub(super) fn keyword_is_literal(keyword: &Keyword, literal: &str) -> bool {
         ..
     }) = &keyword.value
     {
-        string == literal
+        *string == literal
     } else {
         false
     }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/unittest_assert.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/unittest_assert.rs
@@ -393,7 +393,7 @@ impl UnittestAssert {
                 };
                 let node1 = ast::ExprAttribute {
                     value: Box::new(node.into()),
-                    attr: Identifier::new("search".to_string(), TextRange::default()),
+                    attr: Identifier::new("search", TextRange::default()),
                     ctx: ExprContext::Load,
                     range: TextRange::default(),
                 };

--- a/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
@@ -70,7 +70,8 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
                 .settings
                 .flake8_self
                 .ignore_names
-                .contains(attr.as_ref())
+                .iter()
+                .any(|name| name == attr.as_str())
             {
                 return;
             }

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -335,7 +335,7 @@ pub(crate) fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
         let Expr::Name(ast::ExprName { id: func_name, .. }) = func.as_ref() else {
             continue;
         };
-        if func_name != "isinstance" {
+        if func_name.as_str() != "isinstance" {
             continue;
         }
         if !checker.semantic().is_builtin("isinstance") {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -163,7 +163,7 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
     let Expr::Name(ast::ExprName { id, .. }) = attr_value.as_ref() else {
         return;
     };
-    if id != "os" || attr != "environ" {
+    if *id != "os" || attr != "environ" {
         return;
     }
     let Expr::Constant(ast::ExprConstant {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -263,14 +263,14 @@ fn is_main_check(expr: &Expr) -> bool {
     }) = expr
     {
         if let Expr::Name(ast::ExprName { id, .. }) = left.as_ref() {
-            if id == "__name__" {
+            if id.as_str() == "__name__" {
                 if comparators.len() == 1 {
                     if let Expr::Constant(ast::ExprConstant {
                         value: Constant::Str(value),
                         ..
                     }) = &comparators[0]
                     {
-                        if value == "__main__" {
+                        if *value == "__main__" {
                             return true;
                         }
                     }
@@ -950,7 +950,7 @@ pub(crate) fn use_dict_get_with_default(checker: &mut Checker, stmt_if: &ast::St
     let node1 = *test_key.clone();
     let node2 = ast::ExprAttribute {
         value: expected_subscript.clone(),
-        attr: Identifier::new("get".to_string(), TextRange::default()),
+        attr: Identifier::new("get", TextRange::default()),
         ctx: ExprContext::Load,
         range: TextRange::default(),
     };

--- a/crates/ruff/src/rules/flake8_tidy_imports/rules/relative_imports.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/rules/relative_imports.rs
@@ -94,10 +94,7 @@ fn fix_banned_relative_import(
         panic!("Expected Stmt::ImportFrom");
     };
     let node = ast::StmtImportFrom {
-        module: Some(Identifier::new(
-            module_path.to_string(),
-            TextRange::default(),
-        )),
+        module: Some(Identifier::new(module_path, TextRange::default())),
         names: names.clone(),
         level: Some(Int::new(0)),
         range: TextRange::default(),

--- a/crates/ruff/src/rules/flake8_unused_arguments/helpers.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/helpers.rs
@@ -21,11 +21,13 @@ fn is_empty_stmt(stmt: &Stmt) -> bool {
                 if let Some(exc) = exc {
                     match exc.as_ref() {
                         Expr::Name(ast::ExprName { id, .. }) => {
-                            return id == "NotImplementedError" || id == "NotImplemented";
+                            return id.as_str() == "NotImplementedError"
+                                || id.as_str() == "NotImplemented";
                         }
                         Expr::Call(ast::ExprCall { func, .. }) => {
                             if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
-                                return id == "NotImplementedError" || id == "NotImplemented";
+                                return id.as_str() == "NotImplementedError"
+                                    || id.as_str() == "NotImplemented";
                             }
                         }
                         _ => {}

--- a/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -75,7 +75,8 @@ fn build_fstring(joiner: &str, joinees: &[Expr]) -> Option<Expr> {
                             None
                         }
                     })
-                    .join(joiner),
+                    .join(joiner)
+                    .into(),
             ),
             range: TextRange::default(),
             kind: None,

--- a/crates/ruff/src/rules/pandas_vet/rules/assignment_to_df.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/assignment_to_df.rs
@@ -44,7 +44,7 @@ pub(crate) fn assignment_to_df(targets: &[Expr]) -> Option<Diagnostic> {
     let Expr::Name(ast::ExprName { id, .. }) = target else {
         return None;
     };
-    if id != "df" {
+    if id.as_str() != "df" {
         return None;
     }
     Some(Diagnostic::new(PandasDfVariableName, target.range()))

--- a/crates/ruff/src/rules/pandas_vet/rules/pd_merge.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/pd_merge.rs
@@ -57,7 +57,7 @@ impl Violation for PandasUseOfPdMerge {
 pub(crate) fn use_of_pd_merge(checker: &mut Checker, func: &Expr) {
     if let Expr::Attribute(ast::ExprAttribute { attr, value, .. }) = func {
         if let Expr::Name(ast::ExprName { id, .. }) = value.as_ref() {
-            if id == "pd" && attr == "merge" {
+            if id.as_str() == "pd" && attr == "merge" {
                 checker
                     .diagnostics
                     .push(Diagnostic::new(PandasUseOfPdMerge, func.range()));

--- a/crates/ruff/src/rules/pep8_naming/rules/error_suffix_on_exception_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/error_suffix_on_exception_name.rs
@@ -56,7 +56,7 @@ pub(crate) fn error_suffix_on_exception_name(
     if !arguments.is_some_and(|arguments| {
         arguments.args.iter().any(|base| {
             if let Expr::Name(ast::ExprName { id, .. }) = &base {
-                id == "Exception" || id.ends_with("Error")
+                id.as_str() == "Exception" || id.ends_with("Error")
             } else {
                 false
             }

--- a/crates/ruff/src/rules/perflint/rules/unnecessary_list_cast.rs
+++ b/crates/ruff/src/rules/perflint/rules/unnecessary_list_cast.rs
@@ -74,7 +74,7 @@ pub(crate) fn unnecessary_list_cast(checker: &mut Checker, iter: &Expr) {
         return;
     };
 
-    if !(id == "list" && checker.semantic().is_builtin("list")) {
+    if !(id.as_str() == "list" && checker.semantic().is_builtin("list")) {
         return;
     }
 

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -220,7 +220,7 @@ fn function(
                 })
                 .collect::<Vec<_>>();
             let func = Stmt::FunctionDef(ast::StmtFunctionDef {
-                name: Identifier::new(name.to_string(), TextRange::default()),
+                name: Identifier::new(name, TextRange::default()),
                 parameters: Box::new(Parameters {
                     posonlyargs: new_posonlyargs,
                     args: new_args,
@@ -236,7 +236,7 @@ fn function(
         }
     }
     let func = Stmt::FunctionDef(ast::StmtFunctionDef {
-        name: Identifier::new(name.to_string(), TextRange::default()),
+        name: Identifier::new(name, TextRange::default()),
         parameters: Box::new(parameters.clone()),
         body: vec![body],
         decorator_list: vec![],

--- a/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
@@ -60,7 +60,7 @@ pub(crate) fn type_comparison(checker: &mut Checker, compare: &ast::ExprCompare)
             continue;
         };
 
-        if !(id == "type" && checker.semantic().is_builtin("type")) {
+        if !(*id == "type" && checker.semantic().is_builtin("type")) {
             continue;
         }
 
@@ -74,7 +74,7 @@ pub(crate) fn type_comparison(checker: &mut Checker, compare: &ast::ExprCompare)
                     continue;
                 };
 
-                if id == "type" && checker.semantic().is_builtin("type") {
+                if id.as_str() == "type" && checker.semantic().is_builtin("type") {
                     // Allow comparison for types which are not obvious.
                     if arguments
                         .args

--- a/crates/ruff/src/rules/pyflakes/cformat.rs
+++ b/crates/ruff/src/rules/pyflakes/cformat.rs
@@ -1,4 +1,5 @@
 //! Implements helper functions for using vendored/cformat.rs
+use compact_str::CompactString;
 use std::convert::TryFrom;
 use std::str::FromStr;
 
@@ -10,7 +11,7 @@ use rustc_hash::FxHashSet;
 pub(crate) struct CFormatSummary {
     pub(crate) starred: bool,
     pub(crate) num_positional: usize,
-    pub(crate) keywords: FxHashSet<String>,
+    pub(crate) keywords: FxHashSet<CompactString>,
 }
 
 impl From<&CFormatString> for CFormatSummary {
@@ -73,7 +74,10 @@ mod tests {
         let literal = "%(foo)s %s %d %(bar)x";
 
         let expected_positional = 2;
-        let expected_keywords = ["foo", "bar"].into_iter().map(String::from).collect();
+        let expected_keywords = ["foo", "bar"]
+            .into_iter()
+            .map(CompactString::from)
+            .collect();
 
         let format_summary = CFormatSummary::try_from(literal).unwrap();
         assert!(!format_summary.starred);

--- a/crates/ruff/src/rules/pyflakes/format.rs
+++ b/crates/ruff/src/rules/pyflakes/format.rs
@@ -1,4 +1,5 @@
 //! Implements helper functions for using vendored/format.rs
+use compact_str::CompactString;
 use std::convert::TryFrom;
 
 use ruff_python_literal::format::{
@@ -24,7 +25,7 @@ pub(crate) fn error_to_string(err: &FormatParseError) -> String {
 pub(crate) struct FormatSummary {
     pub(crate) autos: Vec<usize>,
     pub(crate) indices: Vec<usize>,
-    pub(crate) keywords: Vec<String>,
+    pub(crate) keywords: Vec<CompactString>,
     pub(crate) has_nested_parts: bool,
 }
 

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_print_syntax.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_print_syntax.rs
@@ -60,7 +60,7 @@ pub(crate) fn invalid_print_syntax(checker: &mut Checker, left: &Expr) {
     let Expr::Name(ast::ExprName { id, .. }) = &left else {
         return;
     };
-    if id != "print" {
+    if *id != "print" {
         return;
     }
     if !checker.semantic().is_builtin("print") {

--- a/crates/ruff/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -54,13 +54,13 @@ fn match_not_implemented(expr: &Expr) -> Option<&Expr> {
     match expr {
         Expr::Call(ast::ExprCall { func, .. }) => {
             if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
-                if id == "NotImplemented" {
+                if *id == "NotImplemented" {
                     return Some(func);
                 }
             }
         }
         Expr::Name(ast::ExprName { id, .. }) => {
-            if id == "NotImplemented" {
+            if *id == "NotImplemented" {
                 return Some(expr);
             }
         }

--- a/crates/ruff/src/rules/pygrep_hooks/rules/no_eval.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/no_eval.rs
@@ -43,7 +43,7 @@ pub(crate) fn no_eval(checker: &mut Checker, func: &Expr) {
     let Expr::Name(ast::ExprName { id, .. }) = func else {
         return;
     };
-    if id != "eval" {
+    if *id != "eval" {
         return;
     }
     if !checker.semantic().is_builtin("eval") {

--- a/crates/ruff/src/rules/pylint/rules/manual_import_from.rs
+++ b/crates/ruff/src/rules/pylint/rules/manual_import_from.rs
@@ -74,7 +74,7 @@ pub(crate) fn manual_from_import(
     if checker.patch(diagnostic.kind.rule()) {
         if names.len() == 1 {
             let node = ast::StmtImportFrom {
-                module: Some(Identifier::new(module.to_string(), TextRange::default())),
+                module: Some(Identifier::new(module, TextRange::default())),
                 names: vec![Alias {
                     name: asname.clone(),
                     asname: None,

--- a/crates/ruff/src/rules/pylint/rules/property_with_parameters.rs
+++ b/crates/ruff/src/rules/pylint/rules/property_with_parameters.rs
@@ -55,7 +55,7 @@ pub(crate) fn property_with_parameters(
 ) {
     if !decorator_list
         .iter()
-        .any(|decorator| matches!(&decorator.expression, Expr::Name(ast::ExprName { id, .. }) if id == "property"))
+        .any(|decorator| matches!(&decorator.expression, Expr::Name(ast::ExprName { id, .. }) if *id == "property"))
     {
         return;
     }

--- a/crates/ruff/src/rules/pylint/rules/repeated_isinstance_calls.rs
+++ b/crates/ruff/src/rules/pylint/rules/repeated_isinstance_calls.rs
@@ -81,7 +81,7 @@ pub(crate) fn repeated_isinstance_calls(
         else {
             continue;
         };
-        if !matches!(func.as_ref(), Expr::Name(ast::ExprName { id, .. }) if id == "isinstance") {
+        if !matches!(func.as_ref(), Expr::Name(ast::ExprName { id, .. }) if *id == "isinstance") {
             continue;
         }
         let [obj, types] = &args[..] else {

--- a/crates/ruff/src/rules/pylint/rules/type_param_name_mismatch.rs
+++ b/crates/ruff/src/rules/pylint/rules/type_param_name_mismatch.rs
@@ -77,7 +77,7 @@ pub(crate) fn type_param_name_mismatch(checker: &mut Checker, value: &Expr, targ
         return;
     };
 
-    if var_name == param_name {
+    if *var_name == param_name {
         return;
     }
 

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -165,7 +165,7 @@ fn create_properties_from_keywords(keywords: &[Keyword]) -> Result<Vec<Stmt>> {
 /// keywords.
 fn create_class_def_stmt(typename: &str, body: Vec<Stmt>, base_class: &Expr) -> Stmt {
     ast::StmtClassDef {
-        name: Identifier::new(typename.to_string(), TextRange::default()),
+        name: Identifier::new(typename, TextRange::default()),
         arguments: Some(Box::new(Arguments {
             args: vec![base_class.clone()],
             keywords: vec![],

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -118,7 +118,7 @@ fn create_class_def_stmt(
     base_class: &Expr,
 ) -> Stmt {
     ast::StmtClassDef {
-        name: Identifier::new(class_name.to_string(), TextRange::default()),
+        name: Identifier::new(class_name, TextRange::default()),
         arguments: Some(Box::new(Arguments {
             args: vec![base_class.clone()],
             keywords: match total_keyword {
@@ -167,7 +167,7 @@ fn properties_from_dict_call(func: &Expr, keywords: &[Keyword]) -> Result<Vec<St
     let Expr::Name(ast::ExprName { id, .. }) = func else {
         bail!("Expected `func` to be `Expr::Name`")
     };
-    if id != "dict" {
+    if *id != "dict" {
         bail!("Expected `id` to be `\"dict\"`")
     }
     if keywords.is_empty() {

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -88,7 +88,7 @@ pub(crate) fn deprecated_unittest_alias(checker: &mut Checker, expr: &Expr) {
     let Expr::Name(ast::ExprName { id, .. }) = value.as_ref() else {
         return;
     };
-    if id != "self" {
+    if *id != "self" {
         return;
     }
     let mut diagnostic = Diagnostic::new(

--- a/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -1,3 +1,4 @@
+use compact_str::CompactString;
 use std::str::FromStr;
 
 use ruff_python_ast::{self as ast, Constant, Expr, Ranged};
@@ -295,7 +296,11 @@ fn convertible(format_string: &CFormatString, params: &Expr) -> bool {
         }
 
         // No equivalent in format.
-        if fmt.mapping_key.as_ref().is_some_and(String::is_empty) {
+        if fmt
+            .mapping_key
+            .as_ref()
+            .is_some_and(CompactString::is_empty)
+        {
             return false;
         }
 

--- a/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -62,7 +62,7 @@ impl AlwaysAutofixableViolation for SuperCallWithParameters {
 /// Returns `true` if a call is an argumented `super` invocation.
 fn is_super_call_with_arguments(func: &Expr, args: &[Expr]) -> bool {
     if let Expr::Name(ast::ExprName { id, .. }) = func {
-        id == "super" && !args.is_empty()
+        *id == "super" && !args.is_empty()
     } else {
         false
     }
@@ -136,7 +136,7 @@ pub(crate) fn super_call_with_parameters(
         return;
     };
 
-    if !(first_arg_id == parent_name.as_str() && second_arg_id == parent_arg.as_str()) {
+    if !(*first_arg_id == parent_name.as_str() && *second_arg_id == parent_arg.as_str()) {
         return;
     }
 

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
@@ -1,3 +1,4 @@
+use compact_str::CompactString;
 use ruff_python_ast::{Expr, ExprName, Ranged, Stmt, StmtAnnAssign, StmtTypeAlias};
 
 use crate::{registry::AsRule, settings::types::PythonVersion};
@@ -25,7 +26,7 @@ use crate::checkers::ast::Checker;
 /// ```
 #[violation]
 pub struct NonPEP695TypeAlias {
-    name: String,
+    name: CompactString,
 }
 
 impl Violation for NonPEP695TypeAlias {

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -51,13 +51,13 @@ pub(crate) fn useless_metaclass_type(
     let [Expr::Name(ast::ExprName { id, .. })] = targets else {
         return;
     };
-    if id != "__metaclass__" {
+    if *id != "__metaclass__" {
         return;
     }
     let Expr::Name(ast::ExprName { id, .. }) = value else {
         return;
     };
-    if id != "type" {
+    if *id != "type" {
         return;
     }
 

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -54,7 +54,7 @@ pub(crate) fn useless_object_inheritance(checker: &mut Checker, class_def: &ast:
         let Expr::Name(ast::ExprName { id, .. }) = base else {
             continue;
         };
-        if id != "object" {
+        if *id != "object" {
             continue;
         }
         if !checker.semantic().is_builtin("object") {

--- a/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use anyhow::Result;
+use compact_str::CompactString;
 use ruff_python_ast::{
     self as ast, Constant, Expr, Operator, ParameterWithDefault, Parameters, Ranged,
 };
@@ -150,7 +151,7 @@ fn generate_fix(checker: &Checker, conversion_type: ConversionType, expr: &Expr)
             let new_expr = Expr::Subscript(ast::ExprSubscript {
                 range: TextRange::default(),
                 value: Box::new(Expr::Name(ast::ExprName {
-                    id: binding,
+                    id: CompactString::from(binding),
                     ctx: ast::ExprContext::Store,
                     range: TextRange::default(),
                 })),

--- a/crates/ruff/src/rules/ruff/rules/pairwise_over_zipped.rs
+++ b/crates/ruff/src/rules/ruff/rules/pairwise_over_zipped.rs
@@ -125,7 +125,7 @@ pub(crate) fn pairwise_over_zipped(checker: &mut Checker, func: &Expr, args: &[E
     }
 
     // Require the function to be the builtin `zip`.
-    if !(id == "zip" && checker.semantic().is_builtin(id)) {
+    if !(*id == "zip" && checker.semantic().is_builtin(id)) {
         return;
     }
 

--- a/crates/ruff/src/rules/tryceratops/rules/useless_try_except.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/useless_try_except.rs
@@ -53,7 +53,7 @@ pub(crate) fn useless_try_except(checker: &mut Checker, handlers: &[ExceptHandle
             if let Some(expr) = exc {
                 // E.g., `except ... as e: raise e`
                 if let Expr::Name(ast::ExprName { id, .. }) = expr.as_ref() {
-                    if name.as_ref().is_some_and(|name| name.as_str() == id) {
+                    if name.as_ref().is_some_and(|name| name.as_str() == *id) {
                         return Some(Diagnostic::new(UselessTryExcept, handler.range()));
                     }
                 }

--- a/crates/ruff/src/rules/tryceratops/rules/verbose_raise.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/verbose_raise.rs
@@ -96,7 +96,7 @@ pub(crate) fn verbose_raise(checker: &mut Checker, handlers: &[ExceptHandler]) {
                 if let Some(exc) = raise.exc.as_ref() {
                     // ...and the raised object is bound to the same name...
                     if let Expr::Name(ast::ExprName { id, .. }) = exc.as_ref() {
-                        if id == exception_name.as_str() {
+                        if id.as_str() == exception_name.as_str() {
                             let mut diagnostic = Diagnostic::new(VerboseRaise, exc.range());
                             if checker.patch(diagnostic.kind.rule()) {
                                 diagnostic.set_fix(Fix::suggested(Edit::range_replacement(

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -20,6 +20,7 @@ ruff_source_file = { path = "../ruff_source_file" }
 ruff_text_size = { path = "../ruff_text_size" }
 
 bitflags = { workspace = true }
+compact_str = { workspace = true }
 is-macro = { workspace = true }
 memchr = { workspace = true }
 num-bigint = { workspace = true }
@@ -35,4 +36,4 @@ insta = { workspace = true }
 ruff_python_parser = { path = "../ruff_python_parser" }
 
 [features]
-serde = ["dep:serde", "ruff_text_size/serde"]
+serde = ["dep:serde", "ruff_text_size/serde", "compact_str/serde"]

--- a/crates/ruff_python_ast/src/all.rs
+++ b/crates/ruff_python_ast/src/all.rs
@@ -52,7 +52,7 @@ where
             }
             Expr::Name(ast::ExprName { id, .. }) => {
                 // Ex) `__all__ = __all__ + multiprocessing.__all__`
-                if id == "__all__" {
+                if id.as_str() == "__all__" {
                     return (None, DunderAllFlags::empty());
                 }
             }

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1132,6 +1132,7 @@ impl Truthiness {
 
 #[cfg(test)]
 mod tests {
+    use compact_str::CompactString;
     use std::borrow::Cow;
     use std::cell::RefCell;
     use std::vec;
@@ -1185,7 +1186,7 @@ mod tests {
     fn any_over_stmt_type_alias() {
         let seen = RefCell::new(Vec::new());
         let name = Expr::Name(ExprName {
-            id: "x".to_string(),
+            id: CompactString::new_inline("x"),
             range: TextRange::default(),
             ctx: ExprContext::Load,
         });

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 use crate::Ranged;
+use compact_str::CompactString;
 use num_bigint::BigInt;
 use ruff_text_size::{TextRange, TextSize};
 use std::fmt;
@@ -109,7 +110,7 @@ pub enum Stmt {
 pub struct StmtLineMagic {
     pub range: TextRange,
     pub kind: MagicKind,
-    pub value: String,
+    pub value: CompactString,
 }
 
 impl From<StmtLineMagic> for Stmt {
@@ -616,7 +617,7 @@ pub enum Expr {
 pub struct ExprLineMagic {
     pub range: TextRange,
     pub kind: MagicKind,
-    pub value: String,
+    pub value: CompactString,
 }
 
 impl From<ExprLineMagic> for Expr {
@@ -989,7 +990,7 @@ impl From<ExprStarred> for Expr {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprName {
     pub range: TextRange,
-    pub id: String,
+    pub id: CompactString,
     pub ctx: ExprContext,
 }
 
@@ -2380,13 +2381,13 @@ impl MagicKind {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Identifier {
-    id: String,
+    id: CompactString,
     range: TextRange,
 }
 
 impl Identifier {
     #[inline]
-    pub fn new(id: impl Into<String>, range: TextRange) -> Self {
+    pub fn new(id: impl Into<CompactString>, range: TextRange) -> Self {
         Self {
             id: id.into(),
             range,
@@ -2398,6 +2399,11 @@ impl Identifier {
     #[inline]
     pub fn as_str(&self) -> &str {
         self.id.as_str()
+    }
+
+    #[inline]
+    pub fn as_compact_str(&self) -> &CompactString {
+        &self.id
     }
 }
 
@@ -2411,7 +2417,7 @@ impl PartialEq<str> for Identifier {
 impl PartialEq<String> for Identifier {
     #[inline]
     fn eq(&self, other: &String) -> bool {
-        &self.id == other
+        self.id == other
     }
 }
 
@@ -2430,29 +2436,21 @@ impl AsRef<str> for Identifier {
     }
 }
 
-impl AsRef<String> for Identifier {
-    #[inline]
-    fn as_ref(&self) -> &String {
-        &self.id
-    }
-}
-
 impl std::fmt::Display for Identifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.id, f)
     }
 }
 
-impl From<Identifier> for String {
-    #[inline]
-    fn from(identifier: Identifier) -> String {
-        identifier.id
-    }
-}
-
 impl Ranged for Identifier {
     fn range(&self) -> TextRange {
         self.range
+    }
+}
+
+impl From<Identifier> for CompactString {
+    fn from(value: Identifier) -> Self {
+        value.id
     }
 }
 

--- a/crates/ruff_python_literal/Cargo.toml
+++ b/crates/ruff_python_literal/Cargo.toml
@@ -13,6 +13,7 @@ license = { workspace = true }
 
 [dependencies]
 bitflags = { workspace = true }
+compact_str = { workspace = true }
 hexf-parse = "0.2.1"
 is-macro.workspace = true
 itertools = { workspace = true }

--- a/crates/ruff_python_literal/src/cformat.rs
+++ b/crates/ruff_python_literal/src/cformat.rs
@@ -1,6 +1,7 @@
 //! Implementation of Printf-Style string formatting
 //! as per the [Python Docs](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting).
 use bitflags::bitflags;
+use compact_str::CompactString;
 use num_traits::Signed;
 use std::{
     cmp, fmt,
@@ -119,7 +120,7 @@ pub enum CFormatQuantity {
 
 #[derive(Debug, PartialEq)]
 pub struct CFormatSpec {
-    pub mapping_key: Option<String>,
+    pub mapping_key: Option<CompactString>,
     pub flags: CConversionFlags,
     pub min_field_width: Option<CFormatQuantity>,
     pub precision: Option<CFormatPrecision>,
@@ -410,7 +411,9 @@ impl CFormatSpec {
     }
 }
 
-fn parse_spec_mapping_key<T, I>(iter: &mut ParseIter<I>) -> Result<Option<String>, ParsingError>
+fn parse_spec_mapping_key<T, I>(
+    iter: &mut ParseIter<I>,
+) -> Result<Option<CompactString>, ParsingError>
 where
     T: Into<char> + Copy,
     I: Iterator<Item = T>,
@@ -546,13 +549,13 @@ where
     Ok(None)
 }
 
-fn parse_text_inside_parentheses<T, I>(iter: &mut ParseIter<I>) -> Option<String>
+fn parse_text_inside_parentheses<T, I>(iter: &mut ParseIter<I>) -> Option<CompactString>
 where
     T: Into<char>,
     I: Iterator<Item = T>,
 {
     let mut counter: i32 = 1;
-    let mut contained_text = String::new();
+    let mut contained_text = CompactString::default();
     loop {
         let (_, c) = iter.next()?;
         let c = c.into();
@@ -776,7 +779,7 @@ mod tests {
     #[test]
     fn test_parse_key() {
         let expected = Ok(CFormatSpec {
-            mapping_key: Some("amount".to_owned()),
+            mapping_key: Some(CompactString::new_inline("amount")),
             format_type: CFormatType::Number(CNumberType::Decimal),
             format_char: 'd',
             min_field_width: None,
@@ -786,7 +789,7 @@ mod tests {
         assert_eq!("%(amount)d".parse::<CFormatSpec>(), expected);
 
         let expected = Ok(CFormatSpec {
-            mapping_key: Some("m((u(((l((((ti))))p)))l))e".to_owned()),
+            mapping_key: Some(CompactString::new("m((u(((l((((ti))))p)))l))e")),
             format_type: CFormatType::Number(CNumberType::Decimal),
             format_char: 'd',
             min_field_width: None,

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -1,5 +1,6 @@
 use itertools::{Itertools, PeekingNext};
 
+use compact_str::CompactString;
 use num_traits::{cast::ToPrimitive, FromPrimitive, Signed};
 use std::error::Error;
 use std::ops::Deref;
@@ -848,7 +849,7 @@ impl FieldNamePart {
 pub enum FieldType {
     Auto,
     Index(usize),
-    Keyword(String),
+    Keyword(CompactString),
 }
 
 #[derive(Debug, PartialEq)]
@@ -860,7 +861,7 @@ pub struct FieldName {
 impl FieldName {
     pub fn parse(text: &str) -> Result<FieldName, FormatParseError> {
         let mut chars = text.chars().peekable();
-        let mut first = String::new();
+        let mut first = CompactString::default();
         for ch in chars.peeking_take_while(|ch| *ch != '.' && *ch != '[') {
             first.push(ch);
         }
@@ -1312,14 +1313,14 @@ mod tests {
         assert_eq!(
             FieldName::parse("key"),
             Ok(FieldName {
-                field_type: FieldType::Keyword("key".to_owned()),
+                field_type: FieldType::Keyword(CompactString::new_inline("key")),
                 parts: Vec::new(),
             })
         );
         assert_eq!(
             FieldName::parse("key.attr[0][string]"),
             Ok(FieldName {
-                field_type: FieldType::Keyword("key".to_owned()),
+                field_type: FieldType::Keyword(CompactString::new_inline("key")),
                 parts: vec![
                     FieldNamePart::Attribute("attr".to_owned()),
                     FieldNamePart::Index(0),

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -18,6 +18,7 @@ ruff_python_ast = { path = "../ruff_python_ast"}
 ruff_text_size = { path = "../ruff_text_size" }
 
 anyhow = { workspace = true }
+compact_str = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
 lalrpop-util = { version = "0.20.0", default-features = false }

--- a/crates/ruff_python_parser/src/python.lalrpop
+++ b/crates/ruff_python_parser/src/python.lalrpop
@@ -270,7 +270,7 @@ ImportAsNames: Vec<ast::Alias> = {
     <location:@L> "(" <i:OneOrMore<ImportAsAlias<Identifier>>> ","? ")" <end_location:@R> => i,
     <location:@L> "*" <end_location:@R> => {
         // Star import all
-        vec![ast::Alias { name: ast::Identifier::new("*", (location..end_location).into()), asname: None, range: (location..end_location).into() }]
+        vec![ast::Alias { name: ast::Identifier::new(compact_str::CompactString::new_inline("*"), (location..end_location).into()), asname: None, range: (location..end_location).into() }]
     },
 };
 
@@ -1836,10 +1836,10 @@ extern {
             kind: <StringKind>,
             triple_quoted: <bool>
         },
-        name => token::Tok::Name { name: <String> },
+        name => token::Tok::Name { name: <compact_str::CompactString> },
         line_magic => token::Tok::MagicCommand {
             kind: <MagicKind>,
-            value: <String>
+            value: <compact_str::CompactString>
         },
         "\n" => token::Tok::Newline,
         ";" => token::Tok::Semi,

--- a/crates/ruff_python_parser/src/python.rs
+++ b/crates/ruff_python_parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: f99d8cb29227bfbe1fa07719f655304a9a93fd4715726687ef40c091adbdbad5
+// sha3: 610d05ec4782fe6dfbe20b76757198e57ba7bf04e19451a8d3b4eeb38c8634ae
 use num_bigint::BigInt;
 use ruff_text_size::TextSize;
 use ruff_python_ast::{self as ast, Ranged, MagicKind};
@@ -47,8 +47,8 @@ mod __parse__Top {
         Variant1((f64, f64)),
         Variant2(f64),
         Variant3(BigInt),
-        Variant4((MagicKind, String)),
-        Variant5(String),
+        Variant4((MagicKind, compact_str::CompactString)),
+        Variant5(compact_str::CompactString),
         Variant6((String, StringKind, bool)),
         Variant7(core::option::Option<token::Tok>),
         Variant8(Option<Box<ast::Parameter>>),
@@ -17563,7 +17563,7 @@ mod __parse__Top {
     fn __pop_Variant4<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
-    ) -> (TextSize, (MagicKind, String), TextSize)
+    ) -> (TextSize, (MagicKind, compact_str::CompactString), TextSize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant4(__v), __r)) => (__l, __v, __r),
@@ -17757,16 +17757,6 @@ mod __parse__Top {
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant86(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant5<
-    >(
-        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
-    ) -> (TextSize, String, TextSize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant5(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -18297,6 +18287,16 @@ mod __parse__Top {
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant17(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant5<
+    >(
+        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
+    ) -> (TextSize, compact_str::CompactString, TextSize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant5(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -31580,7 +31580,7 @@ fn __action67<
 {
     {
         // Star import all
-        vec![ast::Alias { name: ast::Identifier::new("*", (location..end_location).into()), asname: None, range: (location..end_location).into() }]
+        vec![ast::Alias { name: ast::Identifier::new(compact_str::CompactString::new_inline("*"), (location..end_location).into()), asname: None, range: (location..end_location).into() }]
     }
 }
 
@@ -31590,7 +31590,7 @@ fn __action68<
 >(
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, n, _): (TextSize, String, TextSize),
+    (_, n, _): (TextSize, compact_str::CompactString, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -31603,7 +31603,7 @@ fn __action69<
 >(
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, n, _): (TextSize, String, TextSize),
+    (_, n, _): (TextSize, compact_str::CompactString, TextSize),
     (_, n2, _): (TextSize, alloc::vec::Vec<(token::Tok, ast::Identifier)>, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
@@ -31683,7 +31683,7 @@ fn __action73<
 >(
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, m, _): (TextSize, (MagicKind, String), TextSize),
+    (_, m, _): (TextSize, (MagicKind, compact_str::CompactString), TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> Result<ast::Stmt,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
@@ -31711,7 +31711,7 @@ fn __action74<
 >(
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, m, _): (TextSize, (MagicKind, String), TextSize),
+    (_, m, _): (TextSize, (MagicKind, compact_str::CompactString), TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
@@ -34477,7 +34477,7 @@ fn __action234<
 >(
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, s, _): (TextSize, String, TextSize),
+    (_, s, _): (TextSize, compact_str::CompactString, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -45088,7 +45088,7 @@ fn __action777<
 fn __action778<
 >(
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, compact_str::CompactString, TextSize),
     __1: (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -45113,7 +45113,7 @@ fn __action778<
 fn __action779<
 >(
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, compact_str::CompactString, TextSize),
     __1: (TextSize, alloc::vec::Vec<(token::Tok, ast::Identifier)>, TextSize),
     __2: (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
@@ -45977,7 +45977,7 @@ fn __action808<
 fn __action809<
 >(
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, compact_str::CompactString, TextSize),
     __1: (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -46299,7 +46299,7 @@ fn __action819<
 fn __action820<
 >(
     mode: Mode,
-    __0: (TextSize, (MagicKind, String), TextSize),
+    __0: (TextSize, (MagicKind, compact_str::CompactString), TextSize),
     __1: (TextSize, TextSize, TextSize),
 ) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
@@ -46324,7 +46324,7 @@ fn __action820<
 fn __action821<
 >(
     mode: Mode,
-    __0: (TextSize, (MagicKind, String), TextSize),
+    __0: (TextSize, (MagicKind, compact_str::CompactString), TextSize),
     __1: (TextSize, TextSize, TextSize),
 ) -> Result<ast::Stmt,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
@@ -59054,7 +59054,7 @@ fn __action1268<
 fn __action1269<
 >(
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, compact_str::CompactString, TextSize),
 ) -> ast::Identifier
 {
     let __start0 = __0.2;
@@ -59077,7 +59077,7 @@ fn __action1269<
 fn __action1270<
 >(
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, compact_str::CompactString, TextSize),
     __1: (TextSize, alloc::vec::Vec<(token::Tok, ast::Identifier)>, TextSize),
 ) -> ast::Identifier
 {
@@ -59654,7 +59654,7 @@ fn __action1292<
 fn __action1293<
 >(
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, compact_str::CompactString, TextSize),
 ) -> ast::Identifier
 {
     let __start0 = __0.2;
@@ -59971,7 +59971,7 @@ fn __action1304<
 fn __action1305<
 >(
     mode: Mode,
-    __0: (TextSize, (MagicKind, String), TextSize),
+    __0: (TextSize, (MagicKind, compact_str::CompactString), TextSize),
 ) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.2;
@@ -59994,7 +59994,7 @@ fn __action1305<
 fn __action1306<
 >(
     mode: Mode,
-    __0: (TextSize, (MagicKind, String), TextSize),
+    __0: (TextSize, (MagicKind, compact_str::CompactString), TextSize),
 ) -> Result<ast::Stmt,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.2;

--- a/crates/ruff_python_parser/src/soft_keywords.rs
+++ b/crates/ruff_python_parser/src/soft_keywords.rs
@@ -1,4 +1,5 @@
 use crate::{lexer::LexResult, token::Tok, Mode};
+use compact_str::CompactString;
 use itertools::{Itertools, MultiPeek};
 
 /// An [`Iterator`] that transforms a token stream to accommodate soft keywords (namely, `match`
@@ -158,6 +159,6 @@ fn soft_to_name(tok: &Tok) -> Tok {
         _ => unreachable!("other tokens never reach here"),
     };
     Tok::Name {
-        name: name.to_owned(),
+        name: CompactString::new_inline(name),
     }
 }

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -5,6 +5,7 @@
 //!
 //! [CPython source]: https://github.com/python/cpython/blob/dfc2e065a2e71011017077e549cd2f9bf4944c54/Include/internal/pycore_token.h;
 use crate::Mode;
+use compact_str::CompactString;
 use num_bigint::BigInt;
 use ruff_python_ast::MagicKind;
 use ruff_text_size::TextSize;
@@ -16,7 +17,7 @@ pub enum Tok {
     /// Token value for a name, commonly known as an identifier.
     Name {
         /// The name value.
-        name: String,
+        name: CompactString,
     },
     /// Token value for an integer.
     Int {
@@ -48,12 +49,12 @@ pub enum Tok {
     /// prior to parsing when the mode is [`Mode::Jupyter`].
     MagicCommand {
         /// The magic command value.
-        value: String,
+        value: CompactString,
         /// The kind of magic command.
         kind: MagicKind,
     },
     /// Token value for a comment. These are filtered out of the token stream prior to parsing.
-    Comment(String),
+    Comment(CompactString),
     /// Token value for a newline.
     Newline,
     /// Token value for a newline that is not a logical line break. These are filtered out of


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->




## DHat

I ran `dhat` on a `release-debug` profile before and after, but using the standard allocator (we otherwise only see the jmalloc allocations):

### CPython

**Compact**:

```
==201937== 
==201937== Total:     2,283,177,432 bytes in 7,921,922 blocks
==201937== At t-gmax: 78,964,976 bytes in 57,198 blocks
==201937== At t-end:  6,944,207 bytes in 2,902 blocks
==201937== Reads:     10,290,603,461 bytes
==201937== Writes:    9,320,957,577 bytes
==201937== 
```
**Main**:
```
==203074== Total:     2,292,985,670 bytes in 9,444,797 blocks
==203074== At t-gmax: 78,965,000 bytes in 57,199 blocks
==203074== At t-end:  6,944,231 bytes in 2,903 blocks
==203074== Reads:     10,539,612,847 bytes
==203074== Writes:    9,333,587,194 bytes
```


### Homeassitant

**Compact**:

```
==204554== 
==204554== Total:     4,290,188,087 bytes in 13,503,898 blocks
==204554== At t-gmax: 94,286,731 bytes in 34,839 blocks
==204554== At t-end:  9,377,058 bytes in 2,806 blocks
==204554== Reads:     18,020,843,292 bytes
==204554== Writes:    15,588,886,480 bytes
```
**Main**:
```
==203843== 
==203843== Total:     4,315,002,840 bytes in 16,096,248 blocks
==203843== At t-gmax: 94,009,511 bytes in 34,775 blocks
==203843== At t-end:  9,381,062 bytes in 2,812 blocks
==203843== Reads:     18,548,850,275 bytes
==203843== Writes:    15,620,638,174 bytes
```


### Summary

The savings are smaller than I expected (only about 9MB for CPython and 23MB for Homeassitant). The general noise makes it difficult to get to the bottom of it:

* The cpython repo contains many diagnostics 
* The string parser happily allocates a ton of strings
* The generated parser uses `Vec`s for everything... 


## Test Plan

<!-- How was it tested? -->
