### PR TITLE
Add formatting for `MatchCase`

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
@@ -97,6 +97,12 @@ match long_lines:
     case "this is a long line for if condition with parentheses" if (aaaaaaaaahhhhhhhh == 1 and bbbbbbaaaaaaaaaaa == 2):  # comment
         pass
 
+    case "named expressions aren't special" if foo := 1:
+        pass
+
+    case "named expressions aren't that special" if (foo := 1):
+        pass
+
     case "but with already broken long lines" if (
         aaaaaaahhhhhhhhhhh == 1 and
         bbbbbbbbaaaaaahhhh == 2

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
@@ -88,3 +88,17 @@ match newlines:
         pass
     case _:
         pass
+
+
+match long_lines:
+    case "this is a long line for if condition" if aaaaaaaaahhhhhhhh == 1 and bbbbbbaaaaaaaaaaa == 2:  # comment
+        pass
+
+    case "this is a long line for if condition with parentheses" if (aaaaaaaaahhhhhhhh == 1 and bbbbbbaaaaaaaaaaa == 2):  # comment
+        pass
+
+    case "but with already broken long lines" if (
+        aaaaaaahhhhhhhhhhh == 1 and
+        bbbbbbbbaaaaaahhhh == 2
+    ):  # another comment
+        pass

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
@@ -55,3 +55,36 @@ def foo():
     match inside_func:  # comment
         case "bar":
             pass
+
+
+match newlines:
+
+    # case 1 leading comment
+
+
+    case "top level case comment with newlines":  # case dangling comment
+        # pass leading comment
+        pass
+        # pass trailing comment
+
+
+    # case 2 leading comment
+
+
+
+    case "case comment with newlines" if foo == 2:  # second
+        pass
+
+    case "one", "newline" if (foo := 1):  # third
+        pass
+
+
+    case "two newlines":
+        pass
+
+
+
+    case "three newlines":
+        pass
+    case _:
+        pass

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -207,6 +207,7 @@ fn is_first_statement_in_body(statement: AnyNodeRef, has_body: AnyNodeRef) -> bo
         | AnyNodeRef::ExceptHandlerExceptHandler(ast::ExceptHandlerExceptHandler {
             body, ..
         })
+        | AnyNodeRef::MatchCase(ast::MatchCase { body, .. })
         | AnyNodeRef::StmtFunctionDef(ast::StmtFunctionDef { body, .. })
         | AnyNodeRef::StmtClassDef(ast::StmtClassDef { body, .. }) => {
             are_same_optional(statement, body.first())

--- a/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
@@ -46,6 +46,7 @@ impl NeedsParentheses for ExprNamedExpr {
             || parent.is_with_item()
             || parent.is_stmt_delete()
             || parent.is_stmt_for()
+            || parent.is_match_case()
         {
             OptionalParentheses::Always
         } else {

--- a/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
@@ -46,7 +46,6 @@ impl NeedsParentheses for ExprNamedExpr {
             || parent.is_with_item()
             || parent.is_stmt_delete()
             || parent.is_stmt_for()
-            || parent.is_match_case()
         {
             OptionalParentheses::Always
         } else {

--- a/crates/ruff_python_formatter/src/other/match_case.rs
+++ b/crates/ruff_python_formatter/src/other/match_case.rs
@@ -2,7 +2,6 @@ use ruff_formatter::{write, Buffer, FormatResult};
 use ruff_python_ast::MatchCase;
 
 use crate::comments::trailing_comments;
-use crate::expression::parentheses::{is_expression_parenthesized, Parentheses};
 use crate::not_yet_implemented_custom_text;
 use crate::prelude::*;
 use crate::{FormatNodeRule, PyFormatter};
@@ -32,12 +31,7 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
         )?;
 
         if let Some(guard) = guard {
-            write!(f, [space(), text("if"), space()])?;
-            if is_expression_parenthesized(guard.as_ref().into(), f.context().source()) {
-                guard.format().with_options(Parentheses::Always).fmt(f)?;
-            } else {
-                guard.format().fmt(f)?;
-            }
+            write!(f, [space(), text("if"), space(), guard.format()])?;
         }
 
         write!(

--- a/crates/ruff_python_formatter/src/other/match_case.rs
+++ b/crates/ruff_python_formatter/src/other/match_case.rs
@@ -32,7 +32,7 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
         )?;
 
         if let Some(guard) = guard {
-            write!(f, [space(), text("if"), space(),])?;
+            write!(f, [space(), text("if"), space()])?;
             if is_expression_parenthesized(guard.as_ref().into(), f.context().source()) {
                 guard.format().with_options(Parentheses::Always).fmt(f)?;
             } else {
@@ -48,5 +48,10 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
                 block_indent(&body.format())
             ]
         )
+    }
+
+    fn fmt_dangling_comments(&self, _node: &MatchCase, _f: &mut PyFormatter) -> FormatResult<()> {
+        // Handled as part of `fmt_fields`
+        Ok(())
     }
 }

--- a/crates/ruff_python_formatter/src/other/match_case.rs
+++ b/crates/ruff_python_formatter/src/other/match_case.rs
@@ -2,8 +2,7 @@ use ruff_formatter::{write, Buffer, FormatResult};
 use ruff_python_ast::MatchCase;
 
 use crate::comments::trailing_comments;
-use crate::expression::maybe_parenthesize_expression;
-use crate::expression::parentheses::Parenthesize;
+use crate::expression::parentheses::{is_expression_parenthesized, Parentheses};
 use crate::not_yet_implemented_custom_text;
 use crate::prelude::*;
 use crate::{FormatNodeRule, PyFormatter};
@@ -33,15 +32,12 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
         )?;
 
         if let Some(guard) = guard {
-            write!(
-                f,
-                [
-                    space(),
-                    text("if"),
-                    space(),
-                    maybe_parenthesize_expression(guard, item, Parenthesize::Optional)
-                ]
-            )?;
+            write!(f, [space(), text("if"), space(),])?;
+            if is_expression_parenthesized(guard.as_ref().into(), f.context().source()) {
+                guard.format().with_options(Parentheses::Always).fmt(f)?;
+            } else {
+                guard.format().fmt(f)?;
+            }
         }
 
         write!(

--- a/crates/ruff_python_formatter/src/other/match_case.rs
+++ b/crates/ruff_python_formatter/src/other/match_case.rs
@@ -1,6 +1,7 @@
 use ruff_formatter::{write, Buffer, FormatResult};
 use ruff_python_ast::MatchCase;
 
+use crate::comments::trailing_comments;
 use crate::expression::maybe_parenthesize_expression;
 use crate::expression::parentheses::Parenthesize;
 use crate::not_yet_implemented_custom_text;
@@ -19,6 +20,9 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
             body,
         } = item;
 
+        let comments = f.context().comments().clone();
+        let dangling_item_comments = comments.dangling_comments(item);
+
         write!(
             f,
             [
@@ -35,11 +39,18 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
                     space(),
                     text("if"),
                     space(),
-                    maybe_parenthesize_expression(guard, item, Parenthesize::IfBreaks)
+                    maybe_parenthesize_expression(guard, item, Parenthesize::Optional)
                 ]
             )?;
         }
 
-        write!(f, [text(":"), block_indent(&body.format())])
+        write!(
+            f,
+            [
+                text(":"),
+                trailing_comments(dangling_item_comments),
+                block_indent(&body.format())
+            ]
+        )
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/mod.rs
+++ b/crates/ruff_python_formatter/src/pattern/mod.rs
@@ -1,3 +1,8 @@
+use ruff_formatter::{FormatOwnedWithRule, FormatRefWithRule};
+use ruff_python_ast::Pattern;
+
+use crate::prelude::*;
+
 pub(crate) mod pattern_match_as;
 pub(crate) mod pattern_match_class;
 pub(crate) mod pattern_match_mapping;
@@ -6,3 +11,37 @@ pub(crate) mod pattern_match_sequence;
 pub(crate) mod pattern_match_singleton;
 pub(crate) mod pattern_match_star;
 pub(crate) mod pattern_match_value;
+
+#[derive(Default)]
+pub struct FormatPattern;
+
+impl FormatRule<Pattern, PyFormatContext<'_>> for FormatPattern {
+    fn fmt(&self, item: &Pattern, f: &mut PyFormatter) -> FormatResult<()> {
+        match item {
+            Pattern::MatchValue(p) => p.format().fmt(f),
+            Pattern::MatchSingleton(p) => p.format().fmt(f),
+            Pattern::MatchSequence(p) => p.format().fmt(f),
+            Pattern::MatchMapping(p) => p.format().fmt(f),
+            Pattern::MatchClass(p) => p.format().fmt(f),
+            Pattern::MatchStar(p) => p.format().fmt(f),
+            Pattern::MatchAs(p) => p.format().fmt(f),
+            Pattern::MatchOr(p) => p.format().fmt(f),
+        }
+    }
+}
+
+impl<'ast> AsFormat<PyFormatContext<'ast>> for Pattern {
+    type Format<'a> = FormatRefWithRule<'a, Pattern, FormatPattern, PyFormatContext<'ast>>;
+
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(self, FormatPattern)
+    }
+}
+
+impl<'ast> IntoFormat<PyFormatContext<'ast>> for Pattern {
+    type Format = FormatOwnedWithRule<Pattern, FormatPattern, PyFormatContext<'ast>>;
+
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(self, FormatPattern)
+    }
+}

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_complex.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_complex.py.snap
@@ -265,7 +265,7 @@ match x:
 +    case NOT_YET_IMPLEMENTED_Pattern:
          y = 0
 -    case [1, 0] if (x := x[:0]):
