### PR TITLE
Ignore star imports when importing symbols in fixes

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/sys_exit_alias_11.py
+++ b/crates/ruff/resources/test/fixtures/pylint/sys_exit_alias_11.py
@@ -1,0 +1,3 @@
+from sys import *
+
+exit(0)

--- a/crates/ruff/src/importer/mod.rs
+++ b/crates/ruff/src/importer/mod.rs
@@ -301,12 +301,14 @@ impl<'a> Importer<'a> {
             }
             if let Stmt::ImportFrom(ast::StmtImportFrom {
                 module: name,
+                names,
                 level,
-                ..
+                range: _,
             }) = stmt
             {
                 if level.map_or(true, |level| level.to_u32() == 0)
                     && name.as_ref().is_some_and(|name| name == module)
+                    && names.iter().all(|alias| alias.name.as_str() != "*")
                 {
                     import_from = Some(*stmt);
                 }

--- a/crates/ruff/src/rules/pylint/mod.rs
+++ b/crates/ruff/src/rules/pylint/mod.rs
@@ -50,6 +50,7 @@ mod tests {
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_8.py"))]
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_9.py"))]
     #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_10.py"))]
+    #[test_case(Rule::SysExitAlias, Path::new("sys_exit_alias_11.py"))]
     #[test_case(Rule::ContinueInFinally, Path::new("continue_in_finally.py"))]
     #[test_case(Rule::GlobalStatement, Path::new("global_statement.py"))]
     #[test_case(

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_11.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_11.py.snap
@@ -1,0 +1,20 @@
+---
+source: crates/ruff/src/rules/pylint/mod.rs
+---
+sys_exit_alias_11.py:3:1: PLR1722 [*] Use `sys.exit()` instead of `exit`
+  |
+1 | from sys import *
+2 | 
+3 | exit(0)
+  | ^^^^ PLR1722
+  |
+  = help: Replace `exit` with `sys.exit()`
+
+ℹ Suggested fix
+1 1 | from sys import *
+  2 |+import sys
+2 3 | 
+3   |-exit(0)
+  4 |+sys.exit(0)
+
+

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_5.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_5.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/pylint/mod.rs
 ---
-sys_exit_alias_5.py:3:1: PLR1722 Use `sys.exit()` instead of `exit`
+sys_exit_alias_5.py:3:1: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
 1 | from sys import *
 2 | 
@@ -11,7 +11,17 @@ sys_exit_alias_5.py:3:1: PLR1722 Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-sys_exit_alias_5.py:4:1: PLR1722 Use `sys.exit()` instead of `quit`
+ℹ Suggested fix
+1 1 | from sys import *
+  2 |+import sys
+2 3 | 
+3   |-exit(0)
+  4 |+sys.exit(0)
+4 5 | quit(0)
+5 6 | 
+6 7 | 
+
+sys_exit_alias_5.py:4:1: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
 3 | exit(0)
 4 | quit(0)
@@ -19,7 +29,18 @@ sys_exit_alias_5.py:4:1: PLR1722 Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-sys_exit_alias_5.py:8:5: PLR1722 Use `sys.exit()` instead of `exit`
+ℹ Suggested fix
+1 1 | from sys import *
+  2 |+import sys
+2 3 | 
+3 4 | exit(0)
+4   |-quit(0)
+  5 |+sys.exit(0)
+5 6 | 
+6 7 | 
+7 8 | def main():
+
+sys_exit_alias_5.py:8:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
 7 | def main():
 8 |     exit(1)
@@ -28,7 +49,20 @@ sys_exit_alias_5.py:8:5: PLR1722 Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-sys_exit_alias_5.py:9:5: PLR1722 Use `sys.exit()` instead of `quit`
+ℹ Suggested fix
+1  1  | from sys import *
+   2  |+import sys
+2  3  | 
+3  4  | exit(0)
+4  5  | quit(0)
+5  6  | 
+6  7  | 
+7  8  | def main():
+8     |-    exit(1)
+   9  |+    sys.exit(1)
+9  10 |     quit(1)
+
+sys_exit_alias_5.py:9:5: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
 7 | def main():
 8 |     exit(1)
@@ -36,5 +70,18 @@ sys_exit_alias_5.py:9:5: PLR1722 Use `sys.exit()` instead of `quit`
   |     ^^^^ PLR1722
   |
   = help: Replace `quit` with `sys.exit()`
+
+ℹ Suggested fix
+1  1  | from sys import *
+   2  |+import sys
+2  3  | 
+3  4  | exit(0)
+4  5  | quit(0)
+--------------------------------------------------------------------------------
+6  7  | 
+7  8  | def main():
+8  9  |     exit(1)
+9     |-    quit(1)
+   10 |+    sys.exit(1)
 
 


### PR DESCRIPTION
## Summary

Given:

```python
from sys import *

exit(0)
```

We can't add `exit` to `from sys import *`, so we should just ignore it. Ideally, we'd just resolve `exit` in the first place (since it's imported from `from sys import *`), but as long as we don't support wildcard imports, this is more consistent.

Closes https://github.com/astral-sh/ruff/issues/6718.

## Test Plan

`cargo test`
