### PR TITLE
Use SimpleTokenizer in `max_lines`

### DIFF
--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -1436,18 +1436,17 @@ fn is_first_statement_in_alternate_body(statement: AnyNodeRef, has_body: AnyNode
     }
 }
 
-/// Counts the number of newlines in `contents`.
+/// Counts the number of empty lines in `contents`.
 fn max_empty_lines(contents: &str) -> u32 {
     let mut newlines = 0u32;
     let mut max_new_lines = 0;
 
-    let mut tokenizer = SimpleTokenizer::new(contents, TextRange::up_to(contents.text_len()));
-
-    while let Some(token) = tokenizer.next() {
+    for token in SimpleTokenizer::new(contents, TextRange::up_to(contents.text_len())) {
         match token.kind() {
             SimpleTokenKind::Newline => {
                 newlines += 1;
             }
+
             SimpleTokenKind::Whitespace => {}
 
             SimpleTokenKind::Comment => {

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -226,7 +226,7 @@ impl SimpleTokenKind {
         }
     }
 
-    pub const fn is_trivia(self) -> bool {
+    const fn is_trivia(self) -> bool {
         matches!(
             self,
             SimpleTokenKind::Whitespace

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -226,7 +226,7 @@ impl SimpleTokenKind {
         }
     }
 
-    const fn is_trivia(self) -> bool {
+    pub const fn is_trivia(self) -> bool {
         matches!(
             self,
             SimpleTokenKind::Whitespace


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I noticed that this is the only usage of `UniversalNewlineIterator` in the formatter. We prefer to use the `SimpleTokenizer` because it tends to be faster (single pass vs finding the end of the line, and then processing it again). 

I don't expect this to improve performance because the ranges are probably so small that it doesn't matter

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test`

<!-- How was it tested? -->