-+    case NOT_YET_IMPLEMENTED_Pattern if x := x[:0]:
++    case NOT_YET_IMPLEMENTED_Pattern if (x := x[:0]):
          y = 1
 -    case [1, 0]:
 +    case NOT_YET_IMPLEMENTED_Pattern:
@@ -431,7 +431,7 @@ match (0, 1, 2):
 match x:
     case NOT_YET_IMPLEMENTED_Pattern:
         y = 0
-    case NOT_YET_IMPLEMENTED_Pattern if x := x[:0]:
+    case NOT_YET_IMPLEMENTED_Pattern if (x := x[:0]):
         y = 1
     case NOT_YET_IMPLEMENTED_Pattern:
         y = 2

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_extras.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_extras.py.snap
@@ -205,7 +205,7 @@ match bar1:
          assert "map" == b
  
  
-@@ -59,61 +62,47 @@
+@@ -59,61 +62,51 @@
      ),
      case,
  ):
@@ -217,11 +217,11 @@ match bar1:
 -    ):
 +    case NOT_YET_IMPLEMENTED_Pattern:
          pass
--
+ 
 -    case [a as match]:
 +    case NOT_YET_IMPLEMENTED_Pattern:
          pass
--
+ 
 -    case case:
 +    case NOT_YET_IMPLEMENTED_Pattern:
          pass
