### PR TITLE
Fix unreachable in playground

### DIFF
--- a/crates/ruff/src/fs.rs
+++ b/crates/ruff/src/fs.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use globset::GlobMatcher;
 use log::debug;
-use path_absolutize::{path_dedot, Absolutize};
+use path_absolutize::Absolutize;
 
 use crate::registry::RuleSet;
 
@@ -61,7 +61,13 @@ pub fn normalize_path_to<P: AsRef<Path>, R: AsRef<Path>>(path: P, project_root: 
 /// Convert an absolute path to be relative to the current working directory.
 pub fn relativize_path<P: AsRef<Path>>(path: P) -> String {
     let path = path.as_ref();
-    if let Ok(path) = path.strip_prefix(&*path_dedot::CWD) {
+
+    #[cfg(target_arch = "wasm32")]
+    let cwd = Path::new(".");
+    #[cfg(not(target_arch = "wasm32"))]
+    let cwd = path_absolutize::path_dedot::CWD.as_path();
+
+    if let Ok(path) = path.strip_prefix(cwd) {
         return format!("{}", path.display());
     }
     format!("{}", path.display())


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Pasting code with an invalid `noqa` comment (or being in process of writing a noqa comment) makes the playground run into a `unreachable`. 
This is because `path_dedot::CWD`

```
panicked at 'called `Result::unwrap()` on an `Err` value: Error { kind: Unsupported, message: "operation not supported on this platform" }', /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/path-dedot-3.1.0/src/lib.rs:330:70
```

This PR fixes the issue for `noqa` comments. We may want to fix this more holisticly by mocking out all the `CWD` usages by using our own variable. 


<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I tested that the playground no longer crashes when using an invalid `noqa` directive.

<!-- How was it tested? -->
