### PR TITLE
Remove lex and parsing from formatter benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,6 +2141,7 @@ dependencies = [
  "ruff",
  "ruff_python_ast",
  "ruff_python_formatter",
+ "ruff_python_index",
  "ruff_python_parser",
  "serde",
  "serde_json",

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -37,6 +37,7 @@ ureq = "2.6.2"
 ruff.path = "../ruff"
 ruff_python_ast.path = "../ruff_python_ast"
 ruff_python_formatter = { path = "../ruff_python_formatter" }
+ruff_python_index = { path = "../ruff_python_index" }
 ruff_python_parser = { path = "../ruff_python_parser" }
 criterion = { version = "0.5.1"}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR changes the formatter benchmark to only benchmark the formatting time by excluding the lexing and parsing time. 

Excluding the lexing and parsing time (which make up more than 50% of the whole formatting time) allows us to more cleary identify performance changes in the formatter itself.
It further helps to gather profiles that don't include the whole parsing noise.

<!-- What's the purpose of the change? What does it do, and why? -->



<!-- How was it tested? -->
