### PR TITLE
Avoid breaking call chains unnecessarily

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/parentheses/call_chains.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/parentheses/call_chains.py
@@ -154,4 +154,6 @@ zero(
     five,
 )
 
-
+max_message_id = (
+    Message.objects.filter(recipient=recipient).order_by("id").reverse()[0].id
+)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/parentheses/call_chains.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/parentheses/call_chains.py
@@ -157,3 +157,7 @@ zero(
 max_message_id = (
     Message.objects.filter(recipient=recipient).order_by("id").reverse()[0].id
 )
+
+max_message_id = (
+    Message.objects.filter(recipient=recipient).order_by("id").reverse()[0].id()
+)

--- a/crates/ruff_python_formatter/src/expression/expr_attribute.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_attribute.rs
@@ -35,105 +35,116 @@ impl FormatNodeRule<ExprAttribute> for FormatExprAttribute {
 
         let call_chain_layout = self.call_chain_layout.apply_in_node(item, f);
 
-        let needs_parentheses = matches!(
-            value.as_ref(),
-            Expr::Constant(ExprConstant {
-                value: Constant::Int(_) | Constant::Float(_),
-                ..
-            })
-        );
+        let format_inner = format_with(|f: &mut PyFormatter| {
+            let needs_parentheses = matches!(
+                value.as_ref(),
+                Expr::Constant(ExprConstant {
+                    value: Constant::Int(_) | Constant::Float(_),
+                    ..
+                })
+            );
 
-        let comments = f.context().comments().clone();
-        let dangling_comments = comments.dangling_comments(item);
-        let leading_attribute_comments_start =
-            dangling_comments.partition_point(|comment| comment.line_position().is_end_of_line());
-        let (trailing_dot_comments, leading_attribute_comments) =
-            dangling_comments.split_at(leading_attribute_comments_start);
+            let comments = f.context().comments().clone();
+            let dangling_comments = comments.dangling_comments(item);
+            let leading_attribute_comments_start = dangling_comments
+                .partition_point(|comment| comment.line_position().is_end_of_line());
+            let (trailing_dot_comments, leading_attribute_comments) =
+                dangling_comments.split_at(leading_attribute_comments_start);
 
-        if needs_parentheses {
-            value.format().with_options(Parentheses::Always).fmt(f)?;
-        } else if call_chain_layout == CallChainLayout::Fluent {
-            match value.as_ref() {
-                Expr::Attribute(expr) => {
-                    expr.format().with_options(call_chain_layout).fmt(f)?;
-                }
-                Expr::Call(expr) => {
-                    expr.format().with_options(call_chain_layout).fmt(f)?;
-                    if call_chain_layout == CallChainLayout::Fluent {
-                        // Format the dot on its own line
-                        soft_line_break().fmt(f)?;
+            if needs_parentheses {
+                value.format().with_options(Parentheses::Always).fmt(f)?;
+            } else if call_chain_layout == CallChainLayout::Fluent {
+                match value.as_ref() {
+                    Expr::Attribute(expr) => {
+                        expr.format().with_options(call_chain_layout).fmt(f)?;
+                    }
+                    Expr::Call(expr) => {
+                        expr.format().with_options(call_chain_layout).fmt(f)?;
+                        if call_chain_layout == CallChainLayout::Fluent {
+                            // Format the dot on its own line
+                            soft_line_break().fmt(f)?;
+                        }
+                    }
+                    Expr::Subscript(expr) => {
+                        expr.format().with_options(call_chain_layout).fmt(f)?;
+                        if call_chain_layout == CallChainLayout::Fluent {
+                            // Format the dot on its own line
+                            soft_line_break().fmt(f)?;
+                        }
+                    }
+                    _ => {
+                        // This matches [`CallChainLayout::from_expression`]
+                        if is_expression_parenthesized(value.as_ref().into(), f.context().source())
+                        {
+                            value.format().with_options(Parentheses::Always).fmt(f)?;
+                            // Format the dot on its own line
+                            soft_line_break().fmt(f)?;
+                        } else {
+                            value.format().fmt(f)?;
+                        }
                     }
                 }
-                Expr::Subscript(expr) => {
-                    expr.format().with_options(call_chain_layout).fmt(f)?;
-                    if call_chain_layout == CallChainLayout::Fluent {
-                        // Format the dot on its own line
-                        soft_line_break().fmt(f)?;
-                    }
-                }
-                _ => {
-                    // This matches [`CallChainLayout::from_expression`]
-                    if is_expression_parenthesized(value.as_ref().into(), f.context().source()) {
-                        value.format().with_options(Parentheses::Always).fmt(f)?;
-                        // Format the dot on its own line
-                        soft_line_break().fmt(f)?;
-                    } else {
-                        value.format().fmt(f)?;
-                    }
-                }
+            } else {
+                value.format().fmt(f)?;
             }
-        } else {
-            value.format().fmt(f)?;
-        }
 
-        if comments.has_trailing_own_line_comments(value.as_ref()) {
-            hard_line_break().fmt(f)?;
-        }
+            if comments.has_trailing_own_line_comments(value.as_ref()) {
+                hard_line_break().fmt(f)?;
+            }
 
-        if call_chain_layout == CallChainLayout::Fluent {
-            // Fluent style has line breaks before the dot
-            // ```python
-            // blogs3 = (
-            //     Blog.objects.filter(
-            //         entry__headline__contains="Lennon",
-            //     )
-            //     .filter(
-            //         entry__pub_date__year=2008,
-            //     )
-            //     .filter(
-            //         entry__pub_date__year=2008,
-            //     )
-            // )
-            // ```
-            write!(
-                f,
-                [
-                    (!leading_attribute_comments.is_empty()).then_some(hard_line_break()),
-                    leading_comments(leading_attribute_comments),
-                    text("."),
-                    trailing_comments(trailing_dot_comments),
-                    attr.format()
-                ]
-            )
+            if call_chain_layout == CallChainLayout::Fluent {
+                // Fluent style has line breaks before the dot
+                // ```python
+                // blogs3 = (
+                //     Blog.objects.filter(
+                //         entry__headline__contains="Lennon",
+                //     )
+                //     .filter(
+                //         entry__pub_date__year=2008,
+                //     )
+                //     .filter(
+                //         entry__pub_date__year=2008,
+                //     )
+                // )
+                // ```
+                write!(
+                    f,
+                    [
+                        (!leading_attribute_comments.is_empty()).then_some(hard_line_break()),
+                        leading_comments(leading_attribute_comments),
+                        text("."),
+                        trailing_comments(trailing_dot_comments),
+                        attr.format()
+                    ]
+                )
+            } else {
+                // Regular style
+                // ```python
+                // blogs2 = Blog.objects.filter(
+                //     entry__headline__contains="Lennon",
+                // ).filter(
+                //     entry__pub_date__year=2008,
+                // )
+                // ```
+                write!(
+                    f,
+                    [
+                        text("."),
+                        trailing_comments(trailing_dot_comments),
+                        (!leading_attribute_comments.is_empty()).then_some(hard_line_break()),
+                        leading_comments(leading_attribute_comments),
+                        attr.format()
+                    ]
+                )
+            }
+        });
+
+        let is_call_chain_root = self.call_chain_layout == CallChainLayout::Default
+            && call_chain_layout == CallChainLayout::Fluent;
+        if is_call_chain_root {
+            write!(f, [group(&format_inner)])
         } else {
-            // Regular style
-            // ```python
-            // blogs2 = Blog.objects.filter(
-            //     entry__headline__contains="Lennon",
-            // ).filter(
-            //     entry__pub_date__year=2008,
-            // )
-            // ```
-            write!(
-                f,
-                [
-                    text("."),
-                    trailing_comments(trailing_dot_comments),
-                    (!leading_attribute_comments.is_empty()).then_some(hard_line_break()),
-                    leading_comments(leading_attribute_comments),
-                    attr.format()
-                ]
-            )
+            write!(f, [format_inner])
         }
     }
 

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -115,7 +115,7 @@ impl FormatRule<Expr, PyFormatContext<'_>> for FormatExpr {
         };
 
         if parenthesize {
-            parenthesized("(", &format_expr, ")").fmt(f)
+            parenthesized("(", &group(&format_expr), ")").fmt(f)
         } else {
             let level = match f.context().node_level() {
                 NodeLevel::TopLevel | NodeLevel::CompoundStatement => NodeLevel::Expression(None),
@@ -189,11 +189,15 @@ impl Format<PyFormatContext<'_>> for MaybeParenthesizeExpression<'_> {
         match needs_parentheses {
             OptionalParentheses::Multiline if *parenthesize != Parenthesize::IfRequired => {
                 if can_omit_optional_parentheses(expression, f.context()) {
-                    optional_parentheses(&expression.format().with_options(Parentheses::Never))
-                        .fmt(f)
+                    optional_parentheses(&group(
+                        &expression.format().with_options(Parentheses::Never),
+                    ))
+                    .fmt(f)
                 } else {
-                    parenthesize_if_expands(&expression.format().with_options(Parentheses::Never))
-                        .fmt(f)
+                    parenthesize_if_expands(&group(
+                        &expression.format().with_options(Parentheses::Never),
+                    ))
+                    .fmt(f)
                 }
             }
             OptionalParentheses::Always => {

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -115,7 +115,7 @@ impl FormatRule<Expr, PyFormatContext<'_>> for FormatExpr {
         };
 
         if parenthesize {
-            parenthesized("(", &group(&format_expr), ")").fmt(f)
+            parenthesized("(", &format_expr, ")").fmt(f)
         } else {
             let level = match f.context().node_level() {
                 NodeLevel::TopLevel | NodeLevel::CompoundStatement => NodeLevel::Expression(None),
@@ -189,15 +189,11 @@ impl Format<PyFormatContext<'_>> for MaybeParenthesizeExpression<'_> {
         match needs_parentheses {
             OptionalParentheses::Multiline if *parenthesize != Parenthesize::IfRequired => {
                 if can_omit_optional_parentheses(expression, f.context()) {
-                    optional_parentheses(&group(
-                        &expression.format().with_options(Parentheses::Never),
-                    ))
-                    .fmt(f)
+                    optional_parentheses(&expression.format().with_options(Parentheses::Never))
+                        .fmt(f)
                 } else {
-                    parenthesize_if_expands(&group(
-                        &expression.format().with_options(Parentheses::Never),
-                    ))
-                    .fmt(f)
+                    parenthesize_if_expands(&expression.format().with_options(Parentheses::Never))
+                        .fmt(f)
                 }
             }
             OptionalParentheses::Always => {

--- a/crates/ruff_python_formatter/tests/snapshots/format@parentheses__call_chains.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@parentheses__call_chains.py.snap
@@ -163,6 +163,10 @@ zero(
 max_message_id = (
     Message.objects.filter(recipient=recipient).order_by("id").reverse()[0].id
 )
+
+max_message_id = (
+    Message.objects.filter(recipient=recipient).order_by("id").reverse()[0].id()
+)
 ```
 
 ## Output
@@ -339,6 +343,10 @@ zero(
 
 max_message_id = (
     Message.objects.filter(recipient=recipient).order_by("id").reverse()[0].id
+)
+
+max_message_id = (
+    Message.objects.filter(recipient=recipient).order_by("id").reverse()[0].id()
 )
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@parentheses__call_chains.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@parentheses__call_chains.py.snap
@@ -160,7 +160,9 @@ zero(
     five,
 )
 
-
+max_message_id = (
+    Message.objects.filter(recipient=recipient).order_by("id").reverse()[0].id
+)
 ```
 
 ## Output
@@ -333,6 +335,10 @@ zero(
     three,
 ).four(
     five,
+)
+
+max_message_id = (
+    Message.objects.filter(recipient=recipient).order_by("id").reverse()[0].id
 )
 ```
 


### PR DESCRIPTION
## Summary

This PR attempts to fix the formatting of the following expression:

```python
max_message_id = (
    Message.objects.filter(recipient=recipient).order_by("id").reverse()[0].id
)
```

Specifically, Black preserves _that_ formatting, while we do:

```python
max_message_id = (
    Message.objects.filter(recipient=recipient)
    .order_by("id")
    .reverse()[0]
    .id
)
```

The fix here is to add a group around the entire call chain.

## Test Plan

Before:

- `zulip`: 0.99702
- `django`: 0.99784
- `warehouse`: 0.99585
- `build`: 0.75623
- `transformers`: 0.99470
- `cpython`: 0.75989
- `typeshed`: 0.74853

After:

- `zulip`: 0.99703
- `django`: 0.99791
- `warehouse`: 0.99586
- `build`: 0.75623
- `transformers`: 0.99470
- `cpython`: 0.75989
- `typeshed`: 0.74853
