### PR TITLE
Rename `Parameter#arg` and `ParameterWithDefault#def` fields

### DIFF
--- a/crates/ruff/src/checkers/ast/analyze/parameter.rs
+++ b/crates/ruff/src/checkers/ast/analyze/parameter.rs
@@ -8,14 +8,14 @@ use crate::rules::{flake8_builtins, pep8_naming, pycodestyle};
 pub(crate) fn parameter(parameter: &Parameter, checker: &mut Checker) {
     if checker.enabled(Rule::AmbiguousVariableName) {
         if let Some(diagnostic) =
-            pycodestyle::rules::ambiguous_variable_name(&parameter.arg, parameter.range())
+            pycodestyle::rules::ambiguous_variable_name(&parameter.name, parameter.range())
         {
             checker.diagnostics.push(diagnostic);
         }
     }
     if checker.enabled(Rule::InvalidArgumentName) {
         if let Some(diagnostic) = pep8_naming::rules::invalid_argument_name(
-            &parameter.arg,
+            &parameter.name,
             parameter,
             &checker.settings.pep8_naming.ignore_names,
         ) {

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -491,7 +491,7 @@ where
                     .chain(&parameters.args)
                     .chain(&parameters.kwonlyargs)
                 {
-                    if let Some(expr) = &parameter_with_default.def.annotation {
+                    if let Some(expr) = &parameter_with_default.parameter.annotation {
                         if runtime_annotation {
                             self.visit_runtime_annotation(expr);
                         } else {
@@ -896,7 +896,7 @@ where
                 // Visit the default arguments, but avoid the body, which will be deferred.
                 for ParameterWithDefault {
                     default,
-                    def: _,
+                    parameter: _,
                     range: _,
                 } in parameters
                     .posonlyargs
@@ -1298,16 +1298,16 @@ where
         // Bind, but intentionally avoid walking default expressions, as we handle them
         // upstream.
         for parameter_with_default in &parameters.posonlyargs {
-            self.visit_parameter(&parameter_with_default.def);
+            self.visit_parameter(&parameter_with_default.parameter);
         }
         for parameter_with_default in &parameters.args {
-            self.visit_parameter(&parameter_with_default.def);
+            self.visit_parameter(&parameter_with_default.parameter);
         }
         if let Some(arg) = &parameters.vararg {
             self.visit_parameter(arg);
         }
         for parameter_with_default in &parameters.kwonlyargs {
-            self.visit_parameter(&parameter_with_default.def);
+            self.visit_parameter(&parameter_with_default.parameter);
         }
         if let Some(arg) = &parameters.kwarg {
             self.visit_parameter(arg);
@@ -1322,7 +1322,7 @@ where
         // Bind, but intentionally avoid walking the annotation, as we handle it
         // upstream.
         self.add_binding(
-            &parameter.arg,
+            &parameter.name,
             parameter.identifier(),
             BindingKind::Argument,
             BindingFlags::empty(),

--- a/crates/ruff/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff/src/rules/flake8_annotations/rules/definition.rs
@@ -525,7 +525,7 @@ pub(crate) fn definition(
 
     // ANN001, ANN401
     for ParameterWithDefault {
-        def,
+        parameter,
         default: _,
         range: _,
     } in arguments
@@ -542,26 +542,29 @@ pub(crate) fn definition(
         )
     {
         // ANN401 for dynamically typed arguments
-        if let Some(annotation) = &def.annotation {
+        if let Some(annotation) = &parameter.annotation {
             has_any_typed_arg = true;
             if checker.enabled(Rule::AnyType) && !is_overridden {
                 check_dynamically_typed(
                     checker,
                     annotation,
-                    || def.arg.to_string(),
+                    || parameter.name.to_string(),
                     &mut diagnostics,
                 );
             }
         } else {
             if !(checker.settings.flake8_annotations.suppress_dummy_args
-                && checker.settings.dummy_variable_rgx.is_match(&def.arg))
+                && checker
+                    .settings
+                    .dummy_variable_rgx
+                    .is_match(&parameter.name))
             {
                 if checker.enabled(Rule::MissingTypeFunctionArgument) {
                     diagnostics.push(Diagnostic::new(
                         MissingTypeFunctionArgument {
-                            name: def.arg.to_string(),
+                            name: parameter.name.to_string(),
                         },
-                        def.range(),
+                        parameter.range(),
                     ));
                 }
             }
@@ -574,18 +577,18 @@ pub(crate) fn definition(
             has_any_typed_arg = true;
             if !checker.settings.flake8_annotations.allow_star_arg_any {
                 if checker.enabled(Rule::AnyType) && !is_overridden {
-                    let name = &arg.arg;
+                    let name = &arg.name;
                     check_dynamically_typed(checker, expr, || format!("*{name}"), &mut diagnostics);
                 }
             }
         } else {
             if !(checker.settings.flake8_annotations.suppress_dummy_args
-                && checker.settings.dummy_variable_rgx.is_match(&arg.arg))
+                && checker.settings.dummy_variable_rgx.is_match(&arg.name))
             {
                 if checker.enabled(Rule::MissingTypeArgs) {
                     diagnostics.push(Diagnostic::new(
                         MissingTypeArgs {
-                            name: arg.arg.to_string(),
+                            name: arg.name.to_string(),
                         },
                         arg.range(),
                     ));
@@ -600,7 +603,7 @@ pub(crate) fn definition(
             has_any_typed_arg = true;
             if !checker.settings.flake8_annotations.allow_star_arg_any {
                 if checker.enabled(Rule::AnyType) && !is_overridden {
-                    let name = &arg.arg;
+                    let name = &arg.name;
                     check_dynamically_typed(
                         checker,
                         expr,
@@ -611,12 +614,12 @@ pub(crate) fn definition(
             }
         } else {
             if !(checker.settings.flake8_annotations.suppress_dummy_args
-                && checker.settings.dummy_variable_rgx.is_match(&arg.arg))
+                && checker.settings.dummy_variable_rgx.is_match(&arg.name))
             {
                 if checker.enabled(Rule::MissingTypeKwargs) {
                     diagnostics.push(Diagnostic::new(
                         MissingTypeKwargs {
-                            name: arg.arg.to_string(),
+                            name: arg.name.to_string(),
                         },
                         arg.range(),
                     ));
@@ -628,7 +631,7 @@ pub(crate) fn definition(
     // ANN101, ANN102
     if is_method && !visibility::is_staticmethod(cast::decorator_list(stmt), checker.semantic()) {
         if let Some(ParameterWithDefault {
-            def,
+            parameter,
             default: _,
             range: _,
         }) = arguments
@@ -636,23 +639,23 @@ pub(crate) fn definition(
             .first()
             .or_else(|| arguments.args.first())
         {
-            if def.annotation.is_none() {
+            if parameter.annotation.is_none() {
                 if visibility::is_classmethod(cast::decorator_list(stmt), checker.semantic()) {
                     if checker.enabled(Rule::MissingTypeCls) {
                         diagnostics.push(Diagnostic::new(
                             MissingTypeCls {
-                                name: def.arg.to_string(),
+                                name: parameter.name.to_string(),
                             },
-                            def.range(),
+                            parameter.range(),
                         ));
                     }
                 } else {
                     if checker.enabled(Rule::MissingTypeSelf) {
                         diagnostics.push(Diagnostic::new(
                             MissingTypeSelf {
-                                name: def.arg.to_string(),
+                                name: parameter.name.to_string(),
                             },
-                            def.range(),
+                            parameter.range(),
                         ));
                     }
                 }

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_default.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_default.rs
@@ -55,7 +55,7 @@ impl Violation for HardcodedPasswordDefault {
 
 fn check_password_kwarg(parameter: &Parameter, default: &Expr) -> Option<Diagnostic> {
     string_literal(default).filter(|string| !string.is_empty())?;
-    let kwarg_name = &parameter.arg;
+    let kwarg_name = &parameter.name;
     if !matches_password_name(kwarg_name) {
         return None;
     }
@@ -70,7 +70,7 @@ fn check_password_kwarg(parameter: &Parameter, default: &Expr) -> Option<Diagnos
 /// S107
 pub(crate) fn hardcoded_password_default(checker: &mut Checker, parameters: &Parameters) {
     for ParameterWithDefault {
-        def,
+        parameter,
         default,
         range: _,
     } in parameters
@@ -82,7 +82,7 @@ pub(crate) fn hardcoded_password_default(checker: &mut Checker, parameters: &Par
         let Some(default) = default else {
             continue;
         };
-        if let Some(diagnostic) = check_password_kwarg(def, default) {
+        if let Some(diagnostic) = check_password_kwarg(parameter, default) {
             checker.diagnostics.push(diagnostic);
         }
     }

--- a/crates/ruff/src/rules/flake8_boolean_trap/rules/check_boolean_default_value_in_function_definition.rs
+++ b/crates/ruff/src/rules/flake8_boolean_trap/rules/check_boolean_default_value_in_function_definition.rs
@@ -73,7 +73,7 @@ pub(crate) fn check_boolean_default_value_in_function_definition(
     }
 
     for ParameterWithDefault {
-        def: _,
+        parameter: _,
         default,
         range: _,
     } in parameters.args.iter().chain(&parameters.posonlyargs)

--- a/crates/ruff/src/rules/flake8_boolean_trap/rules/check_positional_boolean_in_def.rs
+++ b/crates/ruff/src/rules/flake8_boolean_trap/rules/check_positional_boolean_in_def.rs
@@ -96,15 +96,15 @@ pub(crate) fn check_positional_boolean_in_def(
     }
 
     for ParameterWithDefault {
-        def,
+        parameter,
         default: _,
         range: _,
     } in parameters.posonlyargs.iter().chain(&parameters.args)
     {
-        if def.annotation.is_none() {
+        if parameter.annotation.is_none() {
             continue;
         }
-        let Some(expr) = &def.annotation else {
+        let Some(expr) = &parameter.annotation else {
             continue;
         };
 
@@ -122,7 +122,7 @@ pub(crate) fn check_positional_boolean_in_def(
         }
         checker.diagnostics.push(Diagnostic::new(
             BooleanPositionalArgInFunctionDefinition,
-            def.range(),
+            parameter.range(),
         ));
     }
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
@@ -118,7 +118,7 @@ pub(crate) fn function_call_in_argument_default(checker: &mut Checker, parameter
         let mut visitor = ArgumentDefaultVisitor::new(checker.semantic(), extend_immutable_calls);
         for ParameterWithDefault {
             default,
-            def: _,
+            parameter: _,
             range: _,
         } in parameters
             .posonlyargs

--- a/crates/ruff/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
@@ -77,7 +77,7 @@ where
             }) => {
                 visitor::walk_expr(self, body);
                 for ParameterWithDefault {
-                    def,
+                    parameter,
                     default: _,
                     range: _,
                 } in parameters
@@ -86,7 +86,7 @@ where
                     .chain(&parameters.args)
                     .chain(&parameters.kwonlyargs)
                 {
-                    self.names.remove(def.arg.as_str());
+                    self.names.remove(parameter.name.as_str());
                 }
             }
             _ => visitor::walk_expr(self, expr),

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -60,7 +60,7 @@ impl Violation for MutableArgumentDefault {
 pub(crate) fn mutable_argument_default(checker: &mut Checker, parameters: &Parameters) {
     // Scan in reverse order to right-align zip().
     for ParameterWithDefault {
-        def,
+        parameter,
         default,
         range: _,
     } in parameters
@@ -74,7 +74,7 @@ pub(crate) fn mutable_argument_default(checker: &mut Checker, parameters: &Param
         };
 
         if is_mutable_expr(default, checker.semantic())
-            && !def
+            && !parameter
                 .annotation
                 .as_ref()
                 .is_some_and(|expr| is_immutable_annotation(expr, checker.semantic()))

--- a/crates/ruff/src/rules/flake8_builtins/rules/builtin_argument_shadowing.rs
+++ b/crates/ruff/src/rules/flake8_builtins/rules/builtin_argument_shadowing.rs
@@ -64,12 +64,12 @@ impl Violation for BuiltinArgumentShadowing {
 /// A002
 pub(crate) fn builtin_argument_shadowing(checker: &mut Checker, parameter: &Parameter) {
     if shadows_builtin(
-        parameter.arg.as_str(),
+        parameter.name.as_str(),
         &checker.settings.flake8_builtins.builtins_ignorelist,
     ) {
         checker.diagnostics.push(Diagnostic::new(
             BuiltinArgumentShadowing {
-                name: parameter.arg.to_string(),
+                name: parameter.name.to_string(),
             },
             parameter.range(),
         ));

--- a/crates/ruff/src/rules/flake8_pyi/rules/any_eq_ne_annotation.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/any_eq_ne_annotation.rs
@@ -62,7 +62,7 @@ pub(crate) fn any_eq_ne_annotation(checker: &mut Checker, name: &str, parameters
         return;
     }
 
-    let Some(annotation) = &parameters.args[1].def.annotation else {
+    let Some(annotation) = &parameters.args[1].parameter.annotation else {
         return;
     };
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/exit_annotations.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/exit_annotations.rs
@@ -213,7 +213,7 @@ fn check_positional_args(
     ];
 
     for (arg, (error_info, predicate)) in positional_args.iter().skip(1).take(3).zip(validations) {
-        let Some(annotation) = arg.def.annotation.as_ref() else {
+        let Some(annotation) = arg.parameter.annotation.as_ref() else {
             continue;
         };
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/no_return_argument_annotation.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/no_return_argument_annotation.rs
@@ -53,7 +53,7 @@ pub(crate) fn no_return_argument_annotation(checker: &mut Checker, parameters: &
         .iter()
         .chain(&parameters.args)
         .chain(&parameters.kwonlyargs)
-        .filter_map(|arg| arg.def.annotation.as_ref())
+        .filter_map(|arg| arg.parameter.annotation.as_ref())
     {
         if checker.semantic().match_typing_expr(annotation, "NoReturn") {
             checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
@@ -59,7 +59,7 @@ pub(crate) fn redundant_numeric_union(checker: &mut Checker, parameters: &Parame
         .iter()
         .chain(parameters.posonlyargs.iter())
         .chain(parameters.kwonlyargs.iter())
-        .filter_map(|arg| arg.def.annotation.as_ref())
+        .filter_map(|arg| arg.parameter.annotation.as_ref())
     {
         check_annotation(checker, annotation);
     }

--- a/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -402,7 +402,7 @@ fn is_annotatable_type_alias(value: &Expr, semantic: &SemanticModel) -> bool {
 /// PYI011
 pub(crate) fn typed_argument_simple_defaults(checker: &mut Checker, parameters: &Parameters) {
     for ParameterWithDefault {
-        def,
+        parameter,
         default,
         range: _,
     } in parameters
@@ -414,7 +414,7 @@ pub(crate) fn typed_argument_simple_defaults(checker: &mut Checker, parameters: 
         let Some(default) = default else {
             continue;
         };
-        if def.annotation.is_some() {
+        if parameter.annotation.is_some() {
             if !is_valid_default_value_with_annotation(
                 default,
                 true,
@@ -439,7 +439,7 @@ pub(crate) fn typed_argument_simple_defaults(checker: &mut Checker, parameters: 
 /// PYI014
 pub(crate) fn argument_simple_defaults(checker: &mut Checker, parameters: &Parameters) {
     for ParameterWithDefault {
-        def,
+        parameter,
         default,
         range: _,
     } in parameters
@@ -451,7 +451,7 @@ pub(crate) fn argument_simple_defaults(checker: &mut Checker, parameters: &Param
         let Some(default) = default else {
             continue;
         };
-        if def.annotation.is_none() {
+        if parameter.annotation.is_none() {
             if !is_valid_default_value_with_annotation(
                 default,
                 true,

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -615,17 +615,17 @@ fn check_test_function_args(checker: &mut Checker, parameters: &Parameters) {
         .chain(&parameters.kwonlyargs)
         .for_each(
             |ParameterWithDefault {
-                 def,
+                 parameter,
                  default: _,
                  range: _,
              }| {
-                let name = &def.arg;
+                let name = &parameter.name;
                 if name.starts_with('_') {
                     checker.diagnostics.push(Diagnostic::new(
                         PytestFixtureParamWithoutValue {
                             name: name.to_string(),
                         },
-                        def.range(),
+                        parameter.range(),
                     ));
                 }
             },

--- a/crates/ruff/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
@@ -227,7 +227,7 @@ fn function(
         .iter()
         .chain(&parameters.args)
         .chain(&parameters.kwonlyargs)
-        .map(|parameter_with_default| &parameter_with_default.def)
+        .map(|parameter_with_default| &parameter_with_default.parameter)
         .chain(
             iter::once::<Option<&Parameter>>(parameters.vararg.as_deref())
                 .flatten()
@@ -264,7 +264,7 @@ fn method(
         .chain(&parameters.args)
         .chain(&parameters.kwonlyargs)
         .skip(1)
-        .map(|parameter_with_default| &parameter_with_default.def)
+        .map(|parameter_with_default| &parameter_with_default.parameter)
         .chain(
             iter::once::<Option<&Parameter>>(parameters.vararg.as_deref())
                 .flatten()
@@ -295,14 +295,14 @@ fn call<'a>(
 ) {
     diagnostics.extend(parameters.filter_map(|arg| {
         let binding = values
-            .get(arg.arg.as_str())
+            .get(arg.name.as_str())
             .map(|binding_id| semantic.binding(binding_id))?;
         if binding.kind.is_argument()
             && !binding.is_used()
-            && !dummy_variable_rgx.is_match(arg.arg.as_str())
+            && !dummy_variable_rgx.is_match(arg.name.as_str())
         {
             Some(Diagnostic::new(
-                argumentable.check_for(arg.arg.to_string()),
+                argumentable.check_for(arg.name.to_string()),
                 binding.range,
             ))
         } else {

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
@@ -75,7 +75,7 @@ pub(crate) fn invalid_first_argument_name_for_class_method(
         return None;
     }
     if let Some(ParameterWithDefault {
-        def,
+        parameter,
         default: _,
         range: _,
     }) = parameters
@@ -83,7 +83,7 @@ pub(crate) fn invalid_first_argument_name_for_class_method(
         .first()
         .or_else(|| parameters.args.first())
     {
-        if &def.arg != "cls" {
+        if &parameter.name != "cls" {
             if checker
                 .settings
                 .pep8_naming
@@ -95,7 +95,7 @@ pub(crate) fn invalid_first_argument_name_for_class_method(
             }
             return Some(Diagnostic::new(
                 InvalidFirstArgumentNameForClassMethod,
-                def.range(),
+                parameter.range(),
             ));
         }
     }

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
@@ -76,7 +76,7 @@ pub(crate) fn invalid_first_argument_name_for_method(
         .posonlyargs
         .first()
         .or_else(|| parameters.args.first())?;
-    if &arg.def.arg == "self" {
+    if &arg.parameter.name == "self" {
         return None;
     }
     if checker
@@ -90,6 +90,6 @@ pub(crate) fn invalid_first_argument_name_for_method(
     }
     Some(Diagnostic::new(
         InvalidFirstArgumentNameForMethod,
-        arg.def.range(),
+        arg.parameter.range(),
     ))
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -196,11 +196,11 @@ fn function(
                 .iter()
                 .enumerate()
                 .map(|(idx, parameter)| ParameterWithDefault {
-                    def: Parameter {
+                    parameter: Parameter {
                         annotation: arg_types
                             .get(idx)
                             .map(|arg_type| Box::new(arg_type.clone())),
-                        ..parameter.def.clone()
+                        ..parameter.parameter.clone()
                     },
                     ..parameter.clone()
                 })
@@ -210,11 +210,11 @@ fn function(
                 .iter()
                 .enumerate()
                 .map(|(idx, parameter)| ParameterWithDefault {
-                    def: Parameter {
+                    parameter: Parameter {
                         annotation: arg_types
                             .get(idx + new_posonlyargs.len())
                             .map(|arg_type| Box::new(arg_type.clone())),
-                        ..parameter.def.clone()
+                        ..parameter.parameter.clone()
                     },
                     ..parameter.clone()
                 })

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -1735,7 +1735,7 @@ fn missing_args(checker: &mut Checker, docstring: &Docstring, docstrings_args: &
     // Look for arguments that weren't included in the docstring.
     let mut missing_arg_names: FxHashSet<String> = FxHashSet::default();
     for ParameterWithDefault {
-        def,
+        parameter,
         default: _,
         range: _,
     } in parameters
@@ -1751,7 +1751,7 @@ fn missing_args(checker: &mut Checker, docstring: &Docstring, docstrings_args: &
             ),
         )
     {
-        let arg_name = def.arg.as_str();
+        let arg_name = parameter.name.as_str();
         if !arg_name.starts_with('_') && !docstrings_args.contains(arg_name) {
             missing_arg_names.insert(arg_name.to_string());
         }
@@ -1760,7 +1760,7 @@ fn missing_args(checker: &mut Checker, docstring: &Docstring, docstrings_args: &
     // Check specifically for `vararg` and `kwarg`, which can be prefixed with a
     // single or double star, respectively.
     if let Some(arg) = &parameters.vararg {
-        let arg_name = arg.arg.as_str();
+        let arg_name = arg.name.as_str();
         let starred_arg_name = format!("*{arg_name}");
         if !arg_name.starts_with('_')
             && !docstrings_args.contains(arg_name)
@@ -1770,7 +1770,7 @@ fn missing_args(checker: &mut Checker, docstring: &Docstring, docstrings_args: &
         }
     }
     if let Some(arg) = &parameters.kwarg {
-        let arg_name = arg.arg.as_str();
+        let arg_name = arg.name.as_str();
         let starred_arg_name = format!("**{arg_name}");
         if !arg_name.starts_with('_')
             && !docstrings_args.contains(arg_name)

--- a/crates/ruff/src/rules/pylint/rules/too_many_arguments.rs
+++ b/crates/ruff/src/rules/pylint/rules/too_many_arguments.rs
@@ -64,7 +64,12 @@ pub(crate) fn too_many_arguments(checker: &mut Checker, parameters: &Parameters,
         .iter()
         .chain(&parameters.kwonlyargs)
         .chain(&parameters.posonlyargs)
-        .filter(|arg| !checker.settings.dummy_variable_rgx.is_match(&arg.def.arg))
+        .filter(|arg| {
+            !checker
+                .settings
+                .dummy_variable_rgx
+                .is_match(&arg.parameter.name)
+        })
         .count();
     if num_arguments > checker.settings.pylint.max_args {
         checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -107,8 +107,8 @@ pub(crate) fn super_call_with_parameters(
 
     // Extract the name of the first argument to the enclosing function.
     let Some(ParameterWithDefault {
-        def: Parameter {
-            arg: parent_arg, ..
+        parameter: Parameter {
+            name: parent_arg, ..
         },
         ..
     }) = parent_parameters.args.first()

--- a/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
@@ -169,7 +169,7 @@ fn generate_fix(checker: &Checker, conversion_type: ConversionType, expr: &Expr)
 /// RUF013
 pub(crate) fn implicit_optional(checker: &mut Checker, parameters: &Parameters) {
     for ParameterWithDefault {
-        def,
+        parameter,
         default,
         range: _,
     } in parameters
@@ -182,7 +182,7 @@ pub(crate) fn implicit_optional(checker: &mut Checker, parameters: &Parameters) 
         if !is_const_none(default) {
             continue;
         }
-        let Some(annotation) = &def.annotation else {
+        let Some(annotation) = &parameter.annotation else {
             continue;
         };
 

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -381,7 +381,7 @@ pub struct ComparableParameter<'a> {
 impl<'a> From<&'a ast::Parameter> for ComparableParameter<'a> {
     fn from(arg: &'a ast::Parameter) -> Self {
         Self {
-            arg: arg.arg.as_str(),
+            arg: arg.name.as_str(),
             annotation: arg.annotation.as_ref().map(Into::into),
         }
     }
@@ -396,7 +396,7 @@ pub struct ComparableParameterWithDefault<'a> {
 impl<'a> From<&'a ast::ParameterWithDefault> for ComparableParameterWithDefault<'a> {
     fn from(arg: &'a ast::ParameterWithDefault) -> Self {
         Self {
-            def: (&arg.def).into(),
+            def: (&arg.parameter).into(),
             default: arg.default.as_ref().map(Into::into),
         }
     }

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -370,7 +370,7 @@ where
                         .as_ref()
                         .is_some_and(|expr| any_over_expr(expr, func))
                         || parameter
-                            .def
+                            .parameter
                             .annotation
                             .as_ref()
                             .is_some_and(|expr| any_over_expr(expr, func))
@@ -719,17 +719,17 @@ pub fn includes_arg_name(name: &str, parameters: &Parameters) -> bool {
         .iter()
         .chain(&parameters.args)
         .chain(&parameters.kwonlyargs)
-        .any(|arg| arg.def.arg.as_str() == name)
+        .any(|arg| arg.parameter.name.as_str() == name)
     {
         return true;
     }
     if let Some(arg) = &parameters.vararg {
-        if arg.arg.as_str() == name {
+        if arg.name.as_str() == name {
             return true;
         }
     }
     if let Some(arg) = &parameters.kwarg {
-        if arg.arg.as_str() == name {
+        if arg.name.as_str() == name {
             return true;
         }
     }

--- a/crates/ruff_python_ast/src/identifier.rs
+++ b/crates/ruff_python_ast/src/identifier.rs
@@ -47,7 +47,7 @@ impl Identifier for Parameter {
     ///     ...
     /// ```
     fn identifier(&self) -> TextRange {
-        self.arg.range()
+        self.name.range()
     }
 }
 
@@ -60,7 +60,7 @@ impl Identifier for ParameterWithDefault {
     ///     ...
     /// ```
     fn identifier(&self) -> TextRange {
-        self.def.identifier()
+        self.parameter.identifier()
     }
 }
 

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1826,7 +1826,7 @@ impl From<ExceptHandlerExceptHandler> for ExceptHandler {
 #[derive(Clone, Debug, PartialEq)]
 pub struct Parameter {
     pub range: TextRange,
-    pub arg: Identifier,
+    pub name: Identifier,
     pub annotation: Option<Box<Expr>>,
 }
 
@@ -2069,7 +2069,7 @@ pub struct Parameters {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ParameterWithDefault {
     pub range: TextRange,
-    pub def: Parameter,
+    pub parameter: Parameter,
     pub default: Option<Box<Expr>>,
 }
 
@@ -2113,24 +2113,24 @@ fn clone_boxed_expr(expr: &Box<Expr>) -> Box<Expr> {
 
 impl ParameterWithDefault {
     pub fn as_parameter(&self) -> &Parameter {
-        &self.def
+        &self.parameter
     }
 
     pub fn to_parameter(&self) -> (Parameter, Option<Box<Expr>>) {
         let ParameterWithDefault {
             range: _,
-            def,
+            parameter,
             default,
         } = self;
-        (def.clone(), default.as_ref().map(clone_boxed_expr))
+        (parameter.clone(), default.as_ref().map(clone_boxed_expr))
     }
     pub fn into_parameter(self) -> (Parameter, Option<Box<Expr>>) {
         let ParameterWithDefault {
             range: _,
-            def,
+            parameter,
             default,
         } = self;
-        (def, default)
+        (parameter, default)
     }
 }
 

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -664,16 +664,16 @@ pub fn walk_parameters<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, parameters:
     }
 
     for arg in &parameters.posonlyargs {
-        visitor.visit_parameter(&arg.def);
+        visitor.visit_parameter(&arg.parameter);
     }
     for arg in &parameters.args {
-        visitor.visit_parameter(&arg.def);
+        visitor.visit_parameter(&arg.parameter);
     }
     if let Some(arg) = &parameters.vararg {
         visitor.visit_parameter(arg);
     }
     for arg in &parameters.kwonlyargs {
-        visitor.visit_parameter(&arg.def);
+        visitor.visit_parameter(&arg.parameter);
     }
     if let Some(arg) = &parameters.kwarg {
         visitor.visit_parameter(arg);

--- a/crates/ruff_python_ast/src/visitor/preorder.rs
+++ b/crates/ruff_python_ast/src/visitor/preorder.rs
@@ -785,7 +785,7 @@ pub fn walk_parameter_with_default<'a, V>(
 ) where
     V: PreorderVisitor<'a> + ?Sized,
 {
-    visitor.visit_parameter(&parameter_with_default.def);
+    visitor.visit_parameter(&parameter_with_default.parameter);
     if let Some(expr) = &parameter_with_default.default {
         visitor.visit_expr(expr);
     }

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1355,7 +1355,7 @@ impl<'a> Generator<'a> {
     }
 
     fn unparse_parameter(&mut self, parameter: &Parameter) {
-        self.p_id(&parameter.arg);
+        self.p_id(&parameter.name);
         if let Some(ann) = &parameter.annotation {
             self.p(": ");
             self.unparse_expr(ann, precedence::COMMA);
@@ -1363,7 +1363,7 @@ impl<'a> Generator<'a> {
     }
 
     fn unparse_parameter_with_default(&mut self, parameter_with_default: &ParameterWithDefault) {
-        self.unparse_parameter(&parameter_with_default.def);
+        self.unparse_parameter(&parameter_with_default.parameter);
         if let Some(default) = &parameter_with_default.default {
             self.p("=");
             self.unparse_expr(default, precedence::COMMA);

--- a/crates/ruff_python_formatter/src/other/parameter.rs
+++ b/crates/ruff_python_formatter/src/other/parameter.rs
@@ -10,11 +10,11 @@ impl FormatNodeRule<Parameter> for FormatParameter {
     fn fmt_fields(&self, item: &Parameter, f: &mut PyFormatter) -> FormatResult<()> {
         let Parameter {
             range: _,
-            arg,
+            name,
             annotation,
         } = item;
 
-        arg.format().fmt(f)?;
+        name.format().fmt(f)?;
 
         if let Some(annotation) = annotation {
             write!(f, [text(":"), space(), annotation.format()])?;

--- a/crates/ruff_python_formatter/src/other/parameter_with_default.rs
+++ b/crates/ruff_python_formatter/src/other/parameter_with_default.rs
@@ -11,14 +11,14 @@ impl FormatNodeRule<ParameterWithDefault> for FormatParameterWithDefault {
     fn fmt_fields(&self, item: &ParameterWithDefault, f: &mut PyFormatter) -> FormatResult<()> {
         let ParameterWithDefault {
             range: _,
-            def,
+            parameter,
             default,
         } = item;
 
-        write!(f, [def.format()])?;
+        write!(f, [parameter.format()])?;
 
         if let Some(default) = default {
-            let space = def.annotation.is_some().then_some(space());
+            let space = parameter.annotation.is_some().then_some(space());
             write!(f, [space, text("="), space, group(&default.format())])?;
         }
 

--- a/crates/ruff_python_parser/src/function.rs
+++ b/crates/ruff_python_parser/src/function.rs
@@ -32,12 +32,12 @@ pub(crate) fn validate_arguments(arguments: &ast::Parameters) -> Result<(), Lexi
     for arg in posonlyargs
         .chain(args)
         .chain(kwonlyargs)
-        .map(|arg| &arg.def)
+        .map(|arg| &arg.parameter)
         .chain(vararg)
         .chain(kwarg)
     {
         let range = arg.range;
-        let arg_name = arg.arg.as_str();
+        let arg_name = arg.name.as_str();
         if !all_arg_names.insert(arg_name) {
             return Err(LexicalError {
                 error: LexicalErrorType::DuplicateArgumentError(arg_name.to_string()),
@@ -66,7 +66,7 @@ pub(crate) fn validate_pos_params(
     if let Some(invalid) = first_invalid {
         return Err(LexicalError {
             error: LexicalErrorType::DefaultArgumentError,
-            location: invalid.def.range.start(),
+            location: invalid.parameter.range.start(),
         });
     }
     Ok(())

--- a/crates/ruff_python_parser/src/python.lalrpop
+++ b/crates/ruff_python_parser/src/python.lalrpop
@@ -1138,33 +1138,33 @@ ParameterDef<ParameterType>: ast::ParameterWithDefault = {
 
 UntypedParameter: ast::ParameterWithDefault = {
     <location:@L> <arg:Identifier> <end_location:@R> => {
-        let def = ast::Parameter { arg, annotation: None, range: (location..end_location).into() };
-        ast::ParameterWithDefault { def, default: None, range: (location..end_location).into() }
+        let def = ast::Parameter { name:arg, annotation: None, range: (location..end_location).into() };
+        ast::ParameterWithDefault { parameter:def, default: None, range: (location..end_location).into() }
     },
 };
 StarUntypedParameter: ast::Parameter = {
-    <location:@L> <arg:Identifier> <end_location:@R> => ast::Parameter { arg, annotation: None, range: (location..end_location).into() },
+    <location:@L> <arg:Identifier> <end_location:@R> => ast::Parameter { name:arg, annotation: None, range: (location..end_location).into() },
 };
 
 TypedParameter: ast::ParameterWithDefault = {
     <location:@L> <arg:Identifier> <a:(":" <Test<"all">>)?> <end_location:@R> => {
         let annotation = a.map(Box::new);
-        let def = ast::Parameter { arg, annotation, range: (location..end_location).into() };
-        ast::ParameterWithDefault { def, default: None, range: (location..end_location).into() }
+        let def = ast::Parameter { name:arg, annotation, range: (location..end_location).into() };
+        ast::ParameterWithDefault { parameter:def, default: None, range: (location..end_location).into() }
     },
 };
 
 StarTypedParameter: ast::Parameter = {
     <location:@L> <arg:Identifier> <a:(":" <TestOrStarExpr>)?> <end_location:@R> => {
         let annotation = a.map(Box::new);
-        ast::Parameter { arg, annotation, range: (location..end_location).into() }
+        ast::Parameter { name:arg, annotation, range: (location..end_location).into() }
     },
 };
 
 DoubleStarTypedParameter: ast::Parameter = {
     <location:@L> <arg:Identifier> <a:(":" <Test<"all">>)?> <end_location:@R> => {
         let annotation = a.map(Box::new);
-        ast::Parameter { arg, annotation, range: (location..end_location).into() }
+        ast::Parameter { name:arg, annotation, range: (location..end_location).into() }
     },
 };
 

--- a/crates/ruff_python_parser/src/python.rs
+++ b/crates/ruff_python_parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 9d48ea8f9d9a0a466240b3334066323fb9659fd9efe31f8748e4b940cd71b5e1
+// sha3: c7811af123576ce856886b56b55a0ac5e2f03c8b7458080b2b83fb3bec3d52ef
 use num_bigint::BigInt;
 use ruff_text_size::TextSize;
 use ruff_python_ast::{self as ast, Ranged, MagicKind};
@@ -33553,8 +33553,8 @@ fn __action165<
 ) -> ast::ParameterWithDefault
 {
     {
-        let def = ast::Parameter { arg, annotation: None, range: (location..end_location).into() };
-        ast::ParameterWithDefault { def, default: None, range: (location..end_location).into() }
+        let def = ast::Parameter { name:arg, annotation: None, range: (location..end_location).into() };
+        ast::ParameterWithDefault { parameter:def, default: None, range: (location..end_location).into() }
     }
 }
 
@@ -33568,7 +33568,7 @@ fn __action166<
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::Parameter
 {
-    ast::Parameter { arg, annotation: None, range: (location..end_location).into() }
+    ast::Parameter { name:arg, annotation: None, range: (location..end_location).into() }
 }
 
 #[allow(unused_variables)]
@@ -33584,8 +33584,8 @@ fn __action167<
 {
     {
         let annotation = a.map(Box::new);
-        let def = ast::Parameter { arg, annotation, range: (location..end_location).into() };
-        ast::ParameterWithDefault { def, default: None, range: (location..end_location).into() }
+        let def = ast::Parameter { name:arg, annotation, range: (location..end_location).into() };
+        ast::ParameterWithDefault { parameter:def, default: None, range: (location..end_location).into() }
     }
 }
 
@@ -33602,7 +33602,7 @@ fn __action168<
 {
     {
         let annotation = a.map(Box::new);
-        ast::Parameter { arg, annotation, range: (location..end_location).into() }
+        ast::Parameter { name:arg, annotation, range: (location..end_location).into() }
     }
 }
 
@@ -33619,7 +33619,7 @@ fn __action169<
 {
     {
         let annotation = a.map(Box::new);
-        ast::Parameter { arg, annotation, range: (location..end_location).into() }
+        ast::Parameter { name:arg, annotation, range: (location..end_location).into() }
     }
 }
 

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_kw_only_args.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_kw_only_args.snap
@@ -19,9 +19,9 @@ Ok(
                     kwonlyargs: [
                         ParameterWithDefault {
                             range: 9..10,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 9..10,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "a",
                                     range: 9..10,
                                 },
@@ -31,9 +31,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 12..13,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 12..13,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "b",
                                     range: 12..13,
                                 },
@@ -43,9 +43,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 15..16,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 15..16,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "c",
                                     range: 15..16,
                                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_kw_only_args_with_defaults.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_kw_only_args_with_defaults.snap
@@ -19,9 +19,9 @@ Ok(
                     kwonlyargs: [
                         ParameterWithDefault {
                             range: 9..10,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 9..10,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "a",
                                     range: 9..10,
                                 },
@@ -31,9 +31,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 12..16,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 12..13,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "b",
                                     range: 12..13,
                                 },
@@ -53,9 +53,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 18..22,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 18..19,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "c",
                                     range: 18..19,
                                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_and_kw_only_args.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_and_kw_only_args.snap
@@ -17,9 +17,9 @@ Ok(
                     args: [
                         ParameterWithDefault {
                             range: 6..7,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 6..7,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "a",
                                     range: 6..7,
                                 },
@@ -29,9 +29,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 9..10,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 9..10,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "b",
                                     range: 9..10,
                                 },
@@ -41,9 +41,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 12..13,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 12..13,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "c",
                                     range: 12..13,
                                 },
@@ -56,9 +56,9 @@ Ok(
                     kwonlyargs: [
                         ParameterWithDefault {
                             range: 18..19,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 18..19,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "d",
                                     range: 18..19,
                                 },
@@ -68,9 +68,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 21..22,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 21..22,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "e",
                                     range: 21..22,
                                 },
@@ -80,9 +80,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 24..25,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 24..25,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "f",
                                     range: 24..25,
                                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_and_kw_only_args_with_defaults.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_and_kw_only_args_with_defaults.snap
@@ -17,9 +17,9 @@ Ok(
                     args: [
                         ParameterWithDefault {
                             range: 6..7,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 6..7,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "a",
                                     range: 6..7,
                                 },
@@ -29,9 +29,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 9..10,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 9..10,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "b",
                                     range: 9..10,
                                 },
@@ -41,9 +41,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 12..13,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 12..13,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "c",
                                     range: 12..13,
                                 },
@@ -56,9 +56,9 @@ Ok(
                     kwonlyargs: [
                         ParameterWithDefault {
                             range: 18..19,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 18..19,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "d",
                                     range: 18..19,
                                 },
@@ -68,9 +68,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 21..25,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 21..22,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "e",
                                     range: 21..22,
                                 },
@@ -90,9 +90,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 27..31,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 27..28,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "f",
                                     range: 27..28,
                                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_and_kw_only_args_with_defaults_and_varargs.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_and_kw_only_args_with_defaults_and_varargs.snap
@@ -17,9 +17,9 @@ Ok(
                     args: [
                         ParameterWithDefault {
                             range: 6..7,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 6..7,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "a",
                                     range: 6..7,
                                 },
@@ -29,9 +29,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 9..10,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 9..10,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "b",
                                     range: 9..10,
                                 },
@@ -41,9 +41,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 12..13,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 12..13,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "c",
                                     range: 12..13,
                                 },
@@ -55,7 +55,7 @@ Ok(
                     vararg: Some(
                         Parameter {
                             range: 16..20,
-                            arg: Identifier {
+                            name: Identifier {
                                 id: "args",
                                 range: 16..20,
                             },
@@ -65,9 +65,9 @@ Ok(
                     kwonlyargs: [
                         ParameterWithDefault {
                             range: 22..23,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 22..23,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "d",
                                     range: 22..23,
                                 },
@@ -77,9 +77,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 25..29,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 25..26,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "e",
                                     range: 25..26,
                                 },
@@ -99,9 +99,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 31..35,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 31..32,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "f",
                                     range: 31..32,
                                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_and_kw_only_args_with_defaults_and_varargs_and_kwargs.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_and_kw_only_args_with_defaults_and_varargs_and_kwargs.snap
@@ -17,9 +17,9 @@ Ok(
                     args: [
                         ParameterWithDefault {
                             range: 6..7,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 6..7,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "a",
                                     range: 6..7,
                                 },
@@ -29,9 +29,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 9..10,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 9..10,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "b",
                                     range: 9..10,
                                 },
@@ -41,9 +41,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 12..13,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 12..13,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "c",
                                     range: 12..13,
                                 },
@@ -55,7 +55,7 @@ Ok(
                     vararg: Some(
                         Parameter {
                             range: 16..20,
-                            arg: Identifier {
+                            name: Identifier {
                                 id: "args",
                                 range: 16..20,
                             },
@@ -65,9 +65,9 @@ Ok(
                     kwonlyargs: [
                         ParameterWithDefault {
                             range: 22..23,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 22..23,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "d",
                                     range: 22..23,
                                 },
@@ -77,9 +77,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 25..29,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 25..26,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "e",
                                     range: 25..26,
                                 },
@@ -99,9 +99,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 31..35,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 31..32,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "f",
                                     range: 31..32,
                                 },
@@ -123,7 +123,7 @@ Ok(
                     kwarg: Some(
                         Parameter {
                             range: 39..45,
-                            arg: Identifier {
+                            name: Identifier {
                                 id: "kwargs",
                                 range: 39..45,
                             },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_args.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_args.snap
@@ -17,9 +17,9 @@ Ok(
                     args: [
                         ParameterWithDefault {
                             range: 6..7,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 6..7,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "a",
                                     range: 6..7,
                                 },
@@ -29,9 +29,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 9..10,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 9..10,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "b",
                                     range: 9..10,
                                 },
@@ -41,9 +41,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 12..13,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 12..13,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "c",
                                     range: 12..13,
                                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_args_with_defaults.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_args_with_defaults.snap
@@ -17,9 +17,9 @@ Ok(
                     args: [
                         ParameterWithDefault {
                             range: 6..7,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 6..7,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "a",
                                     range: 6..7,
                                 },
@@ -29,9 +29,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 9..13,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 9..10,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "b",
                                     range: 9..10,
                                 },
@@ -51,9 +51,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 15..19,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 15..16,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "c",
                                     range: 15..16,
                                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_args_with_ranges.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_args_with_ranges.snap
@@ -17,9 +17,9 @@ Ok(
                     args: [
                         ParameterWithDefault {
                             range: 6..7,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 6..7,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "a",
                                     range: 6..7,
                                 },
@@ -29,9 +29,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 9..10,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 9..10,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "b",
                                     range: 9..10,
                                 },
@@ -41,9 +41,9 @@ Ok(
                         },
                         ParameterWithDefault {
                             range: 12..13,
-                            def: Parameter {
+                            parameter: Parameter {
                                 range: 12..13,
-                                arg: Identifier {
+                                name: Identifier {
                                     id: "c",
                                     range: 12..13,
                                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_kw_only_args.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_kw_only_args.snap
@@ -18,9 +18,9 @@ Ok(
                             kwonlyargs: [
                                 ParameterWithDefault {
                                     range: 10..11,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 10..11,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "a",
                                             range: 10..11,
                                         },
@@ -30,9 +30,9 @@ Ok(
                                 },
                                 ParameterWithDefault {
                                     range: 13..14,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 13..14,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "b",
                                             range: 13..14,
                                         },
@@ -42,9 +42,9 @@ Ok(
                                 },
                                 ParameterWithDefault {
                                     range: 16..17,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 16..17,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "c",
                                             range: 16..17,
                                         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_kw_only_args_with_defaults.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_kw_only_args_with_defaults.snap
@@ -18,9 +18,9 @@ Ok(
                             kwonlyargs: [
                                 ParameterWithDefault {
                                     range: 10..11,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 10..11,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "a",
                                             range: 10..11,
                                         },
@@ -30,9 +30,9 @@ Ok(
                                 },
                                 ParameterWithDefault {
                                     range: 13..17,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 13..14,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "b",
                                             range: 13..14,
                                         },
@@ -52,9 +52,9 @@ Ok(
                                 },
                                 ParameterWithDefault {
                                     range: 19..23,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 19..20,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "c",
                                             range: 19..20,
                                         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_pos_and_kw_only_args.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_pos_and_kw_only_args.snap
@@ -16,9 +16,9 @@ Ok(
                             args: [
                                 ParameterWithDefault {
                                     range: 7..8,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 7..8,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "a",
                                             range: 7..8,
                                         },
@@ -28,9 +28,9 @@ Ok(
                                 },
                                 ParameterWithDefault {
                                     range: 10..11,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 10..11,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "b",
                                             range: 10..11,
                                         },
@@ -40,9 +40,9 @@ Ok(
                                 },
                                 ParameterWithDefault {
                                     range: 13..14,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 13..14,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "c",
                                             range: 13..14,
                                         },
@@ -55,9 +55,9 @@ Ok(
                             kwonlyargs: [
                                 ParameterWithDefault {
                                     range: 19..20,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 19..20,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "d",
                                             range: 19..20,
                                         },
@@ -67,9 +67,9 @@ Ok(
                                 },
                                 ParameterWithDefault {
                                     range: 22..23,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 22..23,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "e",
                                             range: 22..23,
                                         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_pos_args.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_pos_args.snap
@@ -16,9 +16,9 @@ Ok(
                             args: [
                                 ParameterWithDefault {
                                     range: 7..8,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 7..8,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "a",
                                             range: 7..8,
                                         },
@@ -28,9 +28,9 @@ Ok(
                                 },
                                 ParameterWithDefault {
                                     range: 10..11,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 10..11,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "b",
                                             range: 10..11,
                                         },
@@ -40,9 +40,9 @@ Ok(
                                 },
                                 ParameterWithDefault {
                                     range: 13..14,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 13..14,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "c",
                                             range: 13..14,
                                         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_pos_args_with_defaults.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_pos_args_with_defaults.snap
@@ -16,9 +16,9 @@ Ok(
                             args: [
                                 ParameterWithDefault {
                                     range: 7..8,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 7..8,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "a",
                                             range: 7..8,
                                         },
@@ -28,9 +28,9 @@ Ok(
                                 },
                                 ParameterWithDefault {
                                     range: 10..14,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 10..11,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "b",
                                             range: 10..11,
                                         },
@@ -50,9 +50,9 @@ Ok(
                                 },
                                 ParameterWithDefault {
                                     range: 16..20,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 16..17,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "c",
                                             range: 16..17,
                                         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__match_as_identifier.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__match_as_identifier.snap
@@ -715,9 +715,9 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                         args: [
                             ParameterWithDefault {
                                 range: 598..603,
-                                def: Parameter {
+                                parameter: Parameter {
                                     range: 598..603,
-                                    arg: Identifier {
+                                    name: Identifier {
                                         id: "query",
                                         range: 598..603,
                                     },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_class.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_class.snap
@@ -41,9 +41,9 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             args: [
                                 ParameterWithDefault {
                                     range: 31..35,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 31..35,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "self",
                                             range: 31..35,
                                         },
@@ -81,9 +81,9 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             args: [
                                 ParameterWithDefault {
                                     range: 70..74,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 70..74,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "self",
                                             range: 70..74,
                                         },
@@ -93,9 +93,9 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                 },
                                 ParameterWithDefault {
                                     range: 76..89,
-                                    def: Parameter {
+                                    parameter: Parameter {
                                         range: 76..79,
-                                        arg: Identifier {
+                                        name: Identifier {
                                             id: "arg",
                                             range: 76..79,
                                         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_function_definition.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_function_definition.snap
@@ -16,9 +16,9 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                 args: [
                     ParameterWithDefault {
                         range: 9..10,
-                        def: Parameter {
+                        parameter: Parameter {
                             range: 9..10,
-                            arg: Identifier {
+                            name: Identifier {
                                 id: "a",
                                 range: 9..10,
                             },
@@ -63,9 +63,9 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                 args: [
                     ParameterWithDefault {
                         range: 34..38,
-                        def: Parameter {
+                        parameter: Parameter {
                             range: 34..38,
-                            arg: Identifier {
+                            name: Identifier {
                                 id: "a",
                                 range: 34..35,
                             },
@@ -137,9 +137,9 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                 args: [
                     ParameterWithDefault {
                         range: 72..76,
-                        def: Parameter {
+                        parameter: Parameter {
                             range: 72..76,
-                            arg: Identifier {
+                            name: Identifier {
                                 id: "a",
                                 range: 72..73,
                             },
@@ -219,9 +219,9 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                 args: [
                     ParameterWithDefault {
                         range: 119..123,
-                        def: Parameter {
+                        parameter: Parameter {
                             range: 119..123,
-                            arg: Identifier {
+                            name: Identifier {
                                 id: "a",
                                 range: 119..120,
                             },
@@ -317,7 +317,7 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                 vararg: Some(
                     Parameter {
                         range: 155..161,
-                        arg: Identifier {
+                        name: Identifier {
                             id: "a",
                             range: 155..156,
                         },
@@ -384,7 +384,7 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                 vararg: Some(
                     Parameter {
                         range: 188..200,
-                        arg: Identifier {
+                        name: Identifier {
                             id: "args",
                             range: 188..192,
                         },
@@ -413,7 +413,7 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                 kwarg: Some(
                     Parameter {
                         range: 204..220,
-                        arg: Identifier {
+                        name: Identifier {
                             id: "kwargs",
                             range: 204..210,
                         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_lambda.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_lambda.snap
@@ -15,9 +15,9 @@ expression: parse_ast
                         args: [
                             ParameterWithDefault {
                                 range: 7..8,
-                                def: Parameter {
+                                parameter: Parameter {
                                     range: 7..8,
-                                    arg: Identifier {
+                                    name: Identifier {
                                         id: "x",
                                         range: 7..8,
                                     },
@@ -27,9 +27,9 @@ expression: parse_ast
                             },
                             ParameterWithDefault {
                                 range: 10..11,
-                                def: Parameter {
+                                parameter: Parameter {
                                     range: 10..11,
-                                    arg: Identifier {
+                                    name: Identifier {
                                         id: "y",
                                         range: 10..11,
                                     },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__type_as_identifier.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__type_as_identifier.snap
@@ -651,9 +651,9 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                         args: [
                             ParameterWithDefault {
                                 range: 514..519,
-                                def: Parameter {
+                                parameter: Parameter {
                                     range: 514..519,
-                                    arg: Identifier {
+                                    name: Identifier {
                                         id: "query",
                                         range: 514..519,
                                     },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__variadic_generics.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__variadic_generics.snap
@@ -17,7 +17,7 @@ expression: parse_ast
                 vararg: Some(
                     Parameter {
                         range: 20..29,
-                        arg: Identifier {
+                        name: Identifier {
                             id: "args",
                             range: 20..24,
                         },


### PR DESCRIPTION
## Summary

This PR renames...

- `Parameter#arg` to `Parameter#name`
- `ParameterWithDefault#def` to `ParameterWithDefault#parameter` (such that `ParameterWithDefault` has a `default` and a `parameter`)

## Test Plan

`cargo test`
