### PR TITLE
Avoid cloning source code multiple times

### DIFF
--- a/crates/ruff/src/source_kind.rs
+++ b/crates/ruff/src/source_kind.rs
@@ -2,19 +2,11 @@ use crate::jupyter::Notebook;
 
 #[derive(Clone, Debug, PartialEq, is_macro::Is)]
 pub enum SourceKind {
-    Python(String),
+    Python,
     Jupyter(Notebook),
 }
 
 impl SourceKind {
-    /// Return the source content.
-    pub fn content(&self) -> &str {
-        match self {
-            SourceKind::Python(content) => content,
-            SourceKind::Jupyter(notebook) => notebook.content(),
-        }
-    }
-
     /// Return the [`Notebook`] if the source kind is [`SourceKind::Jupyter`].
     pub fn notebook(&self) -> Option<&Notebook> {
         if let Self::Jupyter(notebook) = self {


### PR DESCRIPTION
## Summary

In working on https://github.com/astral-sh/ruff/pull/6628, I noticed that we clone the source code contents, potentially multiple times, prior to linting. The issue is that `SourceKind::Python` takes a `String`, so we first have to provide it with a `String`. In the stdin case, that means cloning. However, on top of this, we then have to clone `source_kind.contents()` because `SourceKind` gets mutated. So for stdin, we end up cloning twice. For non-stdin, we end up cloning once, but unnecessarily (since the _contents_ don't get mutated, only the kind).

This PR removes the `String` from `source_kind`, instead requiring that we parse it out elsewhere. It reduces the number of clones down to 1 for Jupyter Notebooks, and zero otherwise.
