### PR TITLE
Replace dynamic implicit concatenation detection with parser flag

### DIFF
--- a/crates/ruff/src/checkers/ast/analyze/definitions.rs
+++ b/crates/ruff/src/checkers/ast/analyze/definitions.rs
@@ -171,7 +171,7 @@ pub(crate) fn definitions(checker: &mut Checker) {
                 expr.start(),
             ));
 
-            if pydocstyle::helpers::should_ignore_docstring(contents) {
+            if pydocstyle::helpers::should_ignore_docstring(expr) {
                 #[allow(deprecated)]
                 let location = checker.locator.compute_source_location(expr.start());
                 warn_user!(

--- a/crates/ruff/src/rules/pydocstyle/helpers.rs
+++ b/crates/ruff/src/rules/pydocstyle/helpers.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use ruff_python_ast::call_path::from_qualified_name;
 use ruff_python_ast::helpers::map_callable;
-use ruff_python_ast::str::is_implicit_concatenation;
+use ruff_python_ast::Expr;
 use ruff_python_semantic::{Definition, SemanticModel};
 use ruff_source_file::UniversalNewlines;
 
@@ -63,9 +63,11 @@ pub(crate) fn should_ignore_definition(
 }
 
 /// Check if a docstring should be ignored.
-pub(crate) fn should_ignore_docstring(contents: &str) -> bool {
+pub(crate) fn should_ignore_docstring(docstring: &Expr) -> bool {
     // Avoid analyzing docstrings that contain implicit string concatenations.
     // Python does consider these docstrings, but they're almost certainly a
     // user error, and supporting them "properly" is extremely difficult.
-    is_implicit_concatenation(contents)
+    docstring
+        .as_constant_expr()
+        .is_some_and(|constant| constant.value.is_implicit_concatenated())
 }

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -2,11 +2,10 @@ use std::fmt;
 use std::str::FromStr;
 
 use num_bigint::BigInt;
-use ruff_python_ast::{self as ast, Constant, Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::str::is_implicit_concatenation;
+use ruff_python_ast::{self as ast, Constant, Expr, Keyword, Ranged};
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -182,6 +181,11 @@ pub(crate) fn native_literals(
                 return;
             };
 
+            // Skip implicit string concatenations.
+            if value.is_implicit_concatenated() {
+                return;
+            }
+
             let Ok(arg_literal_type) = LiteralType::try_from(value) else {
                 return;
             };
@@ -191,13 +195,6 @@ pub(crate) fn native_literals(
             }
 
             let arg_code = checker.locator().slice(arg.range());
-
-            // Skip implicit string concatenations.
-            if matches!(arg_literal_type, LiteralType::Str | LiteralType::Bytes)
-                && is_implicit_concatenation(arg_code)
-            {
-                return;
-            }
 
             let mut diagnostic = Diagnostic::new(NativeLiterals { literal_type }, expr.range());
             if checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff_python_formatter/src/expression/expr_constant.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_constant.rs
@@ -1,9 +1,7 @@
-use ruff_python_ast::{Constant, ExprConstant, Ranged};
-use ruff_text_size::{TextLen, TextRange};
-
 use ruff_formatter::FormatRuleWithOptions;
 use ruff_python_ast::node::AnyNodeRef;
-use ruff_python_ast::str::is_implicit_concatenation;
+use ruff_python_ast::{Constant, ExprConstant, Ranged};
+use ruff_text_size::{TextLen, TextRange};
 
 use crate::expression::number::{FormatComplex, FormatFloat, FormatInt};
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
@@ -80,10 +78,9 @@ impl NeedsParentheses for ExprConstant {
         _parent: AnyNodeRef,
         context: &PyFormatContext,
     ) -> OptionalParentheses {
-        if self.value.is_str() || self.value.is_bytes() {
-            let contents = context.locator().slice(self.range());
+        if self.value.is_implicit_concatenated() {
             // Don't wrap triple quoted strings
-            if is_multiline_string(self, context.source()) || !is_implicit_concatenation(contents) {
+            if is_multiline_string(self, context.source()) {
                 OptionalParentheses::Never
             } else {
                 OptionalParentheses::Multiline


### PR DESCRIPTION
## Summary

In https://github.com/astral-sh/ruff/pull/6512, we added a flag to the AST to mark implicitly-concatenated string expressions. This PR makes use of that flag to remove the `is_implicit_concatenation` method.

## Test Plan

`cargo test`
