### PR TITLE
Use crates.io unicode_names2 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,6 +3003,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+dependencies = [
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,10 +3244,25 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unicode_names2"
-version = "0.6.0"
-source = "git+https://github.com/youknowone/unicode_names2.git?rev=4ce16aa85cbcdd9cc830410f1a72ef9a235f2fde#4ce16aa85cbcdd9cc830410f1a72ef9a235f2fde"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b2c0942619ae1797f999a0ce7efc6c09592ad30e68e16cdbfdcd48a98c3579"
 dependencies = [
  "phf",
+ "unicode_names2_generator",
+]
+
+[[package]]
+name = "unicode_names2_generator"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d0d66ab60be9799a70f8eb227ea43da7dcc47561dd9102cbadacfe0930113f7"
+dependencies = [
+ "getopts",
+ "log",
+ "phf_codegen",
+ "rand",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ insta = { version = "1.33.0", feature = ["filters", "glob"] }
 is-macro = { version = "0.3.0" }
 itertools = { version = "0.11.0" }
 log = { version = "0.4.17" }
-memchr = "2.6.4"
+memchr = { version = "2.6.4" }
 once_cell = { version = "1.17.1" }
 path-absolutize = { version = "3.1.1" }
 proc-macro2 = { version = "1.0.67" }
@@ -45,11 +45,12 @@ syn = { version = "2.0.37" }
 test-case = { version = "3.2.1" }
 thiserror = { version = "1.0.49" }
 toml = { version = "0.7.8" }
-tracing = "0.1.37"
-tracing-indicatif = "0.3.4"
+tracing = { version = "0.1.37" }
+tracing-indicatif = { version = "0.3.4" }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-unicode-ident = "1.0.12"
-unicode-width = "0.1.11"
+unicode-ident = { version = "1.0.12" }
+unicode_names2 = { version = "1.1.0" }
+unicode-width = { version = "0.1.11" }
 uuid = { version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics", "js"] }
 wsl = { version = "0.1.0" }
 

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -70,7 +70,7 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 typed-arena = { version = "2.0.2" }
 unicode-width = { workspace = true }
-unicode_names2 = { version = "0.6.0", git = "https://github.com/youknowone/unicode_names2.git", rev = "4ce16aa85cbcdd9cc830410f1a72ef9a235f2fde" }
+unicode_names2 = { workspace = true }
 wsl = { version = "0.1.0" }
 
 [dev-dependencies]

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -23,7 +23,7 @@ is-macro = { workspace = true }
 itertools = { workspace = true }
 lalrpop-util = { version = "0.20.0", default-features = false }
 unicode-ident = { workspace = true }
-unicode_names2 = { version = "0.6.0", git = "https://github.com/youknowone/unicode_names2.git", rev = "4ce16aa85cbcdd9cc830410f1a72ef9a235f2fde" }
+unicode_names2 = { workspace = true }
 rustc-hash = { workspace = true }
 static_assertions = "1.1.0"
 

--- a/crates/ruff_python_parser/src/parser.rs
+++ b/crates/ruff_python_parser/src/parser.rs
@@ -1313,4 +1313,11 @@ u"foo" f"bar {baz} really" u"bar" "no"
         .unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
+
+    #[test]
+    fn test_unicode_aliases() {
+        // https://github.com/RustPython/RustPython/issues/4566
+        let parse_ast = parse_suite(r#"x = "\N{BACKSPACE}another cool trick""#, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
 }

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__unicode_aliases.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__unicode_aliases.snap
@@ -1,0 +1,32 @@
+---
+source: crates/ruff_python_parser/src/parser.rs
+expression: parse_ast
+---
+[
+    Assign(
+        StmtAssign {
+            range: 0..37,
+            targets: [
+                Name(
+                    ExprName {
+                        range: 0..1,
+                        id: "x",
+                        ctx: Store,
+                    },
+                ),
+            ],
+            value: Constant(
+                ExprConstant {
+                    range: 4..37,
+                    value: Str(
+                        StringConstant {
+                            value: "\u{8}another cool trick",
+                            unicode: false,
+                            implicit_concatenated: false,
+                        },
+                    ),
+                },
+            ),
+        },
+    ),
+]


### PR DESCRIPTION
Update `unicode_names2` to the crates.io release 0.6.0, removing a git dependency.

@youknowone As far as i can tell, all changes from https://github.com/youknowone/unicode_names2 have been merged into https://github.com/progval/unicode_names2, is it correct that all changes needed for the RustPython parser are in the 0.6.0 release on crates.io?