### PR TITLE
Avoid auto-fixing UP032 if comments are present around format call arguments

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP032_0.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP032_0.py
@@ -198,3 +198,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ).format(a=1)
 
 "{}".format(**c)
+
+"{}".format(
+    1  # comment
+)

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -422,6 +422,13 @@ pub(crate) fn f_strings(
     }
 
     let mut diagnostic = Diagnostic::new(FString, expr.range());
+
+    // Avoid autofix if there are comments within the call:
+    // ```
+    // "{}".format(
+    //     0,  # 0
+    // )
+    // ```
     if checker.patch(diagnostic.kind.rule())
         && !checker
             .indexer()

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -9,7 +9,7 @@ use ruff_python_parser::{lexer, Mode, Tok};
 use ruff_text_size::TextRange;
 use rustc_hash::FxHashMap;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::{leading_quote, trailing_quote};
 use ruff_source_file::Locator;
@@ -42,14 +42,16 @@ use crate::rules::pyupgrade::helpers::curly_escape;
 #[violation]
 pub struct FString;
 
-impl AlwaysAutofixableViolation for FString {
+impl Violation for FString {
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("Use f-string instead of `format` call")
     }
 
-    fn autofix_title(&self) -> String {
-        "Convert to f-string".to_string()
+    fn autofix_title(&self) -> Option<String> {
+        Some("Convert to f-string".to_string())
     }
 }
 
@@ -320,7 +322,7 @@ pub(crate) fn f_strings(
         return;
     };
 
-    let Expr::Attribute(ast::ExprAttribute { value, .. }) = func.as_ref() else {
+    let Expr::Attribute(ast::ExprAttribute { value, attr, .. }) = func.as_ref() else {
         return;
     };
 
@@ -420,7 +422,12 @@ pub(crate) fn f_strings(
     }
 
     let mut diagnostic = Diagnostic::new(FString, expr.range());
-    if checker.patch(diagnostic.kind.rule()) {
+    if checker.patch(diagnostic.kind.rule())
+        && !checker
+            .indexer()
+            .comment_ranges()
+            .intersects(TextRange::new(attr.end(), expr.end()))
+    {
         diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
             contents,
             expr.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -318,11 +318,11 @@ pub(crate) fn f_strings(
         return;
     }
 
-    let Expr::Call(ast::ExprCall { func, .. }) = expr else {
+    let Expr::Call(ast::ExprCall { func, arguments, .. }) = expr else {
         return;
     };
 
-    let Expr::Attribute(ast::ExprAttribute { value, attr, .. }) = func.as_ref() else {
+    let Expr::Attribute(ast::ExprAttribute { value, .. }) = func.as_ref() else {
         return;
     };
 
@@ -433,7 +433,7 @@ pub(crate) fn f_strings(
         && !checker
             .indexer()
             .comment_ranges()
-            .intersects(TextRange::new(attr.end(), expr.end()))
+            .intersects(arguments.range())
     {
         diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
             contents,

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP032_0.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP032_0.py.snap
@@ -945,4 +945,15 @@ UP032_0.py:129:1: UP032 [*] Use f-string instead of `format` call
 131 131 | ###
 132 132 | # Non-errors
 
+UP032_0.py:202:1: UP032 Use f-string instead of `format` call
+    |
+200 |   "{}".format(**c)
+201 |   
+202 | / "{}".format(
+203 | |     1  # comment
+204 | | )
+    | |_^ UP032
+    |
+    = help: Convert to f-string
+
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

Fix #6336 

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->


A new test case