### PR TITLE
Match left-hand side `types()` call in `types-comparison`

### DIFF
--- a/crates/ruff/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff/src/checkers/ast/analyze/expression.rs
@@ -1134,12 +1134,14 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 flake8_simplify::rules::double_negation(checker, expr, *op, operand);
             }
         }
-        Expr::Compare(ast::ExprCompare {
-            left,
-            ops,
-            comparators,
-            range: _,
-        }) => {
+        Expr::Compare(
+            compare @ ast::ExprCompare {
+                left,
+                ops,
+                comparators,
+                range: _,
+            },
+        ) => {
             let check_none_comparisons = checker.enabled(Rule::NoneComparison);
             let check_true_false_comparisons = checker.enabled(Rule::TrueFalseComparison);
             if check_none_comparisons || check_true_false_comparisons {
@@ -1157,7 +1159,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 pyflakes::rules::invalid_literal_comparison(checker, left, ops, comparators, expr);
             }
             if checker.enabled(Rule::TypeComparison) {
-                pycodestyle::rules::type_comparison(checker, expr, ops, comparators);
+                pycodestyle::rules::type_comparison(checker, compare);
             }
             if checker.any_enabled(&[
                 Rule::SysVersionCmpStr3,

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E721_E721.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E721_E721.py.snap
@@ -20,16 +20,6 @@ E721.py:5:4: E721 Do not compare types, use `isinstance()`
 7 | #: E721
   |
 
-E721.py:10:4: E721 Do not compare types, use `isinstance()`
-   |
- 8 | import types
- 9 | 
-10 | if res == types.IntType:
-   |    ^^^^^^^^^^^^^^^^^^^^ E721
-11 |     pass
-12 | #: E721
-   |
-
 E721.py:15:4: E721 Do not compare types, use `isinstance()`
    |
 13 | import types


### PR DESCRIPTION
Follow-up to https://github.com/astral-sh/ruff/pull/6325, to avoid false positives in cases like:

```python
if x == int:
    ...
```

Which is valid, since we don't know that we're comparing the type _of_ something -- we're comparing the type objects directly. 