### PR TITLE
Treat comments on open parentheses in return annotations as dangling

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/function.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/function.py
@@ -371,3 +371,41 @@ def f(  # first
     # third
 ):
     ...
+
+# Handle comments on empty tuple return types.
+def zrevrangebylex(self, name: _Key, max: _Value, min: _Value, start: int | None = None, num: int | None = None) -> (  # type: ignore[override]
+): ...
+
+def zrevrangebylex(self, name: _Key, max: _Value, min: _Value, start: int | None = None, num: int | None = None) -> (  # type: ignore[override]
+    # comment
+): ...
+
+def zrevrangebylex(self, name: _Key, max: _Value, min: _Value, start: int | None = None, num: int | None = None) -> (  # type: ignore[override]
+    1
+): ...
+
+def zrevrangebylex(self, name: _Key, max: _Value, min: _Value, start: int | None = None, num: int | None = None) -> (  # type: ignore[override]
+    1, 2
+): ...
+
+def zrevrangebylex(self, name: _Key, max: _Value, min: _Value, start: int | None = None, num: int | None = None) -> (  # type: ignore[override]
+    (1, 2)
+): ...
+
+def handleMatch(  # type: ignore[override] # https://github.com/python/mypy/issues/10197
+    self, m: Match[str], data: str
+) -> Union[Tuple[None, None, None], Tuple[Element, int, int]]:
+    ...
+
+def double(a: int # Hello
+) -> (int):
+    return 2 * a
+
+def double(a: int) -> ( # Hello
+    int
+):
+    return 2*a
+
+def double(a: int) -> ( # Hello
+):
+    return 2*a

--- a/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
@@ -61,17 +61,20 @@ impl FormatNodeRule<StmtFunctionDef> for FormatStmtFunctionDef {
         write!(f, [item.parameters.format()])?;
 
         if let Some(return_annotation) = item.returns.as_ref() {
-            write!(
-                f,
-                [
-                    space(),
-                    text("->"),
-                    space(),
-                    optional_parentheses(
-                        &return_annotation.format().with_options(Parentheses::Never)
-                    )
-                ]
-            )?;
+            write!(f, [space(), text("->"), space()])?;
+            if return_annotation.is_tuple_expr() {
+                write!(
+                    f,
+                    [return_annotation.format().with_options(Parentheses::Never)]
+                )?;
+            } else {
+                write!(
+                    f,
+                    [optional_parentheses(
+                        &return_annotation.format().with_options(Parentheses::Never),
+                    )]
+                )?;
+            }
         }
 
         write!(

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
@@ -377,6 +377,44 @@ def f(  # first
     # third
 ):
     ...
+
+# Handle comments on empty tuple return types.
+def zrevrangebylex(self, name: _Key, max: _Value, min: _Value, start: int | None = None, num: int | None = None) -> (  # type: ignore[override]
+): ...
+
+def zrevrangebylex(self, name: _Key, max: _Value, min: _Value, start: int | None = None, num: int | None = None) -> (  # type: ignore[override]
+    # comment
+): ...
+
+def zrevrangebylex(self, name: _Key, max: _Value, min: _Value, start: int | None = None, num: int | None = None) -> (  # type: ignore[override]
+    1
+): ...
+
+def zrevrangebylex(self, name: _Key, max: _Value, min: _Value, start: int | None = None, num: int | None = None) -> (  # type: ignore[override]
+    1, 2
+): ...
+
+def zrevrangebylex(self, name: _Key, max: _Value, min: _Value, start: int | None = None, num: int | None = None) -> (  # type: ignore[override]
+    (1, 2)
+): ...
+
+def handleMatch(  # type: ignore[override] # https://github.com/python/mypy/issues/10197
+    self, m: Match[str], data: str
+) -> Union[Tuple[None, None, None], Tuple[Element, int, int]]:
+    ...
+
+def double(a: int # Hello
+) -> (int):
+    return 2 * a
+
+def double(a: int) -> ( # Hello
+    int
+):
+    return 2*a
+
+def double(a: int) -> ( # Hello
+):
+    return 2*a
 ```
 
 ## Output
@@ -905,6 +943,89 @@ def f(  # first
     /,  # second
 ):
     ...
+
+
+# Handle comments on empty tuple return types.
+def zrevrangebylex(
+    self,
+    name: _Key,
+    max: _Value,
+    min: _Value,
+    start: int | None = None,
+    num: int | None = None,
+) -> (  # type: ignore[override]
+):
+    ...
+
+
+def zrevrangebylex(
+    self,
+    name: _Key,
+    max: _Value,
+    min: _Value,
+    start: int | None = None,
+    num: int | None = None,
+) -> (  # type: ignore[override]
+    # comment
+):
+    ...
+
+
+def zrevrangebylex(
+    self,
+    name: _Key,
+    max: _Value,
+    min: _Value,
+    start: int | None = None,
+    num: int | None = None,
+) -> 1:  # type: ignore[override]
+    ...
+
+
+def zrevrangebylex(
+    self,
+    name: _Key,
+    max: _Value,
+    min: _Value,
+    start: int | None = None,
+    num: int | None = None,
+) -> (  # type: ignore[override]
+    1,
+    2,
+):
+    ...
+
+
+def zrevrangebylex(
+    self,
+    name: _Key,
+    max: _Value,
+    min: _Value,
+    start: int | None = None,
+    num: int | None = None,
+) -> (1, 2):  # type: ignore[override]
+    ...
+
+
+def handleMatch(  # type: ignore[override] # https://github.com/python/mypy/issues/10197
+    self, m: Match[str], data: str
+) -> Union[Tuple[None, None, None], Tuple[Element, int, int]]:
+    ...
+
+
+def double(
+    a: int,  # Hello
+) -> int:
+    return 2 * a
+
+
+def double(a: int) -> int:  # Hello
+    return 2 * a
+
+
+def double(a: int) -> (  # Hello
+):
+    return 2 * a
 ```
 
 


### PR DESCRIPTION
## Summary

Given:

```python
def double(a: int) -> ( # Hello
    int
):
    return 2*a
```

We currently treat `# Hello` as a trailing comment on the parameters (`(a: int)`). This PR adds a placement method to instead treat it as a dangling comment on the function definition itself, so that it gets formatted at the end of the definition, like:

```python
def double(a: int) -> int:  # Hello
    return 2*a
```

The formatting in this case is unchanged, but it's incorrect IMO for that to be a trailing comment on the parameters, and that placement leads to an instability after changing the grouping in #6410.

Fixing this led to a _different_ instability related to tuple return type annotations, like:

```python
def zrevrangebylex(self, name: _Key, max: _Value, min: _Value, start: int | None = None, num: int | None = None) -> (  # type: ignore[override]
):
    ...
```

(This is a real example.)

To fix, I had to special-case tuples in that spot, though I'm not certain that's correct.
