### PR TITLE
Fix zulip unstable formatting with end-of-line comments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
@@ -211,3 +211,14 @@ for user_id in set(target_user_ids) - {u.user_id for u in updates}:
     log(self.price / self.strike)
     + (self.risk_free - self.div_cont + 0.5 * (self.sigma**2)) * self.exp_time
 ) / self.sigmaT
+
+# Stability with end-of-line comments between empty tuples and bin op
+x = () - (#
+)
+x = (
+    ()
+    - ()  #
+)
+x = (
+    () - ()  #
+)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/delete.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/delete.py
@@ -73,3 +73,7 @@ del (
 
 del (  # dangling end of line comment
 )
+
+del (  # dangling end of line comment
+    # dangling own line comment
+)  # trailing statement comment

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
@@ -217,6 +217,17 @@ for user_id in set(target_user_ids) - {u.user_id for u in updates}:
     log(self.price / self.strike)
     + (self.risk_free - self.div_cont + 0.5 * (self.sigma**2)) * self.exp_time
 ) / self.sigmaT
+
+# Stability with end-of-line comments between empty tuples and bin op
+x = () - (#
+)
+x = (
+    ()
+    - ()  #
+)
+x = (
+    () - ()  #
+)
 ```
 
 ## Output
@@ -488,6 +499,19 @@ for user_id in set(target_user_ids) - {u.user_id for u in updates}:
     log(self.price / self.strike)
     + (self.risk_free - self.div_cont + 0.5 * (self.sigma**2)) * self.exp_time
 ) / self.sigmaT
+
+# Stability with end-of-line comments between empty tuples and bin op
+x = (
+    ()
+    - (  #
+    )
+)
+x = (
+    () - ()  #
+)
+x = (
+    () - ()  #
+)
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__call.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__call.py.snap
@@ -213,7 +213,8 @@ f(
     a.very_long_function_function_that_is_so_long_that_it_expands_the_parent_but_its_only_a_single_argument()
 )
 
-f()  # abc
+f(  # abc
+)
 
 f(  # abc
     # abc

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__dict.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__dict.py.snap
@@ -129,7 +129,8 @@ a = {
     3: True,
 }
 
-x = {}  # dangling end of line comment
+x = {  # dangling end of line comment
+}
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
@@ -165,7 +165,8 @@ a = (
 # Regression test: lambda empty arguments ranges were too long, leading to unstable
 # formatting
 (
-    lambda: (),  #
+    lambda: (  #
+    ),
 )
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__list.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__list.py.snap
@@ -62,7 +62,8 @@ c1 = [ # trailing open bracket
 ```py
 # Dangling comment placement in empty lists
 # Regression test for https://github.com/python/cpython/blob/03160630319ca26dcbbad65225da4248e54c45ec/Tools/c-analyzer/c_analyzer/datafiles.py#L14-L16
-a1 = []  # a
+a1 = [  # a
+]
 a2 = [  # a
     # b
 ]
@@ -93,7 +94,8 @@ c1 = [  # trailing open bracket
 ]  # trailing close bracket
 
 
-[]  # end-of-line comment
+[  # end-of-line comment
+]
 
 [  # end-of-line comment
     # own-line comment

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__delete.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__delete.py.snap
@@ -79,6 +79,10 @@ del (
 
 del (  # dangling end of line comment
 )
+
+del (  # dangling end of line comment
+    # dangling own line comment
+)  # trailing statement comment
 ```
 
 ## Output
@@ -217,6 +221,10 @@ del (
 
 del (  # dangling end of line comment
 )
+
+del (  # dangling end of line comment
+    # dangling own line comment
+)  # trailing statement comment
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__delete.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__delete.py.snap
@@ -215,7 +215,8 @@ del (
 )  # Completed
 # Done
 
-del ()  # dangling end of line comment
+del (  # dangling end of line comment
+)
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
@@ -845,7 +845,8 @@ def f(  # first
     ...
 
 
-def f():  # first  # second
+def f(  # first
+):  # second
     ...
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__raise.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__raise.py.snap
@@ -192,7 +192,8 @@ raise aksjdhflsakhdflkjsadlfajkslhfdkjsaldajlahflashdfljahlfk < (
 )  # the other end
 # sneaky comment
 
-raise ()  # another comment
+raise (  # another comment
+)
 
 raise ()  # what now
 


### PR DESCRIPTION
## Bug

Given
```python
x = () - (#
)
```
the comment is a dangling comment of the empty tuple. This is an end-of-line comment so it may move after the expression. It still expands the parent, so the operator breaks:
```python
x = (
    ()
    - ()  #
)
```
In the next formatting pass, the comment is not a trailing tuple but a trailing bin op comment, so the bin op doesn't break anymore. The comment again expands the parent, so we still add the superfluous parentheses
```python
x = (
    () - ()  #
)
```

## Fix

The new formatting is to keep the comment on the empty tuple. This is a log uglier and again has additional outer parentheses, but it's stable:
```python
x = (
    ()
    - (  #
    )
)
```

## Alternatives

Black formats all the examples above as
```python
x = () - ()  #
```
which i find better. 

I would be happy about any suggestions for better solutions than the current one. I'd mainly need a workaround for expand parent having an effect on the bin op instead of first moving the comment to the end and then applying expand parent to the assign statement.
