### PR TITLE
Rename `JoinedStr` to `FString` in the AST

### DIFF
--- a/crates/ruff/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff/src/checkers/ast/analyze/expression.rs
@@ -923,7 +923,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 pylint::rules::await_outside_async(checker, expr);
             }
         }
-        Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
+        Expr::FString(ast::ExprFString { values, range: _ }) => {
             if checker.enabled(Rule::FStringMissingPlaceholders) {
                 pyflakes::rules::f_string_missing_placeholders(expr, values, checker);
             }

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -1197,7 +1197,7 @@ where
                     ));
                 }
             }
-            Expr::JoinedStr(_) => {
+            Expr::FString(_) => {
                 self.semantic.flags |= SemanticModelFlags::F_STRING;
                 visitor::walk_expr(self, expr);
             }
@@ -1276,7 +1276,7 @@ where
 
     fn visit_format_spec(&mut self, format_spec: &'b Expr) {
         match format_spec {
-            Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
+            Expr::FString(ast::ExprFString { values, range: _ }) => {
                 for value in values {
                     self.visit_expr(value);
                 }

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
@@ -80,7 +80,7 @@ fn matches_string_format_expression(expr: &Expr, model: &SemanticModel) -> bool 
             attr == "format" && string_literal(value).is_some()
         }
         // f"select * from table where val = {val}"
-        Expr::JoinedStr(_) => true,
+        Expr::FString(_) => true,
         _ => false,
     }
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/f_string_docstring.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/f_string_docstring.rs
@@ -50,7 +50,7 @@ pub(crate) fn f_string_docstring(checker: &mut Checker, body: &[Stmt]) {
     let Stmt::Expr(ast::StmtExpr { value, range: _ }) = stmt else {
         return;
     };
-    if !value.is_joined_str_expr() {
+    if !value.is_f_string_expr() {
         return;
     }
     checker

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_expression.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_expression.rs
@@ -54,7 +54,7 @@ pub(crate) fn useless_expression(checker: &mut Checker, value: &Expr) {
     // Ignore strings, to avoid false positives with docstrings.
     if matches!(
         value,
-        Expr::JoinedStr(_)
+        Expr::FString(_)
             | Expr::Constant(ast::ExprConstant {
                 value: Constant::Str(..) | Constant::Ellipsis,
                 ..

--- a/crates/ruff/src/rules/flake8_errmsg/rules/string_in_exception.rs
+++ b/crates/ruff/src/rules/flake8_errmsg/rules/string_in_exception.rs
@@ -210,7 +210,7 @@ pub(crate) fn string_in_exception(checker: &mut Checker, stmt: &Stmt, exc: &Expr
                     }
                 }
                 // Check for f-strings.
-                Expr::JoinedStr(_) => {
+                Expr::FString(_) => {
                     if checker.enabled(Rule::FStringInException) {
                         let mut diagnostic = Diagnostic::new(FStringInException, first.range());
                         if checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff/src/rules/flake8_gettext/rules/f_string_in_gettext_func_call.rs
+++ b/crates/ruff/src/rules/flake8_gettext/rules/f_string_in_gettext_func_call.rs
@@ -52,7 +52,7 @@ impl Violation for FStringInGetTextFuncCall {
 /// INT001
 pub(crate) fn f_string_in_gettext_func_call(checker: &mut Checker, args: &[Expr]) {
     if let Some(first) = args.first() {
-        if first.is_joined_str_expr() {
+        if first.is_f_string_expr() {
             checker
                 .diagnostics
                 .push(Diagnostic::new(FStringInGetTextFuncCall {}, first.range()));

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/rules/explicit.rs
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/rules/explicit.rs
@@ -50,14 +50,14 @@ pub(crate) fn explicit(expr: &Expr, locator: &Locator) -> Option<Diagnostic> {
         if matches!(op, Operator::Add) {
             if matches!(
                 left.as_ref(),
-                Expr::JoinedStr(_)
+                Expr::FString(_)
                     | Expr::Constant(ast::ExprConstant {
                         value: Constant::Str(..) | Constant::Bytes(..),
                         ..
                     })
             ) && matches!(
                 right.as_ref(),
-                Expr::JoinedStr(_)
+                Expr::FString(_)
                     | Expr::Constant(ast::ExprConstant {
                         value: Constant::Str(..) | Constant::Bytes(..),
                         ..

--- a/crates/ruff/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -62,7 +62,7 @@ fn check_msg(checker: &mut Checker, msg: &Expr) {
             _ => {}
         },
         // Check for f-strings.
-        Expr::JoinedStr(_) => {
+        Expr::FString(_) => {
             if checker.enabled(Rule::LoggingFString) {
                 checker
                     .diagnostics

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -63,7 +63,7 @@ pub(super) fn is_empty_or_null_string(expr: &Expr) -> bool {
             ..
         }) => string.is_empty(),
         Expr::Constant(constant) if constant.value.is_none() => true,
-        Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
+        Expr::FString(ast::ExprFString { values, range: _ }) => {
             values.iter().all(is_empty_or_null_string)
         }
         _ => false,

--- a/crates/ruff/src/rules/flynt/helpers.rs
+++ b/crates/ruff/src/rules/flynt/helpers.rs
@@ -52,14 +52,14 @@ fn is_simple_callee(func: &Expr) -> bool {
 }
 
 /// Convert an expression to a f-string element (if it looks like a good idea).
-pub(super) fn to_fstring_elem(expr: &Expr) -> Option<Expr> {
+pub(super) fn to_f_string_element(expr: &Expr) -> Option<Expr> {
     match expr {
-        // These are directly handled by `unparse_fstring_elem`:
+        // These are directly handled by `unparse_f_string_element`:
         Expr::Constant(ast::ExprConstant {
             value: Constant::Str(_),
             ..
         })
-        | Expr::JoinedStr(_)
+        | Expr::FString(_)
         | Expr::FormattedValue(_) => Some(expr.clone()),
         // These should be pretty safe to wrap in a formatted value.
         Expr::Constant(ast::ExprConstant {

--- a/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -87,7 +87,7 @@ fn build_fstring(joiner: &str, joinees: &[Expr]) -> Option<Expr> {
     let mut first = true;
 
     for expr in joinees {
-        if expr.is_joined_str_expr() {
+        if expr.is_f_string_expr() {
             // Oops, already an f-string. We don't know how to handle those
             // gracefully right now.
             return None;
@@ -95,10 +95,10 @@ fn build_fstring(joiner: &str, joinees: &[Expr]) -> Option<Expr> {
         if !std::mem::take(&mut first) {
             fstring_elems.push(helpers::to_constant_string(joiner));
         }
-        fstring_elems.push(helpers::to_fstring_elem(expr)?);
+        fstring_elems.push(helpers::to_f_string_element(expr)?);
     }
 
-    let node = ast::ExprJoinedStr {
+    let node = ast::ExprFString {
         values: fstring_elems,
         range: TextRange::default(),
     };

--- a/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -48,7 +48,7 @@ impl AlwaysAutofixableViolation for FStringMissingPlaceholders {
     }
 }
 
-/// Find f-strings that don't contain any formatted values in a `JoinedStr`.
+/// Find f-strings that don't contain any formatted values in an [`FString`].
 fn find_useless_f_strings<'a>(
     expr: &'a Expr,
     locator: &'a Locator,

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -130,7 +130,7 @@ pub(crate) fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values
         };
 
         match key {
-            Expr::Constant(_) | Expr::Tuple(_) | Expr::JoinedStr(_) => {
+            Expr::Constant(_) | Expr::Tuple(_) | Expr::FString(_) => {
                 if checker.enabled(Rule::MultiValueRepeatedKeyLiteral) {
                     let mut diagnostic = Diagnostic::new(
                         MultiValueRepeatedKeyLiteral {

--- a/crates/ruff/src/rules/pylint/rules/assert_on_string_literal.rs
+++ b/crates/ruff/src/rules/pylint/rules/assert_on_string_literal.rs
@@ -71,7 +71,7 @@ pub(crate) fn assert_on_string_literal(checker: &mut Checker, test: &Expr) {
             }
             _ => {}
         },
-        Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
+        Expr::FString(ast::ExprFString { values, range: _ }) => {
             checker.diagnostics.push(Diagnostic::new(
                 AssertOnStringLiteral {
                     kind: if values.iter().all(|value| match value {

--- a/crates/ruff/src/rules/pylint/rules/invalid_envvar_default.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_envvar_default.rs
@@ -71,7 +71,7 @@ fn is_valid_default(expr: &Expr) -> bool {
         Expr::Constant(ast::ExprConstant {
             value: Constant::Str { .. } | Constant::None { .. },
             ..
-        }) | Expr::JoinedStr(_)
+        }) | Expr::FString(_)
     )
 }
 

--- a/crates/ruff/src/rules/pylint/rules/invalid_envvar_value.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_envvar_value.rs
@@ -68,7 +68,7 @@ fn is_valid_key(expr: &Expr) -> bool {
         Expr::Constant(ast::ExprConstant {
             value: Constant::Str { .. },
             ..
-        }) | Expr::JoinedStr(_)
+        }) | Expr::FString(_)
     )
 }
 

--- a/crates/ruff/src/rules/pylint/rules/single_string_slots.rs
+++ b/crates/ruff/src/rules/pylint/rules/single_string_slots.rs
@@ -70,7 +70,7 @@ pub(crate) fn single_string_slots(checker: &mut Checker, class: &StmtClassDef) {
                                 Expr::Constant(ast::ExprConstant {
                                     value: Constant::Str(_),
                                     ..
-                                }) | Expr::JoinedStr(_)
+                                }) | Expr::FString(_)
                             ) {
                                 checker
                                     .diagnostics
@@ -92,7 +92,7 @@ pub(crate) fn single_string_slots(checker: &mut Checker, class: &StmtClassDef) {
                             Expr::Constant(ast::ExprConstant {
                                 value: Constant::Str(_),
                                 ..
-                            }) | Expr::JoinedStr(_)
+                            }) | Expr::FString(_)
                         ) {
                             checker
                                 .diagnostics

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -150,7 +150,7 @@ pub(crate) fn native_literals(
         if checker
             .semantic()
             .current_expressions()
-            .filter(|expr| expr.is_joined_str_expr())
+            .filter(|expr| expr.is_f_string_expr())
             .count()
             > 1
         {

--- a/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -400,7 +400,7 @@ pub(crate) fn printf_string_formatting(
 
     // Parse the parameters.
     let params_string = match right {
-        Expr::Constant(_) | Expr::JoinedStr(_) => {
+        Expr::Constant(_) | Expr::FString(_) => {
             format!("({})", checker.locator().slice(right.range()))
         }
         Expr::Name(_) | Expr::Attribute(_) | Expr::Subscript(_) | Expr::Call(_) => {

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -226,7 +226,7 @@ pub(crate) fn unnecessary_encode_utf8(checker: &mut Checker, call: &ast::ExprCal
             }
         }
         // Ex) `f"foo{bar}".encode("utf-8")`
-        Expr::JoinedStr(_) => {
+        Expr::FString(_) => {
             if let Some(encoding_arg) = match_encoding_arg(&call.arguments) {
                 if let EncodingArg::Keyword(kwarg) = encoding_arg {
                     // Ex) Convert `f"unicode text©".encode(encoding="utf-8")` to

--- a/crates/ruff/src/rules/ruff/rules/invalid_index_type.rs
+++ b/crates/ruff/src/rules/ruff/rules/invalid_index_type.rs
@@ -63,7 +63,7 @@ pub(crate) fn invalid_index_type(checker: &mut Checker, expr: &ExprSubscript) {
         Expr::List(_)
             | Expr::ListComp(_)
             | Expr::Tuple(_)
-            | Expr::JoinedStr(_)
+            | Expr::FString(_)
             | Expr::Constant(ExprConstant {
                 value: Constant::Str(_) | Constant::Bytes(_),
                 ..
@@ -156,7 +156,7 @@ pub(crate) fn invalid_index_type(checker: &mut Checker, expr: &ExprSubscript) {
 #[derive(Debug)]
 enum CheckableExprType<'a> {
     Constant(&'a Constant),
-    JoinedStr,
+    FString,
     List,
     ListComp,
     SetComp,
@@ -171,7 +171,7 @@ impl fmt::Display for CheckableExprType<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Constant(constant) => f.write_str(constant_type_name(constant)),
-            Self::JoinedStr => f.write_str("str"),
+            Self::FString => f.write_str("str"),
             Self::List => f.write_str("list"),
             Self::SetComp => f.write_str("set comprehension"),
             Self::ListComp => f.write_str("list comprehension"),
@@ -188,7 +188,7 @@ impl<'a> CheckableExprType<'a> {
     fn try_from(expr: &'a Expr) -> Option<Self> {
         match expr {
             Expr::Constant(ExprConstant { value, .. }) => Some(Self::Constant(value)),
-            Expr::JoinedStr(_) => Some(Self::JoinedStr),
+            Expr::FString(_) => Some(Self::FString),
             Expr::List(_) => Some(Self::List),
             Expr::ListComp(_) => Some(Self::ListComp),
             Expr::SetComp(_) => Some(Self::SetComp),

--- a/crates/ruff/src/rules/ruff/rules/unreachable.rs
+++ b/crates/ruff/src/rules/ruff/rules/unreachable.rs
@@ -633,7 +633,7 @@ impl<'stmt> BasicBlocksBuilder<'stmt> {
                         | Expr::Compare(_)
                         | Expr::Call(_)
                         | Expr::FormattedValue(_)
-                        | Expr::JoinedStr(_)
+                        | Expr::FString(_)
                         | Expr::Constant(_)
                         | Expr::Attribute(_)
                         | Expr::Subscript(_)

--- a/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_args.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_args.rs
@@ -54,7 +54,7 @@ where
     F: (Fn(&str) -> bool) + Copy,
 {
     match expr {
-        Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
+        Expr::FString(ast::ExprFString { values, range: _ }) => {
             for value in values {
                 if any_string(value, predicate) {
                     return true;

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -616,7 +616,7 @@ pub struct ExprFormattedValue<'a> {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct ExprJoinedStr<'a> {
+pub struct ExprFString<'a> {
     values: Vec<ComparableExpr<'a>>,
 }
 
@@ -697,7 +697,7 @@ pub enum ComparableExpr<'a> {
     Compare(ExprCompare<'a>),
     Call(ExprCall<'a>),
     FormattedValue(ExprFormattedValue<'a>),
-    JoinedStr(ExprJoinedStr<'a>),
+    FString(ExprFString<'a>),
     Constant(ExprConstant<'a>),
     Attribute(ExprAttribute<'a>),
     Subscript(ExprSubscript<'a>),
@@ -865,8 +865,8 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                 debug_text: debug_text.as_ref(),
                 format_spec: format_spec.as_ref().map(Into::into),
             }),
-            ast::Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
-                Self::JoinedStr(ExprJoinedStr {
+            ast::Expr::FString(ast::ExprFString { values, range: _ }) => {
+                Self::FString(ExprFString {
                     values: values.iter().map(Into::into).collect(),
                 })
             }

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -68,7 +68,7 @@ where
             if !matches!(
                 left.as_ref(),
                 Expr::Constant(_)
-                    | Expr::JoinedStr(_)
+                    | Expr::FString(_)
                     | Expr::List(_)
                     | Expr::Tuple(_)
                     | Expr::Set(_)
@@ -82,7 +82,7 @@ where
             if !matches!(
                 right.as_ref(),
                 Expr::Constant(_)
-                    | Expr::JoinedStr(_)
+                    | Expr::FString(_)
                     | Expr::List(_)
                     | Expr::Tuple(_)
                     | Expr::Set(_)
@@ -126,7 +126,7 @@ where
         Expr::BoolOp(ast::ExprBoolOp {
             values, range: _, ..
         })
-        | Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
+        | Expr::FString(ast::ExprFString { values, range: _ }) => {
             values.iter().any(|expr| any_over_expr(expr, func))
         }
         Expr::NamedExpr(ast::ExprNamedExpr {
@@ -1094,7 +1094,7 @@ impl Truthiness {
                 Constant::Complex { real, imag } => Some(*real != 0.0 || *imag != 0.0),
                 Constant::Ellipsis => Some(true),
             },
-            Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
+            Expr::FString(ast::ExprFString { values, range: _ }) => {
                 if values.is_empty() {
                     Some(false)
                 } else if values.iter().any(|value| {

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -67,7 +67,7 @@ pub enum AnyNode {
     ExprCompare(ast::ExprCompare),
     ExprCall(ast::ExprCall),
     ExprFormattedValue(ast::ExprFormattedValue),
-    ExprJoinedStr(ast::ExprJoinedStr),
+    ExprFString(ast::ExprFString),
     ExprConstant(ast::ExprConstant),
     ExprAttribute(ast::ExprAttribute),
     ExprSubscript(ast::ExprSubscript),
@@ -153,7 +153,7 @@ impl AnyNode {
             | AnyNode::ExprCompare(_)
             | AnyNode::ExprCall(_)
             | AnyNode::ExprFormattedValue(_)
-            | AnyNode::ExprJoinedStr(_)
+            | AnyNode::ExprFString(_)
             | AnyNode::ExprConstant(_)
             | AnyNode::ExprAttribute(_)
             | AnyNode::ExprSubscript(_)
@@ -210,7 +210,7 @@ impl AnyNode {
             AnyNode::ExprCompare(node) => Some(Expr::Compare(node)),
             AnyNode::ExprCall(node) => Some(Expr::Call(node)),
             AnyNode::ExprFormattedValue(node) => Some(Expr::FormattedValue(node)),
-            AnyNode::ExprJoinedStr(node) => Some(Expr::JoinedStr(node)),
+            AnyNode::ExprFString(node) => Some(Expr::FString(node)),
             AnyNode::ExprConstant(node) => Some(Expr::Constant(node)),
             AnyNode::ExprAttribute(node) => Some(Expr::Attribute(node)),
             AnyNode::ExprSubscript(node) => Some(Expr::Subscript(node)),
@@ -325,7 +325,7 @@ impl AnyNode {
             | AnyNode::ExprCompare(_)
             | AnyNode::ExprCall(_)
             | AnyNode::ExprFormattedValue(_)
-            | AnyNode::ExprJoinedStr(_)
+            | AnyNode::ExprFString(_)
             | AnyNode::ExprConstant(_)
             | AnyNode::ExprAttribute(_)
             | AnyNode::ExprSubscript(_)
@@ -419,7 +419,7 @@ impl AnyNode {
             | AnyNode::ExprCompare(_)
             | AnyNode::ExprCall(_)
             | AnyNode::ExprFormattedValue(_)
-            | AnyNode::ExprJoinedStr(_)
+            | AnyNode::ExprFString(_)
             | AnyNode::ExprConstant(_)
             | AnyNode::ExprAttribute(_)
             | AnyNode::ExprSubscript(_)
@@ -498,7 +498,7 @@ impl AnyNode {
             | AnyNode::ExprCompare(_)
             | AnyNode::ExprCall(_)
             | AnyNode::ExprFormattedValue(_)
-            | AnyNode::ExprJoinedStr(_)
+            | AnyNode::ExprFString(_)
             | AnyNode::ExprConstant(_)
             | AnyNode::ExprAttribute(_)
             | AnyNode::ExprSubscript(_)
@@ -602,7 +602,7 @@ impl AnyNode {
             Self::ExprCompare(node) => AnyNodeRef::ExprCompare(node),
             Self::ExprCall(node) => AnyNodeRef::ExprCall(node),
             Self::ExprFormattedValue(node) => AnyNodeRef::ExprFormattedValue(node),
-            Self::ExprJoinedStr(node) => AnyNodeRef::ExprJoinedStr(node),
+            Self::ExprFString(node) => AnyNodeRef::ExprFString(node),
             Self::ExprConstant(node) => AnyNodeRef::ExprConstant(node),
             Self::ExprAttribute(node) => AnyNodeRef::ExprAttribute(node),
             Self::ExprSubscript(node) => AnyNodeRef::ExprSubscript(node),
@@ -1961,12 +1961,12 @@ impl AstNode for ast::ExprFormattedValue {
         AnyNode::from(self)
     }
 }
-impl AstNode for ast::ExprJoinedStr {
+impl AstNode for ast::ExprFString {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
     {
-        if let AnyNode::ExprJoinedStr(node) = kind {
+        if let AnyNode::ExprFString(node) = kind {
             Some(node)
         } else {
             None
@@ -1974,7 +1974,7 @@ impl AstNode for ast::ExprJoinedStr {
     }
 
     fn cast_ref(kind: AnyNodeRef) -> Option<&Self> {
-        if let AnyNodeRef::ExprJoinedStr(node) = kind {
+        if let AnyNodeRef::ExprFString(node) = kind {
             Some(node)
         } else {
             None
@@ -2941,7 +2941,7 @@ impl From<Expr> for AnyNode {
             Expr::Compare(node) => AnyNode::ExprCompare(node),
             Expr::Call(node) => AnyNode::ExprCall(node),
             Expr::FormattedValue(node) => AnyNode::ExprFormattedValue(node),
-            Expr::JoinedStr(node) => AnyNode::ExprJoinedStr(node),
+            Expr::FString(node) => AnyNode::ExprFString(node),
             Expr::Constant(node) => AnyNode::ExprConstant(node),
             Expr::Attribute(node) => AnyNode::ExprAttribute(node),
             Expr::Subscript(node) => AnyNode::ExprSubscript(node),
@@ -3269,9 +3269,9 @@ impl From<ast::ExprFormattedValue> for AnyNode {
     }
 }
 
-impl From<ast::ExprJoinedStr> for AnyNode {
-    fn from(node: ast::ExprJoinedStr) -> Self {
-        AnyNode::ExprJoinedStr(node)
+impl From<ast::ExprFString> for AnyNode {
+    fn from(node: ast::ExprFString) -> Self {
+        AnyNode::ExprFString(node)
     }
 }
 
@@ -3505,7 +3505,7 @@ impl Ranged for AnyNode {
             AnyNode::ExprCompare(node) => node.range(),
             AnyNode::ExprCall(node) => node.range(),
             AnyNode::ExprFormattedValue(node) => node.range(),
-            AnyNode::ExprJoinedStr(node) => node.range(),
+            AnyNode::ExprFString(node) => node.range(),
             AnyNode::ExprConstant(node) => node.range(),
             AnyNode::ExprAttribute(node) => node.range(),
             AnyNode::ExprSubscript(node) => node.range(),
@@ -3591,7 +3591,7 @@ pub enum AnyNodeRef<'a> {
     ExprCompare(&'a ast::ExprCompare),
     ExprCall(&'a ast::ExprCall),
     ExprFormattedValue(&'a ast::ExprFormattedValue),
-    ExprJoinedStr(&'a ast::ExprJoinedStr),
+    ExprFString(&'a ast::ExprFString),
     ExprConstant(&'a ast::ExprConstant),
     ExprAttribute(&'a ast::ExprAttribute),
     ExprSubscript(&'a ast::ExprSubscript),
@@ -3676,7 +3676,7 @@ impl AnyNodeRef<'_> {
             AnyNodeRef::ExprCompare(node) => NonNull::from(*node).cast(),
             AnyNodeRef::ExprCall(node) => NonNull::from(*node).cast(),
             AnyNodeRef::ExprFormattedValue(node) => NonNull::from(*node).cast(),
-            AnyNodeRef::ExprJoinedStr(node) => NonNull::from(*node).cast(),
+            AnyNodeRef::ExprFString(node) => NonNull::from(*node).cast(),
             AnyNodeRef::ExprConstant(node) => NonNull::from(*node).cast(),
             AnyNodeRef::ExprAttribute(node) => NonNull::from(*node).cast(),
             AnyNodeRef::ExprSubscript(node) => NonNull::from(*node).cast(),
@@ -3767,7 +3767,7 @@ impl AnyNodeRef<'_> {
             AnyNodeRef::ExprCompare(_) => NodeKind::ExprCompare,
             AnyNodeRef::ExprCall(_) => NodeKind::ExprCall,
             AnyNodeRef::ExprFormattedValue(_) => NodeKind::ExprFormattedValue,
-            AnyNodeRef::ExprJoinedStr(_) => NodeKind::ExprJoinedStr,
+            AnyNodeRef::ExprFString(_) => NodeKind::ExprFString,
             AnyNodeRef::ExprConstant(_) => NodeKind::ExprConstant,
             AnyNodeRef::ExprAttribute(_) => NodeKind::ExprAttribute,
             AnyNodeRef::ExprSubscript(_) => NodeKind::ExprSubscript,
@@ -3853,7 +3853,7 @@ impl AnyNodeRef<'_> {
             | AnyNodeRef::ExprCompare(_)
             | AnyNodeRef::ExprCall(_)
             | AnyNodeRef::ExprFormattedValue(_)
-            | AnyNodeRef::ExprJoinedStr(_)
+            | AnyNodeRef::ExprFString(_)
             | AnyNodeRef::ExprConstant(_)
             | AnyNodeRef::ExprAttribute(_)
             | AnyNodeRef::ExprSubscript(_)
@@ -3910,7 +3910,7 @@ impl AnyNodeRef<'_> {
             | AnyNodeRef::ExprCompare(_)
             | AnyNodeRef::ExprCall(_)
             | AnyNodeRef::ExprFormattedValue(_)
-            | AnyNodeRef::ExprJoinedStr(_)
+            | AnyNodeRef::ExprFString(_)
             | AnyNodeRef::ExprConstant(_)
             | AnyNodeRef::ExprAttribute(_)
             | AnyNodeRef::ExprSubscript(_)
@@ -4024,7 +4024,7 @@ impl AnyNodeRef<'_> {
             | AnyNodeRef::ExprCompare(_)
             | AnyNodeRef::ExprCall(_)
             | AnyNodeRef::ExprFormattedValue(_)
-            | AnyNodeRef::ExprJoinedStr(_)
+            | AnyNodeRef::ExprFString(_)
             | AnyNodeRef::ExprConstant(_)
             | AnyNodeRef::ExprAttribute(_)
             | AnyNodeRef::ExprSubscript(_)
@@ -4118,7 +4118,7 @@ impl AnyNodeRef<'_> {
             | AnyNodeRef::ExprCompare(_)
             | AnyNodeRef::ExprCall(_)
             | AnyNodeRef::ExprFormattedValue(_)
-            | AnyNodeRef::ExprJoinedStr(_)
+            | AnyNodeRef::ExprFString(_)
             | AnyNodeRef::ExprConstant(_)
             | AnyNodeRef::ExprAttribute(_)
             | AnyNodeRef::ExprSubscript(_)
@@ -4197,7 +4197,7 @@ impl AnyNodeRef<'_> {
             | AnyNodeRef::ExprCompare(_)
             | AnyNodeRef::ExprCall(_)
             | AnyNodeRef::ExprFormattedValue(_)
-            | AnyNodeRef::ExprJoinedStr(_)
+            | AnyNodeRef::ExprFString(_)
             | AnyNodeRef::ExprConstant(_)
             | AnyNodeRef::ExprAttribute(_)
             | AnyNodeRef::ExprSubscript(_)
@@ -4543,9 +4543,9 @@ impl<'a> From<&'a ast::ExprFormattedValue> for AnyNodeRef<'a> {
     }
 }
 
-impl<'a> From<&'a ast::ExprJoinedStr> for AnyNodeRef<'a> {
-    fn from(node: &'a ast::ExprJoinedStr) -> Self {
-        AnyNodeRef::ExprJoinedStr(node)
+impl<'a> From<&'a ast::ExprFString> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprFString) -> Self {
+        AnyNodeRef::ExprFString(node)
     }
 }
 
@@ -4740,7 +4740,7 @@ impl<'a> From<&'a Expr> for AnyNodeRef<'a> {
             Expr::Compare(node) => AnyNodeRef::ExprCompare(node),
             Expr::Call(node) => AnyNodeRef::ExprCall(node),
             Expr::FormattedValue(node) => AnyNodeRef::ExprFormattedValue(node),
-            Expr::JoinedStr(node) => AnyNodeRef::ExprJoinedStr(node),
+            Expr::FString(node) => AnyNodeRef::ExprFString(node),
             Expr::Constant(node) => AnyNodeRef::ExprConstant(node),
             Expr::Attribute(node) => AnyNodeRef::ExprAttribute(node),
             Expr::Subscript(node) => AnyNodeRef::ExprSubscript(node),
@@ -4893,7 +4893,7 @@ impl Ranged for AnyNodeRef<'_> {
             AnyNodeRef::ExprCompare(node) => node.range(),
             AnyNodeRef::ExprCall(node) => node.range(),
             AnyNodeRef::ExprFormattedValue(node) => node.range(),
-            AnyNodeRef::ExprJoinedStr(node) => node.range(),
+            AnyNodeRef::ExprFString(node) => node.range(),
             AnyNodeRef::ExprConstant(node) => node.range(),
             AnyNodeRef::ExprAttribute(node) => node.range(),
             AnyNodeRef::ExprSubscript(node) => node.range(),
@@ -4981,7 +4981,7 @@ pub enum NodeKind {
     ExprCompare,
     ExprCall,
     ExprFormattedValue,
-    ExprJoinedStr,
+    ExprFString,
     ExprConstant,
     ExprAttribute,
     ExprSubscript,

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -550,8 +550,8 @@ pub enum Expr {
     Call(ExprCall),
     #[is(name = "formatted_value_expr")]
     FormattedValue(ExprFormattedValue),
-    #[is(name = "joined_str_expr")]
-    JoinedStr(ExprJoinedStr),
+    #[is(name = "f_string_expr")]
+    FString(ExprFString),
     #[is(name = "constant_expr")]
     Constant(ExprConstant),
     #[is(name = "attribute_expr")]
@@ -878,14 +878,14 @@ pub struct DebugText {
 
 /// See also [JoinedStr](https://docs.python.org/3/library/ast.html#ast.JoinedStr)
 #[derive(Clone, Debug, PartialEq)]
-pub struct ExprJoinedStr {
+pub struct ExprFString {
     pub range: TextRange,
     pub values: Vec<Expr>,
 }
 
-impl From<ExprJoinedStr> for Expr {
-    fn from(payload: ExprJoinedStr) -> Self {
-        Expr::JoinedStr(payload)
+impl From<ExprFString> for Expr {
+    fn from(payload: ExprFString) -> Self {
+        Expr::FString(payload)
     }
 }
 
@@ -2814,7 +2814,7 @@ impl Ranged for crate::nodes::ExprFormattedValue {
         self.range
     }
 }
-impl Ranged for crate::nodes::ExprJoinedStr {
+impl Ranged for crate::nodes::ExprFString {
     fn range(&self) -> TextRange {
         self.range
     }
@@ -2885,7 +2885,7 @@ impl Ranged for crate::Expr {
             Self::Compare(node) => node.range(),
             Self::Call(node) => node.range(),
             Self::FormattedValue(node) => node.range(),
-            Self::JoinedStr(node) => node.range(),
+            Self::FString(node) => node.range(),
             Self::Constant(node) => node.range(),
             Self::Attribute(node) => node.range(),
             Self::Subscript(node) => node.range(),

--- a/crates/ruff_python_ast/src/relocate.rs
+++ b/crates/ruff_python_ast/src/relocate.rs
@@ -140,7 +140,7 @@ pub fn relocate_expr(expr: &mut Expr, location: TextRange) {
                 relocate_expr(expr, location);
             }
         }
-        Expr::JoinedStr(nodes::ExprJoinedStr { values, range }) => {
+        Expr::FString(nodes::ExprFString { values, range }) => {
             *range = location;
             for expr in values {
                 relocate_expr(expr, location);

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -476,7 +476,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
                 visitor.visit_format_spec(expr);
             }
         }
-        Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
+        Expr::FString(ast::ExprFString { values, range: _ }) => {
             for expr in values {
                 visitor.visit_expr(expr);
             }

--- a/crates/ruff_python_ast/src/visitor/preorder.rs
+++ b/crates/ruff_python_ast/src/visitor/preorder.rs
@@ -570,7 +570,7 @@ where
             }
         }
 
-        Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
+        Expr::FString(ast::ExprFString { values, range: _ }) => {
             for expr in values {
                 visitor.visit_expr(expr);
             }

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1104,8 +1104,8 @@ impl<'a> Generator<'a> {
                 *conversion,
                 format_spec.as_deref(),
             ),
-            Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
-                self.unparse_joinedstr(values, false);
+            Expr::FString(ast::ExprFString { values, range: _ }) => {
+                self.unparse_f_string(values, false);
             }
             Expr::Constant(ast::ExprConstant {
                 value,
@@ -1289,9 +1289,9 @@ impl<'a> Generator<'a> {
         }
     }
 
-    fn unparse_fstring_body(&mut self, values: &[Expr], is_spec: bool) {
+    fn unparse_f_string_body(&mut self, values: &[Expr], is_spec: bool) {
         for value in values {
-            self.unparse_fstring_elem(value, is_spec);
+            self.unparse_f_string_elem(value, is_spec);
         }
     }
 
@@ -1330,23 +1330,23 @@ impl<'a> Generator<'a> {
 
         if let Some(spec) = spec {
             self.p(":");
-            self.unparse_fstring_elem(spec, true);
+            self.unparse_f_string_elem(spec, true);
         }
 
         self.p("}");
     }
 
-    fn unparse_fstring_elem(&mut self, expr: &Expr, is_spec: bool) {
+    fn unparse_f_string_elem(&mut self, expr: &Expr, is_spec: bool) {
         match expr {
             Expr::Constant(ast::ExprConstant { value, .. }) => {
                 if let Constant::Str(s) = value {
-                    self.unparse_fstring_str(s);
+                    self.unparse_f_string_literal(s);
                 } else {
                     unreachable!()
                 }
             }
-            Expr::JoinedStr(ast::ExprJoinedStr { values, range: _ }) => {
-                self.unparse_joinedstr(values, is_spec);
+            Expr::FString(ast::ExprFString { values, range: _ }) => {
+                self.unparse_f_string(values, is_spec);
             }
             Expr::FormattedValue(ast::ExprFormattedValue {
                 value,
@@ -1364,14 +1364,14 @@ impl<'a> Generator<'a> {
         }
     }
 
-    fn unparse_fstring_str(&mut self, s: &str) {
+    fn unparse_f_string_literal(&mut self, s: &str) {
         let s = s.replace('{', "{{").replace('}', "}}");
         self.p(&s);
     }
 
-    fn unparse_joinedstr(&mut self, values: &[Expr], is_spec: bool) {
+    fn unparse_f_string(&mut self, values: &[Expr], is_spec: bool) {
         if is_spec {
-            self.unparse_fstring_body(values, is_spec);
+            self.unparse_f_string_body(values, is_spec);
         } else {
             self.p("f");
             let mut generator = Generator::new(
@@ -1382,7 +1382,7 @@ impl<'a> Generator<'a> {
                 },
                 self.line_ending,
             );
-            generator.unparse_fstring_body(values, is_spec);
+            generator.unparse_f_string_body(values, is_spec);
             let body = &generator.buffer;
             self.p_str_repr(body);
         }

--- a/crates/ruff_python_formatter/src/expression/expr_f_string.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_f_string.rs
@@ -5,18 +5,18 @@ use crate::prelude::*;
 use crate::{FormatNodeRule, PyFormatter};
 use ruff_formatter::FormatResult;
 use ruff_python_ast::node::AnyNodeRef;
-use ruff_python_ast::ExprJoinedStr;
+use ruff_python_ast::ExprFString;
 
 #[derive(Default)]
-pub struct FormatExprJoinedStr;
+pub struct FormatExprFString;
 
-impl FormatNodeRule<ExprJoinedStr> for FormatExprJoinedStr {
-    fn fmt_fields(&self, item: &ExprJoinedStr, f: &mut PyFormatter) -> FormatResult<()> {
-        FormatString::new(&AnyString::JoinedStr(item)).fmt(f)
+impl FormatNodeRule<ExprFString> for FormatExprFString {
+    fn fmt_fields(&self, item: &ExprFString, f: &mut PyFormatter) -> FormatResult<()> {
+        FormatString::new(&AnyString::FString(item)).fmt(f)
     }
 }
 
-impl NeedsParentheses for ExprJoinedStr {
+impl NeedsParentheses for ExprFString {
     fn needs_parentheses(
         &self,
         _parent: AnyNodeRef,

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -25,10 +25,10 @@ pub(crate) mod expr_compare;
 pub(crate) mod expr_constant;
 pub(crate) mod expr_dict;
 pub(crate) mod expr_dict_comp;
+pub(crate) mod expr_f_string;
 pub(crate) mod expr_formatted_value;
 pub(crate) mod expr_generator_exp;
 pub(crate) mod expr_if_exp;
-pub(crate) mod expr_joined_str;
 pub(crate) mod expr_lambda;
 pub(crate) mod expr_line_magic;
 pub(crate) mod expr_list;
@@ -85,7 +85,7 @@ impl FormatRule<Expr, PyFormatContext<'_>> for FormatExpr {
             Expr::Compare(expr) => expr.format().with_options(Some(parentheses)).fmt(f),
             Expr::Call(expr) => expr.format().fmt(f),
             Expr::FormattedValue(expr) => expr.format().fmt(f),
-            Expr::JoinedStr(expr) => expr.format().fmt(f),
+            Expr::FString(expr) => expr.format().fmt(f),
             Expr::Constant(expr) => expr.format().fmt(f),
             Expr::Attribute(expr) => expr.format().fmt(f),
             Expr::Subscript(expr) => expr.format().fmt(f),
@@ -223,7 +223,7 @@ impl NeedsParentheses for Expr {
             Expr::Compare(expr) => expr.needs_parentheses(parent, context),
             Expr::Call(expr) => expr.needs_parentheses(parent, context),
             Expr::FormattedValue(expr) => expr.needs_parentheses(parent, context),
-            Expr::JoinedStr(expr) => expr.needs_parentheses(parent, context),
+            Expr::FString(expr) => expr.needs_parentheses(parent, context),
             Expr::Constant(expr) => expr.needs_parentheses(parent, context),
             Expr::Attribute(expr) => expr.needs_parentheses(parent, context),
             Expr::Subscript(expr) => expr.needs_parentheses(parent, context),
@@ -421,7 +421,7 @@ impl<'input> CanOmitOptionalParenthesesVisitor<'input> {
             | Expr::Yield(_)
             | Expr::YieldFrom(_)
             | Expr::FormattedValue(_)
-            | Expr::JoinedStr(_)
+            | Expr::FString(_)
             | Expr::Constant(_)
             | Expr::Starred(_)
             | Expr::Name(_)

--- a/crates/ruff_python_formatter/src/generated.rs
+++ b/crates/ruff_python_formatter/src/generated.rs
@@ -1606,38 +1606,38 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprFormattedValue {
     }
 }
 
-impl FormatRule<ast::ExprJoinedStr, PyFormatContext<'_>>
-    for crate::expression::expr_joined_str::FormatExprJoinedStr
+impl FormatRule<ast::ExprFString, PyFormatContext<'_>>
+    for crate::expression::expr_f_string::FormatExprFString
 {
     #[inline]
-    fn fmt(&self, node: &ast::ExprJoinedStr, f: &mut PyFormatter) -> FormatResult<()> {
-        FormatNodeRule::<ast::ExprJoinedStr>::fmt(self, node, f)
+    fn fmt(&self, node: &ast::ExprFString, f: &mut PyFormatter) -> FormatResult<()> {
+        FormatNodeRule::<ast::ExprFString>::fmt(self, node, f)
     }
 }
-impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprJoinedStr {
+impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprFString {
     type Format<'a> = FormatRefWithRule<
         'a,
-        ast::ExprJoinedStr,
-        crate::expression::expr_joined_str::FormatExprJoinedStr,
+        ast::ExprFString,
+        crate::expression::expr_f_string::FormatExprFString,
         PyFormatContext<'ast>,
     >;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(
             self,
-            crate::expression::expr_joined_str::FormatExprJoinedStr::default(),
+            crate::expression::expr_f_string::FormatExprFString::default(),
         )
     }
 }
-impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprJoinedStr {
+impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprFString {
     type Format = FormatOwnedWithRule<
-        ast::ExprJoinedStr,
-        crate::expression::expr_joined_str::FormatExprJoinedStr,
+        ast::ExprFString,
+        crate::expression::expr_f_string::FormatExprFString,
         PyFormatContext<'ast>,
     >;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(
             self,
-            crate::expression::expr_joined_str::FormatExprJoinedStr::default(),
+            crate::expression::expr_f_string::FormatExprFString::default(),
         )
     }
 }

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_f_string.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_f_string.snap
@@ -6,8 +6,8 @@ expression: parse_ast
     Expr(
         StmtExpr {
             range: 0..14,
-            value: JoinedStr(
-                ExprJoinedStr {
+            value: FString(
+                ExprFString {
                     range: 0..14,
                     values: [
                         Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__try.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__try.snap
@@ -79,8 +79,8 @@ expression: parse_ast
                                             arguments: Arguments {
                                                 range: 61..82,
                                                 args: [
-                                                    JoinedStr(
-                                                        ExprJoinedStr {
+                                                    FString(
+                                                        ExprFString {
                                                             range: 62..81,
                                                             values: [
                                                                 Constant(
@@ -173,8 +173,8 @@ expression: parse_ast
                                             arguments: Arguments {
                                                 range: 113..134,
                                                 args: [
-                                                    JoinedStr(
-                                                        ExprJoinedStr {
+                                                    FString(
+                                                        ExprFString {
                                                             range: 114..133,
                                                             values: [
                                                                 Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__try_star.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__try_star.snap
@@ -195,8 +195,8 @@ expression: parse_ast
                                             arguments: Arguments {
                                                 range: 132..180,
                                                 args: [
-                                                    JoinedStr(
-                                                        ExprJoinedStr {
+                                                    FString(
+                                                        ExprFString {
                                                             range: 133..179,
                                                             values: [
                                                                 Constant(
@@ -323,8 +323,8 @@ expression: parse_ast
                                             arguments: Arguments {
                                                 range: 212..260,
                                                 args: [
-                                                    JoinedStr(
-                                                        ExprJoinedStr {
+                                                    FString(
+                                                        ExprFString {
                                                             range: 213..259,
                                                             values: [
                                                                 Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_constant_range.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_constant_range.snap
@@ -6,8 +6,8 @@ expression: parse_ast
     Expr(
         StmtExpr {
             range: 0..22,
-            value: JoinedStr(
-                ExprJoinedStr {
+            value: FString(
+                ExprFString {
                     range: 0..22,
                     values: [
                         Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_character.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_character.snap
@@ -6,8 +6,8 @@ expression: parse_ast
     Expr(
         StmtExpr {
             range: 0..8,
-            value: JoinedStr(
-                ExprJoinedStr {
+            value: FString(
+                ExprFString {
                     range: 0..8,
                     values: [
                         Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_newline.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_newline.snap
@@ -6,8 +6,8 @@ expression: parse_ast
     Expr(
         StmtExpr {
             range: 0..8,
-            value: JoinedStr(
-                ExprJoinedStr {
+            value: FString(
+                ExprFString {
                     range: 0..8,
                     values: [
                         Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_line_continuation.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_line_continuation.snap
@@ -6,8 +6,8 @@ expression: parse_ast
     Expr(
         StmtExpr {
             range: 0..9,
-            value: JoinedStr(
-                ExprJoinedStr {
+            value: FString(
+                ExprFString {
                     range: 0..9,
                     values: [
                         Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_format.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_format.snap
@@ -21,8 +21,8 @@ expression: parse_ast
             ),
             conversion: None,
             format_spec: Some(
-                JoinedStr(
-                    ExprJoinedStr {
+                FString(
+                    ExprFString {
                         range: 9..12,
                         values: [
                             Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_unescaped_newline.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_unescaped_newline.snap
@@ -6,8 +6,8 @@ expression: parse_ast
     Expr(
         StmtExpr {
             range: 0..11,
-            value: JoinedStr(
-                ExprJoinedStr {
+            value: FString(
+                ExprFString {
                     range: 0..11,
                     values: [
                         Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_1.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_1.snap
@@ -6,8 +6,8 @@ expression: parse_ast
     Expr(
         StmtExpr {
             range: 0..17,
-            value: JoinedStr(
-                ExprJoinedStr {
+            value: FString(
+                ExprFString {
                     range: 0..17,
                     values: [
                         Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_2.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_2.snap
@@ -6,8 +6,8 @@ expression: parse_ast
     Expr(
         StmtExpr {
             range: 0..17,
-            value: JoinedStr(
-                ExprJoinedStr {
+            value: FString(
+                ExprFString {
                     range: 0..17,
                     values: [
                         Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_3.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_3.snap
@@ -6,8 +6,8 @@ expression: parse_ast
     Expr(
         StmtExpr {
             range: 0..22,
-            value: JoinedStr(
-                ExprJoinedStr {
+            value: FString(
+                ExprFString {
                     range: 0..22,
                     values: [
                         Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_spec.snap
@@ -16,8 +16,8 @@ expression: parse_ast
             debug_text: None,
             conversion: None,
             format_spec: Some(
-                JoinedStr(
-                    ExprJoinedStr {
+                FString(
+                    ExprFString {
                         range: 7..13,
                         values: [
                             FormattedValue(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_nested_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_nested_spec.snap
@@ -16,8 +16,8 @@ expression: parse_ast
             debug_text: None,
             conversion: None,
             format_spec: Some(
-                JoinedStr(
-                    ExprJoinedStr {
+                FString(
+                    ExprFString {
                         range: 7..11,
                         values: [
                             Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_f_string_concat_1.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_f_string_concat_1.snap
@@ -6,8 +6,8 @@ expression: parse_ast
     Expr(
         StmtExpr {
             range: 0..18,
-            value: JoinedStr(
-                ExprJoinedStr {
+            value: FString(
+                ExprFString {
                     range: 0..18,
                     values: [
                         Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_f_string_concat_2.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_f_string_concat_2.snap
@@ -6,8 +6,8 @@ expression: parse_ast
     Expr(
         StmtExpr {
             range: 0..22,
-            value: JoinedStr(
-                ExprJoinedStr {
+            value: FString(
+                ExprFString {
                     range: 0..22,
                     values: [
                         Constant(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__raw_fstring.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__raw_fstring.snap
@@ -6,8 +6,8 @@ expression: parse_ast
     Expr(
         StmtExpr {
             range: 0..7,
-            value: JoinedStr(
-                ExprJoinedStr {
+            value: FString(
+                ExprFString {
                     range: 0..7,
                     values: [
                         FormattedValue(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__triple_quoted_raw_fstring.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__triple_quoted_raw_fstring.snap
@@ -6,8 +6,8 @@ expression: parse_ast
     Expr(
         StmtExpr {
             range: 0..11,
-            value: JoinedStr(
-                ExprJoinedStr {
+            value: FString(
+                ExprFString {
                     range: 0..11,
                     values: [
                         FormattedValue(

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -243,7 +243,7 @@ impl<'a> StringParser<'a> {
                     let start_location = self.get_pos();
                     let parsed_spec = self.parse_spec(nested)?;
 
-                    spec = Some(Box::new(Expr::from(ast::ExprJoinedStr {
+                    spec = Some(Box::new(Expr::from(ast::ExprFString {
                         values: parsed_spec,
                         range: self.range(start_location),
                     })));
@@ -671,7 +671,7 @@ pub(crate) fn parse_strings(
         deduped.push(take_current(&mut current, current_start, current_end));
     }
 
-    Ok(Expr::JoinedStr(ast::ExprJoinedStr {
+    Ok(Expr::FString(ast::ExprFString {
         values: deduped,
         range: TextRange::new(initial_start, last_end),
     }))

--- a/crates/ruff_python_semantic/src/analyze/type_inference.rs
+++ b/crates/ruff_python_semantic/src/analyze/type_inference.rs
@@ -54,7 +54,7 @@ impl From<&Expr> for PythonType {
             Expr::ListComp(_) => PythonType::List,
             Expr::Tuple(_) => PythonType::Tuple,
             Expr::GeneratorExp(_) => PythonType::Generator,
-            Expr::JoinedStr(_) => PythonType::String,
+            Expr::FString(_) => PythonType::String,
             Expr::BinOp(ast::ExprBinOp { left, op, .. }) => {
                 // Ex) "a" % "b"
                 if op.is_mod() {


### PR DESCRIPTION
## Summary

Per the proposal in https://github.com/astral-sh/ruff/discussions/6183, this PR renames the `JoinedStr` node to `FString`.
