### PR TITLE
Add support for simple generic type variables to UP040

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP040.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP040.py
@@ -9,6 +9,10 @@ x: TypeAlias = int
 T = typing.TypeVar["T"]
 x: typing.TypeAlias = list[T]
 
+# UP040 call style generic (todo)
+T = typing.TypeVar("T")
+x: typing.TypeAlias = list[T]
+
 # UP040 bounded generic (todo)
 T = typing.TypeVar("T", bound=int)
 x: typing.TypeAlias = list[T]

--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP040.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP040.py
@@ -24,26 +24,15 @@ x: typing.TypeAlias = list[T]
 T = typing.TypeVar("T", covariant=True)
 x: typing.TypeAlias = list[T]
 
-# UP040 with function scope
-T = typing.TypeVar["T"]
-def foo():
-    # reference to global variable
-    x: typing.TypeAlias = list[T]
 
-    # reference to local variable
-    TFUNC = typing.TypeVar("TFUNC")
-    y: typing.TypeAlias = list[TFUNC]
-
-
-
-# UP040 with class variable scope
+# UP040 in class scope
 T = typing.TypeVar["T"]
 class Foo:
     # reference to global variable
     x: typing.TypeAlias = list[T]
 
     # reference to class variable
-    TCLS = typing.TypeVar("TCLS")
+    TCLS = typing.TypeVar["TCLS"]
     y: typing.TypeAlias = list[TCLS]
 
 

--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP040.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP040.py
@@ -25,15 +25,27 @@ T = typing.TypeVar("T", covariant=True)
 x: typing.TypeAlias = list[T]
 
 # UP040 with function scope
+T = typing.TypeVar["T"]
 def foo():
+    # reference to global variable
+    x: typing.TypeAlias = list[T]
+
+    # reference to local variable
     TFUNC = typing.TypeVar("TFUNC")
-    x: typing.TypeAlias = list[TFUNC]
+    y: typing.TypeAlias = list[TFUNC]
+
 
 
 # UP040 with class variable scope
+T = typing.TypeVar["T"]
 class Foo:
+    # reference to global variable
+    x: typing.TypeAlias = list[T]
+
+    # reference to class variable
     TCLS = typing.TypeVar("TCLS")
-    x: typing.TypeAlias = list[TCLS]
+    y: typing.TypeAlias = list[TCLS]
+
 
 
 # OK

--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP040.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP040.py
@@ -6,10 +6,25 @@ x: typing.TypeAlias = int
 x: TypeAlias = int
 
 
-# UP040 with generics (todo)
+# UP040 simple generic
 T = typing.TypeVar["T"]
 x: typing.TypeAlias = list[T]
 
+
+# UP040 bounded generic (todo)
+T = typing.TypeVar("T", bound=int)
+x: typing.TypeAlias = list[T]
+
+T = typing.TypeVar("T", int, str)
+x: typing.TypeAlias = list[T]
+
+# UP040 contravariant generic (todo)
+T = typing.TypeVar("T", contravariant=True)
+x: typing.TypeAlias = list[T]
+
+# UP040 covariant generic (todo)
+T = typing.TypeVar("T", covariant=True)
+x: typing.TypeAlias = list[T]
 
 # OK
 x: TypeAlias

--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP040.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP040.py
@@ -9,7 +9,7 @@ x: TypeAlias = int
 T = typing.TypeVar["T"]
 x: typing.TypeAlias = list[T]
 
-# UP040 call style generic (todo)
+# UP040 call style generic
 T = typing.TypeVar("T")
 x: typing.TypeAlias = list[T]
 
@@ -28,7 +28,6 @@ x: typing.TypeAlias = list[T]
 T = typing.TypeVar("T", covariant=True)
 x: typing.TypeAlias = list[T]
 
-
 # UP040 in class scope
 T = typing.TypeVar["T"]
 class Foo:
@@ -39,7 +38,9 @@ class Foo:
     TCLS = typing.TypeVar["TCLS"]
     y: typing.TypeAlias = list[TCLS]
 
-
+# UP040 wont add generics in fix
+T = typing.TypeVar(*args)
+x: typing.TypeAlias = list[T]
 
 # OK
 x: TypeAlias

--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP040.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP040.py
@@ -5,11 +5,9 @@ from typing import TypeAlias
 x: typing.TypeAlias = int
 x: TypeAlias = int
 
-
 # UP040 simple generic
 T = typing.TypeVar["T"]
 x: typing.TypeAlias = list[T]
-
 
 # UP040 bounded generic (todo)
 T = typing.TypeVar("T", bound=int)
@@ -25,6 +23,18 @@ x: typing.TypeAlias = list[T]
 # UP040 covariant generic (todo)
 T = typing.TypeVar("T", covariant=True)
 x: typing.TypeAlias = list[T]
