### PR TITLE
Parenthesize unsplittable nodes if it makes them fit

### DIFF
--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -2399,6 +2399,7 @@ impl<'a, 'buf, Context> FillBuilder<'a, 'buf, Context> {
 #[derive(Copy, Clone)]
 pub struct BestFitting<'a, Context> {
     variants: Arguments<'a, Context>,
+    mode: BestFittingMode,
 }
 
 impl<'a, Context> BestFitting<'a, Context> {
@@ -2418,7 +2419,115 @@ impl<'a, Context> BestFitting<'a, Context> {
             "Requires at least the least expanded and most expanded variants"
         );
 
-        Self { variants }
+        Self {
+            variants,
+            mode: BestFittingMode::default(),
+        }
+    }
+
+    /// Changes the mode used by this best fitting element to determine whether a variant fits.
+    ///
+    /// ## Examples
+    ///
+    /// ### All Lines
+    ///
+    /// ```
+    /// use ruff_formatter::{Formatted, LineWidth, format, format_args, SimpleFormatOptions};
+    /// use ruff_formatter::prelude::*;
+    ///
+    /// # fn main() -> FormatResult<()> {
+    /// let formatted = format!(
+    ///     SimpleFormatContext::default(),
+    ///     [
+    ///         best_fitting!(
+    ///             // Everything fits on a single line
+    ///             format_args!(
+    ///                 group(&format_args![
+    ///                     text("["),
+    ///                         soft_block_indent(&format_args![
+    ///                         text("1,"),
+    ///                         soft_line_break_or_space(),
+    ///                         text("2,"),
+    ///                         soft_line_break_or_space(),
+    ///                         text("3"),
+    ///                     ]),
+    ///                     text("]")
+    ///                 ]),
+    ///                 space(),
+    ///                 text("+"),
+    ///                 space(),
+    ///                 text("aVeryLongIdentifier")
+    ///             ),
+    ///
+    ///             // Breaks after `[` and prints each elements on a single line
+    ///             // The group is necessary because the variant, by default is printed in flat mode and a
+    ///             // hard line break indicates that the content doesn't fit.
+    ///             format_args!(
+    ///                 text("["),
+    ///                 group(&block_indent(&format_args![text("1,"), hard_line_break(), text("2,"), hard_line_break(), text("3")])).should_expand(true),
+    ///                 text("]"),
+    ///                 space(),
+    ///                 text("+"),
+    ///                 space(),
+    ///                 text("aVeryLongIdentifier")
+    ///             ),
+    ///
+    ///             // Adds parentheses and indents the body, breaks after the operator
+    ///             format_args!(
+    ///                 text("("),
+    ///                 block_indent(&format_args![
+    ///                     text("["),
+    ///                     block_indent(&format_args![
+    ///                         text("1,"),
+    ///                         hard_line_break(),
+    ///                         text("2,"),
+    ///                         hard_line_break(),
+    ///                         text("3"),
+    ///                     ]),
+    ///                     text("]"),
+    ///                     hard_line_break(),
+    ///                     text("+"),
+    ///                     space(),
+    ///                     text("aVeryLongIdentifier")
+    ///                 ]),
+    ///                 text(")")
+    ///             )
+    ///         ).with_mode(BestFittingMode::AllLines)
+    ///     ]
+    /// )?;
+    ///
+    /// let document = formatted.into_document();
+    ///
+    /// // Takes the first variant if everything fits on a single line
+    /// assert_eq!(
+    ///     "[1, 2, 3] + aVeryLongIdentifier",
+    ///     Formatted::new(document.clone(), SimpleFormatContext::default())
+    ///         .print()?
+    ///         .as_code()
+    /// );
+    ///
+    /// // It takes the second if the first variant doesn't fit on a single line. The second variant
+    /// // has some additional line breaks to make sure inner groups don't break
+    /// assert_eq!(
+    ///     "[\n\t1,\n\t2,\n\t3\n] + aVeryLongIdentifier",
+    ///     Formatted::new(document.clone(), SimpleFormatContext::new(SimpleFormatOptions { line_width: 23.try_into().unwrap(), ..SimpleFormatOptions::default() }))
+    ///         .print()?
+    ///         .as_code()
+    /// );
+    ///
+    /// // Prints the last option as last resort
+    /// assert_eq!(
+    ///     "(\n\t[\n\t\t1,\n\t\t2,\n\t\t3\n\t]\n\t+ aVeryLongIdentifier\n)",
+    ///     Formatted::new(document.clone(), SimpleFormatContext::new(SimpleFormatOptions { line_width: 22.try_into().unwrap(), ..SimpleFormatOptions::default() }))
+    ///         .print()?
+    ///         .as_code()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_mode(mut self, mode: BestFittingMode) -> Self {
+        self.mode = mode;
+        self
     }
 }
 
