### PR TITLE
Move `includes_arg_name` onto `Parameters`

### DIFF
--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
@@ -1,11 +1,9 @@
-use ruff_python_ast::{self as ast, Arguments, Comprehension, Expr, ExprContext, Ranged, Stmt};
-
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::includes_arg_name;
 use ruff_python_ast::types::Node;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::{self as ast, Arguments, Comprehension, Expr, ExprContext, Ranged, Stmt};
 
 use crate::checkers::ast::Checker;
 
@@ -103,7 +101,7 @@ impl<'a> Visitor<'a> for SuspiciousVariablesVisitor<'a> {
                             return false;
                         }
 
-                        if includes_arg_name(&loaded.id, parameters) {
+                        if parameters.includes(&loaded.id) {
                             return false;
                         }
 
@@ -189,7 +187,7 @@ impl<'a> Visitor<'a> for SuspiciousVariablesVisitor<'a> {
                                 return false;
                             }
 
-                            if includes_arg_name(&loaded.id, parameters) {
+                            if parameters.includes(&loaded.id) {
                                 return false;
                             }
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -1,13 +1,11 @@
 use std::fmt;
 
-use ruff_python_ast::{self as ast, Arguments, Expr, ExprContext, Parameters, Ranged, Stmt};
-
 use ruff_diagnostics::{AutofixKind, Violation};
 use ruff_diagnostics::{Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::includes_arg_name;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::{self as ast, Arguments, Expr, ExprContext, Parameters, Ranged, Stmt};
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -275,9 +273,13 @@ impl<'a> Visitor<'a> for LateBindingVisitor<'a> {
                 // If we're within a nested lambda...
                 if !self.lambdas.is_empty() {
                     // If the name is defined in the current lambda...
-                    if includes_arg_name(id, self.parameters) {
+                    if self.parameters.includes(id) {
                         // And isn't overridden by any nested lambdas...
-                        if !self.lambdas.iter().any(|args| includes_arg_name(id, args)) {
+                        if !self
+                            .lambdas
+                            .iter()
+                            .any(|parameters| parameters.includes(id))
+                        {
                             // Then it's late-bound.
                             self.late_bound = true;
                         }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -4,7 +4,6 @@ use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::collect_call_path;
-use ruff_python_ast::helpers::includes_arg_name;
 use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
@@ -640,7 +639,7 @@ fn check_fixture_decorator_name(checker: &mut Checker, decorator: &Decorator) {
 
 /// PT021
 fn check_fixture_addfinalizer(checker: &mut Checker, parameters: &Parameters, body: &[Stmt]) {
-    if !includes_arg_name("request", parameters) {
+    if !parameters.includes("request") {
         return;
     }
 

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/patch.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/patch.rs
@@ -1,7 +1,6 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::collect_call_path;
-use ruff_python_ast::helpers::includes_arg_name;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{self as ast, Expr, Parameters, Ranged};
@@ -30,7 +29,7 @@ where
     fn visit_expr(&mut self, expr: &'b Expr) {
         match expr {
             Expr::Name(ast::ExprName { id, .. }) => {
-                if includes_arg_name(id, self.parameters) {
+                if self.parameters.includes(id) {
                     self.uses_args = true;
                 }
             }

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -9,8 +9,8 @@ use ruff_text_size::TextRange;
 use crate::call_path::CallPath;
 use crate::statement_visitor::{walk_body, walk_stmt, StatementVisitor};
 use crate::{
-    self as ast, Arguments, Constant, ExceptHandler, Expr, MatchCase, Parameters, Pattern, Ranged,
-    Stmt, TypeParam,
+    self as ast, Arguments, Constant, ExceptHandler, Expr, MatchCase, Pattern, Ranged, Stmt,
+    TypeParam,
 };
 
 /// Return `true` if the `Stmt` is a compound statement (as opposed to a simple statement).
@@ -710,30 +710,6 @@ pub fn extract_handled_exceptions(handlers: &[ExceptHandler]) -> Vec<&Expr> {
         }
     }
     handled_exceptions
-}
-
-/// Returns `true` if the given name is included in the given [`Parameters`].
-pub fn includes_arg_name(name: &str, parameters: &Parameters) -> bool {
-    if parameters
-        .posonlyargs
-        .iter()
-        .chain(&parameters.args)
-        .chain(&parameters.kwonlyargs)
-        .any(|arg| arg.parameter.name.as_str() == name)
-    {
-        return true;
-    }
-    if let Some(arg) = &parameters.vararg {
-        if arg.name.as_str() == name {
-            return true;
-        }
-    }
-    if let Some(arg) = &parameters.kwarg {
-        if arg.name.as_str() == name {
-            return true;
-        }
-    }
-    false
 }
 
 /// Given an [`Expr`] that can be callable or not (like a decorator, which could

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2080,6 +2080,32 @@ pub struct Parameters {
     pub kwarg: Option<Box<Parameter>>,
 }
 
+impl Parameters {
+    /// Returns `true` if a parameter with the given name included in this [`Parameters`].
+    pub fn includes(&self, name: &str) -> bool {
+        if self
+            .posonlyargs
+            .iter()
+            .chain(&self.args)
+            .chain(&self.kwonlyargs)
+            .any(|arg| arg.parameter.name.as_str() == name)
+        {
+            return true;
+        }
+        if let Some(arg) = &self.vararg {
+            if arg.name.as_str() == name {
+                return true;
+            }
+        }
+        if let Some(arg) = &self.kwarg {
+            if arg.name.as_str() == name {
+                return true;
+            }
+        }
+        false
+    }
+}
+
 /// An alternative type of AST `arg`. This is used for each function argument that might have a default value.
 /// Used by `Arguments` original type.
 ///


### PR DESCRIPTION
## Summary

Like #6279, no reason for this to be a standalone method.
