### PR TITLE
Override fmt_dangling_comments for frequent nodes

### DIFF
--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -780,7 +780,8 @@ where
     Context: FormatContext,
 {
     let mut state = FormatState::new(context);
-    let mut buffer = VecBuffer::with_capacity(arguments.items().len(), &mut state);
+    let mut buffer =
+        VecBuffer::with_capacity(state.context().source_code().as_str().len(), &mut state);
 
     buffer.write_fmt(arguments)?;
 

--- a/crates/ruff_python_formatter/src/expression/expr_compare.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_compare.rs
@@ -69,6 +69,11 @@ impl FormatNodeRule<ExprCompare> for FormatExprCompare {
 
         in_parentheses_only_group(&inner).fmt(f)
     }
+
+    fn fmt_dangling_comments(&self, _node: &ExprCompare, _f: &mut PyFormatter) -> FormatResult<()> {
+        // Node can not have dangling comments
+        Ok(())
+    }
 }
 
 impl NeedsParentheses for ExprCompare {

--- a/crates/ruff_python_formatter/src/expression/expr_name.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_name.rs
@@ -22,6 +22,11 @@ impl FormatNodeRule<ExprName> for FormatExprName {
 
         write!(f, [source_text_slice(*range, ContainsNewlines::No)])
     }
+
+    fn fmt_dangling_comments(&self, _node: &ExprName, _f: &mut PyFormatter) -> FormatResult<()> {
+        // Node cannot have dangling comments
+        Ok(())
+    }
 }
 
 impl NeedsParentheses for ExprName {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I noticed that `fmt_dangling_comments` for `ExprName` and `ExprCompare` shows up in flamegraphs. 

This PR overrides `fmt_dangling_comments` for these expressions as we know that they can't have dangling comments. This comes at the risk
that we may drop such comment if this ever happens to change, but we have the `assert_formatted_all_comments` in debug builds that helps us catch unformatted comments. 

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test`

<!-- How was it tested? -->
