### PR TITLE
Parenthesize NamedExpr if target breaks

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/named_expr.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/named_expr.py
@@ -47,6 +47,13 @@ if (
 ):
     pass
 
+if (
+    x # 2
+    := # 3
+    y
+):
+    pass
+
 y0 = (y1 := f(x))
 
 f(x:=y, z=True)

--- a/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
@@ -75,7 +75,7 @@ impl NeedsParentheses for ExprNamedExpr {
         {
             OptionalParentheses::Always
         } else {
-            OptionalParentheses::Never
+            OptionalParentheses::Multiline
         }
     }
 }

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__named_expr.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__named_expr.py.snap
@@ -53,6 +53,13 @@ if (
 ):
     pass
 
+if (
+    x # 2
+    := # 3
+    y
+):
+    pass
+
 y0 = (y1 := f(x))
 
 f(x:=y, z=True)
@@ -146,6 +153,13 @@ if (
     (  # 4
         y  # 5
     )  # 6
+):
+    pass
+
+if (
+    x  # 2
+    :=  # 3
+    y
 ):
     pass
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR fixes an issue where a `NamedExpr` wasn't parenthesized if the target breaks (e.g. because of a trailing comment)

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Added test

<!-- How was it tested? -->
