### PR TITLE
Omit tuple parentheses in for statements except when absolutely necessary

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/for.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/for.py
@@ -42,3 +42,31 @@ for x in (1, 2, 3):
 
 for x in 1, 2, 3,:
     pass
+
+# Don't keep parentheses around right target if it can made fit by breaking sub expressions
+for column_name, (
+    referenced_column_name,
+    referenced_table_name,
+) in relations.items():
+    pass
+
+for column_name, [
+    referenced_column_name,
+    referenced_table_name,
+] in relations.items():
+    pass
+
+for column_name, [
+    referenced_column_name,
+    referenced_table_name,
+], in relations.items():
+    pass
+
+for (
+    # leading comment
+    column_name, [
+    referenced_column_name,
+    referenced_table_name,
+]) in relations.items():
+    pass
+

--- a/crates/ruff_python_formatter/src/expression/expr_tuple.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_tuple.rs
@@ -8,7 +8,7 @@ use ruff_text_size::TextRange;
 use crate::builders::parenthesize_if_expands;
 use crate::comments::SourceComment;
 use crate::expression::parentheses::{
-    empty_parenthesized, parenthesized, NeedsParentheses, OptionalParentheses,
+    empty_parenthesized, optional_parentheses, parenthesized, NeedsParentheses, OptionalParentheses,
 };
 use crate::prelude::*;
 
@@ -138,7 +138,7 @@ impl FormatNodeRule<ExprTuple> for FormatExprTuple {
                 }
             },
             // If the tuple has parentheses, we generally want to keep them. The exception are for
-            // loops, see `TupleParentheses::StripInsideForLoop` doc comment.
+            // loops, see `TupleParentheses::NeverPreserve` doc comment.
             //
             // Unlike other expression parentheses, tuple parentheses are part of the range of the
             // tuple itself.
@@ -159,7 +159,12 @@ impl FormatNodeRule<ExprTuple> for FormatExprTuple {
                         .finish()
                 }
                 TupleParentheses::Preserve => group(&ExprSequence::new(item)).fmt(f),
-                _ => parenthesize_if_expands(&ExprSequence::new(item)).fmt(f),
+                TupleParentheses::NeverPreserve => {
+                    optional_parentheses(&ExprSequence::new(item)).fmt(f)
+                }
+                TupleParentheses::Default => {
+                    parenthesize_if_expands(&ExprSequence::new(item)).fmt(f)
+                }
             },
         }
     }

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__for.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__for.py.snap
@@ -48,6 +48,34 @@ for x in (1, 2, 3):
 
 for x in 1, 2, 3,:
     pass
+
+# Don't keep parentheses around right target if it can made fit by breaking sub expressions
+for column_name, (
+    referenced_column_name,
+    referenced_table_name,
+) in relations.items():
+    pass
+
+for column_name, [
+    referenced_column_name,
+    referenced_table_name,
+] in relations.items():
+    pass
+
+for column_name, [
+    referenced_column_name,
+    referenced_table_name,
+], in relations.items():
+    pass
+
+for (
+    # leading comment
+    column_name, [
+    referenced_column_name,
+    referenced_table_name,
+]) in relations.items():
+    pass
+
 ```
 
 ## Output
@@ -99,6 +127,38 @@ for x in (
     2,
     3,
 ):
+    pass
+
+# Don't keep parentheses around right target if it can made fit by breaking sub expressions
+for column_name, (
+    referenced_column_name,
+    referenced_table_name,
+) in relations.items():
+    pass
+
+for column_name, [
+    referenced_column_name,
+    referenced_table_name,
+] in relations.items():
+    pass
+
+for (
+    column_name,
+    [
+        referenced_column_name,
+        referenced_table_name,
+    ],
+) in relations.items():
+    pass
+
+for (
+    # leading comment
+    column_name,
+    [
+        referenced_column_name,
+        referenced_table_name,
+    ],
+) in relations.items():
     pass
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR aligns the tuple formatting in for targets with Black's. 

Before: Tuple's inside for targets were always parenthesized if they expand. 
New: Only parenthesize the tuples if splitting after any `(`, `[`, {` doesn't make them fit (and thus, require parentheses to avoid a syntax error).

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Added snapshot tests. 

The similarity index for the django project improves:

**Main**

| project      | similarity index |
|--------------|------------------|
| cpython      | 0.75474          |
| django       | 0.99805          |
| transformers | 0.99620          |
| twine        | 0.99876          |
| typeshed     | 0.99953          |
| warehouse    | 0.99601          |
| zulip        | 0.99727          |

**This PR**
| project      | similarity index |
|--------------|------------------|
| cpython      | 0.75474          |
| django       | **0.99809**          |
| transformers | 0.99620          |
| twine        | 0.99876          |
| typeshed     | 0.99953          |
| warehouse    | 0.99601          |
| zulip        | 0.99727          |


I diffed the output for the django project between main and this PR to verify that there are no regressions
<!-- How was it tested? -->
