### PR TITLE
Move `ExprCall`'s `NeedsParentheses` impl into `expr_call.rs`

### DIFF
--- a/crates/ruff_python_formatter/src/expression/expr_call.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_call.rs
@@ -1,6 +1,8 @@
 use ruff_formatter::write;
+use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::ExprCall;
 
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 use crate::FormatNodeRule;
 
@@ -16,5 +18,15 @@ impl FormatNodeRule<ExprCall> for FormatExprCall {
         } = item;
 
         write!(f, [func.format(), arguments.format()])
+    }
+}
+
+impl NeedsParentheses for ExprCall {
+    fn needs_parentheses(
+        &self,
+        _parent: AnyNodeRef,
+        context: &PyFormatContext,
+    ) -> OptionalParentheses {
+        self.func.needs_parentheses(self.into(), context)
     }
 }

--- a/crates/ruff_python_formatter/src/other/arguments.rs
+++ b/crates/ruff_python_formatter/src/other/arguments.rs
@@ -1,15 +1,13 @@
 use ruff_formatter::write;
-use ruff_python_ast::node::{AnyNodeRef, AstNode};
-use ruff_python_ast::{Arguments, Expr, ExprCall, Ranged};
+use ruff_python_ast::node::AstNode;
+use ruff_python_ast::{Arguments, Expr, Ranged};
 use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
 use ruff_text_size::{TextRange, TextSize};
 
 use crate::builders::empty_parenthesized_with_dangling_comments;
 use crate::comments::trailing_comments;
 use crate::expression::expr_generator_exp::GeneratorExpParentheses;
-use crate::expression::parentheses::{
-    parenthesized, NeedsParentheses, OptionalParentheses, Parentheses,
-};
+use crate::expression::parentheses::{parenthesized, Parentheses};
 use crate::prelude::*;
 use crate::FormatNodeRule;
 
@@ -113,16 +111,6 @@ impl FormatNodeRule<Arguments> for FormatArguments {
     fn fmt_dangling_comments(&self, _node: &Arguments, _f: &mut PyFormatter) -> FormatResult<()> {
         // Handled in `fmt_fields`
         Ok(())
-    }
-}
-
-impl NeedsParentheses for ExprCall {
-    fn needs_parentheses(
-        &self,
-        _parent: AnyNodeRef,
-        context: &PyFormatContext,
-    ) -> OptionalParentheses {
-        self.func.needs_parentheses(self.into(), context)
     }
 }
 


### PR DESCRIPTION
Accidental move.