### PR TITLE
Replace `.map_or(false, $closure)` with `.is_some_and(closure)`

### DIFF
--- a/crates/ruff/src/autofix/mod.rs
+++ b/crates/ruff/src/autofix/mod.rs
@@ -76,7 +76,7 @@ fn apply_fixes<'a>(
             }
 
             // If this fix overlaps with a fix we've already applied, skip it.
-            if last_pos.map_or(false, |last_pos| last_pos >= first.start()) {
+            if last_pos.is_some_and(|last_pos| last_pos >= first.start()) {
                 continue;
             }
         }

--- a/crates/ruff/src/checkers/ast/analyze/definitions.rs
+++ b/crates/ruff/src/checkers/ast/analyze/definitions.rs
@@ -117,7 +117,7 @@ pub(crate) fn definitions(checker: &mut Checker) {
             // interfaces, without any AST nodes in between. Right now, we
             // only error when traversing definition boundaries (functions,
             // classes, etc.).
-            if !overloaded_name.map_or(false, |overloaded_name| {
+            if !overloaded_name.is_some_and(|overloaded_name| {
                 flake8_annotations::helpers::is_overload_impl(
                     definition,
                     &overloaded_name,

--- a/crates/ruff/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff/src/checkers/ast/analyze/expression.rs
@@ -201,14 +201,9 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                     if checker.enabled(Rule::NonLowercaseVariableInFunction) {
                         if checker.semantic.scope().kind.is_any_function() {
                             // Ignore globals.
-                            if !checker
-                                .semantic
-                                .scope()
-                                .get(id)
-                                .map_or(false, |binding_id| {
-                                    checker.semantic.binding(binding_id).is_global()
-                                })
-                            {
+                            if !checker.semantic.scope().get(id).is_some_and(|binding_id| {
+                                checker.semantic.binding(binding_id).is_global()
+                            }) {
                                 pep8_naming::rules::non_lowercase_variable_in_function(
                                     checker, expr, id,
                                 );

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -334,7 +334,7 @@ where
                         if alias
                             .asname
                             .as_ref()
-                            .map_or(false, |asname| asname.as_str() == alias.name.as_str())
+                            .is_some_and(|asname| asname.as_str() == alias.name.as_str())
                         {
                             flags |= BindingFlags::EXPLICIT_EXPORT;
                         }
@@ -379,7 +379,7 @@ where
                         if alias
                             .asname
                             .as_ref()
-                            .map_or(false, |asname| asname.as_str() == alias.name.as_str())
+                            .is_some_and(|asname| asname.as_str() == alias.name.as_str())
                         {
                             flags |= BindingFlags::EXPLICIT_EXPORT;
                         }
@@ -1098,7 +1098,7 @@ where
                                     arg,
                                     range: _,
                                 } = keyword;
-                                if arg.as_ref().map_or(false, |arg| arg == "type") {
+                                if arg.as_ref().is_some_and(|arg| arg == "type") {
                                     self.visit_type_definition(value);
                                 } else {
                                     self.visit_non_type_definition(value);

--- a/crates/ruff/src/docstrings/sections.rs
+++ b/crates/ruff/src/docstrings/sections.rs
@@ -402,7 +402,7 @@ fn is_docstring_section(
     }
 
     // Determine whether the next line is an underline, e.g., "-----".
-    let next_line_is_underline = next_line.map_or(false, |next_line| {
+    let next_line_is_underline = next_line.is_some_and(|next_line| {
         let next_line = next_line.trim();
         if next_line.is_empty() {
             false

--- a/crates/ruff/src/importer/mod.rs
+++ b/crates/ruff/src/importer/mod.rs
@@ -305,7 +305,7 @@ impl<'a> Importer<'a> {
             }) = stmt
             {
                 if level.map_or(true, |level| level.to_u32() == 0)
-                    && name.as_ref().map_or(false, |name| name == module)
+                    && name.as_ref().is_some_and(|name| name == module)
                 {
                     import_from = Some(*stmt);
                 }

--- a/crates/ruff/src/jupyter/notebook.rs
+++ b/crates/ruff/src/jupyter/notebook.rs
@@ -376,7 +376,7 @@ impl Notebook {
                         1
                     } else {
                         let trailing_newline =
-                            usize::from(string_array.last().map_or(false, |s| s.ends_with('\n')));
+                            usize::from(string_array.last().is_some_and(|s| s.ends_with('\n')));
                         u32::try_from(string_array.len() + trailing_newline).unwrap()
                     }
                 }

--- a/crates/ruff/src/message/mod.rs
+++ b/crates/ruff/src/message/mod.rs
@@ -141,7 +141,7 @@ impl<'a> EmitterContext<'a> {
     pub fn is_jupyter_notebook(&self, name: &str) -> bool {
         self.source_kind
             .get(name)
-            .map_or(false, SourceKind::is_jupyter)
+            .is_some_and(SourceKind::is_jupyter)
     }
 
     pub fn source_kind(&self, name: &str) -> Option<&SourceKind> {

--- a/crates/ruff/src/noqa.rs
+++ b/crates/ruff/src/noqa.rs
@@ -60,7 +60,7 @@ impl<'a> Directive<'a> {
             if text[..comment_start]
                 .chars()
                 .last()
-                .map_or(false, |c| c != '#')
+                .is_some_and(|c| c != '#')
             {
                 continue;
             }

--- a/crates/ruff/src/resolver.rs
+++ b/crates/ruff/src/resolver.rs
@@ -304,7 +304,7 @@ pub fn python_files_in_path(
                 if let Ok(entry) = &result {
                     if entry
                         .file_type()
-                        .map_or(false, |file_type| file_type.is_dir())
+                        .is_some_and(|file_type| file_type.is_dir())
                     {
                         match settings_toml(entry.path()) {
                             Ok(Some(pyproject)) => match resolve_scoped_settings(

--- a/crates/ruff/src/rules/airflow/rules/task_variable_name.rs
+++ b/crates/ruff/src/rules/airflow/rules/task_variable_name.rs
@@ -68,7 +68,7 @@ pub(crate) fn variable_name_task_id(
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| matches!(call_path[0], "airflow"))
+        .is_some_and(|call_path| matches!(call_path[0], "airflow"))
     {
         return None;
     }

--- a/crates/ruff/src/rules/flake8_2020/helpers.rs
+++ b/crates/ruff/src/rules/flake8_2020/helpers.rs
@@ -5,5 +5,5 @@ use ruff_python_semantic::SemanticModel;
 pub(super) fn is_sys(expr: &Expr, target: &str, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_call_path(expr)
-        .map_or(false, |call_path| call_path.as_slice() == ["sys", target])
+        .is_some_and(|call_path| call_path.as_slice() == ["sys", target])
 }

--- a/crates/ruff/src/rules/flake8_2020/rules/name_or_attribute.rs
+++ b/crates/ruff/src/rules/flake8_2020/rules/name_or_attribute.rs
@@ -49,9 +49,7 @@ pub(crate) fn name_or_attribute(checker: &mut Checker, expr: &Expr) {
     if checker
         .semantic()
         .resolve_call_path(expr)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["six", "PY3"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["six", "PY3"]))
     {
         checker
             .diagnostics

--- a/crates/ruff/src/rules/flake8_async/rules/blocking_http_call.rs
+++ b/crates/ruff/src/rules/flake8_async/rules/blocking_http_call.rs
@@ -68,7 +68,7 @@ pub(crate) fn blocking_http_call(checker: &mut Checker, expr: &Expr) {
                 .semantic()
                 .resolve_call_path(func)
                 .as_ref()
-                .map_or(false, is_blocking_http_call)
+                .is_some_and(is_blocking_http_call)
             {
                 checker.diagnostics.push(Diagnostic::new(
                     BlockingHttpCallInAsyncFunction,

--- a/crates/ruff/src/rules/flake8_async/rules/blocking_os_call.rs
+++ b/crates/ruff/src/rules/flake8_async/rules/blocking_os_call.rs
@@ -48,7 +48,7 @@ pub(crate) fn blocking_os_call(checker: &mut Checker, expr: &Expr) {
                 .semantic()
                 .resolve_call_path(func)
                 .as_ref()
-                .map_or(false, is_unsafe_os_method)
+                .is_some_and(is_unsafe_os_method)
             {
                 checker
                     .diagnostics

--- a/crates/ruff/src/rules/flake8_async/rules/open_sleep_or_subprocess_call.rs
+++ b/crates/ruff/src/rules/flake8_async/rules/open_sleep_or_subprocess_call.rs
@@ -48,7 +48,7 @@ pub(crate) fn open_sleep_or_subprocess_call(checker: &mut Checker, expr: &Expr) 
                 .semantic()
                 .resolve_call_path(func)
                 .as_ref()
-                .map_or(false, is_open_sleep_or_subprocess_call)
+                .is_some_and(is_open_sleep_or_subprocess_call)
             {
                 checker.diagnostics.push(Diagnostic::new(
                     OpenSleepOrSubprocessInAsyncFunction,

--- a/crates/ruff/src/rules/flake8_bandit/helpers.rs
+++ b/crates/ruff/src/rules/flake8_bandit/helpers.rs
@@ -26,18 +26,14 @@ pub(super) fn is_untyped_exception(type_: Option<&Expr>, semantic: &SemanticMode
     type_.map_or(true, |type_| {
         if let Expr::Tuple(ast::ExprTuple { elts, .. }) = &type_ {
             elts.iter().any(|type_| {
-                semantic
-                    .resolve_call_path(type_)
-                    .map_or(false, |call_path| {
-                        matches!(call_path.as_slice(), ["", "Exception" | "BaseException"])
-                    })
-            })
-        } else {
-            semantic
-                .resolve_call_path(type_)
-                .map_or(false, |call_path| {
+                semantic.resolve_call_path(type_).is_some_and(|call_path| {
                     matches!(call_path.as_slice(), ["", "Exception" | "BaseException"])
                 })
+            })
+        } else {
+            semantic.resolve_call_path(type_).is_some_and(|call_path| {
+                matches!(call_path.as_slice(), ["", "Exception" | "BaseException"])
+            })
         }
     })
 }

--- a/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
@@ -57,9 +57,7 @@ pub(crate) fn bad_file_permissions(
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["os", "chmod"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["os", "chmod"]))
     {
         let call_args = CallArguments::new(args, keywords);
         if let Some(mode_arg) = call_args.argument("mode", 1) {

--- a/crates/ruff/src/rules/flake8_bandit/rules/exec_used.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/exec_used.rs
@@ -35,9 +35,7 @@ pub(crate) fn exec_used(checker: &mut Checker, func: &Expr) {
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["" | "builtin", "exec"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["" | "builtin", "exec"]))
     {
         checker
             .diagnostics

--- a/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -63,9 +63,7 @@ pub(crate) fn jinja2_autoescape_false(checker: &mut Checker, func: &Expr, keywor
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["jinja2", "Environment"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["jinja2", "Environment"]))
     {
         if let Some(keyword) = find_keyword(keywords, "autoescape") {
             match &keyword.value {

--- a/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
@@ -43,9 +43,7 @@ pub(crate) fn logging_config_insecure_listen(
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["logging", "config", "listen"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["logging", "config", "listen"]))
     {
         if find_keyword(keywords, "verify").is_some() {
             return;

--- a/crates/ruff/src/rules/flake8_bandit/rules/paramiko_calls.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/paramiko_calls.rs
@@ -39,9 +39,7 @@ pub(crate) fn paramiko_call(checker: &mut Checker, func: &Expr) {
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["paramiko", "exec_command"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["paramiko", "exec_command"]))
     {
         checker
             .diagnostics

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
@@ -53,7 +53,7 @@ pub(crate) fn request_without_timeout(checker: &mut Checker, func: &Expr, keywor
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
+        .is_some_and(|call_path| {
             matches!(
                 call_path.as_slice(),
                 [

--- a/crates/ruff/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -379,7 +379,7 @@ fn is_partial_path(expr: &Expr) -> bool {
         Expr::List(ast::ExprList { elts, .. }) => elts.first().and_then(string_literal),
         _ => string_literal(expr),
     };
-    string_literal.map_or(false, |text| !is_full_path(text))
+    string_literal.is_some_and(|text| !is_full_path(text))
 }
 
 /// Return `true` if the [`Expr`] is a wildcard command.
@@ -410,7 +410,7 @@ fn is_wildcard_command(expr: &Expr) -> bool {
         has_star && has_command
     } else {
         let string_literal = string_literal(expr);
-        string_literal.map_or(false, |text| {
+        string_literal.is_some_and(|text| {
             text.contains('*')
                 && (text.contains("chown")
                     || text.contains("chmod")

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
@@ -47,7 +47,7 @@ pub(crate) fn snmp_insecure_version(checker: &mut Checker, func: &Expr, keywords
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
+        .is_some_and(|call_path| {
             matches!(call_path.as_slice(), ["pysnmp", "hlapi", "CommunityData"])
         })
     {

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
@@ -51,9 +51,7 @@ pub(crate) fn snmp_weak_cryptography(
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["pysnmp", "hlapi", "UsmUserData"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["pysnmp", "hlapi", "UsmUserData"]))
     {
         if CallArguments::new(args, keywords).len() < 3 {
             checker

--- a/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
@@ -69,16 +69,14 @@ pub(crate) fn unsafe_yaml_load(
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["yaml", "load"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["yaml", "load"]))
     {
         let call_args = CallArguments::new(args, keywords);
         if let Some(loader_arg) = call_args.argument("Loader", 1) {
             if !checker
                 .semantic()
                 .resolve_call_path(loader_arg)
-                .map_or(false, |call_path| {
+                .is_some_and(|call_path| {
                     matches!(call_path.as_slice(), ["yaml", "SafeLoader" | "CSafeLoader"])
                 })
             {

--- a/crates/ruff/src/rules/flake8_blind_except/rules/blind_except.rs
+++ b/crates/ruff/src/rules/flake8_blind_except/rules/blind_except.rs
@@ -77,7 +77,7 @@ pub(crate) fn blind_except(
         if let Stmt::Raise(ast::StmtRaise { exc, .. }) = stmt {
             if let Some(exc) = exc {
                 if let Expr::Name(ast::ExprName { id, .. }) = exc.as_ref() {
-                    name.map_or(false, |name| id == name)
+                    name.is_some_and(|name| id == name)
                 } else {
                     false
                 }

--- a/crates/ruff/src/rules/flake8_boolean_trap/rules/check_boolean_default_value_in_function_definition.rs
+++ b/crates/ruff/src/rules/flake8_boolean_trap/rules/check_boolean_default_value_in_function_definition.rs
@@ -67,7 +67,7 @@ pub(crate) fn check_boolean_default_value_in_function_definition(
 
     if decorator_list.iter().any(|decorator| {
         collect_call_path(&decorator.expression)
-            .map_or(false, |call_path| call_path.as_slice() == [name, "setter"])
+            .is_some_and(|call_path| call_path.as_slice() == [name, "setter"])
     }) {
         return;
     }

--- a/crates/ruff/src/rules/flake8_boolean_trap/rules/check_positional_boolean_in_def.rs
+++ b/crates/ruff/src/rules/flake8_boolean_trap/rules/check_positional_boolean_in_def.rs
@@ -88,7 +88,7 @@ pub(crate) fn check_positional_boolean_in_def(
 
     if decorator_list.iter().any(|decorator| {
         collect_call_path(&decorator.expression)
-            .map_or(false, |call_path| call_path.as_slice() == [name, "setter"])
+            .is_some_and(|call_path| call_path.as_slice() == [name, "setter"])
     }) {
         return;
     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -106,16 +106,14 @@ impl Violation for EmptyMethodWithoutAbstractDecorator {
 
 fn is_abc_class(bases: &[Expr], keywords: &[Keyword], semantic: &SemanticModel) -> bool {
     keywords.iter().any(|keyword| {
-        keyword.arg.as_ref().map_or(false, |arg| arg == "metaclass")
+        keyword.arg.as_ref().is_some_and(|arg| arg == "metaclass")
             && semantic
                 .resolve_call_path(&keyword.value)
-                .map_or(false, |call_path| {
-                    matches!(call_path.as_slice(), ["abc", "ABCMeta"])
-                })
+                .is_some_and(|call_path| matches!(call_path.as_slice(), ["abc", "ABCMeta"]))
     }) || bases.iter().any(|base| {
-        semantic.resolve_call_path(base).map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["abc", "ABC"])
-        })
+        semantic
+            .resolve_call_path(base)
+            .is_some_and(|call_path| matches!(call_path.as_slice(), ["abc", "ABC"]))
     })
 }
 

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -113,9 +113,7 @@ pub(crate) fn assert_raises_exception(checker: &mut Checker, items: &[WithItem])
         } else if checker
             .semantic()
             .resolve_call_path(func)
-            .map_or(false, |call_path| {
-                matches!(call_path.as_slice(), ["pytest", "raises"])
-            })
+            .is_some_and(|call_path| matches!(call_path.as_slice(), ["pytest", "raises"]))
             && find_keyword(keywords, "match").is_none()
         {
             AssertionKind::PytestRaises

--- a/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -70,7 +70,7 @@ impl Violation for CachedInstanceMethod {
 }
 
 fn is_cache_func(expr: &Expr, semantic: &SemanticModel) -> bool {
-    semantic.resolve_call_path(expr).map_or(false, |call_path| {
+    semantic.resolve_call_path(expr).is_some_and(|call_path| {
         matches!(call_path.as_slice(), ["functools", "lru_cache" | "cache"])
     })
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
@@ -157,7 +157,7 @@ impl<'a> Visitor<'a> for SuspiciousVariablesVisitor<'a> {
                 }
 
                 for keyword in keywords {
-                    if keyword.arg.as_ref().map_or(false, |arg| arg == "key")
+                    if keyword.arg.as_ref().is_some_and(|arg| arg == "key")
                         && keyword.value.is_lambda_expr()
                     {
                         self.safe_functions.push(&keyword.value);

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -74,9 +74,10 @@ pub(crate) fn mutable_argument_default(checker: &mut Checker, arguments: &Argume
         };
 
         if is_mutable_expr(default, checker.semantic())
-            && !def.annotation.as_ref().map_or(false, |expr| {
-                is_immutable_annotation(expr, checker.semantic())
-            })
+            && !def
+                .annotation
+                .as_ref()
+                .is_some_and(|expr| is_immutable_annotation(expr, checker.semantic()))
         {
             checker
                 .diagnostics

--- a/crates/ruff/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
@@ -42,9 +42,7 @@ pub(crate) fn no_explicit_stacklevel(checker: &mut Checker, func: &Expr, keyword
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["warnings", "warn"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["warnings", "warn"]))
     {
         return;
     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
@@ -87,7 +87,7 @@ pub(crate) fn raise_without_from_inside_except(
                 if let Some(name) = name {
                     if exc
                         .as_name_expr()
-                        .map_or(false, |ast::ExprName { id, .. }| name == id)
+                        .is_some_and(|ast::ExprName { id, .. }| name == id)
                     {
                         continue;
                     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
@@ -313,9 +313,7 @@ pub(crate) fn reuse_of_groupby_generator(
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["itertools", "groupby"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["itertools", "groupby"]))
     {
         return;
     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
@@ -59,9 +59,7 @@ pub(crate) fn useless_contextlib_suppress(
         && checker
             .semantic()
             .resolve_call_path(func)
-            .map_or(false, |call_path| {
-                matches!(call_path.as_slice(), ["contextlib", "suppress"])
-            })
+            .is_some_and(|call_path| matches!(call_path.as_slice(), ["contextlib", "suppress"]))
     {
         checker
             .diagnostics

--- a/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -76,7 +76,7 @@ fn is_infinite_iterator(arg: &Expr, semantic: &SemanticModel) -> bool {
         return false;
     };
 
-    semantic.resolve_call_path(func).map_or(false, |call_path| {
+    semantic.resolve_call_path(func).is_some_and(|call_path| {
         match call_path.as_slice() {
             ["itertools", "cycle" | "count"] => true,
             ["itertools", "repeat"] => {
@@ -92,7 +92,7 @@ fn is_infinite_iterator(arg: &Expr, semantic: &SemanticModel) -> bool {
 
                 // Ex) `iterools.repeat(1, times=None)`
                 for keyword in keywords {
-                    if keyword.arg.as_ref().map_or(false, |name| name == "times") {
+                    if keyword.arg.as_ref().is_some_and(|name| name == "times") {
                         if is_const_none(&keyword.value) {
                             return true;
                         }

--- a/crates/ruff/src/rules/flake8_builtins/rules/builtin_attribute_shadowing.rs
+++ b/crates/ruff/src/rules/flake8_builtins/rules/builtin_attribute_shadowing.rs
@@ -136,15 +136,15 @@ fn is_standard_library_override(
     match name {
         // Ex) `Event#set`
         "set" => class_def.bases.iter().any(|base| {
-            model.resolve_call_path(base).map_or(false, |call_path| {
-                matches!(call_path.as_slice(), ["threading", "Event"])
-            })
+            model
+                .resolve_call_path(base)
+                .is_some_and(|call_path| matches!(call_path.as_slice(), ["threading", "Event"]))
         }),
         // Ex) `Filter#filter`
         "filter" => class_def.bases.iter().any(|base| {
-            model.resolve_call_path(base).map_or(false, |call_path| {
-                matches!(call_path.as_slice(), ["logging", "Filter"])
-            })
+            model
+                .resolve_call_path(base)
+                .is_some_and(|call_path| matches!(call_path.as_slice(), ["logging", "Filter"]))
         }),
         _ => false,
     }

--- a/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
@@ -1018,7 +1018,7 @@ pub(crate) fn fix_unnecessary_map(
         // If the expression is embedded in an f-string, surround it with spaces to avoid
         // syntax errors.
         if matches!(object_type, ObjectType::Set | ObjectType::Dict) {
-            if parent.map_or(false, ruff_python_ast::Expr::is_formatted_value_expr) {
+            if parent.is_some_and(ruff_python_ast::Expr::is_formatted_value_expr) {
                 content = format!(" {content} ");
             }
         }

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_date_fromtimestamp.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_date_fromtimestamp.rs
@@ -29,7 +29,7 @@ pub(crate) fn call_date_fromtimestamp(checker: &mut Checker, func: &Expr, locati
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
+        .is_some_and(|call_path| {
             matches!(call_path.as_slice(), ["datetime", "date", "fromtimestamp"])
         })
     {

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_date_today.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_date_today.rs
@@ -29,9 +29,7 @@ pub(crate) fn call_date_today(checker: &mut Checker, func: &Expr, location: Text
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["datetime", "date", "today"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["datetime", "date", "today"]))
     {
         checker
             .diagnostics

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
@@ -32,7 +32,7 @@ pub(crate) fn call_datetime_fromtimestamp(
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
+        .is_some_and(|call_path| {
             matches!(
                 call_path.as_slice(),
                 ["datetime", "datetime", "fromtimestamp"]

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
@@ -30,9 +30,7 @@ pub(crate) fn call_datetime_now_without_tzinfo(
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["datetime", "datetime", "now"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["datetime", "datetime", "now"]))
     {
         return;
     }

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
@@ -30,7 +30,7 @@ pub(crate) fn call_datetime_strptime_without_zone(
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
+        .is_some_and(|call_path| {
             matches!(call_path.as_slice(), ["datetime", "datetime", "strptime"])
         })
     {

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_today.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_today.rs
@@ -59,9 +59,7 @@ pub(crate) fn call_datetime_today(checker: &mut Checker, func: &Expr, location: 
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["datetime", "datetime", "today"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["datetime", "datetime", "today"]))
     {
         return;
     }

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
@@ -38,7 +38,7 @@ pub(crate) fn call_datetime_utcfromtimestamp(
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
+        .is_some_and(|call_path| {
             matches!(
                 call_path.as_slice(),
                 ["datetime", "datetime", "utcfromtimestamp"]

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_utcnow.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_utcnow.rs
@@ -33,9 +33,7 @@ pub(crate) fn call_datetime_utcnow(checker: &mut Checker, func: &Expr, location:
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["datetime", "datetime", "utcnow"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["datetime", "datetime", "utcnow"]))
     {
         return;
     }

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
@@ -54,9 +54,7 @@ pub(crate) fn call_datetime_without_tzinfo(
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["datetime", "datetime"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["datetime", "datetime"]))
     {
         return;
     }

--- a/crates/ruff/src/rules/flake8_datetimez/rules/helpers.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/helpers.rs
@@ -5,7 +5,7 @@ use crate::checkers::ast::Checker;
 /// Check if the parent expression is a call to `astimezone`. This assumes that
 /// the current expression is a `datetime.datetime` object.
 pub(crate) fn parent_expr_is_astimezone(checker: &Checker) -> bool {
-    checker.semantic().expr_parent().map_or(false, |parent| {
+    checker.semantic().expr_parent().is_some_and( |parent| {
         matches!(parent, Expr::Attribute(ExprAttribute { attr, .. }) if attr.as_str() == "astimezone")
     })
 }

--- a/crates/ruff/src/rules/flake8_django/rules/helpers.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/helpers.rs
@@ -4,14 +4,14 @@ use ruff_python_semantic::SemanticModel;
 
 /// Return `true` if a Python class appears to be a Django model, based on its base classes.
 pub(super) fn is_model(base: &Expr, semantic: &SemanticModel) -> bool {
-    semantic.resolve_call_path(base).map_or(false, |call_path| {
+    semantic.resolve_call_path(base).is_some_and(|call_path| {
         matches!(call_path.as_slice(), ["django", "db", "models", "Model"])
     })
 }
 
 /// Return `true` if a Python class appears to be a Django model form, based on its base classes.
 pub(super) fn is_model_form(base: &Expr, semantic: &SemanticModel) -> bool {
-    semantic.resolve_call_path(base).map_or(false, |call_path| {
+    semantic.resolve_call_path(base).is_some_and(|call_path| {
         matches!(
             call_path.as_slice(),
             ["django", "forms", "ModelForm"] | ["django", "forms", "models", "ModelForm"]
@@ -21,7 +21,7 @@ pub(super) fn is_model_form(base: &Expr, semantic: &SemanticModel) -> bool {
 
 /// Return `true` if the expression is constructor for a Django model field.
 pub(super) fn is_model_field(expr: &Expr, semantic: &SemanticModel) -> bool {
-    semantic.resolve_call_path(expr).map_or(false, |call_path| {
+    semantic.resolve_call_path(expr).is_some_and(|call_path| {
         call_path
             .as_slice()
             .starts_with(&["django", "db", "models"])

--- a/crates/ruff/src/rules/flake8_django/rules/locals_in_render_function.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/locals_in_render_function.rs
@@ -54,9 +54,7 @@ pub(crate) fn locals_in_render_function(
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["django", "shortcuts", "render"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["django", "shortcuts", "render"]))
     {
         return;
     }
@@ -85,7 +83,7 @@ fn is_locals_call(expr: &Expr, semantic: &SemanticModel) -> bool {
     let Expr::Call(ast::ExprCall { func, .. }) = expr else {
         return false;
     };
-    semantic.resolve_call_path(func).map_or(false, |call_path| {
-        matches!(call_path.as_slice(), ["", "locals"])
-    })
+    semantic
+        .resolve_call_path(func)
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["", "locals"]))
 }

--- a/crates/ruff/src/rules/flake8_django/rules/non_leading_receiver_decorator.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/non_leading_receiver_decorator.rs
@@ -52,11 +52,11 @@ impl Violation for DjangoNonLeadingReceiverDecorator {
 pub(crate) fn non_leading_receiver_decorator(checker: &mut Checker, decorator_list: &[Decorator]) {
     let mut seen_receiver = false;
     for (i, decorator) in decorator_list.iter().enumerate() {
-        let is_receiver = decorator.expression.as_call_expr().map_or(false, |call| {
+        let is_receiver = decorator.expression.as_call_expr().is_some_and(|call| {
             checker
                 .semantic()
                 .resolve_call_path(&call.func)
-                .map_or(false, |call_path| {
+                .is_some_and(|call_path| {
                     matches!(call_path.as_slice(), ["django", "dispatch", "receiver"])
                 })
         });

--- a/crates/ruff/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -112,9 +112,7 @@ fn check_log_record_attr_clash(checker: &mut Checker, extra: &Keyword) {
             if checker
                 .semantic()
                 .resolve_call_path(func)
-                .map_or(false, |call_path| {
-                    matches!(call_path.as_slice(), ["", "dict"])
-                })
+                .is_some_and(|call_path| matches!(call_path.as_slice(), ["", "dict"]))
             {
                 for keyword in keywords {
                     if let Some(attr) = &keyword.arg {

--- a/crates/ruff/src/rules/flake8_no_pep420/rules/implicit_namespace_package.rs
+++ b/crates/ruff/src/rules/flake8_no_pep420/rules/implicit_namespace_package.rs
@@ -47,15 +47,15 @@ pub(crate) fn implicit_namespace_package(
 ) -> Option<Diagnostic> {
     if package.is_none()
         // Ignore non-`.py` files, which don't require an `__init__.py`.
-        && path.extension().map_or(false, |ext| ext == "py")
+        && path.extension().is_some_and( |ext| ext == "py")
         // Ignore any files that are direct children of the project root.
         && !path
             .parent()
-            .map_or(false, |parent| parent == project_root)
+            .is_some_and( |parent| parent == project_root)
         // Ignore any files that are direct children of a source directory (e.g., `src/manage.py`).
         && !path
             .parent()
-            .map_or(false, |parent| src.iter().any(|src| src == parent))
+            .is_some_and( |parent| src.iter().any(|src| src == parent))
     {
         #[cfg(all(test, windows))]
         let path = path

--- a/crates/ruff/src/rules/flake8_pie/rules/non_unique_enums.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules/non_unique_enums.rs
@@ -62,9 +62,7 @@ pub(crate) fn non_unique_enums(checker: &mut Checker, parent: &Stmt, body: &[Stm
         checker
             .semantic()
             .resolve_call_path(expr)
-            .map_or(false, |call_path| {
-                matches!(call_path.as_slice(), ["enum", "Enum"])
-            })
+            .is_some_and(|call_path| matches!(call_path.as_slice(), ["enum", "Enum"]))
     }) {
         return;
     }
@@ -79,9 +77,7 @@ pub(crate) fn non_unique_enums(checker: &mut Checker, parent: &Stmt, body: &[Stm
             if checker
                 .semantic()
                 .resolve_call_path(func)
-                .map_or(false, |call_path| {
-                    matches!(call_path.as_slice(), ["enum", "auto"])
-                })
+                .is_some_and(|call_path| matches!(call_path.as_slice(), ["enum", "auto"]))
             {
                 continue;
             }

--- a/crates/ruff/src/rules/flake8_pie/rules/unnecessary_dict_kwargs.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules/unnecessary_dict_kwargs.rs
@@ -53,7 +53,7 @@ pub(crate) fn unnecessary_dict_kwargs(checker: &mut Checker, expr: &Expr, kwargs
         if kw.arg.is_none() {
             if let Expr::Dict(ast::ExprDict { keys, .. }) = &kw.value {
                 // ensure foo(**{"bar-bar": 1}) doesn't error
-                if keys.iter().all(|expr| expr.as_ref().map_or(false, is_valid_kwarg_name)) ||
+                if keys.iter().all(|expr| expr.as_ref().is_some_and( is_valid_kwarg_name)) ||
                     // handle case of foo(**{**bar})
                     (keys.len() == 1 && keys[0].is_none())
                 {

--- a/crates/ruff/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff/src/rules/flake8_print/rules/print_call.rs
@@ -79,9 +79,10 @@ impl Violation for PPrint {
 pub(crate) fn print_call(checker: &mut Checker, func: &Expr, keywords: &[Keyword]) {
     let diagnostic = {
         let call_path = checker.semantic().resolve_call_path(func);
-        if call_path.as_ref().map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["", "print"])
-        }) {
+        if call_path
+            .as_ref()
+            .is_some_and(|call_path| matches!(call_path.as_slice(), ["", "print"]))
+        {
             // If the print call has a `file=` argument (that isn't `None`, `"sys.stdout"`,
             // or `"sys.stderr"`), don't trigger T201.
             if let Some(keyword) = find_keyword(keywords, "file") {
@@ -98,9 +99,10 @@ pub(crate) fn print_call(checker: &mut Checker, func: &Expr, keywords: &[Keyword
                 }
             }
             Diagnostic::new(Print, func.range())
-        } else if call_path.as_ref().map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["pprint", "pprint"])
-        }) {
+        } else if call_path
+            .as_ref()
+            .is_some_and(|call_path| matches!(call_path.as_slice(), ["pprint", "pprint"]))
+        {
             Diagnostic::new(PPrint, func.range())
         } else {
             return;

--- a/crates/ruff/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
@@ -75,9 +75,7 @@ pub(crate) fn bad_version_info_comparison(checker: &mut Checker, test: &Expr) {
     if !checker
         .semantic()
         .resolve_call_path(left)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["sys", "version_info"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["sys", "version_info"]))
     {
         return;
     }

--- a/crates/ruff/src/rules/flake8_pyi/rules/collections_named_tuple.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/collections_named_tuple.rs
@@ -53,9 +53,7 @@ pub(crate) fn collections_named_tuple(checker: &mut Checker, expr: &Expr) {
     if checker
         .semantic()
         .resolve_call_path(expr)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["collections", "namedtuple"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["collections", "namedtuple"]))
     {
         checker
             .diagnostics

--- a/crates/ruff/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
@@ -67,7 +67,7 @@ pub(crate) fn complex_if_statement_in_stub(checker: &mut Checker, test: &Expr) {
     if checker
         .semantic()
         .resolve_call_path(left)
-        .map_or(false, |call_path| {
+        .is_some_and(|call_path| {
             matches!(call_path.as_slice(), ["sys", "version_info" | "platform"])
         })
     {

--- a/crates/ruff/src/rules/flake8_pyi/rules/exit_annotations.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/exit_annotations.rs
@@ -220,7 +220,7 @@ fn check_positional_args(
         // If there's an annotation that's not `object` or `Unused`, check that the annotated type
         // matches the predicate.
         if non_none_annotation_element(annotation, checker.semantic())
-            .map_or(false, |elem| predicate(elem, checker.semantic()))
+            .is_some_and(|elem| predicate(elem, checker.semantic()))
         {
             continue;
         }
@@ -297,7 +297,7 @@ fn is_object_or_unused(expr: &Expr, model: &SemanticModel) -> bool {
     model
         .resolve_call_path(expr)
         .as_ref()
-        .map_or(false, |call_path| {
+        .is_some_and(|call_path| {
             matches!(
                 call_path.as_slice(),
                 ["" | "builtins", "object"] | ["_typeshed", "Unused"]
@@ -310,9 +310,7 @@ fn is_base_exception(expr: &Expr, model: &SemanticModel) -> bool {
     model
         .resolve_call_path(expr)
         .as_ref()
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["" | "builtins", "BaseException"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["" | "builtins", "BaseException"]))
 }
 
 /// Return `true` if the [`Expr`] is the `types.TracebackType` type.
@@ -320,9 +318,7 @@ fn is_traceback_type(expr: &Expr, model: &SemanticModel) -> bool {
     model
         .resolve_call_path(expr)
         .as_ref()
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["types", "TracebackType"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["types", "TracebackType"]))
 }
 
 /// Return `true` if the [`Expr`] is, e.g., `Type[BaseException]`.
@@ -335,9 +331,7 @@ fn is_base_exception_type(expr: &Expr, model: &SemanticModel) -> bool {
         || model
             .resolve_call_path(value)
             .as_ref()
-            .map_or(false, |call_path| {
-                matches!(call_path.as_slice(), ["" | "builtins", "type"])
-            })
+            .is_some_and(|call_path| matches!(call_path.as_slice(), ["" | "builtins", "type"]))
     {
         is_base_exception(slice, model)
     } else {

--- a/crates/ruff/src/rules/flake8_pyi/rules/iter_method_return_iterable.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/iter_method_return_iterable.rs
@@ -100,7 +100,7 @@ pub(crate) fn iter_method_return_iterable(checker: &mut Checker, definition: &De
     if checker
         .semantic()
         .resolve_call_path(annotation)
-        .map_or(false, |call_path| {
+        .is_some_and(|call_path| {
             if async_ {
                 matches!(
                     call_path.as_slice(),

--- a/crates/ruff/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -252,7 +252,7 @@ fn is_iterator(bases: &[Expr], semantic: &SemanticModel) -> bool {
     bases.iter().any(|expr| {
         semantic
             .resolve_call_path(map_subscript(expr))
-            .map_or(false, |call_path| {
+            .is_some_and(|call_path| {
                 matches!(
                     call_path.as_slice(),
                     ["typing", "Iterator"] | ["collections", "abc", "Iterator"]
@@ -265,7 +265,7 @@ fn is_iterator(bases: &[Expr], semantic: &SemanticModel) -> bool {
 fn is_iterable(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_call_path(map_subscript(expr))
-        .map_or(false, |call_path| {
+        .is_some_and(|call_path| {
             matches!(
                 call_path.as_slice(),
                 ["typing", "Iterable" | "Iterator"]
@@ -279,7 +279,7 @@ fn is_async_iterator(bases: &[Expr], semantic: &SemanticModel) -> bool {
     bases.iter().any(|expr| {
         semantic
             .resolve_call_path(map_subscript(expr))
-            .map_or(false, |call_path| {
+            .is_some_and(|call_path| {
                 matches!(
                     call_path.as_slice(),
                     ["typing", "AsyncIterator"] | ["collections", "abc", "AsyncIterator"]
@@ -292,7 +292,7 @@ fn is_async_iterator(bases: &[Expr], semantic: &SemanticModel) -> bool {
 fn is_async_iterable(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_call_path(map_subscript(expr))
-        .map_or(false, |call_path| {
+        .is_some_and(|call_path| {
             matches!(
                 call_path.as_slice(),
                 ["typing", "AsyncIterable" | "AsyncIterator"]

--- a/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -194,7 +194,7 @@ fn is_valid_default_value_with_annotation(
             return allow_container
                 && keys.len() <= 10
                 && keys.iter().zip(values).all(|(k, v)| {
-                    k.as_ref().map_or(false, |k| {
+                    k.as_ref().is_some_and(|k| {
                         is_valid_default_value_with_annotation(k, false, locator, semantic)
                     }) && is_valid_default_value_with_annotation(v, false, locator, semantic)
                 });
@@ -215,7 +215,7 @@ fn is_valid_default_value_with_annotation(
                     if semantic
                         .resolve_call_path(operand)
                         .as_ref()
-                        .map_or(false, is_allowed_negated_math_attribute)
+                        .is_some_and(is_allowed_negated_math_attribute)
                     {
                         return true;
                     }
@@ -264,7 +264,7 @@ fn is_valid_default_value_with_annotation(
             if semantic
                 .resolve_call_path(default)
                 .as_ref()
-                .map_or(false, is_allowed_math_attribute)
+                .is_some_and(is_allowed_math_attribute)
             {
                 return true;
             }
@@ -332,7 +332,7 @@ fn is_type_var_like_call(expr: &Expr, semantic: &SemanticModel) -> bool {
     let Expr::Call(ast::ExprCall { func, .. }) = expr else {
         return false;
     };
-    semantic.resolve_call_path(func).map_or(false, |call_path| {
+    semantic.resolve_call_path(func).is_some_and(|call_path| {
         matches!(
             call_path.as_slice(),
             [
@@ -370,7 +370,7 @@ fn is_final_assignment(annotation: &Expr, value: &Expr, semantic: &SemanticModel
 /// Returns `true` if the a class is an enum, based on its base classes.
 fn is_enum(bases: &[Expr], semantic: &SemanticModel) -> bool {
     return bases.iter().any(|expr| {
-        semantic.resolve_call_path(expr).map_or(false, |call_path| {
+        semantic.resolve_call_path(expr).is_some_and(|call_path| {
             matches!(
                 call_path.as_slice(),
                 [

--- a/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -107,9 +107,7 @@ pub(crate) fn unrecognized_platform(checker: &mut Checker, test: &Expr) {
     if !checker
         .semantic()
         .resolve_call_path(left)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["sys", "platform"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["sys", "platform"]))
     {
         return;
     }

--- a/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
@@ -138,9 +138,7 @@ pub(crate) fn unrecognized_version_info(checker: &mut Checker, test: &Expr) {
     if !checker
         .semantic()
         .resolve_call_path(map_subscript(left))
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["sys", "version_info"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["sys", "version_info"]))
     {
         return;
     }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -433,7 +433,7 @@ where
                 }
             }
             Expr::Call(ast::ExprCall { func, .. }) => {
-                if collect_call_path(func).map_or(false, |call_path| {
+                if collect_call_path(func).is_some_and(|call_path| {
                     matches!(call_path.as_slice(), ["request", "addfinalizer"])
                 }) {
                     self.addfinalizer_call = Some(expr);

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -21,33 +21,27 @@ pub(super) fn get_mark_decorators(
 }
 
 pub(super) fn is_pytest_fail(call: &Expr, semantic: &SemanticModel) -> bool {
-    semantic.resolve_call_path(call).map_or(false, |call_path| {
-        matches!(call_path.as_slice(), ["pytest", "fail"])
-    })
+    semantic
+        .resolve_call_path(call)
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["pytest", "fail"]))
 }
 
 pub(super) fn is_pytest_fixture(decorator: &Decorator, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_call_path(map_callable(&decorator.expression))
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["pytest", "fixture"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["pytest", "fixture"]))
 }
 
 pub(super) fn is_pytest_yield_fixture(decorator: &Decorator, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_call_path(map_callable(&decorator.expression))
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["pytest", "yield_fixture"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["pytest", "yield_fixture"]))
 }
 
 pub(super) fn is_pytest_parametrize(decorator: &Decorator, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_call_path(map_callable(&decorator.expression))
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["pytest", "mark", "parametrize"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["pytest", "mark", "parametrize"]))
 }
 
 pub(super) fn keyword_is_literal(keyword: &Keyword, literal: &str) -> bool {

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
@@ -78,9 +78,9 @@ impl Violation for PytestRaisesWithoutException {
 }
 
 fn is_pytest_raises(func: &Expr, semantic: &SemanticModel) -> bool {
-    semantic.resolve_call_path(func).map_or(false, |call_path| {
-        matches!(call_path.as_slice(), ["pytest", "raises"])
-    })
+    semantic
+        .resolve_call_path(func)
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["pytest", "raises"]))
 }
 
 const fn is_non_trivial_with_body(body: &[Stmt]) -> bool {

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/unittest_assert.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/unittest_assert.rs
@@ -218,7 +218,7 @@ impl UnittestAssert {
         if keywords.iter().any(|kw| {
             kw.arg
                 .as_ref()
-                .map_or(false, |kwarg_name| !arg_spec.contains(&kwarg_name.as_str()))
+                .is_some_and(|kwarg_name| !arg_spec.contains(&kwarg_name.as_str()))
         }) {
             bail!("Unknown keyword argument");
         }
@@ -240,7 +240,7 @@ impl UnittestAssert {
                 if keyword
                     .arg
                     .as_ref()
-                    .map_or(false, |kwarg_name| &kwarg_name == arg_name)
+                    .is_some_and(|kwarg_name| &kwarg_name == arg_name)
                 {
                     Some(&keyword.value)
                 } else {

--- a/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -59,9 +59,7 @@ pub(crate) fn unnecessary_paren_on_raise_exception(checker: &mut Checker, expr: 
             if checker
                 .semantic()
                 .lookup_attribute(func)
-                .map_or(false, |id| {
-                    checker.semantic().binding(id).kind.is_function_definition()
-                })
+                .is_some_and(|id| checker.semantic().binding(id).kind.is_function_definition())
             {
                 return;
             }

--- a/crates/ruff/src/rules/flake8_return/helpers.rs
+++ b/crates/ruff/src/rules/flake8_return/helpers.rs
@@ -8,7 +8,7 @@ use ruff_source_file::{Locator, UniversalNewlines};
 /// non-`None` value.
 pub(super) fn result_exists(returns: &[&ast::StmtReturn]) -> bool {
     returns.iter().any(|stmt| {
-        stmt.value.as_deref().map_or(false, |value| {
+        stmt.value.as_deref().is_some_and(|value| {
             !matches!(
                 value,
                 Expr::Constant(constant) if constant.value.is_none()

--- a/crates/ruff/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff/src/rules/flake8_return/rules/function.rs
@@ -373,7 +373,7 @@ fn implicit_return_value(checker: &mut Checker, stack: &Stack) {
 
 /// Return `true` if the `func` is a known function that never returns.
 fn is_noreturn_func(func: &Expr, semantic: &SemanticModel) -> bool {
-    semantic.resolve_call_path(func).map_or(false, |call_path| {
+    semantic.resolve_call_path(func).is_some_and(|call_path| {
         matches!(
             call_path.as_slice(),
             ["" | "builtins" | "sys" | "_thread" | "pytest", "exit"]
@@ -552,7 +552,7 @@ fn unnecessary_assign(checker: &mut Checker, stack: &Stack) {
                     if content[after_equals..]
                         .chars()
                         .next()
-                        .map_or(false, char::is_alphabetic)
+                        .is_some_and(char::is_alphabetic)
                     {
                         "return ".to_string()
                     } else {

--- a/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
@@ -156,12 +156,12 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
                         ScopeKind::Class(ast::StmtClassDef { name, .. }) => Some(name),
                         _ => None,
                     })
-                    .map_or(false, |name| {
+                    .is_some_and(|name| {
                         if call_path.as_slice() == [name.as_str()] {
                             checker
                                 .semantic()
                                 .find_binding(name)
-                                .map_or(false, |binding| {
+                                .is_some_and(|binding| {
                                     // TODO(charlie): Could the name ever be bound to a
                                     // _different_ class here?
                                     binding.kind.is_class_definition()

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -119,7 +119,7 @@ pub(crate) fn use_capital_environment_variables(checker: &mut Checker, expr: &Ex
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
+        .is_some_and(|call_path| {
             matches!(
                 call_path.as_slice(),
                 ["os", "environ", "get"] | ["os", "getenv"]

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -574,9 +574,9 @@ fn ternary(target_var: &Expr, body_value: &Expr, test: &Expr, orelse_value: &Exp
 /// Return `true` if the `Expr` contains a reference to any of the given `${module}.${target}`.
 fn contains_call_path(expr: &Expr, targets: &[&[&str]], semantic: &SemanticModel) -> bool {
     any_over_expr(expr, &|expr| {
-        semantic.resolve_call_path(expr).map_or(false, |call_path| {
-            targets.iter().any(|target| &call_path.as_slice() == target)
-        })
+        semantic
+            .resolve_call_path(expr)
+            .is_some_and(|call_path| targets.iter().any(|target| &call_path.as_slice() == target))
     })
 }
 
@@ -767,9 +767,10 @@ pub(crate) fn manual_dict_lookup(checker: &mut Checker, stmt_if: &StmtIf) {
     let [Stmt::Return(ast::StmtReturn { value, range: _ })] = body.as_slice() else {
         return;
     };
-    if value.as_ref().map_or(false, |value| {
-        contains_effect(value, |id| checker.semantic().is_builtin(id))
-    }) {
+    if value
+        .as_ref()
+        .is_some_and(|value| contains_effect(value, |id| checker.semantic().is_builtin(id)))
+    {
         return;
     }
 
@@ -789,7 +790,7 @@ pub(crate) fn manual_dict_lookup(checker: &mut Checker, stmt_if: &StmtIf) {
                 let [Stmt::Return(ast::StmtReturn { value, range: _ })] = body.as_slice() else {
                     return;
                 };
-                if value.as_ref().map_or(false, |value| {
+                if value.as_ref().is_some_and(|value| {
                     contains_effect(value, |id| checker.semantic().is_builtin(id))
                 }) {
                     return;
@@ -815,7 +816,7 @@ pub(crate) fn manual_dict_lookup(checker: &mut Checker, stmt_if: &StmtIf) {
                     return;
                 };
 
-                if value.as_ref().map_or(false, |value| {
+                if value.as_ref().is_some_and(|value| {
                     contains_effect(value, |id| checker.semantic().is_builtin(id))
                 }) {
                     return;

--- a/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -96,7 +96,7 @@ fn key_in_dict(
     // ```
     if value
         .as_name_expr()
-        .map_or(false, |name| matches!(name.id.as_str(), "self"))
+        .is_some_and(|name| matches!(name.id.as_str(), "self"))
     {
         return;
     }

--- a/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -62,7 +62,7 @@ fn match_async_exit_stack(semantic: &SemanticModel) -> bool {
         if let Stmt::With(ast::StmtWith { items, .. }) = parent {
             for item in items {
                 if let Expr::Call(ast::ExprCall { func, .. }) = &item.context_expr {
-                    if semantic.resolve_call_path(func).map_or(false, |call_path| {
+                    if semantic.resolve_call_path(func).is_some_and(|call_path| {
                         matches!(call_path.as_slice(), ["contextlib", "AsyncExitStack"])
                     }) {
                         return true;
@@ -93,7 +93,7 @@ fn match_exit_stack(semantic: &SemanticModel) -> bool {
         if let Stmt::With(ast::StmtWith { items, .. }) = parent {
             for item in items {
                 if let Expr::Call(ast::ExprCall { func, .. }) = &item.context_expr {
-                    if semantic.resolve_call_path(func).map_or(false, |call_path| {
+                    if semantic.resolve_call_path(func).is_some_and(|call_path| {
                         matches!(call_path.as_slice(), ["contextlib", "ExitStack"])
                     }) {
                         return true;
@@ -114,9 +114,7 @@ fn is_open(checker: &mut Checker, func: &Expr) -> bool {
                 Expr::Call(ast::ExprCall { func, .. }) => checker
                     .semantic()
                     .resolve_call_path(func)
-                    .map_or(false, |call_path| {
-                        matches!(call_path.as_slice(), ["pathlib", "Path"])
-                    }),
+                    .is_some_and(|call_path| matches!(call_path.as_slice(), ["pathlib", "Path"])),
                 _ => false,
             }
         }

--- a/crates/ruff/src/rules/flake8_slots/rules/no_slots_in_namedtuple_subclass.rs
+++ b/crates/ruff/src/rules/flake8_slots/rules/no_slots_in_namedtuple_subclass.rs
@@ -70,9 +70,7 @@ pub(crate) fn no_slots_in_namedtuple_subclass(
         checker
             .semantic()
             .resolve_call_path(func)
-            .map_or(false, |call_path| {
-                matches!(call_path.as_slice(), ["collections", "namedtuple"])
-            })
+            .is_some_and(|call_path| matches!(call_path.as_slice(), ["collections", "namedtuple"]))
     }) {
         if !has_slots(&class.body) {
             checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/flake8_slots/rules/no_slots_in_tuple_subclass.rs
+++ b/crates/ruff/src/rules/flake8_slots/rules/no_slots_in_tuple_subclass.rs
@@ -55,7 +55,7 @@ pub(crate) fn no_slots_in_tuple_subclass(checker: &mut Checker, stmt: &Stmt, cla
         checker
             .semantic()
             .resolve_call_path(map_subscript(base))
-            .map_or(false, |call_path| {
+            .is_some_and(|call_path| {
                 matches!(call_path.as_slice(), ["" | "builtins", "tuple"])
                     || checker
                         .semantic()

--- a/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -104,7 +104,7 @@ pub(crate) fn runtime_import_in_type_checking_block(
             };
 
             if checker.rule_is_ignored(Rule::RuntimeImportInTypeCheckingBlock, import.range.start())
-                || import.parent_range.map_or(false, |parent_range| {
+                || import.parent_range.is_some_and(|parent_range| {
                     checker.rule_is_ignored(
                         Rule::RuntimeImportInTypeCheckingBlock,
                         parent_range.start(),

--- a/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -283,7 +283,7 @@ pub(crate) fn typing_only_runtime_import(
             };
 
             if checker.rule_is_ignored(rule_for(import_type), import.range.start())
-                || import.parent_range.map_or(false, |parent_range| {
+                || import.parent_range.is_some_and(|parent_range| {
                     checker.rule_is_ignored(rule_for(import_type), parent_range.start())
                 })
             {

--- a/crates/ruff/src/rules/flake8_use_pathlib/rules/os_sep_split.rs
+++ b/crates/ruff/src/rules/flake8_use_pathlib/rules/os_sep_split.rs
@@ -85,9 +85,7 @@ pub(crate) fn os_sep_split(
     if !checker
         .semantic()
         .resolve_call_path(sep)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["os", "sep"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["os", "sep"]))
     {
         return;
     }

--- a/crates/ruff/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
+++ b/crates/ruff/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
@@ -49,9 +49,7 @@ pub(crate) fn path_constructor_current_directory(checker: &mut Checker, expr: &E
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["pathlib", "Path" | "PurePath"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["pathlib", "Path" | "PurePath"]))
     {
         return;
     }

--- a/crates/ruff/src/rules/isort/annotate.rs
+++ b/crates/ruff/src/rules/isort/annotate.rs
@@ -71,7 +71,7 @@ pub(crate) fn annotate_imports<'a>(
                     // import bar  # noqa`).
                     let mut inline = vec![];
                     if names.len() > 1
-                        || names.first().map_or(false, |alias| {
+                        || names.first().is_some_and(|alias| {
                             locator
                                 .contains_line_break(TextRange::new(import.start(), alias.start()))
                         })

--- a/crates/ruff/src/rules/isort/block.rs
+++ b/crates/ruff/src/rules/isort/block.rs
@@ -144,7 +144,7 @@ where
             while self
                 .splits
                 .peek()
-                .map_or(false, |split| stmt.start() >= **split)
+                .is_some_and(|split| stmt.start() >= **split)
             {
                 self.splits.next();
             }
@@ -165,7 +165,7 @@ where
                 // the case of multiple empty cells).
                 while cell_offsets
                     .peek()
-                    .map_or(false, |split| stmt.start() >= **split)
+                    .is_some_and(|split| stmt.start() >= **split)
                 {
                     cell_offsets.next();
                 }

--- a/crates/ruff/src/rules/isort/categorize.rs
+++ b/crates/ruff/src/rules/isort/categorize.rs
@@ -74,7 +74,7 @@ pub(crate) fn categorize<'a>(
 ) -> &'a ImportSection {
     let module_base = module_name.split('.').next().unwrap();
     let (import_type, reason) = {
-        if level.map_or(false, |level| level > 0) {
+        if level.is_some_and(|level| level > 0) {
             (
                 &ImportSection::Known(ImportType::LocalFolder),
                 Reason::NonZeroLevel,
@@ -113,7 +113,7 @@ pub(crate) fn categorize<'a>(
 }
 
 fn same_package(package: Option<&Path>, module_base: &str) -> bool {
-    package.map_or(false, |package| package.ends_with(module_base))
+    package.is_some_and(|package| package.ends_with(module_base))
 }
 
 fn match_sources<'a>(paths: &'a [PathBuf], base: &str) -> Option<&'a Path> {

--- a/crates/ruff/src/rules/isort/normalize.rs
+++ b/crates/ruff/src/rules/isort/normalize.rs
@@ -58,7 +58,7 @@ pub(crate) fn normalize_imports<'a>(
                 // Whether to track each member of the import as a separate entry.
                 let isolate_aliases = force_single_line
                     && module.map_or(true, |module| !single_line_exclusions.contains(module))
-                    && !names.first().map_or(false, |alias| alias.name == "*");
+                    && !names.first().is_some_and(|alias| alias.name == "*");
 
                 // Insert comments on the statement itself.
                 if isolate_aliases {

--- a/crates/ruff/src/rules/isort/sorting.rs
+++ b/crates/ruff/src/rules/isort/sorting.rs
@@ -35,7 +35,7 @@ fn prefix(
     } else if name.len() > 1 && str::is_cased_uppercase(name) {
         // Ex) `CONSTANT`
         Prefix::Constants
-    } else if name.chars().next().map_or(false, char::is_uppercase) {
+    } else if name.chars().next().is_some_and(char::is_uppercase) {
         // Ex) `Class`
         Prefix::Classes
     } else {

--- a/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -64,7 +64,7 @@ pub(crate) fn inplace_argument(
         if !call_path
             .first()
             .and_then(|module| checker.semantic().find_binding(module))
-            .map_or(false, |binding| {
+            .is_some_and(|binding| {
                 matches!(
                     binding.kind,
                     BindingKind::Import(Import {

--- a/crates/ruff/src/rules/pandas_vet/rules/read_table.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/read_table.rs
@@ -50,9 +50,7 @@ pub(crate) fn use_of_read_table(checker: &mut Checker, func: &Expr, keywords: &[
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["pandas", "read_table"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["pandas", "read_table"]))
     {
         if let Some(Expr::Constant(ast::ExprConstant {
             value: Constant::Str(value),

--- a/crates/ruff/src/rules/pep8_naming/helpers.rs
+++ b/crates/ruff/src/rules/pep8_naming/helpers.rs
@@ -29,7 +29,7 @@ pub(super) fn is_named_tuple_assignment(stmt: &Stmt, semantic: &SemanticModel) -
     let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() else {
         return false;
     };
-    semantic.resolve_call_path(func).map_or(false, |call_path| {
+    semantic.resolve_call_path(func).is_some_and(|call_path| {
         matches!(
             call_path.as_slice(),
             ["collections", "namedtuple"] | ["typing", "NamedTuple"]
@@ -44,9 +44,9 @@ pub(super) fn is_typed_dict_assignment(stmt: &Stmt, semantic: &SemanticModel) ->
     let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() else {
         return false;
     };
-    semantic.resolve_call_path(func).map_or(false, |call_path| {
-        matches!(call_path.as_slice(), ["typing", "TypedDict"])
-    })
+    semantic
+        .resolve_call_path(func)
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["typing", "TypedDict"]))
 }
 
 pub(super) fn is_type_var_assignment(stmt: &Stmt, semantic: &SemanticModel) -> bool {
@@ -56,9 +56,9 @@ pub(super) fn is_type_var_assignment(stmt: &Stmt, semantic: &SemanticModel) -> b
     let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() else {
         return false;
     };
-    semantic.resolve_call_path(func).map_or(false, |call_path| {
-        matches!(call_path.as_slice(), ["typing", "TypeVar" | "NewType"])
-    })
+    semantic
+        .resolve_call_path(func)
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["typing", "TypeVar" | "NewType"]))
 }
 
 pub(super) fn is_typed_dict_class(bases: &[Expr], semantic: &SemanticModel) -> bool {

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_class_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_class_name.rs
@@ -62,7 +62,7 @@ pub(crate) fn invalid_class_name(
     }
 
     let stripped = name.strip_prefix('_').unwrap_or(name);
-    if !stripped.chars().next().map_or(false, char::is_uppercase) || stripped.contains('_') {
+    if !stripped.chars().next().is_some_and(char::is_uppercase) || stripped.contains('_') {
         return Some(Diagnostic::new(
             InvalidClassName {
                 name: name.to_string(),

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_module_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_module_name.rs
@@ -55,7 +55,7 @@ pub(crate) fn invalid_module_name(
 ) -> Option<Diagnostic> {
     if !path
         .extension()
-        .map_or(false, |ext| ext == "py" || ext == "pyi")
+        .is_some_and(|ext| ext == "py" || ext == "pyi")
     {
         return None;
     }
@@ -97,7 +97,7 @@ pub(crate) fn invalid_module_name(
 
 /// Return `true` if a [`Path`] should use the name of its parent directory as its module name.
 fn is_module_file(path: &Path) -> bool {
-    path.file_name().map_or(false, |file_name| {
+    path.file_name().is_some_and(|file_name| {
         file_name == "__init__.py"
             || file_name == "__init__.pyi"
             || file_name == "__main__.py"
@@ -110,5 +110,5 @@ fn is_migration_file(path: &Path) -> bool {
     path.parent()
         .and_then(Path::file_name)
         .and_then(OsStr::to_str)
-        .map_or(false, |parent| matches!(parent, "versions" | "migrations"))
+        .is_some_and(|parent| matches!(parent, "versions" | "migrations"))
 }

--- a/crates/ruff/src/rules/perflint/rules/manual_list_comprehension.rs
+++ b/crates/ruff/src/rules/perflint/rules/manual_list_comprehension.rs
@@ -110,7 +110,7 @@ pub(crate) fn manual_list_comprehension(checker: &mut Checker, target: &Expr, bo
 
     // Ignore direct list copies (e.g., `for x in y: filtered.append(x)`).
     if if_test.is_none() {
-        if arg.as_name_expr().map_or(false, |arg| arg.id == *id) {
+        if arg.as_name_expr().is_some_and(|arg| arg.id == *id) {
             return;
         }
     }
@@ -125,7 +125,7 @@ pub(crate) fn manual_list_comprehension(checker: &mut Checker, target: &Expr, bo
 
     // Avoid, e.g., `for x in y: filtered[x].append(x * x)`.
     if any_over_expr(value, &|expr| {
-        expr.as_name_expr().map_or(false, |expr| expr.id == *id)
+        expr.as_name_expr().is_some_and(|expr| expr.id == *id)
     }) {
         return;
     }
@@ -152,10 +152,10 @@ pub(crate) fn manual_list_comprehension(checker: &mut Checker, target: &Expr, bo
     // filtered = [x for x in y if x in filtered]
     // ```
     if let Some(value_name) = value.as_name_expr() {
-        if if_test.map_or(false, |test| {
+        if if_test.is_some_and(|test| {
             any_over_expr(test, &|expr| {
                 expr.as_name_expr()
-                    .map_or(false, |expr| expr.id == value_name.id)
+                    .is_some_and(|expr| expr.id == value_name.id)
             })
         }) {
             return;

--- a/crates/ruff/src/rules/perflint/rules/manual_list_copy.rs
+++ b/crates/ruff/src/rules/perflint/rules/manual_list_copy.rs
@@ -76,7 +76,7 @@ pub(crate) fn manual_list_copy(checker: &mut Checker, target: &Expr, body: &[Stm
     };
 
     // Only flag direct list copies (e.g., `for x in y: filtered.append(x)`).
-    if !arg.as_name_expr().map_or(false, |arg| arg.id == *id) {
+    if !arg.as_name_expr().is_some_and(|arg| arg.id == *id) {
         return;
     }
 
@@ -90,7 +90,7 @@ pub(crate) fn manual_list_copy(checker: &mut Checker, target: &Expr, body: &[Stm
 
     // Avoid, e.g., `for x in y: filtered[x].append(x)`.
     if any_over_expr(value, &|expr| {
-        expr.as_name_expr().map_or(false, |expr| expr.id == *id)
+        expr.as_name_expr().is_some_and(|expr| expr.id == *id)
     }) {
         return;
     }

--- a/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -68,7 +68,7 @@ pub(crate) fn invalid_escape_sequence(
     let bytes = body.as_bytes();
     for i in memchr_iter(b'\\', bytes) {
         // If the previous character was also a backslash, skip.
-        if prev.map_or(false, |prev| prev == i - 1) {
+        if prev.is_some_and(|prev| prev == i - 1) {
             prev = None;
             continue;
         }
@@ -142,7 +142,7 @@ pub(crate) fn invalid_escape_sequence(
                     .slice(TextRange::up_to(range.start()))
                     .chars()
                     .last()
-                    .map_or(false, |char| char.is_ascii_alphabetic());
+                    .is_some_and(|char| char.is_ascii_alphabetic());
 
                 diagnostic.set_fix(Fix::automatic(Edit::insertion(
                     if requires_space {

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -147,13 +147,10 @@ fn extract_types(annotation: &Expr, semantic: &SemanticModel) -> Option<(Vec<Exp
         return None;
     };
 
-    if !semantic
-        .resolve_call_path(value)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["collections", "abc", "Callable"])
-                || semantic.match_typing_call_path(&call_path, "Callable")
-        })
-    {
+    if !semantic.resolve_call_path(value).is_some_and(|call_path| {
+        matches!(call_path.as_slice(), ["collections", "abc", "Callable"])
+            || semantic.match_typing_call_path(&call_path, "Callable")
+    }) {
         return None;
     }
 

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/indentation.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/indentation.rs
@@ -247,7 +247,7 @@ pub(crate) fn indentation(
     }
     let indent_expect = prev_logical_line
         .and_then(|prev_logical_line| prev_logical_line.tokens_trimmed().last())
-        .map_or(false, |t| t.kind() == TokenKind::Colon);
+        .is_some_and(|t| t.kind() == TokenKind::Colon);
 
     if indent_expect && indent_level <= prev_indent_level.unwrap_or(0) {
         diagnostics.push(if logical_line.is_comment_only() {
@@ -256,7 +256,7 @@ pub(crate) fn indentation(
             DiagnosticKind::from(NoIndentedBlock)
         });
     } else if !indent_expect
-        && prev_indent_level.map_or(false, |prev_indent_level| indent_level > prev_indent_level)
+        && prev_indent_level.is_some_and(|prev_indent_level| indent_level > prev_indent_level)
     {
         diagnostics.push(if logical_line.is_comment_only() {
             DiagnosticKind::from(UnexpectedIndentationComment)

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
@@ -69,7 +69,7 @@ pub(crate) fn missing_whitespace(
                 if !after
                     .chars()
                     .next()
-                    .map_or(false, |c| char::is_whitespace(c) || c == '\\')
+                    .is_some_and(|c| char::is_whitespace(c) || c == '\\')
                 {
                     if let Some(next_token) = iter.peek() {
                         match (kind, next_token.kind()) {

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
@@ -175,8 +175,7 @@ pub(crate) fn whitespace_before_comment(
             };
 
             if is_inline_comment {
-                if bad_prefix.is_some() || comment.chars().next().map_or(false, char::is_whitespace)
-                {
+                if bad_prefix.is_some() || comment.chars().next().is_some_and(char::is_whitespace) {
                     context.push(NoSpaceAfterInlineComment, range);
                 }
             } else if let Some(bad_prefix) = bad_prefix {

--- a/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
@@ -79,8 +79,8 @@ pub(crate) fn type_comparison(
                         && checker
                             .semantic()
                             .resolve_call_path(value)
-                            .map_or(false, |call_path| {
-                                call_path.first().map_or(false, |module| *module == "types")
+                            .is_some_and(|call_path| {
+                                call_path.first().is_some_and(|module| *module == "types")
                             })
                     {
                         checker

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
@@ -182,7 +182,7 @@ pub(crate) fn blank_before_after_function(checker: &mut Checker, docstring: &Doc
         if blank_lines_after == 1
             && lines
                 .find(|line| !line.trim_whitespace_start().starts_with('#'))
-                .map_or(false, |line| INNER_FUNCTION_OR_CLASS_REGEX.is_match(&line))
+                .is_some_and(|line| INNER_FUNCTION_OR_CLASS_REGEX.is_match(&line))
         {
             return;
         }

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -1695,7 +1695,7 @@ fn common_section(
     }
 
     if checker.enabled(Rule::NoBlankLineBeforeSection) {
-        if !context.previous_line().map_or(false, str::is_empty) {
+        if !context.previous_line().is_some_and(str::is_empty) {
             let mut diagnostic = Diagnostic::new(
                 NoBlankLineBeforeSection {
                     name: context.section_name().to_string(),

--- a/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -125,7 +125,7 @@ fn convert_f_string_to_regular_string(
         .slice(TextRange::up_to(prefix_range.start()))
         .chars()
         .last()
-        .map_or(false, |char| content.starts_with(char))
+        .is_some_and(|char| content.starts_with(char))
     {
         content.insert(0, ' ');
     }

--- a/crates/ruff/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_import.rs
@@ -126,7 +126,7 @@ pub(crate) fn unused_import(checker: &Checker, scope: &Scope, diagnostics: &mut 
         };
 
         if checker.rule_is_ignored(Rule::UnusedImport, import.range.start())
-            || import.parent_range.map_or(false, |parent_range| {
+            || import.parent_range.is_some_and(|parent_range| {
                 checker.rule_is_ignored(Rule::UnusedImport, parent_range.start())
             })
         {

--- a/crates/ruff/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
@@ -46,9 +46,7 @@ pub(crate) fn deprecated_log_warn(checker: &mut Checker, func: &Expr) {
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["logging", "warn"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["logging", "warn"]))
     {
         checker
             .diagnostics

--- a/crates/ruff/src/rules/pylint/rules/invalid_envvar_default.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_envvar_default.rs
@@ -87,9 +87,7 @@ pub(crate) fn invalid_envvar_default(
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["os", "getenv"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["os", "getenv"]))
     {
         // Find the `default` argument, if it exists.
         let Some(expr) = args

--- a/crates/ruff/src/rules/pylint/rules/invalid_envvar_value.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_envvar_value.rs
@@ -84,9 +84,7 @@ pub(crate) fn invalid_envvar_value(
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["os", "getenv"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["os", "getenv"]))
     {
         // Find the `key` argument, if it exists.
         let Some(expr) = args

--- a/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
+++ b/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
@@ -174,9 +174,10 @@ impl<'a, 'b> StatementVisitor<'b> for InnerForWithAssignTargetsVisitor<'a, 'b> {
             Stmt::Assign(ast::StmtAssign { targets, value, .. }) => {
                 // Check for single-target assignments which are of the
                 // form `x = cast(..., x)`.
-                if targets.first().map_or(false, |target| {
-                    assignment_is_cast_expr(value, target, self.context)
-                }) {
+                if targets
+                    .first()
+                    .is_some_and(|target| assignment_is_cast_expr(value, target, self.context))
+                {
                     return;
                 }
                 self.assignment_targets.extend(

--- a/crates/ruff/src/rules/pylint/rules/subprocess_popen_preexec_fn.rs
+++ b/crates/ruff/src/rules/pylint/rules/subprocess_popen_preexec_fn.rs
@@ -52,9 +52,7 @@ pub(crate) fn subprocess_popen_preexec_fn(checker: &mut Checker, func: &Expr, kw
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["subprocess", "Popen"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["subprocess", "Popen"]))
     {
         if let Some(keyword) =
             find_keyword(kwargs, "preexec_fn").filter(|keyword| !is_const_none(&keyword.value))

--- a/crates/ruff/src/rules/pylint/rules/type_name_incorrect_variance.rs
+++ b/crates/ruff/src/rules/pylint/rules/type_name_incorrect_variance.rs
@@ -138,7 +138,7 @@ fn mismatch(param_name: &str, covariant: Option<&Expr>, contravariant: Option<&E
     } else if param_name.ends_with("_contra") {
         contravariant.map_or(true, |contravariant| !is_const_true(contravariant))
     } else {
-        covariant.map_or(false, is_const_true) || contravariant.map_or(false, is_const_true)
+        covariant.is_some_and(is_const_true) || contravariant.is_some_and(is_const_true)
     }
 }
 

--- a/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -54,9 +54,7 @@ pub(crate) fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
     if checker
         .semantic()
         .resolve_call_path(expr)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["datetime", "timezone", "utc"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["datetime", "timezone", "utc"]))
     {
         let mut diagnostic = Diagnostic::new(DatetimeTimezoneUTC, expr.range());
         if checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
@@ -71,7 +71,7 @@ pub(crate) fn deprecated_c_element_tree(checker: &mut Checker, stmt: &Stmt) {
             level,
             range: _,
         }) => {
-            if level.map_or(false, |level| level.to_u32() > 0) {
+            if level.is_some_and(|level| level.to_u32() > 0) {
                 // Ex) `import .xml.etree.cElementTree as ET`
             } else if let Some(module) = module {
                 if module == "xml.etree.cElementTree" {

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -549,10 +549,10 @@ pub(crate) fn deprecated_import(
     level: Option<u32>,
 ) {
     // Avoid relative and star imports.
-    if level.map_or(false, |level| level > 0) {
+    if level.is_some_and(|level| level > 0) {
         return;
     }
-    if names.first().map_or(false, |name| &name.name == "*") {
+    if names.first().is_some_and(|name| &name.name == "*") {
         return;
     }
     let Some(module) = module else {

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -251,9 +251,9 @@ fn format_import_from(
 /// UP026
 pub(crate) fn deprecated_mock_attribute(checker: &mut Checker, expr: &Expr) {
     if let Expr::Attribute(ast::ExprAttribute { value, .. }) = expr {
-        if collect_call_path(value).map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["mock", "mock"])
-        }) {
+        if collect_call_path(value)
+            .is_some_and(|call_path| matches!(call_path.as_slice(), ["mock", "mock"]))
+        {
             let mut diagnostic = Diagnostic::new(
                 DeprecatedMockImport {
                     reference_type: MockReference::Attribute,
@@ -322,7 +322,7 @@ pub(crate) fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
             level,
             ..
         }) => {
-            if level.map_or(false, |level| level.to_u32() > 0) {
+            if level.is_some_and(|level| level.to_u32() > 0) {
                 return;
             }
 

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -362,7 +362,7 @@ pub(crate) fn f_strings(
     if existing
         .chars()
         .last()
-        .map_or(false, |char| char.is_ascii_alphabetic())
+        .is_some_and(|char| char.is_ascii_alphabetic())
     {
         contents.insert(0, ' ');
     }

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -75,16 +75,14 @@ pub(crate) fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list:
             && checker
                 .semantic()
                 .resolve_call_path(func)
-                .map_or(false, |call_path| {
-                    matches!(call_path.as_slice(), ["functools", "lru_cache"])
-                })
+                .is_some_and(|call_path| matches!(call_path.as_slice(), ["functools", "lru_cache"]))
         {
             let Keyword {
                 arg,
                 value,
                 range: _,
             } = &keywords[0];
-            if arg.as_ref().map_or(false, |arg| arg == "maxsize") && is_const_none(value) {
+            if arg.as_ref().is_some_and(|arg| arg == "maxsize") && is_const_none(value) {
                 let mut diagnostic = Diagnostic::new(
                     LRUCacheWithMaxsizeNone,
                     TextRange::new(func.end(), decorator.end()),

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -73,9 +73,7 @@ pub(crate) fn lru_cache_without_parameters(checker: &mut Checker, decorator_list
             && checker
                 .semantic()
                 .resolve_call_path(func)
-                .map_or(false, |call_path| {
-                    matches!(call_path.as_slice(), ["functools", "lru_cache"])
-                })
+                .is_some_and(|call_path| matches!(call_path.as_slice(), ["functools", "lru_cache"]))
         {
             let mut diagnostic = Diagnostic::new(
                 LRUCacheWithoutParameters,

--- a/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
@@ -50,9 +50,7 @@ pub(crate) fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["io", "open"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["io", "open"]))
     {
         let mut diagnostic = Diagnostic::new(OpenAlias, expr.range());
         if checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -56,7 +56,7 @@ impl AlwaysAutofixableViolation for OSErrorAlias {
 
 /// Return `true` if an [`Expr`] is an alias of `OSError`.
 fn is_alias(expr: &Expr, semantic: &SemanticModel) -> bool {
-    semantic.resolve_call_path(expr).map_or(false, |call_path| {
+    semantic.resolve_call_path(expr).is_some_and(|call_path| {
         matches!(
             call_path.as_slice(),
             ["", "EnvironmentError" | "IOError" | "WindowsError"]
@@ -67,9 +67,9 @@ fn is_alias(expr: &Expr, semantic: &SemanticModel) -> bool {
 
 /// Return `true` if an [`Expr`] is `OSError`.
 fn is_os_error(expr: &Expr, semantic: &SemanticModel) -> bool {
-    semantic.resolve_call_path(expr).map_or(false, |call_path| {
-        matches!(call_path.as_slice(), ["", "OSError"])
-    })
+    semantic
+        .resolve_call_path(expr)
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["", "OSError"]))
 }
 
 /// Create a [`Diagnostic`] for a single target, like an [`Expr::Name`].

--- a/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -282,9 +282,7 @@ pub(crate) fn outdated_version_block(checker: &mut Checker, stmt_if: &StmtIf) {
         if !checker
             .semantic()
             .resolve_call_path(left)
-            .map_or(false, |call_path| {
-                matches!(call_path.as_slice(), ["sys", "version_info"])
-            })
+            .is_some_and(|call_path| matches!(call_path.as_slice(), ["sys", "version_info"]))
         {
             continue;
         }

--- a/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -295,7 +295,7 @@ fn convertible(format_string: &CFormatString, params: &Expr) -> bool {
         }
 
         // No equivalent in format.
-        if fmt.mapping_key.as_ref().map_or(false, String::is_empty) {
+        if fmt.mapping_key.as_ref().is_some_and(String::is_empty) {
             return false;
         }
 

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -89,9 +89,7 @@ pub(crate) fn replace_stdout_stderr(
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["subprocess", "run"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["subprocess", "run"]))
     {
         // Find `stdout` and `stderr` kwargs.
         let Some(stdout) = find_keyword(keywords, "stdout") else {
@@ -105,15 +103,11 @@ pub(crate) fn replace_stdout_stderr(
         if !checker
             .semantic()
             .resolve_call_path(&stdout.value)
-            .map_or(false, |call_path| {
-                matches!(call_path.as_slice(), ["subprocess", "PIPE"])
-            })
+            .is_some_and(|call_path| matches!(call_path.as_slice(), ["subprocess", "PIPE"]))
             || !checker
                 .semantic()
                 .resolve_call_path(&stderr.value)
-                .map_or(false, |call_path| {
-                    matches!(call_path.as_slice(), ["subprocess", "PIPE"])
-                })
+                .is_some_and(|call_path| matches!(call_path.as_slice(), ["subprocess", "PIPE"]))
         {
             return;
         }

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -54,9 +54,7 @@ pub(crate) fn replace_universal_newlines(checker: &mut Checker, func: &Expr, kwa
     if checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["subprocess", "run"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["subprocess", "run"]))
     {
         let Some(kwarg) = find_keyword(kwargs, "universal_newlines") else {
             return;

--- a/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
@@ -60,9 +60,7 @@ pub(crate) fn type_of_primitive(checker: &mut Checker, expr: &Expr, func: &Expr,
     if !checker
         .semantic()
         .resolve_call_path(func)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["", "type"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["", "type"]))
     {
         return;
     }

--- a/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -49,9 +49,7 @@ pub(crate) fn typing_text_str_alias(checker: &mut Checker, expr: &Expr) {
     if checker
         .semantic()
         .resolve_call_path(expr)
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["typing", "Text"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["typing", "Text"]))
     {
         let mut diagnostic = Diagnostic::new(TypingTextStrAlias, expr.range());
         if checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -109,7 +109,7 @@ fn match_encoding_arg<'a>(args: &'a [Expr], kwargs: &'a [Keyword]) -> Option<Enc
         // Ex `"".encode(kwarg=kwarg)`
         (0, 1) => {
             let kwarg = &kwargs[0];
-            if kwarg.arg.as_ref().map_or(false, |arg| arg == "encoding") {
+            if kwarg.arg.as_ref().is_some_and(|arg| arg == "encoding") {
                 if is_utf8_encoding_arg(&kwarg.value) {
                     return Some(EncodingArg::Keyword(kwarg));
                 }

--- a/crates/ruff/src/rules/ruff/rules/unreachable.rs
+++ b/crates/ruff/src/rules/ruff/rules/unreachable.rs
@@ -378,7 +378,7 @@ fn loop_block<'stmt>(
             // For `break` statements we don't want to continue with the
             // loop, but instead with the statement after the loop (i.e.
             // not change anything).
-            !block.stmts.last().map_or(false, Stmt::is_break_stmt)
+            !block.stmts.last().is_some_and(Stmt::is_break_stmt)
         },
     );
     NextBlock::If {

--- a/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_class.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_class.rs
@@ -69,9 +69,7 @@ pub(crate) fn raise_vanilla_class(checker: &mut Checker, expr: &Expr) {
         } else {
             expr
         })
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["", "Exception"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["", "Exception"]))
     {
         checker
             .diagnostics

--- a/crates/ruff/src/rules/tryceratops/rules/raise_within_try.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/raise_within_try.rs
@@ -114,7 +114,7 @@ pub(crate) fn raise_within_try(checker: &mut Checker, body: &[Stmt], handlers: &
                 checker
                     .semantic()
                     .resolve_call_path(expr)
-                    .map_or(false, |call_path| {
+                    .is_some_and(|call_path| {
                         matches!(call_path.as_slice(), ["", "Exception" | "BaseException"])
                     })
             })

--- a/crates/ruff/src/rules/tryceratops/rules/reraise_no_cause.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/reraise_no_cause.rs
@@ -56,7 +56,7 @@ pub(crate) fn reraise_no_cause(checker: &mut Checker, body: &[Stmt]) {
 
     for (range, exc, cause) in raises {
         if cause.is_none() {
-            if exc.map_or(false, Expr::is_call_expr) {
+            if exc.is_some_and(Expr::is_call_expr) {
                 checker
                     .diagnostics
                     .push(Diagnostic::new(ReraiseNoCause, range));

--- a/crates/ruff/src/rules/tryceratops/rules/type_check_without_type_error.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/type_check_without_type_error.rs
@@ -78,7 +78,7 @@ fn check_type_check_call(checker: &mut Checker, call: &Expr) -> bool {
     checker
         .semantic()
         .resolve_call_path(call)
-        .map_or(false, |call_path| {
+        .is_some_and(|call_path| {
             matches!(
                 call_path.as_slice(),
                 ["", "isinstance" | "issubclass" | "callable"]
@@ -103,7 +103,7 @@ fn is_builtin_exception(checker: &mut Checker, exc: &Expr) -> bool {
     return checker
         .semantic()
         .resolve_call_path(exc)
-        .map_or(false, |call_path| {
+        .is_some_and(|call_path| {
             matches!(
                 call_path.as_slice(),
                 [

--- a/crates/ruff/src/rules/tryceratops/rules/useless_try_except.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/useless_try_except.rs
@@ -53,7 +53,7 @@ pub(crate) fn useless_try_except(checker: &mut Checker, handlers: &[ExceptHandle
             if let Some(expr) = exc {
                 // E.g., `except ... as e: raise e`
                 if let Expr::Name(ast::ExprName { id, .. }) = expr.as_ref() {
-                    if name.as_ref().map_or(false, |name| name.as_str() == id) {
+                    if name.as_ref().is_some_and(|name| name.as_str() == id) {
                         return Some(Diagnostic::new(UselessTryExcept, handler.range()));
                     }
                 }

--- a/crates/ruff_cli/src/bin/ruff.rs
+++ b/crates/ruff_cli/src/bin/ruff.rs
@@ -31,9 +31,10 @@ pub fn main() -> ExitCode {
     // default for convenience and backwards-compatibility, so we just
     // preprocess the arguments accordingly before passing them to Clap.
     if let Some(arg) = args.get(1) {
-        if arg.to_str().map_or(false, |arg| {
-            !Command::has_subcommand(rewrite_legacy_subcommand(arg))
-        }) && arg != "-h"
+        if arg
+            .to_str()
+            .is_some_and(|arg| !Command::has_subcommand(rewrite_legacy_subcommand(arg)))
+            && arg != "-h"
             && arg != "--help"
             && arg != "-V"
             && arg != "--version"

--- a/crates/ruff_cli/tests/black_compatibility_test.rs
+++ b/crates/ruff_cli/tests/black_compatibility_test.rs
@@ -166,7 +166,7 @@ fn test_ruff_black_compatibility() -> Result<()> {
             entry
                 .path()
                 .extension()
-                .map_or(false, |ext| ext == "py" || ext == "pyi")
+                .is_some_and(|ext| ext == "py" || ext == "pyi")
                 && !excludes.contains(&entry.path().file_name().unwrap().to_str().unwrap())
         });
 

--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -559,7 +559,7 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 ///
 ///         let recorded = recording.stop();
 ///
-///         let is_labelled = recorded.first().map_or(false, |element| element.has_label(LabelId::of(MyLabels::Main)));
+///         let is_labelled = recorded.first().is_some_and( |element| element.has_label(LabelId::of(MyLabels::Main)));
 ///
 ///         if is_labelled {
 ///             write!(f, [text(" has label `Main`")])

--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -287,7 +287,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                         _ => unreachable!(),
                     }
 
-                    let is_next_text = iter.peek().map_or(false, |e| e.is_text() || e.is_space());
+                    let is_next_text = iter.peek().is_some_and(|e| e.is_text() || e.is_space());
 
                     if !is_next_text {
                         write!(f, [text("\"")])?;
@@ -683,7 +683,7 @@ impl FormatElements for [FormatElement] {
 
     fn has_label(&self, expected: LabelId) -> bool {
         self.first()
-            .map_or(false, |element| element.has_label(expected))
+            .is_some_and(|element| element.has_label(expected))
     }
 
     fn start_tag(&self, kind: TagKind) -> Option<&Tag> {

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2378,10 +2378,10 @@ pub enum Constant {
 
 impl Constant {
     pub fn is_true(self) -> bool {
-        self.bool().map_or(false, |b| b)
+        self.bool().is_some_and(|b| b)
     }
     pub fn is_false(self) -> bool {
-        self.bool().map_or(false, |b| !b)
+        self.bool().is_some_and(|b| !b)
     }
     pub fn complex(self) -> Option<(f64, f64)> {
         match self {

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -830,11 +830,11 @@ fn handle_slice_comments<'a>(
 fn handle_leading_function_with_decorators_comment(comment: DecoratedComment) -> CommentPlacement {
     let is_preceding_decorator = comment
         .preceding_node()
-        .map_or(false, |node| node.is_decorator());
+        .is_some_and(|node| node.is_decorator());
 
     let is_following_arguments = comment
         .following_node()
-        .map_or(false, |node| node.is_arguments());
+        .is_some_and(|node| node.is_arguments());
 
     if comment.line_position().is_own_line() && is_preceding_decorator && is_following_arguments {
         CommentPlacement::dangling(comment.enclosing_node(), comment)
@@ -1237,7 +1237,7 @@ fn are_same_optional<'a, T>(left: AnyNodeRef, right: Option<T>) -> bool
 where
     T: Into<AnyNodeRef<'a>>,
 {
-    right.map_or(false, |right| left.ptr_eq(right.into()))
+    right.is_some_and(|right| left.ptr_eq(right.into()))
 }
 
 /// The last child of the last branch, if the node hs multiple branches.

--- a/crates/ruff_python_formatter/src/expression/expr_constant.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_constant.rs
@@ -101,7 +101,7 @@ pub(super) fn is_multiline_string(constant: &ExprConstant, source: &str) -> bool
         let quotes =
             StringQuotes::parse(&contents[TextRange::new(prefix.text_len(), contents.text_len())]);
 
-        quotes.map_or(false, StringQuotes::is_triple) && contents.contains(['\n', '\r'])
+        quotes.is_some_and(StringQuotes::is_triple) && contents.contains(['\n', '\r'])
     } else {
         false
     }

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -422,10 +422,10 @@ impl<'input> CanOmitOptionalParenthesesVisitor<'input> {
             // Only use the layout if the first or last expression has parentheses of some sort.
             let first_parenthesized = self
                 .first
-                .map_or(false, |first| has_parentheses(first, self.source));
+                .is_some_and(|first| has_parentheses(first, self.source));
             let last_parenthesized = self
                 .last
-                .map_or(false, |last| has_parentheses(last, self.source));
+                .is_some_and(|last| has_parentheses(last, self.source));
             first_parenthesized || last_parenthesized
         }
     }

--- a/crates/ruff_python_literal/src/float.rs
+++ b/crates/ruff_python_literal/src/float.rs
@@ -15,10 +15,10 @@ fn trim_slice<T>(v: &[T], mut trim: impl FnMut(&T) -> bool) -> &[T] {
     // it.take_while_ref(&mut trim).for_each(drop);
     // hmm.. `&mut slice::Iter<_>` is not `Clone`
     // it.by_ref().rev().take_while_ref(&mut trim).for_each(drop);
-    while it.clone().next().map_or(false, &mut trim) {
+    while it.clone().next().is_some_and(&mut trim) {
         it.next();
     }
-    while it.clone().next_back().map_or(false, &mut trim) {
+    while it.clone().next_back().is_some_and(&mut trim) {
         it.next_back();
     }
     it.as_slice()

--- a/crates/ruff_python_parser/src/soft_keywords.rs
+++ b/crates/ruff_python_parser/src/soft_keywords.rs
@@ -132,8 +132,8 @@ where
             }
         }
 
-        self.start_of_line = next.as_ref().map_or(false, |lex_result| {
-            lex_result.as_ref().map_or(false, |(tok, _)| {
+        self.start_of_line = next.as_ref().is_some_and(|lex_result| {
+            lex_result.as_ref().is_ok_and(|(tok, _)| {
                 if matches!(tok, Tok::NonLogicalNewline | Tok::Comment { .. }) {
                     return self.start_of_line;
                 }

--- a/crates/ruff_python_parser/src/typing.rs
+++ b/crates/ruff_python_parser/src/typing.rs
@@ -27,7 +27,7 @@ pub fn parse_type_annotation(
 ) -> Result<(Expr, AnnotationKind)> {
     let expression = &source[range];
 
-    if str::raw_contents(expression).map_or(false, |body| body == value) {
+    if str::raw_contents(expression).is_some_and(|body| body == value) {
         // The annotation is considered "simple" if and only if the raw representation (e.g.,
         // `List[int]` within "List[int]") exactly matches the parsed representation. This
         // isn't the case, e.g., for implicit concatenations, or for annotations that contain

--- a/crates/ruff_python_resolver/src/native_module.rs
+++ b/crates/ruff_python_resolver/src/native_module.rs
@@ -28,7 +28,7 @@ pub(crate) fn is_native_module_file_name(module_name: &str, file_name: &Path) ->
     // The file name must be that of a native module.
     if !file_name
         .extension()
-        .map_or(false, is_native_module_file_extension)
+        .is_some_and(is_native_module_file_extension)
     {
         return false;
     };
@@ -45,7 +45,7 @@ pub(crate) fn find_native_module(
     Ok(dir_path
         .read_dir()?
         .flatten()
-        .filter(|entry| entry.file_type().map_or(false, |ft| ft.is_file()))
+        .filter(|entry| entry.file_type().is_ok_and(|ft| ft.is_file()))
         .map(|entry| entry.path())
         .find(|path| is_native_module_file_name(module_name, path)))
 }

--- a/crates/ruff_python_resolver/src/resolver.rs
+++ b/crates/ruff_python_resolver/src/resolver.rs
@@ -292,7 +292,7 @@ fn resolve_best_absolute_import<Host: host::Host>(
                     && typings_import
                         .resolved_paths
                         .last()
-                        .map_or(false, |path| path.as_os_str().is_empty())
+                        .is_some_and(|path| path.as_os_str().is_empty())
                 {
                     if typings_import
                         .implicit_imports
@@ -381,9 +381,10 @@ fn resolve_best_absolute_import<Host: host::Host>(
             typeshed_root.display()
         );
         if typeshed_root != execution_environment.root {
-            if best_result_so_far.as_ref().map_or(false, |result| {
-                result.py_typed_info.is_some() && !result.is_partly_resolved
-            }) {
+            if best_result_so_far
+                .as_ref()
+                .is_some_and(|result| result.py_typed_info.is_some() && !result.is_partly_resolved)
+            {
                 return best_result_so_far;
             }
         }

--- a/crates/ruff_python_resolver/src/search.rs
+++ b/crates/ruff_python_resolver/src/search.rs
@@ -81,7 +81,7 @@ fn find_site_packages_path(
         if let Some(preferred_dir) = candidate_dirs.iter().find(|dir| {
             dir.file_name()
                 .and_then(OsStr::to_str)
-                .map_or(false, |name| name == python_version.dir())
+                .is_some_and(|name| name == python_version.dir())
         }) {
             debug!("Found path `{}`", preferred_dir.display());
             return Some(preferred_dir.join(SITE_PACKAGES));
@@ -235,7 +235,7 @@ fn build_typeshed_third_party_package_map(
                     if inner_entry
                         .path()
                         .extension()
-                        .map_or(false, |extension| extension == "pyi")
+                        .is_some_and(|extension| extension == "pyi")
                     {
                         if let Some(stripped_file_name) = inner_entry
                             .path()

--- a/crates/ruff_python_semantic/src/analyze/branch_detection.rs
+++ b/crates/ruff_python_semantic/src/analyze/branch_detection.rs
@@ -12,7 +12,7 @@ fn common_ancestor(
     stop: Option<NodeId>,
     node_tree: &Nodes,
 ) -> Option<NodeId> {
-    if stop.map_or(false, |stop| left == stop || right == stop) {
+    if stop.is_some_and(|stop| left == stop || right == stop) {
         return None;
     }
 
@@ -89,7 +89,7 @@ fn descendant_of<'a>(
     node_tree: &Nodes<'a>,
 ) -> bool {
     ancestors.iter().any(|ancestor| {
-        node_tree.node_id(ancestor).map_or(false, |ancestor| {
+        node_tree.node_id(ancestor).is_some_and(|ancestor| {
             common_ancestor(stmt, ancestor, Some(stop), node_tree).is_some()
         })
     })

--- a/crates/ruff_python_semantic/src/analyze/function_type.rs
+++ b/crates/ruff_python_semantic/src/analyze/function_type.rs
@@ -31,7 +31,7 @@ pub fn classify(
         // `@staticmethod`).
         semantic
             .resolve_call_path(map_callable(&decorator.expression))
-            .map_or(false, |call_path| {
+            .is_some_and(|call_path| {
                 matches!(
                     call_path.as_slice(),
                     ["", "staticmethod"] | ["abc", "abstractstaticmethod"]
@@ -47,7 +47,7 @@ pub fn classify(
             // The class itself extends a known metaclass, so all methods are class methods.
             semantic
                 .resolve_call_path(map_callable(expr))
-                .map_or(false, |call_path| {
+                .is_some_and( |call_path| {
                     matches!(call_path.as_slice(), ["", "type"] | ["abc", "ABCMeta"])
                 })
         })
@@ -55,7 +55,7 @@ pub fn classify(
             // The method is decorated with a class method decorator (like `@classmethod`).
             semantic
                 .resolve_call_path(map_callable(&decorator.expression))
-                .map_or(false, |call_path| {
+                .is_some_and( |call_path| {
                     matches!(
                         call_path.as_slice(),
                         ["", "classmethod"] | ["abc", "abstractclassmethod"]

--- a/crates/ruff_python_semantic/src/analyze/logging.rs
+++ b/crates/ruff_python_semantic/src/analyze/logging.rs
@@ -74,9 +74,7 @@ pub fn exc_info<'a>(keywords: &'a [Keyword], semantic: &SemanticModel) -> Option
         .value
         .as_call_expr()
         .and_then(|call| semantic.resolve_call_path(&call.func))
-        .map_or(false, |call_path| {
-            matches!(call_path.as_slice(), ["sys", "exc_info"])
-        })
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["sys", "exc_info"]))
     {
         return Some(exc_info);
     }

--- a/crates/ruff_python_semantic/src/analyze/visibility.rs
+++ b/crates/ruff_python_semantic/src/analyze/visibility.rs
@@ -18,9 +18,7 @@ pub fn is_staticmethod(decorator_list: &[Decorator], semantic: &SemanticModel) -
     decorator_list.iter().any(|decorator| {
         semantic
             .resolve_call_path(map_callable(&decorator.expression))
-            .map_or(false, |call_path| {
-                matches!(call_path.as_slice(), ["", "staticmethod"])
-            })
+            .is_some_and(|call_path| matches!(call_path.as_slice(), ["", "staticmethod"]))
     })
 }
 
@@ -29,9 +27,7 @@ pub fn is_classmethod(decorator_list: &[Decorator], semantic: &SemanticModel) ->
     decorator_list.iter().any(|decorator| {
         semantic
             .resolve_call_path(map_callable(&decorator.expression))
-            .map_or(false, |call_path| {
-                matches!(call_path.as_slice(), ["", "classmethod"])
-            })
+            .is_some_and(|call_path| matches!(call_path.as_slice(), ["", "classmethod"]))
     })
 }
 
@@ -54,7 +50,7 @@ pub fn is_abstract(decorator_list: &[Decorator], semantic: &SemanticModel) -> bo
     decorator_list.iter().any(|decorator| {
         semantic
             .resolve_call_path(map_callable(&decorator.expression))
-            .map_or(false, |call_path| {
+            .is_some_and(|call_path| {
                 matches!(
                     call_path.as_slice(),
                     [
@@ -80,7 +76,7 @@ pub fn is_property(
     decorator_list.iter().any(|decorator| {
         semantic
             .resolve_call_path(map_callable(&decorator.expression))
-            .map_or(false, |call_path| {
+            .is_some_and(|call_path| {
                 matches!(
                     call_path.as_slice(),
                     ["", "property"] | ["functools", "cached_property"]
@@ -208,7 +204,7 @@ pub(crate) fn method_visibility(stmt: &Stmt) -> Visibility {
         }) => {
             // Is this a setter or deleter?
             if decorator_list.iter().any(|decorator| {
-                collect_call_path(&decorator.expression).map_or(false, |call_path| {
+                collect_call_path(&decorator.expression).is_some_and(|call_path| {
                     call_path.as_slice() == [name, "setter"]
                         || call_path.as_slice() == [name, "deleter"]
                 })

--- a/crates/ruff_python_semantic/src/definition.rs
+++ b/crates/ruff_python_semantic/src/definition.rs
@@ -150,8 +150,8 @@ impl<'a> Definitions<'a> {
                         MemberKind::Class => {
                             let parent = &definitions[member.parent];
                             if parent.visibility.is_private()
-                                || exports.map_or(false, |exports| {
-                                    member.name().map_or(false, |name| !exports.contains(&name))
+                                || exports.is_some_and(|exports| {
+                                    member.name().is_some_and(|name| !exports.contains(&name))
                                 })
                             {
                                 Visibility::Private
@@ -180,8 +180,8 @@ impl<'a> Definitions<'a> {
                         MemberKind::Function => {
                             let parent = &definitions[member.parent];
                             if parent.visibility.is_private()
-                                || exports.map_or(false, |exports| {
-                                    member.name().map_or(false, |name| !exports.contains(&name))
+                                || exports.is_some_and(|exports| {
+                                    member.name().is_some_and(|name| !exports.contains(&name))
                                 })
                             {
                                 Visibility::Private

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -163,9 +163,8 @@ impl<'a> SemanticModel<'a> {
 
     /// Return `true` if the `Expr` is a reference to `typing.${target}`.
     pub fn match_typing_expr(&self, expr: &Expr, target: &str) -> bool {
-        self.resolve_call_path(expr).map_or(false, |call_path| {
-            self.match_typing_call_path(&call_path, target)
-        })
+        self.resolve_call_path(expr)
+            .is_some_and(|call_path| self.match_typing_call_path(&call_path, target))
     }
 
     /// Return `true` if the call path is a reference to `typing.${target}`.
@@ -245,7 +244,7 @@ impl<'a> SemanticModel<'a> {
     /// Return `true` if `member` is bound as a builtin.
     pub fn is_builtin(&self, member: &str) -> bool {
         self.find_binding(member)
-            .map_or(false, |binding| binding.kind.is_builtin())
+            .is_some_and(|binding| binding.kind.is_builtin())
     }
 
     /// Return `true` if `member` is an "available" symbol, i.e., a symbol that has not been bound

--- a/crates/ruff_python_stdlib/src/identifiers.rs
+++ b/crates/ruff_python_stdlib/src/identifiers.rs
@@ -5,10 +5,7 @@ use crate::keyword::is_keyword;
 pub fn is_identifier(name: &str) -> bool {
     // Is the first character a letter or underscore?
     let mut chars = name.chars();
-    if !chars
-        .next()
-        .map_or(false, |c| c.is_alphabetic() || c == '_')
-    {
+    if !chars.next().is_some_and(|c| c.is_alphabetic() || c == '_') {
         return false;
     }
 
@@ -41,7 +38,7 @@ pub fn is_module_name(name: &str) -> bool {
     let mut chars = name.chars();
     if !chars
         .next()
-        .map_or(false, |c| c.is_ascii_lowercase() || c == '_')
+        .is_some_and(|c| c.is_ascii_lowercase() || c == '_')
     {
         return false;
     }

--- a/crates/ruff_python_stdlib/src/path.rs
+++ b/crates/ruff_python_stdlib/src/path.rs
@@ -3,23 +3,23 @@ use std::path::Path;
 /// Return `true` if the [`Path`] appears to be that of a Python file.
 pub fn is_python_file(path: &Path) -> bool {
     path.extension()
-        .map_or(false, |ext| ext == "py" || ext == "pyi")
+        .is_some_and(|ext| ext == "py" || ext == "pyi")
 }
 
 /// Return `true` if the [`Path`] is named `pyproject.toml`.
 pub fn is_project_toml(path: &Path) -> bool {
     path.file_name()
-        .map_or(false, |name| name == "pyproject.toml")
+        .is_some_and(|name| name == "pyproject.toml")
 }
 
 /// Return `true` if the [`Path`] appears to be that of a Python interface definition file (`.pyi`).
 pub fn is_python_stub_file(path: &Path) -> bool {
-    path.extension().map_or(false, |ext| ext == "pyi")
+    path.extension().is_some_and(|ext| ext == "pyi")
 }
 
 /// Return `true` if the [`Path`] appears to be that of a Jupyter notebook (`.ipynb`).
 pub fn is_jupyter_notebook(path: &Path) -> bool {
-    path.extension().map_or(false, |ext| ext == "ipynb")
+    path.extension().is_some_and(|ext| ext == "ipynb")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**Summary** [Option::is_some_and](https://doc.rust-lang.org/stable/std/option/enum.Option.html#method.is_some_and) and [Result::is_ok_and](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_ok_and) are new methods is rust 1.70. I find them way more readable than `.map_or(false, ...)`.

The changes are `s/.map_or(false,/.is_some_and(/g`, then manually switching to `is_ok_and` where the value is a Result rather than an Option.

**Test Plan** n/a^
