### PR TITLE
Avoid attempting to fix unconventional submodule imports

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_import_conventions/defaults.py
+++ b/crates/ruff/resources/test/fixtures/flake8_import_conventions/defaults.py
@@ -1,22 +1,29 @@
-import math  # not checked
+def not_checked():
+    import math
 
-import altair  # unconventional
-import matplotlib.pyplot  # unconventional
-import numpy  # unconventional
-import pandas  # unconventional
-import seaborn  # unconventional
-import tkinter  # unconventional
 
-import altair as altr  # unconventional
-import matplotlib.pyplot as plot  # unconventional
-import numpy as nmp  # unconventional
-import pandas as pdas  # unconventional
-import seaborn as sbrn  # unconventional
-import tkinter as tkr  # unconventional
+def unconventional():
+    import altair
+    import matplotlib.pyplot
+    import numpy
+    import pandas
+    import seaborn
+    import tkinter
 
-import altair as alt  # conventional
-import matplotlib.pyplot as plt  # conventional
-import numpy as np  # conventional
-import pandas as pd  # conventional
-import seaborn as sns  # conventional
-import tkinter as tk  # conventional
+
+def unconventional_aliases():
+    import altair as altr
+    import matplotlib.pyplot as plot
+    import numpy as nmp
+    import pandas as pdas
+    import seaborn as sbrn
+    import tkinter as tkr
+
+
+def conventional_aliases():
+    import altair as alt
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import pandas as pd
+    import seaborn as sns
+    import tkinter as tk

