### PR TITLE
Don't trigger `eq-without-hash` when `__hash__` is explicitly set to `None`

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/eq_without_hash.py
+++ b/crates/ruff/resources/test/fixtures/pylint/eq_without_hash.py
@@ -1,10 +1,11 @@
-class Person:
+class Person:  # [eq-without-hash]
     def __init__(self):
         self.name = "monty"
 
     def __eq__(self, other):
         return isinstance(other, Person) and other.name == self.name
 
+# OK
 class Language:
     def __init__(self):
         self.name = "python"
@@ -14,3 +15,9 @@ class Language:
 
     def __hash__(self):
         return hash(self.name)
+
+class MyClass:
+    def __eq__(self, other):
+        return True
+
+    __hash__ = None

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLW1641_eq_without_hash.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLW1641_eq_without_hash.py.snap
@@ -3,7 +3,7 @@ source: crates/ruff/src/rules/pylint/mod.rs
 ---
 eq_without_hash.py:1:7: PLW1641 Object does not implement `__hash__` method
   |
-1 | class Person:
+1 | class Person:  # [eq-without-hash]
   |       ^^^^^^ PLW1641
 2 |     def __init__(self):
 3 |         self.name = "monty"


### PR DESCRIPTION
## Summary
Closes #6701 

## Test Plan

`cargo test`
