### PR TITLE
Remove `SemanticModel#find_binding`

### DIFF
--- a/crates/ruff/src/rules/pandas_vet/helpers.rs
+++ b/crates/ruff/src/rules/pandas_vet/helpers.rs
@@ -1,4 +1,3 @@
-use ruff_python_ast as ast;
 use ruff_python_ast::Expr;
 use ruff_python_semantic::{BindingKind, Imported, SemanticModel};
 
@@ -26,23 +25,26 @@ pub(super) fn test_expression(expr: &Expr, semantic: &SemanticModel) -> Resoluti
         | Expr::ListComp(_)
         | Expr::DictComp(_)
         | Expr::GeneratorExp(_) => Resolution::IrrelevantExpression,
-        Expr::Name(ast::ExprName { id, .. }) => semantic.find_binding(id).map_or(
-            Resolution::IrrelevantBinding,
-            |binding| match &binding.kind {
-                BindingKind::Annotation
-                | BindingKind::Argument
-                | BindingKind::Assignment
-                | BindingKind::NamedExprAssignment
-                | BindingKind::UnpackedAssignment
-                | BindingKind::LoopVar
-                | BindingKind::Global
-                | BindingKind::Nonlocal(_) => Resolution::RelevantLocal,
-                BindingKind::Import(import) if matches!(import.call_path(), ["pandas"]) => {
-                    Resolution::PandasModule
-                }
-                _ => Resolution::IrrelevantBinding,
-            },
-        ),
+        Expr::Name(name) => {
+            semantic
+                .resolve_name(name)
+                .map_or(Resolution::IrrelevantBinding, |id| {
+                    match &semantic.binding(id).kind {
+                        BindingKind::Annotation
+                        | BindingKind::Argument
+                        | BindingKind::Assignment
+                        | BindingKind::NamedExprAssignment
+                        | BindingKind::UnpackedAssignment
+                        | BindingKind::LoopVar
+                        | BindingKind::Global
+                        | BindingKind::Nonlocal(_) => Resolution::RelevantLocal,
+                        BindingKind::Import(import) if matches!(import.call_path(), ["pandas"]) => {
+                            Resolution::PandasModule
+                        }
+                        _ => Resolution::IrrelevantBinding,
+                    }
+                })
+        }
         _ => Resolution::RelevantLocal,
     }
 }


### PR DESCRIPTION
## Summary

This method is almost never what you actually want, because it doesn't respect Python's scoping semantics. For example, if you call this within a class method, it will return class attributes, whereas Python actually _skips_ symbols in classes unless the load occurs within the class itself. I also want to move away from these kinds of dynamic lookups and more towards `resolve_name`, which performs a lookup based on the stored `BindingId` at the time of symbol resolution, and will make it much easier for us to separate model building from linting in the near future.

## Test Plan

`cargo test`
