### PR TITLE
Add empty lines before nested functions and classes

### DIFF
--- a/crates/ruff_python_formatter/src/module/mod_module.rs
+++ b/crates/ruff_python_formatter/src/module/mod_module.rs
@@ -1,4 +1,4 @@
-use crate::statement::suite::SuiteLevel;
+use crate::statement::suite::SuiteKind;
 use crate::{AsFormat, FormatNodeRule, PyFormatter};
 use ruff_formatter::prelude::hard_line_break;
 use ruff_formatter::{write, Buffer, FormatResult};
@@ -13,7 +13,7 @@ impl FormatNodeRule<ModModule> for FormatModModule {
         write!(
             f,
             [
-                body.format().with_options(SuiteLevel::TopLevel),
+                body.format().with_options(SuiteKind::TopLevel),
                 // Trailing newline at the end of the file
                 hard_line_break()
             ]

--- a/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
@@ -7,6 +7,7 @@ use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
 use crate::comments::trailing_comments;
 use crate::expression::parentheses::{parenthesized, Parentheses};
 use crate::prelude::*;
+use crate::statement::suite::SuiteKind;
 
 #[derive(Default)]
 pub struct FormatStmtClassDef;
@@ -52,7 +53,7 @@ impl FormatNodeRule<StmtClassDef> for FormatStmtClassDef {
             [
                 text(":"),
                 trailing_comments(trailing_head_comments),
-                block_indent(&body.format())
+                block_indent(&body.format().with_options(SuiteKind::Class))
             ]
         )
     }

--- a/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
@@ -8,6 +8,7 @@ use crate::comments::{leading_comments, trailing_comments};
 
 use crate::expression::parentheses::{optional_parentheses, Parentheses};
 use crate::prelude::*;
+use crate::statement::suite::SuiteKind;
 use crate::FormatNodeRule;
 
 #[derive(Default)]
@@ -111,7 +112,7 @@ impl FormatRule<AnyFunctionDefinition<'_>, PyFormatContext<'_>> for FormatAnyFun
             [
                 text(":"),
                 trailing_comments(trailing_definition_comments),
-                block_indent(&item.body().format())
+                block_indent(&item.body().format().with_options(SuiteKind::Function))
             ]
         )
     }

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__function2.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__function2.py.snap
@@ -73,22 +73,13 @@ with hmm_but_this_should_get_two_preceding_newlines():
  elif os.name == "nt":
      try:
          import msvcrt
-@@ -45,21 +44,16 @@
-             pass
- 
-     except ImportError:
--
-         def i_should_be_followed_by_only_one_newline():
-             pass
- 
- elif False:
--
+@@ -54,12 +53,10 @@
      class IHopeYouAreHavingALovelyDay:
          def __call__(self):
              print("i_should_be_followed_by_only_one_newline")
 -
  else:
--
+ 
      def foo():
          pass
 -
@@ -146,14 +137,17 @@ elif os.name == "nt":
             pass
 
     except ImportError:
+
         def i_should_be_followed_by_only_one_newline():
             pass
 
 elif False:
+
     class IHopeYouAreHavingALovelyDay:
         def __call__(self):
             print("i_should_be_followed_by_only_one_newline")
 else:
+
     def foo():
         pass
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
@@ -344,6 +344,7 @@ def with_leading_comment():
 # looking from the position of the if
 # Regression test for https://github.com/python/cpython/blob/ad56340b665c5d8ac1f318964f71697bba41acb7/Lib/logging/__init__.py#L253-L260
 if True:
+
     def f1():
         pass  # a
 else:
@@ -351,6 +352,7 @@ else:
 
 # Here it's actually a trailing comment
 if True:
+
     def f2():
         pass
         # a

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__if.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__if.py.snap
@@ -203,14 +203,17 @@ def f():
 
 
 if True:
+
     def f():
         pass
         # 1
 elif True:
+
     def f():
         pass
         # 2
 else:
+
     def f():
         pass
         # 3

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__try.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__try.py.snap
@@ -263,18 +263,22 @@ except RuntimeError:
     raise
 
 try:
+
     def f():
         pass
         # a
 except:
+
     def f():
         pass
         # b
 else:
+
     def f():
         pass
         # c
 finally:
+
     def f():
         pass
         # d


### PR DESCRIPTION
## Summary

This PR ensures that if a function or class is the first statement in a nested suite that _isn't_ a function or class body, we insert a leading newline.

For example, given:

```python
def f():
    if True:

        def register_type():
            pass
```

We _want_ to preserve the newline, whereas today, we remove it.

Note that this only applies when the function or class doesn't have any leading comments.

Closes https://github.com/astral-sh/ruff/issues/6066.
