### PR TITLE
Add API to chain comment placement operations

### DIFF
--- a/crates/ruff_python_formatter/src/comments/visitor.rs
+++ b/crates/ruff_python_formatter/src/comments/visitor.rs
@@ -658,6 +658,17 @@ impl<'a> CommentPlacement<'a> {
             comment: comment.into(),
         }
     }
+
+    /// Chains the placement with the given function.
+    ///
+    /// Returns `self` when the placement is non-[`CommentPlacement::Default`]. Otherwise, calls the
+    /// function with the comment and returns the result.
+    pub(super) fn then_with<F: FnOnce(DecoratedComment<'a>) -> Self>(self, f: F) -> Self {
+        match self {
+            Self::Default(comment) => f(comment),
+            _ => self,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]


### PR DESCRIPTION
## Summary

This PR adds an API for chaining comment placement methods based on the [`then_with`](https://doc.rust-lang.org/std/cmp/enum.Ordering.html#method.then_with) from `Ordering` in the standard library.

For example, you can now do:

```rust
try_some_case(comment).then_with(|comment| try_some_other_case_if_still_default(comment))
```

This lets us avoid this kind of pattern, which I've seen in `placement.rs` and used myself before:

```rust
let comment = match handle_own_line_comment_between_branches(comment, preceding, locator) {
    CommentPlacement::Default(comment) => comment,
    placement => return placement,
};
```
