### PR TITLE
Assume Python 3.8 instead of 3.10 for target version

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,13 @@
 # Breaking Changes
 
+## 0.0.283
+
+### The target Python version now defaults to 3.8 instead of 3.10 ([#6397](https://github.com/astral-sh/ruff/pull/6397))
+
+Previously, when a target Python version was not specified, Ruff would use a default of Python 3.10. However, it is safer to default to an _older_ Python version to avoid assuming the availability of new features. We now default to the oldest supported Python version which is currently Python 3.8.
+
+(We still support Python 3.7 but since [it has reached EOL](https://devguide.python.org/versions/#unsupported-versions) we've decided not to make it the default here.)
+
 ## 0.0.277
 
 ### `.ipynb_checkpoints`, `.pyenv`, `.pytest_cache`, and `.vscode` are now excluded by default ([#5513](https://github.com/astral-sh/ruff/pull/5513))

--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ line-length = 88
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.10.
-target-version = "py310"
+# Assume Python 3.8
+target-version = "py38"
 
 [tool.ruff.mccabe]
 # Unlike Flake8, default to a complexity level of 10.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,8 +53,8 @@ line-length = 88
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.10.
-target-version = "py310"
+# Assume Python 3.8
+target-version = "py38"
 ```
 
 As an example, the following would configure Ruff to: (1) enforce flake8-bugbear rules, in addition


### PR DESCRIPTION
The target version should be the oldest supported version instead of an arbitary version. Since 3.7 is EOL, we should use 3.8. I would like to follow this up with more comprehensive default detection based on the environment.
