### PR TITLE
Add `is_` and `is_not` to excluded functions for `FBT003`

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_boolean_trap/FBT.py
+++ b/crates/ruff/resources/test/fixtures/flake8_boolean_trap/FBT.py
@@ -67,7 +67,8 @@ cfg.getboolean("hello", True)
 os.set_blocking(0, False)
 g_action.set_enabled(True)
 settings.set_enable_developer_extras(True)
-
+foo.is_(True)
+bar.is_not(False)
 
 class Registry:
     def __init__(self) -> None:

--- a/crates/ruff/src/rules/flake8_boolean_trap/helpers.rs
+++ b/crates/ruff/src/rules/flake8_boolean_trap/helpers.rs
@@ -28,6 +28,8 @@ pub(super) fn is_allowed_func_call(name: &str) -> bool {
             | "index"
             | "insert"
             | "int"
+            | "is_"
+            | "is_not"
             | "param"
             | "pop"
             | "remove"

--- a/crates/ruff/src/rules/flake8_boolean_trap/snapshots/ruff__rules__flake8_boolean_trap__tests__FBT001_FBT.py.snap
+++ b/crates/ruff/src/rules/flake8_boolean_trap/snapshots/ruff__rules__flake8_boolean_trap__tests__FBT001_FBT.py.snap
@@ -81,12 +81,12 @@ FBT.py:19:5: FBT001 Boolean positional arg in function definition
 21 |     kwonly_nonvalued_nohint,
    |
 
-FBT.py:85:19: FBT001 Boolean positional arg in function definition
+FBT.py:86:19: FBT001 Boolean positional arg in function definition
    |
-84 |     # FBT001: Boolean positional arg in function definition
-85 |     def foo(self, value: bool) -> None:
+85 |     # FBT001: Boolean positional arg in function definition
+86 |     def foo(self, value: bool) -> None:
    |                   ^^^^^^^^^^^ FBT001
-86 |         pass
+87 |         pass
    |
 
 

--- a/crates/ruff/src/rules/flake8_boolean_trap/snapshots/ruff__rules__flake8_boolean_trap__tests__FBT003_FBT.py.snap
+++ b/crates/ruff/src/rules/flake8_boolean_trap/snapshots/ruff__rules__flake8_boolean_trap__tests__FBT003_FBT.py.snap
@@ -34,6 +34,8 @@ FBT.py:69:38: FBT003 Boolean positional value in function call
 68 | g_action.set_enabled(True)
 69 | settings.set_enable_developer_extras(True)
    |                                      ^^^^ FBT003
+70 | foo.is_(True)
+71 | bar.is_not(False)
    |
 
 


### PR DESCRIPTION
These methods are commonly used in SQLAlchemy.

See https://github.com/astral-sh/ruff/discussions/6302