--- a/crates/ruff/src/rules/flake8_import_conventions/rules/unconventional_import_alias.rs
+++ b/crates/ruff/src/rules/flake8_import_conventions/rules/unconventional_import_alias.rs
@@ -80,13 +80,15 @@ pub(crate) fn unconventional_import_alias(
         binding.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        if checker.semantic().is_available(expected_alias) {
-            diagnostic.try_set_fix(|| {
-                let scope = &checker.semantic().scopes[binding.scope];
-                let (edit, rest) =
-                    Renamer::rename(name, expected_alias, scope, checker.semantic())?;
-                Ok(Fix::suggested_edits(edit, rest))
-            });
+        if !import.is_submodule_import() {
+            if checker.semantic().is_available(expected_alias) {
+                diagnostic.try_set_fix(|| {
+                    let scope = &checker.semantic().scopes[binding.scope];
+                    let (edit, rest) =
+                        Renamer::rename(name, expected_alias, scope, checker.semantic())?;
+                    Ok(Fix::suggested_edits(edit, rest))
+                });
+            }
         }
     }
     Some(diagnostic)

--- a/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__defaults.snap
+++ b/crates/ruff/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__defaults.snap
@@ -1,132 +1,238 @@
 ---
 source: crates/ruff/src/rules/flake8_import_conventions/mod.rs
 ---
-defaults.py:3:8: ICN001 `altair` should be imported as `alt`
+defaults.py:6:12: ICN001 [*] `altair` should be imported as `alt`
   |
-1 | import math  # not checked
-2 | 
-3 | import altair  # unconventional
-  |        ^^^^^^ ICN001
-4 | import matplotlib.pyplot  # unconventional
-5 | import numpy  # unconventional
+5 | def unconventional():
+6 |     import altair
+  |            ^^^^^^ ICN001
+7 |     import matplotlib.pyplot
+8 |     import numpy
   |
   = help: Alias `altair` to `alt`
 
-defaults.py:4:8: ICN001 `matplotlib.pyplot` should be imported as `plt`
+ℹ Suggested fix
+3 3 | 
+4 4 | 
+5 5 | def unconventional():
+6   |-    import altair
+  6 |+    import altair as alt
+7 7 |     import matplotlib.pyplot
+8 8 |     import numpy
+9 9 |     import pandas
+
+defaults.py:7:12: ICN001 `matplotlib.pyplot` should be imported as `plt`
   |
-3 | import altair  # unconventional
-4 | import matplotlib.pyplot  # unconventional
-  |        ^^^^^^^^^^^^^^^^^ ICN001
-5 | import numpy  # unconventional
-6 | import pandas  # unconventional
+5 | def unconventional():
+6 |     import altair
+7 |     import matplotlib.pyplot
+  |            ^^^^^^^^^^^^^^^^^ ICN001
+8 |     import numpy
+9 |     import pandas
   |
   = help: Alias `matplotlib.pyplot` to `plt`
 
-defaults.py:5:8: ICN001 `numpy` should be imported as `np`
-  |
-3 | import altair  # unconventional
-4 | import matplotlib.pyplot  # unconventional
-5 | import numpy  # unconventional
-  |        ^^^^^ ICN001
-6 | import pandas  # unconventional
-7 | import seaborn  # unconventional
-  |
-  = help: Alias `numpy` to `np`
-
-defaults.py:6:8: ICN001 `pandas` should be imported as `pd`
-  |
-4 | import matplotlib.pyplot  # unconventional
-5 | import numpy  # unconventional
-6 | import pandas  # unconventional
-  |        ^^^^^^ ICN001
-7 | import seaborn  # unconventional
-8 | import tkinter  # unconventional
-  |
-  = help: Alias `pandas` to `pd`
-
-defaults.py:7:8: ICN001 `seaborn` should be imported as `sns`
-  |
-5 | import numpy  # unconventional
-6 | import pandas  # unconventional
-7 | import seaborn  # unconventional
-  |        ^^^^^^^ ICN001
-8 | import tkinter  # unconventional
-  |
-  = help: Alias `seaborn` to `sns`
-
-defaults.py:8:8: ICN001 `tkinter` should be imported as `tk`
+defaults.py:8:12: ICN001 [*] `numpy` should be imported as `np`
    |
- 6 | import pandas  # unconventional
- 7 | import seaborn  # unconventional
- 8 | import tkinter  # unconventional
-   |        ^^^^^^^ ICN001
- 9 | 
-10 | import altair as altr  # unconventional
-   |
-   = help: Alias `tkinter` to `tk`
-
-defaults.py:10:18: ICN001 `altair` should be imported as `alt`
-   |
- 8 | import tkinter  # unconventional
- 9 | 
-10 | import altair as altr  # unconventional
-   |                  ^^^^ ICN001
-11 | import matplotlib.pyplot as plot  # unconventional
-12 | import numpy as nmp  # unconventional
-   |
-   = help: Alias `altair` to `alt`
-
-defaults.py:11:29: ICN001 `matplotlib.pyplot` should be imported as `plt`
-   |
-10 | import altair as altr  # unconventional
-11 | import matplotlib.pyplot as plot  # unconventional
-   |                             ^^^^ ICN001
-12 | import numpy as nmp  # unconventional
-13 | import pandas as pdas  # unconventional
-   |
-   = help: Alias `matplotlib.pyplot` to `plt`
-
-defaults.py:12:17: ICN001 `numpy` should be imported as `np`
-   |
-10 | import altair as altr  # unconventional
-11 | import matplotlib.pyplot as plot  # unconventional
-12 | import numpy as nmp  # unconventional
-   |                 ^^^ ICN001
-13 | import pandas as pdas  # unconventional
-14 | import seaborn as sbrn  # unconventional
+ 6 |     import altair
+ 7 |     import matplotlib.pyplot
+ 8 |     import numpy
+   |            ^^^^^ ICN001
+ 9 |     import pandas
+10 |     import seaborn
    |
    = help: Alias `numpy` to `np`
 
-defaults.py:13:18: ICN001 `pandas` should be imported as `pd`
+ℹ Suggested fix
+5 5 | def unconventional():
+6 6 |     import altair
+7 7 |     import matplotlib.pyplot
+8   |-    import numpy
+  8 |+    import numpy as np
+9 9 |     import pandas
+10 10 |     import seaborn
+11 11 |     import tkinter
+
+defaults.py:9:12: ICN001 [*] `pandas` should be imported as `pd`
    |
-11 | import matplotlib.pyplot as plot  # unconventional
-12 | import numpy as nmp  # unconventional
-13 | import pandas as pdas  # unconventional
-   |                  ^^^^ ICN001
-14 | import seaborn as sbrn  # unconventional
-15 | import tkinter as tkr  # unconventional
+ 7 |     import matplotlib.pyplot
+ 8 |     import numpy
+ 9 |     import pandas
+   |            ^^^^^^ ICN001
+10 |     import seaborn
+11 |     import tkinter
    |
    = help: Alias `pandas` to `pd`
 
-defaults.py:14:19: ICN001 `seaborn` should be imported as `sns`
+ℹ Suggested fix
+6  6  |     import altair
+7  7  |     import matplotlib.pyplot
+8  8  |     import numpy
+9     |-    import pandas
+   9  |+    import pandas as pd
+10 10 |     import seaborn
+11 11 |     import tkinter
+12 12 | 
+
+defaults.py:10:12: ICN001 [*] `seaborn` should be imported as `sns`
    |
-12 | import numpy as nmp  # unconventional
-13 | import pandas as pdas  # unconventional
-14 | import seaborn as sbrn  # unconventional
-   |                   ^^^^ ICN001
-15 | import tkinter as tkr  # unconventional
+ 8 |     import numpy
+ 9 |     import pandas
+10 |     import seaborn
+   |            ^^^^^^^ ICN001
+11 |     import tkinter
    |
    = help: Alias `seaborn` to `sns`
 
-defaults.py:15:19: ICN001 `tkinter` should be imported as `tk`
+ℹ Suggested fix
+7  7  |     import matplotlib.pyplot
+8  8  |     import numpy
+9  9  |     import pandas
+10    |-    import seaborn
+   10 |+    import seaborn as sns
+11 11 |     import tkinter
+12 12 | 
+13 13 | 
+
+defaults.py:11:12: ICN001 [*] `tkinter` should be imported as `tk`
    |
-13 | import pandas as pdas  # unconventional
-14 | import seaborn as sbrn  # unconventional
-15 | import tkinter as tkr  # unconventional
-   |                   ^^^ ICN001
-16 | 
-17 | import altair as alt  # conventional
+ 9 |     import pandas
+10 |     import seaborn
+11 |     import tkinter
+   |            ^^^^^^^ ICN001
    |
    = help: Alias `tkinter` to `tk`
+
+ℹ Suggested fix
+8  8  |     import numpy
+9  9  |     import pandas
+10 10 |     import seaborn
+11    |-    import tkinter
+   11 |+    import tkinter as tk
+12 12 | 
+13 13 | 
+14 14 | def unconventional_aliases():
+
+defaults.py:15:22: ICN001 [*] `altair` should be imported as `alt`
+   |
+14 | def unconventional_aliases():
+15 |     import altair as altr
+   |                      ^^^^ ICN001
+16 |     import matplotlib.pyplot as plot
+17 |     import numpy as nmp
+   |
+   = help: Alias `altair` to `alt`
+
+ℹ Suggested fix
+12 12 | 
+13 13 | 
+14 14 | def unconventional_aliases():
+15    |-    import altair as altr
+   15 |+    import altair as alt
+16 16 |     import matplotlib.pyplot as plot
+17 17 |     import numpy as nmp
+18 18 |     import pandas as pdas
+
+defaults.py:16:33: ICN001 [*] `matplotlib.pyplot` should be imported as `plt`
+   |
+14 | def unconventional_aliases():
+15 |     import altair as altr
+16 |     import matplotlib.pyplot as plot
+   |                                 ^^^^ ICN001
+17 |     import numpy as nmp
+18 |     import pandas as pdas
+   |
+   = help: Alias `matplotlib.pyplot` to `plt`
+
+ℹ Suggested fix
+13 13 | 
+14 14 | def unconventional_aliases():
+15 15 |     import altair as altr
+16    |-    import matplotlib.pyplot as plot
+   16 |+    import matplotlib.pyplot as plt
+17 17 |     import numpy as nmp
+18 18 |     import pandas as pdas
+19 19 |     import seaborn as sbrn
+
+defaults.py:17:21: ICN001 [*] `numpy` should be imported as `np`
+   |
+15 |     import altair as altr
+16 |     import matplotlib.pyplot as plot
+17 |     import numpy as nmp
+   |                     ^^^ ICN001
+18 |     import pandas as pdas
+19 |     import seaborn as sbrn
+   |
+   = help: Alias `numpy` to `np`
+
+ℹ Suggested fix
+14 14 | def unconventional_aliases():
+15 15 |     import altair as altr
+16 16 |     import matplotlib.pyplot as plot
+17    |-    import numpy as nmp
+   17 |+    import numpy as np
+18 18 |     import pandas as pdas
+19 19 |     import seaborn as sbrn
+20 20 |     import tkinter as tkr
+
+defaults.py:18:22: ICN001 [*] `pandas` should be imported as `pd`
+   |
+16 |     import matplotlib.pyplot as plot
+17 |     import numpy as nmp
+18 |     import pandas as pdas
+   |                      ^^^^ ICN001
+19 |     import seaborn as sbrn
+20 |     import tkinter as tkr
+   |
+   = help: Alias `pandas` to `pd`
+
+ℹ Suggested fix
+15 15 |     import altair as altr
+16 16 |     import matplotlib.pyplot as plot
+17 17 |     import numpy as nmp
+18    |-    import pandas as pdas
+   18 |+    import pandas as pd
+19 19 |     import seaborn as sbrn
+20 20 |     import tkinter as tkr
+21 21 | 
+
+defaults.py:19:23: ICN001 [*] `seaborn` should be imported as `sns`
+   |
+17 |     import numpy as nmp
+18 |     import pandas as pdas
+19 |     import seaborn as sbrn
+   |                       ^^^^ ICN001
+20 |     import tkinter as tkr
+   |
+   = help: Alias `seaborn` to `sns`
+
+ℹ Suggested fix
+16 16 |     import matplotlib.pyplot as plot
+17 17 |     import numpy as nmp
+18 18 |     import pandas as pdas
+19    |-    import seaborn as sbrn
+   19 |+    import seaborn as sns
+20 20 |     import tkinter as tkr
+21 21 | 
+22 22 | 
+
+defaults.py:20:23: ICN001 [*] `tkinter` should be imported as `tk`
+   |
+18 |     import pandas as pdas
+19 |     import seaborn as sbrn
+20 |     import tkinter as tkr
+   |                       ^^^ ICN001
+   |
+   = help: Alias `tkinter` to `tk`
+
+ℹ Suggested fix
+17 17 |     import numpy as nmp
+18 18 |     import pandas as pdas
+19 19 |     import seaborn as sbrn
+20    |-    import tkinter as tkr
+   20 |+    import tkinter as tk
+21 21 | 
+22 22 | 
+23 23 | def conventional_aliases():
 
 


### PR DESCRIPTION
## Summary

Avoid attempting to rewrite `import matplotlib.pyplot` as `import matplotlib.pyplot as plt`. We can't support these right now, since we don't track references at the attribute level (like `matplotlib.pyplot`).

Closes https://github.com/astral-sh/ruff/issues/6719.
