### PR TITLE
Revert change to `require_git(false)` in `WalkBuilder`

### DIFF
--- a/crates/ruff/src/resolver.rs
+++ b/crates/ruff/src/resolver.rs
@@ -262,7 +262,6 @@ pub fn python_files_in_path(
         builder.add(path);
     }
     builder.standard_filters(pyproject_config.settings.lib.respect_gitignore);
-    builder.require_git(false);
     builder.hidden(false);
     let walker = builder.build_parallel();
 


### PR DESCRIPTION
## Summary

This was changed to fix https://github.com/astral-sh/ruff/issues/5930 (respect `.gitignore` for unzipped source repositories), but led to undesirable behavior whereby `.gitignore` files in parent directories are respected regardless of whether you're working in a child git repository (see: https://github.com/astral-sh/ruff/issues/6335). The latter is a bigger problem than the former is an important use-case to support, so pragmatically erring on the side of a revert.

Closes https://github.com/astral-sh/ruff/issues/6335.