### PR TITLE
Set a default on `PythonVersion`

### DIFF
--- a/crates/ruff/src/settings/defaults.rs
+++ b/crates/ruff/src/settings/defaults.rs
@@ -24,8 +24,6 @@ pub const PREFIXES: &[RuleSelector] = &[
     RuleSelector::Linter(Linter::Pyflakes),
 ];
 
-pub const TARGET_VERSION: PythonVersion = PythonVersion::Py38;
-
 pub const TASK_TAGS: &[&str] = &["TODO", "FIXME", "XXX"];
 
 pub static DUMMY_VARIABLE_RGX: Lazy<Regex> =
@@ -91,7 +89,7 @@ impl Default for Settings {
             respect_gitignore: true,
             src: vec![path_dedot::CWD.clone()],
             tab_size: TabSize::default(),
-            target_version: TARGET_VERSION,
+            target_version: PythonVersion::default(),
             task_tags: TASK_TAGS.iter().map(ToString::to_string).collect(),
             typing_modules: vec![],
             flake8_annotations: flake8_annotations::settings::Settings::default(),

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -183,7 +183,7 @@ impl Settings {
                 .src
                 .unwrap_or_else(|| vec![project_root.to_path_buf()]),
             project_root: project_root.to_path_buf(),
-            target_version: config.target_version.unwrap_or(defaults::TARGET_VERSION),
+            target_version: config.target_version.unwrap_or_default(),
             task_tags: config.task_tags.unwrap_or_else(|| {
                 defaults::TASK_TAGS
                     .iter()

--- a/crates/ruff/src/settings/types.rs
+++ b/crates/ruff/src/settings/types.rs
@@ -19,13 +19,25 @@ use crate::registry::RuleSet;
 use crate::rule_selector::RuleSelector;
 
 #[derive(
-    Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize, CacheKey, EnumIter,
+    Clone,
+    Copy,
+    Debug,
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq,
+    Default,
+    Serialize,
+    Deserialize,
+    CacheKey,
+    EnumIter,
 )]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum PythonVersion {
     Py37,
+    #[default]
     Py38,
     Py39,
     Py310,

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -20,6 +20,7 @@ use ruff::rules::{
 };
 use ruff::settings::configuration::Configuration;
 use ruff::settings::options::Options;
+use ruff::settings::types::PythonVersion;
 use ruff::settings::{defaults, flags, Settings};
 use ruff_python_ast::PySourceType;
 use ruff_python_codegen::Stylist;
@@ -134,7 +135,7 @@ impl Workspace {
             line_length: Some(LineLength::default()),
             select: Some(defaults::PREFIXES.to_vec()),
             tab_size: Some(TabSize::default()),
-            target_version: Some(defaults::TARGET_VERSION),
+            target_version: Some(PythonVersion::default()),
             // Ignore a bunch of options that don't make sense in a single-file editor.
             cache_dir: None,
             exclude: None,


### PR DESCRIPTION
## Summary

I think it makes sense for `PythonVersion::default()` to return our minimum-supported non-EOL version.

## Test Plan

`cargo test`
