### PR TITLE
Add trailing comma when single parameter doesn't fit

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/function.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/function.py
@@ -435,3 +435,9 @@ def f[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa](aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 def f[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa](aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) -> a:
     ...
+
+def f(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+    ...
+
+def f(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, a) -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+    ...

--- a/crates/ruff_python_formatter/src/other/parameters.rs
+++ b/crates/ruff_python_formatter/src/other/parameters.rs
@@ -247,6 +247,14 @@ impl FormatNodeRule<Parameters> for FormatParameters {
             // No parameters, format any dangling comments between `()`
             write!(f, [empty_parenthesized("(", dangling, ")")])
         } else {
+            let maybe_grouped = format_with(|f| {
+                if num_parameters == 1 {
+                    format_inner.fmt(f)
+                } else {
+                    group(&format_inner).fmt(f)
+                }
+            });
+
             // Intentionally avoid `parenthesized`, which groups the entire formatted contents.
             // We want parameters to be grouped alongside return types, one level up, so we
             // format them "inline" here.
@@ -254,8 +262,8 @@ impl FormatNodeRule<Parameters> for FormatParameters {
                 f,
                 [
                     text("("),
-                    &dangling_open_parenthesis_comments(parenthesis_dangling),
-                    &soft_block_indent(&format_args!(&group(&format_inner),)),
+                    dangling_open_parenthesis_comments(parenthesis_dangling),
+                    soft_block_indent(&maybe_grouped),
                     text(")")
                 ]
             )

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__return_annotation_brackets.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__return_annotation_brackets.py.snap
@@ -106,7 +106,7 @@ def foo() -> tuple[int, int, int,]:
  
 -def double(a: int) -> int:  # Hello
 +def double(
-+    a: int
++    a: int,
 +) -> (
 +    int  # Hello
 +):
@@ -158,7 +158,7 @@ def double(a: int) -> int:  # Hello
 
 
 def double(
-    a: int
+    a: int,
 ) -> (
     int  # Hello
 ):

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
@@ -441,6 +441,12 @@ def f[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa](aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 def f[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa](aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) -> a:
     ...
+
+def f(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+    ...
+
+def f(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, a) -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+    ...
 ```
 
 ## Output
@@ -951,7 +957,7 @@ def f(  # first
 
 
 def f(  # first
-    a
+    a,
 ):  # second
     ...
 
@@ -1050,7 +1056,7 @@ def double(a: int) -> int:  # Hello
 
 
 def double(
-    a: int
+    a: int,
 ) -> (  # Hello
 ):
     return 2 * a
@@ -1059,7 +1065,7 @@ def double(
 # Breaking over parameters and return types. (Black adds a trailing comma when the
 # function arguments break here with a single argument; we do not.)
 def f(
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
 ) -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
     ...
 
@@ -1071,13 +1077,13 @@ def f(
 
 
 def f(
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
 ) -> a:
     ...
 
 
 def f(
-    a
+    a,
 ) -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
     ...
 
@@ -1095,14 +1101,26 @@ def f[
 
 
 def f[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa](
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
 ) -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
     ...
 
 
 def f[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa](
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
 ) -> a:
+    ...
+
+
+def f(
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+) -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+    ...
+
+
+def f(
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, a
+) -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
     ...
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Ensures that the formatter inserts a trailing comma if a single-parameter signature doesn't fit on the line

```python
def f(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
    ...

# Before
def f(
    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
) -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
    ...

# After / Black
def f(
    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
) -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
    ...
```

## Open questions

It's unclear if this is the desired behavior. It makes adding new arguments easier, but seems somewhat inconsistent with multiple arguments when they fit on a line when breaking after the `(` because we don't add trailing comments in that case (only when it is necessary to put each argument on its own line)

```python
def f(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, a) -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
    ...

# Formatted (without a trailing comma)
def f(
	   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, a
) -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
    ...
```


<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test`

Interestingly, this seems to reduce the Black compatibility. 

* zulip: similarity index 0.99702 -> 0.99689
* django: similarity index 0.99784 -> 0.99784
* warehouse: similarity index 0.99585 -> 0.99584
* build: similarity index 0.75623 - >0.75623
* transformers: similarity index 0.99470 -> 0.99470
* cpython: similarity index 0.75988 -> 0.75988
* typeshed: similarity index 0.74853 -> 0.74852