### PR TITLE
Preserve yield parentheses

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/yield.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/yield.py
@@ -65,3 +65,35 @@ def foo():
         test, # comment 4
         1
     )
+
+yield ("Cache key will cause errors if used with memcached: %r " "(longer than %s)" % (
+    key,
+    MEMCACHE_MAX_KEY_LENGTH,
+)
+       )
+
+yield "Cache key will cause errors if used with memcached: %r " "(longer than %s)" % (
+    key,
+    MEMCACHE_MAX_KEY_LENGTH,
+)
+
+
+yield ("Unnecessary")
+
+
+yield (
+    "#   * Make sure each ForeignKey and OneToOneField has `on_delete` set "
+    "to the desired behavior"
+)
+yield (
+    "#   * Remove `managed = False` lines if you wish to allow "
+    "Django to create, modify, and delete the table"
+)
+yield (
+    "# Feel free to rename the models, but don't rename db_table values or "
+    "field names."
+)
+
+yield "#   * Make sure each ForeignKey and OneToOneField has `on_delete` set "    "to the desired behavior"
+yield "#   * Remove `managed = False` lines if you wish to allow " "Django to create, modify, and delete the table"
+yield "# Feel free to rename the models, but don't rename db_table values or "    "field names."

--- a/crates/ruff_python_formatter/src/expression/expr_await.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_await.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<ExprAwait> for FormatExprAwait {
             [
                 text("await"),
                 space(),
-                maybe_parenthesize_expression(value, item, Parenthesize::IfRequired)
+                maybe_parenthesize_expression(value, item, Parenthesize::IfBreaks)
             ]
         )
     }

