### PR TITLE
Format `PatternMatchSingleton`

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
@@ -141,3 +141,20 @@ match pattern_comments:
     no_comments
     ):
         pass
+
+
+match pattern_singleton:
+    case (
+        # leading 1
+        # leading 2
+        None  # trailing
+        # trailing own 1
+        # trailing own 2
+    ):
+        pass
+    case (
+        True  # trailing
+    ):
+        ...
+    case False:
+        ...

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_singleton.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_singleton.rs
@@ -1,13 +1,18 @@
-use ruff_formatter::{write, Buffer, FormatResult};
-use ruff_python_ast::PatternMatchSingleton;
+use crate::prelude::*;
+use ruff_python_ast::{Constant, PatternMatchSingleton};
 
-use crate::{not_yet_implemented_custom_text, FormatNodeRule, PyFormatter};
+use crate::{FormatNodeRule, PyFormatter};
 
 #[derive(Default)]
 pub struct FormatPatternMatchSingleton;
 
 impl FormatNodeRule<PatternMatchSingleton> for FormatPatternMatchSingleton {
     fn fmt_fields(&self, item: &PatternMatchSingleton, f: &mut PyFormatter) -> FormatResult<()> {
-        write!(f, [not_yet_implemented_custom_text("None", item)])
+        match item.value {
+            Constant::None => text("None").fmt(f),
+            Constant::Bool(true) => text("True").fmt(f),
+            Constant::Bool(false) => text("False").fmt(f),
+            _ => unreachable!(),
+        }
     }
 }

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_complex.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_complex.py.snap
@@ -292,7 +292,7 @@ match x:
          y = 0
  # case black_test_patma_232
  match x:
-@@ -108,37 +108,37 @@
+@@ -108,7 +108,7 @@
          y = 0
  # case black_test_patma_058
  match x:
@@ -301,8 +301,7 @@ match x:
          y = 0
  # case black_test_patma_233
  match x:
--    case False:
-+    case None:
+@@ -116,29 +116,29 @@
          y = 0
  # case black_test_patma_078
  match x:
@@ -460,7 +459,7 @@ match x:
         y = 0
 # case black_test_patma_233
 match x:
-    case None:
+    case False:
         y = 0
 # case black_test_patma_078
 match x:

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -147,6 +147,23 @@ match pattern_comments:
     no_comments
     ):
         pass
+
+
+match pattern_singleton:
+    case (
+        # leading 1
+        # leading 2
+        None  # trailing
+        # trailing own 1
+        # trailing own 2
+    ):
+        pass
+    case (
+        True  # trailing
+    ):
+        ...
+    case False:
+        ...
 ```
 
 ## Output
@@ -285,6 +302,23 @@ match pattern_comments:
 match pattern_comments:
     case (x as NOT_YET_IMPLEMENTED_PatternMatchAs):
         pass
+
+
+match pattern_singleton:
+    case (
+        # leading 1
+        # leading 2
+        None  # trailing
+        # trailing own 1
+        # trailing own 2
+    ):
+        pass
+    case (
+        True  # trailing
+    ):
+        ...
+    case False:
+        ...
 ```
 
 


### PR DESCRIPTION
## Summary
There's a case where a trailing comment ins't formatted like in Black. Consider the following code:
```python
match x:
    case (
            None # trailing
            ):
        ...
```

Black formats to
```python
match x:
    case (None):  # trailing
        ...
```

And Ruff will format to
```python
match x:
    case (
        None  # trailing
    ):
        ...
```
Closes #6557

## Test Plan

`cargo test`
