### PR TITLE
Formatter comment handling nits

### DIFF
--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -1270,7 +1270,6 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                             MeasureMode::FirstLine => return Fits::Yes,
                             MeasureMode::AllLines => {
                                 self.state.line_width = 0;
-                                self.state.pending_indent = args.indention();
                                 continue;
                             }
                         }

--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -152,12 +152,10 @@ impl Format<PyFormatContext<'_>> for FormatTrailingComments<'_> {
                 write!(
                     f,
                     [
-                        line_suffix(&format_with(|f| {
-                            write!(
-                                f,
-                                [empty_lines(lines_before_comment), format_comment(trailing)]
-                            )
-                        })),
+                        line_suffix(&format_args![
+                            empty_lines(lines_before_comment),
+                            format_comment(trailing)
+                        ]),
                         expand_parent()
                     ]
                 )?;


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Two small improvements that I came across when working on suppression comments. 

1. We don't need to queue an indent in `fits_text`, because we also don't do it in `print_text` (because it would break verbatim texts).
2. Use `format_args` instead of `format_with`

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test`

<!-- How was it tested? -->