--- a/crates/ruff_python_formatter/src/expression/expr_yield.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_yield.rs
@@ -90,7 +90,7 @@ impl Format<PyFormatContext<'_>> for AnyExpressionYield<'_> {
                 [
                     text(keyword),
                     space(),
-                    maybe_parenthesize_expression(val, self, Parenthesize::IfRequired)
+                    maybe_parenthesize_expression(val, self, Parenthesize::Optional)
                 ]
             )?;
         } else {

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -190,16 +190,13 @@ impl Format<PyFormatContext<'_>> for MaybeParenthesizeExpression<'_> {
             return expression.format().with_options(Parentheses::Always).fmt(f);
         }
 
-        let needs_parentheses = expression.needs_parentheses(*parent, f.context());
-        let needs_parentheses = match parenthesize {
-            Parenthesize::IfRequired => match needs_parentheses {
-                OptionalParentheses::Always => OptionalParentheses::Always,
-                _ if f.context().node_level().is_parenthesized() => OptionalParentheses::Never,
-                needs_parentheses => needs_parentheses,
-            },
-            Parenthesize::Optional
-            | Parenthesize::IfBreaks
-            | Parenthesize::IfBreaksOrIfRequired => needs_parentheses,
+        let needs_parentheses = match expression.needs_parentheses(*parent, f.context()) {
+            OptionalParentheses::Always => OptionalParentheses::Always,
+            // The reason to add parentheses is to avoid a syntax error when breaking an expression over multiple lines.
+            // Therefore, it is unnecessary to add an additional pair of parentheses if an outer expression
+            // is parenthesized.
+            _ if f.context().node_level().is_parenthesized() => OptionalParentheses::Never,
+            needs_parentheses => needs_parentheses,
         };
 
         match needs_parentheses {

--- a/crates/ruff_python_formatter/src/expression/parentheses.rs
+++ b/crates/ruff_python_formatter/src/expression/parentheses.rs
@@ -41,9 +41,8 @@ pub(crate) enum Parenthesize {
     /// Parenthesizes the expression only if it doesn't fit on a line.
     IfBreaks,
 
-    /// Only adds parentheses if absolutely necessary:
-    /// * The expression is not enclosed by another parenthesized expression and it expands over multiple lines
-    /// * The expression has leading or trailing comments. Adding parentheses is desired to prevent the comments from wandering.
+    /// Only adds parentheses if the expression has leading or trailing comments.
+    /// Adding parentheses is desired to prevent the comments from wandering.
     IfRequired,
 
     /// Parenthesizes the expression if the group doesn't fit on a line (e.g., even name expressions are parenthesized), or if

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__yield.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__yield.py.snap
@@ -71,6 +71,38 @@ def foo():
         test, # comment 4
         1
     )
+
+yield ("Cache key will cause errors if used with memcached: %r " "(longer than %s)" % (
+    key,
+    MEMCACHE_MAX_KEY_LENGTH,
+)
+       )
+
+yield "Cache key will cause errors if used with memcached: %r " "(longer than %s)" % (
+    key,
+    MEMCACHE_MAX_KEY_LENGTH,
+)
+
+
+yield ("Unnecessary")
+
+
+yield (
+    "#   * Make sure each ForeignKey and OneToOneField has `on_delete` set "
+    "to the desired behavior"
+)
+yield (
+    "#   * Remove `managed = False` lines if you wish to allow "
+    "Django to create, modify, and delete the table"
+)
+yield (
+    "# Feel free to rename the models, but don't rename db_table values or "
+    "field names."
+)
+
+yield "#   * Make sure each ForeignKey and OneToOneField has `on_delete` set "    "to the desired behavior"
+yield "#   * Remove `managed = False` lines if you wish to allow " "Django to create, modify, and delete the table"
+yield "# Feel free to rename the models, but don't rename db_table values or "    "field names."
 ```
 
 ## Output
@@ -110,7 +142,7 @@ def foo():
 
     for e in l:
         # comment
-        yield e  # Too many parentheses
+        yield (e)  # Too many parentheses
         # comment
 
     for ridiculouslylongelementnameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee in l:
@@ -135,6 +167,51 @@ def foo():
             )
         )
     )
+
+
+yield (
+    "Cache key will cause errors if used with memcached: %r "
+    "(longer than %s)"
+    % (
+        key,
+        MEMCACHE_MAX_KEY_LENGTH,
+    )
+)
+
+yield "Cache key will cause errors if used with memcached: %r " "(longer than %s)" % (
+    key,
+    MEMCACHE_MAX_KEY_LENGTH,
+)
+
+
+yield ("Unnecessary")
+
+
+yield (
+    "#   * Make sure each ForeignKey and OneToOneField has `on_delete` set "
+    "to the desired behavior"
+)
+yield (
+    "#   * Remove `managed = False` lines if you wish to allow "
+    "Django to create, modify, and delete the table"
+)
+yield (
+    "# Feel free to rename the models, but don't rename db_table values or "
+    "field names."
+)
+
+yield (
+    "#   * Make sure each ForeignKey and OneToOneField has `on_delete` set "
+    "to the desired behavior"
+)
+yield (
+    "#   * Remove `managed = False` lines if you wish to allow "
+    "Django to create, modify, and delete the table"
+)
+yield (
+    "# Feel free to rename the models, but don't rename db_table values or "
+    "field names."
+)
 ```
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR ensures that parentheses around yielded values are preserved to increase Black compatibility. 

Closes https://github.com/astral-sh/ruff/issues/6762

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

See added tests. The last three line require https://github.com/astral-sh/ruff/pull/6734

I diffed the output before/after for the django project to verify that their are no remaining `yield` mismatches and that this PR introduces new regressions.

**Main**

| project      | similarity index |
|--------------|------------------|
| cpython      | 0.75474          |
| django       | 0.99805          |
| transformers | 0.99620          |
| twine        | 0.99876          |
| typeshed     | 0.99953          |
| warehouse    | 0.99601          |
| zulip        | 0.99727          |

**PR**

| project      | similarity index |
|--------------|------------------|
| cpython      | 0.75472          |
| django       | **0.99809**          |
| transformers | 0.99620          |
| twine        | 0.99876          |
| typeshed     | 0.99953          |
| warehouse    | 0.99601          |
| zulip        | 0.99727          |


<!-- How was it tested? -->
