### PR TITLE
Fix inconsistent `expr_lambda` formatting

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
@@ -118,3 +118,38 @@ lambda a, /, c: a
     # 4
     None # 5
 )
+
+(
+    lambda
+    # comment
+    *x: x
+)
+
+(
+    lambda
+    # comment 1
+    *
+    # comment 2
+    x:
+    # comment 3
+    x
+)
+
+(
+    lambda # comment 1
+    * # comment 2
+    x: # comment 3
+    x
+)
+
+lambda *x\
+    :x
+
+(
+    lambda
+    # comment
+    *\
+        x: x
+)
+
+

--- a/crates/ruff_python_formatter/src/expression/expr_lambda.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_lambda.rs
@@ -20,6 +20,7 @@ impl FormatNodeRule<ExprLambda> for FormatExprLambda {
 
         let comments = f.context().comments().clone();
         let dangling = comments.dangling(item);
+        let body_leading = comments.leading(body.as_ref());
 
         write!(f, [token("lambda")])?;
 
@@ -41,6 +42,11 @@ impl FormatNodeRule<ExprLambda> for FormatExprLambda {
             write!(f, [space()])?;
         } else {
             write!(f, [dangling_comments(dangling)])?;
+        }
+
+        // Insert hard line break if body has leading comment to ensure consistent formatting
+        if !body_leading.is_empty() {
+            write!(f, [hard_line_break()])?;
         }
 
         write!(f, [body.format()])

--- a/crates/ruff_python_formatter/src/expression/expr_lambda.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_lambda.rs
@@ -20,7 +20,6 @@ impl FormatNodeRule<ExprLambda> for FormatExprLambda {
 
         let comments = f.context().comments().clone();
         let dangling = comments.dangling(item);
-        let body_leading = comments.leading(body.as_ref());
 
         write!(f, [token("lambda")])?;
 
@@ -45,7 +44,7 @@ impl FormatNodeRule<ExprLambda> for FormatExprLambda {
         }
 
         // Insert hard line break if body has leading comment to ensure consistent formatting
-        if !body_leading.is_empty() {
+        if comments.has_leading(body.as_ref()) {
             write!(f, [hard_line_break()])?;
         }
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
@@ -124,6 +124,41 @@ lambda a, /, c: a
     # 4
     None # 5
 )
+
+(
+    lambda
+    # comment
+    *x: x
+)
+
+(
+    lambda
+    # comment 1
+    *
+    # comment 2
+    x:
+    # comment 3
+    x
+)
+
+(
+    lambda # comment 1
+    * # comment 2
+    x: # comment 3
+    x
+)
+
+lambda *x\
+    :x
+
+(
+    lambda
+    # comment
+    *\
+        x: x
+)
+
+
 ```
 
 ## Output
@@ -185,7 +220,8 @@ lambda x: lambda y: lambda z: (
 # Trailing
 
 a = (
-    lambda: # Dangling
+    lambda: 
+    # Dangling
     1
 )
 
@@ -232,21 +268,50 @@ lambda a, /, c: a
 
 # Dangling comments without parameters.
 (
-    lambda: # 3
+    lambda: 
+    # 3
     None
 )
 
 (
-    lambda: # 3
+    lambda: 
+    # 3
     None
 )
 
 (
-    lambda: # 1
+    lambda: 
+    # 1
     # 2
     # 3
     # 4
     None  # 5
+)
+
+(
+    lambda # comment
+    *x: x
+)
+
+(
+    lambda # comment 1
+    # comment 2
+    *x: 
+    # comment 3
+    x
+)
+
+(
+    lambda # comment 1
+    # comment 2
+    *x: x  # comment 3
+)
+
+lambda *x: x
+
+(
+    lambda # comment
+    *x: x
 )
 ```
 


### PR DESCRIPTION
## Summary
Lambda expression formatting ran into an issue with comments placed like:

```python
(
    lambda
    x:
    # comment 
    x
)
```
Which would be formatted first as:
```python
(
    lambda x: # comment 
    x
)
```
And on a second pass into:
```python
(
    lambda x: x  # comment 
)
```
This was caused by `# comment` changing from a leading comment of the body of the lambda expr to a trailing one after the first pass.

This PR adds test cases for this and similar scenarios and adds additional logic to insert a hard line break if the body has leading comments to ensure consistent formatting.

## Test Plan

Additional test cases added. Comment formatting already deviated from `black` here so it is to be decided if this is the preferred way to handle these comments.

## Issue link

Closes: https://github.com/astral-sh/ruff/issues/6284
