### PR TITLE
Update `StmtMatch` formatting snapshots

### DIFF
--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -90,7 +90,11 @@ match (  # hello
         pass
 
 
-match [first, second, third]:  # comment  # another comment
+match [  # comment
+    first,
+    second,
+    third,
+]:  # another comment
     case NOT_YET_IMPLEMENTED_Pattern:
         pass
 


### PR DESCRIPTION
This PR fixes the CI failure on `main` by updating the snapshots for `StmtMatch`
formatting.
