### PR TITLE
Rename Comments methods

### DIFF
--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -33,7 +33,7 @@ impl Format<PyFormatContext<'_>> for FormatLeadingComments<'_> {
         let comments = f.context().comments().clone();
 
         let leading_comments = match self {
-            FormatLeadingComments::Node(node) => comments.leading_comments(*node),
+            FormatLeadingComments::Node(node) => comments.leading(*node),
             FormatLeadingComments::Comments(comments) => comments,
         };
 
@@ -124,7 +124,7 @@ impl Format<PyFormatContext<'_>> for FormatTrailingComments<'_> {
         let comments = f.context().comments().clone();
 
         let trailing_comments = match self {
-            FormatTrailingComments::Node(node) => comments.trailing_comments(*node),
+            FormatTrailingComments::Node(node) => comments.trailing(*node),
             FormatTrailingComments::Comments(comments) => comments,
         };
 
@@ -198,7 +198,7 @@ impl Format<PyFormatContext<'_>> for FormatDanglingComments<'_> {
 
         let dangling_comments = match self {
             Self::Comments(comments) => comments,
-            Self::Node(node) => comments.dangling_comments(*node),
+            Self::Node(node) => comments.dangling(*node),
         };
 
         let mut first = true;

--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -418,24 +418,6 @@ impl<'a> Comments<'a> {
             .leading_dangling_trailing(&NodeRefEqualityKey::from_ref(node.into()))
     }
 
-    /// Returns any comments on the open parenthesis of a `node`.
-    ///
-    /// For example, `# comment` in:
-    /// ```python
-    /// (  # comment
-    ///    foo.bar
-    /// )
-    /// ```
-    #[inline]
-    pub(crate) fn open_parenthesis<T>(&self, node: T) -> Option<&SourceComment>
-    where
-        T: Into<AnyNodeRef<'a>>,
-    {
-        self.leading(node)
-            .first()
-            .filter(|comment| comment.line_position.is_end_of_line())
-    }
-
     #[inline(always)]
     #[cfg(not(debug_assertions))]
     pub(crate) fn assert_all_formatted(&self, _source_code: SourceCode) {}

--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -332,16 +332,16 @@ impl<'a> Comments<'a> {
 
     /// Returns `true` if the given `node` has any [leading comments](self#leading-comments).
     #[inline]
-    pub(crate) fn has_leading_comments<T>(&self, node: T) -> bool
+    pub(crate) fn has_leading<T>(&self, node: T) -> bool
     where
         T: Into<AnyNodeRef<'a>>,
     {
-        !self.leading_comments(node).is_empty()
+        !self.leading(node).is_empty()
     }
 
     /// Returns the `node`'s [leading comments](self#leading-comments).
     #[inline]
-    pub(crate) fn leading_comments<T>(&self, node: T) -> &[SourceComment]
+    pub(crate) fn leading<T>(&self, node: T) -> &[SourceComment]
     where
         T: Into<AnyNodeRef<'a>>,
     {
@@ -351,15 +351,15 @@ impl<'a> Comments<'a> {
     }
 
     /// Returns `true` if node has any [dangling comments](self#dangling-comments).
-    pub(crate) fn has_dangling_comments<T>(&self, node: T) -> bool
+    pub(crate) fn has_dangling<T>(&self, node: T) -> bool
     where
         T: Into<AnyNodeRef<'a>>,
     {
-        !self.dangling_comments(node).is_empty()
+        !self.dangling(node).is_empty()
     }
 
     /// Returns the [dangling comments](self#dangling-comments) of `node`
-    pub(crate) fn dangling_comments<T>(&self, node: T) -> &[SourceComment]
+    pub(crate) fn dangling<T>(&self, node: T) -> &[SourceComment]
     where
         T: Into<AnyNodeRef<'a>>,
     {
@@ -370,7 +370,7 @@ impl<'a> Comments<'a> {
 
     /// Returns the `node`'s [trailing comments](self#trailing-comments).
     #[inline]
-    pub(crate) fn trailing_comments<T>(&self, node: T) -> &[SourceComment]
+    pub(crate) fn trailing<T>(&self, node: T) -> &[SourceComment]
     where
         T: Into<AnyNodeRef<'a>>,
     {
@@ -381,43 +381,35 @@ impl<'a> Comments<'a> {
 
     /// Returns `true` if the given `node` has any [trailing comments](self#trailing-comments).
     #[inline]
-    pub(crate) fn has_trailing_comments<T>(&self, node: T) -> bool
+    pub(crate) fn has_trailing<T>(&self, node: T) -> bool
     where
         T: Into<AnyNodeRef<'a>>,
     {
-        !self.trailing_comments(node).is_empty()
+        !self.trailing(node).is_empty()
     }
 
     /// Returns `true` if the given `node` has any [trailing own line comments](self#trailing-comments).
     #[inline]
-    pub(crate) fn has_trailing_own_line_comments<T>(&self, node: T) -> bool
+    pub(crate) fn has_trailing_own_line<T>(&self, node: T) -> bool
     where
         T: Into<AnyNodeRef<'a>>,
     {
-        self.trailing_comments(node)
+        self.trailing(node)
             .iter()
             .any(|comment| comment.line_position().is_own_line())
     }
 
     /// Returns an iterator over the [leading](self#leading-comments) and [trailing comments](self#trailing-comments) of `node`.
-    pub(crate) fn leading_trailing_comments<T>(
-        &self,
-        node: T,
-    ) -> impl Iterator<Item = &SourceComment>
+    pub(crate) fn leading_trailing<T>(&self, node: T) -> impl Iterator<Item = &SourceComment>
     where
         T: Into<AnyNodeRef<'a>>,
     {
-        let node = node.into();
-        self.leading_comments(node)
-            .iter()
-            .chain(self.trailing_comments(node).iter())
+        let comments = self.leading_dangling_trailing(node);
+        comments.leading.iter().chain(comments.trailing)
     }
 
     /// Returns an iterator over the [leading](self#leading-comments), [dangling](self#dangling-comments), and [trailing](self#trailing) comments of `node`.
-    pub(crate) fn leading_dangling_trailing_comments<T>(
-        &self,
-        node: T,
-    ) -> LeadingDanglingTrailingComments
+    pub(crate) fn leading_dangling_trailing<T>(&self, node: T) -> LeadingDanglingTrailingComments
     where
         T: Into<AnyNodeRef<'a>>,
     {
@@ -435,21 +427,21 @@ impl<'a> Comments<'a> {
     /// )
     /// ```
     #[inline]
-    pub(crate) fn open_parenthesis_comment<T>(&self, node: T) -> Option<&SourceComment>
+    pub(crate) fn open_parenthesis<T>(&self, node: T) -> Option<&SourceComment>
     where
         T: Into<AnyNodeRef<'a>>,
     {
-        self.leading_comments(node)
+        self.leading(node)
             .first()
             .filter(|comment| comment.line_position.is_end_of_line())
     }
 
     #[inline(always)]
     #[cfg(not(debug_assertions))]
-    pub(crate) fn assert_formatted_all_comments(&self, _source_code: SourceCode) {}
+    pub(crate) fn assert_all_formatted(&self, _source_code: SourceCode) {}
 
     #[cfg(debug_assertions)]
-    pub(crate) fn assert_formatted_all_comments(&self, source_code: SourceCode) {
+    pub(crate) fn assert_all_formatted(&self, source_code: SourceCode) {
         use std::fmt::Write;
 
         let mut output = String::new();
@@ -481,7 +473,7 @@ impl<'a> Comments<'a> {
     /// normally if `node` is the first or last node of a suppression range.
     #[cfg(debug_assertions)]
     pub(crate) fn mark_verbatim_node_comments_formatted(&self, node: AnyNodeRef) {
-        for dangling in self.dangling_comments(node) {
+        for dangling in self.dangling(node) {
             dangling.mark_formatted();
         }
 
@@ -505,7 +497,7 @@ struct MarkVerbatimCommentsAsFormattedVisitor<'a>(&'a Comments<'a>);
 
 impl<'a> PreorderVisitor<'a> for MarkVerbatimCommentsAsFormattedVisitor<'a> {
     fn enter_node(&mut self, node: AnyNodeRef<'a>) -> TraversalSignal {
-        for comment in self.0.leading_dangling_trailing_comments(node) {
+        for comment in self.0.leading_dangling_trailing(node) {
             comment.mark_formatted();
         }
 

--- a/crates/ruff_python_formatter/src/expression/expr_attribute.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_attribute.rs
@@ -45,7 +45,7 @@ impl FormatNodeRule<ExprAttribute> for FormatExprAttribute {
             );
 
             let comments = f.context().comments().clone();
-            let dangling_comments = comments.dangling_comments(item);
+            let dangling_comments = comments.dangling(item);
             let leading_attribute_comments_start = dangling_comments
                 .partition_point(|comment| comment.line_position().is_end_of_line());
             let (trailing_dot_comments, leading_attribute_comments) =
@@ -88,7 +88,7 @@ impl FormatNodeRule<ExprAttribute> for FormatExprAttribute {
                 value.format().fmt(f)?;
             }
 
-            if comments.has_trailing_own_line_comments(value.as_ref()) {
+            if comments.has_trailing_own_line(value.as_ref()) {
                 hard_line_break().fmt(f)?;
             }
 
@@ -171,10 +171,10 @@ impl NeedsParentheses for ExprAttribute {
             OptionalParentheses::Multiline
         } else if context
             .comments()
-            .dangling_comments(self)
+            .dangling(self)
             .iter()
             .any(|comment| comment.line_position().is_own_line())
-            || context.comments().has_trailing_own_line_comments(self)
+            || context.comments().has_trailing_own_line(self)
         {
             OptionalParentheses::Always
         } else {

--- a/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
@@ -29,10 +29,7 @@ impl FormatNodeRule<ExprBinOp> for FormatExprBinOp {
 
         match Self::layout(item, f.context()) {
             BinOpLayout::LeftString(expression) => {
-                let right_has_leading_comment = f
-                    .context()
-                    .comments()
-                    .has_leading_comments(item.right.as_ref());
+                let right_has_leading_comment = comments.has_leading(item.right.as_ref());
 
                 let format_right_and_op = format_with(|f| {
                     if right_has_leading_comment {
@@ -98,7 +95,7 @@ impl FormatNodeRule<ExprBinOp> for FormatExprBinOp {
                             right,
                         } = current;
 
-                        let operator_comments = comments.dangling_comments(current);
+                        let operator_comments = comments.dangling(current);
                         let needs_space = !is_simple_power_expression(current);
 
                         let before_operator_space = if needs_space {
@@ -117,9 +114,7 @@ impl FormatNodeRule<ExprBinOp> for FormatExprBinOp {
                         )?;
 
                         // Format the operator on its own line if the right side has any leading comments.
-                        if comments.has_leading_comments(right.as_ref())
-                            || !operator_comments.is_empty()
-                        {
+                        if comments.has_leading(right.as_ref()) || !operator_comments.is_empty() {
                             hard_line_break().fmt(f)?;
                         } else if needs_space {
                             space().fmt(f)?;
@@ -171,8 +166,8 @@ impl FormatExprBinOp {
 
             if bin_op.op == Operator::Mod
                 && context.node_level().is_parenthesized()
-                && !comments.has_dangling_comments(constant)
-                && !comments.has_dangling_comments(bin_op)
+                && !comments.has_dangling(constant)
+                && !comments.has_dangling(bin_op)
             {
                 BinOpLayout::LeftString(constant)
             } else {

--- a/crates/ruff_python_formatter/src/expression/expr_bool_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bool_op.rs
@@ -50,7 +50,7 @@ impl FormatNodeRule<ExprBoolOp> for FormatExprBoolOp {
             FormatValue { value: first }.fmt(f)?;
 
             for value in values {
-                let leading_value_comments = comments.leading_comments(value);
+                let leading_value_comments = comments.leading(value);
                 // Format the expressions leading comments **before** the operator
                 if leading_value_comments.is_empty() {
                     write!(f, [in_parentheses_only_soft_line_break_or_space()])?;

--- a/crates/ruff_python_formatter/src/expression/expr_compare.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_compare.rs
@@ -29,7 +29,7 @@ impl FormatNodeRule<ExprCompare> for FormatExprCompare {
             assert_eq!(comparators.len(), ops.len());
 
             for (operator, comparator) in ops.iter().zip(comparators) {
-                let leading_comparator_comments = comments.leading_comments(comparator);
+                let leading_comparator_comments = comments.leading(comparator);
                 if leading_comparator_comments.is_empty() {
                     write!(f, [in_parentheses_only_soft_line_break_or_space()])?;
                 } else {

--- a/crates/ruff_python_formatter/src/expression/expr_dict.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_dict.rs
@@ -43,7 +43,7 @@ impl Format<PyFormatContext<'_>> for KeyValuePair<'_> {
             )
         } else {
             let comments = f.context().comments().clone();
-            let leading_value_comments = comments.leading_comments(self.value);
+            let leading_value_comments = comments.leading(self.value);
             write!(
                 f,
                 [
@@ -67,7 +67,7 @@ impl FormatNodeRule<ExprDict> for FormatExprDict {
         debug_assert_eq!(keys.len(), values.len());
 
         let comments = f.context().comments().clone();
-        let dangling = comments.dangling_comments(item);
+        let dangling = comments.dangling(item);
 
         if values.is_empty() {
             return empty_parenthesized("{", dangling, "}").fmt(f);

--- a/crates/ruff_python_formatter/src/expression/expr_dict_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_dict_comp.rs
@@ -29,7 +29,7 @@ impl FormatNodeRule<ExprDictComp> for FormatExprDictComp {
         });
 
         let comments = f.context().comments().clone();
-        let dangling = comments.dangling_comments(item);
+        let dangling = comments.dangling(item);
 
         write!(
             f,

--- a/crates/ruff_python_formatter/src/expression/expr_generator_exp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_generator_exp.rs
@@ -51,7 +51,7 @@ impl FormatNodeRule<ExprGeneratorExp> for FormatExprGeneratorExp {
         });
 
         let comments = f.context().comments().clone();
-        let dangling = comments.dangling_comments(item);
+        let dangling = comments.dangling(item);
 
         if self.parentheses == GeneratorExpParentheses::StripIfOnlyFunctionArg
             && dangling.is_empty()

--- a/crates/ruff_python_formatter/src/expression/expr_if_exp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_if_exp.rs
@@ -30,12 +30,12 @@ impl FormatNodeRule<ExprIfExp> for FormatExprIfExp {
             [in_parentheses_only_group(&format_args![
                 body.format(),
                 in_parentheses_only_soft_line_break_or_space(),
-                leading_comments(comments.leading_comments(test.as_ref())),
+                leading_comments(comments.leading(test.as_ref())),
                 text("if"),
                 space(),
                 test.format(),
                 in_parentheses_only_soft_line_break_or_space(),
-                leading_comments(comments.leading_comments(orelse.as_ref())),
+                leading_comments(comments.leading(orelse.as_ref())),
                 text("else"),
                 space(),
                 orelse.format()

--- a/crates/ruff_python_formatter/src/expression/expr_list.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_list.rs
@@ -21,7 +21,7 @@ impl FormatNodeRule<ExprList> for FormatExprList {
         } = item;
 
         let comments = f.context().comments().clone();
-        let dangling = comments.dangling_comments(item);
+        let dangling = comments.dangling(item);
 
         if elts.is_empty() {
             return empty_parenthesized("[", dangling, "]").fmt(f);

--- a/crates/ruff_python_formatter/src/expression/expr_list_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_list_comp.rs
@@ -27,7 +27,7 @@ impl FormatNodeRule<ExprListComp> for FormatExprListComp {
         });
 
         let comments = f.context().comments().clone();
-        let dangling = comments.dangling_comments(item);
+        let dangling = comments.dangling(item);
 
         write!(
             f,

--- a/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
@@ -22,7 +22,7 @@ impl FormatNodeRule<ExprNamedExpr> for FormatExprNamedExpr {
 
         // This context, a dangling comment is an end-of-line comment on the same line as the `:=`.
         let comments = f.context().comments().clone();
-        let dangling = comments.dangling_comments(item);
+        let dangling = comments.dangling(item);
 
         write!(
             f,

--- a/crates/ruff_python_formatter/src/expression/expr_set.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_set.rs
@@ -22,7 +22,7 @@ impl FormatNodeRule<ExprSet> for FormatExprSet {
         });
 
         let comments = f.context().comments().clone();
-        let dangling = comments.dangling_comments(item);
+        let dangling = comments.dangling(item);
 
         parenthesized("{", &joined, "}")
             .with_dangling_comments(dangling)

--- a/crates/ruff_python_formatter/src/expression/expr_set_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_set_comp.rs
@@ -27,7 +27,7 @@ impl FormatNodeRule<ExprSetComp> for FormatExprSetComp {
         });
 
         let comments = f.context().comments().clone();
-        let dangling = comments.dangling_comments(item);
+        let dangling = comments.dangling(item);
 
         write!(
             f,

--- a/crates/ruff_python_formatter/src/expression/expr_slice.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_slice.rs
@@ -39,7 +39,7 @@ impl FormatNodeRule<ExprSlice> for FormatExprSlice {
         // to handle newlines and spacing, or the node is None and we insert the corresponding
         // slice of dangling comments
         let comments = f.context().comments().clone();
-        let slice_dangling_comments = comments.dangling_comments(item.as_any_node_ref());
+        let slice_dangling_comments = comments.dangling(item.as_any_node_ref());
         // Put the dangling comments (where the nodes are missing) into buckets
         let first_colon_partition_index =
             slice_dangling_comments.partition_point(|x| x.slice().start() < first_colon.start());
@@ -102,7 +102,7 @@ impl FormatNodeRule<ExprSlice> for FormatExprSlice {
 
         // Upper
         if let Some(upper) = upper {
-            let upper_leading_comments = comments.leading_comments(upper.as_ref());
+            let upper_leading_comments = comments.leading(upper.as_ref());
             leading_comments_spacing(f, upper_leading_comments)?;
             write!(f, [upper.format(), line_suffix_boundary()])?;
         } else {
@@ -134,7 +134,7 @@ impl FormatNodeRule<ExprSlice> for FormatExprSlice {
                 space().fmt(f)?;
             }
             if let Some(step) = step {
-                let step_leading_comments = comments.leading_comments(step.as_ref());
+                let step_leading_comments = comments.leading(step.as_ref());
                 leading_comments_spacing(f, step_leading_comments)?;
                 step.format().fmt(f)?;
             } else if !dangling_step_comments.is_empty() {

--- a/crates/ruff_python_formatter/src/expression/expr_starred.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_starred.rs
@@ -21,7 +21,7 @@ impl FormatNodeRule<ExprStarred> for FormatExprStarred {
         } = item;
 
         let comments = f.context().comments().clone();
-        let dangling = comments.dangling_comments(item);
+        let dangling = comments.dangling(item);
 
         write!(f, [text("*"), dangling_comments(dangling), value.format()])
     }

--- a/crates/ruff_python_formatter/src/expression/expr_subscript.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_subscript.rs
@@ -37,7 +37,7 @@ impl FormatNodeRule<ExprSubscript> for FormatExprSubscript {
         let call_chain_layout = self.call_chain_layout.apply_in_node(item, f);
 
         let comments = f.context().comments().clone();
-        let dangling_comments = comments.dangling_comments(item.as_any_node_ref());
+        let dangling_comments = comments.dangling(item.as_any_node_ref());
         debug_assert!(
             dangling_comments.len() <= 1,
             "A subscript expression can only have a single dangling comment, the one after the bracket"

--- a/crates/ruff_python_formatter/src/expression/expr_tuple.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_tuple.rs
@@ -107,7 +107,7 @@ impl FormatNodeRule<ExprTuple> for FormatExprTuple {
         } = item;
 
         let comments = f.context().comments().clone();
-        let dangling = comments.dangling_comments(item);
+        let dangling = comments.dangling(item);
 
         // Handle the edge cases of an empty tuple and a tuple with one element
         //

--- a/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
@@ -39,7 +39,7 @@ impl FormatNodeRule<ExprUnaryOp> for FormatExprUnaryOp {
         // (not # comment
         //      a)
         // ```
-        let leading_operand_comments = comments.leading_comments(operand.as_ref());
+        let leading_operand_comments = comments.leading(operand.as_ref());
         let trailing_operator_comments_end =
             leading_operand_comments.partition_point(|p| p.line_position().is_end_of_line());
         let (trailing_operator_comments, leading_operand_comments) =

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -108,7 +108,7 @@ impl FormatRule<Expr, PyFormatContext<'_>> for FormatExpr {
 
         if parenthesize {
             let comments = f.context().comments().clone();
-            let open_parenthesis_comment = comments.open_parenthesis_comment(expression);
+            let open_parenthesis_comment = comments.open_parenthesis(expression);
             parenthesized("(", &format_expr, ")")
                 .with_dangling_comments(
                     open_parenthesis_comment
@@ -167,8 +167,8 @@ impl Format<PyFormatContext<'_>> for MaybeParenthesizeExpression<'_> {
         let preserve_parentheses = parenthesize.is_optional()
             && is_expression_parenthesized((*expression).into(), f.context().source());
 
-        let has_comments = comments.has_leading_comments(*expression)
-            || comments.has_trailing_own_line_comments(*expression);
+        let has_comments =
+            comments.has_leading(*expression) || comments.has_trailing_own_line(*expression);
 
         // If the expression has comments, we always want to preserve the parentheses. This also
         // ensures that we correctly handle parenthesized comments, and don't need to worry about
@@ -655,11 +655,7 @@ pub(crate) fn has_own_parentheses(
         Expr::List(ast::ExprList { elts, .. })
         | Expr::Set(ast::ExprSet { elts, .. })
         | Expr::Tuple(ast::ExprTuple { elts, .. }) => {
-            if !elts.is_empty()
-                || context
-                    .comments()
-                    .has_dangling_comments(AnyNodeRef::from(expr))
-            {
+            if !elts.is_empty() || context.comments().has_dangling(AnyNodeRef::from(expr)) {
                 Some(OwnParentheses::NonEmpty)
             } else {
                 Some(OwnParentheses::Empty)
@@ -667,22 +663,14 @@ pub(crate) fn has_own_parentheses(
         }
 
         Expr::Dict(ast::ExprDict { keys, .. }) => {
-            if !keys.is_empty()
-                || context
-                    .comments()
-                    .has_dangling_comments(AnyNodeRef::from(expr))
-            {
+            if !keys.is_empty() || context.comments().has_dangling(AnyNodeRef::from(expr)) {
                 Some(OwnParentheses::NonEmpty)
             } else {
                 Some(OwnParentheses::Empty)
             }
         }
         Expr::Call(ast::ExprCall { arguments, .. }) => {
-            if !arguments.is_empty()
-                || context
-                    .comments()
-                    .has_dangling_comments(AnyNodeRef::from(expr))
-            {
+            if !arguments.is_empty() || context.comments().has_dangling(AnyNodeRef::from(expr)) {
                 Some(OwnParentheses::NonEmpty)
             } else {
                 Some(OwnParentheses::Empty)

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -108,7 +108,20 @@ impl FormatRule<Expr, PyFormatContext<'_>> for FormatExpr {
 
         if parenthesize {
             let comments = f.context().comments().clone();
-            let open_parenthesis_comment = comments.open_parenthesis(expression);
+
+            // Any comments on the open parenthesis of a `node`.
+            //
+            // For example, `# comment` in:
+            // ```python
+            // (  # comment
+            //    foo.bar
+            // )
+            // ```
+            let open_parenthesis_comment = comments
+                .leading(expression)
+                .first()
+                .filter(|comment| comment.line_position().is_end_of_line());
+
             parenthesized("(", &format_expr, ")")
                 .with_dangling_comments(
                     open_parenthesis_comment

--- a/crates/ruff_python_formatter/src/expression/string.rs
+++ b/crates/ruff_python_formatter/src/expression/string.rs
@@ -160,7 +160,7 @@ impl Format<PyFormatContext<'_>> for FormatStringContinuation<'_> {
         let comments = f.context().comments().clone();
         let locator = f.context().locator();
         let quote_style = f.options().quote_style();
-        let mut dangling_comments = comments.dangling_comments(self.string);
+        let mut dangling_comments = comments.dangling(self.string);
 
         let string_range = self.string.range();
         let string_content = locator.slice(string_range);

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -49,7 +49,7 @@ where
     fn fmt(&self, node: &N, f: &mut PyFormatter) -> FormatResult<()> {
         let comments = f.context().comments().clone();
 
-        let node_comments = comments.leading_dangling_trailing_comments(node.as_any_node_ref());
+        let node_comments = comments.leading_dangling_trailing(node.as_any_node_ref());
 
         if self.is_suppressed(node_comments.trailing, f.context()) {
             suppressed_node(node.as_any_node_ref()).fmt(f)
@@ -161,7 +161,7 @@ pub fn format_node<'a>(
     formatted
         .context()
         .comments()
-        .assert_formatted_all_comments(SourceCode::new(source));
+        .assert_all_formatted(SourceCode::new(source));
     Ok(formatted)
 }
 

--- a/crates/ruff_python_formatter/src/other/arguments.rs
+++ b/crates/ruff_python_formatter/src/other/arguments.rs
@@ -24,7 +24,7 @@ impl FormatNodeRule<Arguments> for FormatArguments {
         // ```
         if item.args.is_empty() && item.keywords.is_empty() {
             let comments = f.context().comments().clone();
-            let dangling = comments.dangling_comments(item);
+            let dangling = comments.dangling(item);
             return write!(f, [empty_parenthesized("(", dangling, ")")]);
         }
 
@@ -77,7 +77,7 @@ impl FormatNodeRule<Arguments> for FormatArguments {
         //     c,
         // )
         let comments = f.context().comments().clone();
-        let dangling_comments = comments.dangling_comments(item.as_any_node_ref());
+        let dangling_comments = comments.dangling(item.as_any_node_ref());
 
         write!(
             f,

--- a/crates/ruff_python_formatter/src/other/comprehension.rs
+++ b/crates/ruff_python_formatter/src/other/comprehension.rs
@@ -15,7 +15,7 @@ impl FormatNodeRule<Comprehension> for FormatComprehension {
 
         impl Format<PyFormatContext<'_>> for Spacer<'_> {
             fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
-                if f.context().comments().has_leading_comments(self.0) {
+                if f.context().comments().has_leading(self.0) {
                     soft_line_break_or_space().fmt(f)
                 } else {
                     space().fmt(f)
@@ -36,13 +36,13 @@ impl FormatNodeRule<Comprehension> for FormatComprehension {
         }
 
         let comments = f.context().comments().clone();
-        let dangling_item_comments = comments.dangling_comments(item);
+        let dangling_item_comments = comments.dangling(item);
         let (before_target_comments, before_in_comments) = dangling_item_comments.split_at(
             dangling_item_comments
                 .partition_point(|comment| comment.slice().end() < target.start()),
         );
 
-        let trailing_in_comments = comments.dangling_comments(iter);
+        let trailing_in_comments = comments.dangling(iter);
 
         let in_spacer = format_with(|f| {
             if before_in_comments.is_empty() {
@@ -73,7 +73,7 @@ impl FormatNodeRule<Comprehension> for FormatComprehension {
             let joined = format_with(|f| {
                 let mut joiner = f.join_with(soft_line_break_or_space());
                 for if_case in ifs {
-                    let dangling_if_comments = comments.dangling_comments(if_case);
+                    let dangling_if_comments = comments.dangling(if_case);
 
                     let (own_line_if_comments, end_of_line_if_comments) = dangling_if_comments
                         .split_at(

--- a/crates/ruff_python_formatter/src/other/except_handler_except_handler.rs
+++ b/crates/ruff_python_formatter/src/other/except_handler_except_handler.rs
@@ -46,7 +46,7 @@ impl FormatNodeRule<ExceptHandlerExceptHandler> for FormatExceptHandlerExceptHan
         } = item;
 
         let comments_info = f.context().comments().clone();
-        let dangling_comments = comments_info.dangling_comments(item);
+        let dangling_comments = comments_info.dangling(item);
 
         write!(
             f,

--- a/crates/ruff_python_formatter/src/other/match_case.rs
+++ b/crates/ruff_python_formatter/src/other/match_case.rs
@@ -22,7 +22,7 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
         } = item;
 
         let comments = f.context().comments().clone();
-        let dangling_item_comments = comments.dangling_comments(item);
+        let dangling_item_comments = comments.dangling(item);
 
         write!(
             f,
@@ -33,7 +33,7 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
                     &format_with(|f| {
                         write!(f, [text("case"), space()])?;
 
-                        let leading_pattern_comments = comments.leading_comments(pattern);
+                        let leading_pattern_comments = comments.leading(pattern);
                         if !leading_pattern_comments.is_empty() {
                             parenthesized(
                                 "(",

--- a/crates/ruff_python_formatter/src/other/parameters.rs
+++ b/crates/ruff_python_formatter/src/other/parameters.rs
@@ -63,7 +63,7 @@ impl FormatNodeRule<Parameters> for FormatParameters {
         let (slash, star) = find_parameter_separators(f.context().source(), item);
 
         let comments = f.context().comments().clone();
-        let dangling = comments.dangling_comments(item);
+        let dangling = comments.dangling(item);
 
         // First dangling comment: trailing the opening parenthesis, e.g.:
         // ```python

--- a/crates/ruff_python_formatter/src/other/with_item.rs
+++ b/crates/ruff_python_formatter/src/other/with_item.rs
@@ -19,7 +19,7 @@ impl FormatNodeRule<WithItem> for FormatWithItem {
         } = item;
 
         let comments = f.context().comments().clone();
-        let trailing_as_comments = comments.dangling_comments(item);
+        let trailing_as_comments = comments.dangling(item);
 
         write!(
             f,

--- a/crates/ruff_python_formatter/src/statement/stmt_assign.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_assign.rs
@@ -63,7 +63,7 @@ impl Format<PyFormatContext<'_>> for FormatTargets<'_> {
         if let Some((first, rest)) = self.targets.split_first() {
             let comments = f.context().comments();
 
-            let parenthesize = if comments.has_leading_comments(first) {
+            let parenthesize = if comments.has_leading(first) {
                 ParenthesizeTarget::Always
             } else if has_own_parentheses(first, f.context()).is_some() {
                 ParenthesizeTarget::Never

--- a/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
@@ -25,7 +25,7 @@ impl FormatNodeRule<StmtClassDef> for FormatStmtClassDef {
 
         let comments = f.context().comments().clone();
 
-        let dangling_comments = comments.dangling_comments(item);
+        let dangling_comments = comments.dangling(item);
         let trailing_definition_comments_start =
             dangling_comments.partition_point(|comment| comment.line_position().is_own_line());
 
@@ -93,11 +93,11 @@ impl FormatNodeRule<StmtClassDef> for FormatStmtClassDef {
                             // ```
                             if arguments.is_empty()
                                 && comments
-                                    .dangling_comments(arguments)
+                                    .dangling(arguments)
                                     .iter()
                                     .all(|comment| comment.line_position().is_end_of_line())
                             {
-                                let dangling = comments.dangling_comments(arguments);
+                                let dangling = comments.dangling(arguments);
                                 write!(f, [trailing_comments(dangling)])?;
                             } else {
                                 write!(f, [arguments.format()])?;

--- a/crates/ruff_python_formatter/src/statement/stmt_for.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_for.rs
@@ -39,7 +39,7 @@ impl FormatNodeRule<StmtFor> for FormatStmtFor {
         } = item;
 
         let comments = f.context().comments().clone();
-        let dangling_comments = comments.dangling_comments(item);
+        let dangling_comments = comments.dangling(item);
         let body_start = body.first().map_or(iter.end(), Stmt::start);
         let or_else_comments_start =
             dangling_comments.partition_point(|comment| comment.slice().end() < body_start);

--- a/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
@@ -29,7 +29,7 @@ impl FormatNodeRule<StmtFunctionDef> for FormatStmtFunctionDef {
 
         let comments = f.context().comments().clone();
 
-        let dangling_comments = comments.dangling_comments(item);
+        let dangling_comments = comments.dangling(item);
         let trailing_definition_comments_start =
             dangling_comments.partition_point(|comment| comment.line_position().is_own_line());
 
@@ -64,19 +64,17 @@ impl FormatNodeRule<StmtFunctionDef> for FormatStmtFunctionDef {
                                 write!(f, [space(), text("->"), space()])?;
 
                                 if return_annotation.is_tuple_expr() {
-                                    let parentheses = if comments
-                                        .has_leading_comments(return_annotation.as_ref())
-                                    {
-                                        Parentheses::Always
-                                    } else {
-                                        Parentheses::Never
-                                    };
+                                    let parentheses =
+                                        if comments.has_leading(return_annotation.as_ref()) {
+                                            Parentheses::Always
+                                        } else {
+                                            Parentheses::Never
+                                        };
                                     write!(
                                         f,
                                         [return_annotation.format().with_options(parentheses)]
                                     )?;
-                                } else if comments.has_trailing_comments(return_annotation.as_ref())
-                                {
+                                } else if comments.has_trailing(return_annotation.as_ref()) {
                                     // Intentionally parenthesize any return annotations with trailing comments.
                                     // This avoids an instability in cases like:
                                     // ```python

--- a/crates/ruff_python_formatter/src/statement/stmt_global.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_global.rs
@@ -14,10 +14,7 @@ impl FormatNodeRule<StmtGlobal> for FormatStmtGlobal {
         // Join the `global` names, breaking across continuation lines if necessary, unless the
         // `global` statement has a trailing comment, in which case, breaking the names would
         // move the comment "off" of the `global` statement.
-        if f.context()
-            .comments()
-            .has_trailing_comments(item.as_any_node_ref())
-        {
+        if f.context().comments().has_trailing(item.as_any_node_ref()) {
             let joined = format_with(|f| {
                 f.join_with(format_args![text(","), space()])
                     .entries(item.names.iter().formatted())

--- a/crates/ruff_python_formatter/src/statement/stmt_if.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_if.rs
@@ -22,7 +22,7 @@ impl FormatNodeRule<StmtIf> for FormatStmtIf {
         } = item;
 
         let comments = f.context().comments().clone();
-        let trailing_colon_comment = comments.dangling_comments(item);
+        let trailing_colon_comment = comments.dangling(item);
 
         write!(
             f,
@@ -73,8 +73,8 @@ pub(crate) fn format_elif_else_clause(
     } = item;
 
     let comments = f.context().comments().clone();
-    let trailing_colon_comment = comments.dangling_comments(item);
-    let leading_comments = comments.leading_comments(item);
+    let trailing_colon_comment = comments.dangling(item);
+    let leading_comments = comments.leading(item);
 
     write!(
         f,

--- a/crates/ruff_python_formatter/src/statement/stmt_import_from.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_import_from.rs
@@ -59,7 +59,7 @@ impl FormatNodeRule<StmtImportFrom> for FormatStmtImportFrom {
         // )
         // ```
         let comments = f.context().comments().clone();
-        let parenthesized_comments = comments.dangling_comments(item.as_any_node_ref());
+        let parenthesized_comments = comments.dangling(item.as_any_node_ref());
 
         if parenthesized_comments.is_empty() {
             parenthesize_if_expands(&names).fmt(f)

--- a/crates/ruff_python_formatter/src/statement/stmt_match.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_match.rs
@@ -21,7 +21,7 @@ impl FormatNodeRule<StmtMatch> for FormatStmtMatch {
         } = item;
 
         let comments = f.context().comments().clone();
-        let dangling_item_comments = comments.dangling_comments(item);
+        let dangling_item_comments = comments.dangling(item);
 
         // There can be at most one dangling comment after the colon in a match statement.
         debug_assert!(dangling_item_comments.len() <= 1);
@@ -53,7 +53,7 @@ impl FormatNodeRule<StmtMatch> for FormatStmtMatch {
                 f,
                 [block_indent(&format_args!(
                     leading_alternate_branch_comments(
-                        comments.leading_comments(case),
+                        comments.leading(case),
                         last_case.body.last(),
                     ),
                     case.format()

--- a/crates/ruff_python_formatter/src/statement/stmt_nonlocal.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_nonlocal.rs
@@ -14,10 +14,7 @@ impl FormatNodeRule<StmtNonlocal> for FormatStmtNonlocal {
         // Join the `nonlocal` names, breaking across continuation lines if necessary, unless the
         // `nonlocal` statement has a trailing comment, in which case, breaking the names would
         // move the comment "off" of the `nonlocal` statement.
-        if f.context()
-            .comments()
-            .has_trailing_comments(item.as_any_node_ref())
-        {
+        if f.context().comments().has_trailing(item.as_any_node_ref()) {
             let joined = format_with(|f| {
                 f.join_with(format_args![text(","), space()])
                     .entries(item.names.iter().formatted())

--- a/crates/ruff_python_formatter/src/statement/stmt_try.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_try.rs
@@ -63,13 +63,13 @@ impl FormatNodeRule<StmtTry> for FormatStmtTry {
         } = item;
 
         let comments_info = f.context().comments().clone();
-        let mut dangling_comments = comments_info.dangling_comments(item);
+        let mut dangling_comments = comments_info.dangling(item);
 
         (_, dangling_comments) = format_case(item, CaseKind::Try, None, dangling_comments, f)?;
         let mut previous_node = body.last();
 
         for handler in handlers {
-            let handler_comments = comments_info.leading_comments(handler);
+            let handler_comments = comments_info.leading(handler);
             write!(
                 f,
                 [

--- a/crates/ruff_python_formatter/src/statement/stmt_while.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_while.rs
@@ -22,7 +22,7 @@ impl FormatNodeRule<StmtWhile> for FormatStmtWhile {
         } = item;
 
         let comments = f.context().comments().clone();
-        let dangling_comments = comments.dangling_comments(item.as_any_node_ref());
+        let dangling_comments = comments.dangling(item.as_any_node_ref());
 
         let body_start = body.first().map_or(test.end(), Stmt::start);
         let or_else_comments_start =

--- a/crates/ruff_python_formatter/src/statement/stmt_with.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_with.rs
@@ -33,7 +33,7 @@ impl FormatNodeRule<StmtWith> for FormatStmtWith {
         //     ...
         // ```
         let comments = f.context().comments().clone();
-        let dangling_comments = comments.dangling_comments(item.as_any_node_ref());
+        let dangling_comments = comments.dangling(item.as_any_node_ref());
         let partition_point = dangling_comments.partition_point(|comment| {
             item.items
                 .first()
@@ -86,9 +86,7 @@ impl FormatNodeRule<StmtWith> for FormatStmtWith {
                         } else if let [item] = item.items.as_slice() {
                             // This is similar to `maybe_parenthesize_expression`, but we're not dealing with an
                             // expression here, it's a `WithItem`.
-                            if comments.has_leading_comments(item)
-                                || comments.has_trailing_own_line_comments(item)
-                            {
+                            if comments.has_leading(item) || comments.has_trailing_own_line(item) {
                                 optional_parentheses(&item.format()).fmt(f)?;
                             } else {
                                 item.format().fmt(f)?;

--- a/crates/ruff_python_formatter/src/type_param/type_params.rs
+++ b/crates/ruff_python_formatter/src/type_param/type_params.rs
@@ -22,7 +22,7 @@ impl FormatNodeRule<TypeParams> for FormatTypeParams {
         //     c,
         // ] = ...
         let comments = f.context().comments().clone();
-        let dangling_comments = comments.dangling_comments(item.as_any_node_ref());
+        let dangling_comments = comments.dangling(item.as_any_node_ref());
         write!(f, [trailing_comments(dangling_comments)])?;
 
         let items = format_with(|f| {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR removes the `_comments` from `f.context().comments()` as they seem redudant:

```rust
comments.has_leading_comments(node);

# new
comments.has_leading(node);
```

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test`

<!-- How was it tested? -->
