### PR TITLE
Replace `inline(always)` with `inline`

### DIFF
--- a/crates/ruff_formatter/src/arguments.rs
+++ b/crates/ruff_formatter/src/arguments.rs
@@ -33,8 +33,7 @@ impl<'fmt, Context> Argument<'fmt, Context> {
     #[doc(hidden)]
     #[inline]
     pub fn new<F: Format<Context>>(value: &'fmt F) -> Self {
-        #[allow(clippy::inline_always)]
-        #[inline(always)]
+        #[inline]
         fn formatter<F: Format<Context>, Context>(
             ptr: *const c_void,
             fmt: &mut Formatter<Context>,
@@ -52,8 +51,7 @@ impl<'fmt, Context> Argument<'fmt, Context> {
     }
 
     /// Formats the value stored by this argument using the given formatter.
-    #[allow(clippy::inline_always)]
-    #[inline(always)]
+    #[inline]
     pub(super) fn format(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         (self.formatter)(self.value, f)
     }
@@ -82,9 +80,8 @@ impl<'fmt, Context> Argument<'fmt, Context> {
 pub struct Arguments<'fmt, Context>(pub &'fmt [Argument<'fmt, Context>]);
 
 impl<'fmt, Context> Arguments<'fmt, Context> {
-    #[allow(clippy::inline_always)]
     #[doc(hidden)]
-    #[inline(always)]
+    #[inline]
     pub fn new(arguments: &'fmt [Argument<'fmt, Context>]) -> Self {
         Self(arguments)
     }
@@ -106,8 +103,7 @@ impl<Context> Clone for Arguments<'_, Context> {
 }
 
 impl<Context> Format<Context> for Arguments<'_, Context> {
-    #[allow(clippy::inline_always)]
-    #[inline(always)]
+    #[inline]
     fn fmt(&self, formatter: &mut Formatter<Context>) -> FormatResult<()> {
         formatter.write_fmt(*self)
     }

--- a/crates/ruff_python_ast/src/visitor/preorder.rs
+++ b/crates/ruff_python_ast/src/visitor/preorder.rs
@@ -7,8 +7,7 @@ use crate::{
 
 /// Visitor that traverses all nodes recursively in pre-order.
 pub trait PreorderVisitor<'a> {
-    #[allow(clippy::inline_always)]
-    #[inline(always)]
+    #[inline]
     fn enter_node(&mut self, _node: AnyNodeRef<'a>) -> TraversalSignal {
         TraversalSignal::Traverse
     }

--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -442,7 +442,7 @@ impl<'a> Comments<'a> {
 
     #[inline(always)]
     #[cfg(not(debug_assertions))]
-    pub(crate) fn mark_verbatim_node_comments_formatted(&self, node: AnyNodeRef) {}
+    pub(crate) fn mark_verbatim_node_comments_formatted(&self, _node: AnyNodeRef) {}
 
     /// Marks the comments of a node printed in verbatim (suppressed) as formatted.
     ///


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Follow up of [this comment](https://github.com/astral-sh/ruff/pull/6549#discussion_r1293401324). 

Replaces all `inline(always)` with `inline` except for the few places where it attributes an empty method/function. 

## Performance

No meaningful change.

```
Gnuplot not found, using plotters backend
formatter/numpy/globals.py
                        time:   [38.375 µs 38.471 µs 38.589 µs]
                        thrpt:  [76.463 MiB/s 76.698 MiB/s 76.891 MiB/s]
                 change:
                        time:   [-1.5720% -1.1271% -0.7137%] (p = 0.00 < 0.05)
                        thrpt:  [+0.7189% +1.1399% +1.5972%]
                        Change within noise threshold.
formatter/pydantic/types.py
                        time:   [805.00 µs 805.70 µs 806.44 µs]
                        thrpt:  [31.624 MiB/s 31.653 MiB/s 31.681 MiB/s]
                 change:
                        time:   [+0.5153% +0.9531% +1.3701%] (p = 0.00 < 0.05)
                        thrpt:  [-1.3515% -0.9441% -0.5126%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
formatter/numpy/ctypeslib.py
                        time:   [384.13 µs 385.59 µs 387.20 µs]
                        thrpt:  [43.004 MiB/s 43.184 MiB/s 43.347 MiB/s]
                 change:
                        time:   [-4.2419% -3.6520% -3.0507%] (p = 0.00 < 0.05)
                        thrpt:  [+3.1466% +3.7904% +4.4298%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) high mild
  3 (3.00%) high severe
formatter/large/dataset.py
                        time:   [2.0589 ms 2.0611 ms 2.0633 ms]
                        thrpt:  [19.717 MiB/s 19.739 MiB/s 19.760 MiB/s]
                 change:
                        time:   [+1.9929% +2.4425% +2.8925%] (p = 0.00 < 0.05)
                        thrpt:  [-2.8112% -2.3843% -1.9539%]
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

## Test Plan

`cargo test`

<!-- How was it tested? -->
