### PR TITLE
Manually parenthesize tuple expr in `B014` autofix

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B014.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B014.py
@@ -74,3 +74,10 @@ try:
 except (ValueError, binascii.Error):
     # binascii.Error is a subclass of ValueError.
     pass
+
+
+# https://github.com/astral-sh/ruff/issues/6412
+try:
+    pass
+except (ValueError, ValueError, TypeError):
+    pass

--- a/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -150,7 +150,9 @@ fn duplicate_handler_exceptions<'a>(
                     if unique_elts.len() == 1 {
                         checker.generator().expr(unique_elts[0])
                     } else {
-                        checker.generator().expr(&type_pattern(unique_elts))
+                        // Multiple exceptions must always be parenthesized. This is done
+                        // manually as the generator never parenthesizes lone tuples.
+                        format!("({})", checker.generator().expr(&type_pattern(unique_elts)))
                     },
                     expr.range(),
                 )));

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B014_B014.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B014_B014.py.snap
@@ -64,4 +64,22 @@ B014.py:49:8: B014 [*] Exception handler with duplicate exception: `re.error`
 51 51 |     pass
 52 52 | 
 
+B014.py:82:8: B014 [*] Exception handler with duplicate exception: `ValueError`
+   |
+80 | try:
+81 |     pass
+82 | except (ValueError, ValueError, TypeError):
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B014
+83 |     pass
+   |
+   = help: De-duplicate exceptions
+
+ℹ Fix
+79 79 | # https://github.com/astral-sh/ruff/issues/6412
+80 80 | try:
+81 81 |     pass
+82    |-except (ValueError, ValueError, TypeError):
+   82 |+except (ValueError, TypeError):
+83 83 |     pass
+
 


### PR DESCRIPTION
## Summary

Manually add the parentheses around tuple expressions for the autofix in `B014`.
This is also done in various other autofixes as well such as for [`RUF005`](https://github.com/astral-sh/ruff/blob/6df5ab40987cba7bb5681c2445caaf83ebcfbf7d/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs#L183-L184), [`UP024`](https://github.com/astral-sh/ruff/blob/6df5ab40987cba7bb5681c2445caaf83ebcfbf7d/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs#L137-L137).

### Alternate Solution

An alternate solution would be to fix this in the `Generator` itself by checking
if the tuple expression needs to be generated at the top-level or not. If so,
then always add the parentheses.

```rust
                } else if level == 0 {
                    // Top-level tuples are always parenthesized.
                    self.p("(");
                    let mut first = true;
                    for elt in elts {
                        self.p_delim(&mut first, ", ");
                        self.unparse_expr(elt, precedence::COMMA);
                    }
                    self.p_if(elts.len() == 1, ",");
                    self.p(")");
```

## Test Plan

Add a regression test for this case in `B014`.

fixes: #6412
