### PR TITLE
Respect dummy-variable-rgx for unused bound exceptions

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyflakes/F841_0.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F841_0.py
@@ -145,3 +145,9 @@ def f() -> None:
     obj = Foo()
     obj.do_thing()
 
+
+def f():
+    try:
+        pass
+    except Exception as _:
+        pass

--- a/crates/ruff/src/checkers/ast/analyze/bindings.rs
+++ b/crates/ruff/src/checkers/ast/analyze/bindings.rs
@@ -18,7 +18,13 @@ pub(crate) fn bindings(checker: &mut Checker) {
 
     for binding in checker.semantic.bindings.iter() {
         if checker.enabled(Rule::UnusedVariable) {
-            if binding.kind.is_bound_exception() && !binding.is_used() {
+            if binding.kind.is_bound_exception()
+                && !binding.is_used()
+                && !checker
+                    .settings
+                    .dummy_variable_rgx
+                    .is_match(binding.name(checker.locator))
+            {
                 let mut diagnostic = Diagnostic::new(
                     pyflakes::rules::UnusedVariable {
                         name: binding.name(checker.locator).to_string(),

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -312,10 +312,13 @@ pub(crate) fn unused_variable(checker: &Checker, scope: &Scope, diagnostics: &mu
                 && !binding.is_global()
                 && !binding.is_used()
                 && !checker.settings.dummy_variable_rgx.is_match(name)
-                && name != "__tracebackhide__"
-                && name != "__traceback_info__"
-                && name != "__traceback_supplement__"
-                && name != "__debuggerskip__"
+                && !matches!(
+                    name,
+                    "__tracebackhide__"
+                        | "__traceback_info__"
+                        | "__traceback_supplement__"
+                        | "__debuggerskip__"
+                )
             {
                 return Some((name.to_string(), binding.range, binding.source));
             }

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__f841_dummy_variable_rgx.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__f841_dummy_variable_rgx.snap
@@ -256,4 +256,22 @@ F841_0.py:127:21: F841 Local variable `value` is assigned to but never used
     |
     = help: Remove assignment to unused variable `value`
 
+F841_0.py:152:25: F841 [*] Local variable `_` is assigned to but never used
+    |
+150 |     try:
+151 |         pass
+152 |     except Exception as _:
+    |                         ^ F841
+153 |         pass
+    |
+    = help: Remove assignment to unused variable `_`
+
+ℹ Fix
+149 149 | def f():
+150 150 |     try:
+151 151 |         pass
+152     |-    except Exception as _:
+    152 |+    except Exception:
+153 153 |         pass
+
 


### PR DESCRIPTION
## Summary

This PR respects our unused variable regex when flagging bound exceptions, so that you no longer get a violation for, e.g.:

```python
def f():
    try:
        pass
    except Exception as _:
        pass
```

This is an odd pattern, but I think it's surprising that the regex _isn't_ respected here.

Closes https://github.com/astral-sh/ruff/issues/6391

## Test Plan

`cargo test`
