### PR TITLE
Use `range: _` in lieu of `range: _range`

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -590,7 +590,7 @@ where
                 self.visit_body(body);
             }
             Stmt::TypeAlias(ast::StmtTypeAlias {
-                range: _range,
+                range: _,
                 name,
                 type_params,
                 value,

--- a/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -120,10 +120,7 @@ fn is_abc_class(bases: &[Expr], keywords: &[Keyword], semantic: &SemanticModel) 
 fn is_empty_body(body: &[Stmt]) -> bool {
     body.iter().all(|stmt| match stmt {
         Stmt::Pass(_) => true,
-        Stmt::Expr(ast::StmtExpr {
-            value,
-            range: _range,
-        }) => match value.as_ref() {
+        Stmt::Expr(ast::StmtExpr { value, range: _ }) => match value.as_ref() {
             Expr::Constant(ast::ExprConstant { value, .. }) => {
                 matches!(value, Constant::Str(..) | Constant::Ellipsis)
             }

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -727,7 +727,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
             ast::Expr::BoolOp(ast::ExprBoolOp {
                 op,
                 values,
-                range: _range,
+                range: _,
             }) => Self::BoolOp(ExprBoolOp {
                 op: (*op).into(),
                 values: values.iter().map(Into::into).collect(),
@@ -735,7 +735,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
             ast::Expr::NamedExpr(ast::ExprNamedExpr {
                 target,
                 value,
-                range: _range,
+                range: _,
             }) => Self::NamedExpr(ExprNamedExpr {
                 target: target.into(),
                 value: value.into(),
@@ -744,7 +744,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                 left,
                 op,
                 right,
-                range: _range,
+                range: _,
             }) => Self::BinOp(ExprBinOp {
                 left: left.into(),
                 op: (*op).into(),
@@ -753,7 +753,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
             ast::Expr::UnaryOp(ast::ExprUnaryOp {
                 op,
                 operand,
-                range: _range,
+                range: _,
             }) => Self::UnaryOp(ExprUnaryOp {
                 op: (*op).into(),
                 operand: operand.into(),
@@ -761,7 +761,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
             ast::Expr::Lambda(ast::ExprLambda {
                 parameters,
                 body,
-                range: _range,
+                range: _,
             }) => Self::Lambda(ExprLambda {
                 parameters: (parameters.as_ref()).into(),
                 body: body.into(),
@@ -770,7 +770,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                 test,
                 body,
                 orelse,
-                range: _range,
+                range: _,
             }) => Self::IfExp(ExprIfExp {
                 test: test.into(),
                 body: body.into(),
@@ -779,7 +779,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
             ast::Expr::Dict(ast::ExprDict {
                 keys,
                 values,
-                range: _range,
+                range: _,
             }) => Self::Dict(ExprDict {
                 keys: keys
                     .iter()
@@ -787,16 +787,13 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                     .collect(),
                 values: values.iter().map(Into::into).collect(),
             }),
-            ast::Expr::Set(ast::ExprSet {
-                elts,
-                range: _range,
-            }) => Self::Set(ExprSet {
+            ast::Expr::Set(ast::ExprSet { elts, range: _ }) => Self::Set(ExprSet {
                 elts: elts.iter().map(Into::into).collect(),
             }),
             ast::Expr::ListComp(ast::ExprListComp {
                 elt,
                 generators,
-                range: _range,
+                range: _,
             }) => Self::ListComp(ExprListComp {
                 elt: elt.into(),
                 generators: generators.iter().map(Into::into).collect(),
@@ -804,7 +801,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
             ast::Expr::SetComp(ast::ExprSetComp {
                 elt,
                 generators,
-                range: _range,
+                range: _,
             }) => Self::SetComp(ExprSetComp {
                 elt: elt.into(),
                 generators: generators.iter().map(Into::into).collect(),
@@ -813,7 +810,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                 key,
                 value,
                 generators,
-                range: _range,
+                range: _,
             }) => Self::DictComp(ExprDictComp {
                 key: key.into(),
                 value: value.into(),
@@ -822,34 +819,27 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
             ast::Expr::GeneratorExp(ast::ExprGeneratorExp {
                 elt,
                 generators,
-                range: _range,
+                range: _,
             }) => Self::GeneratorExp(ExprGeneratorExp {
                 elt: elt.into(),
                 generators: generators.iter().map(Into::into).collect(),
             }),
-            ast::Expr::Await(ast::ExprAwait {
-                value,
-                range: _range,
-            }) => Self::Await(ExprAwait {
+            ast::Expr::Await(ast::ExprAwait { value, range: _ }) => Self::Await(ExprAwait {
                 value: value.into(),
             }),
-            ast::Expr::Yield(ast::ExprYield {
-                value,
-                range: _range,
-            }) => Self::Yield(ExprYield {
+            ast::Expr::Yield(ast::ExprYield { value, range: _ }) => Self::Yield(ExprYield {
                 value: value.as_ref().map(Into::into),
             }),
-            ast::Expr::YieldFrom(ast::ExprYieldFrom {
-                value,
-                range: _range,
-            }) => Self::YieldFrom(ExprYieldFrom {
-                value: value.into(),
-            }),
+            ast::Expr::YieldFrom(ast::ExprYieldFrom { value, range: _ }) => {
+                Self::YieldFrom(ExprYieldFrom {
+                    value: value.into(),
+                })
+            }
             ast::Expr::Compare(ast::ExprCompare {
                 left,
                 ops,
                 comparators,
-                range: _range,
+                range: _,
             }) => Self::Compare(ExprCompare {
                 left: left.into(),
                 ops: ops.iter().copied().map(Into::into).collect(),
@@ -858,7 +848,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
             ast::Expr::Call(ast::ExprCall {
                 func,
                 arguments,
-                range: _range,
+                range: _,
             }) => Self::Call(ExprCall {
                 func: func.into(),
                 arguments: arguments.into(),
@@ -868,23 +858,22 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                 conversion,
                 debug_text,
                 format_spec,
-                range: _range,
+                range: _,
             }) => Self::FormattedValue(ExprFormattedValue {
                 value: value.into(),
                 conversion: *conversion,
                 debug_text: debug_text.as_ref(),
                 format_spec: format_spec.as_ref().map(Into::into),
             }),
-            ast::Expr::JoinedStr(ast::ExprJoinedStr {
-                values,
-                range: _range,
-            }) => Self::JoinedStr(ExprJoinedStr {
-                values: values.iter().map(Into::into).collect(),
-            }),
+            ast::Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
+                Self::JoinedStr(ExprJoinedStr {
+                    values: values.iter().map(Into::into).collect(),
+                })
+            }
             ast::Expr::Constant(ast::ExprConstant {
                 value,
                 kind,
-                range: _range,
+                range: _,
             }) => Self::Constant(ExprConstant {
                 value: value.into(),
                 kind: kind.as_ref().map(String::as_str),
@@ -893,7 +882,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                 value,
                 attr,
                 ctx,
-                range: _range,
+                range: _,
             }) => Self::Attribute(ExprAttribute {
                 value: value.into(),
                 attr: attr.as_str(),
@@ -903,7 +892,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                 value,
                 slice,
                 ctx,
-                range: _range,
+                range: _,
             }) => Self::Subscript(ExprSubscript {
                 value: value.into(),
                 slice: slice.into(),
@@ -912,23 +901,19 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
             ast::Expr::Starred(ast::ExprStarred {
                 value,
                 ctx,
-                range: _range,
+                range: _,
             }) => Self::Starred(ExprStarred {
                 value: value.into(),
                 ctx: ctx.into(),
             }),
-            ast::Expr::Name(ast::ExprName {
-                id,
-                ctx,
-                range: _range,
-            }) => Self::Name(ExprName {
+            ast::Expr::Name(ast::ExprName { id, ctx, range: _ }) => Self::Name(ExprName {
                 id: id.as_str(),
                 ctx: ctx.into(),
             }),
             ast::Expr::List(ast::ExprList {
                 elts,
                 ctx,
-                range: _range,
+                range: _,
             }) => Self::List(ExprList {
                 elts: elts.iter().map(Into::into).collect(),
                 ctx: ctx.into(),
@@ -936,7 +921,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
             ast::Expr::Tuple(ast::ExprTuple {
                 elts,
                 ctx,
-                range: _range,
+                range: _,
             }) => Self::Tuple(ExprTuple {
                 elts: elts.iter().map(Into::into).collect(),
                 ctx: ctx.into(),
@@ -945,7 +930,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                 lower,
                 upper,
                 step,
-                range: _range,
+                range: _,
             }) => Self::Slice(ExprSlice {
                 lower: lower.as_ref().map(Into::into),
                 upper: upper.as_ref().map(Into::into),
@@ -954,7 +939,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
             ast::Expr::LineMagic(ast::ExprLineMagic {
                 kind,
                 value,
-                range: _range,
+                range: _,
             }) => Self::LineMagic(ExprLineMagic {
                 kind: *kind,
                 value: value.as_str(),
@@ -1249,7 +1234,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 decorator_list,
                 returns,
                 type_params,
-                range: _range,
+                range: _,
             }) => Self::FunctionDef(StmtFunctionDef {
                 name: name.as_str(),
                 parameters: parameters.into(),
@@ -1265,7 +1250,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 decorator_list,
                 returns,
                 type_params,
-                range: _range,
+                range: _,
             }) => Self::AsyncFunctionDef(StmtAsyncFunctionDef {
                 name: name.as_str(),
                 parameters: parameters.into(),
@@ -1280,7 +1265,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 body,
                 decorator_list,
                 type_params,
-                range: _range,
+                range: _,
             }) => Self::ClassDef(StmtClassDef {
                 name: name.as_str(),
                 arguments: arguments.as_ref().map(Into::into),
@@ -1288,20 +1273,14 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 decorator_list: decorator_list.iter().map(Into::into).collect(),
                 type_params: type_params.as_ref().map(Into::into),
             }),
-            ast::Stmt::Return(ast::StmtReturn {
-                value,
-                range: _range,
-            }) => Self::Return(StmtReturn {
+            ast::Stmt::Return(ast::StmtReturn { value, range: _ }) => Self::Return(StmtReturn {
                 value: value.as_ref().map(Into::into),
             }),
-            ast::Stmt::Delete(ast::StmtDelete {
-                targets,
-                range: _range,
-            }) => Self::Delete(StmtDelete {
+            ast::Stmt::Delete(ast::StmtDelete { targets, range: _ }) => Self::Delete(StmtDelete {
                 targets: targets.iter().map(Into::into).collect(),
             }),
             ast::Stmt::TypeAlias(ast::StmtTypeAlias {
-                range: _range,
+                range: _,
                 name,
                 type_params,
                 value,
@@ -1313,7 +1292,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
             ast::Stmt::Assign(ast::StmtAssign {
                 targets,
                 value,
-                range: _range,
+                range: _,
             }) => Self::Assign(StmtAssign {
                 targets: targets.iter().map(Into::into).collect(),
                 value: value.into(),
@@ -1322,7 +1301,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 target,
                 op,
                 value,
-                range: _range,
+                range: _,
             }) => Self::AugAssign(StmtAugAssign {
                 target: target.into(),
                 op: (*op).into(),
@@ -1333,7 +1312,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 annotation,
                 value,
                 simple,
-                range: _range,
+                range: _,
             }) => Self::AnnAssign(StmtAnnAssign {
                 target: target.into(),
                 annotation: annotation.into(),
@@ -1345,7 +1324,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 iter,
                 body,
                 orelse,
-                range: _range,
+                range: _,
             }) => Self::For(StmtFor {
                 target: target.into(),
                 iter: iter.into(),
@@ -1357,7 +1336,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 iter,
                 body,
                 orelse,
-                range: _range,
+                range: _,
             }) => Self::AsyncFor(StmtAsyncFor {
                 target: target.into(),
                 iter: iter.into(),
@@ -1368,7 +1347,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 test,
                 body,
                 orelse,
-                range: _range,
+                range: _,
             }) => Self::While(StmtWhile {
                 test: test.into(),
                 body: body.iter().map(Into::into).collect(),
@@ -1378,7 +1357,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 test,
                 body,
                 elif_else_clauses,
-                range: _range,
+                range: _,
             }) => Self::If(StmtIf {
                 test: test.into(),
                 body: body.iter().map(Into::into).collect(),
@@ -1387,7 +1366,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
             ast::Stmt::With(ast::StmtWith {
                 items,
                 body,
-                range: _range,
+                range: _,
             }) => Self::With(StmtWith {
                 items: items.iter().map(Into::into).collect(),
                 body: body.iter().map(Into::into).collect(),
@@ -1395,7 +1374,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
             ast::Stmt::AsyncWith(ast::StmtAsyncWith {
                 items,
                 body,
-                range: _range,
+                range: _,
             }) => Self::AsyncWith(StmtAsyncWith {
                 items: items.iter().map(Into::into).collect(),
                 body: body.iter().map(Into::into).collect(),
@@ -1403,7 +1382,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
             ast::Stmt::Match(ast::StmtMatch {
                 subject,
                 cases,
-                range: _range,
+                range: _,
             }) => Self::Match(StmtMatch {
                 subject: subject.into(),
                 cases: cases.iter().map(Into::into).collect(),
@@ -1411,7 +1390,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
             ast::Stmt::Raise(ast::StmtRaise {
                 exc,
                 cause,
-                range: _range,
+                range: _,
             }) => Self::Raise(StmtRaise {
                 exc: exc.as_ref().map(Into::into),
                 cause: cause.as_ref().map(Into::into),
@@ -1421,7 +1400,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 handlers,
                 orelse,
                 finalbody,
-                range: _range,
+                range: _,
             }) => Self::Try(StmtTry {
                 body: body.iter().map(Into::into).collect(),
                 handlers: handlers.iter().map(Into::into).collect(),
@@ -1433,7 +1412,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 handlers,
                 orelse,
                 finalbody,
-                range: _range,
+                range: _,
             }) => Self::TryStar(StmtTryStar {
                 body: body.iter().map(Into::into).collect(),
                 handlers: handlers.iter().map(Into::into).collect(),
@@ -1443,51 +1422,41 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
             ast::Stmt::Assert(ast::StmtAssert {
                 test,
                 msg,
-                range: _range,
+                range: _,
             }) => Self::Assert(StmtAssert {
                 test: test.into(),
                 msg: msg.as_ref().map(Into::into),
             }),
-            ast::Stmt::Import(ast::StmtImport {
-                names,
-                range: _range,
-            }) => Self::Import(StmtImport {
+            ast::Stmt::Import(ast::StmtImport { names, range: _ }) => Self::Import(StmtImport {
                 names: names.iter().map(Into::into).collect(),
             }),
             ast::Stmt::ImportFrom(ast::StmtImportFrom {
                 module,
                 names,
                 level,
-                range: _range,
+                range: _,
             }) => Self::ImportFrom(StmtImportFrom {
                 module: module.as_deref(),
                 names: names.iter().map(Into::into).collect(),
                 level: *level,
             }),
-            ast::Stmt::Global(ast::StmtGlobal {
-                names,
-                range: _range,
-            }) => Self::Global(StmtGlobal {
+            ast::Stmt::Global(ast::StmtGlobal { names, range: _ }) => Self::Global(StmtGlobal {
                 names: names.iter().map(ast::Identifier::as_str).collect(),
             }),
-            ast::Stmt::Nonlocal(ast::StmtNonlocal {
-                names,
-                range: _range,
-            }) => Self::Nonlocal(StmtNonlocal {
-                names: names.iter().map(ast::Identifier::as_str).collect(),
-            }),
+            ast::Stmt::Nonlocal(ast::StmtNonlocal { names, range: _ }) => {
+                Self::Nonlocal(StmtNonlocal {
+                    names: names.iter().map(ast::Identifier::as_str).collect(),
+                })
+            }
             ast::Stmt::LineMagic(ast::StmtLineMagic {
                 kind,
                 value,
-                range: _range,
+                range: _,
             }) => Self::LineMagic(StmtLineMagic {
                 kind: *kind,
                 value: value.as_str(),
             }),
-            ast::Stmt::Expr(ast::StmtExpr {
-                value,
-                range: _range,
-            }) => Self::Expr(StmtExpr {
+            ast::Stmt::Expr(ast::StmtExpr { value, range: _ }) => Self::Expr(StmtExpr {
                 value: value.into(),
             }),
             ast::Stmt::Pass(_) => Self::Pass,

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -52,7 +52,7 @@ where
         if let Expr::Call(ast::ExprCall {
             func,
             arguments: Arguments { args, keywords, .. },
-            range: _range,
+            range: _,
         }) = expr
         {
             // Ex) `list()`
@@ -126,18 +126,15 @@ where
     }
     match expr {
         Expr::BoolOp(ast::ExprBoolOp {
-            values,
-            range: _range,
-            ..
+            values, range: _, ..
         })
-        | Expr::JoinedStr(ast::ExprJoinedStr {
-            values,
-            range: _range,
-        }) => values.iter().any(|expr| any_over_expr(expr, func)),
+        | Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
+            values.iter().any(|expr| any_over_expr(expr, func))
+        }
         Expr::NamedExpr(ast::ExprNamedExpr {
             target,
             value,
-            range: _range,
+            range: _,
         }) => any_over_expr(target, func) || any_over_expr(value, func),
         Expr::BinOp(ast::ExprBinOp { left, right, .. }) => {
             any_over_expr(left, func) || any_over_expr(right, func)
@@ -148,44 +145,35 @@ where
             test,
             body,
             orelse,
-            range: _range,
+            range: _,
         }) => any_over_expr(test, func) || any_over_expr(body, func) || any_over_expr(orelse, func),
         Expr::Dict(ast::ExprDict {
             keys,
             values,
-            range: _range,
+            range: _,
         }) => values
             .iter()
             .chain(keys.iter().flatten())
             .any(|expr| any_over_expr(expr, func)),
-        Expr::Set(ast::ExprSet {
-            elts,
-            range: _range,
-        })
-        | Expr::List(ast::ExprList {
-            elts,
-            range: _range,
-            ..
-        })
-        | Expr::Tuple(ast::ExprTuple {
-            elts,
-            range: _range,
-            ..
-        }) => elts.iter().any(|expr| any_over_expr(expr, func)),
+        Expr::Set(ast::ExprSet { elts, range: _ })
+        | Expr::List(ast::ExprList { elts, range: _, .. })
+        | Expr::Tuple(ast::ExprTuple { elts, range: _, .. }) => {
+            elts.iter().any(|expr| any_over_expr(expr, func))
+        }
         Expr::ListComp(ast::ExprListComp {
             elt,
             generators,
-            range: _range,
+            range: _,
         })
         | Expr::SetComp(ast::ExprSetComp {
             elt,
             generators,
-            range: _range,
+            range: _,
         })
         | Expr::GeneratorExp(ast::ExprGeneratorExp {
             elt,
             generators,
-            range: _range,
+            range: _,
         }) => {
             any_over_expr(elt, func)
                 || generators.iter().any(|generator| {
@@ -198,7 +186,7 @@ where
             key,
             value,
             generators,
-            range: _range,
+            range: _,
         }) => {
             any_over_expr(key, func)
                 || any_over_expr(value, func)
@@ -208,28 +196,15 @@ where
                         || generator.ifs.iter().any(|expr| any_over_expr(expr, func))
                 })
         }
-        Expr::Await(ast::ExprAwait {
-            value,
-            range: _range,
-        })
-        | Expr::YieldFrom(ast::ExprYieldFrom {
-            value,
-            range: _range,
-        })
+        Expr::Await(ast::ExprAwait { value, range: _ })
+        | Expr::YieldFrom(ast::ExprYieldFrom { value, range: _ })
         | Expr::Attribute(ast::ExprAttribute {
-            value,
-            range: _range,
-            ..
+            value, range: _, ..
         })
         | Expr::Starred(ast::ExprStarred {
-            value,
-            range: _range,
-            ..
+            value, range: _, ..
         }) => any_over_expr(value, func),
-        Expr::Yield(ast::ExprYield {
-            value,
-            range: _range,
-        }) => value
+        Expr::Yield(ast::ExprYield { value, range: _ }) => value
             .as_ref()
             .is_some_and(|value| any_over_expr(value, func)),
         Expr::Compare(ast::ExprCompare {
@@ -238,7 +213,7 @@ where
         Expr::Call(ast::ExprCall {
             func: call_func,
             arguments: Arguments { args, keywords, .. },
-            range: _range,
+            range: _,
         }) => {
             any_over_expr(call_func, func)
                 || args.iter().any(|expr| any_over_expr(expr, func))
@@ -261,7 +236,7 @@ where
             lower,
             upper,
             step,
-            range: _range,
+            range: _,
         }) => {
             lower
                 .as_ref()
@@ -296,15 +271,11 @@ where
     F: Fn(&Expr) -> bool,
 {
     match pattern {
-        Pattern::MatchValue(ast::PatternMatchValue {
-            value,
-            range: _range,
-        }) => any_over_expr(value, func),
+        Pattern::MatchValue(ast::PatternMatchValue { value, range: _ }) => {
+            any_over_expr(value, func)
+        }
         Pattern::MatchSingleton(_) => false,
-        Pattern::MatchSequence(ast::PatternMatchSequence {
-            patterns,
-            range: _range,
-        }) => patterns
+        Pattern::MatchSequence(ast::PatternMatchSequence { patterns, range: _ }) => patterns
             .iter()
             .any(|pattern| any_over_pattern(pattern, func)),
         Pattern::MatchMapping(ast::PatternMatchMapping { keys, patterns, .. }) => {
@@ -331,10 +302,7 @@ where
         Pattern::MatchAs(ast::PatternMatchAs { pattern, .. }) => pattern
             .as_ref()
             .is_some_and(|pattern| any_over_pattern(pattern, func)),
-        Pattern::MatchOr(ast::PatternMatchOr {
-            patterns,
-            range: _range,
-        }) => patterns
+        Pattern::MatchOr(ast::PatternMatchOr { patterns, range: _ }) => patterns
             .iter()
             .any(|pattern| any_over_pattern(pattern, func)),
     }
@@ -426,16 +394,12 @@ where
                     .iter()
                     .any(|decorator| any_over_expr(&decorator.expression, func))
         }
-        Stmt::Return(ast::StmtReturn {
-            value,
-            range: _range,
-        }) => value
+        Stmt::Return(ast::StmtReturn { value, range: _ }) => value
             .as_ref()
             .is_some_and(|value| any_over_expr(value, func)),
-        Stmt::Delete(ast::StmtDelete {
-            targets,
-            range: _range,
-        }) => targets.iter().any(|expr| any_over_expr(expr, func)),
+        Stmt::Delete(ast::StmtDelete { targets, range: _ }) => {
+            targets.iter().any(|expr| any_over_expr(expr, func))
+        }
         Stmt::TypeAlias(ast::StmtTypeAlias {
             name,
             type_params,
@@ -491,13 +455,13 @@ where
             test,
             body,
             orelse,
-            range: _range,
+            range: _,
         }) => any_over_expr(test, func) || any_over_body(body, func) || any_over_body(orelse, func),
         Stmt::If(ast::StmtIf {
             test,
             body,
             elif_else_clauses,
-            range: _range,
+            range: _,
         }) => {
             any_over_expr(test, func)
                 || any_over_body(body, func)
@@ -522,7 +486,7 @@ where
         Stmt::Raise(ast::StmtRaise {
             exc,
             cause,
-            range: _range,
+            range: _,
         }) => {
             exc.as_ref().is_some_and(|value| any_over_expr(value, func))
                 || cause
@@ -534,14 +498,14 @@ where
             handlers,
             orelse,
             finalbody,
-            range: _range,
+            range: _,
         })
         | Stmt::TryStar(ast::StmtTryStar {
             body,
             handlers,
             orelse,
             finalbody,
-            range: _range,
+            range: _,
         }) => {
             any_over_body(body, func)
                 || handlers.iter().any(|handler| {
@@ -559,7 +523,7 @@ where
         Stmt::Assert(ast::StmtAssert {
             test,
             msg,
-            range: _range,
+            range: _,
         }) => {
             any_over_expr(test, func)
                 || msg.as_ref().is_some_and(|value| any_over_expr(value, func))
@@ -567,7 +531,7 @@ where
         Stmt::Match(ast::StmtMatch {
             subject,
             cases,
-            range: _range,
+            range: _,
         }) => {
             any_over_expr(subject, func)
                 || cases.iter().any(|case| {
@@ -575,7 +539,7 @@ where
                         pattern,
                         guard,
                         body,
-                        range: _range,
+                        range: _,
                     } = case;
                     any_over_pattern(pattern, func)
                         || guard.as_ref().is_some_and(|expr| any_over_expr(expr, func))
@@ -586,10 +550,7 @@ where
         Stmt::ImportFrom(_) => false,
         Stmt::Global(_) => false,
         Stmt::Nonlocal(_) => false,
-        Stmt::Expr(ast::StmtExpr {
-            value,
-            range: _range,
-        }) => any_over_expr(value, func),
+        Stmt::Expr(ast::StmtExpr { value, range: _ }) => any_over_expr(value, func),
         Stmt::Pass(_) | Stmt::Break(_) | Stmt::Continue(_) => false,
         Stmt::LineMagic(_) => false,
     }
@@ -935,7 +896,7 @@ where
             Stmt::Raise(ast::StmtRaise {
                 exc,
                 cause,
-                range: _range,
+                range: _,
             }) => {
                 self.raises
                     .push((stmt.range(), exc.as_deref(), cause.as_deref()));
@@ -974,11 +935,7 @@ where
 
 /// Return `true` if a `Stmt` is a docstring.
 pub fn is_docstring_stmt(stmt: &Stmt) -> bool {
-    if let Stmt::Expr(ast::StmtExpr {
-        value,
-        range: _range,
-    }) = stmt
-    {
+    if let Stmt::Expr(ast::StmtExpr { value, range: _ }) = stmt {
         matches!(
             value.as_ref(),
             Expr::Constant(ast::ExprConstant {
@@ -997,11 +954,7 @@ pub fn on_conditional_branch<'a>(parents: &mut impl Iterator<Item = &'a Stmt>) -
         if matches!(parent, Stmt::If(_) | Stmt::While(_) | Stmt::Match(_)) {
             return true;
         }
-        if let Stmt::Expr(ast::StmtExpr {
-            value,
-            range: _range,
-        }) = parent
-        {
+        if let Stmt::Expr(ast::StmtExpr { value, range: _ }) = parent {
             if value.is_if_exp_expr() {
                 return true;
             }
@@ -1126,10 +1079,7 @@ impl Truthiness {
                 Constant::Complex { real, imag } => Some(*real != 0.0 || *imag != 0.0),
                 Constant::Ellipsis => Some(true),
             },
-            Expr::JoinedStr(ast::ExprJoinedStr {
-                values,
-                range: _range,
-            }) => {
+            Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
                 if values.is_empty() {
                     Some(false)
                 } else if values.iter().any(|value| {

--- a/crates/ruff_python_ast/src/statement_visitor.rs
+++ b/crates/ruff_python_ast/src/statement_visitor.rs
@@ -76,7 +76,7 @@ pub fn walk_stmt<'a, V: StatementVisitor<'a> + ?Sized>(visitor: &mut V, stmt: &'
             handlers,
             orelse,
             finalbody,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_body(body);
             for except_handler in handlers {
@@ -90,7 +90,7 @@ pub fn walk_stmt<'a, V: StatementVisitor<'a> + ?Sized>(visitor: &mut V, stmt: &'
             handlers,
             orelse,
             finalbody,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_body(body);
             for except_handler in handlers {

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -166,24 +166,18 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
             }
             visitor.visit_body(body);
         }
-        Stmt::Return(ast::StmtReturn {
-            value,
-            range: _range,
-        }) => {
+        Stmt::Return(ast::StmtReturn { value, range: _ }) => {
             if let Some(expr) = value {
                 visitor.visit_expr(expr);
             }
         }
-        Stmt::Delete(ast::StmtDelete {
-            targets,
-            range: _range,
-        }) => {
+        Stmt::Delete(ast::StmtDelete { targets, range: _ }) => {
             for expr in targets {
                 visitor.visit_expr(expr);
             }
         }
         Stmt::TypeAlias(ast::StmtTypeAlias {
-            range: _range,
+            range: _,
             name,
             type_params,
             value,
@@ -204,7 +198,7 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
             target,
             op,
             value,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(value);
             visitor.visit_operator(op);
@@ -250,7 +244,7 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
             test,
             body,
             orelse,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(test);
             visitor.visit_body(body);
@@ -260,7 +254,7 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
             test,
             body,
             elif_else_clauses,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(test);
             visitor.visit_body(body);
@@ -286,7 +280,7 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
         Stmt::Match(ast::StmtMatch {
             subject,
             cases,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(subject);
             for match_case in cases {
@@ -296,7 +290,7 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
         Stmt::Raise(ast::StmtRaise {
             exc,
             cause,
-            range: _range,
+            range: _,
         }) => {
             if let Some(expr) = exc {
                 visitor.visit_expr(expr);
@@ -310,7 +304,7 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
             handlers,
             orelse,
             finalbody,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_body(body);
             for except_handler in handlers {
@@ -324,7 +318,7 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
             handlers,
             orelse,
             finalbody,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_body(body);
             for except_handler in handlers {
@@ -336,17 +330,14 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
         Stmt::Assert(ast::StmtAssert {
             test,
             msg,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(test);
             if let Some(expr) = msg {
                 visitor.visit_expr(expr);
             }
         }
-        Stmt::Import(ast::StmtImport {
-            names,
-            range: _range,
-        }) => {
+        Stmt::Import(ast::StmtImport { names, range: _ }) => {
             for alias in names {
                 visitor.visit_alias(alias);
             }
@@ -358,10 +349,7 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
         }
         Stmt::Global(_) => {}
         Stmt::Nonlocal(_) => {}
-        Stmt::Expr(ast::StmtExpr {
-            value,
-            range: _range,
-        }) => visitor.visit_expr(value),
+        Stmt::Expr(ast::StmtExpr { value, range: _ }) => visitor.visit_expr(value),
         Stmt::Pass(_) | Stmt::Break(_) | Stmt::Continue(_) | Stmt::LineMagic(_) => {}
     }
 }
@@ -379,7 +367,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
         Expr::BoolOp(ast::ExprBoolOp {
             op,
             values,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_bool_op(op);
             for expr in values {
@@ -389,7 +377,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
         Expr::NamedExpr(ast::ExprNamedExpr {
             target,
             value,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(value);
             visitor.visit_expr(target);
@@ -398,7 +386,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
             left,
             op,
             right,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(left);
             visitor.visit_operator(op);
@@ -407,7 +395,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
         Expr::UnaryOp(ast::ExprUnaryOp {
             op,
             operand,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_unary_op(op);
             visitor.visit_expr(operand);
@@ -415,7 +403,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
         Expr::Lambda(ast::ExprLambda {
             parameters,
             body,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_parameters(parameters);
             visitor.visit_expr(body);
@@ -424,7 +412,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
             test,
             body,
             orelse,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(test);
             visitor.visit_expr(body);
@@ -433,7 +421,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
         Expr::Dict(ast::ExprDict {
             keys,
             values,
-            range: _range,
+            range: _,
         }) => {
             for expr in keys.iter().flatten() {
                 visitor.visit_expr(expr);
@@ -442,10 +430,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
                 visitor.visit_expr(expr);
             }
         }
-        Expr::Set(ast::ExprSet {
-            elts,
-            range: _range,
-        }) => {
+        Expr::Set(ast::ExprSet { elts, range: _ }) => {
             for expr in elts {
                 visitor.visit_expr(expr);
             }
@@ -453,7 +438,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
         Expr::ListComp(ast::ExprListComp {
             elt,
             generators,
-            range: _range,
+            range: _,
         }) => {
             for comprehension in generators {
                 visitor.visit_comprehension(comprehension);
@@ -463,7 +448,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
         Expr::SetComp(ast::ExprSetComp {
             elt,
             generators,
-            range: _range,
+            range: _,
         }) => {
             for comprehension in generators {
                 visitor.visit_comprehension(comprehension);
@@ -474,7 +459,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
             key,
             value,
             generators,
-            range: _range,
+            range: _,
         }) => {
             for comprehension in generators {
                 visitor.visit_comprehension(comprehension);
@@ -485,34 +470,25 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
         Expr::GeneratorExp(ast::ExprGeneratorExp {
             elt,
             generators,
-            range: _range,
+            range: _,
         }) => {
             for comprehension in generators {
                 visitor.visit_comprehension(comprehension);
             }
             visitor.visit_expr(elt);
         }
-        Expr::Await(ast::ExprAwait {
-            value,
-            range: _range,
-        }) => visitor.visit_expr(value),
-        Expr::Yield(ast::ExprYield {
-            value,
-            range: _range,
-        }) => {
+        Expr::Await(ast::ExprAwait { value, range: _ }) => visitor.visit_expr(value),
+        Expr::Yield(ast::ExprYield { value, range: _ }) => {
             if let Some(expr) = value {
                 visitor.visit_expr(expr);
             }
         }
-        Expr::YieldFrom(ast::ExprYieldFrom {
-            value,
-            range: _range,
-        }) => visitor.visit_expr(value),
+        Expr::YieldFrom(ast::ExprYieldFrom { value, range: _ }) => visitor.visit_expr(value),
         Expr::Compare(ast::ExprCompare {
             left,
             ops,
             comparators,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(left);
             for cmp_op in ops {
@@ -525,7 +501,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
         Expr::Call(ast::ExprCall {
             func,
             arguments,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(func);
             visitor.visit_arguments(arguments);
@@ -538,10 +514,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
                 visitor.visit_format_spec(expr);
             }
         }
-        Expr::JoinedStr(ast::ExprJoinedStr {
-            values,
-            range: _range,
-        }) => {
+        Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
             for expr in values {
                 visitor.visit_expr(expr);
             }
@@ -555,7 +528,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
             value,
             slice,
             ctx,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(value);
             visitor.visit_expr(slice);
@@ -564,7 +537,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
         Expr::Starred(ast::ExprStarred {
             value,
             ctx,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(value);
             visitor.visit_expr_context(ctx);
@@ -575,7 +548,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
         Expr::List(ast::ExprList {
             elts,
             ctx,
-            range: _range,
+            range: _,
         }) => {
             for expr in elts {
                 visitor.visit_expr(expr);
@@ -585,7 +558,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
         Expr::Tuple(ast::ExprTuple {
             elts,
             ctx,
-            range: _range,
+            range: _,
         }) => {
             for expr in elts {
                 visitor.visit_expr(expr);
@@ -596,7 +569,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
             lower,
             upper,
             step,
-            range: _range,
+            range: _,
         }) => {
             if let Some(expr) = lower {
                 visitor.visit_expr(expr);
@@ -733,15 +706,11 @@ pub fn walk_match_case<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, match_case:
 
 pub fn walk_pattern<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, pattern: &'a Pattern) {
     match pattern {
-        Pattern::MatchValue(ast::PatternMatchValue {
-            value,
-            range: _range,
-        }) => visitor.visit_expr(value),
+        Pattern::MatchValue(ast::PatternMatchValue { value, .. }) => {
+            visitor.visit_expr(value);
+        }
         Pattern::MatchSingleton(_) => {}
-        Pattern::MatchSequence(ast::PatternMatchSequence {
-            patterns,
-            range: _range,
-        }) => {
+        Pattern::MatchSequence(ast::PatternMatchSequence { patterns, .. }) => {
             for pattern in patterns {
                 visitor.visit_pattern(pattern);
             }
@@ -775,10 +744,7 @@ pub fn walk_pattern<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, pattern: &'a P
                 visitor.visit_pattern(pattern);
             }
         }
-        Pattern::MatchOr(ast::PatternMatchOr {
-            patterns,
-            range: _range,
-        }) => {
+        Pattern::MatchOr(ast::PatternMatchOr { patterns, .. }) => {
             for pattern in patterns {
                 visitor.visit_pattern(pattern);
             }

--- a/crates/ruff_python_ast/src/visitor/preorder.rs
+++ b/crates/ruff_python_ast/src/visitor/preorder.rs
@@ -136,10 +136,7 @@ where
     V: PreorderVisitor<'a> + ?Sized,
 {
     match stmt {
-        Stmt::Expr(ast::StmtExpr {
-            value,
-            range: _range,
-        }) => visitor.visit_expr(value),
+        Stmt::Expr(ast::StmtExpr { value, range: _ }) => visitor.visit_expr(value),
 
         Stmt::FunctionDef(ast::StmtFunctionDef {
             parameters,
@@ -196,26 +193,20 @@ where
             visitor.visit_body(body);
         }
 
-        Stmt::Return(ast::StmtReturn {
-            value,
-            range: _range,
-        }) => {
+        Stmt::Return(ast::StmtReturn { value, range: _ }) => {
             if let Some(expr) = value {
                 visitor.visit_expr(expr);
             }
         }
 
-        Stmt::Delete(ast::StmtDelete {
-            targets,
-            range: _range,
-        }) => {
+        Stmt::Delete(ast::StmtDelete { targets, range: _ }) => {
             for expr in targets {
                 visitor.visit_expr(expr);
             }
         }
 
         Stmt::TypeAlias(ast::StmtTypeAlias {
-            range: _range,
+            range: _,
             name,
             type_params,
             value,
@@ -243,7 +234,7 @@ where
             target,
             op,
             value,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(target);
             visitor.visit_operator(op);
@@ -288,7 +279,7 @@ where
             test,
             body,
             orelse,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(test);
             visitor.visit_body(body);
@@ -299,7 +290,7 @@ where
             test,
             body,
             elif_else_clauses,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(test);
             visitor.visit_body(body);
@@ -327,7 +318,7 @@ where
         Stmt::Match(ast::StmtMatch {
             subject,
             cases,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(subject);
             for match_case in cases {
@@ -338,7 +329,7 @@ where
         Stmt::Raise(ast::StmtRaise {
             exc,
             cause,
-            range: _range,
+            range: _,
         }) => {
             if let Some(expr) = exc {
                 visitor.visit_expr(expr);
@@ -353,14 +344,14 @@ where
             handlers,
             orelse,
             finalbody,
-            range: _range,
+            range: _,
         })
         | Stmt::TryStar(ast::StmtTryStar {
             body,
             handlers,
             orelse,
             finalbody,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_body(body);
             for except_handler in handlers {
@@ -373,7 +364,7 @@ where
         Stmt::Assert(ast::StmtAssert {
             test,
             msg,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(test);
             if let Some(expr) = msg {
@@ -381,10 +372,7 @@ where
             }
         }
 
-        Stmt::Import(ast::StmtImport {
-            names,
-            range: _range,
-        }) => {
+        Stmt::Import(ast::StmtImport { names, range: _ }) => {
             for alias in names {
                 visitor.visit_alias(alias);
             }
@@ -429,7 +417,7 @@ where
         Expr::BoolOp(ast::ExprBoolOp {
             op,
             values,
-            range: _range,
+            range: _,
         }) => match values.as_slice() {
             [left, rest @ ..] => {
                 visitor.visit_expr(left);
@@ -446,7 +434,7 @@ where
         Expr::NamedExpr(ast::ExprNamedExpr {
             target,
             value,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(target);
             visitor.visit_expr(value);
@@ -456,7 +444,7 @@ where
             left,
             op,
             right,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(left);
             visitor.visit_operator(op);
@@ -466,7 +454,7 @@ where
         Expr::UnaryOp(ast::ExprUnaryOp {
             op,
             operand,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_unary_op(op);
             visitor.visit_expr(operand);
@@ -475,7 +463,7 @@ where
         Expr::Lambda(ast::ExprLambda {
             parameters,
             body,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_parameters(parameters);
             visitor.visit_expr(body);
@@ -485,7 +473,7 @@ where
             test,
             body,
             orelse,
-            range: _range,
+            range: _,
         }) => {
             // `body if test else orelse`
             visitor.visit_expr(body);
@@ -496,7 +484,7 @@ where
         Expr::Dict(ast::ExprDict {
             keys,
             values,
-            range: _range,
+            range: _,
         }) => {
             for (key, value) in keys.iter().zip(values) {
                 if let Some(key) = key {
@@ -506,10 +494,7 @@ where
             }
         }
 
-        Expr::Set(ast::ExprSet {
-            elts,
-            range: _range,
-        }) => {
+        Expr::Set(ast::ExprSet { elts, range: _ }) => {
             for expr in elts {
                 visitor.visit_expr(expr);
             }
@@ -518,7 +503,7 @@ where
         Expr::ListComp(ast::ExprListComp {
             elt,
             generators,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(elt);
             for comprehension in generators {
@@ -529,7 +514,7 @@ where
         Expr::SetComp(ast::ExprSetComp {
             elt,
             generators,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(elt);
             for comprehension in generators {
@@ -541,7 +526,7 @@ where
             key,
             value,
             generators,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(key);
             visitor.visit_expr(value);
@@ -554,7 +539,7 @@ where
         Expr::GeneratorExp(ast::ExprGeneratorExp {
             elt,
             generators,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(elt);
             for comprehension in generators {
@@ -562,19 +547,10 @@ where
             }
         }
 
-        Expr::Await(ast::ExprAwait {
-            value,
-            range: _range,
-        })
-        | Expr::YieldFrom(ast::ExprYieldFrom {
-            value,
-            range: _range,
-        }) => visitor.visit_expr(value),
+        Expr::Await(ast::ExprAwait { value, range: _ })
+        | Expr::YieldFrom(ast::ExprYieldFrom { value, range: _ }) => visitor.visit_expr(value),
 
-        Expr::Yield(ast::ExprYield {
-            value,
-            range: _range,
-        }) => {
+        Expr::Yield(ast::ExprYield { value, range: _ }) => {
             if let Some(expr) = value {
                 visitor.visit_expr(expr);
             }
@@ -584,7 +560,7 @@ where
             left,
             ops,
             comparators,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(left);
 
@@ -597,7 +573,7 @@ where
         Expr::Call(ast::ExprCall {
             func,
             arguments,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(func);
             visitor.visit_arguments(arguments);
@@ -613,10 +589,7 @@ where
             }
         }
 
-        Expr::JoinedStr(ast::ExprJoinedStr {
-            values,
-            range: _range,
-        }) => {
+        Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
             for expr in values {
                 visitor.visit_expr(expr);
             }
@@ -641,7 +614,7 @@ where
             value,
             slice,
             ctx: _,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(value);
             visitor.visit_expr(slice);
@@ -649,7 +622,7 @@ where
         Expr::Starred(ast::ExprStarred {
             value,
             ctx: _,
-            range: _range,
+            range: _,
         }) => {
             visitor.visit_expr(value);
         }
@@ -663,7 +636,7 @@ where
         Expr::List(ast::ExprList {
             elts,
             ctx: _,
-            range: _range,
+            range: _,
         }) => {
             for expr in elts {
                 visitor.visit_expr(expr);
@@ -672,7 +645,7 @@ where
         Expr::Tuple(ast::ExprTuple {
             elts,
             ctx: _,
-            range: _range,
+            range: _,
         }) => {
             for expr in elts {
                 visitor.visit_expr(expr);
@@ -683,7 +656,7 @@ where
             lower,
             upper,
             step,
-            range: _range,
+            range: _,
         }) => {
             if let Some(expr) = lower {
                 visitor.visit_expr(expr);
@@ -864,22 +837,15 @@ where
     V: PreorderVisitor<'a> + ?Sized,
 {
     match pattern {
-        Pattern::MatchValue(ast::PatternMatchValue {
-            value,
-            range: _range,
-        }) => visitor.visit_expr(value),
+        Pattern::MatchValue(ast::PatternMatchValue { value, range: _ }) => {
+            visitor.visit_expr(value);
+        }
 
-        Pattern::MatchSingleton(ast::PatternMatchSingleton {
-            value,
-            range: _range,
-        }) => {
+        Pattern::MatchSingleton(ast::PatternMatchSingleton { value, range: _ }) => {
             visitor.visit_constant(value);
         }
 
-        Pattern::MatchSequence(ast::PatternMatchSequence {
-            patterns,
-            range: _range,
-        }) => {
+        Pattern::MatchSequence(ast::PatternMatchSequence { patterns, range: _ }) => {
             for pattern in patterns {
                 visitor.visit_pattern(pattern);
             }
@@ -926,10 +892,7 @@ where
             }
         }
 
-        Pattern::MatchOr(ast::PatternMatchOr {
-            patterns,
-            range: _range,
-        }) => {
+        Pattern::MatchOr(ast::PatternMatchOr { patterns, range: _ }) => {
             for pattern in patterns {
                 visitor.visit_pattern(pattern);
             }

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -322,10 +322,7 @@ impl<'a> Generator<'a> {
                     self.newlines(2);
                 }
             }
-            Stmt::Return(ast::StmtReturn {
-                value,
-                range: _range,
-            }) => {
+            Stmt::Return(ast::StmtReturn { value, range: _ }) => {
                 statement!({
                     if let Some(expr) = value {
                         self.p("return ");
@@ -335,10 +332,7 @@ impl<'a> Generator<'a> {
                     }
                 });
             }
-            Stmt::Delete(ast::StmtDelete {
-                targets,
-                range: _range,
-            }) => {
+            Stmt::Delete(ast::StmtDelete { targets, range: _ }) => {
                 statement!({
                     self.p("del ");
                     let mut first = true;
@@ -361,7 +355,7 @@ impl<'a> Generator<'a> {
                 target,
                 op,
                 value,
-                range: _range,
+                range: _,
             }) => {
                 statement!({
                     self.unparse_expr(target, precedence::AUG_ASSIGN);
@@ -390,7 +384,7 @@ impl<'a> Generator<'a> {
                 annotation,
                 value,
                 simple,
-                range: _range,
+                range: _,
             }) => {
                 statement!({
                     let need_parens = matches!(target.as_ref(), Expr::Name(_)) && !simple;
@@ -453,7 +447,7 @@ impl<'a> Generator<'a> {
                 test,
                 body,
                 orelse,
-                range: _range,
+                range: _,
             }) => {
                 statement!({
                     self.p("while ");
@@ -472,7 +466,7 @@ impl<'a> Generator<'a> {
                 test,
                 body,
                 elif_else_clauses,
-                range: _range,
+                range: _,
             }) => {
                 statement!({
                     self.p("if ");
@@ -523,7 +517,7 @@ impl<'a> Generator<'a> {
             Stmt::Match(ast::StmtMatch {
                 subject,
                 cases,
-                range: _range,
+                range: _,
             }) => {
                 statement!({
                     self.p("match ");
@@ -540,7 +534,7 @@ impl<'a> Generator<'a> {
             }
             Stmt::TypeAlias(ast::StmtTypeAlias {
                 name,
-                range: _range,
+                range: _,
                 type_params,
                 value,
             }) => {
@@ -555,7 +549,7 @@ impl<'a> Generator<'a> {
             Stmt::Raise(ast::StmtRaise {
                 exc,
                 cause,
-                range: _range,
+                range: _,
             }) => {
                 statement!({
                     self.p("raise");
@@ -574,7 +568,7 @@ impl<'a> Generator<'a> {
                 handlers,
                 orelse,
                 finalbody,
-                range: _range,
+                range: _,
             }) => {
                 statement!({
                     self.p("try:");
@@ -605,7 +599,7 @@ impl<'a> Generator<'a> {
                 handlers,
                 orelse,
                 finalbody,
-                range: _range,
+                range: _,
             }) => {
                 statement!({
                     self.p("try:");
@@ -634,7 +628,7 @@ impl<'a> Generator<'a> {
             Stmt::Assert(ast::StmtAssert {
                 test,
                 msg,
-                range: _range,
+                range: _,
             }) => {
                 statement!({
                     self.p("assert ");
@@ -645,10 +639,7 @@ impl<'a> Generator<'a> {
                     }
                 });
             }
-            Stmt::Import(ast::StmtImport {
-                names,
-                range: _range,
-            }) => {
+            Stmt::Import(ast::StmtImport { names, range: _ }) => {
                 statement!({
                     self.p("import ");
                     let mut first = true;
@@ -662,7 +653,7 @@ impl<'a> Generator<'a> {
                 module,
                 names,
                 level,
-                range: _range,
+                range: _,
             }) => {
                 statement!({
                     self.p("from ");
@@ -680,10 +671,7 @@ impl<'a> Generator<'a> {
                     }
                 });
             }
-            Stmt::Global(ast::StmtGlobal {
-                names,
-                range: _range,
-            }) => {
+            Stmt::Global(ast::StmtGlobal { names, range: _ }) => {
                 statement!({
                     self.p("global ");
                     let mut first = true;
@@ -693,10 +681,7 @@ impl<'a> Generator<'a> {
                     }
                 });
             }
-            Stmt::Nonlocal(ast::StmtNonlocal {
-                names,
-                range: _range,
-            }) => {
+            Stmt::Nonlocal(ast::StmtNonlocal { names, range: _ }) => {
                 statement!({
                     self.p("nonlocal ");
                     let mut first = true;
@@ -706,10 +691,7 @@ impl<'a> Generator<'a> {
                     }
                 });
             }
-            Stmt::Expr(ast::StmtExpr {
-                value,
-                range: _range,
-            }) => {
+            Stmt::Expr(ast::StmtExpr { value, range: _ }) => {
                 statement!({
                     self.unparse_expr(value, precedence::EXPR);
                 });
@@ -743,7 +725,7 @@ impl<'a> Generator<'a> {
                 type_,
                 name,
                 body,
-                range: _range,
+                range: _,
             }) => {
                 self.p("except");
                 if star {
@@ -765,22 +747,13 @@ impl<'a> Generator<'a> {
 
     fn unparse_pattern(&mut self, ast: &Pattern) {
         match ast {
-            Pattern::MatchValue(ast::PatternMatchValue {
-                value,
-                range: _range,
-            }) => {
+            Pattern::MatchValue(ast::PatternMatchValue { value, range: _ }) => {
                 self.unparse_expr(value, precedence::MAX);
             }
-            Pattern::MatchSingleton(ast::PatternMatchSingleton {
-                value,
-                range: _range,
-            }) => {
+            Pattern::MatchSingleton(ast::PatternMatchSingleton { value, range: _ }) => {
                 self.unparse_constant(value);
             }
-            Pattern::MatchSequence(ast::PatternMatchSequence {
-                patterns,
-                range: _range,
-            }) => {
+            Pattern::MatchSequence(ast::PatternMatchSequence { patterns, range: _ }) => {
                 self.p("[");
                 let mut first = true;
                 for pattern in patterns {
@@ -793,7 +766,7 @@ impl<'a> Generator<'a> {
                 keys,
                 patterns,
                 rest,
-                range: _range,
+                range: _,
             }) => {
                 self.p("{");
                 let mut first = true;
@@ -811,10 +784,7 @@ impl<'a> Generator<'a> {
                 self.p("}");
             }
             Pattern::MatchClass(_) => {}
-            Pattern::MatchStar(ast::PatternMatchStar {
-                name,
-                range: _range,
-            }) => {
+            Pattern::MatchStar(ast::PatternMatchStar { name, range: _ }) => {
                 self.p("*");
                 if let Some(name) = name {
                     self.p_id(name);
@@ -825,7 +795,7 @@ impl<'a> Generator<'a> {
             Pattern::MatchAs(ast::PatternMatchAs {
                 pattern,
                 name,
-                range: _range,
+                range: _,
             }) => {
                 if let Some(pattern) = pattern {
                     self.unparse_pattern(pattern);
@@ -837,10 +807,7 @@ impl<'a> Generator<'a> {
                     self.p("_");
                 }
             }
-            Pattern::MatchOr(ast::PatternMatchOr {
-                patterns,
-                range: _range,
-            }) => {
+            Pattern::MatchOr(ast::PatternMatchOr { patterns, range: _ }) => {
                 let mut first = true;
                 for pattern in patterns {
                     self.p_delim(&mut first, " | ");
@@ -918,7 +885,7 @@ impl<'a> Generator<'a> {
             Expr::BoolOp(ast::ExprBoolOp {
                 op,
                 values,
-                range: _range,
+                range: _,
             }) => {
                 let (op, prec) = opprec!(bin, op, BoolOp, And("and", AND), Or("or", OR));
                 group_if!(prec, {
@@ -932,7 +899,7 @@ impl<'a> Generator<'a> {
             Expr::NamedExpr(ast::ExprNamedExpr {
                 target,
                 value,
-                range: _range,
+                range: _,
             }) => {
                 group_if!(precedence::NAMED_EXPR, {
                     self.unparse_expr(target, precedence::NAMED_EXPR);
@@ -944,7 +911,7 @@ impl<'a> Generator<'a> {
                 left,
                 op,
                 right,
-                range: _range,
+                range: _,
             }) => {
                 let rassoc = matches!(op, Operator::Pow);
                 let (op, prec) = opprec!(
@@ -974,7 +941,7 @@ impl<'a> Generator<'a> {
             Expr::UnaryOp(ast::ExprUnaryOp {
                 op,
                 operand,
-                range: _range,
+                range: _,
             }) => {
                 let (op, prec) = opprec!(
                     un,
@@ -993,7 +960,7 @@ impl<'a> Generator<'a> {
             Expr::Lambda(ast::ExprLambda {
                 parameters,
                 body,
-                range: _range,
+                range: _,
             }) => {
                 group_if!(precedence::LAMBDA, {
                     let npos = parameters.args.len() + parameters.posonlyargs.len();
@@ -1007,7 +974,7 @@ impl<'a> Generator<'a> {
                 test,
                 body,
                 orelse,
-                range: _range,
+                range: _,
             }) => {
                 group_if!(precedence::IF_EXP, {
                     self.unparse_expr(body, precedence::IF_EXP + 1);
@@ -1020,7 +987,7 @@ impl<'a> Generator<'a> {
             Expr::Dict(ast::ExprDict {
                 keys,
                 values,
-                range: _range,
+                range: _,
             }) => {
                 self.p("{");
                 let mut first = true;
@@ -1037,10 +1004,7 @@ impl<'a> Generator<'a> {
                 }
                 self.p("}");
             }
-            Expr::Set(ast::ExprSet {
-                elts,
-                range: _range,
-            }) => {
+            Expr::Set(ast::ExprSet { elts, range: _ }) => {
                 if elts.is_empty() {
                     self.p("set()");
                 } else {
@@ -1056,7 +1020,7 @@ impl<'a> Generator<'a> {
             Expr::ListComp(ast::ExprListComp {
                 elt,
                 generators,
-                range: _range,
+                range: _,
             }) => {
                 self.p("[");
                 self.unparse_expr(elt, precedence::COMPREHENSION_ELEMENT);
@@ -1066,7 +1030,7 @@ impl<'a> Generator<'a> {
             Expr::SetComp(ast::ExprSetComp {
                 elt,
                 generators,
-                range: _range,
+                range: _,
             }) => {
                 self.p("{");
                 self.unparse_expr(elt, precedence::COMPREHENSION_ELEMENT);
@@ -1077,7 +1041,7 @@ impl<'a> Generator<'a> {
                 key,
                 value,
                 generators,
-                range: _range,
+                range: _,
             }) => {
                 self.p("{");
                 self.unparse_expr(key, precedence::COMPREHENSION_ELEMENT);
@@ -1089,26 +1053,20 @@ impl<'a> Generator<'a> {
             Expr::GeneratorExp(ast::ExprGeneratorExp {
                 elt,
                 generators,
-                range: _range,
+                range: _,
             }) => {
                 self.p("(");
                 self.unparse_expr(elt, precedence::COMPREHENSION_ELEMENT);
                 self.unparse_comp(generators);
                 self.p(")");
             }
-            Expr::Await(ast::ExprAwait {
-                value,
-                range: _range,
-            }) => {
+            Expr::Await(ast::ExprAwait { value, range: _ }) => {
                 group_if!(precedence::AWAIT, {
                     self.p("await ");
                     self.unparse_expr(value, precedence::MAX);
                 });
             }
-            Expr::Yield(ast::ExprYield {
-                value,
-                range: _range,
-            }) => {
+            Expr::Yield(ast::ExprYield { value, range: _ }) => {
                 group_if!(precedence::YIELD, {
                     self.p("yield");
                     if let Some(value) = value {
@@ -1117,10 +1075,7 @@ impl<'a> Generator<'a> {
                     }
                 });
             }
-            Expr::YieldFrom(ast::ExprYieldFrom {
-                value,
-                range: _range,
-            }) => {
+            Expr::YieldFrom(ast::ExprYieldFrom { value, range: _ }) => {
                 group_if!(precedence::YIELD_FROM, {
                     self.p("yield from ");
                     self.unparse_expr(value, precedence::MAX);
@@ -1130,7 +1085,7 @@ impl<'a> Generator<'a> {
                 left,
                 ops,
                 comparators,
-                range: _range,
+                range: _,
             }) => {
                 group_if!(precedence::CMP, {
                     let new_lvl = precedence::CMP + 1;
@@ -1156,7 +1111,7 @@ impl<'a> Generator<'a> {
             Expr::Call(ast::ExprCall {
                 func,
                 arguments,
-                range: _range,
+                range: _,
             }) => {
                 self.unparse_expr(func, precedence::MAX);
                 self.p("(");
@@ -1164,7 +1119,7 @@ impl<'a> Generator<'a> {
                     [Expr::GeneratorExp(ast::ExprGeneratorExp {
                         elt,
                         generators,
-                        range: _range,
+                        range: _,
                     })],
                     [],
                 ) = (arguments.args.as_slice(), arguments.keywords.as_slice())
@@ -1197,23 +1152,20 @@ impl<'a> Generator<'a> {
                 debug_text,
                 conversion,
                 format_spec,
-                range: _range,
+                range: _,
             }) => self.unparse_formatted(
                 value,
                 debug_text.as_ref(),
                 *conversion,
                 format_spec.as_deref(),
             ),
-            Expr::JoinedStr(ast::ExprJoinedStr {
-                values,
-                range: _range,
-            }) => {
+            Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
                 self.unparse_joinedstr(values, false);
             }
             Expr::Constant(ast::ExprConstant {
                 value,
                 kind,
-                range: _range,
+                range: _,
             }) => {
                 if let Some(kind) = kind {
                     self.p(kind);
@@ -1273,7 +1225,7 @@ impl<'a> Generator<'a> {
                 lower,
                 upper,
                 step,
-                range: _range,
+                range: _,
             }) => {
                 if let Some(lower) = lower {
                     self.unparse_expr(lower, precedence::SLICE);
@@ -1448,10 +1400,7 @@ impl<'a> Generator<'a> {
                     unreachable!()
                 }
             }
-            Expr::JoinedStr(ast::ExprJoinedStr {
-                values,
-                range: _range,
-            }) => {
+            Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
                 self.unparse_joinedstr(values, is_spec);
             }
             Expr::FormattedValue(ast::ExprFormattedValue {
@@ -1459,7 +1408,7 @@ impl<'a> Generator<'a> {
                 debug_text,
                 conversion,
                 format_spec,
-                range: _range,
+                range: _,
             }) => self.unparse_formatted(
                 value,
                 debug_text.as_ref(),

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -223,7 +223,7 @@ pub fn is_immutable_annotation(expr: &Expr, semantic: &SemanticModel) -> bool {
             left,
             op: Operator::BitOr,
             right,
-            range: _range,
+            range: _,
         }) => is_immutable_annotation(left, semantic) && is_immutable_annotation(right, semantic),
         Expr::Constant(ast::ExprConstant {
             value: Constant::None,


### PR DESCRIPTION
## Summary

`range: _range` is slightly inconvenient because you can't use it multiple times within a single match, unlike `_`.
