### PR TITLE
Avoid panic in unused arguments rule for parameter-free lambda

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_unused_arguments/ARG.py
+++ b/crates/ruff/resources/test/fixtures/flake8_unused_arguments/ARG.py
@@ -27,6 +27,8 @@ def f(cls, x):
 ###
 lambda x: print("Hello, world!")
 
+lambda: print("Hello, world!")
+
 
 class C:
     ###

--- a/crates/ruff/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
@@ -436,23 +436,22 @@ pub(crate) fn unused_arguments(
                 }
             }
         }
-        ScopeKind::Lambda(ast::ExprLambda {
-            parameters: Some(parameters),
-            ..
-        }) => {
-            if checker.enabled(Argumentable::Lambda.rule_code()) {
-                function(
-                    Argumentable::Lambda,
-                    parameters,
-                    scope,
-                    checker.semantic(),
-                    &checker.settings.dummy_variable_rgx,
-                    checker
-                        .settings
-                        .flake8_unused_arguments
-                        .ignore_variadic_names,
-                    diagnostics,
-                );
+        ScopeKind::Lambda(ast::ExprLambda { parameters, .. }) => {
+            if let Some(parameters) = parameters {
+                if checker.enabled(Argumentable::Lambda.rule_code()) {
+                    function(
+                        Argumentable::Lambda,
+                        parameters,
+                        scope,
+                        checker.semantic(),
+                        &checker.settings.dummy_variable_rgx,
+                        checker
+                            .settings
+                            .flake8_unused_arguments
+                            .ignore_variadic_names,
+                        diagnostics,
+                    );
+                }
             }
         }
         _ => panic!("Expected ScopeKind::Function | ScopeKind::Lambda"),

--- a/crates/ruff/src/rules/flake8_unused_arguments/snapshots/ruff__rules__flake8_unused_arguments__tests__ARG002_ARG.py.snap
+++ b/crates/ruff/src/rules/flake8_unused_arguments/snapshots/ruff__rules__flake8_unused_arguments__tests__ARG002_ARG.py.snap
@@ -1,40 +1,40 @@
 ---
 source: crates/ruff/src/rules/flake8_unused_arguments/mod.rs
 ---
-ARG.py:35:17: ARG002 Unused method argument: `x`
+ARG.py:37:17: ARG002 Unused method argument: `x`
    |
-33 |     # Unused arguments.
-34 |     ###
-35 |     def f(self, x):
+35 |     # Unused arguments.
+36 |     ###
+37 |     def f(self, x):
    |                 ^ ARG002
-36 |         print("Hello, world!")
+38 |         print("Hello, world!")
    |
 
-ARG.py:38:20: ARG002 Unused method argument: `x`
+ARG.py:40:20: ARG002 Unused method argument: `x`
    |
-36 |         print("Hello, world!")
-37 | 
-38 |     def f(self, /, x):
+38 |         print("Hello, world!")
+39 | 
+40 |     def f(self, /, x):
    |                    ^ ARG002
-39 |         print("Hello, world!")
+41 |         print("Hello, world!")
    |
 
-ARG.py:41:16: ARG002 Unused method argument: `x`
+ARG.py:43:16: ARG002 Unused method argument: `x`
    |
-39 |         print("Hello, world!")
-40 | 
-41 |     def f(cls, x):
+41 |         print("Hello, world!")
+42 | 
+43 |     def f(cls, x):
    |                ^ ARG002
-42 |         print("Hello, world!")
+44 |         print("Hello, world!")
    |
 
-ARG.py:190:24: ARG002 Unused method argument: `x`
+ARG.py:192:24: ARG002 Unused method argument: `x`
     |
-188 | ###
-189 | class C:
-190 |     def __init__(self, x) -> None:
+190 | ###
+191 | class C:
+192 |     def __init__(self, x) -> None:
     |                        ^ ARG002
-191 |         print("Hello, world!")
+193 |         print("Hello, world!")
     |
 
 

--- a/crates/ruff/src/rules/flake8_unused_arguments/snapshots/ruff__rules__flake8_unused_arguments__tests__ARG003_ARG.py.snap
+++ b/crates/ruff/src/rules/flake8_unused_arguments/snapshots/ruff__rules__flake8_unused_arguments__tests__ARG003_ARG.py.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/ruff/src/rules/flake8_unused_arguments/mod.rs
 ---
-ARG.py:45:16: ARG003 Unused class method argument: `x`
+ARG.py:47:16: ARG003 Unused class method argument: `x`
    |
-44 |     @classmethod
-45 |     def f(cls, x):
+46 |     @classmethod
+47 |     def f(cls, x):
    |                ^ ARG003
-46 |         print("Hello, world!")
+48 |         print("Hello, world!")
    |
 
 

--- a/crates/ruff/src/rules/flake8_unused_arguments/snapshots/ruff__rules__flake8_unused_arguments__tests__ARG004_ARG.py.snap
+++ b/crates/ruff/src/rules/flake8_unused_arguments/snapshots/ruff__rules__flake8_unused_arguments__tests__ARG004_ARG.py.snap
@@ -1,28 +1,28 @@
 ---
 source: crates/ruff/src/rules/flake8_unused_arguments/mod.rs
 ---
-ARG.py:49:11: ARG004 Unused static method argument: `cls`
+ARG.py:51:11: ARG004 Unused static method argument: `cls`
    |
-48 |     @staticmethod
-49 |     def f(cls, x):
+50 |     @staticmethod
+51 |     def f(cls, x):
    |           ^^^ ARG004
-50 |         print("Hello, world!")
+52 |         print("Hello, world!")
    |
 
-ARG.py:49:16: ARG004 Unused static method argument: `x`
+ARG.py:51:16: ARG004 Unused static method argument: `x`
    |
-48 |     @staticmethod
-49 |     def f(cls, x):
+50 |     @staticmethod
+51 |     def f(cls, x):
    |                ^ ARG004
-50 |         print("Hello, world!")
+52 |         print("Hello, world!")
    |
 
-ARG.py:53:11: ARG004 Unused static method argument: `x`
+ARG.py:55:11: ARG004 Unused static method argument: `x`
    |
-52 |     @staticmethod
-53 |     def f(x):
+54 |     @staticmethod
+55 |     def f(x):
    |           ^ ARG004
-54 |         print("Hello, world!")
+56 |         print("Hello, world!")
    |
 
 

--- a/crates/ruff/src/rules/flake8_unused_arguments/snapshots/ruff__rules__flake8_unused_arguments__tests__ARG005_ARG.py.snap
+++ b/crates/ruff/src/rules/flake8_unused_arguments/snapshots/ruff__rules__flake8_unused_arguments__tests__ARG005_ARG.py.snap
@@ -7,6 +7,8 @@ ARG.py:28:8: ARG005 Unused lambda argument: `x`
 27 | ###
 28 | lambda x: print("Hello, world!")
    |        ^ ARG005
+29 | 
+30 | lambda: print("Hello, world!")
    |
 
 


### PR DESCRIPTION
## Summary

This was just a mistake in pattern-matching with no test coverage.

## Test Plan

`cargo test`
