### PR TITLE
Avoid `S108` if path is inside `tempfile.*` call

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_bandit/S108.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bandit/S108.py
@@ -14,3 +14,19 @@ with open("/dev/shm/unit/test", "w") as f:
 # not ok by config
 with open("/foo/bar", "w") as f:
     f.write("def")
+
+# Using `tempfile` module should be ok
+import tempfile
+from tempfile import TemporaryDirectory
+
+with tempfile.NamedTemporaryFile(dir="/tmp") as f:
+    f.write(b"def")
+
+with tempfile.NamedTemporaryFile(dir="/var/tmp") as f:
+    f.write(b"def")
+
+with tempfile.TemporaryDirectory(dir="/dev/shm") as d:
+    pass
+
+with TemporaryDirectory(dir="/tmp") as d:
+    pass

--- a/crates/ruff/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff/src/checkers/ast/analyze/expression.rs
@@ -1229,11 +1229,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 }
             }
             if checker.enabled(Rule::HardcodedTempFile) {
-                if let Some(diagnostic) =
-                    flake8_bandit::rules::hardcoded_tmp_directory(checker, expr, value)
-                {
-                    checker.diagnostics.push(diagnostic);
-                }
+                flake8_bandit::rules::hardcoded_tmp_directory(checker, expr, value);
             }
             if checker.enabled(Rule::UnicodeKindPrefix) {
                 pyupgrade::rules::unicode_kind_prefix(checker, expr, kind.as_deref());

--- a/crates/ruff/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff/src/checkers/ast/analyze/expression.rs
@@ -1229,11 +1229,9 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 }
             }
             if checker.enabled(Rule::HardcodedTempFile) {
-                if let Some(diagnostic) = flake8_bandit::rules::hardcoded_tmp_directory(
-                    expr,
-                    value,
-                    &checker.settings.flake8_bandit.hardcoded_tmp_directory,
-                ) {
+                if let Some(diagnostic) =
+                    flake8_bandit::rules::hardcoded_tmp_directory(checker, expr, value)
+                {
                     checker.diagnostics.push(diagnostic);
                 }
             }

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
@@ -3,6 +3,8 @@ use ruff_python_ast::{Expr, Ranged};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 
+use crate::checkers::ast::Checker;
+
 /// ## What it does
 /// Checks for the use of hardcoded temporary file or directory paths.
 ///
@@ -50,11 +52,33 @@ impl Violation for HardcodedTempFile {
 
 /// S108
 pub(crate) fn hardcoded_tmp_directory(
+    checker: &Checker,
     expr: &Expr,
     value: &str,
-    prefixes: &[String],
 ) -> Option<Diagnostic> {
-    if prefixes.iter().any(|prefix| value.starts_with(prefix)) {
+    if checker
+        .semantic()
+        .current_expression_parent()
+        .is_some_and(|expr| {
+            let Some(call) = expr.as_call_expr() else {
+                return false;
+            };
+            checker
+                .semantic()
+                .resolve_call_path(&call.func)
+                .is_some_and(|call_path| call_path.as_slice().starts_with(&["tempfile"]))
+        })
+    {
+        return None;
+    }
+
+    if checker
+        .settings
+        .flake8_bandit
+        .hardcoded_tmp_directory
+        .iter()
+        .any(|prefix| value.starts_with(prefix))
+    {
         Some(Diagnostic::new(
             HardcodedTempFile {
                 string: value.to_string(),


### PR DESCRIPTION
## Summary

Avoid `S108` if path is inside `tempfile.*` call

## Test Plan

Add test cases with `tempfile` calls.

fixes: #6355
