### PR TITLE
Omit formatter PRs from releases by default

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,7 @@ changelog:
     labels:
       - internal
       - documentation
+      - formatter
   categories:
     - title: Breaking Changes
       labels:


### PR DESCRIPTION
I end up removing these manually every time, seems easier to just omit them for now.