### PR TITLE
Track formatting all comments

### DIFF
--- a/crates/ruff_python_formatter/src/expression/expr_formatted_value.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_formatted_value.rs
@@ -1,7 +1,7 @@
 use crate::context::PyFormatContext;
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
-use crate::{not_yet_implemented, FormatNodeRule, PyFormatter};
-use ruff_formatter::{write, Buffer, FormatResult};
+use crate::{FormatNodeRule, PyFormatter};
+use ruff_formatter::FormatResult;
 use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::ExprFormattedValue;
 
@@ -9,8 +9,8 @@ use ruff_python_ast::ExprFormattedValue;
 pub struct FormatExprFormattedValue;
 
 impl FormatNodeRule<ExprFormattedValue> for FormatExprFormattedValue {
-    fn fmt_fields(&self, item: &ExprFormattedValue, f: &mut PyFormatter) -> FormatResult<()> {
-        write!(f, [not_yet_implemented(item)])
+    fn fmt_fields(&self, _item: &ExprFormattedValue, _f: &mut PyFormatter) -> FormatResult<()> {
+        unreachable!("Handled inside of `FormatExprFString");
     }
 }
 

--- a/crates/ruff_python_formatter/src/other/match_case.rs
+++ b/crates/ruff_python_formatter/src/other/match_case.rs
@@ -14,7 +14,7 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
     fn fmt_fields(&self, item: &MatchCase, f: &mut PyFormatter) -> FormatResult<()> {
         let MatchCase {
             range: _,
-            pattern: _,
+            pattern,
             guard,
             body,
         } = item;
@@ -24,7 +24,17 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
             [
                 text("case"),
                 space(),
-                not_yet_implemented_custom_text("NOT_YET_IMPLEMENTED_Pattern"),
+                format_with(|f: &mut PyFormatter| {
+                    let comments = f.context().comments();
+
+                    for comment in comments.leading_trailing_comments(pattern) {
+                        // This is a lie, but let's go with it.
+                        comment.mark_formatted();
+                    }
+
+                    // Replace the whole `format_with` with `pattern.format()` once pattern formatting is implemented.
+                    not_yet_implemented_custom_text("NOT_YET_IMPLEMENTED_Pattern", pattern).fmt(f)
+                }),
             ]
         )?;
 


### PR DESCRIPTION
We currently don't format all comments as match statements are not yet implemented. We can work around this for the top level match statement by setting them manually formatted but the mocked-out top level match doesn't call into its children so they would still have unformatted comments