### PR TITLE
Fix formatting of trailing unescaped quotes in raw triple quoted strings

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
@@ -27,6 +27,7 @@ R"Test"
 # Block conversion if there is an unescaped quote just before the end of the triple
 # quoted string
 r'''\""'''
+r'''""'''
 r'\""'
 
 'This string will not include \

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
@@ -24,6 +24,11 @@ U"Test"
 r"Test"
 R"Test"
 
+# Block conversion if there is an unescaped quote just before the end of the triple
+# quoted string
+r'''\""'''
+r'\""'
+
 'This string will not include \
 backslashes or newline characters.'
 

--- a/crates/ruff_python_formatter/src/expression/string.rs
+++ b/crates/ruff_python_formatter/src/expression/string.rs
@@ -324,16 +324,16 @@ fn preferred_quotes_raw(
                 }
 
                 match chars.peek() {
-                    // We can't turn `r'''\""'''` into `r"""\"""""`, the last previously inner quote
-                    // we shorten the quoted part and turn the last triple quote char into an
-                    // unterminated string start.
+                    // We can't turn `r'''\""'''` into `r"""\"""""`, this would confuse the parser
+                    // about where the closing triple quotes start
                     None => break true,
                     Some(next) if *next == configured_quote_char => {
                         // `""` or `''`
                         chars.next();
 
-                        if chars.peek() == Some(&configured_quote_char) {
-                            // `"""` or `'''`
+                        // We can't turn `r'''""'''` into `r""""""""`, nor can we have
+                        // `"""` or `'''` respectively inside the string
+                        if chars.peek() == None || chars.peek() == Some(&configured_quote_char) {
                             break true;
                         }
                     }

--- a/crates/ruff_python_formatter/src/expression/string.rs
+++ b/crates/ruff_python_formatter/src/expression/string.rs
@@ -333,7 +333,7 @@ fn preferred_quotes_raw(
 
                         // We can't turn `r'''""'''` into `r""""""""`, nor can we have
                         // `"""` or `'''` respectively inside the string
-                        if chars.peek() == None || chars.peek() == Some(&configured_quote_char) {
+                        if chars.peek().is_none() || chars.peek() == Some(&configured_quote_char) {
                             break true;
                         }
                     }

--- a/crates/ruff_python_formatter/src/expression/string.rs
+++ b/crates/ruff_python_formatter/src/expression/string.rs
@@ -323,14 +323,21 @@ fn preferred_quotes_raw(
                     break true;
                 }
 
-                if chars.peek() == Some(&configured_quote_char) {
-                    // `""` or `''`
-                    chars.next();
+                match chars.peek() {
+                    // We can't turn `r'''\""'''` into `r"""\"""""`, the last previously inner quote
+                    // we shorten the quoted part and turn the last triple quote char into an
+                    // unterminated string start.
+                    None => break true,
+                    Some(next) if *next == configured_quote_char => {
+                        // `""` or `''`
+                        chars.next();
 
-                    if chars.peek() == Some(&configured_quote_char) {
-                        // `"""` or `'''`
-                        break true;
+                        if chars.peek() == Some(&configured_quote_char) {
+                            // `"""` or `'''`
+                            break true;
+                        }
                     }
+                    _ => {}
                 }
             }
             Some(_) => continue,

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -33,6 +33,7 @@ R"Test"
 # Block conversion if there is an unescaped quote just before the end of the triple
 # quoted string
 r'''\""'''
+r'''""'''
 r'\""'
 
 'This string will not include \
@@ -170,6 +171,7 @@ R"Test"
 # Block conversion if there is an unescaped quote just before the end of the triple
 # quoted string
 r'''\""'''
+r'''""'''
 r'\""'
 
 "This string will not include \
@@ -323,6 +325,7 @@ R'Test'
 # Block conversion if there is an unescaped quote just before the end of the triple
 # quoted string
 r'''\""'''
+r'''""'''
 r'\""'
 
 'This string will not include \

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -30,6 +30,11 @@ U"Test"
 r"Test"
 R"Test"
 
+# Block conversion if there is an unescaped quote just before the end of the triple
+# quoted string
+r'''\""'''
+r'\""'
+
 'This string will not include \
 backslashes or newline characters.'
 
@@ -161,6 +166,11 @@ magic-trailing-comma    = Respect
 
 r"Test"
 R"Test"
+
+# Block conversion if there is an unescaped quote just before the end of the triple
+# quoted string
+r'''\""'''
+r'\""'
 
 "This string will not include \
 backslashes or newline characters."
@@ -309,6 +319,11 @@ magic-trailing-comma    = Respect
 
 r'Test'
 R'Test'
+
+# Block conversion if there is an unescaped quote just before the end of the triple
+# quoted string
+r'''\""'''
+r'\""'
 
 'This string will not include \
 backslashes or newline characters.'


### PR DESCRIPTION
**Summary** This prevents us from turning `r'''\""'''` into `r"""\"""""`, which is invalid syntax.

This PR fixes CI, which is currently broken on main (in a way that still passes on linter PRs and allows merging formatter PRs, but it's bad to have a job be red). Once merged, i'll make the formatted ecosystem checks a required check.

**Test Plan** Added a regression test.