@@ -255,11 +255,11 @@ match bar1:
 -    case 1 as a:
 +    case NOT_YET_IMPLEMENTED_Pattern:
          pass
--
+ 
 -    case 2 as b, 3 as c:
 +    case NOT_YET_IMPLEMENTED_Pattern:
          pass
--
+ 
 -    case 4 as d, (5 as e), (6 | 7 as g), *h:
 +    case NOT_YET_IMPLEMENTED_Pattern:
          pass
@@ -351,8 +351,10 @@ match match(
 ):
     case NOT_YET_IMPLEMENTED_Pattern:
         pass
+
     case NOT_YET_IMPLEMENTED_Pattern:
         pass
+
     case NOT_YET_IMPLEMENTED_Pattern:
         pass
 
@@ -377,8 +379,10 @@ match something:
 match something:
     case NOT_YET_IMPLEMENTED_Pattern:
         pass
+
     case NOT_YET_IMPLEMENTED_Pattern:
         pass
+
     case NOT_YET_IMPLEMENTED_Pattern:
         pass
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_simple.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_simple.py.snap
@@ -203,7 +203,7 @@ def where_is(point):
  
  match event.get():
 -    case Click((x, y), button=Button.LEFT):  # This is a left click
-+    case NOT_YET_IMPLEMENTED_Pattern:
++    case NOT_YET_IMPLEMENTED_Pattern:  # This is a left click
          handle_click_at(x, y)
 -    case Click():
 +    case NOT_YET_IMPLEMENTED_Pattern:
@@ -306,7 +306,7 @@ match event.get():
         raise ValueError(f"Unrecognized event: {other_event}")
 
 match event.get():
-    case NOT_YET_IMPLEMENTED_Pattern:
+    case NOT_YET_IMPLEMENTED_Pattern:  # This is a left click
         handle_click_at(x, y)
     case NOT_YET_IMPLEMENTED_Pattern:
         pass  # ignore other clicks

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__remove_newline_after_match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__remove_newline_after_match.py.snap
@@ -31,21 +31,21 @@ def http_status(status):
 ```diff
 --- Black
 +++ Ruff
-@@ -1,13 +1,10 @@
+@@ -1,13 +1,13 @@
  def http_status(status):
      match status:
 -        case 400:
 +        case NOT_YET_IMPLEMENTED_Pattern:
              return "Bad request"
--
+ 
 -        case 401:
 +        case NOT_YET_IMPLEMENTED_Pattern:
              return "Unauthorized"
--
+ 
 -        case 403:
 +        case NOT_YET_IMPLEMENTED_Pattern:
              return "Forbidden"
--
+ 
 -        case 404:
 +        case NOT_YET_IMPLEMENTED_Pattern:
              return "Not found"
@@ -58,10 +58,13 @@ def http_status(status):
     match status:
         case NOT_YET_IMPLEMENTED_Pattern:
             return "Bad request"
+
         case NOT_YET_IMPLEMENTED_Pattern:
             return "Unauthorized"
+
         case NOT_YET_IMPLEMENTED_Pattern:
             return "Forbidden"
+
         case NOT_YET_IMPLEMENTED_Pattern:
             return "Not found"
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -92,6 +92,8 @@ match newlines:
 
     case "three newlines":
         pass
+    case _:
+        pass
 ```
 
 ## Output
