### PR TITLE
Make `Buffer::write_element` non-failable

### DIFF
--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -203,7 +203,8 @@ impl Line {
 
 impl<Context> Format<Context> for Line {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Line(self.mode))
+        f.write_element(FormatElement::Line(self.mode));
+        Ok(())
     }
 }
 
@@ -266,7 +267,8 @@ pub struct StaticText {
 
 impl<Context> Format<Context> for StaticText {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::StaticText { text: self.text })
+        f.write_element(FormatElement::StaticText { text: self.text });
+        Ok(())
     }
 }
 
@@ -326,7 +328,8 @@ pub struct SourcePosition(TextSize);
 
 impl<Context> Format<Context> for SourcePosition {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::SourcePosition(self.0))
+        f.write_element(FormatElement::SourcePosition(self.0));
+        Ok(())
     }
 }
 
@@ -346,12 +349,14 @@ pub struct DynamicText<'a> {
 impl<Context> Format<Context> for DynamicText<'_> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         if let Some(source_position) = self.position {
-            f.write_element(FormatElement::SourcePosition(source_position))?;
+            f.write_element(FormatElement::SourcePosition(source_position));
         }
 
         f.write_element(FormatElement::DynamicText {
             text: self.text.to_string().into_boxed_str(),
-        })
+        });
+
+        Ok(())
     }
 }
 
@@ -419,7 +424,9 @@ where
         f.write_element(FormatElement::SourceCodeSlice {
             slice,
             contains_newlines,
-        })
+        });
+
+        Ok(())
     }
 }
 
@@ -466,9 +473,11 @@ pub struct LineSuffix<'a, Context> {
 
 impl<Context> Format<Context> for LineSuffix<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartLineSuffix))?;
+        f.write_element(FormatElement::Tag(StartLineSuffix));
         Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndLineSuffix))
+        f.write_element(FormatElement::Tag(EndLineSuffix));
+
+        Ok(())
     }
 }
 
@@ -513,7 +522,9 @@ pub struct LineSuffixBoundary;
 
 impl<Context> Format<Context> for LineSuffixBoundary {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::LineSuffixBoundary)
+        f.write_element(FormatElement::LineSuffixBoundary);
+
+        Ok(())
     }
 }
 
@@ -598,9 +609,11 @@ pub struct FormatLabelled<'a, Context> {
 
 impl<Context> Format<Context> for FormatLabelled<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartLabelled(self.label_id)))?;
+        f.write_element(FormatElement::Tag(StartLabelled(self.label_id)));
         Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndLabelled))
+        f.write_element(FormatElement::Tag(EndLabelled));
+
+        Ok(())
     }
 }
 
@@ -639,7 +652,9 @@ pub struct Space;
 
 impl<Context> Format<Context> for Space {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Space)
+        f.write_element(FormatElement::Space);
+
+        Ok(())
     }
 }
 
@@ -695,9 +710,11 @@ pub struct Indent<'a, Context> {
 
 impl<Context> Format<Context> for Indent<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartIndent))?;
+        f.write_element(FormatElement::Tag(StartIndent));
         Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndIndent))
+        f.write_element(FormatElement::Tag(EndIndent));
+
+        Ok(())
     }
 }
 
@@ -766,9 +783,11 @@ pub struct Dedent<'a, Context> {
 
 impl<Context> Format<Context> for Dedent<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartDedent(self.mode)))?;
+        f.write_element(FormatElement::Tag(StartDedent(self.mode)));
         Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndDedent))
+        f.write_element(FormatElement::Tag(EndDedent));
+
+        Ok(())
     }
 }
 
@@ -951,9 +970,11 @@ pub struct Align<'a, Context> {
 
 impl<Context> Format<Context> for Align<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartAlign(tag::Align(self.count))))?;
+        f.write_element(FormatElement::Tag(StartAlign(tag::Align(self.count))));
         Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndAlign))
+        f.write_element(FormatElement::Tag(EndAlign));
+
+        Ok(())
     }
 }
 
@@ -1171,7 +1192,7 @@ impl<Context> Format<Context> for BlockIndent<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         let snapshot = f.snapshot();
 
-        f.write_element(FormatElement::Tag(StartIndent))?;
+        f.write_element(FormatElement::Tag(StartIndent));
 
         match self.mode {
             IndentMode::Soft => write!(f, [soft_line_break()])?,
@@ -1192,7 +1213,7 @@ impl<Context> Format<Context> for BlockIndent<'_, Context> {
             return Ok(());
         }
 
