### PR TITLE
Don't require docstrings in `.pyi` files

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -232,6 +232,11 @@ impl<'a> Checker<'a> {
         &self.semantic
     }
 
+    /// Return `true` if the current file is a stub file (`.pyi`).
+    pub(crate) const fn is_stub(&self) -> bool {
+        self.is_stub
+    }
+
     /// The [`Path`] to the file under analysis.
     pub(crate) const fn path(&self) -> &'a Path {
         self.path

--- a/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
@@ -523,6 +523,10 @@ pub(crate) fn not_missing(
     definition: &Definition,
     visibility: Visibility,
 ) -> bool {
+    if checker.is_stub() {
+        return true;
+    }
+
     if visibility.is_private() {
         return true;
     }


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/6224.