### PR TITLE
Fix comment formatting for yielded tuples

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/starred.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/starred.py
@@ -23,3 +23,11 @@ call(
         [What, i, this, s, very, long, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]
     ] # trailing value comment
 )
+
+call(
+    x,
+    * # Trailing star comment
+    (  # Leading value comment
+        y
+    )
+)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/yield.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/yield.py
@@ -57,3 +57,11 @@ def foo():
 
     yield from (yield l)
 
+    (
+        yield
+        #comment 1
+        * # comment 2
+        # comment 3
+        test, # comment 4
+        1
+    )

--- a/crates/ruff_python_formatter/src/expression/expr_starred.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_starred.rs
@@ -1,6 +1,6 @@
 use ruff_python_ast::ExprStarred;
 
-use crate::comments::SourceComment;
+use crate::comments::{dangling_comments, SourceComment};
 use ruff_formatter::write;
 use ruff_python_ast::node::AnyNodeRef;
 
@@ -20,7 +20,10 @@ impl FormatNodeRule<ExprStarred> for FormatExprStarred {
             ctx: _,
         } = item;
 
-        write!(f, [text("*"), value.format()])
+        let comments = f.context().comments().clone();
+        let dangling = comments.dangling_comments(item);
+
+        write!(f, [text("*"), dangling_comments(dangling), value.format()])
     }
 
     fn fmt_dangling_comments(

--- a/crates/ruff_python_formatter/src/expression/expr_tuple.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_tuple.rs
@@ -204,7 +204,7 @@ impl NeedsParentheses for ExprTuple {
 }
 
 /// Check if a tuple has already had parentheses in the input
-fn is_tuple_parenthesized(tuple: &ExprTuple, source: &str) -> bool {
+pub(crate) fn is_tuple_parenthesized(tuple: &ExprTuple, source: &str) -> bool {
     let Some(elt) = tuple.elts.first() else {
         return false;
     };

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__starred.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__starred.py.snap
@@ -29,6 +29,14 @@ call(
         [What, i, this, s, very, long, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]
     ] # trailing value comment
 )
+
+call(
+    x,
+    * # Trailing star comment
+    (  # Leading value comment
+        y
+    )
+)
 ```
 
 ## Output
@@ -52,8 +60,7 @@ call(
 
 call(
     # Leading starred comment
-    # Leading value comment
-    *(
+    *(  # Leading value comment
         [
             What,
             i,
@@ -82,6 +89,14 @@ call(
             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
         ]
     ],  # trailing value comment
+)
+
+call(
+    x,
+    # Trailing star comment
+    *(  # Leading value comment
+        y
+    ),
 )
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__yield.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__yield.py.snap
@@ -63,6 +63,14 @@ def foo():
 
     yield from (yield l)
 
+    (
+        yield
+        #comment 1
+        * # comment 2
+        # comment 3
+        test, # comment 4
+        1
+    )
 ```
 
 ## Output
@@ -115,6 +123,18 @@ def foo():
         pass
 
     yield from (yield l)
+
+    (
+        yield (
+            # comment 1
+            (
+                # comment 2
+                # comment 3
+                *test,  # comment 4
+                1,
+            )
+        )
+    )
 ```
 
 


### PR DESCRIPTION
## Summary
Closes https://github.com/astral-sh/ruff/issues/6384, although I think the issue was fixed already on main, for the most part.

The linked issue is around formatting expressions like:

```python
def test():
    (
        yield 
        #comment 1
        * # comment 2
        # comment 3
        test # comment 4
    )

```

On main, prior to this PR, we now format like:

```python
def test():
    (
        yield (
            # comment 1
            # comment 2
            # comment 3
            *test
        )  # comment 4
    )
```

Which strikes me as reasonable. (We can't test this, since it's a syntax error after for our parser, despite being a syntax error in both cases from CPython's perspective.)

Meanwhile, Black does:

```python
def test():
    (
        yield
        # comment 1
        *  # comment 2
        # comment 3
        test  # comment 4
    )
```

So our formatting differs in that we move comments between the star and the expression above the star.

As of this PR, we also support formatting this input, which is valid:

```python
def test():
    (
        yield 
        #comment 1
        * # comment 2
        # comment 3
        test, # comment 4
        1
    )
```

Like:

```python
def test():
    (
        yield (
            # comment 1
            (
                # comment 2
                # comment 3
                *test,  # comment 4
                1,
            )
        )
    )
```

There were two fixes here: (1) marking starred comments as dangling and formatting them properly; and (2) supporting parenthesized comments for tuples that don't contain their own parentheses, as is often the case for yielded tuples (previously, we hit a debug assert).

Note that this diff

## Test Plan
cargo test