### PR TITLE
Use `Arguments` node to power `remove_argument` method

### DIFF
--- a/crates/ruff/src/autofix/edits.rs
+++ b/crates/ruff/src/autofix/edits.rs
@@ -1,14 +1,15 @@
 //! Interface for generating autofix edits from higher-level actions (e.g., "remove an argument").
+
 use anyhow::{bail, Result};
-use ruff_python_ast::{self as ast, ExceptHandler, Expr, Keyword, Ranged, Stmt};
-use ruff_python_parser::{lexer, Mode};
-use ruff_text_size::{TextLen, TextRange, TextSize};
 
 use ruff_diagnostics::Edit;
+use ruff_python_ast::{self as ast, Arguments, ExceptHandler, Expr, Keyword, Ranged, Stmt};
 use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;
+use ruff_python_parser::{lexer, Mode};
 use ruff_python_trivia::{has_leading_content, is_python_whitespace, PythonWhitespace};
 use ruff_source_file::{Locator, NewlineWithTrailingNewline};
+use ruff_text_size::{TextLen, TextRange, TextSize};
 
 use crate::autofix::codemods;
 
@@ -74,102 +75,86 @@ pub(crate) fn remove_unused_imports<'a>(
 ///
 /// Supports the removal of parentheses when this is the only (kw)arg left.
 /// For this behavior, set `remove_parentheses` to `true`.
