### PR TITLE
Fix name of rule in example of `extend-per-file-ignores` in options.rs

### DIFF
--- a/crates/ruff/src/settings/options.rs
+++ b/crates/ruff/src/settings/options.rs
@@ -596,7 +596,7 @@ pub struct Options {
         default = "{}",
         value_type = "dict[str, list[RuleSelector]]",
         example = r#"
-            # Also ignore `E401` in all `__init__.py` files.
+            # Also ignore `E402` in all `__init__.py` files.
             [tool.ruff.extend-per-file-ignores]
             "__init__.py" = ["E402"]
         "#


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?

-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fix name of rule in example of `extend-per-file-ignores` in `options.rs` file.

It was `E401` but in configuration example `E402` was listed. Just a tiny mismatch.

## Test Plan

<!-- How was it tested? -->

Just by my eyes :).