### PR TITLE
Avoid hard line break after dangling open-parenthesis comments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/list.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/list.py
@@ -44,3 +44,9 @@ c1 = [ # trailing open bracket
 [  # end-of-line comment
     1
 ]
+
+[  # inner comment
+    first,
+    second,
+    third
+]  # outer comment

--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -95,8 +95,9 @@ use std::rc::Rc;
 use ruff_python_ast::{Mod, Ranged};
 
 pub(crate) use format::{
-    dangling_comments, dangling_node_comments, leading_alternate_branch_comments, leading_comments,
-    leading_node_comments, trailing_comments, trailing_node_comments,
+    dangling_comments, dangling_node_comments, dangling_open_parenthesis_comments,
+    leading_alternate_branch_comments, leading_comments, leading_node_comments, trailing_comments,
+    trailing_node_comments,
 };
 use ruff_formatter::{SourceCode, SourceCodeSlice};
 use ruff_python_ast::node::AnyNodeRef;

--- a/crates/ruff_python_formatter/src/expression/parentheses.rs
+++ b/crates/ruff_python_formatter/src/expression/parentheses.rs
@@ -4,7 +4,7 @@ use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::Ranged;
 use ruff_python_trivia::{first_non_trivia_token, SimpleToken, SimpleTokenKind, SimpleTokenizer};
 
-use crate::comments::{dangling_comments, SourceComment};
+use crate::comments::{dangling_open_parenthesis_comments, SourceComment};
 use crate::context::{NodeLevel, WithNodeLevel};
 use crate::prelude::*;
 
@@ -117,7 +117,7 @@ where
 }
 
 /// Formats `content` enclosed by the `left` and `right` parentheses, along with any dangling
-/// comments that on the parentheses themselves.
+/// comments on the opening parenthesis itself.
 pub(crate) fn parenthesized_with_dangling_comments<'content, 'ast, Content>(
     left: &'static str,
     comments: &'content [SourceComment],
@@ -155,8 +155,8 @@ impl<'ast> Format<PyFormatContext<'ast>> for FormatParenthesized<'_, 'ast> {
             } else {
                 group(&format_args![
                     text(self.left),
-                    &line_suffix(&dangling_comments(self.comments)),
-                    &group(&soft_block_indent(&Arguments::from(&self.content))),
+                    &dangling_open_parenthesis_comments(self.comments),
+                    &soft_block_indent(&Arguments::from(&self.content)),
                     text(self.right)
                 ])
                 .fmt(f)
@@ -319,9 +319,10 @@ impl<'ast> Format<PyFormatContext<'ast>> for FormatInParenthesesOnlyGroup<'_, 'a
 
 #[cfg(test)]
 mod tests {
-    use crate::expression::parentheses::is_expression_parenthesized;
     use ruff_python_ast::node::AnyNodeRef;
     use ruff_python_parser::parse_expression;
+
+    use crate::expression::parentheses::is_expression_parenthesized;
 
     #[test]
     fn test_has_parentheses() {

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__multiline_consecutive_open_parentheses_ignore.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__multiline_consecutive_open_parentheses_ignore.py.snap
@@ -33,18 +33,19 @@ print(   "111"       ) # type: ignore
 ```diff
 --- Black
 +++ Ruff
-@@ -1,10 +1,8 @@
+@@ -1,12 +1,6 @@
  # This is a regression test. Issue #3737
  
 -a = (  # type: ignore
-+a = int(  # type: ignore  # type: ignore
-     int(  # type: ignore
+-    int(  # type: ignore
 -        int(  # type: ignore
 -            int(6)  # type: ignore
 -        )
-+        int(6)  # type: ignore
-     )
- )
+-    )
+-)
++a = int(int(int(6)))  # type: ignore  # type: ignore  # type: ignore  # type: ignore
+ 
+ b = int(6)
  
 ```
 
@@ -53,11 +54,7 @@ print(   "111"       ) # type: ignore
 ```py
 # This is a regression test. Issue #3737
 
-a = int(  # type: ignore  # type: ignore
-    int(  # type: ignore
-        int(6)  # type: ignore
-    )
-)
+a = int(int(int(6)))  # type: ignore  # type: ignore  # type: ignore  # type: ignore
 
 b = int(6)
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__list.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__list.py.snap
@@ -50,6 +50,12 @@ c1 = [ # trailing open bracket
 [  # end-of-line comment
     1
 ]
+
+[  # inner comment
+    first,
+    second,
+    third
+]  # outer comment
 ```
 
 ## Output
@@ -94,6 +100,8 @@ c1 = [  # trailing open bracket
 ]
 
 [1]  # end-of-line comment
+
+[first, second, third]  # inner comment  # outer comment
 ```
 
 


### PR DESCRIPTION
## Summary

Given:

```python
[  # comment
    first,
    second,
    third
]  # another comment
```

We were adding a hard line break as part of the formatting of `# comment`, which led to the following formatting:

```python
[first, second, third]  # comment
  # another comment
```

Closes https://github.com/astral-sh/ruff/issues/6367.
