### PR TITLE
Check .git in formatter progress checkouts for build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -339,8 +339,5 @@ jobs:
         run: scripts/formatter_ecosystem_checks.sh
       - name: "Github step summary"
         run: grep "similarity index" target/progress_projects_log.txt | sort > $GITHUB_STEP_SUMMARY
-      # CPython is not black formatted, so we run only the stability check
-      - name: "Clone CPython 3.10"
-        run: git clone --branch 3.10 --depth 1 https://github.com/python/cpython.git crates/ruff/resources/test/cpython
-      - name: "Check CPython stability"
-        run: cargo run --bin ruff_dev -- format-dev --stability-check crates/ruff/resources/test/cpython
+      - name: "Remove checkouts from cache"
+        run: rm -r target/progress_projects

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
               - "!crates/ruff_formatter/**"
               - "!crates/ruff_dev/**"
               - "!crates/ruff_shrinking/**"
-              - scripts/check_ecosystem.py
+              - scripts/*
 
             formatter:
               - Cargo.toml
@@ -56,6 +56,7 @@ jobs:
               - crates/ruff_text_size/**
               - crates/ruff_python_parser/**
               - crates/ruff_dev/**
+              - scripts/*
 
   cargo-fmt:
     name: "cargo fmt"

--- a/scripts/formatter_ecosystem_checks.sh
+++ b/scripts/formatter_ecosystem_checks.sh
@@ -17,40 +17,40 @@ dir="$target/progress_projects"
 mkdir -p "$dir"
 
 # small util library
-if [ ! -d "$dir/build" ]; then
+if [ ! -d "$dir/build/.git" ]; then
   git clone --filter=tree:0 https://github.com/pypa/build "$dir/build"
-  git -C "$dir/build" checkout d90f9ac6503a40ddbfaef94b7a7040f87178a4b3
 fi
+git -C "$dir/build" checkout d90f9ac6503a40ddbfaef94b7a7040f87178a4b3
 # web framework that implements a lot of magic
-if [ ! -d "$dir/django" ]; then
+if [ ! -d "$dir/django/.git" ]; then
   git clone --filter=tree:0 https://github.com/django/django "$dir/django"
-  git -C "$dir/django" checkout 95e4d6b81312fdd9f8ebf3385be1c1331168b5cf
 fi
+git -C "$dir/django" checkout 95e4d6b81312fdd9f8ebf3385be1c1331168b5cf
 # an ML project
-if [ ! -d "$dir/transformers" ]; then
+if [ ! -d "$dir/transformers/.git" ]; then
   git clone --filter=tree:0 https://github.com/huggingface/transformers "$dir/transformers"
-  git -C "$dir/transformers" checkout c9a82be592ca305180a7ab6a36e884bca1d426b8
 fi
+git -C "$dir/django" checkout 95e4d6b81312fdd9f8ebf3385be1c1331168b5cf
 # type annotations
-if [ ! -d "$dir/typeshed" ]; then
+if [ ! -d "$dir/typeshed/.git" ]; then
   git clone --filter=tree:0 https://github.com/python/typeshed "$dir/typeshed"
-  git -C "$dir/typeshed" checkout 7d33060e6ae3ebe54462a891f0c566c97371915b
 fi
+git -C "$dir/typeshed" checkout 7d33060e6ae3ebe54462a891f0c566c97371915b
 # python 3.11, typing and 100% test coverage
-if [ ! -d "$dir/warehouse" ]; then
+if [ ! -d "$dir/warehouse/.git" ]; then
   git clone --filter=tree:0 https://github.com/pypi/warehouse "$dir/warehouse"
-  git -C "$dir/warehouse" checkout fe6455c0a946e81f61d72edc1049f536d8bba903
 fi
+git -C "$dir/warehouse" checkout fe6455c0a946e81f61d72edc1049f536d8bba903
 # zulip, a django user
-if [ ! -d "$dir/zulip" ]; then
+if [ ! -d "$dir/zulip/.git" ]; then
   git clone --filter=tree:0 https://github.com/zulip/zulip "$dir/zulip"
-  git -C "$dir/zulip" checkout 6cb080c4479546a7f5cb017fcddea56605910b48
 fi
+git -C "$dir/zulip" checkout 6cb080c4479546a7f5cb017fcddea56605910b48
 # cpython itself
-if [ ! -d "$dir/cpython" ]; then
+if [ ! -d "$dir/cpython/.git" ]; then
   git clone --filter=tree:0 https://github.com/python/cpython "$dir/cpython"
-  git -C "$dir/cpython" checkout 45de31db9cc9be945702f3a7ca35bbb9f98476af
 fi
+git -C "$dir/cpython" checkout 45de31db9cc9be945702f3a7ca35bbb9f98476af
 
 # Uncomment if you want to update the hashes
 # for i in "$dir"/*/; do git -C "$i" switch main && git -C "$i" pull && echo "# $(basename "$i") $(git -C "$i" rev-parse HEAD)"; done


### PR DESCRIPTION
From the formatter progress CI logs:
```
2023-08-07T03:49:02.5178602Z + mkdir -p /home/runner/work/ruff/ruff/target/progress_projects
2023-08-07T03:49:02.5193474Z + '[' '!' -d /home/runner/work/ruff/ruff/target/progress_projects/build ']'
2023-08-07T03:49:02.5194228Z + '[' '!' -d /home/runner/work/ruff/ruff/target/progress_projects/django ']'
2023-08-07T03:49:02.5194966Z + git clone --filter=tree:0 https://github.com/django/django /home/runner/work/ruff/ruff/target/progress_projects/django
2023-08-07T03:49:02.5209260Z Cloning into '/home/runner/work/ruff/ruff/target/progress_projects/django'...
```
```
2023-08-07T03:51:17.4726088Z [2m2023-08-07T03:51:17.472404Z[0m [31mERROR[0m Failed /home/runner/work/ruff/ruff/target/progress_projects/build: no python files in ["/home/runner/work/ruff/ruff/target/progress_projects/build"]
```

Seems that build exists but is an empty cached folder. These changes should fix this by a) checking for `.git` instead of just the folder existing b) running the commit checkout unconditionally. The latter is also important if we ever want to update the SHAs.
