### PR TITLE
Formatter: Add SourceType to context to enable special formatting for stub files

### DIFF
--- a/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
@@ -52,15 +52,13 @@ pub(crate) fn type_comparison(checker: &mut Checker, compare: &ast::ExprCompare)
         }
 
         // Left-hand side must be, e.g., `type(obj)`.
-        let Expr::Call(ast::ExprCall {
-            func,  ..
-        }) = left else {
+        let Expr::Call(ast::ExprCall { func, .. }) = left else {
             continue;
         };
 
         let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() else {
-                continue;
-            };
+            continue;
+        };
 
         if !(id == "type" && checker.semantic().is_builtin("type")) {
             continue;

--- a/crates/ruff_benchmark/benches/formatter.rs
+++ b/crates/ruff_benchmark/benches/formatter.rs
@@ -1,6 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use ruff_benchmark::{TestCase, TestCaseSpeed, TestFile, TestFileDownloadError};
 use ruff_python_formatter::{format_module, PyFormatOptions};
+use std::path::Path;
 use std::time::Duration;
 
 #[cfg(target_os = "windows")]
@@ -51,8 +52,8 @@ fn benchmark_formatter(criterion: &mut Criterion) {
             &case,
             |b, case| {
                 b.iter(|| {
-                    format_module(case.code(), PyFormatOptions::default())
-                        .expect("Formatting to succeed")
+                    let options = PyFormatOptions::from_extension(Path::new(case.name())).unwrap();
+                    format_module(case.code(), options).expect("Formatting to succeed")
                 });
             },
         );

--- a/crates/ruff_benchmark/benches/formatter.rs
+++ b/crates/ruff_benchmark/benches/formatter.rs
@@ -52,7 +52,7 @@ fn benchmark_formatter(criterion: &mut Criterion) {
             &case,
             |b, case| {
                 b.iter(|| {
-                    let options = PyFormatOptions::from_extension(Path::new(case.name())).unwrap();
+                    let options = PyFormatOptions::from_extension(Path::new(case.name()));
                     format_module(case.code(), options).expect("Formatting to succeed")
                 });
             },

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -165,7 +165,7 @@ fn format(files: &[PathBuf]) -> Result<ExitStatus> {
         // Check if we should read from stdin
         [path] if path == Path::new("-") => {
             let unformatted = read_from_stdin()?;
-            let options = PyFormatOptions::from_extension(Path::new("stdin.py")).unwrap();
+            let options = PyFormatOptions::from_extension(Path::new("stdin.py"));
             let formatted = format_module(&unformatted, options)?;
             stdout().lock().write_all(formatted.as_code().as_bytes())?;
         }
@@ -173,8 +173,7 @@ fn format(files: &[PathBuf]) -> Result<ExitStatus> {
             for file in files {
                 let unformatted = std::fs::read_to_string(file)
                     .with_context(|| format!("Could not read {}: ", file.display()))?;
-                let options = PyFormatOptions::from_extension(file)
-                    .context("Unknown file extension, expected .py or .pyi")?;
+                let options = PyFormatOptions::from_extension(file);
                 let formatted = format_module(&unformatted, options)?;
                 std::fs::write(file, formatted.as_code().as_bytes())
                     .with_context(|| format!("Could not write to {}, exiting", file.display()))?;

--- a/crates/ruff_dev/src/format_dev.rs
+++ b/crates/ruff_dev/src/format_dev.rs
@@ -460,9 +460,7 @@ fn format_dir_entry(
     }
 
     let file = dir_entry.path().to_path_buf();
-    let options = options
-        .to_py_format_options(&file)
-        .context("Unknown file extension, expected .py or .pyi")?;
+    let options = options.to_py_format_options(&file);
     // Handle panics (mostly in `debug_assert!`)
     let result = match catch_unwind(|| format_dev_file(&file, stability_check, write, options)) {
         Ok(result) => result,
@@ -868,8 +866,7 @@ mod tests {
         "};
         let options = BlackOptions::from_toml(toml, Path::new("pyproject.toml"))
             .unwrap()
-            .to_py_format_options(Path::new("code_inline.py"))
-            .unwrap();
+            .to_py_format_options(Path::new("code_inline.py"));
         assert_eq!(options.line_width(), LineWidth::try_from(119).unwrap());
         assert!(matches!(
             options.magic_trailing_comma(),
@@ -888,8 +885,7 @@ mod tests {
         "#};
         let options = BlackOptions::from_toml(toml, Path::new("pyproject.toml"))
             .unwrap()
-            .to_py_format_options(Path::new("code_inline.py"))
-            .unwrap();
+            .to_py_format_options(Path::new("code_inline.py"));
         assert_eq!(options.line_width(), LineWidth::try_from(130).unwrap());
         assert!(matches!(
             options.magic_trailing_comma(),

--- a/crates/ruff_dev/src/format_dev.rs
+++ b/crates/ruff_dev/src/format_dev.rs
@@ -835,9 +835,8 @@ impl BlackOptions {
         Self::from_toml(&fs::read_to_string(&path)?, repo)
     }
 
-    fn to_py_format_options(&self, file: &Path) -> Option<PyFormatOptions> {
-        let mut options = PyFormatOptions::from_extension(file)?;
-        options
+    fn to_py_format_options(&self, file: &Path) -> PyFormatOptions {
+        PyFormatOptions::from_extension(file)
             .with_line_width(
                 LineWidth::try_from(self.line_length).expect("Invalid line length limit"),
             )
@@ -845,8 +844,7 @@ impl BlackOptions {
                 MagicTrailingComma::Ignore
             } else {
                 MagicTrailingComma::Respect
-            });
-        Some(options)
+            })
     }
 }
 

--- a/crates/ruff_dev/src/format_dev.rs
+++ b/crates/ruff_dev/src/format_dev.rs
@@ -376,10 +376,10 @@ fn format_dev_project(
 
     // TODO(konstin): The assumptions between this script (one repo) and ruff (pass in a bunch of
     // files) mismatch.
-    let options = BlackOptions::from_file(&files[0])?.to_py_format_options();
+    let black_options = BlackOptions::from_file(&files[0])?;
     debug!(
         parent: None,
-        "Options for {}: {options:?}",
+        "Options for {}: {black_options:?}",
         files[0].display()
     );
 
@@ -398,7 +398,7 @@ fn format_dev_project(
         paths
             .into_par_iter()
             .map(|dir_entry| {
-                let result = format_dir_entry(dir_entry, stability_check, write, &options);
+                let result = format_dir_entry(dir_entry, stability_check, write, &black_options);
                 pb_span.pb_inc(1);
                 result
             })
@@ -447,7 +447,7 @@ fn format_dir_entry(
     dir_entry: Result<DirEntry, ignore::Error>,
     stability_check: bool,
     write: bool,
-    options: &PyFormatOptions,
+    options: &BlackOptions,
 ) -> anyhow::Result<(Result<Statistics, CheckFileError>, PathBuf), Error> {
     let dir_entry = match dir_entry.context("Iterating the files in the repository failed") {
         Ok(dir_entry) => dir_entry,
@@ -460,27 +460,29 @@ fn format_dir_entry(
     }
 
     let file = dir_entry.path().to_path_buf();
+    let options = options
+        .to_py_format_options(&file)
+        .context("Unknown file extension, expected .py or .pyi")?;
     // Handle panics (mostly in `debug_assert!`)
-    let result =
-        match catch_unwind(|| format_dev_file(&file, stability_check, write, options.clone())) {
-            Ok(result) => result,
-            Err(panic) => {
-                if let Some(message) = panic.downcast_ref::<String>() {
-                    Err(CheckFileError::Panic {
-                        message: message.clone(),
-                    })
-                } else if let Some(&message) = panic.downcast_ref::<&str>() {
-                    Err(CheckFileError::Panic {
-                        message: message.to_string(),
-                    })
-                } else {
-                    Err(CheckFileError::Panic {
-                        // This should not happen, but it can
-                        message: "(Panic didn't set a string message)".to_string(),
-                    })
-                }
+    let result = match catch_unwind(|| format_dev_file(&file, stability_check, write, options)) {
+        Ok(result) => result,
+        Err(panic) => {
+            if let Some(message) = panic.downcast_ref::<String>() {
+                Err(CheckFileError::Panic {
+                    message: message.clone(),
+                })
+            } else if let Some(&message) = panic.downcast_ref::<&str>() {
+                Err(CheckFileError::Panic {
+                    message: message.to_string(),
+                })
+            } else {
+                Err(CheckFileError::Panic {
+                    // This should not happen, but it can
+                    message: "(Panic didn't set a string message)".to_string(),
+                })
             }
-        };
+        }
+    };
     Ok((result, file))
 }
 
@@ -833,8 +835,8 @@ impl BlackOptions {
         Self::from_toml(&fs::read_to_string(&path)?, repo)
     }
 
-    fn to_py_format_options(&self) -> PyFormatOptions {
-        let mut options = PyFormatOptions::default();
+    fn to_py_format_options(&self, file: &Path) -> Option<PyFormatOptions> {
+        let mut options = PyFormatOptions::from_extension(file)?;
         options
             .with_line_width(
                 LineWidth::try_from(self.line_length).expect("Invalid line length limit"),
@@ -844,7 +846,7 @@ impl BlackOptions {
             } else {
                 MagicTrailingComma::Respect
             });
-        options
+        Some(options)
     }
 }
 
@@ -868,7 +870,8 @@ mod tests {
         "};
         let options = BlackOptions::from_toml(toml, Path::new("pyproject.toml"))
             .unwrap()
-            .to_py_format_options();
+            .to_py_format_options(Path::new("code_inline.py"))
+            .unwrap();
         assert_eq!(options.line_width(), LineWidth::try_from(119).unwrap());
         assert!(matches!(
             options.magic_trailing_comma(),
@@ -887,7 +890,8 @@ mod tests {
         "#};
         let options = BlackOptions::from_toml(toml, Path::new("pyproject.toml"))
             .unwrap()
-            .to_py_format_options();
+            .to_py_format_options(Path::new("code_inline.py"))
+            .unwrap();
         assert_eq!(options.line_width(), LineWidth::try_from(130).unwrap());
         assert!(matches!(
             options.magic_trailing_comma(),

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -1,4 +1,5 @@
 use ruff_text_size::{TextRange, TextSize};
+use std::path::Path;
 
 pub mod all;
 pub mod call_path;
@@ -47,5 +48,38 @@ where
 {
     fn range(&self) -> TextRange {
         T::range(self)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum PySourceType {
+    #[default]
+    Python,
+    Stub,
+    Jupyter,
+}
+
+impl PySourceType {
+    pub const fn is_python(&self) -> bool {
+        matches!(self, PySourceType::Python)
+    }
+
+    pub const fn is_stub(&self) -> bool {
+        matches!(self, PySourceType::Stub)
+    }
+
+    pub const fn is_jupyter(&self) -> bool {
+        matches!(self, PySourceType::Jupyter)
+    }
+}
+
+impl From<&Path> for PySourceType {
+    fn from(path: &Path) -> Self {
+        match path.extension() {
+            Some(ext) if ext == "pyi" => PySourceType::Stub,
+            Some(ext) if ext == "ipynb" => PySourceType::Jupyter,
+            _ => PySourceType::Python,
+        }
     }
 }

--- a/crates/ruff_python_formatter/Cargo.toml
+++ b/crates/ruff_python_formatter/Cargo.toml
@@ -32,7 +32,7 @@ smallvec = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-ruff_formatter = { path = "../ruff_formatter", features = ["serde"]}
+ruff_formatter = { path = "../ruff_formatter", features = ["serde"] }
 
 insta = { workspace = true, features = ["glob"] }
 serde = { workspace = true }
@@ -43,8 +43,8 @@ similar = { workspace = true }
 name = "ruff_python_formatter_fixtures"
 path = "tests/fixtures.rs"
 test = true
-required-features = [ "serde" ]
+required-features = ["serde"]
 
 [features]
-serde = ["dep:serde", "ruff_formatter/serde", "ruff_source_file/serde"]
+serde = ["dep:serde", "ruff_formatter/serde", "ruff_source_file/serde", "ruff_python_ast/serde"]
 default = ["serde"]

--- a/crates/ruff_python_formatter/src/cli.rs
+++ b/crates/ruff_python_formatter/src/cli.rs
@@ -57,7 +57,7 @@ pub fn format_and_debug_print(input: &str, cli: &Cli, source_type: &Path) -> Res
     let python_ast =
         parse_tokens(tokens, Mode::Module, "<filename>").context("Syntax error in input")?;
 
-    let options = PyFormatOptions::from_extension(source_type).unwrap();
+    let options = PyFormatOptions::from_extension(source_type);
     let formatted = format_node(&python_ast, &comment_ranges, input, options)
         .context("Failed to format node")?;
     if cli.print_ir {

--- a/crates/ruff_python_formatter/src/cli.rs
+++ b/crates/ruff_python_formatter/src/cli.rs
@@ -1,14 +1,14 @@
 #![allow(clippy::print_stdout)]
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use clap::{command, Parser, ValueEnum};
-use ruff_python_parser::lexer::lex;
-use ruff_python_parser::{parse_tokens, Mode};
 
 use ruff_formatter::SourceCode;
 use ruff_python_index::CommentRangesBuilder;
+use ruff_python_parser::lexer::lex;
+use ruff_python_parser::{parse_tokens, Mode};
 
 use crate::{format_node, PyFormatOptions};
 
@@ -37,7 +37,7 @@ pub struct Cli {
     pub print_comments: bool,
 }
 
-pub fn format_and_debug_print(input: &str, cli: &Cli) -> Result<String> {
+pub fn format_and_debug_print(input: &str, cli: &Cli, source_type: &Path) -> Result<String> {
     let mut tokens = Vec::new();
     let mut comment_ranges = CommentRangesBuilder::default();
 
@@ -57,13 +57,9 @@ pub fn format_and_debug_print(input: &str, cli: &Cli) -> Result<String> {
     let python_ast =
         parse_tokens(tokens, Mode::Module, "<filename>").context("Syntax error in input")?;
 
-    let formatted = format_node(
-        &python_ast,
-        &comment_ranges,
-        input,
-        PyFormatOptions::default(),
-    )
-    .context("Failed to format node")?;
+    let options = PyFormatOptions::from_extension(source_type).unwrap();
+    let formatted = format_node(&python_ast, &comment_ranges, input, options)
+        .context("Failed to format node")?;
     if cli.print_ir {
         println!("{}", formatted.document().display(SourceCode::new(input)));
     }

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -2,7 +2,7 @@ use crate::comments::{
     dangling_node_comments, leading_node_comments, trailing_node_comments, Comments,
 };
 use crate::context::PyFormatContext;
-pub use crate::options::{MagicTrailingComma, PyFormatOptions, QuoteStyle, SourceType};
+pub use crate::options::{MagicTrailingComma, PyFormatOptions, QuoteStyle};
 use ruff_formatter::format_element::tag;
 use ruff_formatter::prelude::{
     dynamic_text, source_position, source_text_slice, text, ContainsNewlines, Formatter, Tag,
@@ -324,7 +324,7 @@ with [
         // Parse the AST.
         let source_path = "code_inline.py";
         let python_ast = parse_tokens(tokens, Mode::Module, source_path).unwrap();
-        let options = PyFormatOptions::from_extension(Path::new(source_path)).unwrap();
+        let options = PyFormatOptions::from_extension(Path::new(source_path));
         let formatted = format_node(&python_ast, &comment_ranges, src, options).unwrap();
 
         // Uncomment the `dbg` to print the IR.

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -2,7 +2,7 @@ use crate::comments::{
     dangling_node_comments, leading_node_comments, trailing_node_comments, Comments,
 };
 use crate::context::PyFormatContext;
-pub use crate::options::{MagicTrailingComma, PyFormatOptions, QuoteStyle};
+pub use crate::options::{MagicTrailingComma, PyFormatOptions, QuoteStyle, SourceType};
 use ruff_formatter::format_element::tag;
 use ruff_formatter::prelude::{
     dynamic_text, source_position, source_text_slice, text, ContainsNewlines, Formatter, Tag,
@@ -255,6 +255,7 @@ mod tests {
     use ruff_python_index::CommentRangesBuilder;
     use ruff_python_parser::lexer::lex;
     use ruff_python_parser::{parse_tokens, Mode};
+    use std::path::Path;
 
     /// Very basic test intentionally kept very similar to the CLI
     #[test]
@@ -321,15 +322,10 @@ with [
         let comment_ranges = comment_ranges.finish();
 
         // Parse the AST.
-        let python_ast = parse_tokens(tokens, Mode::Module, "<filename>").unwrap();
-
-        let formatted = format_node(
-            &python_ast,
-            &comment_ranges,
-            src,
-            PyFormatOptions::default(),
-        )
-        .unwrap();
+        let source_path = "code_inline.py";
+        let python_ast = parse_tokens(tokens, Mode::Module, source_path).unwrap();
+        let options = PyFormatOptions::from_extension(Path::new(source_path)).unwrap();
+        let formatted = format_node(&python_ast, &comment_ranges, src, options).unwrap();
 
         // Uncomment the `dbg` to print the IR.
         // Use `dbg_write!(f, []) instead of `write!(f, [])` in your formatting code to print some IR

--- a/crates/ruff_python_formatter/src/main.rs
+++ b/crates/ruff_python_formatter/src/main.rs
@@ -1,4 +1,5 @@
 use std::io::{stdout, Read, Write};
+use std::path::Path;
 use std::{fs, io};
 
 use anyhow::{bail, Context, Result};
@@ -25,7 +26,8 @@ fn main() -> Result<()> {
             );
         }
         let input = read_from_stdin()?;
-        let formatted = format_and_debug_print(&input, &cli)?;
+        // It seems reasonable to give this a dummy name
+        let formatted = format_and_debug_print(&input, &cli, Path::new("stdin.py"))?;
         if cli.check {
             if formatted == input {
                 return Ok(());
@@ -37,7 +39,7 @@ fn main() -> Result<()> {
         for file in &cli.files {
             let input = fs::read_to_string(file)
                 .with_context(|| format!("Could not read {}: ", file.display()))?;
-            let formatted = format_and_debug_print(&input, &cli)?;
+            let formatted = format_and_debug_print(&input, &cli, file)?;
             match cli.emit {
                 Some(Emit::Stdout) => stdout().lock().write_all(formatted.as_bytes())?,
                 None | Some(Emit::Files) => {

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -1,32 +1,7 @@
 use ruff_formatter::printer::{LineEnding, PrinterOptions};
 use ruff_formatter::{FormatOptions, IndentStyle, LineWidth};
-use std::ffi::OsStr;
+use ruff_python_ast::PySourceType;
 use std::path::Path;
-
-#[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum SourceType {
-    /// A `.py` file
-    Py,
-    /// A `.pyi` file
-    Pyi,
-}
-
-impl SourceType {
-    pub fn from_path(path: &Path) -> Option<Self> {
-        match path.extension().and_then(OsStr::to_str) {
-            Some("py") => Some(Self::Py),
-            Some("pyi") => Some(Self::Pyi),
-            _ => None,
-        }
-    }
-}
-
-impl Default for SourceType {
-    fn default() -> Self {
-        Self::Py
-    }
-}
 
 #[derive(Clone, Debug)]
 #[cfg_attr(
@@ -36,7 +11,7 @@ impl Default for SourceType {
 )]
 pub struct PyFormatOptions {
     /// Whether we're in a `.py` file or `.pyi` file, which have different rules
-    source_type: SourceType,
+    source_type: PySourceType,
 
     /// Specifies the indent style:
     /// * Either a tab
@@ -61,7 +36,7 @@ fn default_line_width() -> LineWidth {
 impl Default for PyFormatOptions {
     fn default() -> Self {
         Self {
-            source_type: SourceType::default(),
+            source_type: PySourceType::default(),
             indent_style: IndentStyle::Space(4),
             line_width: LineWidth::try_from(88).unwrap(),
             quote_style: QuoteStyle::default(),
@@ -72,11 +47,11 @@ impl Default for PyFormatOptions {
 
 impl PyFormatOptions {
     /// Otherwise sets the defaults. Returns none if the extension is unknown
-    pub fn from_extension(path: &Path) -> Option<Self> {
-        Some(Self::from_source_type(SourceType::from_path(path)?))
+    pub fn from_extension(path: &Path) -> Self {
+        Self::from_source_type(PySourceType::from(path))
     }
 
-    pub fn from_source_type(source_type: SourceType) -> Self {
+    pub fn from_source_type(source_type: PySourceType) -> Self {
         Self {
             source_type,
             ..Self::default()
@@ -96,17 +71,17 @@ impl PyFormatOptions {
         self
     }
 
-    pub fn with_magic_trailing_comma(&mut self, trailing_comma: MagicTrailingComma) -> &mut Self {
+    pub fn with_magic_trailing_comma(mut self, trailing_comma: MagicTrailingComma) -> Self {
         self.magic_trailing_comma = trailing_comma;
         self
     }
 
-    pub fn with_indent_style(&mut self, indent_style: IndentStyle) -> &mut Self {
+    pub fn with_indent_style(mut self, indent_style: IndentStyle) -> Self {
         self.indent_style = indent_style;
         self
     }
 
-    pub fn with_line_width(&mut self, line_width: LineWidth) -> &mut Self {
+    pub fn with_line_width(mut self, line_width: LineWidth) -> Self {
         self.line_width = line_width;
         self
     }

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -71,16 +71,19 @@ impl PyFormatOptions {
         self
     }
 
+    #[must_use]
     pub fn with_magic_trailing_comma(mut self, trailing_comma: MagicTrailingComma) -> Self {
         self.magic_trailing_comma = trailing_comma;
         self
     }
 
+    #[must_use]
     pub fn with_indent_style(mut self, indent_style: IndentStyle) -> Self {
         self.indent_style = indent_style;
         self
     }
 
+    #[must_use]
     pub fn with_line_width(mut self, line_width: LineWidth) -> Self {
         self.line_width = line_width;
         self

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -3,7 +3,7 @@ use ruff_formatter::{FormatOptions, IndentStyle, LineWidth};
 use std::ffi::OsStr;
 use std::path::Path;
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SourceType {
     /// A `.py` file

--- a/crates/ruff_python_formatter/tests/fixtures.rs
+++ b/crates/ruff_python_formatter/tests/fixtures.rs
@@ -17,7 +17,7 @@ fn black_compatibility() {
             let reader = BufReader::new(options_file);
             serde_json::from_reader(reader).expect("Options to be a valid Json file")
         } else {
-            PyFormatOptions::default()
+            PyFormatOptions::from_extension(input_path).unwrap()
         };
 
         let printed = format_module(&content, options.clone()).unwrap_or_else(|err| {
@@ -106,11 +106,11 @@ fn format() {
     let test_file = |input_path: &Path| {
         let content = fs::read_to_string(input_path).unwrap();
 
-        let options = PyFormatOptions::default();
+        let options = PyFormatOptions::from_extension(input_path).unwrap();
         let printed = format_module(&content, options.clone()).expect("Formatting to succeed");
         let formatted_code = printed.as_code();
 
-        ensure_stability_when_formatting_twice(formatted_code, options, input_path);
+        ensure_stability_when_formatting_twice(formatted_code, options.clone(), input_path);
 
         let mut snapshot = format!("## Input\n{}", CodeFrame::new("py", &content));
 
@@ -139,7 +139,6 @@ fn format() {
                 .unwrap();
             }
         } else {
-            let options = PyFormatOptions::default();
             let printed = format_module(&content, options.clone()).expect("Formatting to succeed");
             let formatted_code = printed.as_code();
 

--- a/crates/ruff_python_formatter/tests/fixtures.rs
+++ b/crates/ruff_python_formatter/tests/fixtures.rs
@@ -17,7 +17,7 @@ fn black_compatibility() {
             let reader = BufReader::new(options_file);
             serde_json::from_reader(reader).expect("Options to be a valid Json file")
         } else {
-            PyFormatOptions::from_extension(input_path).unwrap()
+            PyFormatOptions::from_extension(input_path)
         };
 
         let printed = format_module(&content, options.clone()).unwrap_or_else(|err| {
@@ -106,7 +106,7 @@ fn format() {
     let test_file = |input_path: &Path| {
         let content = fs::read_to_string(input_path).unwrap();
 
-        let options = PyFormatOptions::from_extension(input_path).unwrap();
+        let options = PyFormatOptions::from_extension(input_path);
         let printed = format_module(&content, options.clone()).expect("Formatting to succeed");
         let formatted_code = printed.as_code();
 

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -22,7 +22,7 @@ use ruff::settings::configuration::Configuration;
 use ruff::settings::options::Options;
 use ruff::settings::{defaults, flags, Settings};
 use ruff_python_codegen::Stylist;
-use ruff_python_formatter::{format_module, format_node, PyFormatOptions};
+use ruff_python_formatter::{format_module, format_node, PyFormatOptions, SourceType};
 use ruff_python_index::{CommentRangesBuilder, Indexer};
 use ruff_source_file::{Locator, SourceLocation};
 
@@ -262,7 +262,9 @@ impl Workspace {
     }
 
     pub fn format(&self, contents: &str) -> Result<String, Error> {
-        let printed = format_module(contents, PyFormatOptions::default()).map_err(into_error)?;
+        // TODO(konstin): Add an options for py/pyi to the UI (1/2)
+        let options = PyFormatOptions::from_source_type(SourceType::default());
+        let printed = format_module(contents, options).map_err(into_error)?;
 
         Ok(printed.into_code())
     }
@@ -278,13 +280,10 @@ impl Workspace {
         let comment_ranges = comment_ranges.finish();
         let module = parse_tokens(tokens, Mode::Module, ".").map_err(into_error)?;
 
-        let formatted = format_node(
-            &module,
-            &comment_ranges,
-            contents,
-            PyFormatOptions::default(),
-        )
-        .map_err(into_error)?;
+        // TODO(konstin): Add an options for py/pyi to the UI (2/2)
+        let options = PyFormatOptions::from_source_type(SourceType::default());
+        let formatted =
+            format_node(&module, &comment_ranges, contents, options).map_err(into_error)?;
 
         Ok(format!("{formatted}"))
     }

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -23,7 +23,7 @@ use ruff::settings::options::Options;
 use ruff::settings::{defaults, flags, Settings};
 use ruff_python_ast::PySourceType;
 use ruff_python_codegen::Stylist;
-use ruff_python_formatter::{format_module, format_node, PyFormatOptions, SourceType};
+use ruff_python_formatter::{format_module, format_node, PyFormatOptions};
 use ruff_python_index::{CommentRangesBuilder, Indexer};
 use ruff_source_file::{Locator, SourceLocation};
 

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -21,6 +21,7 @@ use ruff::rules::{
 use ruff::settings::configuration::Configuration;
 use ruff::settings::options::Options;
 use ruff::settings::{defaults, flags, Settings};
+use ruff_python_ast::PySourceType;
 use ruff_python_codegen::Stylist;
 use ruff_python_formatter::{format_module, format_node, PyFormatOptions, SourceType};
 use ruff_python_index::{CommentRangesBuilder, Indexer};
@@ -263,7 +264,7 @@ impl Workspace {
 
     pub fn format(&self, contents: &str) -> Result<String, Error> {
         // TODO(konstin): Add an options for py/pyi to the UI (1/2)
-        let options = PyFormatOptions::from_source_type(SourceType::default());
+        let options = PyFormatOptions::from_source_type(PySourceType::default());
         let printed = format_module(contents, options).map_err(into_error)?;
 
         Ok(printed.into_code())
@@ -281,7 +282,7 @@ impl Workspace {
         let module = parse_tokens(tokens, Mode::Module, ".").map_err(into_error)?;
 
         // TODO(konstin): Add an options for py/pyi to the UI (2/2)
-        let options = PyFormatOptions::from_source_type(SourceType::default());
+        let options = PyFormatOptions::from_source_type(PySourceType::default());
         let formatted =
             format_node(&module, &comment_ranges, contents, options).map_err(into_error)?;
 


### PR DESCRIPTION
**Summary** This adds the information whether we're in a .py python source file or in a .pyi stub file to enable people working on #5822 and related issues.

I'm not completely happy with `Default` for something that depends on the input.

**Test Plan** None, this is currently unused, i'm leaving this to first implementation of stub file specific formatting.
