### PR TITLE
Attach trailing `WithItem` comments to the optional variable

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
@@ -254,3 +254,35 @@ with (
 
 with (foo() as bar, baz() as bop):
     pass
+
+# Trailing comments on items, broken by commas and parentheses.
+with (
+    a
+    as
+    # comment
+    b  # leading comment
+): ...
+
+
+with (
+    a
+    as
+    b,  # leading comment
+    c as d
+): ...
+
+
+with (
+    a
+    as
+    b  # leading comment
+    ,c as d
+): ...
+
+
+with (
+    a as (
+    b  # leading comment
+    )
+    ,c as d
+): ...

--- a/crates/ruff_python_formatter/src/other/with_item.rs
+++ b/crates/ruff_python_formatter/src/other/with_item.rs
@@ -33,7 +33,8 @@ impl FormatNodeRule<WithItem> for FormatWithItem {
             write!(f, [space(), text("as"), space()])?;
 
             if trailing_as_comments.is_empty() {
-                write!(f, [optional_vars.format()])?;
+                maybe_parenthesize_expression(optional_vars, item, Parenthesize::IfRequired)
+                    .fmt(f)?;
             } else {
                 write!(
                     f,

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
@@ -260,6 +260,38 @@ with (
 
 with (foo() as bar, baz() as bop):
     pass
+
+# Trailing comments on items, broken by commas and parentheses.
+with (
+    a
+    as
+    # comment
+    b  # leading comment
+): ...
+
+
+with (
+    a
+    as
+    b,  # leading comment
+    c as d
+): ...
+
+
+with (
+    a
+    as
+    b  # leading comment
+    ,c as d
+): ...
+
+
+with (
+    a as (
+    b  # leading comment
+    )
+    ,c as d
+): ...
 ```
 
 ## Output
@@ -290,8 +322,8 @@ with (
 with (
     a as (  # a  # as
         # own line
-        b
-    ),  # b  # comma
+        b  # b
+    ),  # comma
     c,  # c
 ):  # colon
     ...  # body
@@ -299,8 +331,8 @@ with (
 
 with a as (  # a  # as
     # own line
-    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-):  # b
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  # b
+):
     pass
 
 
@@ -375,8 +407,8 @@ with (
     a
     # trailing own line comment
 ) as (  # trailing as same line comment
-    b
-):  # trailing b same line comment
+    b  # trailing b same line comment
+):
     ...
 
 with (
@@ -533,6 +565,34 @@ with (
 
 with foo() as bar, baz() as bop:
     pass
+
+# Trailing comments on items, broken by commas and parentheses.
+with a as (
+    # comment
+    b  # leading comment
+):
+    ...
+
+
+with (
+    a as b,  # leading comment
+    c as d,
+):
+    ...
+
+
+with (
+    a as b,  # leading comment
+    c as d,
+):
+    ...
+
+
+with (
+    a as b,  # leading comment
+    c as d,
+):
+    ...
 ```
 
 


### PR DESCRIPTION
## Summary

This PR modifies our comment handling of `WithItem` nodes by attaching trailing comments to the optional variable rather than the `WithItem` itself, if there are no clear delimiters between the comment and the optional variable.

As a concrete example, given:

```python
with (
    (a
    # trailing own line comment
    )
    as # trailing as same line comment
    b # trailing b same line comment
): ...
```

We now format as:

```python
with (
    a
    # trailing own line comment
) as (  # trailing as same line comment
    b  # trailing b same line comment
):
    ...
```

Prior to this PR, we formatted as:

```python
with (
    a
    # trailing own line comment
) as (  # trailing as same line comment
    b
):  # trailing b same line comment
    ...
```

## Test Plan

`cargo test`
