### PR TITLE
Set default version to py38

### DIFF
--- a/crates/ruff/src/settings/options.rs
+++ b/crates/ruff/src/settings/options.rs
@@ -456,7 +456,7 @@ pub struct Options {
     /// contained an `__init__.py` file.
     pub namespace_packages: Option<Vec<String>>,
     #[option(
-        default = r#""py310""#,
+        default = r#""py38""#,
         value_type = r#""py37" | "py38" | "py39" | "py310" | "py311" | "py312""#,
         example = r#"
             # Always generate Python 3.7-compatible code.


### PR DESCRIPTION
## Summary

In https://github.com/astral-sh/ruff/pull/6397, the documentation was updated stating that the default target-version is now "py38", but the actual default value wasn't updated and remained py310. This commit updates the default value to match what the documentation says.

## Test Plan

I ran `cargo test`, which passed for me, and `cargo insta review`, which claimed no snapshots needed to be reviewed.
