### PR TITLE
Add regular expression example for `per-file-ignores`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,7 @@ unfixable = ["B"]
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["E402"]
 "path/to/file.py" = ["E402"]
+"{tests,docs,tools}/*" = ["E402"]  # regular expression is supported
 ```
 
 Plugin configurations should be expressed as subsections, e.g.:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,7 +77,7 @@ unfixable = ["B"]
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["E402"]
 "path/to/file.py" = ["E402"]
-"{tests,docs,tools}/*" = ["E402"]  # regular expression is supported
+"**/{tests,docs,tools}/*" = ["E402"]
 ```
 
 Plugin configurations should be expressed as subsections, e.g.:


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Hi! This is my first PR to `ruff` and thanks for this amazing project. While I am working on my project, I need to set different rules for my `test/` folder and the main `src` package.

It's not immediately obvious that the [`tool.ruff.per-file-ignores`](https://beta.ruff.rs/docs/settings/#per-file-ignores) support regular expression. It is useful to set rules on directory level. The PR add a simple example to make it clear this support regex.


<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
