### PR TITLE
Fast path for ASCII only identifiers start

### DIFF
--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -50,17 +50,24 @@ where
 
         let node_comments = comments.leading_dangling_trailing_comments(node.as_any_node_ref());
 
-        leading_comments(node_comments.leading).fmt(f)?;
-        self.fmt_node(node, f)?;
-        self.fmt_dangling_comments(node_comments.dangling, f)?;
-        trailing_comments(node_comments.trailing).fmt(f)
-    }
+        write!(
+            f,
+            [
+                leading_comments(node_comments.leading),
+                source_position(node.start())
+            ]
+        )?;
 
-    /// Formats the node without comments. Ignores any suppression comments.
-    fn fmt_node(&self, node: &N, f: &mut PyFormatter) -> FormatResult<()> {
-        write!(f, [source_position(node.start())])?;
         self.fmt_fields(node, f)?;
-        write!(f, [source_position(node.end())])
+        self.fmt_dangling_comments(node_comments.dangling, f)?;
+
+        write!(
+            f,
+            [
+                source_position(node.end()),
+                trailing_comments(node_comments.trailing)
+            ]
+        )
     }
 
     /// Formats the node's fields.

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -85,7 +85,11 @@ pub fn lines_after_ignoring_trivia(offset: TextSize, code: &str) -> u32 {
 }
 
 fn is_identifier_start(c: char) -> bool {
-    c.is_ascii_alphabetic() || c == '_' || is_non_ascii_identifier_start(c)
+    if c.is_ascii() {
+        c.is_ascii_alphabetic() || c == '_'
+    } else {
+        is_xid_start(c)
+    }
 }
 
 // Checks if the character c is a valid continuation character as described
@@ -96,10 +100,6 @@ fn is_identifier_continuation(c: char) -> bool {
     } else {
         is_xid_continue(c)
     }
-}
-
-fn is_non_ascii_identifier_start(c: char) -> bool {
-    is_xid_start(c)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR adds a fast path for ASCII only identifier starts. 

I noticed during profiling that the `binary_search` method is called a lot and wondered why. It turned out, it is used by the `xid_start` function and we call it when lexing identifiers.
However, the function shouldn't be called at all for my test file because it only contains ASCII characters. 

This PR "fixes" our `is_identifier_start` to **not** call into `xid_start` if the character is ascii only.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test`

<!-- How was it tested? -->

I verified that `binary_search` no longer appears in the profile. 
