### PR TITLE
Fix typo in `ruff_python_formatter` documentation

### DIFF
--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -41,7 +41,7 @@ include!("../../ruff_formatter/shared_traits.rs");
 /// 'ast is the lifetime of the source code (input), 'buf is the lifetime of the buffer (output)
 pub(crate) type PyFormatter<'ast, 'buf> = Formatter<'buf, PyFormatContext<'ast>>;
 
-/// Rule for formatting a JavaScript [`AstNode`].
+/// Rule for formatting a Python [`AstNode`].
 pub(crate) trait FormatNodeRule<N>
 where
     N: AstNode,


### PR DESCRIPTION
## Summary

In the documentation was written `Javascript` but we are working with `Python` here :)

## Test Plan

n/a
