### PR TITLE
Add Tombstone format element

### DIFF
--- a/crates/ruff_formatter/src/format_element.rs
+++ b/crates/ruff_formatter/src/format_element.rs
@@ -61,6 +61,10 @@ pub enum FormatElement {
 
     /// A [Tag] that marks the start/end of some content to which some special formatting is applied.
     Tag(Tag),
+
+    /// No-op format element. Used to *remove* content in post processing phases without
+    /// needing to move the whole vector.
+    Tombstone,
 }
 
 impl std::fmt::Debug for FormatElement {
@@ -95,6 +99,7 @@ impl std::fmt::Debug for FormatElement {
             FormatElement::SourcePosition(position) => {
                 fmt.debug_tuple("SourcePosition").field(position).finish()
             }
+            FormatElement::Tombstone => fmt.write_str("Tombstone"),
         }
     }
 }
@@ -273,7 +278,8 @@ impl FormatElements for FormatElement {
             FormatElement::LineSuffixBoundary
             | FormatElement::Space
             | FormatElement::Tag(_)
-            | FormatElement::SourcePosition(_) => false,
+            | FormatElement::SourcePosition(_)
+            | FormatElement::Tombstone => false,
         }
     }
 

--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -346,6 +346,8 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                     write!(f, [text("])")])?;
                 }
 
+                FormatElement::Tombstone => write!(f, [text("tombstone")])?,
+
                 FormatElement::Interned(interned) => {
                     let interned_elements = &mut f.context_mut().printed_interned_elements;
 

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -142,6 +142,8 @@ impl<'a> Printer<'a> {
                 queue.extend_back(content);
             }
 
+            FormatElement::Tombstone => {}
+
             FormatElement::Tag(StartGroup(group)) => {
                 let print_mode =
                     self.print_group(TagKind::Group, group.mode(), args, queue, stack)?;
@@ -1076,6 +1078,8 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
             }
 
             FormatElement::Interned(content) => self.queue.extend_back(content),
+
+            FormatElement::Tombstone => {}
 
             FormatElement::Tag(StartIndent) => {
                 self.stack.push(


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR adds a `Tombstone` format element. It's sole purpose is to allow for cheap "removal" 
of `FormatElement`s from an already created document by replacing them with a `FormatElement` that has a *void* semantics. 

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
