### PR TITLE
Add deprecated unittest assertions to PT009

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_pytest_style/PT009.py
+++ b/crates/ruff/resources/test/fixtures/flake8_pytest_style/PT009.py
@@ -80,3 +80,15 @@ class Test(unittest.TestCase):
 
     def test_assert_not_regexp_matches(self):
         self.assertNotRegex("abc", r"abc")  # Error
+
+    def test_fail_if(self):
+        self.failIf("abc")  # Error
+
+    def test_fail_unless(self):
+        self.failUnless("abc")  # Error
+
+    def test_fail_unless_equal(self):
+        self.failUnlessEqual(1, 2)  # Error
+
+    def test_fail_if_equal(self):
+        self.failIfEqual(1, 2)  # Error

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT009.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT009.snap
@@ -548,6 +548,8 @@ PT009.py:82:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
 81 |     def test_assert_not_regexp_matches(self):
 82 |         self.assertNotRegex("abc", r"abc")  # Error
    |         ^^^^^^^^^^^^^^^^^^^ PT009
+83 | 
+84 |     def test_fail_if(self):
    |
    = help: Replace `assertNotRegex(...)` with `assert ...`
 
@@ -557,5 +559,83 @@ PT009.py:82:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
 81 81 |     def test_assert_not_regexp_matches(self):
 82    |-        self.assertNotRegex("abc", r"abc")  # Error
    82 |+        assert not re.search("abc", "abc")  # Error
+83 83 | 
+84 84 |     def test_fail_if(self):
+85 85 |         self.failIf("abc")  # Error
+
+PT009.py:85:9: PT009 [*] Use a regular `assert` instead of unittest-style `failIf`
+   |
+84 |     def test_fail_if(self):
+85 |         self.failIf("abc")  # Error
+   |         ^^^^^^^^^^^ PT009
+86 | 
+87 |     def test_fail_unless(self):
+   |
+   = help: Replace `failIf(...)` with `assert ...`
+
+ℹ Suggested fix
+82 82 |         self.assertNotRegex("abc", r"abc")  # Error
+83 83 | 
+84 84 |     def test_fail_if(self):
+85    |-        self.failIf("abc")  # Error
+   85 |+        assert not "abc"  # Error
+86 86 | 
+87 87 |     def test_fail_unless(self):
+88 88 |         self.failUnless("abc")  # Error
+
+PT009.py:88:9: PT009 [*] Use a regular `assert` instead of unittest-style `failUnless`
+   |
+87 |     def test_fail_unless(self):
+88 |         self.failUnless("abc")  # Error
+   |         ^^^^^^^^^^^^^^^ PT009
+89 | 
+90 |     def test_fail_unless_equal(self):
+   |
+   = help: Replace `failUnless(...)` with `assert ...`
+
+ℹ Suggested fix
+85 85 |         self.failIf("abc")  # Error
+86 86 | 
+87 87 |     def test_fail_unless(self):
+88    |-        self.failUnless("abc")  # Error
+   88 |+        assert "abc"  # Error
+89 89 | 
+90 90 |     def test_fail_unless_equal(self):
+91 91 |         self.failUnlessEqual(1, 2)  # Error
+
+PT009.py:91:9: PT009 [*] Use a regular `assert` instead of unittest-style `failUnlessEqual`
+   |
+90 |     def test_fail_unless_equal(self):
+91 |         self.failUnlessEqual(1, 2)  # Error
+   |         ^^^^^^^^^^^^^^^^^^^^ PT009
+92 | 
+93 |     def test_fail_if_equal(self):
+   |
+   = help: Replace `failUnlessEqual(...)` with `assert ...`
+
+ℹ Suggested fix
+88 88 |         self.failUnless("abc")  # Error
+89 89 | 
+90 90 |     def test_fail_unless_equal(self):
+91    |-        self.failUnlessEqual(1, 2)  # Error
+   91 |+        assert 1 == 2  # Error
+92 92 | 
+93 93 |     def test_fail_if_equal(self):
+94 94 |         self.failIfEqual(1, 2)  # Error
+
+PT009.py:94:9: PT009 [*] Use a regular `assert` instead of unittest-style `failIfEqual`
+   |
+93 |     def test_fail_if_equal(self):
+94 |         self.failIfEqual(1, 2)  # Error
+   |         ^^^^^^^^^^^^^^^^ PT009
+   |
+   = help: Replace `failIfEqual(...)` with `assert ...`
+
+ℹ Suggested fix
+91 91 |         self.failUnlessEqual(1, 2)  # Error
+92 92 | 
+93 93 |     def test_fail_if_equal(self):
+94    |-        self.failIfEqual(1, 2)  # Error
+   94 |+        assert 1 != 2  # Error
 
 

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -59,21 +59,21 @@ impl AlwaysAutofixableViolation for DeprecatedUnittestAlias {
 
 static DEPRECATED_ALIASES: Lazy<FxHashMap<&'static str, &'static str>> = Lazy::new(|| {
     FxHashMap::from_iter([
-        ("failUnlessEqual", "assertEqual"),
-        ("assertEquals", "assertEqual"),
-        ("failIfEqual", "assertNotEqual"),
-        ("assertNotEquals", "assertNotEqual"),
-        ("failUnless", "assertTrue"),
-        ("assert_", "assertTrue"),
-        ("failIf", "assertFalse"),
-        ("failUnlessRaises", "assertRaises"),
-        ("failUnlessAlmostEqual", "assertAlmostEqual"),
         ("assertAlmostEquals", "assertAlmostEqual"),
-        ("failIfAlmostEqual", "assertNotAlmostEqual"),
+        ("assertEquals", "assertEqual"),
         ("assertNotAlmostEquals", "assertNotAlmostEqual"),
-        ("assertRegexpMatches", "assertRegex"),
+        ("assertNotEquals", "assertNotEqual"),
         ("assertNotRegexpMatches", "assertNotRegex"),
         ("assertRaisesRegexp", "assertRaisesRegex"),
+        ("assertRegexpMatches", "assertRegex"),
+        ("assert_", "assertTrue"),
+        ("failIf", "assertFalse"),
+        ("failIfAlmostEqual", "assertNotAlmostEqual"),
+        ("failIfEqual", "assertNotEqual"),
+        ("failUnless", "assertTrue"),
+        ("failUnlessAlmostEqual", "assertAlmostEqual"),
+        ("failUnlessEqual", "assertEqual"),
+        ("failUnlessRaises", "assertRaises"),
     ])
 });
 


### PR DESCRIPTION
## Summary

This rule was missing `self.failIf` and friends.

## Test Plan

`cargo test`
