### PR TITLE
Make formatter ecosystem check failure output better understandable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -336,7 +336,7 @@ jobs:
       - name: "Formatter progress"
         run: scripts/formatter_ecosystem_checks.sh
       - name: "Github step summary"
-        run: grep "similarity index" target/progress_projects_report.txt | sort > $GITHUB_STEP_SUMMARY
+        run: grep "similarity index" target/progress_projects_log.txt | sort > $GITHUB_STEP_SUMMARY
       # CPython is not black formatted, so we run only the stability check
       - name: "Clone CPython 3.10"
         run: git clone --branch 3.10 --depth 1 https://github.com/python/cpython.git crates/ruff/resources/test/cpython

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,7 @@ jobs:
               - crates/ruff_python_index/**
               - crates/ruff_text_size/**
               - crates/ruff_python_parser/**
+              - crates/ruff_dev/**
 
   cargo-fmt:
     name: "cargo fmt"

--- a/scripts/formatter_ecosystem_checks.sh
+++ b/scripts/formatter_ecosystem_checks.sh
@@ -41,19 +41,24 @@ if [ ! -d "$dir/warehouse" ]; then
   git clone --filter=tree:0 https://github.com/pypi/warehouse "$dir/warehouse"
   git -C "$dir/warehouse" checkout fe6455c0a946e81f61d72edc1049f536d8bba903
 fi
-# django project
+# zulip, a django user
 if [ ! -d "$dir/zulip" ]; then
   git clone --filter=tree:0 https://github.com/zulip/zulip "$dir/zulip"
   git -C "$dir/zulip" checkout 6cb080c4479546a7f5cb017fcddea56605910b48
+fi
+# cpython itself
+if [ ! -d "$dir/cpython" ]; then
+  git clone --filter=tree:0 https://github.com/python/cpython "$dir/cpython"
+  git -C "$dir/cpython" checkout 45de31db9cc9be945702f3a7ca35bbb9f98476af
 fi
 
 # Uncomment if you want to update the hashes
 # for i in "$dir"/*/; do git -C "$i" switch main && git -C "$i" pull && echo "# $(basename "$i") $(git -C "$i" rev-parse HEAD)"; done
 
 time cargo run --bin ruff_dev -- format-dev --stability-check --error-file "$target/progress_projects_errors.txt" \
-  --multi-project "$dir" >"$target/progress_projects_report.txt" || (
+  --log-file "$target/progress_projects_log.txt" --files-with-errors 25 --multi-project "$dir" || (
   echo "Ecosystem check failed"
-  cat "$target/progress_projects_report.txt"
+  cat "$target/progress_projects_log.txt"
   exit 1
 )
-grep "similarity index" "$target/progress_projects_report.txt" | sort
+grep "similarity index" "$target/progress_projects_log.txt" | sort


### PR DESCRIPTION
**Summary** Prompted by https://github.com/astral-sh/ruff/pull/6257#issuecomment-1661308410, it tried to make the ecosystem script output on failure better understandable. All log messages are now written to a file, which is printed on error. Running locally progress is still shown.

Looking through the log output i saw that we currently log syntax errors in input, which is confusing because they aren't actual errors, but we don't check that these files don't change due to parser regressions or improvements. I added `--files-with-errors` to catch that.

**Test Plan** CI