### PR TITLE
Print log when formatter ecosystem checks fail

### DIFF
--- a/crates/ruff_python_formatter/src/expression/expr_subscript.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_subscript.rs
@@ -27,7 +27,7 @@ impl FormatNodeRule<ExprSubscript> for FormatExprSubscript {
         let dangling_comments = comments.dangling_comments(item.as_any_node_ref());
         debug_assert!(
             dangling_comments.len() <= 1,
-            "The subscript expression must have at most a single comment, the one after the bracket"
+            "A subscript expression can only have a single dangling comment, the one after the bracket"
         );
 
         if let NodeLevel::Expression(Some(group_id)) = f.context().node_level() {

--- a/scripts/formatter_progress.sh
+++ b/scripts/formatter_progress.sh
@@ -51,5 +51,9 @@ fi
 # for i in "$dir"/*/; do git -C "$i" switch main && git -C "$i" pull && echo "# $(basename "$i") $(git -C "$i" rev-parse HEAD)"; done
 
 time cargo run --bin ruff_dev -- format-dev --stability-check --error-file "$target/progress_projects_errors.txt" \
-  --multi-project "$dir" >"$target/progress_projects_report.txt"
+  --multi-project "$dir" >"$target/progress_projects_report.txt" || (
+  echo "Ecosystem check failed"
+  cat "$target/progress_projects_report.txt"
+  exit 1
+)
 grep "similarity index" "$target/progress_projects_report.txt" | sort


### PR DESCRIPTION
**Summary** Print the errors when the formatter ecosystem checks failed. Im not happy that we current collect the log in the first place, but this is the less invasive change and we need it to unblock reviewing #6152.

**Test Plan** https://github.com/astral-sh/ruff/actions/runs/5713112075/job/15477879403?pr=6188