-        f.write_element(FormatElement::Tag(EndIndent))?;
+        f.write_element(FormatElement::Tag(EndIndent));
 
         match self.mode {
             IndentMode::Soft => write!(f, [soft_line_break()]),
@@ -1404,11 +1425,13 @@ impl<Context> Format<Context> for Group<'_, Context> {
 
         f.write_element(FormatElement::Tag(StartGroup(
             tag::Group::new().with_id(self.group_id).with_mode(mode),
-        )))?;
+        )));
 
         Arguments::from(&self.content).fmt(f)?;
 
-        f.write_element(FormatElement::Tag(EndGroup))
+        f.write_element(FormatElement::Tag(EndGroup));
+
+        Ok(())
     }
 }
 
@@ -1536,9 +1559,11 @@ impl<Context> Format<Context> for ConditionalGroup<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         f.write_element(FormatElement::Tag(StartConditionalGroup(
             tag::ConditionalGroup::new(self.condition),
-        )))?;
+        )));
         f.write_fmt(Arguments::from(&self.content))?;
-        f.write_element(FormatElement::Tag(EndConditionalGroup))
+        f.write_element(FormatElement::Tag(EndConditionalGroup));
+
+        Ok(())
     }
 }
 
@@ -1596,7 +1621,9 @@ pub struct ExpandParent;
 
 impl<Context> Format<Context> for ExpandParent {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::ExpandParent)
+        f.write_element(FormatElement::ExpandParent);
+
+        Ok(())
     }
 }
 
@@ -1838,9 +1865,11 @@ impl<Context> Format<Context> for IfGroupBreaks<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         f.write_element(FormatElement::Tag(StartConditionalContent(
             Condition::new(self.mode).with_group_id(self.group_id),
-        )))?;
+        )));
         Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndConditionalContent))
+        f.write_element(FormatElement::Tag(EndConditionalContent));
+
+        Ok(())
     }
 }
 
@@ -1960,9 +1989,11 @@ pub struct IndentIfGroupBreaks<'a, Context> {
 
 impl<Context> Format<Context> for IndentIfGroupBreaks<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartIndentIfGroupBreaks(self.group_id)))?;
+        f.write_element(FormatElement::Tag(StartIndentIfGroupBreaks(self.group_id)));
         Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndIndentIfGroupBreaks))
+        f.write_element(FormatElement::Tag(EndIndentIfGroupBreaks));
+
+        Ok(())
     }
 }
 
@@ -2050,9 +2081,11 @@ impl<Context> Format<Context> for FitsExpanded<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         f.write_element(FormatElement::Tag(StartFitsExpanded(
             tag::FitsExpanded::new().with_condition(self.condition),
-        )))?;
+        )));
         f.write_fmt(Arguments::from(&self.content))?;
-        f.write_element(FormatElement::Tag(EndFitsExpanded))
+        f.write_element(FormatElement::Tag(EndFitsExpanded));
+
+        Ok(())
     }
 }
 
@@ -2306,10 +2339,10 @@ pub struct FillBuilder<'fmt, 'buf, Context> {
 
 impl<'a, 'buf, Context> FillBuilder<'a, 'buf, Context> {
     pub(crate) fn new(fmt: &'a mut Formatter<'buf, Context>) -> Self {
-        let result = fmt.write_element(FormatElement::Tag(StartFill));
+        fmt.write_element(FormatElement::Tag(StartFill));
 
         Self {
-            result,
+            result: Ok(()),
             fmt,
             empty: true,
         }
@@ -2338,14 +2371,15 @@ impl<'a, 'buf, Context> FillBuilder<'a, 'buf, Context> {
             if self.empty {
                 self.empty = false;
             } else {
-                self.fmt.write_element(FormatElement::Tag(StartEntry))?;
+                self.fmt.write_element(FormatElement::Tag(StartEntry));
                 separator.fmt(self.fmt)?;
-                self.fmt.write_element(FormatElement::Tag(EndEntry))?;
+                self.fmt.write_element(FormatElement::Tag(EndEntry));
             }
 
-            self.fmt.write_element(FormatElement::Tag(StartEntry))?;
+            self.fmt.write_element(FormatElement::Tag(StartEntry));
             entry.fmt(self.fmt)?;
-            self.fmt.write_element(FormatElement::Tag(EndEntry))
+            self.fmt.write_element(FormatElement::Tag(EndEntry));
+            Ok(())
         });
 
         self
@@ -2353,8 +2387,10 @@ impl<'a, 'buf, Context> FillBuilder<'a, 'buf, Context> {
 
     /// Finishes the output and returns any error encountered
     pub fn finish(&mut self) -> FormatResult<()> {
+        if self.result.is_ok() {
+            self.fmt.write_element(FormatElement::Tag(EndFill));
+        }
         self.result
-            .and_then(|_| self.fmt.write_element(FormatElement::Tag(EndFill)))
     }
 }
 
@@ -2394,9 +2430,9 @@ impl<Context> Format<Context> for BestFitting<'_, Context> {
         let mut formatted_variants = Vec::with_capacity(variants.len());
 
         for variant in variants {
-            buffer.write_element(FormatElement::Tag(StartEntry))?;
+            buffer.write_element(FormatElement::Tag(StartEntry));
             buffer.write_fmt(Arguments::from(variant))?;
-            buffer.write_element(FormatElement::Tag(EndEntry))?;
+            buffer.write_element(FormatElement::Tag(EndEntry));
 
             formatted_variants.push(buffer.take_vec().into_boxed_slice());
         }
@@ -2412,6 +2448,8 @@ impl<Context> Format<Context> for BestFitting<'_, Context> {
             }
         };
 
