### PR TITLE
Tweak background on theme button

### DIFF
--- a/playground/src/Editor/ShareButton.tsx
+++ b/playground/src/Editor/ShareButton.tsx
@@ -14,7 +14,7 @@ export default function ShareButton({ onShare }: { onShare?: () => void }) {
   return copied ? (
     <AstralButton
       type="button"
-      className="relative flex-none leading-6 py-1.5 px-3 cursor-auto shadow-copied"
+      className="relative flex-none leading-6 py-1.5 px-3 cursor-auto dark:shadow-copied"
     >
       <span
         className="absolute inset-0 flex items-center justify-center invisible"
@@ -22,7 +22,7 @@ export default function ShareButton({ onShare }: { onShare?: () => void }) {
       >
         Share
       </span>
-      <span className="" aria-hidden="false">
+      <span aria-hidden="false">
         Copied!
       </span>
     </AstralButton>

--- a/playground/src/Editor/ThemeButton.tsx
+++ b/playground/src/Editor/ThemeButton.tsx
@@ -14,7 +14,7 @@ export default function ThemeButton({
   return (
     <AstralButton
       type="button"
-      className="ml-4 sm:ml-0 shadow-sm"
+      className="ml-4 sm:ml-0 dark:shadow-copied"
       onClick={() => onChange(theme === "light" ? "dark" : "light")}
     >
       <span className="sr-only">
@@ -28,7 +28,7 @@ export default function ThemeButton({
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
-        className="stroke-black hover:stroke-radiate hover:fill-black fill-radiate"
+        className="stroke-black hover:stroke-white hover:fill-black fill-radiate"
       >
         <g className="dark:opacity-0">
           <path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"></path>

--- a/playground/src/index.css
+++ b/playground/src/index.css
@@ -17,8 +17,8 @@ html,
 }
 
 .shadow-copied {
-  --tw-shadow: 0 0 0 1px theme("colors.radiate"),
-    inset 0 0 0 1px theme("colors.radiate");
+  --tw-shadow: 0 0 0 1px theme("colors.white"),
+    inset 0 0 0 1px theme("colors.white");
   --tw-shadow-colored: 0 0 0 1px var(--tw-shadow-color),
     inset 0 0 0 1px var(--tw-shadow-color);
 


### PR DESCRIPTION
## Summary

It's now white on-hover as opposed to yellow, to match the copy button:

<img width="1792" alt="Screen Shot 2023-08-02 at 8 52 10 PM" src="https://github.com/astral-sh/ruff/assets/1309177/96d5cbf9-ef33-4fba-8888-f2a4af9a6ec4">
