### PR TITLE
Rename semantic model methods to use `current_*` prefix

### DIFF
--- a/crates/ruff/src/checkers/ast/analyze/deferred_for_loops.rs
+++ b/crates/ruff/src/checkers/ast/analyze/deferred_for_loops.rs
@@ -16,7 +16,7 @@ pub(crate) fn deferred_for_loops(checker: &mut Checker) {
             })
             | Stmt::AsyncFor(ast::StmtAsyncFor {
                 target, iter, body, ..
-            }) = &checker.semantic.stmt()
+            }) = &checker.semantic.current_statement()
             {
                 if checker.enabled(Rule::UnusedLoopControlVariable) {
                     flake8_bugbear::rules::unused_loop_control_variable(checker, target, body);

--- a/crates/ruff/src/checkers/ast/analyze/deferred_scopes.rs
+++ b/crates/ruff/src/checkers/ast/analyze/deferred_scopes.rs
@@ -112,7 +112,11 @@ pub(crate) fn deferred_scopes(checker: &mut Checker) {
                     // If the bindings are in different forks, abort.
                     if shadowed.source.map_or(true, |left| {
                         binding.source.map_or(true, |right| {
-                            branch_detection::different_forks(left, right, &checker.semantic.stmts)
+                            branch_detection::different_forks(
+                                left,
+                                right,
+                                &checker.semantic.statements,
+                            )
                         })
                     }) {
                         continue;
@@ -172,7 +176,7 @@ pub(crate) fn deferred_scopes(checker: &mut Checker) {
                         if shadowed.kind.is_function_definition()
                             && visibility::is_overload(
                                 cast::decorator_list(
-                                    checker.semantic.stmts[shadowed.source.unwrap()],
+                                    checker.semantic.statements[shadowed.source.unwrap()],
                                 ),
                                 &checker.semantic,
                             )
@@ -195,7 +199,11 @@ pub(crate) fn deferred_scopes(checker: &mut Checker) {
                     // If the bindings are in different forks, abort.
                     if shadowed.source.map_or(true, |left| {
                         binding.source.map_or(true, |right| {
-                            branch_detection::different_forks(left, right, &checker.semantic.stmts)
+                            branch_detection::different_forks(
+                                left,
+                                right,
+                                &checker.semantic.statements,
+                            )
                         })
                     }) {
                         continue;

--- a/crates/ruff/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff/src/checkers/ast/analyze/statement.rs
@@ -53,7 +53,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             if checker.enabled(Rule::BreakOutsideLoop) {
                 if let Some(diagnostic) = pyflakes::rules::break_outside_loop(
                     stmt,
-                    &mut checker.semantic.parents().skip(1),
+                    &mut checker.semantic.current_statements().skip(1),
                 ) {
                     checker.diagnostics.push(diagnostic);
                 }
@@ -63,7 +63,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             if checker.enabled(Rule::ContinueOutsideLoop) {
                 if let Some(diagnostic) = pyflakes::rules::continue_outside_loop(
                     stmt,
-                    &mut checker.semantic.parents().skip(1),
+                    &mut checker.semantic.current_statements().skip(1),
                 ) {
                     checker.diagnostics.push(diagnostic);
                 }
@@ -113,7 +113,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 if let Some(diagnostic) =
                     pep8_naming::rules::invalid_first_argument_name_for_class_method(
                         checker,
-                        checker.semantic.scope(),
+                        checker.semantic.current_scope(),
                         name,
                         decorator_list,
                         parameters,
@@ -125,7 +125,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             if checker.enabled(Rule::InvalidFirstArgumentNameForMethod) {
                 if let Some(diagnostic) = pep8_naming::rules::invalid_first_argument_name_for_method(
                     checker,
-                    checker.semantic.scope(),
+                    checker.semantic.current_scope(),
                     name,
                     decorator_list,
                     parameters,
@@ -193,7 +193,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             }
             if checker.enabled(Rule::DunderFunctionName) {
                 if let Some(diagnostic) = pep8_naming::rules::dunder_function_name(
-                    checker.semantic.scope(),
+                    checker.semantic.current_scope(),
                     stmt,
                     name,
                     &checker.settings.pep8_naming.ignore_names,
@@ -348,7 +348,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             if checker.enabled(Rule::YieldInForLoop) {
                 pyupgrade::rules::yield_in_for_loop(checker, stmt);
             }
-            if let ScopeKind::Class(class_def) = checker.semantic.scope().kind {
+            if let ScopeKind::Class(class_def) = checker.semantic.current_scope().kind {
                 if checker.enabled(Rule::BuiltinAttributeShadowing) {
                     flake8_builtins::rules::builtin_method_shadowing(
                         checker,
@@ -766,7 +766,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     }
                 } else if &alias.name == "*" {
                     if checker.enabled(Rule::UndefinedLocalWithNestedImportStarUsage) {
-                        if !matches!(checker.semantic.scope().kind, ScopeKind::Module) {
+                        if !matches!(checker.semantic.current_scope().kind, ScopeKind::Module) {
                             checker.diagnostics.push(Diagnostic::new(
                                 pyflakes::rules::UndefinedLocalWithNestedImportStarUsage {
                                     name: helpers::format_import_from(level, module),
@@ -982,7 +982,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 flake8_simplify::rules::nested_if_statements(
                     checker,
                     if_,
-                    checker.semantic.stmt_parent(),
+                    checker.semantic.current_statement_parent(),
                 );
             }
             if checker.enabled(Rule::IfWithSameArms) {
@@ -1004,7 +1004,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 tryceratops::rules::type_check_without_type_error(
                     checker,
                     if_,
-                    checker.semantic.stmt_parent(),
+                    checker.semantic.current_statement_parent(),
                 );
             }
             if checker.enabled(Rule::OutdatedVersionBlock) {
@@ -1110,7 +1110,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     checker,
                     stmt,
                     body,
-                    checker.semantic.stmt_parent(),
+                    checker.semantic.current_statement_parent(),
                 );
             }
             if checker.enabled(Rule::RedefinedLoopName) {
@@ -1338,7 +1338,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     // Ignore assignments in function bodies; those are covered by other rules.
                     if !checker
                         .semantic
-                        .scopes()
+                        .current_scopes()
                         .any(|scope| scope.kind.is_any_function())
                     {
                         if checker.enabled(Rule::UnprefixedTypeParam) {
@@ -1403,7 +1403,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                         // Ignore assignments in function bodies; those are covered by other rules.
                         if !checker
                             .semantic
-                            .scopes()
+                            .current_scopes()
                             .any(|scope| scope.kind.is_any_function())
                         {
                             flake8_pyi::rules::annotated_assignment_default_in_stub(

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
@@ -63,7 +63,7 @@ fn matches_string_format_expression(expr: &Expr, model: &SemanticModel) -> bool 
         }) => {
             // Only evaluate the full BinOp, not the nested components.
             if model
-                .expr_parent()
+                .current_expression_parent()
                 .map_or(true, |parent| !parent.is_bin_op_expr())
             {
                 if any_over_expr(expr, &has_string_literal) {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -77,7 +77,7 @@ fn is_cache_func(expr: &Expr, semantic: &SemanticModel) -> bool {
 
 /// B019
 pub(crate) fn cached_instance_method(checker: &mut Checker, decorator_list: &[Decorator]) {
-    if !checker.semantic().scope().kind.is_class() {
+    if !checker.semantic().current_scope().kind.is_class() {
         return;
     }
     for decorator in decorator_list {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -97,7 +97,7 @@ pub(crate) fn setattr_with_constant(
     if let Stmt::Expr(ast::StmtExpr {
         value: child,
         range: _,
-    }) = checker.semantic().stmt()
+    }) = checker.semantic().current_statement()
     {
         if expr == child.as_ref() {
             let mut diagnostic = Diagnostic::new(SetAttrWithConstant, expr.range());

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -159,7 +159,7 @@ pub(crate) fn unused_loop_control_variable(checker: &mut Checker, target: &Expr,
                 if certainty.into() {
                     // Avoid fixing if the variable, or any future bindings to the variable, are
                     // used _after_ the loop.
-                    let scope = checker.semantic().scope();
+                    let scope = checker.semantic().current_scope();
                     if scope
                         .get_all(name)
                         .map(|binding_id| checker.semantic().binding(binding_id))

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
@@ -43,8 +43,8 @@ pub(crate) fn call_datetime_strptime_without_zone(checker: &mut Checker, call: &
     };
 
     let (Some(grandparent), Some(parent)) = (
-        checker.semantic().expr_grandparent(),
-        checker.semantic().expr_parent(),
+        checker.semantic().current_expression_grandparent(),
+        checker.semantic().current_expression_parent(),
     ) else {
         checker.diagnostics.push(Diagnostic::new(
             CallDatetimeStrptimeWithoutZone,

--- a/crates/ruff/src/rules/flake8_datetimez/rules/helpers.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/helpers.rs
@@ -6,7 +6,7 @@ use crate::checkers::ast::Checker;
 /// Check if the parent expression is a call to `astimezone`. This assumes that
 /// the current expression is a `datetime.datetime` object.
 pub(super) fn parent_expr_is_astimezone(checker: &Checker) -> bool {
-    checker.semantic().expr_parent().is_some_and( |parent| {
+    checker.semantic().current_expression_parent().is_some_and( |parent| {
         matches!(parent, Expr::Attribute(ExprAttribute { attr, .. }) if attr.as_str() == "astimezone")
     })
 }

--- a/crates/ruff/src/rules/flake8_pyi/rules/any_eq_ne_annotation.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/any_eq_ne_annotation.rs
@@ -66,7 +66,7 @@ pub(crate) fn any_eq_ne_annotation(checker: &mut Checker, name: &str, parameters
         return;
     };
 
-    if !checker.semantic().scope().kind.is_class() {
+    if !checker.semantic().current_scope().kind.is_class() {
         return;
     }
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/custom_type_var_return_type.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/custom_type_var_return_type.rs
@@ -91,7 +91,7 @@ pub(crate) fn custom_type_var_return_type(
         return;
     };
 
-    if !checker.semantic().scope().kind.is_class() {
+    if !checker.semantic().current_scope().kind.is_class() {
         return;
     };
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -119,7 +119,7 @@ pub(crate) fn non_self_return_type(
     parameters: &Parameters,
     async_: bool,
 ) {
-    let ScopeKind::Class(class_def) = checker.semantic().scope().kind else {
+    let ScopeKind::Class(class_def) = checker.semantic().current_scope().kind else {
         return;
     };
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -349,8 +349,8 @@ fn is_type_var_like_call(expr: &Expr, semantic: &SemanticModel) -> bool {
 fn is_special_assignment(target: &Expr, semantic: &SemanticModel) -> bool {
     if let Expr::Name(ast::ExprName { id, .. }) = target {
         match id.as_str() {
-            "__all__" => semantic.scope().kind.is_module(),
-            "__match_args__" | "__slots__" => semantic.scope().kind.is_class(),
+            "__all__" => semantic.current_scope().kind.is_module(),
+            "__match_args__" | "__slots__" => semantic.current_scope().kind.is_class(),
             _ => false,
         }
     } else {
@@ -569,7 +569,9 @@ pub(crate) fn unannotated_assignment_in_stub(
         return;
     }
 
-    if let ScopeKind::Class(ast::StmtClassDef { arguments, .. }) = checker.semantic().scope().kind {
+    if let ScopeKind::Class(ast::StmtClassDef { arguments, .. }) =
+        checker.semantic().current_scope().kind
+    {
         if is_enum(arguments.as_deref(), checker.semantic()) {
             return;
         }

--- a/crates/ruff/src/rules/flake8_pyi/rules/str_or_repr_defined_in_stub.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/str_or_repr_defined_in_stub.rs
@@ -63,7 +63,7 @@ pub(crate) fn str_or_repr_defined_in_stub(checker: &mut Checker, stmt: &Stmt) {
         return;
     }
 
-    if !checker.semantic().scope().kind.is_class() {
+    if !checker.semantic().current_scope().kind.is_class() {
         return;
     }
 
@@ -96,11 +96,12 @@ pub(crate) fn str_or_repr_defined_in_stub(checker: &mut Checker, stmt: &Stmt) {
         stmt.identifier(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        let stmt = checker.semantic().stmt();
-        let parent = checker.semantic().stmt_parent();
+        let stmt = checker.semantic().current_statement();
+        let parent = checker.semantic().current_statement_parent();
         let edit = delete_stmt(stmt, parent, checker.locator(), checker.indexer());
         diagnostic.set_fix(
-            Fix::automatic(edit).isolate(checker.isolation(checker.semantic().stmt_parent())),
+            Fix::automatic(edit)
+                .isolate(checker.isolation(checker.semantic().current_statement_parent())),
         );
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
@@ -43,7 +43,7 @@ impl AlwaysAutofixableViolation for StringOrBytesTooLong {
 /// PYI053
 pub(crate) fn string_or_bytes_too_long(checker: &mut Checker, expr: &Expr) {
     // Ignore docstrings.
-    if is_docstring_stmt(checker.semantic().stmt()) {
+    if is_docstring_stmt(checker.semantic().current_statement()) {
         return;
     }
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/unused_private_type_definition.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unused_private_type_definition.rs
@@ -173,7 +173,8 @@ pub(crate) fn unused_private_type_var(
         let Some(source) = binding.source else {
             continue;
         };
-        let Stmt::Assign(ast::StmtAssign { targets, value, .. }) = checker.semantic().stmts[source]
+        let Stmt::Assign(ast::StmtAssign { targets, value, .. }) =
+            checker.semantic().statements[source]
         else {
             continue;
         };
@@ -217,7 +218,7 @@ pub(crate) fn unused_private_protocol(
             continue;
         };
 
-        let Stmt::ClassDef(class_def) = checker.semantic().stmts[source] else {
+        let Stmt::ClassDef(class_def) = checker.semantic().statements[source] else {
             continue;
         };
 
@@ -260,7 +261,7 @@ pub(crate) fn unused_private_type_alias(
         };
         let Stmt::AnnAssign(ast::StmtAnnAssign {
             target, annotation, ..
-        }) = checker.semantic().stmts[source]
+        }) = checker.semantic().statements[source]
         else {
             continue;
         };
@@ -304,7 +305,7 @@ pub(crate) fn unused_private_typed_dict(
         let Some(source) = binding.source else {
             continue;
         };
-        let Stmt::ClassDef(class_def) = checker.semantic().stmts[source] else {
+        let Stmt::ClassDef(class_def) = checker.semantic().statements[source] else {
             continue;
         };
 

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -246,8 +246,8 @@ pub(crate) fn unittest_assertion(
                 if checker.patch(diagnostic.kind.rule()) {
                     // We're converting an expression to a statement, so avoid applying the fix if
                     // the assertion is part of a larger expression.
-                    if checker.semantic().stmt().is_expr_stmt()
-                        && checker.semantic().expr_parent().is_none()
+                    if checker.semantic().current_statement().is_expr_stmt()
+                        && checker.semantic().current_expression_parent().is_none()
                         && !checker.indexer().comment_ranges().intersects(expr.range())
                     {
                         if let Ok(stmt) = unittest_assert.generate_assert(args, keywords) {

--- a/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
@@ -77,7 +77,7 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
 
             // Ignore accesses on instances within special methods (e.g., `__eq__`).
             if let ScopeKind::Function(ast::StmtFunctionDef { name, .. }) =
-                checker.semantic().scope().kind
+                checker.semantic().current_scope().kind
             {
                 if matches!(
                     name.as_str(),

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -155,14 +155,14 @@ pub(crate) fn negation_with_equal_op(
     if !matches!(&ops[..], [CmpOp::Eq]) {
         return;
     }
-    if is_exception_check(checker.semantic().stmt()) {
+    if is_exception_check(checker.semantic().current_statement()) {
         return;
     }
 
     // Avoid flagging issues in dunder implementations.
     if let ScopeKind::Function(ast::StmtFunctionDef { name, .. })
     | ScopeKind::AsyncFunction(ast::StmtAsyncFunctionDef { name, .. }) =
-        &checker.semantic().scope().kind
+        &checker.semantic().current_scope().kind
     {
         if is_dunder_method(name) {
             return;
@@ -213,14 +213,14 @@ pub(crate) fn negation_with_not_equal_op(
     if !matches!(&ops[..], [CmpOp::NotEq]) {
         return;
     }
-    if is_exception_check(checker.semantic().stmt()) {
+    if is_exception_check(checker.semantic().current_statement()) {
         return;
     }
 
     // Avoid flagging issues in dunder implementations.
     if let ScopeKind::Function(ast::StmtFunctionDef { name, .. })
     | ScopeKind::AsyncFunction(ast::StmtAsyncFunctionDef { name, .. }) =
-        &checker.semantic().scope().kind
+        &checker.semantic().current_scope().kind
     {
         if is_dunder_method(name) {
             return;

--- a/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -60,7 +60,7 @@ impl Violation for ReimplementedBuiltin {
 
 /// SIM110, SIM111
 pub(crate) fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt) {
-    if !checker.semantic().scope().kind.is_any_function() {
+    if !checker.semantic().current_scope().kind.is_any_function() {
         return;
     }
 
@@ -73,7 +73,7 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt) {
     // - `for` loop with an `else: return True` or `else: return False`.
     // - `for` loop followed by `return True` or `return False`.
     let Some(terminal) = match_else_return(stmt).or_else(|| {
-        let parent = checker.semantic().stmt_parent()?;
+        let parent = checker.semantic().current_statement_parent()?;
         let suite = traversal::suite(stmt, parent)?;
         let sibling = traversal::next_sibling(stmt, suite)?;
         match_sibling_return(stmt, sibling)

--- a/crates/ruff/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/helpers.rs
@@ -35,7 +35,7 @@ pub(crate) fn runtime_evaluated(
 }
 
 fn runtime_evaluated_base_class(base_classes: &[String], semantic: &SemanticModel) -> bool {
-    let ScopeKind::Class(class_def) = &semantic.scope().kind else {
+    let ScopeKind::Class(class_def) = &semantic.current_scope().kind else {
         return false;
     };
 
@@ -49,7 +49,7 @@ fn runtime_evaluated_base_class(base_classes: &[String], semantic: &SemanticMode
 }
 
 fn runtime_evaluated_decorators(decorators: &[String], semantic: &SemanticModel) -> bool {
-    let ScopeKind::Class(class_def) = &semantic.scope().kind else {
+    let ScopeKind::Class(class_def) = &semantic.current_scope().kind else {
         return false;
     };
 

--- a/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -58,8 +58,8 @@ pub(crate) fn empty_type_checking_block(checker: &mut Checker, stmt: &ast::StmtI
     let mut diagnostic = Diagnostic::new(EmptyTypeCheckingBlock, stmt.range());
     if checker.patch(diagnostic.kind.rule()) {
         // Delete the entire type-checking block.
-        let stmt = checker.semantic().stmt();
-        let parent = checker.semantic().stmt_parent();
+        let stmt = checker.semantic().current_statement();
+        let parent = checker.semantic().current_statement_parent();
         let edit = autofix::edits::delete_stmt(stmt, parent, checker.locator(), checker.indexer());
         diagnostic.set_fix(Fix::automatic(edit).isolate(checker.isolation(parent)));
     }

--- a/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -93,7 +93,7 @@ pub(crate) fn runtime_import_in_type_checking_block(
                     .is_runtime()
             })
         {
-            let Some(stmt_id) = binding.source else {
+            let Some(statement_id) = binding.source else {
                 continue;
             };
 
@@ -113,20 +113,23 @@ pub(crate) fn runtime_import_in_type_checking_block(
                 })
             {
                 ignores_by_statement
-                    .entry(stmt_id)
+                    .entry(statement_id)
                     .or_default()
                     .push(import);
             } else {
-                errors_by_statement.entry(stmt_id).or_default().push(import);
+                errors_by_statement
+                    .entry(statement_id)
+                    .or_default()
+                    .push(import);
             }
         }
     }
 
     // Generate a diagnostic for every import, but share a fix across all imports within the same
     // statement (excluding those that are ignored).
-    for (stmt_id, imports) in errors_by_statement {
+    for (statement_id, imports) in errors_by_statement {
         let fix = if checker.patch(Rule::RuntimeImportInTypeCheckingBlock) {
-            fix_imports(checker, stmt_id, &imports).ok()
+            fix_imports(checker, statement_id, &imports).ok()
         } else {
             None
         };
@@ -189,9 +192,9 @@ struct ImportBinding<'a> {
 }
 
 /// Generate a [`Fix`] to remove runtime imports from a type-checking block.
-fn fix_imports(checker: &Checker, stmt_id: NodeId, imports: &[ImportBinding]) -> Result<Fix> {
-    let stmt = checker.semantic().stmts[stmt_id];
-    let parent = checker.semantic().stmts.parent(stmt);
+fn fix_imports(checker: &Checker, statement_id: NodeId, imports: &[ImportBinding]) -> Result<Fix> {
+    let statement = checker.semantic().statements[statement_id];
+    let parent = checker.semantic().statements.parent(statement);
     let member_names: Vec<Cow<'_, str>> = imports
         .iter()
         .map(|ImportBinding { import, .. }| import.member_name())
@@ -209,7 +212,7 @@ fn fix_imports(checker: &Checker, stmt_id: NodeId, imports: &[ImportBinding]) ->
     // Step 1) Remove the import.
     let remove_import_edit = autofix::edits::remove_unused_imports(
         member_names.iter().map(AsRef::as_ref),
-        stmt,
+        statement,
         parent,
         checker.locator(),
         checker.stylist(),
@@ -219,7 +222,7 @@ fn fix_imports(checker: &Checker, stmt_id: NodeId, imports: &[ImportBinding]) ->
     // Step 2) Add the import to the top-level.
     let add_import_edit = checker.importer().runtime_import_edit(
         &ImportedMembers {
-            statement: stmt,
+            statement,
             names: member_names.iter().map(AsRef::as_ref).collect(),
         },
         at,

--- a/crates/ruff/src/rules/pandas_vet/rules/attr.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/attr.rs
@@ -53,7 +53,7 @@ pub(crate) fn attr(checker: &mut Checker, attr: &str, value: &Expr, attr_expr: &
     };
 
     // Avoid flagging on function calls (e.g., `df.values()`).
-    if let Some(parent) = checker.semantic().expr_parent() {
+    if let Some(parent) = checker.semantic().current_expression_parent() {
         if matches!(parent, Expr::Call(_)) {
             return;
         }

--- a/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -85,8 +85,8 @@ pub(crate) fn inplace_argument(checker: &mut Checker, call: &ast::ExprCall) {
                     // 2. The call is part of a larger expression (we're converting an expression to a
                     //    statement, and expressions can't contain statements).
                     if !seen_star
-                        && checker.semantic().stmt().is_expr_stmt()
-                        && checker.semantic().expr_parent().is_none()
+                        && checker.semantic().current_statement().is_expr_stmt()
+                        && checker.semantic().current_expression_parent().is_none()
                     {
                         if let Some(fix) = convert_inplace_argument_to_assignment(
                             call,

--- a/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_class_scope.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_class_scope.rs
@@ -69,7 +69,7 @@ pub(crate) fn mixed_case_variable_in_class_scope(
         return;
     }
 
-    let parent = checker.semantic().stmt();
+    let parent = checker.semantic().current_statement();
 
     if helpers::is_named_tuple_assignment(parent, checker.semantic())
         || helpers::is_typed_dict_class(arguments, checker.semantic())

--- a/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
@@ -75,7 +75,7 @@ pub(crate) fn mixed_case_variable_in_global_scope(checker: &mut Checker, expr: &
         return;
     }
 
-    let parent = checker.semantic().stmt();
+    let parent = checker.semantic().current_statement();
     if helpers::is_named_tuple_assignment(parent, checker.semantic()) {
         return;
     }

--- a/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
@@ -65,7 +65,7 @@ pub(crate) fn non_lowercase_variable_in_function(checker: &mut Checker, expr: &E
         return;
     }
 
-    let parent = checker.semantic().stmt();
+    let parent = checker.semantic().current_statement();
     if helpers::is_named_tuple_assignment(parent, checker.semantic())
         || helpers::is_typed_dict_assignment(parent, checker.semantic())
         || helpers::is_type_var_assignment(parent, checker.semantic())

--- a/crates/ruff/src/rules/perflint/rules/incorrect_dict_iterator.rs
+++ b/crates/ruff/src/rules/perflint/rules/incorrect_dict_iterator.rs
@@ -167,7 +167,7 @@ fn is_unused(expr: &Expr, model: &SemanticModel) -> bool {
             //
             // print(bar)
             // ```
-            let scope = model.scope();
+            let scope = model.current_scope();
             scope
                 .get_all(id)
                 .map(|binding_id| model.binding(binding_id))

--- a/crates/ruff/src/rules/perflint/rules/unnecessary_list_cast.rs
+++ b/crates/ruff/src/rules/perflint/rules/unnecessary_list_cast.rs
@@ -102,12 +102,12 @@ pub(crate) fn unnecessary_list_cast(checker: &mut Checker, iter: &Expr) {
             range: iterable_range,
             ..
         }) => {
-            let scope = checker.semantic().scope();
+            let scope = checker.semantic().current_scope();
             if let Some(binding_id) = scope.get(id) {
                 let binding = checker.semantic().binding(binding_id);
                 if binding.kind.is_assignment() || binding.kind.is_named_expr_assignment() {
                     if let Some(parent_id) = binding.source {
-                        let parent = checker.semantic().stmts[parent_id];
+                        let parent = checker.semantic().statements[parent_id];
                         if let Stmt::Assign(ast::StmtAssign { value, .. })
                         | Stmt::AnnAssign(ast::StmtAnnAssign {
                             value: Some(value), ..

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -116,10 +116,10 @@ pub(crate) fn lambda_assignment(
             // rewriting it as a function declaration may break type-checking.
             // See: https://github.com/astral-sh/ruff/issues/3046
             // See: https://github.com/astral-sh/ruff/issues/5421
-            if (annotation.is_some() && checker.semantic().scope().kind.is_class())
+            if (annotation.is_some() && checker.semantic().current_scope().kind.is_class())
                 || checker
                     .semantic()
-                    .scope()
+                    .current_scope()
                     .get_all(id)
                     .any(|binding_id| checker.semantic().binding(binding_id).kind.is_annotation())
             {

--- a/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
@@ -33,7 +33,7 @@ impl Violation for ReturnOutsideFunction {
 
 pub(crate) fn return_outside_function(checker: &mut Checker, stmt: &Stmt) {
     if matches!(
-        checker.semantic().scope().kind,
+        checker.semantic().current_scope().kind,
         ScopeKind::Class(_) | ScopeKind::Module
     ) {
         checker

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -326,8 +326,8 @@ pub(crate) fn unused_variable(checker: &Checker, scope: &Scope, diagnostics: &mu
         let mut diagnostic = Diagnostic::new(UnusedVariable { name }, range);
         if checker.patch(diagnostic.kind.rule()) {
             if let Some(source) = source {
-                let stmt = checker.semantic().stmts[source];
-                let parent = checker.semantic().stmts.parent(stmt);
+                let stmt = checker.semantic().statements[source];
+                let parent = checker.semantic().statements.parent(stmt);
                 if let Some(fix) = remove_unused_variable(stmt, parent, range, checker) {
                     diagnostic.set_fix(fix);
                 }

--- a/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
@@ -55,7 +55,7 @@ impl Violation for YieldOutsideFunction {
 
 pub(crate) fn yield_outside_function(checker: &mut Checker, expr: &Expr) {
     if matches!(
-        checker.semantic().scope().kind,
+        checker.semantic().current_scope().kind,
         ScopeKind::Class(_) | ScopeKind::Module
     ) {
         let keyword = match expr {

--- a/crates/ruff/src/rules/pylint/helpers.rs
+++ b/crates/ruff/src/rules/pylint/helpers.rs
@@ -23,7 +23,7 @@ pub(super) fn type_param_name(arguments: &Arguments) -> Option<&str> {
 }
 
 pub(super) fn in_dunder_init(semantic: &SemanticModel, settings: &Settings) -> bool {
-    let scope = semantic.scope();
+    let scope = semantic.current_scope();
     let (ScopeKind::Function(ast::StmtFunctionDef {
         name,
         decorator_list,

--- a/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
+++ b/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
@@ -67,7 +67,7 @@ pub(crate) fn compare_to_empty_string(
     // DataFrame and np.ndarray indexing.
     if checker
         .semantic()
-        .expr_ancestors()
+        .current_expressions()
         .any(Expr::is_subscript_expr)
     {
         return;

--- a/crates/ruff/src/rules/pylint/rules/invalid_str_return.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_str_return.rs
@@ -29,7 +29,7 @@ pub(crate) fn invalid_str_return(checker: &mut Checker, name: &str, body: &[Stmt
         return;
     }
 
-    if !checker.semantic().scope().kind.is_class() {
+    if !checker.semantic().current_scope().kind.is_class() {
         return;
     }
 

--- a/crates/ruff/src/rules/pylint/rules/self_assigning_variable.rs
+++ b/crates/ruff/src/rules/pylint/rules/self_assigning_variable.rs
@@ -62,7 +62,7 @@ pub(crate) fn self_assigning_variable(checker: &mut Checker, target: &Expr, valu
 
     // Assignments in class bodies are attributes (e.g., `x = x` assigns `x` to `self.x`, and thus
     // is not a self-assignment).
-    if checker.semantic().scope().kind.is_class() {
+    if checker.semantic().current_scope().kind.is_class() {
         return;
     }
 

--- a/crates/ruff/src/rules/pylint/rules/unexpected_special_method_signature.rs
+++ b/crates/ruff/src/rules/pylint/rules/unexpected_special_method_signature.rs
@@ -143,7 +143,7 @@ pub(crate) fn unexpected_special_method_signature(
     decorator_list: &[Decorator],
     parameters: &Parameters,
 ) {
-    if !checker.semantic().scope().kind.is_class() {
+    if !checker.semantic().current_scope().kind.is_class() {
         return;
     }
 

--- a/crates/ruff/src/rules/pylint/rules/yield_from_in_async_function.rs
+++ b/crates/ruff/src/rules/pylint/rules/yield_from_in_async_function.rs
@@ -38,7 +38,7 @@ impl Violation for YieldFromInAsyncFunction {
 
 /// PLE1700
 pub(crate) fn yield_from_in_async_function(checker: &mut Checker, expr: &ExprYieldFrom) {
-    let scope = checker.semantic().scope();
+    let scope = checker.semantic().current_scope();
     if scope.kind.is_async_function() {
         checker
             .diagnostics

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -149,7 +149,7 @@ pub(crate) fn native_literals(
     if checker.semantic().in_f_string() {
         if checker
             .semantic()
-            .expr_ancestors()
+            .current_expressions()
             .filter(|expr| expr.is_joined_str_expr())
             .count()
             > 1

--- a/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -124,8 +124,8 @@ fn fix_py2_block(checker: &Checker, stmt_if: &StmtIf, branch: &IfElifBranch) -> 
         BranchKind::If => match stmt_if.elif_else_clauses.first() {
             // If we have a lone `if`, delete as statement (insert pass in parent if required)
             None => {
-                let stmt = checker.semantic().stmt();
-                let parent = checker.semantic().stmt_parent();
+                let stmt = checker.semantic().current_statement();
+                let parent = checker.semantic().current_statement_parent();
                 let edit = delete_stmt(stmt, parent, checker.locator(), checker.indexer());
                 Some(Fix::suggested(edit))
             }

--- a/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -80,14 +80,14 @@ pub(crate) fn super_call_with_parameters(
     if !is_super_call_with_arguments(func, args) {
         return;
     }
-    let scope = checker.semantic().scope();
+    let scope = checker.semantic().current_scope();
 
     // Check: are we in a Function scope?
     if !scope.kind.is_any_function() {
         return;
     }
 
-    let mut parents = checker.semantic().parents();
+    let mut parents = checker.semantic().current_statements();
 
     // For a `super` invocation to be unnecessary, the first argument needs to match
     // the enclosing class, and the second argument needs to match the first

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -122,14 +122,14 @@ pub(crate) fn unnecessary_builtin_import(
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            let stmt = checker.semantic().stmt();
-            let parent = checker.semantic().stmt_parent();
+            let statement = checker.semantic().current_statement();
+            let parent = checker.semantic().current_statement_parent();
             let edit = autofix::edits::remove_unused_imports(
                 unused_imports
                     .iter()
                     .map(|alias| &alias.name)
                     .map(ruff_python_ast::Identifier::as_str),
-                stmt,
+                statement,
                 parent,
                 checker.locator(),
                 checker.stylist(),

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -111,14 +111,14 @@ pub(crate) fn unnecessary_future_import(checker: &mut Checker, stmt: &Stmt, name
 
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            let stmt = checker.semantic().stmt();
-            let parent = checker.semantic().stmt_parent();
+            let statement = checker.semantic().current_statement();
+            let parent = checker.semantic().current_statement_parent();
             let edit = autofix::edits::remove_unused_imports(
                 unused_imports
                     .iter()
                     .map(|alias| &alias.name)
                     .map(ruff_python_ast::Identifier::as_str),
-                stmt,
+                statement,
                 parent,
                 checker.locator(),
                 checker.stylist(),

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -63,8 +63,8 @@ pub(crate) fn useless_metaclass_type(
 
     let mut diagnostic = Diagnostic::new(UselessMetaclassType, stmt.range());
     if checker.patch(diagnostic.kind.rule()) {
-        let stmt = checker.semantic().stmt();
-        let parent = checker.semantic().stmt_parent();
+        let stmt = checker.semantic().current_statement();
+        let parent = checker.semantic().current_statement_parent();
         let edit = autofix::edits::delete_stmt(stmt, parent, checker.locator(), checker.indexer());
         diagnostic.set_fix(Fix::automatic(edit).isolate(checker.isolation(parent)));
     }

--- a/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -166,7 +166,7 @@ fn concatenate_expressions(expr: &Expr) -> Option<(Expr, Type)> {
 pub(crate) fn collection_literal_concatenation(checker: &mut Checker, expr: &Expr) {
     // If the expression is already a child of an addition, we'll have analyzed it already.
     if matches!(
-        checker.semantic().expr_parent(),
+        checker.semantic().current_expression_parent(),
         Some(Expr::BinOp(ast::ExprBinOp {
             op: Operator::Add,
             ..

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -185,7 +185,7 @@ impl<'a> Binding<'a> {
     /// Returns the range of the binding's parent.
     pub fn parent_range(&self, semantic: &SemanticModel) -> Option<TextRange> {
         self.source
-            .map(|node_id| semantic.stmts[node_id])
+            .map(|node_id| semantic.statements[node_id])
             .and_then(|parent| {
                 if parent.is_import_from_stmt() {
                     Some(parent.range())


### PR DESCRIPTION
## Summary

This PR attempts to draw a clearer divide between "methods that take (e.g.) an expression or statement as input" and "methods that rely on the _current_ expression or statement" in the semantic model, by renaming methods like `stmt()` to `current_statement()`.

This had led to confusion in the past. For example, prior to this PR, we had `scope()` (which returns the current scope), and `parent_scope`, which returns the parent _of a scope that's passed in_. Now, the API is clearer: `current_scope` returns the current scope, and `parent_scope` takes a scope as argument and returns its parent.

Per above, I also changed `stmt` to `statement` and `expr` to `expression`.