+
+# UP040 with function scope
+def foo():
+    TFUNC = typing.TypeVar("TFUNC")
+    x: typing.TypeAlias = list[TFUNC]
+
+
+# UP040 with class variable scope
+class Foo:
+    TCLS = typing.TypeVar("TCLS")
+    x: typing.TypeAlias = list[TCLS]
+
 
 # OK
 x: TypeAlias

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
@@ -166,7 +166,7 @@ impl<'a> Visitor<'a> for TypeVarReferenceVisitor<'a> {
                                     })
                                 )
                             })
-                            && arguments.keywords.len() == 0
+                            && arguments.keywords.is_empty()
                         {
                             self.names.push(name);
                         }

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
@@ -127,11 +127,11 @@ impl<'a> Visitor<'a> for TypeVarNameVisitor<'a> {
     fn visit_expr(&mut self, expr: &'a Expr) {
         match expr {
             Expr::Name(name) if name.ctx.is_load() => {
-                let Some(Some(Stmt::Assign(StmtAssign { value, .. }))) =
+                let Some(Stmt::Assign(StmtAssign { value, .. })) =
                     self.semantic
                         .scope()
                         .get(name.id.as_str())
-                        .map(|binding_id| {
+                        .and_then(|binding_id| {
                             self.semantic
                                 .binding(binding_id)
                                 .source

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
@@ -136,7 +136,7 @@ impl<'a> Visitor<'a> for TypeVarReferenceVisitor<'a> {
                             self.semantic
                                 .binding(binding_id)
                                 .source
-                                .map(|node_id| self.semantic.stmts[node_id])
+                                .map(|node_id| self.semantic.statement(node_id))
                         }) else {
                             return;
                         };

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__non_pep695_type_alias_py312.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__non_pep695_type_alias_py312.snap
@@ -18,7 +18,7 @@ UP040.py:5:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of th
   5 |+type x = int
 6 6 | x: TypeAlias = int
 7 7 | 
-8 8 | 
+8 8 | # UP040 simple generic
 
 UP040.py:6:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
   |
@@ -26,6 +26,8 @@ UP040.py:6:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of th
 5 | x: typing.TypeAlias = int
 6 | x: TypeAlias = int
   | ^^^^^^^^^^^^^^^^^^ UP040
+7 | 
+8 | # UP040 simple generic
   |
   = help: Use the `type` keyword
 
@@ -36,109 +38,149 @@ UP040.py:6:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of th
 6   |-x: TypeAlias = int
   6 |+type x = int
 7 7 | 
-8 8 | 
-9 9 | # UP040 simple generic
+8 8 | # UP040 simple generic
+9 9 | T = typing.TypeVar["T"]
 
-UP040.py:11:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+UP040.py:10:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
- 9 | # UP040 simple generic
-10 | T = typing.TypeVar["T"]
-11 | x: typing.TypeAlias = list[T]
+ 8 | # UP040 simple generic
+ 9 | T = typing.TypeVar["T"]
+10 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
+11 | 
+12 | # UP040 bounded generic (todo)
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-8  8  | 
-9  9  | # UP040 simple generic
-10 10 | T = typing.TypeVar["T"]
-11    |-x: typing.TypeAlias = list[T]
-   11 |+type x[T] = list[T]
-12 12 | 
-13 13 | 
-14 14 | # UP040 bounded generic (todo)
+7  7  | 
+8  8  | # UP040 simple generic
+9  9  | T = typing.TypeVar["T"]
+10    |-x: typing.TypeAlias = list[T]
+   10 |+type x[T] = list[T]
+11 11 | 
+12 12 | # UP040 bounded generic (todo)
+13 13 | T = typing.TypeVar("T", bound=int)
 
-UP040.py:16:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+UP040.py:14:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-14 | # UP040 bounded generic (todo)
-15 | T = typing.TypeVar("T", bound=int)
-16 | x: typing.TypeAlias = list[T]
+12 | # UP040 bounded generic (todo)
+13 | T = typing.TypeVar("T", bound=int)
+14 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
-17 | 
-18 | T = typing.TypeVar("T", int, str)
+15 | 
+16 | T = typing.TypeVar("T", int, str)
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-13 13 | 
-14 14 | # UP040 bounded generic (todo)
-15 15 | T = typing.TypeVar("T", bound=int)
-16    |-x: typing.TypeAlias = list[T]
-   16 |+type x = list[T]
-17 17 | 
-18 18 | T = typing.TypeVar("T", int, str)
-19 19 | x: typing.TypeAlias = list[T]
+11 11 | 
+12 12 | # UP040 bounded generic (todo)
+13 13 | T = typing.TypeVar("T", bound=int)
+14    |-x: typing.TypeAlias = list[T]
+   14 |+type x = list[T]
+15 15 | 
+16 16 | T = typing.TypeVar("T", int, str)
+17 17 | x: typing.TypeAlias = list[T]
 
-UP040.py:19:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+UP040.py:17:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-18 | T = typing.TypeVar("T", int, str)
-19 | x: typing.TypeAlias = list[T]
+16 | T = typing.TypeVar("T", int, str)
+17 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
-20 | 
-21 | # UP040 contravariant generic (todo)
+18 | 
+19 | # UP040 contravariant generic (todo)
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-16 16 | x: typing.TypeAlias = list[T]
-17 17 | 
-18 18 | T = typing.TypeVar("T", int, str)
-19    |-x: typing.TypeAlias = list[T]
-   19 |+type x = list[T]
-20 20 | 
-21 21 | # UP040 contravariant generic (todo)
-22 22 | T = typing.TypeVar("T", contravariant=True)
+14 14 | x: typing.TypeAlias = list[T]
+15 15 | 
+16 16 | T = typing.TypeVar("T", int, str)
+17    |-x: typing.TypeAlias = list[T]
+   17 |+type x = list[T]
+18 18 | 
+19 19 | # UP040 contravariant generic (todo)
+20 20 | T = typing.TypeVar("T", contravariant=True)
 
-UP040.py:23:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+UP040.py:21:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-21 | # UP040 contravariant generic (todo)
-22 | T = typing.TypeVar("T", contravariant=True)
-23 | x: typing.TypeAlias = list[T]
+19 | # UP040 contravariant generic (todo)
+20 | T = typing.TypeVar("T", contravariant=True)
+21 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
-24 | 
-25 | # UP040 covariant generic (todo)
+22 | 
+23 | # UP040 covariant generic (todo)
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-20 20 | 
-21 21 | # UP040 contravariant generic (todo)
-22 22 | T = typing.TypeVar("T", contravariant=True)
-23    |-x: typing.TypeAlias = list[T]
-   23 |+type x = list[T]
-24 24 | 
-25 25 | # UP040 covariant generic (todo)
-26 26 | T = typing.TypeVar("T", covariant=True)
+18 18 | 
+19 19 | # UP040 contravariant generic (todo)
+20 20 | T = typing.TypeVar("T", contravariant=True)
+21    |-x: typing.TypeAlias = list[T]
+   21 |+type x = list[T]
+22 22 | 
+23 23 | # UP040 covariant generic (todo)
+24 24 | T = typing.TypeVar("T", covariant=True)
 
-UP040.py:27:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+UP040.py:25:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-25 | # UP040 covariant generic (todo)
-26 | T = typing.TypeVar("T", covariant=True)
-27 | x: typing.TypeAlias = list[T]
+23 | # UP040 covariant generic (todo)
+24 | T = typing.TypeVar("T", covariant=True)
+25 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
-28 | 
-29 | # OK
+26 | 
+27 | # UP040 with function scope
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-24 24 | 
-25 25 | # UP040 covariant generic (todo)
-26 26 | T = typing.TypeVar("T", covariant=True)
-27    |-x: typing.TypeAlias = list[T]
-   27 |+type x = list[T]
-28 28 | 
-29 29 | # OK
-30 30 | x: TypeAlias
+22 22 | 
+23 23 | # UP040 covariant generic (todo)
+24 24 | T = typing.TypeVar("T", covariant=True)
+25    |-x: typing.TypeAlias = list[T]
+   25 |+type x = list[T]
+26 26 | 
+27 27 | # UP040 with function scope
+28 28 | def foo():
+
+UP040.py:30:5: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+   |
+28 | def foo():
+29 |     TFUNC = typing.TypeVar("TFUNC")
+30 |     x: typing.TypeAlias = list[TFUNC]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
+   |
+   = help: Use the `type` keyword
+
+ℹ Fix
+27 27 | # UP040 with function scope
+28 28 | def foo():
+29 29 |     TFUNC = typing.TypeVar("TFUNC")
+30    |-    x: typing.TypeAlias = list[TFUNC]
+   30 |+    type x = list[TFUNC]
+31 31 | 
+32 32 | 
+33 33 | # UP040 with class variable scope
+
+UP040.py:36:5: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+   |
+34 | class Foo:
+35 |     TCLS = typing.TypeVar("TCLS")
+36 |     x: typing.TypeAlias = list[TCLS]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
+   |
+   = help: Use the `type` keyword
+
+ℹ Fix
+33 33 | # UP040 with class variable scope
+34 34 | class Foo:
+35 35 |     TCLS = typing.TypeVar("TCLS")
+36    |-    x: typing.TypeAlias = list[TCLS]
+   36 |+    type x = list[TCLS]
+37 37 | 
+38 38 | 
+39 39 | # OK
 
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__non_pep695_type_alias_py312.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__non_pep695_type_alias_py312.snap
@@ -48,7 +48,7 @@ UP040.py:10:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of t
 10 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
 11 | 
-12 | # UP040 call style generic (todo)
+12 | # UP040 call style generic
    |
    = help: Use the `type` keyword
 
@@ -59,12 +59,12 @@ UP040.py:10:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of t
 10    |-x: typing.TypeAlias = list[T]
    10 |+type x[T] = list[T]
 11 11 | 
-12 12 | # UP040 call style generic (todo)
+12 12 | # UP040 call style generic
 13 13 | T = typing.TypeVar("T")
 
 UP040.py:14:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-12 | # UP040 call style generic (todo)
+12 | # UP040 call style generic
 13 | T = typing.TypeVar("T")
 14 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
@@ -75,10 +75,10 @@ UP040.py:14:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of t
 
 ℹ Fix
 11 11 | 
-12 12 | # UP040 call style generic (todo)
+12 12 | # UP040 call style generic
 13 13 | T = typing.TypeVar("T")
 14    |-x: typing.TypeAlias = list[T]
-   14 |+type x = list[T]
+   14 |+type x[T] = list[T]
 15 15 | 
 16 16 | # UP040 bounded generic (todo)
 17 17 | T = typing.TypeVar("T", bound=int)
@@ -151,6 +151,8 @@ UP040.py:29:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of t
 28 | T = typing.TypeVar("T", covariant=True)
 29 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
+30 | 
+31 | # UP040 in class scope
    |
    = help: Use the `type` keyword
 
@@ -161,47 +163,70 @@ UP040.py:29:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of t
 29    |-x: typing.TypeAlias = list[T]
    29 |+type x = list[T]
 30 30 | 
-31 31 | 
-32 32 | # UP040 in class scope
+31 31 | # UP040 in class scope
+32 32 | T = typing.TypeVar["T"]
 
-UP040.py:36:5: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+UP040.py:35:5: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-34 | class Foo:
-35 |     # reference to global variable
-36 |     x: typing.TypeAlias = list[T]
+33 | class Foo:
+34 |     # reference to global variable
+35 |     x: typing.TypeAlias = list[T]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
-37 | 
-38 |     # reference to class variable
+36 | 
+37 |     # reference to class variable
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-33 33 | T = typing.TypeVar["T"]
-34 34 | class Foo:
-35 35 |     # reference to global variable
-36    |-    x: typing.TypeAlias = list[T]
-   36 |+    type x[T] = list[T]
-37 37 | 
-38 38 |     # reference to class variable
-39 39 |     TCLS = typing.TypeVar["TCLS"]
+32 32 | T = typing.TypeVar["T"]
+33 33 | class Foo:
+34 34 |     # reference to global variable
+35    |-    x: typing.TypeAlias = list[T]
+   35 |+    type x[T] = list[T]
+36 36 | 
+37 37 |     # reference to class variable
+38 38 |     TCLS = typing.TypeVar["TCLS"]
 
-UP040.py:40:5: UP040 [*] Type alias `y` uses `TypeAlias` annotation instead of the `type` keyword
+UP040.py:39:5: UP040 [*] Type alias `y` uses `TypeAlias` annotation instead of the `type` keyword
    |
-38 |     # reference to class variable
-39 |     TCLS = typing.TypeVar["TCLS"]
-40 |     y: typing.TypeAlias = list[TCLS]
+37 |     # reference to class variable
+38 |     TCLS = typing.TypeVar["TCLS"]
+39 |     y: typing.TypeAlias = list[TCLS]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
+40 | 
+41 | # UP040 wont add generics in fix
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-37 37 | 
-38 38 |     # reference to class variable
-39 39 |     TCLS = typing.TypeVar["TCLS"]
-40    |-    y: typing.TypeAlias = list[TCLS]
-   40 |+    type y[TCLS] = list[TCLS]
-41 41 | 
-42 42 | 
-43 43 | 
+36 36 | 
+37 37 |     # reference to class variable
+38 38 |     TCLS = typing.TypeVar["TCLS"]
+39    |-    y: typing.TypeAlias = list[TCLS]
+   39 |+    type y[TCLS] = list[TCLS]
+40 40 | 
+41 41 | # UP040 wont add generics in fix
+42 42 | T = typing.TypeVar(*args)
+
+UP040.py:43:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+   |
+41 | # UP040 wont add generics in fix
+42 | T = typing.TypeVar(*args)
+43 | x: typing.TypeAlias = list[T]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
+44 | 
+45 | # OK
+   |
+   = help: Use the `type` keyword
+
+ℹ Fix
+40 40 | 
+41 41 | # UP040 wont add generics in fix
+42 42 | T = typing.TypeVar(*args)
+43    |-x: typing.TypeAlias = list[T]
+   43 |+type x = list[T]
+44 44 | 
+45 45 | # OK
+46 46 | x: TypeAlias
 
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__non_pep695_type_alias_py312.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__non_pep695_type_alias_py312.snap
@@ -48,7 +48,7 @@ UP040.py:10:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of t
 10 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
 11 | 
-12 | # UP040 bounded generic (todo)
+12 | # UP040 call style generic (todo)
    |
    = help: Use the `type` keyword
 
@@ -59,128 +59,149 @@ UP040.py:10:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of t
 10    |-x: typing.TypeAlias = list[T]
    10 |+type x[T] = list[T]
 11 11 | 
-12 12 | # UP040 bounded generic (todo)
-13 13 | T = typing.TypeVar("T", bound=int)
+12 12 | # UP040 call style generic (todo)
+13 13 | T = typing.TypeVar("T")
 
 UP040.py:14:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-12 | # UP040 bounded generic (todo)
-13 | T = typing.TypeVar("T", bound=int)
+12 | # UP040 call style generic (todo)
+13 | T = typing.TypeVar("T")
 14 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
 15 | 
-16 | T = typing.TypeVar("T", int, str)
+16 | # UP040 bounded generic (todo)
    |
    = help: Use the `type` keyword
 
 ℹ Fix
 11 11 | 
-12 12 | # UP040 bounded generic (todo)
-13 13 | T = typing.TypeVar("T", bound=int)
+12 12 | # UP040 call style generic (todo)
+13 13 | T = typing.TypeVar("T")
 14    |-x: typing.TypeAlias = list[T]
    14 |+type x = list[T]
 15 15 | 
-16 16 | T = typing.TypeVar("T", int, str)
-17 17 | x: typing.TypeAlias = list[T]
+16 16 | # UP040 bounded generic (todo)
+17 17 | T = typing.TypeVar("T", bound=int)
 
-UP040.py:17:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+UP040.py:18:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-16 | T = typing.TypeVar("T", int, str)
-17 | x: typing.TypeAlias = list[T]
+16 | # UP040 bounded generic (todo)
+17 | T = typing.TypeVar("T", bound=int)
+18 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
-18 | 
-19 | # UP040 contravariant generic (todo)
+19 | 
+20 | T = typing.TypeVar("T", int, str)
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-14 14 | x: typing.TypeAlias = list[T]
 15 15 | 
-16 16 | T = typing.TypeVar("T", int, str)
-17    |-x: typing.TypeAlias = list[T]
-   17 |+type x = list[T]
-18 18 | 
-19 19 | # UP040 contravariant generic (todo)
-20 20 | T = typing.TypeVar("T", contravariant=True)
+16 16 | # UP040 bounded generic (todo)
+17 17 | T = typing.TypeVar("T", bound=int)
+18    |-x: typing.TypeAlias = list[T]
+   18 |+type x = list[T]
+19 19 | 
+20 20 | T = typing.TypeVar("T", int, str)
+21 21 | x: typing.TypeAlias = list[T]
 
 UP040.py:21:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-19 | # UP040 contravariant generic (todo)
-20 | T = typing.TypeVar("T", contravariant=True)
+20 | T = typing.TypeVar("T", int, str)
 21 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
 22 | 
-23 | # UP040 covariant generic (todo)
+23 | # UP040 contravariant generic (todo)
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-18 18 | 
-19 19 | # UP040 contravariant generic (todo)
-20 20 | T = typing.TypeVar("T", contravariant=True)
+18 18 | x: typing.TypeAlias = list[T]
+19 19 | 
+20 20 | T = typing.TypeVar("T", int, str)
 21    |-x: typing.TypeAlias = list[T]
    21 |+type x = list[T]
 22 22 | 
-23 23 | # UP040 covariant generic (todo)
-24 24 | T = typing.TypeVar("T", covariant=True)
+23 23 | # UP040 contravariant generic (todo)
+24 24 | T = typing.TypeVar("T", contravariant=True)
 
 UP040.py:25:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-23 | # UP040 covariant generic (todo)
-24 | T = typing.TypeVar("T", covariant=True)
+23 | # UP040 contravariant generic (todo)
+24 | T = typing.TypeVar("T", contravariant=True)
 25 | x: typing.TypeAlias = list[T]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
+26 | 
+27 | # UP040 covariant generic (todo)
+   |
+   = help: Use the `type` keyword
+
+ℹ Fix
+22 22 | 
+23 23 | # UP040 contravariant generic (todo)
+24 24 | T = typing.TypeVar("T", contravariant=True)
+25    |-x: typing.TypeAlias = list[T]
+   25 |+type x = list[T]
+26 26 | 
+27 27 | # UP040 covariant generic (todo)
+28 28 | T = typing.TypeVar("T", covariant=True)
+
+UP040.py:29:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+   |
+27 | # UP040 covariant generic (todo)
+28 | T = typing.TypeVar("T", covariant=True)
+29 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-22 22 | 
-23 23 | # UP040 covariant generic (todo)
-24 24 | T = typing.TypeVar("T", covariant=True)
-25    |-x: typing.TypeAlias = list[T]
-   25 |+type x = list[T]
 26 26 | 
-27 27 | 
-28 28 | # UP040 in class scope
+27 27 | # UP040 covariant generic (todo)
+28 28 | T = typing.TypeVar("T", covariant=True)
+29    |-x: typing.TypeAlias = list[T]
+   29 |+type x = list[T]
+30 30 | 
+31 31 | 
+32 32 | # UP040 in class scope
 
-UP040.py:32:5: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+UP040.py:36:5: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-30 | class Foo:
-31 |     # reference to global variable
-32 |     x: typing.TypeAlias = list[T]
+34 | class Foo:
+35 |     # reference to global variable
+36 |     x: typing.TypeAlias = list[T]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
-33 | 
-34 |     # reference to class variable
+37 | 
+38 |     # reference to class variable
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-29 29 | T = typing.TypeVar["T"]
-30 30 | class Foo:
-31 31 |     # reference to global variable
-32    |-    x: typing.TypeAlias = list[T]
-   32 |+    type x[T] = list[T]
-33 33 | 
-34 34 |     # reference to class variable
-35 35 |     TCLS = typing.TypeVar["TCLS"]
+33 33 | T = typing.TypeVar["T"]
+34 34 | class Foo:
+35 35 |     # reference to global variable
+36    |-    x: typing.TypeAlias = list[T]
+   36 |+    type x[T] = list[T]
+37 37 | 
+38 38 |     # reference to class variable
+39 39 |     TCLS = typing.TypeVar["TCLS"]
 
-UP040.py:36:5: UP040 [*] Type alias `y` uses `TypeAlias` annotation instead of the `type` keyword
+UP040.py:40:5: UP040 [*] Type alias `y` uses `TypeAlias` annotation instead of the `type` keyword
    |
-34 |     # reference to class variable
-35 |     TCLS = typing.TypeVar["TCLS"]
-36 |     y: typing.TypeAlias = list[TCLS]
+38 |     # reference to class variable
+39 |     TCLS = typing.TypeVar["TCLS"]
+40 |     y: typing.TypeAlias = list[TCLS]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-33 33 | 
-34 34 |     # reference to class variable
-35 35 |     TCLS = typing.TypeVar["TCLS"]
-36    |-    y: typing.TypeAlias = list[TCLS]
-   36 |+    type y[TCLS] = list[TCLS]
 37 37 | 
-38 38 | 
-39 39 | 
+38 38 |     # reference to class variable
+39 39 |     TCLS = typing.TypeVar["TCLS"]
+40    |-    y: typing.TypeAlias = list[TCLS]
+   40 |+    type y[TCLS] = list[TCLS]
+41 41 | 
+42 42 | 
+43 43 | 
 
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__non_pep695_type_alias_py312.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__non_pep695_type_alias_py312.snap
@@ -37,11 +37,11 @@ UP040.py:6:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of th
   6 |+type x = int
 7 7 | 
 8 8 | 
-9 9 | # UP040 with generics (todo)
+9 9 | # UP040 simple generic
 
 UP040.py:11:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
- 9 | # UP040 with generics (todo)
+ 9 | # UP040 simple generic
 10 | T = typing.TypeVar["T"]
 11 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
@@ -50,12 +50,95 @@ UP040.py:11:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of t
 
 ℹ Fix
 8  8  | 
-9  9  | # UP040 with generics (todo)
+9  9  | # UP040 simple generic
 10 10 | T = typing.TypeVar["T"]
 11    |-x: typing.TypeAlias = list[T]
-   11 |+type x = list[T]
+   11 |+type x[T] = list[T]
 12 12 | 
 13 13 | 
-14 14 | # OK
+14 14 | # UP040 bounded generic (todo)
+
+UP040.py:16:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+   |
+14 | # UP040 bounded generic (todo)
+15 | T = typing.TypeVar("T", bound=int)
+16 | x: typing.TypeAlias = list[T]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
+17 | 
+18 | T = typing.TypeVar("T", int, str)
+   |
+   = help: Use the `type` keyword
+
+ℹ Fix
+13 13 | 
+14 14 | # UP040 bounded generic (todo)
+15 15 | T = typing.TypeVar("T", bound=int)
+16    |-x: typing.TypeAlias = list[T]
+   16 |+type x = list[T]
+17 17 | 
+18 18 | T = typing.TypeVar("T", int, str)
+19 19 | x: typing.TypeAlias = list[T]
+
+UP040.py:19:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+   |
+18 | T = typing.TypeVar("T", int, str)
+19 | x: typing.TypeAlias = list[T]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
+20 | 
+21 | # UP040 contravariant generic (todo)
+   |
+   = help: Use the `type` keyword
+
+ℹ Fix
+16 16 | x: typing.TypeAlias = list[T]
+17 17 | 
+18 18 | T = typing.TypeVar("T", int, str)
+19    |-x: typing.TypeAlias = list[T]
+   19 |+type x = list[T]
+20 20 | 
+21 21 | # UP040 contravariant generic (todo)
+22 22 | T = typing.TypeVar("T", contravariant=True)
+
+UP040.py:23:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+   |
+21 | # UP040 contravariant generic (todo)
+22 | T = typing.TypeVar("T", contravariant=True)
+23 | x: typing.TypeAlias = list[T]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
+24 | 
+25 | # UP040 covariant generic (todo)
+   |
+   = help: Use the `type` keyword
+
+ℹ Fix
+20 20 | 
+21 21 | # UP040 contravariant generic (todo)
+22 22 | T = typing.TypeVar("T", contravariant=True)
+23    |-x: typing.TypeAlias = list[T]
+   23 |+type x = list[T]
+24 24 | 
+25 25 | # UP040 covariant generic (todo)
+26 26 | T = typing.TypeVar("T", covariant=True)
+
+UP040.py:27:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+   |
+25 | # UP040 covariant generic (todo)
+26 | T = typing.TypeVar("T", covariant=True)
+27 | x: typing.TypeAlias = list[T]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
+28 | 
+29 | # OK
+   |
+   = help: Use the `type` keyword
+
+ℹ Fix
+24 24 | 
+25 25 | # UP040 covariant generic (todo)
+26 26 | T = typing.TypeVar("T", covariant=True)
+27    |-x: typing.TypeAlias = list[T]
+   27 |+type x = list[T]
+28 28 | 
+29 29 | # OK
+30 30 | x: TypeAlias
 
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__non_pep695_type_alias_py312.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__non_pep695_type_alias_py312.snap
@@ -143,44 +143,86 @@ UP040.py:25:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of t
    25 |+type x = list[T]
 26 26 | 
 27 27 | # UP040 with function scope
-28 28 | def foo():
+28 28 | T = typing.TypeVar["T"]
 
-UP040.py:30:5: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+UP040.py:31:5: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-28 | def foo():
-29 |     TFUNC = typing.TypeVar("TFUNC")
-30 |     x: typing.TypeAlias = list[TFUNC]
+29 | def foo():
+30 |     # reference to global variable
+31 |     x: typing.TypeAlias = list[T]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
+32 | 
+33 |     # reference to local variable
+   |
+   = help: Use the `type` keyword
+
+ℹ Fix
+28 28 | T = typing.TypeVar["T"]
+29 29 | def foo():
+30 30 |     # reference to global variable
+31    |-    x: typing.TypeAlias = list[T]
+   31 |+    type x[T] = list[T]
+32 32 | 
+33 33 |     # reference to local variable
+34 34 |     TFUNC = typing.TypeVar("TFUNC")
+
+UP040.py:35:5: UP040 [*] Type alias `y` uses `TypeAlias` annotation instead of the `type` keyword
+   |
+33 |     # reference to local variable
+34 |     TFUNC = typing.TypeVar("TFUNC")
+35 |     y: typing.TypeAlias = list[TFUNC]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-27 27 | # UP040 with function scope
-28 28 | def foo():
-29 29 |     TFUNC = typing.TypeVar("TFUNC")
-30    |-    x: typing.TypeAlias = list[TFUNC]
-   30 |+    type x = list[TFUNC]
-31 31 | 
 32 32 | 
-33 33 | # UP040 with class variable scope
+33 33 |     # reference to local variable
+34 34 |     TFUNC = typing.TypeVar("TFUNC")
+35    |-    y: typing.TypeAlias = list[TFUNC]
+   35 |+    type y = list[TFUNC]
+36 36 | 
+37 37 | 
+38 38 | 
 
-UP040.py:36:5: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+UP040.py:43:5: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-34 | class Foo:
-35 |     TCLS = typing.TypeVar("TCLS")
-36 |     x: typing.TypeAlias = list[TCLS]
+41 | class Foo:
+42 |     # reference to global variable
+43 |     x: typing.TypeAlias = list[T]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
+44 | 
+45 |     # reference to class variable
+   |
+   = help: Use the `type` keyword
+
+ℹ Fix
+40 40 | T = typing.TypeVar["T"]
+41 41 | class Foo:
+42 42 |     # reference to global variable
+43    |-    x: typing.TypeAlias = list[T]
+   43 |+    type x[T] = list[T]
+44 44 | 
+45 45 |     # reference to class variable
+46 46 |     TCLS = typing.TypeVar("TCLS")
+
+UP040.py:47:5: UP040 [*] Type alias `y` uses `TypeAlias` annotation instead of the `type` keyword
+   |
+45 |     # reference to class variable
+46 |     TCLS = typing.TypeVar("TCLS")
+47 |     y: typing.TypeAlias = list[TCLS]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-33 33 | # UP040 with class variable scope
-34 34 | class Foo:
-35 35 |     TCLS = typing.TypeVar("TCLS")
-36    |-    x: typing.TypeAlias = list[TCLS]
-   36 |+    type x = list[TCLS]
-37 37 | 
-38 38 | 
-39 39 | # OK
+44 44 | 
+45 45 |     # reference to class variable
+46 46 |     TCLS = typing.TypeVar("TCLS")
+47    |-    y: typing.TypeAlias = list[TCLS]
+   47 |+    type y = list[TCLS]
+48 48 | 
+49 49 | 
+50 50 | 
 
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__non_pep695_type_alias_py312.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__non_pep695_type_alias_py312.snap
@@ -130,8 +130,6 @@ UP040.py:25:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of t
 24 | T = typing.TypeVar("T", covariant=True)
 25 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
-26 | 
-27 | # UP040 with function scope
    |
    = help: Use the `type` keyword
 
@@ -142,87 +140,47 @@ UP040.py:25:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of t
 25    |-x: typing.TypeAlias = list[T]
    25 |+type x = list[T]
 26 26 | 
-27 27 | # UP040 with function scope
-28 28 | T = typing.TypeVar["T"]
+27 27 | 
+28 28 | # UP040 in class scope
 
-UP040.py:31:5: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
+UP040.py:32:5: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-29 | def foo():
-30 |     # reference to global variable
-31 |     x: typing.TypeAlias = list[T]
+30 | class Foo:
+31 |     # reference to global variable
+32 |     x: typing.TypeAlias = list[T]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
-32 | 
-33 |     # reference to local variable
+33 | 
+34 |     # reference to class variable
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-28 28 | T = typing.TypeVar["T"]
-29 29 | def foo():
-30 30 |     # reference to global variable
-31    |-    x: typing.TypeAlias = list[T]
-   31 |+    type x[T] = list[T]
-32 32 | 
-33 33 |     # reference to local variable
-34 34 |     TFUNC = typing.TypeVar("TFUNC")
+29 29 | T = typing.TypeVar["T"]
+30 30 | class Foo:
+31 31 |     # reference to global variable
+32    |-    x: typing.TypeAlias = list[T]
+   32 |+    type x[T] = list[T]
+33 33 | 
+34 34 |     # reference to class variable
+35 35 |     TCLS = typing.TypeVar["TCLS"]
 
-UP040.py:35:5: UP040 [*] Type alias `y` uses `TypeAlias` annotation instead of the `type` keyword
+UP040.py:36:5: UP040 [*] Type alias `y` uses `TypeAlias` annotation instead of the `type` keyword
    |
-33 |     # reference to local variable
-34 |     TFUNC = typing.TypeVar("TFUNC")
-35 |     y: typing.TypeAlias = list[TFUNC]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
-   |
-   = help: Use the `type` keyword
-
-ℹ Fix
-32 32 | 
-33 33 |     # reference to local variable
-34 34 |     TFUNC = typing.TypeVar("TFUNC")
-35    |-    y: typing.TypeAlias = list[TFUNC]
-   35 |+    type y = list[TFUNC]
-36 36 | 
-37 37 | 
-38 38 | 
-
-UP040.py:43:5: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
-   |
-41 | class Foo:
-42 |     # reference to global variable
-43 |     x: typing.TypeAlias = list[T]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
-44 | 
-45 |     # reference to class variable
-   |
-   = help: Use the `type` keyword
-
-ℹ Fix
-40 40 | T = typing.TypeVar["T"]
-41 41 | class Foo:
-42 42 |     # reference to global variable
-43    |-    x: typing.TypeAlias = list[T]
-   43 |+    type x[T] = list[T]
-44 44 | 
-45 45 |     # reference to class variable
-46 46 |     TCLS = typing.TypeVar("TCLS")
-
-UP040.py:47:5: UP040 [*] Type alias `y` uses `TypeAlias` annotation instead of the `type` keyword
-   |
-45 |     # reference to class variable
-46 |     TCLS = typing.TypeVar("TCLS")
-47 |     y: typing.TypeAlias = list[TCLS]
+34 |     # reference to class variable
+35 |     TCLS = typing.TypeVar["TCLS"]
+36 |     y: typing.TypeAlias = list[TCLS]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
    |
    = help: Use the `type` keyword
 
 ℹ Fix
-44 44 | 
-45 45 |     # reference to class variable
-46 46 |     TCLS = typing.TypeVar("TCLS")
-47    |-    y: typing.TypeAlias = list[TCLS]
-   47 |+    type y = list[TCLS]
-48 48 | 
-49 49 | 
-50 50 | 
+33 33 | 
+34 34 |     # reference to class variable
+35 35 |     TCLS = typing.TypeVar["TCLS"]
+36    |-    y: typing.TypeAlias = list[TCLS]
+   36 |+    type y[TCLS] = list[TCLS]
+37 37 | 
+38 38 | 
+39 39 | 
 
 


### PR DESCRIPTION
Extends #6289 to support moving type variable usage in type aliases to use PEP-695.

Does not remove the possibly unused type variable declaration. Presumably this is handled by other rules, but is not working for me.

Does not handle type variables with bounds or variance declarations yet.

Part of #4617 