### PR TITLE
Change `model: &SemanticModel` to `semantic: &SemanticModel`

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -176,13 +176,12 @@ impl<'a> Checker<'a> {
     ///
     /// If the current expression in the context is not an f-string, returns ``None``.
     pub(crate) fn f_string_quote_style(&self) -> Option<Quote> {
-        let model = &self.semantic;
-        if !model.in_f_string() {
+        if !self.semantic.in_f_string() {
             return None;
         }
 
         // Find the quote character used to start the containing f-string.
-        let expr = model.current_expression()?;
+        let expr = self.semantic.current_expression()?;
         let string_range = self.indexer.f_string_range(expr.start())?;
         let trailing_quote = trailing_quote(self.locator.slice(string_range))?;
 

--- a/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
@@ -112,21 +112,21 @@ fn py_stat(call_path: &CallPath) -> Option<u16> {
     }
 }
 
-fn int_value(expr: &Expr, model: &SemanticModel) -> Option<u16> {
+fn int_value(expr: &Expr, semantic: &SemanticModel) -> Option<u16> {
     match expr {
         Expr::Constant(ast::ExprConstant {
             value: Constant::Int(value),
             ..
         }) => value.to_u16(),
-        Expr::Attribute(_) => model.resolve_call_path(expr).as_ref().and_then(py_stat),
+        Expr::Attribute(_) => semantic.resolve_call_path(expr).as_ref().and_then(py_stat),
         Expr::BinOp(ast::ExprBinOp {
             left,
             op,
             right,
             range: _,
         }) => {
-            let left_value = int_value(left, model)?;
-            let right_value = int_value(right, model)?;
+            let left_value = int_value(left, semantic)?;
+            let right_value = int_value(right, semantic)?;
             match op {
                 Operator::BitAnd => Some(left_value & right_value),
                 Operator::BitOr => Some(left_value | right_value),

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
@@ -53,7 +53,7 @@ fn matches_sql_statement(string: &str) -> bool {
     SQL_REGEX.is_match(string)
 }
 
-fn matches_string_format_expression(expr: &Expr, model: &SemanticModel) -> bool {
+fn matches_string_format_expression(expr: &Expr, semantic: &SemanticModel) -> bool {
     match expr {
         // "select * from table where val = " + "str" + ...
         // "select * from table where val = %s" % ...
@@ -62,7 +62,7 @@ fn matches_string_format_expression(expr: &Expr, model: &SemanticModel) -> bool 
             ..
         }) => {
             // Only evaluate the full BinOp, not the nested components.
-            if model
+            if semantic
                 .current_expression_parent()
                 .map_or(true, |parent| !parent.is_bin_op_expr())
             {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
@@ -67,9 +67,9 @@ struct ArgumentDefaultVisitor<'a> {
 }
 
 impl<'a> ArgumentDefaultVisitor<'a> {
-    fn new(model: &'a SemanticModel<'a>, extend_immutable_calls: Vec<CallPath<'a>>) -> Self {
+    fn new(semantic: &'a SemanticModel<'a>, extend_immutable_calls: Vec<CallPath<'a>>) -> Self {
         Self {
-            semantic: model,
+            semantic,
             extend_immutable_calls,
             diagnostics: Vec::new(),
         }

--- a/crates/ruff/src/rules/flake8_builtins/rules/builtin_attribute_shadowing.rs
+++ b/crates/ruff/src/rules/flake8_builtins/rules/builtin_attribute_shadowing.rs
@@ -131,7 +131,7 @@ pub(crate) fn builtin_method_shadowing(
 fn is_standard_library_override(
     name: &str,
     class_def: &ast::StmtClassDef,
-    model: &SemanticModel,
+    semantic: &SemanticModel,
 ) -> bool {
     let Some(Arguments { args: bases, .. }) = class_def.arguments.as_deref() else {
         return false;
@@ -139,13 +139,13 @@ fn is_standard_library_override(
     match name {
         // Ex) `Event#set`
         "set" => bases.iter().any(|base| {
-            model
+            semantic
                 .resolve_call_path(base)
                 .is_some_and(|call_path| matches!(call_path.as_slice(), ["threading", "Event"]))
         }),
         // Ex) `Filter#filter`
         "filter" => bases.iter().any(|base| {
-            model
+            semantic
                 .resolve_call_path(base)
                 .is_some_and(|call_path| matches!(call_path.as_slice(), ["logging", "Filter"]))
         }),

--- a/crates/ruff/src/rules/flake8_pyi/rules/redundant_literal_union.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/redundant_literal_union.rs
@@ -121,7 +121,7 @@ impl fmt::Display for ExprType {
 
 /// Return the [`ExprType`] of an [`Expr]` if it is a builtin type (e.g. `int`, `bool`, `float`,
 /// `str`, `bytes`, or `complex`).
-fn match_builtin_type(expr: &Expr, model: &SemanticModel) -> Option<ExprType> {
+fn match_builtin_type(expr: &Expr, semantic: &SemanticModel) -> Option<ExprType> {
     let name = expr.as_name_expr()?;
     let result = match name.id.as_str() {
         "int" => ExprType::Int,
@@ -132,7 +132,7 @@ fn match_builtin_type(expr: &Expr, model: &SemanticModel) -> Option<ExprType> {
         "complex" => ExprType::Complex,
         _ => return None,
     };
-    if !model.is_builtin(name.id.as_str()) {
+    if !semantic.is_builtin(name.id.as_str()) {
         return None;
     }
     Some(result)

--- a/crates/ruff/src/rules/flake8_slots/rules/no_slots_in_str_subclass.rs
+++ b/crates/ruff/src/rules/flake8_slots/rules/no_slots_in_str_subclass.rs
@@ -66,10 +66,10 @@ pub(crate) fn no_slots_in_str_subclass(checker: &mut Checker, stmt: &Stmt, class
 
 /// Return `true` if the class is a subclass of `str`, but _not_ a subclass of `enum.Enum`,
 /// `enum.IntEnum`, etc.
-fn is_str_subclass(bases: &[Expr], model: &SemanticModel) -> bool {
+fn is_str_subclass(bases: &[Expr], semantic: &SemanticModel) -> bool {
     let mut is_str_subclass = false;
     for base in bases {
-        if let Some(call_path) = model.resolve_call_path(base) {
+        if let Some(call_path) = semantic.resolve_call_path(base) {
             match call_path.as_slice() {
                 ["" | "builtins", "str"] => {
                     is_str_subclass = true;

--- a/crates/ruff/src/rules/perflint/rules/incorrect_dict_iterator.rs
+++ b/crates/ruff/src/rules/perflint/rules/incorrect_dict_iterator.rs
@@ -148,9 +148,11 @@ impl fmt::Display for DictSubset {
 }
 
 /// Returns `true` if the given expression is either an unused value or a tuple of unused values.
-fn is_unused(expr: &Expr, model: &SemanticModel) -> bool {
+fn is_unused(expr: &Expr, semantic: &SemanticModel) -> bool {
     match expr {
-        Expr::Tuple(ast::ExprTuple { elts, .. }) => elts.iter().all(|expr| is_unused(expr, model)),
+        Expr::Tuple(ast::ExprTuple { elts, .. }) => {
+            elts.iter().all(|expr| is_unused(expr, semantic))
+        }
         Expr::Name(ast::ExprName { id, .. }) => {
             // Treat a variable as used if it has any usages, _or_ it's shadowed by another variable
             // with usages.
@@ -167,10 +169,10 @@ fn is_unused(expr: &Expr, model: &SemanticModel) -> bool {
             //
             // print(bar)
             // ```
-            let scope = model.current_scope();
+            let scope = semantic.current_scope();
             scope
                 .get_all(id)
-                .map(|binding_id| model.binding(binding_id))
+                .map(|binding_id| semantic.binding(binding_id))
                 .filter(|binding| binding.range.start() >= expr.range().start())
                 .all(|binding| !binding.is_used())
         }

--- a/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -116,11 +116,11 @@ const OPEN_FUNC_NAME: &str = "open";
 const MODE_KEYWORD_ARGUMENT: &str = "mode";
 
 /// Returns `true` if the given `call` is a call to the `open` builtin.
-fn is_open_builtin(func: &Expr, model: &SemanticModel) -> bool {
+fn is_open_builtin(func: &Expr, semantic: &SemanticModel) -> bool {
     let Some(ast::ExprName { id, .. }) = func.as_name_expr() else {
         return false;
     };
-    id.as_str() == OPEN_FUNC_NAME && model.is_builtin(id)
+    id.as_str() == OPEN_FUNC_NAME && semantic.is_builtin(id)
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/crates/ruff/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
+++ b/crates/ruff/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
@@ -149,7 +149,7 @@ struct IterationTarget {
 ///
 /// As a special-case, given `[x for x in y]`, returns the range of `y` (rather than the
 /// redundant comprehension).
-fn match_iteration_target(expr: &Expr, model: &SemanticModel) -> Option<IterationTarget> {
+fn match_iteration_target(expr: &Expr, semantic: &SemanticModel) -> Option<IterationTarget> {
     let result = match expr {
         Expr::Call(ast::ExprCall {
             func,
@@ -166,7 +166,7 @@ fn match_iteration_target(expr: &Expr, model: &SemanticModel) -> Option<Iteratio
                 return None;
             };
 
-            if !model.is_builtin(id.as_str()) {
+            if !semantic.is_builtin(id.as_str()) {
                 return None;
             }
 

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -1113,7 +1113,7 @@ impl<'a> SemanticModel<'a> {
         exceptions
     }
 
-    /// Generate a [`Snapshot`] of the current model.
+    /// Generate a [`Snapshot`] of the current semantic model.
     pub fn snapshot(&self) -> Snapshot {
         Snapshot {
             scope_id: self.scope_id,
@@ -1124,7 +1124,7 @@ impl<'a> SemanticModel<'a> {
         }
     }
 
-    /// Restore the model to the given [`Snapshot`].
+    /// Restore the semantic model to the given [`Snapshot`].
     pub fn restore(&mut self, snapshot: Snapshot) {
         let Snapshot {
             scope_id,


### PR DESCRIPTION
Use the same naming conventions everywhere. See: https://github.com/astral-sh/ruff/pull/6314/files#r1284457874.
