### PR TITLE
Avoid `PTH206` with `maxsplit`

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_use_pathlib/PTH206.py
+++ b/crates/ruff/resources/test/fixtures/flake8_use_pathlib/PTH206.py
@@ -18,3 +18,5 @@ file_name.split(os.sep)
 
 # OK
 "foo/bar/".split("/")
+"foo/bar/".split(os.sep, 1)
+"foo/bar/".split(1, sep=os.sep)

--- a/crates/ruff/src/rules/flake8_use_pathlib/rules/os_sep_split.rs
+++ b/crates/ruff/src/rules/flake8_use_pathlib/rules/os_sep_split.rs
@@ -60,7 +60,12 @@ pub(crate) fn os_sep_split(checker: &mut Checker, call: &ast::ExprCall) {
         return;
     };
 
-    // Match `.split(os.sep)` or `.split(sep=os.sep)`
+    // Match `.split(os.sep)` or `.split(sep=os.sep)`, but avoid cases in which a `maxsplit` is
+    // specified.
+    if call.arguments.len() != 1 {
+        return;
+    }
+
     let Some(sep) = call.arguments.find_argument("sep", 0) else {
         return;
     };


### PR DESCRIPTION
## Summary

Avoid suggesting `Path.parts` when a `maxsplit` is specified, since these behavior differently.

## Test Plan

`cargo test`