-        f.write_element(element)
+        f.write_element(element);
+
+        Ok(())
     }
 }

--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -251,10 +251,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                 | FormatElement::StaticText { .. }
                 | FormatElement::DynamicText { .. }
                 | FormatElement::SourceCodeSlice { .. }) => {
-                    fn write_escaped(
-                        element: &FormatElement,
-                        f: &mut Formatter<IrFormatContext>,
-                    ) -> FormatResult<()> {
+                    fn write_escaped(element: &FormatElement, f: &mut Formatter<IrFormatContext>) {
                         let text = match element {
                             FormatElement::StaticText { text } => text,
                             FormatElement::DynamicText { text } => text.as_ref(),
@@ -267,9 +264,9 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                         if text.contains('"') {
                             f.write_element(FormatElement::DynamicText {
                                 text: text.replace('"', r#"\""#).into(),
-                            })
+                            });
                         } else {
-                            f.write_element(element.clone())
+                            f.write_element(element.clone());
                         }
                     }
 
@@ -284,7 +281,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                             write!(f, [text(" ")])?;
                         }
                         element if element.is_text() => {
-                            write_escaped(element, f)?;
+                            write_escaped(element, f);
                         }
                         _ => unreachable!(),
                     }
@@ -334,7 +331,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                     f.write_elements([
                         FormatElement::Tag(StartIndent),
                         FormatElement::Line(LineMode::Hard),
-                    ])?;
+                    ]);
 
                     for variant in variants {
                         write!(f, [&**variant, hard_line_break()])?;
@@ -343,7 +340,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                     f.write_elements([
                         FormatElement::Tag(EndIndent),
                         FormatElement::Line(LineMode::Hard),
-                    ])?;
+                    ]);
 
                     write!(f, [text("])")])?;
                 }
@@ -631,7 +628,9 @@ impl Format<IrFormatContext<'_>> for ContentArrayStart {
             FormatElement::Tag(StartGroup(tag::Group::new())),
             FormatElement::Tag(StartIndent),
             FormatElement::Line(LineMode::Soft),
-        ])
+        ]);
+
+        Ok(())
     }
 }
 
@@ -644,7 +643,7 @@ impl Format<IrFormatContext<'_>> for ContentArrayEnd {
             FormatElement::Tag(EndIndent),
             FormatElement::Line(LineMode::Soft),
             FormatElement::Tag(EndGroup),
-        ])?;
+        ]);
 
         write!(f, [text("]")])
     }

--- a/crates/ruff_formatter/src/format_extensions.rs
+++ b/crates/ruff_formatter/src/format_extensions.rs
@@ -166,7 +166,7 @@ where
 
         match result {
             Ok(Some(elements)) => {
-                f.write_element(elements.clone())?;
+                f.write_element(elements.clone());
 
                 Ok(())
             }

--- a/crates/ruff_formatter/src/formatter.rs
+++ b/crates/ruff_formatter/src/formatter.rs
@@ -206,8 +206,8 @@ impl<Context> Buffer for Formatter<'_, Context> {
     type Context = Context;
 
     #[inline]
-    fn write_element(&mut self, element: FormatElement) -> FormatResult<()> {
-        self.buffer.write_element(element)
+    fn write_element(&mut self, element: FormatElement) {
+        self.buffer.write_element(element);
     }
 
     fn elements(&self) -> &[FormatElement] {

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -42,8 +42,7 @@ use crate::format_element::document::Document;
 use crate::printer::{Printer, PrinterOptions};
 pub use arguments::{Argument, Arguments};
 pub use buffer::{
-    Buffer, BufferExtensions, BufferSnapshot, Inspect, PreambleBuffer, RemoveSoftLinesBuffer,
-    VecBuffer,
+    Buffer, BufferExtensions, BufferSnapshot, Inspect, RemoveSoftLinesBuffer, VecBuffer,
 };
 pub use builders::BestFitting;
 pub use source_code::{SourceCode, SourceCodeSlice};

--- a/crates/ruff_python_formatter/src/expression/parentheses.rs
+++ b/crates/ruff_python_formatter/src/expression/parentheses.rs
@@ -268,7 +268,8 @@ impl<'ast> Format<PyFormatContext<'ast>> for InParenthesesOnlyLineBreak {
                 f.write_element(FormatElement::Line(match self {
                     InParenthesesOnlyLineBreak::SoftLineBreak => LineMode::Soft,
                     InParenthesesOnlyLineBreak::SoftLineBreakOrSpace => LineMode::SoftOrSpace,
-                }))
+                }));
+                Ok(())
             }
         }
     }

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -184,11 +184,11 @@ impl Format<PyFormatContext<'_>> for NotYetImplementedCustomText<'_> {
             tag::VerbatimKind::Verbatim {
                 length: self.text.text_len(),
             },
-        )))?;
+        )));
 
         text(self.text).fmt(f)?;
 
