### PR TITLE
Move `empty_parenthesized` into the `parentheses.rs`

### DIFF
--- a/crates/ruff_python_formatter/src/builders.rs
+++ b/crates/ruff_python_formatter/src/builders.rs
@@ -3,7 +3,6 @@ use ruff_python_ast::Ranged;
 use ruff_python_trivia::{SimpleToken, SimpleTokenKind, SimpleTokenizer};
 use ruff_text_size::{TextRange, TextSize};
 
-use crate::comments::{dangling_comments, trailing_comments, SourceComment};
 use crate::context::{NodeLevel, WithNodeLevel};
 use crate::prelude::*;
 use crate::MagicTrailingComma;
@@ -207,66 +206,5 @@ impl<'fmt, 'ast, 'buf> JoinCommaSeparatedBuilder<'fmt, 'ast, 'buf> {
 
             Ok(())
         })
-    }
-}
-
-/// Format comments inside empty parentheses, brackets or curly braces.
-///
-/// Empty `()`, `[]` and `{}` are special because there can be dangling comments, and they can be in
-/// two positions:
-/// ```python
-/// x = [  # end-of-line
-///     # own line
-/// ]
-/// ```
-/// These comments are dangling because they can't be assigned to any element inside as they would
-/// in all other cases.
-pub(crate) fn empty_parenthesized_with_dangling_comments(
-    opening: StaticText,
-    comments: &[SourceComment],
-    closing: StaticText,
-) -> EmptyWithDanglingComments {
-    EmptyWithDanglingComments {
-        opening,
-        comments,
-        closing,
-    }
-}
-
-pub(crate) struct EmptyWithDanglingComments<'a> {
-    opening: StaticText,
-    comments: &'a [SourceComment],
-    closing: StaticText,
-}
-
-impl<'ast> Format<PyFormatContext<'ast>> for EmptyWithDanglingComments<'_> {
-    fn fmt(&self, f: &mut Formatter<PyFormatContext>) -> FormatResult<()> {
-        let end_of_line_split = self
-            .comments
-            .partition_point(|comment| comment.line_position().is_end_of_line());
-        debug_assert!(self.comments[end_of_line_split..]
-            .iter()
-            .all(|comment| comment.line_position().is_own_line()));
-        write!(
-            f,
-            [group(&format_args![
-                self.opening,
-                // end-of-line comments
-                trailing_comments(&self.comments[..end_of_line_split]),
-                // Avoid unstable formatting with
-                // ```python
-                // x = () - (#
-                // )
-                // ```
-                // Without this the comment would go after the empty tuple first, but still expand
-                // the bin op. In the second formatting pass they are trailing bin op comments
-                // so the bin op collapse. Suboptimally we keep parentheses around the bin op in
-                // either case.
-                (!self.comments[..end_of_line_split].is_empty()).then_some(hard_line_break()),
-                // own line comments, which need to be indented
-                soft_block_indent(&dangling_comments(&self.comments[end_of_line_split..])),
-                self.closing
-            ])]
-        )
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_dict.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_dict.rs
@@ -4,9 +4,10 @@ use ruff_python_ast::Ranged;
 use ruff_python_ast::{Expr, ExprDict};
 use ruff_text_size::TextRange;
 
-use crate::builders::empty_parenthesized_with_dangling_comments;
 use crate::comments::leading_comments;
-use crate::expression::parentheses::{parenthesized, NeedsParentheses, OptionalParentheses};
+use crate::expression::parentheses::{
+    empty_parenthesized, parenthesized, NeedsParentheses, OptionalParentheses,
+};
 use crate::prelude::*;
 use crate::FormatNodeRule;
 
@@ -69,8 +70,7 @@ impl FormatNodeRule<ExprDict> for FormatExprDict {
         let dangling = comments.dangling_comments(item);
 
         if values.is_empty() {
-            return empty_parenthesized_with_dangling_comments(text("{"), dangling, text("}"))
-                .fmt(f);
+            return empty_parenthesized("{", dangling, "}").fmt(f);
         }
 
         let format_pairs = format_with(|f| {

--- a/crates/ruff_python_formatter/src/expression/expr_list.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_list.rs
@@ -1,9 +1,10 @@
-use ruff_formatter::prelude::{format_with, text};
+use ruff_formatter::prelude::format_with;
 use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::{ExprList, Ranged};
 
-use crate::builders::empty_parenthesized_with_dangling_comments;
-use crate::expression::parentheses::{parenthesized, NeedsParentheses, OptionalParentheses};
+use crate::expression::parentheses::{
+    empty_parenthesized, parenthesized, NeedsParentheses, OptionalParentheses,
+};
 use crate::prelude::*;
 use crate::FormatNodeRule;
 
@@ -22,8 +23,7 @@ impl FormatNodeRule<ExprList> for FormatExprList {
         let dangling = comments.dangling_comments(item);
 
         if elts.is_empty() {
-            return empty_parenthesized_with_dangling_comments(text("["), dangling, text("]"))
-                .fmt(f);
+            return empty_parenthesized("[", dangling, "]").fmt(f);
         }
 
         let items = format_with(|f| {

--- a/crates/ruff_python_formatter/src/expression/expr_tuple.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_tuple.rs
@@ -4,8 +4,10 @@ use ruff_python_ast::ExprTuple;
 use ruff_python_ast::{Expr, Ranged};
 use ruff_text_size::TextRange;
 
-use crate::builders::{empty_parenthesized_with_dangling_comments, parenthesize_if_expands};
-use crate::expression::parentheses::{parenthesized, NeedsParentheses, OptionalParentheses};
+use crate::builders::parenthesize_if_expands;
+use crate::expression::parentheses::{
+    empty_parenthesized, parenthesized, NeedsParentheses, OptionalParentheses,
+};
 use crate::prelude::*;
 
 #[derive(Eq, PartialEq, Debug, Default)]
@@ -117,8 +119,7 @@ impl FormatNodeRule<ExprTuple> for FormatExprTuple {
         // In all other cases comments get assigned to a list element
         match elts.as_slice() {
             [] => {
-                return empty_parenthesized_with_dangling_comments(text("("), dangling, text(")"))
-                    .fmt(f);
+                return empty_parenthesized("(", dangling, ")").fmt(f);
             }
             [single] => match self.parentheses {
                 TupleParentheses::Preserve

--- a/crates/ruff_python_formatter/src/other/arguments.rs
+++ b/crates/ruff_python_formatter/src/other/arguments.rs
@@ -4,9 +4,8 @@ use ruff_python_ast::{Arguments, Expr, Ranged};
 use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
 use ruff_text_size::{TextRange, TextSize};
 
-use crate::builders::empty_parenthesized_with_dangling_comments;
 use crate::expression::expr_generator_exp::GeneratorExpParentheses;
-use crate::expression::parentheses::{parenthesized, Parentheses};
+use crate::expression::parentheses::{empty_parenthesized, parenthesized, Parentheses};
 use crate::prelude::*;
 use crate::FormatNodeRule;
 
@@ -24,14 +23,8 @@ impl FormatNodeRule<Arguments> for FormatArguments {
         // ```
         if item.args.is_empty() && item.keywords.is_empty() {
             let comments = f.context().comments().clone();
-            return write!(
-                f,
-                [empty_parenthesized_with_dangling_comments(
-                    text("("),
-                    comments.dangling_comments(item),
-                    text(")"),
-                )]
-            );
+            let dangling = comments.dangling_comments(item);
+            return write!(f, [empty_parenthesized("(", dangling, ")")]);
         }
 
         let all_arguments = format_with(|f: &mut PyFormatter| {

--- a/crates/ruff_python_formatter/src/other/parameters.rs
+++ b/crates/ruff_python_formatter/src/other/parameters.rs
@@ -6,12 +6,11 @@ use ruff_python_ast::{Parameters, Ranged};
 use ruff_python_trivia::{SimpleToken, SimpleTokenKind, SimpleTokenizer};
 use ruff_text_size::{TextRange, TextSize};
 
-use crate::builders::empty_parenthesized_with_dangling_comments;
 use crate::comments::{
     leading_comments, leading_node_comments, trailing_comments, CommentLinePosition, SourceComment,
 };
 use crate::context::{NodeLevel, WithNodeLevel};
-use crate::expression::parentheses::parenthesized;
+use crate::expression::parentheses::{empty_parenthesized, parenthesized};
 use crate::prelude::*;
 use crate::FormatNodeRule;
 
@@ -245,14 +244,7 @@ impl FormatNodeRule<Parameters> for FormatParameters {
             write!(f, [group(&format_inner)])
         } else if num_parameters == 0 {
             // No parameters, format any dangling comments between `()`
-            write!(
-                f,
-                [empty_parenthesized_with_dangling_comments(
-                    text("("),
-                    dangling,
-                    text(")"),
-                )]
-            )
+            write!(f, [empty_parenthesized("(", dangling, ")")])
         } else {
             write!(
                 f,


### PR DESCRIPTION
## Summary

This PR moves `empty_parenthesized` such that it's peer to `parenthesized`, and changes the API to better match that of `parenthesized` (takes `&str` rather than `StaticText`, has a `with_dangling_comments` method, etc.).

It may be intentionally _not_ part of `parentheses.rs`, but to me they're so similar that it makes more sense for them to be in the same module, with the same API, etc.
