### PR TITLE
Fix `fmt:skip` for function with return type

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_skip/type_params.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_skip/type_params.py
@@ -26,3 +26,13 @@ def test  [
     B,
 ]  (): # fmt: skip
     ...
+
+def test  [
+    # comment
+    A,
+
+    # another
+
+    B,
+]  () -> str: # fmt: skip
+    ...

--- a/crates/ruff_python_formatter/src/statement/clause.rs
+++ b/crates/ruff_python_formatter/src/statement/clause.rs
@@ -108,13 +108,17 @@ impl<'a> ClauseHeader<'a> {
                 is_async: _,
                 decorator_list: _,
                 name: _,
-                returns: _,
+                returns,
                 body: _,
             }) => {
                 if let Some(type_params) = type_params.as_ref() {
                     visit(type_params, visitor);
                 }
                 visit(parameters.as_ref(), visitor);
+
+                if let Some(returns) = returns.as_deref() {
+                    visit(returns, visitor);
+                }
             }
             ClauseHeader::If(StmtIf {
                 test,

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_skip__type_params.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_skip__type_params.py.snap
@@ -32,6 +32,16 @@ def test  [
     B,
 ]  (): # fmt: skip
     ...
+
+def test  [
+    # comment
+    A,
+
+    # another
+
+    B,
+]  () -> str: # fmt: skip
+    ...
 ```
 
 ## Output
@@ -66,6 +76,17 @@ def test  [
 
     B,
 ]  ():  # fmt: skip
+    ...
+
+
+def test  [
+    # comment
+    A,
+
+    # another
+
+    B,
+]  () -> str:  # fmt: skip
     ...
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes the `:` extraction for a function definition with a return type annotation.

closes https://github.com/astral-sh/ruff/issues/6726

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Added a new test

<!-- How was it tested? -->
