### PR TITLE
Update `UP032` to support `await` expressions

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP032_0.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP032_0.py
@@ -117,6 +117,15 @@ def e():
 
 assert"{}".format(1)
 
+
+async def c():
+    return "{}".format(await 3)
+
+
+async def c():
+    return "{}".format(1 + await 3)
+
+
 ###
 # Non-errors
 ###
@@ -180,13 +189,6 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
         3,
     ]
 )
-
-async def c():
-    return "{}".format(await 3)
-
-
-async def c():
-    return "{}".format(1 + await 3)
 
 (
     "{a}"

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -130,10 +130,7 @@ impl<'a> FormatSummaryValues<'a> {
 /// Return `true` if the string contains characters that are forbidden by
 /// argument identifiers.
 fn contains_invalids(string: &str) -> bool {
-    string.contains('*')
-        || string.contains('\'')
-        || string.contains('"')
-        || string.contains("await")
+    string.contains('*') || string.contains('\'') || string.contains('"')
 }
 
 enum FormatContext {

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP032_0.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP032_0.py.snap
@@ -877,8 +877,6 @@ UP032_0.py:118:7: UP032 [*] Use f-string instead of `format` call
     |
 118 | assert"{}".format(1)
     |       ^^^^^^^^^^^^^^ UP032
-119 | 
-120 | ###
     |
     = help: Convert to f-string
 
@@ -889,7 +887,43 @@ UP032_0.py:118:7: UP032 [*] Use f-string instead of `format` call
 118     |-assert"{}".format(1)
     118 |+assert f"{1}"
 119 119 | 
-120 120 | ###
-121 121 | # Non-errors
+120 120 | 
+121 121 | async def c():
+
+UP032_0.py:122:12: UP032 [*] Use f-string instead of `format` call
+    |
+121 | async def c():
+122 |     return "{}".format(await 3)
+    |            ^^^^^^^^^^^^^^^^^^^^ UP032
+    |
+    = help: Convert to f-string
+
+ℹ Suggested fix
+119 119 | 
+120 120 | 
+121 121 | async def c():
+122     |-    return "{}".format(await 3)
+    122 |+    return f"{await 3}"
+123 123 | 
+124 124 | 
+125 125 | async def c():
+
+UP032_0.py:126:12: UP032 [*] Use f-string instead of `format` call
+    |
+125 | async def c():
+126 |     return "{}".format(1 + await 3)
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^ UP032
+    |
+    = help: Convert to f-string
+
+ℹ Suggested fix
+123 123 | 
+124 124 | 
+125 125 | async def c():
+126     |-    return "{}".format(1 + await 3)
+    126 |+    return f"{1 + await 3}"
+127 127 | 
+128 128 | 
+129 129 | ###
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

In Python >= 3.7, `await` can be included in f-strings. 

https://bugs.python.org/issue28942

## Test Plan

<!-- How was it tested? -->

Existing tests
