### PR TITLE
Improve Ruff Formatter Interoperability

### DIFF
--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -92,7 +92,13 @@ impl FromStr for IndentStyle {
             "tab" | "Tabs" => Ok(Self::Tab),
             "space" | "Spaces" => Ok(Self::Space(IndentStyle::DEFAULT_SPACES)),
             // TODO: replace this error with a diagnostic
-            _ => Err("Value not supported for IndentStyle"),
+            v => {
+                let v = v.strip_prefix("Spaces, size: ").unwrap_or(v);
+
+                u8::from_str(v)
+                    .map(Self::Space)
+                    .map_err(|_| "Value not supported for IndentStyle")
+            }
         }
     }
 }

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -2,6 +2,7 @@ use ruff_formatter::printer::{LineEnding, PrinterOptions};
 use ruff_formatter::{FormatOptions, IndentStyle, LineWidth};
 use ruff_python_ast::PySourceType;
 use std::path::Path;
+use std::str::FromStr;
 
 #[derive(Clone, Debug)]
 #[cfg_attr(
@@ -16,6 +17,7 @@ pub struct PyFormatOptions {
     /// Specifies the indent style:
     /// * Either a tab
     /// * or a specific amount of spaces
+    #[cfg_attr(feature = "serde", serde(default = "default_indent_style"))]
     indent_style: IndentStyle,
 
     /// The preferred line width at which the formatter should wrap lines.
@@ -33,12 +35,16 @@ fn default_line_width() -> LineWidth {
     LineWidth::try_from(88).unwrap()
 }
 
+fn default_indent_style() -> IndentStyle {
+    IndentStyle::Space(4)
+}
+
 impl Default for PyFormatOptions {
     fn default() -> Self {
         Self {
             source_type: PySourceType::default(),
-            indent_style: IndentStyle::Space(4),
-            line_width: LineWidth::try_from(88).unwrap(),
+            indent_style: default_indent_style(),
+            line_width: default_line_width(),
             quote_style: QuoteStyle::default(),
             magic_trailing_comma: MagicTrailingComma::default(),
         }
@@ -66,7 +72,8 @@ impl PyFormatOptions {
         self.quote_style
     }
 
-    pub fn with_quote_style(&mut self, style: QuoteStyle) -> &mut Self {
+    #[must_use]
+    pub fn with_quote_style(mut self, style: QuoteStyle) -> Self {
         self.quote_style = style;
         self
     }
@@ -150,6 +157,19 @@ impl TryFrom<char> for QuoteStyle {
     }
 }
 
+impl FromStr for QuoteStyle {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "\"" | "double" | "Double" => Ok(Self::Double),
+            "'" | "single" | "Single" => Ok(Self::Single),
+            // TODO: replace this error with a diagnostic
+            _ => Err("Value not supported for QuoteStyle"),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, Default)]
 #[cfg_attr(
     feature = "serde",
@@ -165,5 +185,18 @@ pub enum MagicTrailingComma {
 impl MagicTrailingComma {
     pub const fn is_respect(self) -> bool {
         matches!(self, Self::Respect)
+    }
+}
+
+impl FromStr for MagicTrailingComma {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "respect" | "Respect" => Ok(Self::Respect),
+            "ignore" | "Ignore" => Ok(Self::Ignore),
+            // TODO: replace this error with a diagnostic
+            _ => Err("Value not supported for MagicTrailingComma"),
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Thank you for developing such an amazing project.

I am currently trying to port the ruff python formatter to wasm. See https://github.com/wasm-fmt/ruff_fmt
I ran into some issues that prevented me from moving forward.

Here are some changes to make it more interoperable for downstream developers:

1. ~Change the visibility of some structs. This is a straightforward task, adding some missing `pub` keywords.~
2. ~Export some default config functions.~
3. Implement `FromStr` for some structs, so that users can easily parse configuration from strings.
4. Fix `with_quote_style`
5. Fix `indent_style` serde default value


## Test Plan

Most of the changes don't involve logic changes, except for a couple of `FromStrs`, and I'll add test cases if necessary.