@@ -176,6 +178,8 @@ match newlines:
     case NOT_YET_IMPLEMENTED_Pattern:
         pass
 
+    case NOT_YET_IMPLEMENTED_Pattern:
+        pass
     case NOT_YET_IMPLEMENTED_Pattern:
         pass
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -94,6 +94,20 @@ match newlines:
         pass
     case _:
         pass
+
+
+match long_lines:
+    case "this is a long line for if condition" if aaaaaaaaahhhhhhhh == 1 and bbbbbbaaaaaaaaaaa == 2:  # comment
+        pass
+
+    case "this is a long line for if condition with parentheses" if (aaaaaaaaahhhhhhhh == 1 and bbbbbbaaaaaaaaaaa == 2):  # comment
+        pass
+
+    case "but with already broken long lines" if (
+        aaaaaaahhhhhhhhhhh == 1 and
+        bbbbbbbbaaaaaahhhh == 2
+    ):  # another comment
+        pass
 ```
 
 ## Output
@@ -181,6 +195,21 @@ match newlines:
     case NOT_YET_IMPLEMENTED_Pattern:
         pass
     case NOT_YET_IMPLEMENTED_Pattern:
+        pass
+
+
+match long_lines:
+    case NOT_YET_IMPLEMENTED_Pattern if aaaaaaaaahhhhhhhh == 1 and bbbbbbaaaaaaaaaaa == 2:  # comment
+        pass
+
+    case NOT_YET_IMPLEMENTED_Pattern if (
+        aaaaaaaaahhhhhhhh == 1 and bbbbbbaaaaaaaaaaa == 2
+    ):  # comment
+        pass
+
+    case NOT_YET_IMPLEMENTED_Pattern if (
+        aaaaaaahhhhhhhhhhh == 1 and bbbbbbbbaaaaaahhhh == 2
+    ):  # another comment
         pass
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -103,6 +103,12 @@ match long_lines:
     case "this is a long line for if condition with parentheses" if (aaaaaaaaahhhhhhhh == 1 and bbbbbbaaaaaaaaaaa == 2):  # comment
         pass
 
+    case "named expressions aren't special" if foo := 1:
+        pass
+
+    case "named expressions aren't that special" if (foo := 1):
+        pass
+
     case "but with already broken long lines" if (
         aaaaaaahhhhhhhhhhh == 1 and
         bbbbbbbbaaaaaahhhh == 2
@@ -205,6 +211,12 @@ match long_lines:
     case NOT_YET_IMPLEMENTED_Pattern if (
         aaaaaaaaahhhhhhhh == 1 and bbbbbbaaaaaaaaaaa == 2
     ):  # comment
+        pass
+
+    case NOT_YET_IMPLEMENTED_Pattern if foo := 1:
+        pass
+
+    case NOT_YET_IMPLEMENTED_Pattern if (foo := 1):
         pass
 
     case NOT_YET_IMPLEMENTED_Pattern if (

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -61,6 +61,37 @@ def foo():
     match inside_func:  # comment
         case "bar":
             pass
+
+
+match newlines:
+
+    # case 1 leading comment
+
+
+    case "top level case comment with newlines":  # case dangling comment
+        # pass leading comment
+        pass
+        # pass trailing comment
+
+
+    # case 2 leading comment
+
+
+
+    case "case comment with newlines" if foo == 2:  # second
+        pass
+
+    case "one", "newline" if (foo := 1):  # third
+        pass
+
+
+    case "two newlines":
+        pass
+
+
+
+    case "three newlines":
+        pass
 ```
 
 ## Output
@@ -124,6 +155,29 @@ def foo():
     match inside_func:  # comment
         case NOT_YET_IMPLEMENTED_Pattern:
             pass
+
+
+match newlines:
+    # case 1 leading comment
+
+    case NOT_YET_IMPLEMENTED_Pattern:  # case dangling comment
+        # pass leading comment
+        pass
+        # pass trailing comment
+
+    # case 2 leading comment
+
+    case NOT_YET_IMPLEMENTED_Pattern if foo == 2:  # second
+        pass
+
+    case NOT_YET_IMPLEMENTED_Pattern if (foo := 1):  # third
+        pass
+
+    case NOT_YET_IMPLEMENTED_Pattern:
+        pass
+
+    case NOT_YET_IMPLEMENTED_Pattern:
+        pass
 ```
 
 


### PR DESCRIPTION
## Summary

This PR adds formatting support for `MatchCase` node with subs for the `Pattern`
nodes.

## Test Plan

Added test cases for case node handling with comments, newlines.

resolves: #6299