-        f.write_element(FormatElement::Tag(Tag::EndVerbatim))?;
+        f.write_element(FormatElement::Tag(Tag::EndVerbatim));
 
         f.context()
             .comments()

--- a/crates/ruff_python_formatter/src/verbatim.rs
+++ b/crates/ruff_python_formatter/src/verbatim.rs
@@ -855,7 +855,7 @@ impl Format<PyFormatContext<'_>> for VerbatimText {
             tag::VerbatimKind::Verbatim {
                 length: self.verbatim_range.len(),
             },
-        )))?;
+        )));
 
         match normalize_newlines(f.context().locator().slice(self.verbatim_range), ['\r']) {
             Cow::Borrowed(_) => {
@@ -878,6 +878,7 @@ impl Format<PyFormatContext<'_>> for VerbatimText {
             }
         }
 
-        f.write_element(FormatElement::Tag(Tag::EndVerbatim))
+        f.write_element(FormatElement::Tag(Tag::EndVerbatim));
+        Ok(())
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR changes the `Buffer::write_element` return type from `FormatResult<()>` to `()` (void). 

Local benchmarks show that this improves performance significantly and the only possible error for `write_element` to fail is if `Vec` fails to allocate, which we don't need to handle.

There's one downside to this. The reason why `Buffer::write_element` is that a wrapper `Buffer` (see the removed `PreambleBuffer`) can intercept the writing of an element and write additional content. 
This is a neat feature but wrapping `Buffer`s (especially if done recursively, e.g. in every Expression) comes with a significant performance penalty because each wrapping requires a dynamic dispatch call. That's why `Buffer`s haven't been used as much and are generally discouraged.  

There's a more performant solution for preambles today that didn't exist when the Buffer was introduced.

* Create a snapshot
* write the preamble
* perform a rollback if no content was written since the preamble

However, this doesn't work for use cases where the preamble itself is expensive OR for cases where an element should be written as a response to another element (e.g. write a line break after each "break_here" text). 

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test`


```
Gnuplot not found, using plotters backend
formatter/numpy/globals.py
                        time:   [38.464 µs 38.507 µs 38.553 µs]
                        thrpt:  [76.535 MiB/s 76.627 MiB/s 76.712 MiB/s]
                 change:
                        time:   [-4.3802% -4.2067% -4.0365%] (p = 0.00 < 0.05)
                        thrpt:  [+4.2063% +4.3914% +4.5809%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
formatter/pydantic/types.py
                        time:   [769.99 µs 770.45 µs 771.00 µs]
                        thrpt:  [33.078 MiB/s 33.102 MiB/s 33.121 MiB/s]
                 change:
                        time:   [-2.5591% -2.3013% -2.0730%] (p = 0.00 < 0.05)
                        thrpt:  [+2.1168% +2.3555% +2.6263%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
formatter/numpy/ctypeslib.py
                        time:   [378.12 µs 378.37 µs 378.65 µs]
                        thrpt:  [43.975 MiB/s 44.007 MiB/s 44.037 MiB/s]
                 change:
                        time:   [-2.0623% -1.7352% -1.4174%] (p = 0.00 < 0.05)
                        thrpt:  [+1.4378% +1.7659% +2.1057%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe
Benchmarking formatter/large/dataset.py: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.7s, enable flat sampling, or reduce sample count to 50.
formatter/large/dataset.py
                        time:   [1.9180 ms 1.9197 ms 1.9216 ms]
                        thrpt:  [21.171 MiB/s 21.192 MiB/s 21.211 MiB/s]
                 change:
                        time:   [-2.0365% -1.8731% -1.7127%] (p = 0.00 < 0.05)
                        thrpt:  [+1.7426% +1.9089% +2.0788%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

```

<!-- How was it tested? -->
