### PR TITLE
Add support for nested replacements inside format specifications

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/bad_string_format_character.py
+++ b/crates/ruff/resources/test/fixtures/pylint/bad_string_format_character.py
@@ -14,7 +14,10 @@
 
 "{:s} {:y}".format("hello", "world")  # [bad-format-character]
 
-"{:*^30s}".format("centered")
+"{:*^30s}".format("centered") # OK
+"{:{s}}".format("hello", s="s")  # OK (nested replacement value not checked)
+
+"{:{s:y}}".format("hello", s="s")  # [bad-format-character] (nested replacement format spec checked)
 
 ## f-strings
 

--- a/crates/ruff/src/rules/pyflakes/format.rs
+++ b/crates/ruff/src/rules/pyflakes/format.rs
@@ -11,7 +11,9 @@ pub(crate) fn error_to_string(err: &FormatParseError) -> String {
         FormatParseError::InvalidCharacterAfterRightBracket => {
             "Only '.' or '[' may follow ']' in format field specifier"
         }
-        FormatParseError::InvalidFormatSpecifier => "Max string recursion exceeded",
+        FormatParseError::PlaceholderRecursionExceeded => {
+            "Max format placeholder recursion exceeded"
+        }
         FormatParseError::MissingStartBracket => "Single '}' encountered in format string",
         FormatParseError::MissingRightBracket => "Expected '}' before end of string",
         FormatParseError::UnmatchedBracket => "Single '{' encountered in format string",

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F521_F521.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F521_F521.py.snap
@@ -28,7 +28,7 @@ F521.py:3:1: F521 `.format` call has invalid format string: Expected '}' before 
 5 | "{:{:{}}}".format(1, 2, 3)
   |
 
-F521.py:5:1: F521 `.format` call has invalid format string: Max string recursion exceeded
+F521.py:5:1: F521 `.format` call has invalid format string: Max format placeholder recursion exceeded
   |
 3 | "{foo[}".format(foo=1)
 4 | # too much string recursion (placeholder-in-placeholder)

--- a/crates/ruff/src/rules/pylint/rules/bad_string_format_character.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_string_format_character.rs
@@ -63,7 +63,7 @@ pub(crate) fn call(checker: &mut Checker, string: &str, range: TextRange) {
                 }
                 Err(_) => {}
                 Ok(format_spec) => {
-                    for replacement in format_spec.replacements {
+                    for replacement in format_spec.replacements() {
                         let FormatPart::Field { format_spec, .. } = replacement else {
                             continue;
                         };

--- a/crates/ruff/src/rules/pylint/rules/bad_string_format_character.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_string_format_character.rs
@@ -68,7 +68,7 @@ pub(crate) fn call(checker: &mut Checker, string: &str, range: TextRange) {
                             continue;
                         };
                         if let Err(FormatSpecError::InvalidFormatType) =
-                            FormatSpec::parse(&format_spec)
+                            FormatSpec::parse(format_spec)
                         {
                             checker.diagnostics.push(Diagnostic::new(
                                 BadStringFormatCharacter {

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE1300_bad_string_format_character.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE1300_bad_string_format_character.py.snap
@@ -48,7 +48,17 @@ bad_string_format_character.py:15:1: PLE1300 Unsupported format character 'y'
 15 | "{:s} {:y}".format("hello", "world")  # [bad-format-character]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLE1300
 16 | 
-17 | "{:*^30s}".format("centered")
+17 | "{:*^30s}".format("centered") # OK
+   |
+
+bad_string_format_character.py:20:1: PLE1300 Unsupported format character 'y'
+   |
+18 | "{:{s}}".format("hello", s="s")  # OK (nested replacement value not checked)
+19 | 
+20 | "{:{s:y}}".format("hello", s="s")  # [bad-format-character] (nested replacement format spec checked)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLE1300
+21 | 
+22 | ## f-strings
    |
 
 

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -203,6 +203,12 @@ impl FormatParse for FormatType {
 /// "hello {name:{fmt:*>}}".format(name="test", fmt="<20")
 /// ```
 ///
+/// However, replacements can only be singly nested (preserving our sanity).
+/// A [`FormatSpecError::ReplacementNotAllowed`] will be raised while parsing in this case.
+/// ```python
+/// "hello {name:{fmt:{not_allowed}}}".format(name="test", fmt="<20")  # Syntax error
+/// ```
+///
 /// When replacements are present in a format specification, we will parse them and
 /// store them in [`FormatSpec`] but will otherwise ignore them if they would introduce
 /// an invalid format specification at runtime.

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -312,10 +312,9 @@ fn parse_precision(text: &str) -> Result<(Option<usize>, &str), FormatSpecError>
 
 /// Parses a format part within a format spec
 fn parse_nested_format_part<'a>(
-    parts: &'a RefCell<Vec<FormatPart>>,
+    parts: &mut Vec<FormatPart>,
     text: &'a str,
 ) -> Result<&'a str, FormatSpecError> {
-    let mut parts = parts.borrow_mut();
     let mut end_bracket_pos = None;
     let mut left = String::new();
 
@@ -352,25 +351,25 @@ fn parse_nested_format_part<'a>(
 
 impl FormatSpec {
     pub fn parse(text: &str) -> Result<Self, FormatSpecError> {
-        let replacements = RefCell::new(vec![]);
+        let mut replacements = vec![];
         // get_integer in CPython
-        let text = parse_nested_format_part(&replacements, text)?;
+        let text = parse_nested_format_part(&mut replacements, text)?;
         let (conversion, text) = FormatConversion::parse(text);
-        let text = parse_nested_format_part(&replacements, text)?;
+        let text = parse_nested_format_part(&mut replacements, text)?;
         let (mut fill, mut align, text) = parse_fill_and_align(text);
-        let text = parse_nested_format_part(&replacements, text)?;
+        let text = parse_nested_format_part(&mut replacements, text)?;
         let (sign, text) = FormatSign::parse(text);
-        let text = parse_nested_format_part(&replacements, text)?;
+        let text = parse_nested_format_part(&mut replacements, text)?;
         let (alternate_form, text) = parse_alternate_form(text);
-        let text = parse_nested_format_part(&replacements, text)?;
+        let text = parse_nested_format_part(&mut replacements, text)?;
         let (zero, text) = parse_zero(text);
-        let text = parse_nested_format_part(&replacements, text)?;
+        let text = parse_nested_format_part(&mut replacements, text)?;
         let (width, text) = parse_number(text)?;
-        let text = parse_nested_format_part(&replacements, text)?;
+        let text = parse_nested_format_part(&mut replacements, text)?;
         let (grouping_option, text) = FormatGrouping::parse(text);
-        let text = parse_nested_format_part(&replacements, text)?;
+        let text = parse_nested_format_part(&mut replacements, text)?;
         let (precision, text) = parse_precision(text)?;
-        let text = parse_nested_format_part(&replacements, text)?;
+        let text = parse_nested_format_part(&mut replacements, text)?;
 
         let (format_type, _text) = if text.is_empty() {
             (None, text)
@@ -402,7 +401,7 @@ impl FormatSpec {
             grouping_option,
             precision,
             format_type,
-            replacements: replacements.take(),
+            replacements,
         })
     }
 }

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -233,7 +233,7 @@ pub struct FormatSpec {
     // Ex) `f` in `'{:+f}'`
     format_type: Option<FormatType>,
     // Ex) `x` and `y` in `'{:*{x},{y}b}'`
-    replacements: Vec<FormatPart>,
+    pub replacements: Vec<FormatPart>,
 }
 
 fn get_num_digits(text: &str) -> usize {

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -795,7 +795,7 @@ mod tests {
     }
 
     #[test]
-    fn test_format_parse_nested_specifier() {
+    fn test_format_parse_nested_replacement() {
         let expected = Ok(FormatString {
             format_parts: vec![
                 FormatPart::Literal("abcd".to_owned()),

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -236,11 +236,12 @@ pub struct FormatSpec {
     replacements: Vec<FormatPart>,
 }
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
 pub enum AllowPlaceholderNesting {
     #[default]
     Yes,
     No,
+    AllowPlaceholderNesting,
 }
 
 fn get_num_digits(text: &str) -> usize {
@@ -387,6 +388,10 @@ impl FormatSpec {
             format_type,
             replacements,
         })
+    }
+
+    pub fn replacements(&self) -> &[FormatPart] {
+        return self.replacements.as_slice();
     }
 }
 
@@ -644,7 +649,6 @@ impl FormatString {
         let mut left = String::new();
 
         for (idx, c) in text.char_indices() {
-            println!("Parsing {:?} {:?}", c, nested);
             if c == '{' {
                 // There may be one layer nesting brackets in spec
                 if nested || allow_nesting == AllowPlaceholderNesting::No {
@@ -661,10 +665,9 @@ impl FormatString {
                 }
                 let (_, right) = text.split_at(idx + 1);
                 let format_part = FormatString::parse_part_in_brackets(&left)?;
-                return Ok((format_part, &right));
-            } else {
-                left.push(c);
+                return Ok((format_part, right));
             }
+            left.push(c);
         }
         Err(FormatParseError::UnmatchedBracket)
     }

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -793,7 +793,7 @@ mod tests {
             replacements: vec![FormatPart::Field {
                 field_name: "x".to_string(),
                 conversion_spec: None,
-                format_spec: "".to_string(),
+                format_spec: String::new(),
             }],
         });
         assert_eq!(FormatSpec::parse("{x}"), expected);
@@ -815,7 +815,7 @@ mod tests {
                 FormatPart::Field {
                     field_name: "x".to_string(),
                     conversion_spec: None,
-                    format_spec: "".to_string(),
+                    format_spec: String::new(),
                 },
                 FormatPart::Field {
                     field_name: "y".to_string(),
@@ -825,7 +825,7 @@ mod tests {
                 FormatPart::Field {
                     field_name: "z".to_string(),
                     conversion_spec: None,
-                    format_spec: "".to_string(),
+                    format_spec: String::new(),
                 },
             ],
         });
@@ -847,7 +847,7 @@ mod tests {
             replacements: vec![FormatPart::Field {
                 field_name: "x".to_string(),
                 conversion_spec: None,
-                format_spec: "".to_string(),
+                format_spec: String::new(),
             }],
         });
         assert_eq!(FormatSpec::parse("<{x}20b"), expected);

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -340,7 +340,7 @@ fn parse_nested_format_part<'a>(
     if let Some(pos) = end_bracket_pos {
         let (_, right) = text.split_at(pos);
         let format_part = FormatString::parse_part_in_brackets(&left)
-            .map_err(|err| FormatSpecError::InvalidReplacement(err))?;
+            .map_err(FormatSpecError::InvalidReplacement)?;
         parts.push(format_part);
         Ok(&right[1..])
     } else {

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -659,9 +659,9 @@ impl FormatString {
                     left.push(c);
                     continue;
                 }
-                let (_, right) = text.split_at(idx);
+                let (_, right) = text.split_at(idx + 1);
                 let format_part = FormatString::parse_part_in_brackets(&left)?;
-                return Ok((format_part, &right[1..]));
+                return Ok((format_part, &right));
             } else {
                 left.push(c);
             }
@@ -959,6 +959,10 @@ mod tests {
         );
         assert_eq!(
             FormatSpec::parse("}"),
+            Err(FormatSpecError::InvalidFormatType)
+        );
+        assert_eq!(
+            FormatSpec::parse("{}}"),
             Err(FormatSpecError::InvalidFormatType)
         );
         assert_eq!(

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -233,7 +233,7 @@ pub struct FormatSpec {
     // Ex) `f` in `'{:+f}'`
     format_type: Option<FormatType>,
     // Ex) `x` and `y` in `'{:*{x},{y}b}'`
-    pub replacements: Vec<FormatPart>,
+    replacements: Vec<FormatPart>,
 }
 
 fn get_num_digits(text: &str) -> usize {


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/6442

Python string formatting like `"hello {place}".format(place="world")` supports format specifications for replaced content such as `"hello {place:>10}".format(place="world")` which will align the text to the right in a container filled up to ten characters. 

Ruff parses formatted strings into `FormatPart`s each of which is either a `Field` (content in `{...}`) or a `Literal` (the normal content). Fields are parsed into name and format specifier sections (we'll ignore conversion specifiers for now).

There are a myriad of specifiers that can be used in a `FormatSpec`. Unfortunately for linters, the specifier values can be dynamically set. For example, `"hello {place:{align}{width}}".format(place="world", align=">", width=10)` and `"hello {place:{fmt}}".format(place="world", fmt=">10")` will yield the same string as before but variables can be used to determine the formatting. In this case, when parsing the format specifier we can't know what _kind_ of specifier is being used as their meaning is determined by both position and value.

Ruff does not support nested replacements and our current data model does not support the concept. Here the data model is updated to support this concept, although linting of specifications with replacements will be inherently limited. We could split format specifications into two types, one without any replacements that we can perform lints with and one with replacements that we cannot inspect. However, it seems excessive to drop all parsing of format specifiers due to the presence of a replacement. Instead, I've opted to parse replacements eagerly and ignore their possible effect on other format specifiers. This will allow us to retain a simple interface for `FormatSpec` and most syntax checks. We may need to add some handling to relax errors if a replacement was seen previously.

It's worth noting that the nested replacement _can_ also include a format specification although it may fail at runtime if you produce an invalid outer format specification. For example, `"hello {place:{fmt:<2}}".format(place="world", fmt=">10")` is valid so we need to represent each nested replacement as a full `FormatPart`.

## Test plan

Adding unit tests for `FormatSpec` parsing and snapshots for PLE1300