### PR TITLE
Expand parents whenever open-parenthesis comments are present

### DIFF
--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -260,11 +260,10 @@ impl Format<PyFormatContext<'_>> for FormatDanglingOpenParenthesisComments<'_> {
 
             write!(
                 f,
-                [line_suffix(&format_args![
-                    space(),
-                    space(),
-                    format_comment(comment)
-                ])]
+                [
+                    line_suffix(&format_args![space(), space(), format_comment(comment)]),
+                    expand_parent()
+                ]
             )?;
             comment.mark_formatted();
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__multiline_consecutive_open_parentheses_ignore.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__multiline_consecutive_open_parentheses_ignore.py.snap
@@ -33,20 +33,18 @@ print(   "111"       ) # type: ignore
 ```diff
 --- Black
 +++ Ruff
-@@ -1,12 +1,6 @@
+@@ -1,9 +1,9 @@
  # This is a regression test. Issue #3737
  
 -a = (  # type: ignore
--    int(  # type: ignore
--        int(  # type: ignore
++a = int(  # type: ignore  # type: ignore
+     int(  # type: ignore
+         int(  # type: ignore
 -            int(6)  # type: ignore
--        )
--    )
--)
-+a = int(int(int(6)))  # type: ignore  # type: ignore  # type: ignore  # type: ignore
- 
- b = int(6)
- 
++            6
+         )
+     )
+ )
 ```
 
 ## Ruff Output
@@ -54,7 +52,13 @@ print(   "111"       ) # type: ignore
 ```py
 # This is a regression test. Issue #3737
 
-a = int(int(int(6)))  # type: ignore  # type: ignore  # type: ignore  # type: ignore
+a = int(  # type: ignore  # type: ignore
+    int(  # type: ignore
+        int(  # type: ignore
+            6
+        )
+    )
+)
 
 b = int(6)
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__torture.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__torture.py.snap
@@ -50,14 +50,15 @@ assert (
  )  #
  
  assert sort_by_dependency(
-@@ -25,9 +25,7 @@
+@@ -25,9 +25,9 @@
  class A:
      def foo(self):
          for _ in range(10):
 -            aaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbb.cccccccccc(
--                xxxxxxxxxxxx
++            aaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbb.cccccccccc(  # pylint: disable=no-member
+                 xxxxxxxxxxxx
 -            )  # pylint: disable=no-member
-+            aaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbb.cccccccccc(xxxxxxxxxxxx)  # pylint: disable=no-member
++            )
  
  
  def test(self, othr):
@@ -93,7 +94,9 @@ importA
 class A:
     def foo(self):
         for _ in range(10):
-            aaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbb.cccccccccc(xxxxxxxxxxxx)  # pylint: disable=no-member
+            aaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbb.cccccccccc(  # pylint: disable=no-member
+                xxxxxxxxxxxx
+            )
 
 
 def test(self, othr):

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__call.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__call.py.snap
@@ -223,7 +223,9 @@ f(
     # abc
 )
 
-f(1)  # abc
+f(  # abc
+    1
+)
 
 f(
     # abc

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__dict_comp.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__dict_comp.py.snap
@@ -265,7 +265,10 @@ selected_choices = {
 
 {
     k: v
-    for (x, aaaayaaaayaaaayaaaayaaaayaaaayaaaayaaaayaaaayaaaayaaaayaaaayaaaayaaaay) in z  # foo
+    for (  # foo
+        x,
+        aaaayaaaayaaaayaaaayaaaayaaaayaaaayaaaayaaaayaaaayaaaayaaaayaaaayaaaay,
+    ) in z
 }
 
 a = {

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__list.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__list.py.snap
@@ -99,9 +99,15 @@ c1 = [  # trailing open bracket
     # own-line comment
 ]
 
-[1]  # end-of-line comment
+[  # end-of-line comment
+    1
+]
 
-[first, second, third]  # inner comment  # outer comment
+[  # inner comment
+    first,
+    second,
+    third,
+]  # outer comment
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
@@ -885,7 +885,9 @@ def f(  # first
     ...
 
 
-def f(a):  # first  # second
+def f(  # first
+    a
+):  # second
     ...
 
 


### PR DESCRIPTION
## Summary

This PR modifies our dangling-open-parenthesis handling to _always_ expand the parent expression.

So, for example, given:

```python
a = int(  # type: ignore
    int(  # type: ignore
        int(  # type: ignore
            6
        )
    )
)
```

We now retain that as stable formatting, instead of truncating like:

```python
a = int(int(int(6)))  # comment  # comment  # comment
```

Note that Black _does_ collapse comments like this _unless_ they're `# type: ignore` comments, and perhaps in some other cases, so this is an intentional deviation ([playground](https://black.vercel.app/?version=main&state=_Td6WFoAAATm1rRGAgAhARYAAAB0L-Wj4AFEAHpdAD2IimZxl1N_WlOfrjryFgvD4ScVsKPztqdHDGJUg5knO0JCdpUfW1IrWSNmIJPx95s0hP-pRNkCQNH64-eIznIvXjeWBQ5-qax0oNw4yMOuhwr2azvMRZaEB5r8IXVPHmRCJp7fe7y4290u1zzxqK_nAi6q_5sI-jsAAAAA8HgZ9V7hG3QAAZYBxQIAAGnCHXexxGf7AgAAAAAEWVo=)).