### PR TITLE
Return a slice in `StmtClassDef#bases`

### DIFF
--- a/crates/ruff/src/rules/flake8_builtins/rules/builtin_attribute_shadowing.rs
+++ b/crates/ruff/src/rules/flake8_builtins/rules/builtin_attribute_shadowing.rs
@@ -79,6 +79,7 @@ pub(crate) fn builtin_attribute_shadowing(
         // subscripting and not through attribute access.
         if class_def
             .bases()
+            .iter()
             .any(|base| checker.semantic().match_typing_expr(base, "TypedDict"))
         {
             return;

--- a/crates/ruff/src/rules/flake8_pie/rules/non_unique_enums.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules/non_unique_enums.rs
@@ -58,7 +58,7 @@ pub(crate) fn non_unique_enums(checker: &mut Checker, parent: &Stmt, body: &[Stm
         return;
     };
 
-    if !parent.bases().any(|expr| {
+    if !parent.bases().iter().any(|expr| {
         checker
             .semantic()
             .resolve_call_path(expr)

--- a/crates/ruff/src/rules/flake8_pyi/rules/unused_private_type_definition.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unused_private_type_definition.rs
@@ -223,6 +223,7 @@ pub(crate) fn unused_private_protocol(
 
         if !class_def
             .bases()
+            .iter()
             .any(|base| checker.semantic().match_typing_expr(base, "Protocol"))
         {
             continue;
@@ -309,6 +310,7 @@ pub(crate) fn unused_private_typed_dict(
 
         if !class_def
             .bases()
+            .iter()
             .any(|base| checker.semantic().match_typing_expr(base, "TypedDict"))
         {
             continue;

--- a/crates/ruff/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/helpers.rs
@@ -39,7 +39,7 @@ fn runtime_evaluated_base_class(base_classes: &[String], semantic: &SemanticMode
         return false;
     };
 
-    class_def.bases().any(|base| {
+    class_def.bases().iter().any(|base| {
         semantic.resolve_call_path(base).is_some_and(|call_path| {
             base_classes
                 .iter()

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -167,21 +167,19 @@ pub struct StmtClassDef {
 
 impl StmtClassDef {
     /// Return an iterator over the bases of the class.
-    pub fn bases(&self) -> impl Iterator<Item = &Expr> {
-        self.arguments
-            .as_ref()
-            .map(|arguments| &arguments.args)
-            .into_iter()
-            .flatten()
+    pub fn bases(&self) -> &[Expr] {
+        match &self.arguments {
+            Some(arguments) => &arguments.args,
+            None => &[],
+        }
     }
 
     /// Return an iterator over the metaclass keywords of the class.
-    pub fn keywords(&self) -> impl Iterator<Item = &Keyword> {
-        self.arguments
-            .as_ref()
-            .map(|arguments| &arguments.keywords)
-            .into_iter()
-            .flatten()
+    pub fn keywords(&self) -> &[Keyword] {
+        match &self.arguments {
+            Some(arguments) => &arguments.keywords,
+            None => &[],
+        }
     }
 }
 

--- a/crates/ruff_python_semantic/src/analyze/function_type.rs
+++ b/crates/ruff_python_semantic/src/analyze/function_type.rs
@@ -42,7 +42,7 @@ pub fn classify(
         FunctionType::StaticMethod
     } else if matches!(name, "__new__" | "__init_subclass__" | "__class_getitem__")
     // Special-case class method, like `__new__`.
-        || class_def.bases().any(|expr| {
+        || class_def.bases().iter().any(|expr| {
             // The class itself extends a known metaclass, so all methods are class methods.
             semantic
                 .resolve_call_path(map_callable(expr))


### PR DESCRIPTION
Slices are strictly more flexible, since you can always convert to an iterator, etc., but not the other way around. Suggested in https://github.com/astral-sh/ruff/pull/6259#discussion_r1282730994.
