### PR TITLE
Add a note on `__future__` imports and `keep-runtime-typing` to pyupgrade rules

### DIFF
--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -20,8 +20,16 @@ use crate::registry::AsRule;
 ///
 /// When available, the [PEP 585] syntax should be used instead of importing
 /// members from the `typing` module, as it's more concise and readable.
-/// Importing those members from `typing` is considered deprecated as of PEP
-/// 585.
+/// Importing those members from `typing` is considered deprecated as of [PEP
+/// 585].
+///
+/// This rule is enabled when targeting Python 3.9 or later (see:
+/// [`target-version`]). By default, it's _also_ enabled for earlier Python
+/// versions if `from __future__ import annotations` is present, as
+/// `__future__` annotations are not evaluated at runtime. If your code relies
+/// on runtime type annotations (either directly or via a library like
+/// Pydantic), you can disable this behavior for Python versions prior to 3.9
+/// by setting [`pyupgrade.keep-runtime-typing`] to `true`.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -18,6 +18,14 @@ use crate::registry::AsRule;
 /// `|` operator. This syntax is more concise and readable than the previous
 /// `typing.Union` and `typing.Optional` syntaxes.
 ///
+/// This rule is enabled when targeting Python 3.10 or later (see:
+/// [`target-version`]). By default, it's _also_ enabled for earlier Python
+/// versions if `from __future__ import annotations` is present, as
+/// `__future__` annotations are not evaluated at runtime. If your code relies
+/// on runtime type annotations (either directly or via a library like
+/// Pydantic), you can disable this behavior for Python versions prior to 3.10
+/// by setting [`pyupgrade.keep-runtime-typing`] to `true`.
+///
 /// ## Example
 /// ```python
 /// from typing import Union


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/6740.

