### PR TITLE
Don't detect `pandas#values` for stores, deletes, or class accesses

### DIFF
--- a/crates/ruff/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff/src/checkers/ast/analyze/expression.rs
@@ -261,7 +261,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 pylint::rules::load_before_global_declaration(checker, id, expr);
             }
         }
-        Expr::Attribute(ast::ExprAttribute { attr, value, .. }) => {
+        Expr::Attribute(attribute) => {
             // Ex) typing.List[...]
             if checker.any_enabled(&[
                 Rule::FutureRewritableTypeAnnotation,
@@ -323,7 +323,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
             if checker.enabled(Rule::CollectionsNamedTuple) {
                 flake8_pyi::rules::collections_named_tuple(checker, expr);
             }
-            pandas_vet::rules::attr(checker, attr, value, expr);
+            pandas_vet::rules::attr(checker, attribute);
         }
         Expr::Call(
             call @ ast::ExprCall {

--- a/crates/ruff/src/rules/pandas_vet/helpers.rs
+++ b/crates/ruff/src/rules/pandas_vet/helpers.rs
@@ -30,8 +30,15 @@ pub(super) fn test_expression(expr: &Expr, semantic: &SemanticModel) -> Resoluti
                 .resolve_name(name)
                 .map_or(Resolution::IrrelevantBinding, |id| {
                     match &semantic.binding(id).kind {
+                        BindingKind::Argument => {
+                            // Avoid, e.g., `self.values`.
+                            if matches!(name.id.as_str(), "self" | "cls") {
+                                Resolution::IrrelevantBinding
+                            } else {
+                                Resolution::RelevantLocal
+                            }
+                        }
                         BindingKind::Annotation
-                        | BindingKind::Argument
                         | BindingKind::Assignment
                         | BindingKind::NamedExprAssignment
                         | BindingKind::UnpackedAssignment

--- a/crates/ruff/src/rules/pandas_vet/mod.rs
+++ b/crates/ruff/src/rules/pandas_vet/mod.rs
@@ -212,6 +212,23 @@ mod tests {
     #[test_case(
         r#"
         import pandas as pd
+        x = pd.DataFrame()
+        x.values = 1
+    "#,
+        "PD011_pass_values_store"
+    )]
+    #[test_case(
+        r#"
+        class Class:
+            def __init__(self, values: str) -> None:
+                self.values = values
+                print(self.values)
+    "#,
+        "PD011_pass_values_instance"
+    )]
+    #[test_case(
+        r#"
+        import pandas as pd
         result = {}.values
     "#,
         "PD011_pass_values_dict"

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_values_instance.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_values_instance.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_values_store.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_values_store.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+


### PR DESCRIPTION
## Summary

Ensures we avoid cases like:

```python
x.values = 1
```

Since Pandas doesn't even expose a setter for that. We also avoid cases like:

```python
print(self.values)
```

Since it's overwhelming likely to be a false positive.

Closes https://github.com/astral-sh/ruff/issues/6630.

## Test Plan

`cargo test`
