### PR TITLE
Allow generic tuple and list calls in __all__

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/invalid_all_format.py
+++ b/crates/ruff/resources/test/fixtures/pylint/invalid_all_format.py
@@ -40,3 +40,4 @@ __all__ = __all__ + ["Hello"]
 
 __all__ = __all__ + multiprocessing.__all__
 
+__all__ = list[str](["Hello", "world"])

--- a/crates/ruff_python_ast/src/all.rs
+++ b/crates/ruff_python_ast/src/all.rs
@@ -1,3 +1,4 @@
+use crate::helpers::map_subscript;
 use crate::{self as ast, Constant, Expr, Stmt};
 use bitflags::bitflags;
 
@@ -67,9 +68,9 @@ where
                 keywords,
                 ..
             }) => {
-                // Allow `tuple()` and `list()` calls.
+                // Allow `tuple()`, `list()`, and their generic forms, like `list[int]()`.
                 if keywords.is_empty() && args.len() <= 1 {
-                    if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
+                    if let Expr::Name(ast::ExprName { id, .. }) = map_subscript(func) {
                         let id = id.as_str();
                         if matches!(id, "tuple" | "list") && is_builtin(id) {
                             let [arg] = args.as_slice() else {


### PR DESCRIPTION
## Summary

Allows, e.g., `__all__ = list[str]()`.

Closes https://github.com/astral-sh/ruff/issues/6226.