### PR TITLE
Update lexer tests to use snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2399,6 +2399,7 @@ dependencies = [
  "ruff_text_size",
  "rustc-hash",
  "static_assertions",
+ "test-case",
  "tiny-keccak",
  "unic-emoji-char",
  "unic-ucd-ident",

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -31,6 +31,7 @@ static_assertions = "1.1.0"
 
 [dev-dependencies]
 insta = { workspace = true }
+test-case = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__assignment.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__assignment.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(source)
+---
+[
+    Name {
+        name: "a_variable",
+    },
+    Equal,
+    Int {
+        value: 99,
+    },
+    Plus,
+    Int {
+        value: 2,
+    },
+    Minus,
+    Int {
+        value: 0,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__empty_ipython_escape_command.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__empty_ipython_escape_command.snap
@@ -1,0 +1,51 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_jupyter_source(source)
+---
+[
+    IpyEscapeCommand {
+        value: "",
+        kind: Magic,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "",
+        kind: Magic2,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "",
+        kind: Shell,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "",
+        kind: ShCap,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "",
+        kind: Help,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "",
+        kind: Help2,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "",
+        kind: Paren,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "",
+        kind: Quote,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "",
+        kind: Quote2,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command.snap
@@ -1,0 +1,61 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_jupyter_source(source)
+---
+[
+    IpyEscapeCommand {
+        value: "foo",
+        kind: Help,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "foo",
+        kind: Help2,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "timeit a = b",
+        kind: Magic,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "timeit a % 3",
+        kind: Magic,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "matplotlib     --inline",
+        kind: Magic,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "pwd   && ls -a | sed 's/^/\\\\    /'",
+        kind: Shell,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "cd /Users/foo/Library/Application\\ Support/",
+        kind: ShCap,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "foo 1 2",
+        kind: Paren,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "foo 1 2",
+        kind: Quote,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "foo 1 2",
+        kind: Quote2,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "ls",
+        kind: Shell,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_assignment.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_assignment.snap
@@ -1,0 +1,42 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_jupyter_source(source)
+---
+[
+    Name {
+        name: "pwd",
+    },
+    Equal,
+    IpyEscapeCommand {
+        value: "pwd",
+        kind: Shell,
+    },
+    Newline,
+    Name {
+        name: "foo",
+    },
+    Equal,
+    IpyEscapeCommand {
+        value: "timeit a = b",
+        kind: Magic,
+    },
+    Newline,
+    Name {
+        name: "bar",
+    },
+    Equal,
+    IpyEscapeCommand {
+        value: "timeit a % 3",
+        kind: Magic,
+    },
+    Newline,
+    Name {
+        name: "baz",
+    },
+    Equal,
+    IpyEscapeCommand {
+        value: "matplotlib         inline",
+        kind: Magic,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_indentation.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_indentation.snap
@@ -1,0 +1,17 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_jupyter_source(source)
+---
+[
+    If,
+    True,
+    Colon,
+    Newline,
+    Indent,
+    IpyEscapeCommand {
+        value: "matplotlib         --inline",
+        kind: Magic,
+    },
+    Newline,
+    Dedent,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_help_end_escape_command.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_help_end_escape_command.snap
@@ -1,0 +1,86 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_jupyter_source(source)
+---
+[
+    IpyEscapeCommand {
+        value: "foo",
+        kind: Help,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "foo",
+        kind: Help,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "   foo  ?",
+        kind: Help2,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "foo",
+        kind: Help2,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "foo",
+        kind: Help2,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "foo",
+        kind: Help,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "foo",
+        kind: Help2,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "foo???",
+        kind: Help2,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "?foo???",
+        kind: Help2,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "foo",
+        kind: Help,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: " ?",
+        kind: Help2,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "??",
+        kind: Help2,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "%foo",
+        kind: Help,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "%foo",
+        kind: Help2,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "foo???",
+        kind: Magic2,
+    },
+    Newline,
+    IpyEscapeCommand {
+        value: "pwd",
+        kind: Help,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__logical_newline_line_comment.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__logical_newline_line_comment.snap
@@ -1,0 +1,14 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(source)
+---
+[
+    Comment(
+        "#Hello",
+    ),
+    NonLogicalNewline,
+    Comment(
+        "#World",
+    ),
+    NonLogicalNewline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__non_logical_newline_in_string_continuation.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__non_logical_newline_in_string_continuation.snap
@@ -1,0 +1,34 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(source)
+---
+[
+    Lpar,
+    NonLogicalNewline,
+    String {
+        value: "a",
+        kind: String,
+        triple_quoted: false,
+    },
+    NonLogicalNewline,
+    String {
+        value: "b",
+        kind: String,
+        triple_quoted: false,
+    },
+    NonLogicalNewline,
+    NonLogicalNewline,
+    String {
+        value: "c",
+        kind: String,
+        triple_quoted: false,
+    },
+    String {
+        value: "d",
+        kind: String,
+        triple_quoted: false,
+    },
+    NonLogicalNewline,
+    Rpar,
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__numbers.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__numbers.snap
@@ -1,0 +1,42 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(source)
+---
+[
+    Int {
+        value: 47,
+    },
+    Int {
+        value: 10,
+    },
+    Int {
+        value: 13,
+    },
+    Int {
+        value: 0,
+    },
+    Int {
+        value: 123,
+    },
+    Int {
+        value: 1234567890,
+    },
+    Float {
+        value: 0.2,
+    },
+    Float {
+        value: 100.0,
+    },
+    Float {
+        value: 2100.0,
+    },
+    Complex {
+        real: 0.0,
+        imag: 2.0,
+    },
+    Complex {
+        real: 0.0,
+        imag: 2.2,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__operators.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__operators.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(source)
+---
+[
+    DoubleSlash,
+    DoubleSlash,
+    DoubleSlashEqual,
+    Slash,
+    Slash,
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string.snap
@@ -1,0 +1,52 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(source)
+---
+[
+    String {
+        value: "double",
+        kind: String,
+        triple_quoted: false,
+    },
+    String {
+        value: "single",
+        kind: String,
+        triple_quoted: false,
+    },
+    String {
+        value: "can\\'t",
+        kind: String,
+        triple_quoted: false,
+    },
+    String {
+        value: "\\\\\\\"",
+        kind: String,
+        triple_quoted: false,
+    },
+    String {
+        value: "\\t\\r\\n",
+        kind: String,
+        triple_quoted: false,
+    },
+    String {
+        value: "\\g",
+        kind: String,
+        triple_quoted: false,
+    },
+    String {
+        value: "raw\\'",
+        kind: RawString,
+        triple_quoted: false,
+    },
+    String {
+        value: "\\420",
+        kind: String,
+        triple_quoted: false,
+    },
+    String {
+        value: "\\200\\0a",
+        kind: String,
+        triple_quoted: false,
+    },
+    Newline,
+]


### PR DESCRIPTION
## Summary

This PR updates the lexer tests to use the snapshot testing framework. It also
makes the following changes:
* Remove the use of macros in the lexer tests
* Use `test_case` for EOL tests

## Test Plan

```
cargo test --package ruff_python_parser --lib --all-features -- lexer::tests --no-capture
```
