### PR TITLE
Respect typing_extensions imports of Annotated for B006.

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_B008.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_B008.py
@@ -256,3 +256,20 @@ def mutable_annotations(
     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
 ):
     pass
+
+from typing_extensions import Annotated as Annotated_te
+
+def immutable_annotations(
+    a: Sequence[int] | None = [],
+    b: Optional[abc.Mapping[int, int]] = {},
+    c: Annotated_te[Union[abc.Set[str], abc.Sized], "annotation"] = set(),
+):
+    pass
+
+
+def mutable_annotations(
+    a: list[int] | None = [],
+    b: Optional[Dict[int, int]] = {},
+    c: Annotated_te[Union[Set[str], abc.Sized], "annotation"] = set(),
+):
+    pass

--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_B008.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_B008.py
@@ -240,12 +240,16 @@ def foo(f=lambda x: print(x)):
 
 from collections import abc
 from typing import Annotated, Dict, Optional, Sequence, Union, Set
+import typing_extensions
 
 
 def immutable_annotations(
     a: Sequence[int] | None = [],
     b: Optional[abc.Mapping[int, int]] = {},
     c: Annotated[Union[abc.Set[str], abc.Sized], "annotation"] = set(),
+    d: typing_extensions.Annotated[
+        Union[abc.Set[str], abc.Sized], "annotation"
+    ] = set(),
 ):
     pass
 
@@ -254,22 +258,6 @@ def mutable_annotations(
     a: list[int] | None = [],
     b: Optional[Dict[int, int]] = {},
     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-):
-    pass
-
-from typing_extensions import Annotated as Annotated_te
-
-def immutable_annotations(
-    a: Sequence[int] | None = [],
-    b: Optional[abc.Mapping[int, int]] = {},
-    c: Annotated_te[Union[abc.Set[str], abc.Sized], "annotation"] = set(),
-):
-    pass
-
-
-def mutable_annotations(
-    a: list[int] | None = [],
-    b: Optional[Dict[int, int]] = {},
-    c: Annotated_te[Union[Set[str], abc.Sized], "annotation"] = set(),
+    d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
 ):
     pass

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
@@ -81,62 +81,43 @@ B006_B008.py:221:20: B006 Do not use mutable data structures for argument defaul
 222 |     pass
     |
 
-B006_B008.py:254:27: B006 Do not use mutable data structures for argument defaults
+B006_B008.py:258:27: B006 Do not use mutable data structures for argument defaults
     |
-253 | def mutable_annotations(
-254 |     a: list[int] | None = [],
+257 | def mutable_annotations(
+258 |     a: list[int] | None = [],
     |                           ^^ B006
-255 |     b: Optional[Dict[int, int]] = {},
-256 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+259 |     b: Optional[Dict[int, int]] = {},
+260 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
 
-B006_B008.py:255:35: B006 Do not use mutable data structures for argument defaults
+B006_B008.py:259:35: B006 Do not use mutable data structures for argument defaults
     |
-253 | def mutable_annotations(
-254 |     a: list[int] | None = [],
-255 |     b: Optional[Dict[int, int]] = {},
+257 | def mutable_annotations(
+258 |     a: list[int] | None = [],
+259 |     b: Optional[Dict[int, int]] = {},
     |                                   ^^ B006
-256 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-257 | ):
+260 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+261 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
 
-B006_B008.py:256:62: B006 Do not use mutable data structures for argument defaults
+B006_B008.py:260:62: B006 Do not use mutable data structures for argument defaults
     |
-254 |     a: list[int] | None = [],
-255 |     b: Optional[Dict[int, int]] = {},
-256 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+258 |     a: list[int] | None = [],
+259 |     b: Optional[Dict[int, int]] = {},
+260 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |                                                              ^^^^^ B006
-257 | ):
-258 |     pass
+261 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+262 | ):
     |
 
-B006_B008.py:271:27: B006 Do not use mutable data structures for argument defaults
+B006_B008.py:261:80: B006 Do not use mutable data structures for argument defaults
     |
-270 | def mutable_annotations(
-271 |     a: list[int] | None = [],
-    |                           ^^ B006
-272 |     b: Optional[Dict[int, int]] = {},
-273 |     c: Annotated_te[Union[Set[str], abc.Sized], "annotation"] = set(),
-    |
-
-B006_B008.py:272:35: B006 Do not use mutable data structures for argument defaults
-    |
-270 | def mutable_annotations(
-271 |     a: list[int] | None = [],
-272 |     b: Optional[Dict[int, int]] = {},
-    |                                   ^^ B006
-273 |     c: Annotated_te[Union[Set[str], abc.Sized], "annotation"] = set(),
-274 | ):
-    |
-
-B006_B008.py:273:65: B006 Do not use mutable data structures for argument defaults
-    |
-271 |     a: list[int] | None = [],
-272 |     b: Optional[Dict[int, int]] = {},
-273 |     c: Annotated_te[Union[Set[str], abc.Sized], "annotation"] = set(),
-    |                                                                 ^^^^^ B006
-274 | ):
-275 |     pass
+259 |     b: Optional[Dict[int, int]] = {},
+260 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+261 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+    |                                                                                ^^^^^ B006
+262 | ):
+263 |     pass
     |
 
 

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
@@ -110,4 +110,33 @@ B006_B008.py:256:62: B006 Do not use mutable data structures for argument defaul
 258 |     pass
     |
 
+B006_B008.py:271:27: B006 Do not use mutable data structures for argument defaults
+    |
+270 | def mutable_annotations(
+271 |     a: list[int] | None = [],
+    |                           ^^ B006
+272 |     b: Optional[Dict[int, int]] = {},
+273 |     c: Annotated_te[Union[Set[str], abc.Sized], "annotation"] = set(),
+    |
+
+B006_B008.py:272:35: B006 Do not use mutable data structures for argument defaults
+    |
+270 | def mutable_annotations(
+271 |     a: list[int] | None = [],
+272 |     b: Optional[Dict[int, int]] = {},
+    |                                   ^^ B006
+273 |     c: Annotated_te[Union[Set[str], abc.Sized], "annotation"] = set(),
+274 | ):
+    |
+
+B006_B008.py:273:65: B006 Do not use mutable data structures for argument defaults
+    |
+271 |     a: list[int] | None = [],
+272 |     b: Optional[Dict[int, int]] = {},
+273 |     c: Annotated_te[Union[Set[str], abc.Sized], "annotation"] = set(),
+    |                                                                 ^^^^^ B006
+274 | ):
+275 |     pass
+    |
+
 

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -207,7 +207,7 @@ pub fn is_immutable_annotation(expr: &Expr, semantic: &SemanticModel) -> bool {
                     }
                 } else if matches!(call_path.as_slice(), ["typing", "Optional"]) {
                     is_immutable_annotation(slice, semantic)
-                } else if matches!(call_path.as_slice(), ["typing", "Annotated"]) {
+                } else if is_pep_593_generic_type(call_path.as_slice()) {
                     if let Expr::Tuple(ast::ExprTuple { elts, .. }) = slice.as_ref() {
                         elts.first()
                             .is_some_and(|elt| is_immutable_annotation(elt, semantic))


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
`typing_extensions.Annotated` should be treated the same way as `typing.Annotated`.

## Test Plan

<!-- How was it tested? -->
