### PR TITLE
Remove `Statements#depth`

### DIFF
--- a/crates/ruff_python_semantic/src/statements.rs
+++ b/crates/ruff_python_semantic/src/statements.rs
@@ -22,8 +22,6 @@ struct StatementWithParent<'a> {
     statement: &'a Stmt,
     /// The ID of the parent of this node, if any.
     parent: Option<StatementId>,
-    /// The depth of this node in the tree.
-    depth: u32,
 }
 
 /// The statements of a program indexed by [`StatementId`]
@@ -46,11 +44,8 @@ impl<'a> Statements<'a> {
         if let Some(existing_id) = self.statement_to_id.insert(RefEquality(statement), next_id) {
             panic!("Statements already exists with ID: {existing_id:?}");
         }
-        self.statements.push(StatementWithParent {
-            statement,
-            parent,
-            depth: parent.map_or(0, |parent| self.statements[parent].depth + 1),
-        })
+        self.statements
+            .push(StatementWithParent { statement, parent })
     }
 
     /// Returns the [`StatementId`] of the given statement.
@@ -63,12 +58,6 @@ impl<'a> Statements<'a> {
     #[inline]
     pub fn parent_id(&self, statement_id: StatementId) -> Option<StatementId> {
         self.statements[statement_id].parent
-    }
-
-    /// Return the depth of the statement.
-    #[inline]
-    pub(crate) fn depth(&self, id: StatementId) -> u32 {
-        self.statements[id].depth
     }
 
     /// Returns an iterator over all [`StatementId`] ancestors, starting from the given [`StatementId`].


### PR DESCRIPTION
## Summary

This PR removes the depth tracking in `Statements`, in favor of just checking against the ancestors iterators directly in `common_ancestor`. Specifically, given two nodes `left` and `right`, we take the ancestors of `right`, then iterate over the ancestors of `left`, and stop as soon as we find an ancestor of `left` that's also an ancestor of `right`.

IIUC the computational complexity here is worse, since we now have a quadratic check in comparing two vectors... although we now store less data, shorter stacks (no recursion), etc., and I doubt this is a common enough operation to show up in benchmarking? This only runs when we have shadowed variables, and the shadowed variable is unused.
