### PR TITLE
Use `parenthesized_with_dangling_comments` in arguments formatter

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/call.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/call.py
@@ -111,3 +111,7 @@ f (
     1
     # abc
 )
+
+threshold_date = datetime.datetime.now() - datetime.timedelta(  # comment
+    days=threshold_days_threshold_days
+)

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__call.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__call.py.snap
@@ -117,6 +117,10 @@ f (
     1
     # abc
 )
+
+threshold_date = datetime.datetime.now() - datetime.timedelta(  # comment
+    days=threshold_days_threshold_days
+)
 ```
 
 ## Output
@@ -229,6 +233,10 @@ f(
 f(
     1
     # abc
+)
+
+threshold_date = datetime.datetime.now() - datetime.timedelta(  # comment
+    days=threshold_days_threshold_days
 )
 ```
 


### PR DESCRIPTION
## Summary

Fixes an instability whereby this:

```python
def get_recent_deployments(threshold_days: int) -> Set[str]:
    # Returns a list of deployments not older than threshold days
    # including `/root/zulip` directory if it exists.
    recent = set()
    threshold_date = datetime.datetime.now() - datetime.timedelta(  # noqa: DTZ005
        days=threshold_days
    )
```

Was being formatted as:

```python
def get_recent_deployments(threshold_days: int) -> Set[str]:
    # Returns a list of deployments not older than threshold days
    # including `/root/zulip` directory if it exists.
    recent = set()
    threshold_date = (
        datetime.datetime.now()
        - datetime.timedelta(days=threshold_days)  # noqa: DTZ005
    )
```

Which was in turn being formatted as:

```python
def get_recent_deployments(threshold_days: int) -> Set[str]:
    # Returns a list of deployments not older than threshold days
    # including `/root/zulip` directory if it exists.
    recent = set()
    threshold_date = (
        datetime.datetime.now() - datetime.timedelta(days=threshold_days)  # noqa: DTZ005
    )
```

The second-to-third formattings still differs from Black because we aren't taking the line suffix into account when splitting (https://github.com/astral-sh/ruff/issues/6377), but the first formatting is correct and should be unchanged (i.e., the first-to-second formattings is incorrect, and fixed here).

## Test Plan

`cargo run --bin ruff_dev -- format-dev --stability-check ../zulip`
