### PR TITLE
Avoid marking inner-parenthesized comments as dangling bracket comments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/call.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/call.py
@@ -115,3 +115,9 @@ f (
 threshold_date = datetime.datetime.now() - datetime.timedelta(  # comment
     days=threshold_days_threshold_days
 )
+
+f(
+    (  # comment
+        1
+    )
+)

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__call.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__call.py.snap
@@ -121,6 +121,12 @@ f (
 threshold_date = datetime.datetime.now() - datetime.timedelta(  # comment
     days=threshold_days_threshold_days
 )
+
+f(
+    (  # comment
+        1
+    )
+)
 ```
 
 ## Output
@@ -240,6 +246,13 @@ f(
 
 threshold_date = datetime.datetime.now() - datetime.timedelta(  # comment
     days=threshold_days_threshold_days
+)
+
+f(
+    (
+        # comment
+        1
+    )
 )
 ```
 


### PR DESCRIPTION
## Summary

The bracketed-end-of-line comment rule is meant to assign comments like this as "immediately following the bracket":

```python
f(  # comment
    1
)
```

However, the logic was such that we treated this equivalently:

```python
f(
    (  # comment
        1
    )
)
```

This PR modifies the placement logic to ensure that we only skip the opening bracket, and not any nested brackets. The above is now formatted as:

```python
f(
    (
        # comment
        1
    )
)
```

(But will be corrected once we handle parenthesized comments properly.)

## Test Plan

`cargo test`

Confirmed no change in similarity score.
