### PR TITLE
Respect file-level `# ruff: noqa` suppressions for `unused-noqa` rule

### DIFF
--- a/crates/ruff/resources/test/fixtures/ruff/RUF100_4.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF100_4.py
@@ -1,0 +1,5 @@
+# ruff: noqa: RUF100
+
+import os  # noqa: F401
+
+print(os.sep)

--- a/crates/ruff/src/checkers/noqa.rs
+++ b/crates/ruff/src/checkers/noqa.rs
@@ -94,8 +94,15 @@ pub(crate) fn check_noqa(
         }
     }
 
-    // Enforce that the noqa directive was actually used (RUF100).
-    if analyze_directives && settings.rules.enabled(Rule::UnusedNOQA) {
+    // Enforce that the noqa directive was actually used (RUF100), unless RUF100 was itself
+    // suppressed.
+    if settings.rules.enabled(Rule::UnusedNOQA)
+        && analyze_directives
+        && !exemption.is_some_and(|exemption| match exemption {
+            FileExemption::All => true,
+            FileExemption::Codes(codes) => codes.contains(&Rule::UnusedNOQA.noqa_code()),
+        })
+    {
         for line in noqa_directives.lines() {
             match &line.directive {
                 Directive::All(directive) => {

--- a/crates/ruff/src/rules/ruff/mod.rs
+++ b/crates/ruff/src/rules/ruff/mod.rs
@@ -157,6 +157,16 @@ mod tests {
     }
 
     #[test]
+    fn ruf100_4() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("ruff/RUF100_4.py"),
+            &settings::Settings::for_rules(vec![Rule::UnusedNOQA, Rule::UnusedImport]),
+        )?;
+        assert_messages!(diagnostics);
+        Ok(())
+    }
+
+    #[test]
     fn flake8_noqa() -> Result<()> {
         let diagnostics = test_path(
             Path::new("ruff/flake8_noqa.py"),

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_4.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_4.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/ruff/mod.rs
+---
+


### PR DESCRIPTION
## Summary

We weren't respecting `# ruff: noqa: RUF100`, i.e., file-level suppressions for the `unused-noqa` rule itself.

Closes https://github.com/astral-sh/ruff/issues/6385.
