### PR TITLE
move comments from expressions in f-strings out

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -24,3 +24,12 @@ result_f = (
     r'  \[Previous line repeated (\d+) more times\]' '\n'
     'RecursionError: maximum recursion depth exceeded\n'
 )
+
+
+# Regression for fstring dropping comments that were accidentally attached to
+# an expression inside a formatted value
+(
+    f'{1}'
+    # comment
+    ''
+)

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -80,6 +80,7 @@ pub(super) fn place_comment<'a>(
                 CommentPlacement::Default(comment)
             }
         }
+        AnyNodeRef::ExprFString(fstring) => CommentPlacement::dangling(fstring, comment),
         AnyNodeRef::ExprList(_)
         | AnyNodeRef::ExprSet(_)
         | AnyNodeRef::ExprGeneratorExp(_)

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -30,6 +30,15 @@ result_f = (
     r'  \[Previous line repeated (\d+) more times\]' '\n'
     'RecursionError: maximum recursion depth exceeded\n'
 )
+
+
+# Regression for fstring dropping comments that were accidentally attached to
+# an expression inside a formatted value
+(
+    f'{1}'
+    # comment
+    ''
+)
 ```
 
 ## Output
@@ -57,6 +66,15 @@ result_f = (
     r"  \[Previous line repeated (\d+) more times\]"
     "\n"
     "RecursionError: maximum recursion depth exceeded\n"
+)
+
+
+# Regression for fstring dropping comments that were accidentally attached to
+# an expression inside a formatted value
+(
+    f"{1}"
+    # comment
+    ""
 )
 ```
 


### PR DESCRIPTION
move comments from expressions inside f-strings out to the containing f-string.

`py<3.12` doesn't support comments inside formatted values. once we support 3.12+ f-strings we may need to revisit this. i suspect we'll end up with chunks of different behaviour for pre vs post 3.12 f-strings and this will be part of that.

fixes #6476 