### PR TITLE
Bump version to 0.0.284

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,12 +1,14 @@
 # Breaking Changes
 
-## 0.0.283
+## 0.0.283 / 0.284
 
 ### The target Python version now defaults to 3.8 instead of 3.10 ([#6397](https://github.com/astral-sh/ruff/pull/6397))
 
 Previously, when a target Python version was not specified, Ruff would use a default of Python 3.10. However, it is safer to default to an _older_ Python version to avoid assuming the availability of new features. We now default to the oldest supported Python version which is currently Python 3.8.
 
 (We still support Python 3.7 but since [it has reached EOL](https://devguide.python.org/versions/#unsupported-versions) we've decided not to make it the default here.)
+
+Note this change was announced in 0.0.283 but not active until 0.0.284.
 
 ## 0.0.277
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flake8-to-ruff"
-version = "0.0.283"
+version = "0.0.284"
 dependencies = [
  "anyhow",
  "clap",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "ruff"
-version = "0.0.283"
+version = "0.0.284"
 dependencies = [
  "annotate-snippets 0.9.1",
  "anyhow",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_cli"
-version = "0.0.283"
+version = "0.0.284"
 dependencies = [
  "annotate-snippets 0.9.1",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Ruff can also be used as a [pre-commit](https://pre-commit.com) hook:
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.0.283
+  rev: v0.0.284
   hooks:
     - id: ruff
 ```

--- a/crates/flake8_to_ruff/Cargo.toml
+++ b/crates/flake8_to_ruff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flake8-to-ruff"
-version = "0.0.283"
+version = "0.0.284"
 description = """
 Convert Flake8 configuration files to Ruff configuration files.
 """

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff"
-version = "0.0.283"
+version = "0.0.284"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_cli"
-version = "0.0.283"
+version = "0.0.284"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -242,7 +242,7 @@ This tutorial has focused on Ruff's command-line interface, but Ruff can also be
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.0.283
+  rev: v0.0.284
   hooks:
     - id: ruff
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -22,7 +22,7 @@ Ruff can also be used as a [pre-commit](https://pre-commit.com) hook:
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.0.283
+  rev: v0.0.284
   hooks:
     - id: ruff
 ```
@@ -32,7 +32,7 @@ Or, to enable autofix:
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.0.283
+  rev: v0.0.284
   hooks:
     - id: ruff
       args: [ --fix, --exit-non-zero-on-fix ]
@@ -43,7 +43,7 @@ Or, to run the hook on Jupyter Notebooks too:
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.0.283
+  rev: v0.0.284
   hooks:
     - id: ruff
       types_or: [python, pyi, jupyter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 
 [project]
 name = "ruff"
-version = "0.0.283"
+version = "0.0.284"
 description = "An extremely fast Python linter, written in Rust."
 authors = [{ name = "Charlie Marsh", email = "charlie.r.marsh@gmail.com" }]
 maintainers = [{ name = "Charlie Marsh", email = "charlie.r.marsh@gmail.com" }]


### PR DESCRIPTION
## What's Changed

This release fixes a few bugs, notably the previous release announced a breaking change where the default target
Python version changed from 3.10 to 3.8 but it was not applied. Thanks to @rco-ableton for fixing this in 
https://github.com/astral-sh/ruff/pull/6444

### Bug Fixes
* Do not trigger `S108` if path is inside `tempfile.*` call by @dhruvmanila in https://github.com/astral-sh/ruff/pull/6416
* Do not allow on zero tab width by @tjkuson in https://github.com/astral-sh/ruff/pull/6429
* Fix false-positive in submodule resolution by @charliermarsh in https://github.com/astral-sh/ruff/pull/6435

## New Contributors
* @rco-ableton made their first contribution in https://github.com/astral-sh/ruff/pull/6444

**Full Changelog**: https://github.com/astral-sh/ruff/compare/v0.0.283...v0.0.284