-///
-/// TODO(charlie): Migrate this signature to take [`Arguments`] rather than
-/// separate args and keywords.
-pub(crate) fn remove_argument(
-    locator: &Locator,
-    call_at: TextSize,
-    expr_range: TextRange,
-    args: &[Expr],
-    keywords: &[Keyword],
+pub(crate) fn remove_argument<T: Ranged>(
+    argument: &T,
+    arguments: &Arguments,
     remove_parentheses: bool,
+    locator: &Locator,
 ) -> Result<Edit> {
     // TODO(sbrugman): Preserve trailing comments.
-    let contents = locator.after(call_at);
+    if arguments.keywords.len() + arguments.args.len() > 1 {
+        let mut fix_start = None;
+        let mut fix_end = None;
 
-    let mut fix_start = None;
-    let mut fix_end = None;
-
-    let n_arguments = keywords.len() + args.len();
-    if n_arguments == 0 {
-        bail!("No arguments or keywords to remove");
-    }
-
-    if n_arguments == 1 {
-        // Case 1: there is only one argument.
-        let mut count = 0u32;
-        for (tok, range) in lexer::lex_starts_at(contents, Mode::Module, call_at).flatten() {
-            if tok.is_lpar() {
-                if count == 0 {
-                    fix_start = Some(if remove_parentheses {
-                        range.start()
-                    } else {
-                        range.start() + TextSize::from(1)
-                    });
-                }
-                count = count.saturating_add(1);
-            }
-
-            if tok.is_rpar() {
-                count = count.saturating_sub(1);
-                if count == 0 {
-                    fix_end = Some(if remove_parentheses {
+        if arguments
+            .args
+            .iter()
+            .map(Expr::start)
+            .chain(arguments.keywords.iter().map(Keyword::start))
+            .any(|location| location > argument.start())
+        {
+            // Case 1: argument or keyword is _not_ the last node, so delete from the start of the
+            // argument to the end of the subsequent comma.
+            let mut seen_comma = false;
+            for (tok, range) in lexer::lex_starts_at(
+                locator.slice(arguments.range()),
+                Mode::Module,
+                arguments.start(),
+            )
+            .flatten()
+            {
+                if seen_comma {
+                    if tok.is_non_logical_newline() {
+                        // Also delete any non-logical newlines after the comma.
+                        continue;
+                    }
+                    fix_end = Some(if tok.is_newline() {
                         range.end()
                     } else {
-                        range.end() - TextSize::from(1)
+                        range.start()
                     });
                     break;
                 }
+                if range.start() == argument.start() {
+                    fix_start = Some(range.start());
+                }
+                if fix_start.is_some() && tok.is_comma() {
+                    seen_comma = true;
+                }
+            }
+        } else {
+            // Case 2: argument or keyword is the last node, so delete from the start of the
+            // previous comma to the end of the argument.
+            for (tok, range) in lexer::lex_starts_at(
+                locator.slice(arguments.range()),
+                Mode::Module,
+                arguments.start(),
+            )
+            .flatten()
+            {
+                if range.start() == argument.start() {
+                    fix_end = Some(argument.end());
+                    break;
+                }
+                if tok.is_comma() {
+                    fix_start = Some(range.start());
+                }
             }
         }
-    } else if args
-        .iter()
-        .map(Expr::start)
-        .chain(keywords.iter().map(Keyword::start))
-        .any(|location| location > expr_range.start())
-    {
-        // Case 2: argument or keyword is _not_ the last node.
-        let mut seen_comma = false;
-        for (tok, range) in lexer::lex_starts_at(contents, Mode::Module, call_at).flatten() {
-            if seen_comma {
-                if tok.is_non_logical_newline() {
-                    // Also delete any non-logical newlines after the comma.
-                    continue;
-                }
-                fix_end = Some(if tok.is_newline() {
-                    range.end()
-                } else {
-                    range.start()
-                });
-                break;
-            }
-            if range.start() == expr_range.start() {
-                fix_start = Some(range.start());
-            }
-            if fix_start.is_some() && tok.is_comma() {
-                seen_comma = true;
+
+        match (fix_start, fix_end) {
+            (Some(start), Some(end)) => Ok(Edit::deletion(start, end)),
+            _ => {
+                bail!("No fix could be constructed")
             }
         }
     } else {
-        // Case 3: argument or keyword is the last node, so we have to find the last
-        // comma in the stmt.
-        for (tok, range) in lexer::lex_starts_at(contents, Mode::Module, call_at).flatten() {
-            if range.start() == expr_range.start() {
-                fix_end = Some(expr_range.end());
-                break;
-            }
-            if tok.is_comma() {
-                fix_start = Some(range.start());
-            }
-        }
-    }
-
-    match (fix_start, fix_end) {
-        (Some(start), Some(end)) => Ok(Edit::deletion(start, end)),
-        _ => {
-            bail!("No fix could be constructed")
-        }
+        // Only one argument; remove it (but preserve parentheses, if needed).
+        Ok(if remove_parentheses {
+            Edit::deletion(arguments.start(), arguments.end())
+        } else {
+            Edit::replacement("()".to_string(), arguments.start(), arguments.end())
+        })
     }
 }
 
@@ -297,11 +282,11 @@ fn next_stmt_break(semicolon: TextSize, locator: &Locator) -> TextSize {
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
+
     use ruff_python_ast::Ranged;
     use ruff_python_parser::parse_suite;
-    use ruff_text_size::TextSize;
-
     use ruff_source_file::Locator;
+    use ruff_text_size::TextSize;
 
     use crate::autofix::edits::{next_stmt_break, trailing_semicolon};
 

--- a/crates/ruff/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff/src/checkers/ast/analyze/expression.rs
@@ -426,7 +426,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 pyupgrade::rules::super_call_with_parameters(checker, expr, func, args);
             }
             if checker.enabled(Rule::UnnecessaryEncodeUTF8) {
-                pyupgrade::rules::unnecessary_encode_utf8(checker, expr, func, args, keywords);
+                pyupgrade::rules::unnecessary_encode_utf8(checker, call);
             }
             if checker.enabled(Rule::RedundantOpenModes) {
                 pyupgrade::rules::redundant_open_modes(checker, expr);
@@ -441,7 +441,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 pyupgrade::rules::replace_universal_newlines(checker, func, keywords);
             }
             if checker.enabled(Rule::ReplaceStdoutStderr) {
-                pyupgrade::rules::replace_stdout_stderr(checker, expr, func, args, keywords);
+                pyupgrade::rules::replace_stdout_stderr(checker, call);
             }
             if checker.enabled(Rule::OSErrorAlias) {
                 pyupgrade::rules::os_error_alias_call(checker, func);
@@ -677,7 +677,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 flake8_debugger::rules::debugger_call(checker, expr, func);
             }
             if checker.enabled(Rule::PandasUseOfInplaceArgument) {
-                pandas_vet::rules::inplace_argument(checker, expr, func, args, keywords);
+                pandas_vet::rules::inplace_argument(checker, call);
             }
             pandas_vet::rules::call(checker, func);
             if checker.enabled(Rule::PandasUseOfDotReadTable) {

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -1,9 +1,5 @@
 use std::fmt;
 
-use ruff_python_ast::{self as ast, Expr, ParameterWithDefault, Parameters, Ranged, Stmt};
-use ruff_python_ast::{Arguments, Decorator};
-use ruff_text_size::{TextLen, TextRange};
-
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -12,8 +8,11 @@ use ruff_python_ast::helpers::{find_keyword, includes_arg_name};
 use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::Decorator;
+use ruff_python_ast::{self as ast, Expr, ParameterWithDefault, Parameters, Ranged, Stmt};
 use ruff_python_semantic::analyze::visibility::is_abstract;
 use ruff_python_semantic::SemanticModel;
+use ruff_text_size::{TextLen, TextRange};
 
 use crate::autofix::edits::remove_argument;
 use crate::checkers::ast::Checker;
@@ -476,18 +475,13 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &D
     match &decorator.expression {
         Expr::Call(ast::ExprCall {
             func,
-            arguments:
-                Arguments {
-                    args,
-                    keywords,
-                    range: _,
-                },
+            arguments,
             range: _,
         }) => {
             if checker.enabled(Rule::PytestFixtureIncorrectParenthesesStyle) {
                 if !checker.settings.flake8_pytest_style.fixture_parentheses
-                    && args.is_empty()
-                    && keywords.is_empty()
+                    && arguments.args.is_empty()
+                    && arguments.keywords.is_empty()
                 {
                     let fix = Fix::automatic(Edit::deletion(func.end(), decorator.end()));
                     pytest_fixture_parentheses(
@@ -501,7 +495,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &D
             }
 
             if checker.enabled(Rule::PytestFixturePositionalArgs) {
-                if !args.is_empty() {
+                if !arguments.args.is_empty() {
                     checker.diagnostics.push(Diagnostic::new(
                         PytestFixturePositionalArgs {
                             function: func_name.to_string(),
@@ -512,21 +506,14 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &D
             }
 
             if checker.enabled(Rule::PytestExtraneousScopeFunction) {
-                if let Some(scope_keyword) = find_keyword(keywords, "scope") {
-                    if keyword_is_literal(scope_keyword, "function") {
+                if let Some(keyword) = find_keyword(&arguments.keywords, "scope") {
+                    if keyword_is_literal(keyword, "function") {
                         let mut diagnostic =
-                            Diagnostic::new(PytestExtraneousScopeFunction, scope_keyword.range());
+                            Diagnostic::new(PytestExtraneousScopeFunction, keyword.range());
                         if checker.patch(diagnostic.kind.rule()) {
                             diagnostic.try_set_fix(|| {
-                                remove_argument(
-                                    checker.locator(),
-                                    func.end(),
-                                    scope_keyword.range,
-                                    args,
-                                    keywords,
-                                    false,
-                                )
-                                .map(Fix::suggested)
+                                remove_argument(keyword, arguments, false, checker.locator())
+                                    .map(Fix::suggested)
                             });
                         }
                         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -1,10 +1,9 @@
-use ruff_python_ast::{self as ast, Constant, Expr, Keyword, Ranged};
-use ruff_python_parser::{lexer, Mode, Tok};
-use ruff_text_size::TextRange;
-
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::{self as ast, Arguments, Constant, Expr, Keyword, Ranged};
+use ruff_python_parser::{lexer, Mode, Tok};
 use ruff_source_file::Locator;
+use ruff_text_size::TextRange;
 
 use crate::autofix::edits::remove_argument;
 use crate::checkers::ast::Checker;
@@ -95,23 +94,21 @@ enum EncodingArg<'a> {
 
 /// Return the encoding argument to an `encode` call, if it can be determined to be a
 /// UTF-8-equivalent encoding.
-fn match_encoding_arg<'a>(args: &'a [Expr], kwargs: &'a [Keyword]) -> Option<EncodingArg<'a>> {
-    match (args.len(), kwargs.len()) {
+fn match_encoding_arg(arguments: &Arguments) -> Option<EncodingArg> {
+    match (arguments.args.as_slice(), arguments.keywords.as_slice()) {
         // Ex `"".encode()`
-        (0, 0) => return Some(EncodingArg::Empty),
+        ([], []) => return Some(EncodingArg::Empty),
         // Ex `"".encode(encoding)`
-        (1, 0) => {
-            let arg = &args[0];
+        ([arg], []) => {
             if is_utf8_encoding_arg(arg) {
                 return Some(EncodingArg::Positional(arg));
             }
         }
         // Ex `"".encode(kwarg=kwarg)`
-        (0, 1) => {
-            let kwarg = &kwargs[0];
-            if kwarg.arg.as_ref().is_some_and(|arg| arg == "encoding") {
-                if is_utf8_encoding_arg(&kwarg.value) {
-                    return Some(EncodingArg::Keyword(kwarg));
+        ([], [keyword]) => {
+            if keyword.arg.as_ref().is_some_and(|arg| arg == "encoding") {
+                if is_utf8_encoding_arg(&keyword.value) {
+                    return Some(EncodingArg::Keyword(keyword));
                 }
             }
         }
@@ -122,7 +119,7 @@ fn match_encoding_arg<'a>(args: &'a [Expr], kwargs: &'a [Keyword]) -> Option<Enc
 }
 
 /// Return a [`Fix`] replacing the call to encode with a byte string.
-fn replace_with_bytes_literal(locator: &Locator, expr: &Expr) -> Fix {
+fn replace_with_bytes_literal<T: Ranged>(locator: &Locator, expr: &T) -> Fix {
     // Build up a replacement string by prefixing all string tokens with `b`.
     let contents = locator.slice(expr.range());
     let mut replacement = String::with_capacity(contents.len() + 1);
@@ -149,14 +146,8 @@ fn replace_with_bytes_literal(locator: &Locator, expr: &Expr) -> Fix {
 }
 
 /// UP012
-pub(crate) fn unnecessary_encode_utf8(
-    checker: &mut Checker,
-    expr: &Expr,
-    func: &Expr,
-    args: &[Expr],
-    kwargs: &[Keyword],
-) {
-    let Some(variable) = match_encoded_variable(func) else {
+pub(crate) fn unnecessary_encode_utf8(checker: &mut Checker, call: &ast::ExprCall) {
+    let Some(variable) = match_encoded_variable(&call.func) else {
         return;
     };
     match variable {
@@ -165,17 +156,17 @@ pub(crate) fn unnecessary_encode_utf8(
             ..
         }) => {
             // Ex) `"str".encode()`, `"str".encode("utf-8")`
-            if let Some(encoding_arg) = match_encoding_arg(args, kwargs) {
+            if let Some(encoding_arg) = match_encoding_arg(&call.arguments) {
                 if literal.is_ascii() {
                     // Ex) Convert `"foo".encode()` to `b"foo"`.
                     let mut diagnostic = Diagnostic::new(
                         UnnecessaryEncodeUTF8 {
                             reason: Reason::BytesLiteral,
                         },
-                        expr.range(),
+                        call.range(),
                     );
                     if checker.patch(Rule::UnnecessaryEncodeUTF8) {
-                        diagnostic.set_fix(replace_with_bytes_literal(checker.locator(), expr));
+                        diagnostic.set_fix(replace_with_bytes_literal(checker.locator(), call));
                     }
                     checker.diagnostics.push(diagnostic);
                 } else if let EncodingArg::Keyword(kwarg) = encoding_arg {
@@ -185,19 +176,12 @@ pub(crate) fn unnecessary_encode_utf8(
                         UnnecessaryEncodeUTF8 {
                             reason: Reason::DefaultArgument,
                         },
-                        expr.range(),
+                        call.range(),
                     );
                     if checker.patch(Rule::UnnecessaryEncodeUTF8) {
                         diagnostic.try_set_fix(|| {
-                            remove_argument(
-                                checker.locator(),
-                                func.end(),
-                                kwarg.range(),
-                                args,
-                                kwargs,
-                                false,
-                            )
-                            .map(Fix::automatic)
+                            remove_argument(kwarg, &call.arguments, false, checker.locator())
+                                .map(Fix::automatic)
                         });
                     }
                     checker.diagnostics.push(diagnostic);
@@ -207,19 +191,12 @@ pub(crate) fn unnecessary_encode_utf8(
                         UnnecessaryEncodeUTF8 {
                             reason: Reason::DefaultArgument,
                         },
-                        expr.range(),
+                        call.range(),
                     );
                     if checker.patch(Rule::UnnecessaryEncodeUTF8) {
                         diagnostic.try_set_fix(|| {
-                            remove_argument(
-                                checker.locator(),
-                                func.end(),
-                                arg.range(),
-                                args,
-                                kwargs,
-                                false,
-                            )
-                            .map(Fix::automatic)
+                            remove_argument(arg, &call.arguments, false, checker.locator())
+                                .map(Fix::automatic)
                         });
                     }
                     checker.diagnostics.push(diagnostic);
@@ -228,7 +205,7 @@ pub(crate) fn unnecessary_encode_utf8(
         }
         // Ex) `f"foo{bar}".encode("utf-8")`
         Expr::JoinedStr(_) => {
-            if let Some(encoding_arg) = match_encoding_arg(args, kwargs) {
+            if let Some(encoding_arg) = match_encoding_arg(&call.arguments) {
                 if let EncodingArg::Keyword(kwarg) = encoding_arg {
                     // Ex) Convert `f"unicode text©".encode(encoding="utf-8")` to
                     // `f"unicode text©".encode()`.
@@ -236,19 +213,12 @@ pub(crate) fn unnecessary_encode_utf8(
                         UnnecessaryEncodeUTF8 {
                             reason: Reason::DefaultArgument,
                         },
-                        expr.range(),
+                        call.range(),
                     );
                     if checker.patch(Rule::UnnecessaryEncodeUTF8) {
                         diagnostic.try_set_fix(|| {
-                            remove_argument(
-                                checker.locator(),
-                                func.end(),
-                                kwarg.range(),
-                                args,
-                                kwargs,
-                                false,
-                            )
-                            .map(Fix::automatic)
+                            remove_argument(kwarg, &call.arguments, false, checker.locator())
+                                .map(Fix::automatic)
                         });
                     }
                     checker.diagnostics.push(diagnostic);
@@ -258,19 +228,12 @@ pub(crate) fn unnecessary_encode_utf8(
                         UnnecessaryEncodeUTF8 {
                             reason: Reason::DefaultArgument,
                         },
-                        expr.range(),
+                        call.range(),
                     );
                     if checker.patch(Rule::UnnecessaryEncodeUTF8) {
                         diagnostic.try_set_fix(|| {
-                            remove_argument(
-                                checker.locator(),
-                                func.end(),
-                                arg.range(),
-                                args,
-                                kwargs,
-                                false,
-                            )
-                            .map(Fix::automatic)
+                            remove_argument(arg, &call.arguments, false, checker.locator())
+                                .map(Fix::automatic)
                         });
                     }
                     checker.diagnostics.push(diagnostic);


### PR DESCRIPTION
## Summary

Internal refactor to take advantage of the new `Arguments` node, to power our `remove_argument` fix action.

## Test Plan

`cargo test`
