### PR TITLE
Refactor `SourceKind` to store file content

### DIFF
--- a/crates/ruff/src/jupyter/notebook.rs
+++ b/crates/ruff/src/jupyter/notebook.rs
@@ -424,12 +424,13 @@ impl Notebook {
     }
 
     /// Update the notebook with the given sourcemap and transformed content.
-    pub(crate) fn update(&mut self, source_map: &SourceMap, transformed: &str) {
+    pub(crate) fn update(&mut self, source_map: &SourceMap, transformed: String) {
         // Cell offsets must be updated before updating the cell content as
         // it depends on the offsets to extract the cell content.
+        self.index.take();
         self.update_cell_offsets(source_map);
-        self.update_cell_content(transformed);
-        self.source_code = transformed.to_string();
+        self.update_cell_content(&transformed);
+        self.source_code = transformed;
     }
 
     /// Return a slice of [`Cell`] in the Jupyter notebook.

--- a/crates/ruff/src/message/azure.rs
+++ b/crates/ruff/src/message/azure.rs
@@ -18,7 +18,7 @@ impl Emitter for AzureEmitter {
         context: &EmitterContext,
     ) -> anyhow::Result<()> {
         for message in messages {
-            let location = if context.is_jupyter_notebook(message.filename()) {
+            let location = if context.is_notebook(message.filename()) {
                 // We can't give a reasonable location for the structured formats,
                 // so we show one that's clearly a fallback
                 SourceLocation::default()

--- a/crates/ruff/src/message/github.rs
+++ b/crates/ruff/src/message/github.rs
@@ -20,7 +20,7 @@ impl Emitter for GithubEmitter {
     ) -> anyhow::Result<()> {
         for message in messages {
             let source_location = message.compute_start_location();
-            let location = if context.is_jupyter_notebook(message.filename()) {
+            let location = if context.is_notebook(message.filename()) {
                 // We can't give a reasonable location for the structured formats,
                 // so we show one that's clearly a fallback
                 SourceLocation::default()

--- a/crates/ruff/src/message/gitlab.rs
+++ b/crates/ruff/src/message/gitlab.rs
@@ -63,7 +63,7 @@ impl Serialize for SerializedMessages<'_> {
             let start_location = message.compute_start_location();
             let end_location = message.compute_end_location();
 
-            let lines = if self.context.is_jupyter_notebook(message.filename()) {
+            let lines = if self.context.is_notebook(message.filename()) {
                 // We can't give a reasonable location for the structured formats,
                 // so we show one that's clearly a fallback
                 json!({

--- a/crates/ruff/src/message/grouped.rs
+++ b/crates/ruff/src/message/grouped.rs
@@ -13,7 +13,6 @@ use crate::message::text::{MessageCodeFrame, RuleCodeAndBody};
 use crate::message::{
     group_messages_by_filename, Emitter, EmitterContext, Message, MessageWithLocation,
 };
-use crate::source_kind::SourceKind;
 
 #[derive(Default)]
 pub struct GroupedEmitter {
@@ -66,10 +65,7 @@ impl Emitter for GroupedEmitter {
                     writer,
                     "{}",
                     DisplayGroupedMessage {
-                        jupyter_index: context
-                            .source_kind(message.filename())
-                            .and_then(SourceKind::notebook)
-                            .map(Notebook::index),
+                        jupyter_index: context.notebook(message.filename()).map(Notebook::index),
                         message,
                         show_fix_status: self.show_fix_status,
                         show_source: self.show_source,

--- a/crates/ruff/src/message/junit.rs
+++ b/crates/ruff/src/message/junit.rs
@@ -45,7 +45,7 @@ impl Emitter for JunitEmitter {
                     } = message;
                     let mut status = TestCaseStatus::non_success(NonSuccessKind::Failure);
                     status.set_message(message.kind.body.clone());
-                    let location = if context.is_jupyter_notebook(message.filename()) {
+                    let location = if context.is_notebook(message.filename()) {
                         // We can't give a reasonable location for the structured formats,
                         // so we show one that's clearly a fallback
                         SourceLocation::default()

--- a/crates/ruff/src/message/mod.rs
+++ b/crates/ruff/src/message/mod.rs
@@ -134,14 +134,12 @@ pub struct EmitterContext<'a> {
 }
 
 impl<'a> EmitterContext<'a> {
-    pub fn new(source_kind: &'a FxHashMap<String, Notebook>) -> Self {
-        Self {
-            notebooks: source_kind,
-        }
+    pub fn new(notebooks: &'a FxHashMap<String, Notebook>) -> Self {
+        Self { notebooks }
     }
 
     /// Tests if the file with `name` is a jupyter notebook.
-    pub fn is_jupyter_notebook(&self, name: &str) -> bool {
+    pub fn is_notebook(&self, name: &str) -> bool {
         self.notebooks.contains_key(name)
     }
 

--- a/crates/ruff/src/message/pylint.rs
+++ b/crates/ruff/src/message/pylint.rs
@@ -19,7 +19,7 @@ impl Emitter for PylintEmitter {
         context: &EmitterContext,
     ) -> anyhow::Result<()> {
         for message in messages {
-            let row = if context.is_jupyter_notebook(message.filename()) {
+            let row = if context.is_notebook(message.filename()) {
                 // We can't give a reasonable location for the structured formats,
                 // so we show one that's clearly a fallback
                 OneIndexed::from_zero_indexed(0)

--- a/crates/ruff/src/message/text.rs
+++ b/crates/ruff/src/message/text.rs
@@ -6,9 +6,9 @@ use annotate_snippets::display_list::{DisplayList, FormatOptions};
 use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
 use bitflags::bitflags;
 use colored::Colorize;
-use ruff_text_size::{TextRange, TextSize};
 
 use ruff_source_file::{OneIndexed, SourceLocation};
+use ruff_text_size::{TextRange, TextSize};
 
 use crate::fs::relativize_path;
 use crate::jupyter::{JupyterIndex, Notebook};
@@ -16,7 +16,6 @@ use crate::line_width::{LineWidth, TabSize};
 use crate::message::diff::Diff;
 use crate::message::{Emitter, EmitterContext, Message};
 use crate::registry::AsRule;
-use crate::source_kind::SourceKind;
 
 bitflags! {
     #[derive(Default)]
@@ -72,10 +71,7 @@ impl Emitter for TextEmitter {
             )?;
 
             let start_location = message.compute_start_location();
-            let jupyter_index = context
-                .source_kind(message.filename())
-                .and_then(SourceKind::notebook)
-                .map(Notebook::index);
+            let jupyter_index = context.notebook(message.filename()).map(Notebook::index);
 
             // Check if we're working on a jupyter notebook and translate positions with cell accordingly
             let diagnostic_location = if let Some(jupyter_index) = jupyter_index {

--- a/crates/ruff/src/source_kind.rs
+++ b/crates/ruff/src/source_kind.rs
@@ -1,8 +1,9 @@
+use crate::autofix::source_map::SourceMap;
 use crate::jupyter::Notebook;
 
 #[derive(Clone, Debug, PartialEq, is_macro::Is)]
 pub enum SourceKind {
-    Python,
+    Python(String),
     Jupyter(Notebook),
 }
 
@@ -13,6 +14,25 @@ impl SourceKind {
             Some(notebook)
         } else {
             None
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn updated(&self, new_source: String, source_map: &SourceMap) -> Self {
+        match self {
+            SourceKind::Jupyter(notebook) => {
+                let mut cloned = notebook.clone();
+                cloned.update(source_map, new_source);
+                SourceKind::Jupyter(cloned)
+            }
+            SourceKind::Python(_) => SourceKind::Python(new_source),
+        }
+    }
+
+    pub fn source_code(&self) -> &str {
+        match self {
+            SourceKind::Python(source) => source,
+            SourceKind::Jupyter(notebook) => notebook.source_code(),
         }
     }
 }

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -7,6 +7,7 @@ use criterion::{
 
 use ruff::linter::lint_only;
 use ruff::settings::{flags, Settings};
+use ruff::source_kind::SourceKind;
 use ruff::RuleSelector;
 use ruff_benchmark::{TestCase, TestCaseSpeed, TestFile, TestFileDownloadError};
 use ruff_python_ast::PySourceType;
@@ -57,15 +58,15 @@ fn benchmark_linter(mut group: BenchmarkGroup<WallTime>, settings: &Settings) {
             BenchmarkId::from_parameter(case.name()),
             &case,
             |b, case| {
+                let kind = SourceKind::Python(case.code().to_string());
                 b.iter(|| {
                     let path = case.path();
                     let result = lint_only(
-                        case.code(),
                         &path,
                         None,
                         settings,
                         flags::Noqa::Enabled,
-                        None,
+                        &kind,
                         PySourceType::from(path.as_path()),
                     );
 

--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -445,9 +445,9 @@ mod tests {
         }
 
         // Not stored in the cache.
-        expected_diagnostics.source_kind.clear();
-        got_diagnostics.source_kind.clear();
-        assert!(expected_diagnostics == got_diagnostics);
+        expected_diagnostics.notebooks.clear();
+        got_diagnostics.notebooks.clear();
+        assert_eq!(expected_diagnostics, got_diagnostics);
     }
 
     #[test]

--- a/crates/ruff_cli/src/commands/run_stdin.rs
+++ b/crates/ruff_cli/src/commands/run_stdin.rs
@@ -37,7 +37,7 @@ pub(crate) fn run_stdin(
     let mut diagnostics = lint_stdin(
         filename,
         package_root,
-        &stdin,
+        stdin,
         &pyproject_config.settings.lib,
         noqa,
         autofix,

--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(target_family = "wasm", allow(dead_code))]
 
-use std::borrow::Cow;
 use std::fs::write;
 use std::io;
 use std::io::Write;
@@ -257,8 +256,7 @@ pub(crate) fn lint_path(
     // Extract the sources from the file.
     let LintSources {
         source_type,
-        mut source_kind,
-        contents,
+        source_kind,
     } = match LintSources::try_from_path(path) {
         Ok(sources) => sources,
         Err(SourceExtractionError::Io(err)) => {
@@ -282,18 +280,17 @@ pub(crate) fn lint_path(
             transformed,
             fixed,
         }) = lint_fix(
-            &contents,
             path,
             package,
             noqa,
             &settings.lib,
-            &mut source_kind,
+            &source_kind,
             source_type,
         ) {
             if !fixed.is_empty() {
                 match autofix {
-                    flags::FixMode::Apply => match &source_kind {
-                        SourceKind::Python => {
+                    flags::FixMode::Apply => match transformed.as_ref() {
+                        SourceKind::Python(transformed) => {
                             write(path, transformed.as_bytes())?;
                         }
                         SourceKind::Jupyter(notebook) => {
@@ -301,10 +298,10 @@ pub(crate) fn lint_path(
                         }
                     },
                     flags::FixMode::Diff => {
-                        match &source_kind {
-                            SourceKind::Python => {
+                        match transformed.as_ref() {
+                            SourceKind::Python(transformed) => {
                                 let mut stdout = io::stdout().lock();
-                                TextDiff::from_lines(&contents, &transformed)
+                                TextDiff::from_lines(source_kind.source_code(), transformed)
                                     .unified_diff()
                                     .header(&fs::relativize_path(path), &fs::relativize_path(path))
                                     .to_writer(&mut stdout)?;
@@ -314,10 +311,7 @@ pub(crate) fn lint_path(
                             SourceKind::Jupyter(dest_notebook) => {
                                 // We need to load the notebook again, since we might've
                                 // mutated it.
-                                let src_notebook = match notebook_from_path(path) {
-                                    Ok(notebook) => notebook,
-                                    Err(diagnostic) => return Ok(*diagnostic),
-                                };
+                                let src_notebook = source_kind.as_jupyter().unwrap();
                                 let mut stdout = io::stdout().lock();
                                 for ((idx, src_cell), dest_cell) in src_notebook
                                     .cells()
@@ -369,12 +363,11 @@ pub(crate) fn lint_path(
         } else {
             // If we fail to autofix, lint the original source code.
             let result = lint_only(
-                &contents,
                 path,
                 package,
                 &settings.lib,
                 noqa,
-                Some(&source_kind),
+                &source_kind,
                 source_type,
             );
             let fixed = FxHashMap::default();
@@ -382,12 +375,11 @@ pub(crate) fn lint_path(
         }
     } else {
         let result = lint_only(
-            &contents,
             path,
             package,
             &settings.lib,
             noqa,
-            Some(&source_kind),
+            &source_kind,
             source_type,
         );
         let fixed = FxHashMap::default();
@@ -408,7 +400,10 @@ pub(crate) fn lint_path(
             "{}",
             DisplayParseError::new(
                 err,
-                SourceCode::new(&contents, &LineIndex::from_source_text(&contents)),
+                SourceCode::new(
+                    source_kind.source_code(),
+                    &LineIndex::from_source_text(source_kind.source_code())
+                ),
                 Some(&source_kind),
             )
         );
@@ -438,7 +433,7 @@ pub(crate) fn lint_path(
 pub(crate) fn lint_stdin(
     path: Option<&Path>,
     package: Option<&Path>,
-    contents: &str,
+    contents: String,
     settings: &Settings,
     noqa: flags::Noqa,
     autofix: flags::FixMode,
@@ -446,8 +441,7 @@ pub(crate) fn lint_stdin(
     // Extract the sources from the file.
     let LintSources {
         source_type,
-        mut source_kind,
-        contents,
+        source_kind,
     } = match LintSources::try_from_source_code(contents, path) {
         Ok(sources) => sources,
         Err(SourceExtractionError::Io(err)) => {
@@ -472,23 +466,25 @@ pub(crate) fn lint_stdin(
             transformed,
             fixed,
         }) = lint_fix(
-            &contents,
             path.unwrap_or_else(|| Path::new("-")),
             package,
             noqa,
             settings,
-            &mut source_kind,
+            &source_kind,
             source_type,
         ) {
             match autofix {
                 flags::FixMode::Apply => {
                     // Write the contents to stdout, regardless of whether any errors were fixed.
-                    io::stdout().write_all(transformed.as_bytes())?;
+                    io::stdout().write_all(transformed.source_code().as_bytes())?;
                 }
                 flags::FixMode::Diff => {
                     // But only write a diff if it's non-empty.
                     if !fixed.is_empty() {
-                        let text_diff = TextDiff::from_lines(&contents, &transformed);
+                        let text_diff = TextDiff::from_lines(
+                            source_kind.source_code(),
+                            transformed.source_code(),
+                        );
                         let mut unified_diff = text_diff.unified_diff();
                         if let Some(path) = path {
                             unified_diff
@@ -508,31 +504,29 @@ pub(crate) fn lint_stdin(
         } else {
             // If we fail to autofix, lint the original source code.
             let result = lint_only(
-                &contents,
                 path.unwrap_or_else(|| Path::new("-")),
                 package,
                 settings,
                 noqa,
-                Some(&source_kind),
+                &source_kind,
                 source_type,
             );
             let fixed = FxHashMap::default();
 
             // Write the contents to stdout anyway.
             if autofix.is_apply() {
-                io::stdout().write_all(contents.as_bytes())?;
+                io::stdout().write_all(source_kind.source_code().as_bytes())?;
             }
 
             (result, fixed)
         }
     } else {
         let result = lint_only(
-            &contents,
             path.unwrap_or_else(|| Path::new("-")),
             package,
             settings,
             noqa,
-            Some(&source_kind),
+            &source_kind,
             source_type,
         );
         let fixed = FxHashMap::default();
@@ -560,16 +554,14 @@ pub(crate) fn lint_stdin(
 }
 
 #[derive(Debug)]
-struct LintSources<'a> {
+struct LintSources {
     /// The "type" of source code, e.g. `.py`, `.pyi`, `.ipynb`, etc.
     source_type: PySourceType,
     /// The "kind" of source, e.g. Python file, Jupyter Notebook, etc.
     source_kind: SourceKind,
-    /// The contents of the source code.
-    contents: Cow<'a, str>,
 }
 
-impl<'a> LintSources<'a> {
+impl LintSources {
     /// Extract the lint [`LintSources`] from the given file path.
     fn try_from_path(path: &Path) -> Result<LintSources, SourceExtractionError> {
         let source_type = PySourceType::from(path);
@@ -577,20 +569,17 @@ impl<'a> LintSources<'a> {
         // Read the file from disk.
         if source_type.is_jupyter() {
             let notebook = notebook_from_path(path).map_err(SourceExtractionError::Diagnostics)?;
-            let contents = notebook.source_code().to_string();
             let source_kind = SourceKind::Jupyter(notebook);
             Ok(LintSources {
                 source_type,
                 source_kind,
-                contents: Cow::Owned(contents),
             })
         } else {
             // This is tested by ruff_cli integration test `unreadable_file`
             let contents = std::fs::read_to_string(path).map_err(SourceExtractionError::Io)?;
             Ok(LintSources {
                 source_type,
-                source_kind: SourceKind::Python,
-                contents: Cow::Owned(contents),
+                source_kind: SourceKind::Python(contents),
             })
         }
     }
@@ -599,26 +588,23 @@ impl<'a> LintSources<'a> {
     /// file path indicating the path to the file from which the contents were read. If provided,
     /// the file path should be used for diagnostics, but not for reading the file from disk.
     fn try_from_source_code(
-        source_code: &'a str,
+        source_code: String,
         path: Option<&Path>,
-    ) -> Result<LintSources<'a>, SourceExtractionError> {
+    ) -> Result<LintSources, SourceExtractionError> {
         let source_type = path.map(PySourceType::from).unwrap_or_default();
 
         if source_type.is_jupyter() {
-            let notebook = notebook_from_source_code(source_code, path)
+            let notebook = notebook_from_source_code(&source_code, path)
                 .map_err(SourceExtractionError::Diagnostics)?;
-            let contents = notebook.source_code().to_string();
             let source_kind = SourceKind::Jupyter(notebook);
             Ok(LintSources {
                 source_type,
                 source_kind,
-                contents: Cow::Owned(contents),
             })
         } else {
             Ok(LintSources {
                 source_type,
-                source_kind: SourceKind::Python,
-                contents: Cow::Borrowed(source_code),
+                source_kind: SourceKind::Python(source_code),
             })
         }
     }

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -177,7 +177,7 @@ impl Printer {
             return Ok(());
         }
 
-        let context = EmitterContext::new(&diagnostics.source_kind);
+        let context = EmitterContext::new(&diagnostics.notebooks);
 
         match self.format {
             SerializationFormat::Json => {
@@ -364,7 +364,7 @@ impl Printer {
                 writeln!(writer)?;
             }
 
-            let context = EmitterContext::new(&diagnostics.source_kind);
+            let context = EmitterContext::new(&diagnostics.notebooks);
             TextEmitter::default()
                 .with_show_fix_status(show_fix_status(self.autofix_level))
                 .with_show_source(self.flags.intersects(Flags::SHOW_SOURCE))


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR changes two things. You may want to take a look at the individual commits. I'm not entirely convinced whether we should land this change and it certainly needs more testing:

1. It changes `Diagnostics` to store the notebooks rather than the `SourceKind`. The sole reason is that we don't need the kind. We only need the notebook index to resolve cells. Ideally, this would be handled by a custom diagnostic kind, but we aren't there yet
2. I changed `SourceKind` to store the content for both `Notebooks` and regular Python files. This allows us to align `lint_fix` to never return the input in place, and instead return the updated result as a `Cow<'a, SourceKind>`. I find this easier to reason about than having to remember that notebooks are updated in place, but regular source code is not. However, this has the downside that we now need to clone the Notebooks, which may be rather expensive (multiple large vecs). 

I'm looking for general feedback. Also happy if someone with more understanding on jupyter notebooks wants to take this over.

## Test Plan

<!-- How was it tested? -->
