### PR TITLE
Simplify `parenthesized` formatting

### DIFF
--- a/crates/ruff_python_formatter/src/expression/parentheses.rs
+++ b/crates/ruff_python_formatter/src/expression/parentheses.rs
@@ -144,22 +144,13 @@ impl<'content, 'ast> FormatParenthesized<'content, 'ast> {
 impl<'ast> Format<PyFormatContext<'ast>> for FormatParenthesized<'_, 'ast> {
     fn fmt(&self, f: &mut Formatter<PyFormatContext<'ast>>) -> FormatResult<()> {
         let inner = format_with(|f| {
-            if self.comments.is_empty() {
-                group(&format_args![
-                    text(self.left),
-                    &soft_block_indent(&Arguments::from(&self.content)),
-                    text(self.right)
-                ])
-                .fmt(f)
-            } else {
-                group(&format_args![
-                    text(self.left),
-                    &dangling_open_parenthesis_comments(self.comments),
-                    &soft_block_indent(&Arguments::from(&self.content)),
-                    text(self.right)
-                ])
-                .fmt(f)
-            }
+            group(&format_args![
+                text(self.left),
+                &dangling_open_parenthesis_comments(self.comments),
+                &soft_block_indent(&Arguments::from(&self.content)),
+                text(self.right)
+            ])
+            .fmt(f)
         });
 
         let current_level = f.context().node_level();


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR removes the branching on whether `comments` is empty in `parenthesized` because `danling_open_parenthesis_comments` only emits content if `comments` isn't empty.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test`

<!-- How was it tested? -->