@@ -2445,6 +2554,7 @@ impl<Context> Format<Context> for BestFitting<'_, Context> {
                 variants: format_element::BestFittingVariants::from_vec_unchecked(
                     formatted_variants,
                 ),
+                mode: self.mode,
             }
         };
 

--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -2525,6 +2525,7 @@ impl<'a, Context> BestFitting<'a, Context> {
     /// # Ok(())
     /// # }
     /// ```
+    #[must_use]
     pub fn with_mode(mut self, mode: BestFittingMode) -> Self {
         self.mode = mode;
         self

--- a/crates/ruff_formatter/src/format_element.rs
+++ b/crates/ruff_formatter/src/format_element.rs
@@ -57,7 +57,10 @@ pub enum FormatElement {
 
     /// A list of different variants representing the same content. The printer picks the best fitting content.
     /// Line breaks inside of a best fitting don't propagate to parent groups.
-    BestFitting { variants: BestFittingVariants },
+    BestFitting {
+        variants: BestFittingVariants,
+        mode: BestFittingMode,
+    },
 
     /// A [Tag] that marks the start/end of some content to which some special formatting is applied.
     Tag(Tag),
@@ -84,9 +87,10 @@ impl std::fmt::Debug for FormatElement {
                 .field(contains_newlines)
                 .finish(),
             FormatElement::LineSuffixBoundary => write!(fmt, "LineSuffixBoundary"),
-            FormatElement::BestFitting { variants } => fmt
+            FormatElement::BestFitting { variants, mode } => fmt
                 .debug_struct("BestFitting")
                 .field("variants", variants)
+                .field("mode", &mode)
                 .finish(),
             FormatElement::Interned(interned) => fmt.debug_list().entries(&**interned).finish(),
             FormatElement::Tag(tag) => fmt.debug_tuple("Tag").field(tag).finish(),
@@ -293,6 +297,29 @@ impl FormatElements for FormatElement {
             _ => None,
         }
     }
+}
+
+/// Mode used to determine if any variant (except the most expanded) fits for [`BestFittingVariants`].
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+pub enum BestFittingMode {
+    /// The variant fits if the content up to the first hard or a soft line break inside a [`Group`] with
+    /// [`PrintMode::Expanded`] fits on the line. The default mode.
+    ///
+    /// [`Group`]: tag::Group
+    #[default]
+    FirstLine,
+
+    /// A variant fits if all lines fit into the configured print width. A line ends if by any
+    /// hard or a soft line break inside a [`Group`] with [`PrintMode::Expanded`].
+    /// The content doesn't fit if there's any hard line break  outside a [`Group`] with [`PrintMode::Expanded`]
+    /// (a hard line break in content that should be considered in [`PrintMode::Flat`].
+    ///
+    /// Use this mode with caution as it requires measuring all content of the variant which is more
+    /// expensive than using [`BestFittingMode::FirstLine`].
+    ///
+    /// [`Group`]: tag::Group
+    AllLines,
 }
 
 /// The different variants for this element.

--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -81,7 +81,7 @@ impl Document {
                             interned_expands
                         }
                     }
-                    FormatElement::BestFitting { variants } => {
+                    FormatElement::BestFitting { variants, mode: _ } => {
                         enclosing.push(Enclosing::BestFitting);
 
                         for variant in variants {
@@ -326,7 +326,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                     write!(f, [text("line_suffix_boundary")])?;
                 }
 
-                FormatElement::BestFitting { variants } => {
+                FormatElement::BestFitting { variants, mode } => {
                     write!(f, [text("best_fitting([")])?;
                     f.write_elements([
                         FormatElement::Tag(StartIndent),
@@ -341,6 +341,16 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                         FormatElement::Tag(EndIndent),
                         FormatElement::Line(LineMode::Hard),
                     ]);
+
+                    if *mode != BestFittingMode::FirstLine {
+                        write!(
+                            f,
+                            [
+                                dynamic_text(&std::format!("mode: {mode:?},"), None),
+                                space()
+                            ]
+                        )?;
+                    }
 
                     write!(f, [text("])")])?;
                 }

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/named_expr.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/named_expr.py
@@ -47,6 +47,13 @@ if (
 ):
     pass
 
+if (
+    x # 2
+    := # 3
+    y
+):
+    pass
+
 y0 = (y1 := f(x))
 
 f(x:=y, z=True)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unary.py
@@ -140,3 +140,9 @@ if not \
 # Regression: https://github.com/astral-sh/ruff/issues/5338
 if a and not aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
     ...
+
+if (
+  not
+  # comment
+  a):
+    ...

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unspittable.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unspittable.py
@@ -1,0 +1,54 @@
+x = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+x_aa = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+xxxxx = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+while (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    pass
+
+while aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+    pass
+
+# Only applies in `Parenthesize::IfBreaks` positions
+raise aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+raise (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+)
+
+raise a from aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+raise a from aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+# Can never apply on expression statement level
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+# Is it only relevant for items that can't break
+
+aaaaaaa = 111111111111111111111111111111111111111111111111111111111111111111111111111111
+aaaaaaa = (
+    1111111111111111111111111111111111111111111111111111111111111111111111111111111
+)
+
+aaaaaaa = """111111111111111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111111111111111111111111"""
+
+# Never parenthesize multiline strings
+aaaaaaa = (
+    """1111111111111111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111111111111111111111111"""
+)
+
+
+
+aaaaaaaa = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbb
+aaaaaaaa = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+aaaaaaaa = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+
+for converter in connection.ops.get_db_converters(
+    expression
+) + expression.get_db_converters(connection):
+    ...

--- a/crates/ruff_python_formatter/src/expression/expr_call.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_call.rs
@@ -69,7 +69,10 @@ impl NeedsParentheses for ExprCall {
         {
             OptionalParentheses::Multiline
         } else {
-            self.func.needs_parentheses(self.into(), context)
+            match self.func.needs_parentheses(self.into(), context) {
+                OptionalParentheses::IfFits => OptionalParentheses::Never,
+                parentheses => parentheses,
+            }
         }
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_name.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_name.rs
@@ -2,7 +2,7 @@ use crate::comments::SourceComment;
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 use crate::FormatNodeRule;
-use ruff_formatter::{write, FormatContext};
+use ruff_formatter::{write, FormatContext, FormatOptions};
 use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::ExprName;
 
@@ -38,9 +38,14 @@ impl NeedsParentheses for ExprName {
     fn needs_parentheses(
         &self,
         _parent: AnyNodeRef,
-        _context: &PyFormatContext,
+        context: &PyFormatContext,
     ) -> OptionalParentheses {
-        OptionalParentheses::Never
+        let text = &context.source()[self.range];
+        if text.len() < context.options().line_width().value() as usize && text.len() > 10 {
+            OptionalParentheses::IfFits
+        } else {
+            OptionalParentheses::Never
+        }
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
@@ -75,7 +75,7 @@ impl NeedsParentheses for ExprNamedExpr {
         {
             OptionalParentheses::Always
         } else {
-            OptionalParentheses::Never
+            OptionalParentheses::Multiline
         }
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_subscript.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_subscript.rs
@@ -101,7 +101,10 @@ impl NeedsParentheses for ExprSubscript {
             {
                 OptionalParentheses::Multiline
             } else {
-                self.value.needs_parentheses(self.into(), context)
+                match self.value.needs_parentheses(self.into(), context) {
+                    OptionalParentheses::IfFits => OptionalParentheses::Never,
+                    parentheses => parentheses,
+                }
             }
         }
     }

--- a/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
@@ -3,7 +3,7 @@ use ruff_python_ast::{ExprUnaryOp, Ranged};
 use ruff_text_size::{TextLen, TextRange};
 
 use ruff_formatter::prelude::{hard_line_break, space, text};
-use ruff_formatter::{Format, FormatContext, FormatResult};
+use ruff_formatter::{Format, FormatResult};
 use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
 
@@ -57,7 +57,7 @@ impl FormatNodeRule<ExprUnaryOp> for FormatExprUnaryOp {
         //  a)
         // ```
         if !leading_operand_comments.is_empty()
-            && !is_operand_parenthesized(item, f.context().source_code().as_str())
+            && !is_operand_parenthesized(item, f.context().source())
         {
             hard_line_break().fmt(f)?;
         } else if op.is_not() {

--- a/crates/ruff_python_formatter/src/expression/parentheses.rs
+++ b/crates/ruff_python_formatter/src/expression/parentheses.rs
@@ -15,11 +15,16 @@ pub(crate) enum OptionalParentheses {
     /// Add parentheses if the expression expands over multiple lines
     Multiline,
 
-    /// Always set parentheses regardless if the expression breaks or if they were
+    /// Always set parentheses regardless if the expression breaks or if they are
     /// present in the source.
     Always,
 
-    /// Never add parentheses
+    /// Add parentheses if it helps to make this expression fit. Otherwise never add parentheses.
+    /// This mode should only be used for expressions that don't have their own split points, e.g. identifiers,
+    /// or constants.
+    IfFits,
+
+    /// Never add parentheses. Use it for expressions that have their own parentheses or if the expression body always spans multiple lines (multiline strings).
     Never,
 }
 
@@ -49,6 +54,7 @@ pub(crate) enum Parenthesize {
     /// Parenthesizes the expression if the group doesn't fit on a line (e.g., even name expressions are parenthesized), or if
     /// the expression doesn't break, but _does_ reports that it always requires parentheses in this position (e.g., walrus
     /// operators in function return annotations).
+    // TODO can this be replaced by IfBreaks
     IfBreaksOrIfRequired,
 }
 

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -243,12 +243,10 @@ if True:
     #[test]
     fn quick_test() {
         let src = r#"
-@MyDecorator(list = a) # fmt: skip
-# trailing comment
-class Test:
-    pass
-
-
+for converter in connection.ops.get_db_converters(
+    expression
+) + expression.get_db_converters(connection):
+    ...
 "#;
         // Tokenize once
         let mut tokens = Vec::new();
@@ -285,9 +283,10 @@ class Test:
 
         assert_eq!(
             printed.as_code(),
-            r#"while True:
-    if something.changed:
-        do.stuff()  # trailing comment
+            r#"for converter in connection.ops.get_db_converters(
+    expression
+) + expression.get_db_converters(connection):
+    ...
 "#
         );
     }

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__remove_parens.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__remove_parens.py.snap
@@ -80,24 +80,6 @@ def example8():
          except Exception as e:
              pass
  
-@@ -30,15 +32,11 @@
- 
- 
- def example2():
--    return (
--        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
--    )
-+    return "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
- 
- 
- def example3():
--    return (
--        1111111111111111111111111111111111111111111111111111111111111111111111111111111
--    )
-+    return 1111111111111111111111111111111111111111111111111111111111111111111111111111111
- 
- 
- def example4():
 ```
 
 ## Ruff Output
@@ -137,11 +119,15 @@ def example1point5():
 
 
 def example2():
-    return "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    return (
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    )
 
 
 def example3():
-    return 1111111111111111111111111111111111111111111111111111111111111111111111111111111
+    return (
+        1111111111111111111111111111111111111111111111111111111111111111111111111111111
+    )
 
 
 def example4():

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__trailing_commas_in_leading_parts.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__trailing_commas_in_leading_parts.py.snap
@@ -56,14 +56,6 @@ assert xxxxxxxxx.xxxxxxxxx.xxxxxxxxx(
  
  
  # Example from https://github.com/psf/black/issues/3229
-@@ -45,6 +43,4 @@
- # Regression test for https://github.com/psf/black/issues/3414.
- assert xxxxxxxxx.xxxxxxxxx.xxxxxxxxx(
-     xxxxxxxxx
--).xxxxxxxxxxxxxxxxxx(), (
--    "xxx {xxxxxxxxx} xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
--)
-+).xxxxxxxxxxxxxxxxxx(), "xxx {xxxxxxxxx} xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
 
 ## Ruff Output
@@ -114,7 +106,9 @@ assert (
 # Regression test for https://github.com/psf/black/issues/3414.
 assert xxxxxxxxx.xxxxxxxxx.xxxxxxxxx(
     xxxxxxxxx
-).xxxxxxxxxxxxxxxxxx(), "xxx {xxxxxxxxx} xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+).xxxxxxxxxxxxxxxxxx(), (
+    "xxx {xxxxxxxxx} xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+)
 ```
 
 ## Black Output

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__named_expr.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__named_expr.py.snap
@@ -53,6 +53,13 @@ if (
 ):
     pass
 
+if (
+    x # 2
+    := # 3
+    y
+):
+    pass
+
 y0 = (y1 := f(x))
 
 f(x:=y, z=True)
@@ -146,6 +153,13 @@ if (
     (  # 4
         y  # 5
     )  # 6
+):
+    pass
+
+if (
+    x  # 2
+    :=  # 3
+    y
 ):
     pass
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__unary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__unary.py.snap
@@ -146,6 +146,12 @@ if not \
 # Regression: https://github.com/astral-sh/ruff/issues/5338
 if a and not aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
     ...
+
+if (
+  not
+  # comment
+  a):
+    ...
 ```
 
 ## Output
@@ -302,6 +308,13 @@ if (
     a
     and not aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    ...
+
+if (
+    not
+    # comment
+    a
 ):
     ...
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__unspittable.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__unspittable.py.snap
@@ -1,0 +1,126 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unspittable.py
+---
+## Input
+```py
+x = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+x_aa = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+xxxxx = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+while (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    pass
+
+while aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+    pass
+
+# Only applies in `Parenthesize::IfBreaks` positions
+raise aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+raise (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+)
+
+raise a from aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+raise a from aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+# Can never apply on expression statement level
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+# Is it only relevant for items that can't break
+
+aaaaaaa = 111111111111111111111111111111111111111111111111111111111111111111111111111111
+aaaaaaa = (
+    1111111111111111111111111111111111111111111111111111111111111111111111111111111
+)
+
+aaaaaaa = """111111111111111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111111111111111111111111"""
+
+# Never parenthesize multiline strings
+aaaaaaa = (
+    """1111111111111111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111111111111111111111111"""
+)
+
+
+
+aaaaaaaa = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbb
+aaaaaaaa = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+aaaaaaaa = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+
+for converter in connection.ops.get_db_converters(
+    expression
+) + expression.get_db_converters(connection):
+    ...
+```
+
+## Output
+```py
+x = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+x_aa = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+xxxxx = (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+)
+
+while (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
+    pass
+
+while aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+    pass
+
+# Only applies in `Parenthesize::IfBreaks` positions
+raise aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+raise (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+)
+
+raise a from aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+raise a from aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+# Can never apply on expression statement level
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+# Is it only relevant for items that can't break
+
+aaaaaaa = 111111111111111111111111111111111111111111111111111111111111111111111111111111
+aaaaaaa = (
+    1111111111111111111111111111111111111111111111111111111111111111111111111111111
+)
+
+aaaaaaa = """111111111111111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111111111111111111111111"""
+
+# Never parenthesize multiline strings
+aaaaaaa = """1111111111111111111111111111111111111111111111111111111111111111111111111111
+1111111111111111111111111111111111111111111111111111111111111111111111111111111111111"""
+
+
+aaaaaaaa = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbb
+aaaaaaaa = (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+)
+
+aaaaaaaa = (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+)
+
+
+for converter in connection.ops.get_db_converters(
+    expression
+) + expression.get_db_converters(connection):
+    ...
+```
+
+
+


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR implements black's logic where it parenthesizes unsplittable nodes like constants or identifiers
if it makes them fit the line

closes https://github.com/astral-sh/ruff/issues/6271

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I added new test plans, diffed the output for `django` to ensure this PR introduces no regression, and verified that the similarity indices improve

**main**

| project      | similarity index |
|--------------|------------------|
| cpython      | 0.75473          |
| django       | 0.99805          |
| transformers | 0.99620          |
| twine        | 0.99876          |
| typeshed     | 0.99953          |
| warehouse    | 0.99601          |
| zulip        | 0.99727          |

**This PR**

| project      | similarity index |
|--------------|------------------|
| cpython      | 0.75475          |
| django       | 0.99880          |
| transformers | 0.99629          |
| twine        | 0.99929          |
| typeshed     | 0.99953          |
| warehouse    | 0.99613          |
| zulip        | 0.99852          |


<!-- How was it tested? -->
