### PR TITLE
Support `IfExp` with dual string arms in `invalid-envvar-value`

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/invalid_envvar_default.py
+++ b/crates/ruff/resources/test/fixtures/pylint/invalid_envvar_default.py
@@ -10,3 +10,4 @@ os.getenv("AA", "GOOD" + "BAD")
 os.getenv("AA", "GOOD" + 1)
 os.getenv("AA", "GOOD %s" % "BAD")
 os.getenv("B", Z)
+

--- a/crates/ruff/resources/test/fixtures/pylint/invalid_envvar_value.py
+++ b/crates/ruff/resources/test/fixtures/pylint/invalid_envvar_value.py
@@ -10,6 +10,8 @@ os.getenv(key="foo", default="bar")
 os.getenv(key=f"foo", default="bar")
 os.getenv(key="foo" + "bar", default=1)
 os.getenv(key=1 + "bar", default=1)  # [invalid-envvar-value]
+os.getenv("PATH_TEST" if using_clear_path else "PATH_ORIG")
+os.getenv(1 if using_clear_path else "PATH_ORIG")
 
 AA = "aa"
 os.getenv(AA)

--- a/crates/ruff/src/rules/pylint/rules/invalid_str_return.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_str_return.rs
@@ -41,7 +41,6 @@ pub(crate) fn invalid_str_return(checker: &mut Checker, name: &str, body: &[Stmt
 
     for stmt in returns {
         if let Some(value) = stmt.value.as_deref() {
-            // Disallow other, non-
             if !matches!(
                 PythonType::from(value),
                 PythonType::String | PythonType::Unknown

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE1507_invalid_envvar_value.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE1507_invalid_envvar_value.py.snap
@@ -31,14 +31,4 @@ invalid_envvar_value.py:8:11: PLE1507 Invalid type for initial `os.getenv` argum
 10 | os.getenv(key=f"foo", default="bar")
    |
 
-invalid_envvar_value.py:12:15: PLE1507 Invalid type for initial `os.getenv` argument; expected `str`
-   |
-10 | os.getenv(key=f"foo", default="bar")
-11 | os.getenv(key="foo" + "bar", default=1)
-12 | os.getenv(key=1 + "bar", default=1)  # [invalid-envvar-value]
-   |               ^^^^^^^^^ PLE1507
-13 | 
-14 | AA = "aa"
-   |
-
 

--- a/crates/ruff_python_semantic/src/analyze/type_inference.rs
+++ b/crates/ruff_python_semantic/src/analyze/type_inference.rs
@@ -1,7 +1,7 @@
 //! Analysis rules to perform basic type inference on individual expressions.
 
 use ruff_python_ast as ast;
-use ruff_python_ast::{Constant, Expr};
+use ruff_python_ast::{Constant, Expr, Operator};
 
 /// An extremely simple type inference system for individual expressions.
 ///
@@ -9,7 +9,7 @@ use ruff_python_ast::{Constant, Expr};
 /// such as strings, integers, floats, and containers. It cannot infer the
 /// types of variables or expressions that are not statically known from
 /// individual AST nodes alone.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, is_macro::Is)]
 pub enum PythonType {
     /// A string literal, such as `"hello"`.
     String,
@@ -55,27 +55,43 @@ impl From<&Expr> for PythonType {
             Expr::Tuple(_) => PythonType::Tuple,
             Expr::GeneratorExp(_) => PythonType::Generator,
             Expr::FString(_) => PythonType::String,
-            Expr::BinOp(ast::ExprBinOp { left, op, .. }) => {
-                // Ex) "a" % "b"
-                if op.is_mod() {
-                    if matches!(
-                        left.as_ref(),
-                        Expr::Constant(ast::ExprConstant {
-                            value: Constant::Str(..),
-                            ..
-                        })
-                    ) {
-                        return PythonType::String;
+            Expr::IfExp(ast::ExprIfExp { body, orelse, .. }) => {
+                let body = PythonType::from(body.as_ref());
+                let orelse = PythonType::from(orelse.as_ref());
+                // TODO(charlie): If we have two known types, we should return a union. As-is,
+                // callers that ignore the `Unknown` type will allow invalid expressions (e.g.,
+                // if you're testing for strings, you may accept `String` or `Unknown`, and you'd
+                // now accept, e.g., `1 if True else "a"`, which resolves to `Unknown`).
+                if body == orelse {
+                    body
+                } else {
+                    PythonType::Unknown
+                }
+            }
+            Expr::BinOp(ast::ExprBinOp {
+                left, op, right, ..
+            }) => {
+                match op {
+                    // Ex) "a" + "b"
+                    Operator::Add => {
+                        match (
+                            PythonType::from(left.as_ref()),
+                            PythonType::from(right.as_ref()),
+                        ) {
+                            (PythonType::String, PythonType::String) => return PythonType::String,
+                            (PythonType::Bytes, PythonType::Bytes) => return PythonType::Bytes,
+                            // TODO(charlie): If we have two known types, they may be incompatible.
+                            // Return an error (e.g., for `1 + "a"`).
+                            _ => {}
+                        }
                     }
-                    if matches!(
-                        left.as_ref(),
-                        Expr::Constant(ast::ExprConstant {
-                            value: Constant::Bytes(..),
-                            ..
-                        })
-                    ) {
-                        return PythonType::Bytes;
-                    }
+                    // Ex) "a" % "b"
+                    Operator::Mod => match PythonType::from(left.as_ref()) {
+                        PythonType::String => return PythonType::String,
+                        PythonType::Bytes => return PythonType::Bytes,
+                        _ => {}
+                    },
+                    _ => {}
                 }
                 PythonType::Unknown
             }


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/6537. We need to improve the `PythonType` algorithm, so this also documents some of its limitations as TODOs.
