### PR TITLE
Flag `comparison-with-itself` on builtin calls

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/comparison_with_itself.py
+++ b/crates/ruff/resources/test/fixtures/pylint/comparison_with_itself.py
@@ -19,6 +19,10 @@ foo in foo
 
 foo not in foo
 
+id(foo) == id(foo)
+
+len(foo) == len(foo)
+
 # Non-errors.
 "foo" == "foo"  # This is flagged by `comparison-of-constant` instead.
 
@@ -43,3 +47,11 @@ foo is not bar
 foo in bar
 
 foo not in bar
+
+x(foo) == y(foo)
+
+id(foo) == id(bar)
+
+id(foo, bar) == id(foo, bar)
+
+id(foo, bar=1) == id(foo, bar=1)

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR0124_comparison_with_itself.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR0124_comparison_with_itself.py.snap
@@ -97,7 +97,27 @@ comparison_with_itself.py:20:1: PLR0124 Name compared with itself, consider repl
 20 | foo not in foo
    | ^^^ PLR0124
 21 | 
-22 | # Non-errors.
+22 | id(foo) == id(foo)
+   |
+
+comparison_with_itself.py:22:1: PLR0124 Name compared with itself, consider replacing `id(foo) == id(foo)`
+   |
+20 | foo not in foo
+21 | 
+22 | id(foo) == id(foo)
+   | ^^^^^^^ PLR0124
+23 | 
+24 | len(foo) == len(foo)
+   |
+
+comparison_with_itself.py:24:1: PLR0124 Name compared with itself, consider replacing `len(foo) == len(foo)`
+   |
+22 | id(foo) == id(foo)
+23 | 
+24 | len(foo) == len(foo)
+   | ^^^^^^^^ PLR0124
+25 | 
+26 | # Non-errors.
    |
 
 


### PR DESCRIPTION
## Summary

Extends `comparison-with-itself` to cover simple function calls on known-pure functions, like `id`. For example, we now flag `id(x) == id(x)`.

Closes https://github.com/astral-sh/ruff/issues/6276.

## Test Plan

`cargo test`
