### PR TITLE
Preserve empty lines between try clause headers

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/try.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/try.py
@@ -146,3 +146,23 @@ except (
     # comment
 ):
     pass
+
+
+try:
+    pass
+
+finally:
+    pass
+
+
+try:
+    pass
+
+except ZeroDivisonError:
+    pass
+
+else:
+    pass
+
+finally:
+    pass

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -243,12 +243,11 @@ if True:
     #[test]
     fn quick_test() {
         let src = r#"
-@MyDecorator(list = a) # fmt: skip
-# trailing comment
-class Test:
+try:
     pass
 
-
+finally:
+    pass
 "#;
         // Tokenize once
         let mut tokens = Vec::new();

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -243,11 +243,12 @@ if True:
     #[test]
     fn quick_test() {
         let src = r#"
-try:
+@MyDecorator(list = a) # fmt: skip
+# trailing comment
+class Test:
     pass
 
-finally:
-    pass
+
 "#;
         // Tokenize once
         let mut tokens = Vec::new();

--- a/crates/ruff_python_formatter/src/statement/stmt_try.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_try.rs
@@ -105,9 +105,9 @@ impl FormatNodeRule<StmtTry> for FormatStmtTry {
 }
 
 fn format_case<'a>(
-    try_statement: &StmtTry,
+    try_statement: &'a StmtTry,
     kind: CaseKind,
-    previous_node: Option<&Stmt>,
+    previous_node: Option<&'a Stmt>,
     dangling_comments: &'a [SourceComment],
     f: &mut PyFormatter,
 ) -> FormatResult<(Option<&'a Stmt>, &'a [SourceComment])> {
@@ -141,9 +141,9 @@ fn format_case<'a>(
                 clause_body(body, trailing_case_comments),
             ]
         )?;
-        (None, rest)
+        (Some(last), rest)
     } else {
-        (None, dangling_comments)
+        (previous_node, dangling_comments)
     })
 }
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__try.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__try.py.snap
@@ -152,6 +152,26 @@ except (
     # comment
 ):
     pass
+
+
+try:
+    pass
+
+finally:
+    pass
+
+
+try:
+    pass
+
+except ZeroDivisonError:
+    pass
+
+else:
+    pass
+
+finally:
+    pass
 ```
 
 ## Output
@@ -319,6 +339,26 @@ except (
     ZeroDivisionError
     # comment
 ):
+    pass
+
+
+try:
+    pass
+
+finally:
+    pass
+
+
+try:
+    pass
+
+except ZeroDivisonError:
+    pass
+
+else:
+    pass
+
+finally:
     pass
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR fixes the formatting of the finally clause to correctly preserve empty lines separating it from the preceding try body.



<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

New snapshot tests. 

The similarity index for django and transformers improves by a tiny bit. 

**This PR**

| project      | similarity index |
|--------------|------------------|
| cpython      | 0.75479          |
| django       | **0.99806**          |
| transformers | **0.99621**          |
| twine        | 0.99876          |
| typeshed     | 0.99953          |
| warehouse    | 0.99601          |
| zulip        | 0.99727          |

**Main**

| project      | similarity index |
|--------------|------------------|
| cpython      | 0.75474          |
| django       | 0.99805          |
| transformers | 0.99620          |
| twine        | 0.99876          |
| typeshed     | 0.99953          |
| warehouse    | 0.99601          |
| zulip        | 0.99727          |
