### PR TITLE
Avoid E231 if comma is at end-of-line

### DIFF
--- a/crates/ruff/resources/test/fixtures/pycodestyle/E23.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/E23.py
@@ -28,3 +28,6 @@ mdtypes_template = {
     'tag_full': [('mdtype', 'u4'), ('byte_count', 'u4')],
     'tag_smalldata':[('byte_count_mdtype', 'u4'), ('data', 'S4')],
 }
+
+#: Okay
+a = (1,

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
@@ -81,10 +81,10 @@ pub(crate) fn missing_whitespace(
             TokenKind::Comma | TokenKind::Semi | TokenKind::Colon => {
                 let after = line.text_after(token);
 
-                if !after
+                if after
                     .chars()
                     .next()
-                    .is_some_and(|c| char::is_whitespace(c) || c == '\\')
+                    .is_some_and(|c| !(char::is_whitespace(c) || c == '\\'))
                 {
                     if let Some(next_token) = iter.peek() {
                         match (kind, next_token.kind()) {

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E231_E23.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E231_E23.py.snap
@@ -98,5 +98,7 @@ E23.py:29:20: E231 [*] Missing whitespace after ':'
 29    |-    'tag_smalldata':[('byte_count_mdtype', 'u4'), ('data', 'S4')],
    29 |+    'tag_smalldata': [('byte_count_mdtype', 'u4'), ('data', 'S4')],
 30 30 | }
+31 31 | 
+32 32 | #: Okay
 
 


### PR DESCRIPTION
## Summary

I don't know how this could come up in valid Python, but anyway...

Closes https://github.com/astral-sh/ruff/issues/6738.
