### PR TITLE
formatter: `WithNodeLevel` helper

### DIFF
--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -3,12 +3,14 @@ use std::cmp::Ordering;
 use ruff_python_ast as ast;
 use ruff_python_ast::{Expr, Operator};
 
-use ruff_formatter::{FormatOwnedWithRule, FormatRefWithRule, FormatRule, FormatRuleWithOptions};
+use ruff_formatter::{
+    write, FormatOwnedWithRule, FormatRefWithRule, FormatRule, FormatRuleWithOptions,
+};
 use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::visitor::preorder::{walk_expr, PreorderVisitor};
 
 use crate::builders::parenthesize_if_expands;
-use crate::context::NodeLevel;
+use crate::context::{NodeLevel, WithNodeLevel};
 use crate::expression::parentheses::{
     is_expression_parenthesized, optional_parentheses, parenthesized, NeedsParentheses,
     OptionalParentheses, Parentheses, Parenthesize,
@@ -106,21 +108,16 @@ impl FormatRule<Expr, PyFormatContext<'_>> for FormatExpr {
         if parenthesize {
             parenthesized("(", &format_expr, ")").fmt(f)
         } else {
-            let saved_level = match f.context().node_level() {
-                saved_level @ (NodeLevel::TopLevel | NodeLevel::CompoundStatement) => {
-                    f.context_mut().set_node_level(NodeLevel::Expression(None));
-                    Some(saved_level)
+            let level = match f.context().node_level() {
+                NodeLevel::TopLevel | NodeLevel::CompoundStatement => NodeLevel::Expression(None),
+                saved_level @ (NodeLevel::Expression(_) | NodeLevel::ParenthesizedExpression) => {
+                    saved_level
                 }
-                NodeLevel::Expression(_) | NodeLevel::ParenthesizedExpression => None,
             };
 
-            let result = Format::fmt(&format_expr, f);
+            let mut f = WithNodeLevel::new(level, f);
 
-            if let Some(saved_level) = saved_level {
-                f.context_mut().set_node_level(saved_level);
-            }
-
-            result
+            write!(f, [format_expr])
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
There are multiple places where we have formatting code that changes the node level and needs to restore
it once the formatting is complete. 

This is very error prone because it is easy to early return on a formatting error without resturing the node level on the context. 

This PR introduces a new `WithNodeLevel` helper struct that changes the `node_level` during construction and restores it in its `Drop` implementation. 
The new `struct` can be used with the `write` macro because it implements `write_fmt`. However, it lacks the extension methods like `join`, because it isn't a `Formatter` (can't be)

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test`
<!-- How was it tested? -->
