### PR TITLE
Use a unified policy abstraction for the `flake8-tidy-imports` rules

### DIFF
--- a/crates/ruff/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff/src/checkers/ast/analyze/statement.rs
@@ -560,18 +560,26 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     }
                 }
                 if checker.enabled(Rule::BannedApi) {
-                    flake8_tidy_imports::rules::name_or_parent_is_banned(
+                    flake8_tidy_imports::rules::banned_api(
                         checker,
-                        &alias.name,
-                        alias,
+                        &flake8_tidy_imports::matchers::NameMatchPolicy::MatchNameOrParent(
+                            flake8_tidy_imports::matchers::MatchNameOrParent {
+                                module: &alias.name,
+                            },
+                        ),
+                        &alias,
                     );
                 }
 
                 if checker.enabled(Rule::BannedModuleLevelImports) {
-                    flake8_tidy_imports::rules::name_or_parent_is_banned_at_module_level(
+                    flake8_tidy_imports::rules::banned_module_level_imports(
                         checker,
-                        &alias.name,
-                        alias.range(),
+                        &flake8_tidy_imports::matchers::NameMatchPolicy::MatchNameOrParent(
+                            flake8_tidy_imports::matchers::MatchNameOrParent {
+                                module: &alias.name,
+                            },
+                        ),
+                        &alias,
                     );
                 }
 
@@ -729,16 +737,27 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 if let Some(module) =
                     helpers::resolve_imported_module_path(level, module, checker.module_path)
                 {
-                    flake8_tidy_imports::rules::name_or_parent_is_banned(checker, &module, stmt);
+                    flake8_tidy_imports::rules::banned_api(
+                        checker,
+                        &flake8_tidy_imports::matchers::NameMatchPolicy::MatchNameOrParent(
+                            flake8_tidy_imports::matchers::MatchNameOrParent { module: &module },
+                        ),
+                        &stmt,
+                    );
 
                     for alias in names {
                         if &alias.name == "*" {
                             continue;
                         }
-                        flake8_tidy_imports::rules::name_is_banned(
+                        flake8_tidy_imports::rules::banned_api(
                             checker,
-                            format!("{module}.{}", alias.name),
-                            alias,
+                            &flake8_tidy_imports::matchers::NameMatchPolicy::MatchName(
+                                flake8_tidy_imports::matchers::MatchName {
+                                    module: &module,
+                                    member: &alias.name,
+                                },
+                            ),
+                            &alias,
                         );
                     }
                 }
@@ -747,20 +766,27 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 if let Some(module) =
                     helpers::resolve_imported_module_path(level, module, checker.module_path)
                 {
-                    flake8_tidy_imports::rules::name_or_parent_is_banned_at_module_level(
+                    flake8_tidy_imports::rules::banned_module_level_imports(
                         checker,
-                        &module,
-                        stmt.range(),
+                        &flake8_tidy_imports::matchers::NameMatchPolicy::MatchNameOrParent(
+                            flake8_tidy_imports::matchers::MatchNameOrParent { module: &module },
+                        ),
+                        &stmt,
                     );
 
                     for alias in names {
                         if &alias.name == "*" {
                             continue;
                         }
-                        flake8_tidy_imports::rules::name_is_banned_at_module_level(
+                        flake8_tidy_imports::rules::banned_module_level_imports(
                             checker,
-                            &format!("{module}.{}", alias.name),
-                            alias.range(),
+                            &flake8_tidy_imports::matchers::NameMatchPolicy::MatchName(
+                                flake8_tidy_imports::matchers::MatchName {
+                                    module: &module,
+                                    member: &alias.name,
+                                },
+                            ),
+                            &alias,
                         );
                     }
                 }

--- a/crates/ruff/src/rules/flake8_tidy_imports/matchers.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/matchers.rs
@@ -1,0 +1,75 @@
+/// Match an imported member against the ban policy. For example, given `from foo import bar`,
+/// `foo` is the module and `bar` is the member. Performs an exact match.
+#[derive(Debug)]
+pub(crate) struct MatchName<'a> {
+    pub(crate) module: &'a str,
+    pub(crate) member: &'a str,
+}
+
+impl MatchName<'_> {
+    fn is_match(&self, banned_module: &str) -> bool {
+        // Ex) Match banned `foo.bar` to import `foo.bar`, without allocating, assuming that
+        // `module` is `foo`, `member` is `bar`, and `banned_module` is `foo.bar`.
+        banned_module
+            .strip_prefix(self.module)
+            .and_then(|banned_module| banned_module.strip_prefix('.'))
+            .and_then(|banned_module| banned_module.strip_prefix(self.member))
+            .is_some_and(str::is_empty)
+    }
+}
+
+/// Match an imported module against the ban policy. For example, given `import foo.bar`,
+/// `foo.bar` is the module. Matches against the module name or any of its parents.
+#[derive(Debug)]
+pub(crate) struct MatchNameOrParent<'a> {
+    pub(crate) module: &'a str,
+}
+
+impl MatchNameOrParent<'_> {
+    fn is_match(&self, banned_module: &str) -> bool {
+        // Ex) Match banned `foo` to import `foo`.
+        if self.module == banned_module {
+            return true;
+        }
+
+        // Ex) Match banned `foo` to import `foo.bar`.
+        if self
+            .module
+            .strip_prefix(banned_module)
+            .is_some_and(|suffix| suffix.starts_with('.'))
+        {
+            return true;
+        }
+
+        false
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum NameMatchPolicy<'a> {
+    /// Only match an exact module name (e.g., given `import foo.bar`, only match `foo.bar`).
+    MatchName(MatchName<'a>),
+    /// Match an exact module name or any of its parents (e.g., given `import foo.bar`, match
+    /// `foo.bar` or `foo`).
+    MatchNameOrParent(MatchNameOrParent<'a>),
+}
+
+impl NameMatchPolicy<'_> {
+    pub(crate) fn find<'a>(&self, banned_modules: impl Iterator<Item = &'a str>) -> Option<String> {
+        for banned_module in banned_modules {
+            match self {
+                NameMatchPolicy::MatchName(matcher) => {
+                    if matcher.is_match(banned_module) {
+                        return Some(banned_module.to_string());
+                    }
+                }
+                NameMatchPolicy::MatchNameOrParent(matcher) => {
+                    if matcher.is_match(banned_module) {
+                        return Some(banned_module.to_string());
+                    }
+                }
+            }
+        }
+        None
+    }
+}

--- a/crates/ruff/src/rules/flake8_tidy_imports/mod.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/mod.rs
@@ -1,4 +1,5 @@
 //! Rules from [flake8-tidy-imports](https://pypi.org/project/flake8-tidy-imports/).
+pub(crate) mod matchers;
 pub mod options;
 pub(crate) mod rules;
 pub mod settings;


### PR DESCRIPTION
## Summary

Generalizes the abstractions for name matching introduced in https://github.com/astral-sh/ruff/pull/6378 and applies them to the existing `banned_api` rule, such that both rules have a uniform API and implementation.

## Test Plan

`cargo test`
