### PR TITLE
Printer: Reserve buffer upfront

### DIFF
--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -319,20 +319,20 @@ where
     Context: FormatContext,
 {
     pub fn print(&self) -> PrintResult<Printed> {
-        let source_code = self.context.source_code();
-        let print_options = self.context.options().as_print_options();
-        let printed = Printer::new(source_code, print_options).print(&self.document)?;
-
-        Ok(printed)
+        let printer = self.create_printer();
+        printer.print(&self.document)
     }
 
     pub fn print_with_indent(&self, indent: u16) -> PrintResult<Printed> {
+        let printer = self.create_printer();
+        printer.print_with_indent(&self.document, indent)
+    }
+
+    fn create_printer(&self) -> Printer {
         let source_code = self.context.source_code();
         let print_options = self.context.options().as_print_options();
-        let printed =
-            Printer::new(source_code, print_options).print_with_indent(&self.document, indent)?;
 
-        Ok(printed)
+        Printer::new(source_code, print_options)
     }
 }
 

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -40,7 +40,7 @@ impl<'a> Printer<'a> {
         Self {
             source_code,
             options,
-            state: PrinterState::default(),
+            state: PrinterState::with_capacity(source_code.as_str().len()),
         }
     }
 
@@ -755,6 +755,15 @@ struct PrinterState<'a> {
     // vec every time a group gets measured
     fits_stack: Vec<StackFrame>,
     fits_queue: Vec<&'a [FormatElement]>,
+}
+
+impl<'a> PrinterState<'a> {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            buffer: String::with_capacity(capacity),
+            ..Self::default()
+        }
+    }
 }
 
 /// Tracks the mode in which groups with ids are printed. Stores the groups at `group.id()` index.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I did some profiling on the formatter and noticed that we end up growing the `Printer` buffer multiple times. This PR tries to reduce the number of times that we need to grow the formatted string buffer by allocating a buffer of the same size as the unformatted document. 
This should be a good default because most files in a project are already formatted (we neither allocate too much nor too little).  

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

This improved the formatter time by about 2%

`cargo test`

<!-- How was it tested? -->
