### PR TITLE
Fix `bad-string-format-character` when a placeholder occurs within a format spec part

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/bad_string_format_character.py
+++ b/crates/ruff/resources/test/fixtures/pylint/bad_string_format_character.py
@@ -17,7 +17,9 @@
 "{:*^30s}".format("centered") # OK
 "{:{s}}".format("hello", s="s")  # OK (nested replacement value not checked)
 "{:{s:y}}".format("hello", s="s")  # [bad-format-character] (nested replacement format spec checked)
-"{0:.{prec}g}".format(1.23, prec=15)  # OK (cannot validate after nested replacement)
+"{0:.{prec}g}".format(1.23, prec=15)  # OK
+"{0:.{foo}x{bar}y{foobar}g}".format(...)  # OK (all nested replacements are consumed without considering in between chars)
+"{0:.{foo}{bar}{foobar}y}".format(...)  # [bad-format-character] (check value after replacements)
 
 ## f-strings
 

--- a/crates/ruff/resources/test/fixtures/pylint/bad_string_format_character.py
+++ b/crates/ruff/resources/test/fixtures/pylint/bad_string_format_character.py
@@ -16,8 +16,8 @@
 
 "{:*^30s}".format("centered") # OK
 "{:{s}}".format("hello", s="s")  # OK (nested replacement value not checked)
-
 "{:{s:y}}".format("hello", s="s")  # [bad-format-character] (nested replacement format spec checked)
+"{0:.{prec}g}".format(1.23, prec=15)  # OK (cannot validate after nested replacement)
 
 ## f-strings
 

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE1300_bad_string_format_character.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE1300_bad_string_format_character.py.snap
@@ -51,14 +51,13 @@ bad_string_format_character.py:15:1: PLE1300 Unsupported format character 'y'
 17 | "{:*^30s}".format("centered") # OK
    |
 
-bad_string_format_character.py:20:1: PLE1300 Unsupported format character 'y'
+bad_string_format_character.py:19:1: PLE1300 Unsupported format character 'y'
    |
+17 | "{:*^30s}".format("centered") # OK
 18 | "{:{s}}".format("hello", s="s")  # OK (nested replacement value not checked)
-19 | 
-20 | "{:{s:y}}".format("hello", s="s")  # [bad-format-character] (nested replacement format spec checked)
+19 | "{:{s:y}}".format("hello", s="s")  # [bad-format-character] (nested replacement format spec checked)
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLE1300
-21 | 
-22 | ## f-strings
+20 | "{0:.{prec}g}".format(1.23, prec=15)  # OK (cannot validate after nested replacement)
    |
 
 

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE1300_bad_string_format_character.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE1300_bad_string_format_character.py.snap
@@ -57,7 +57,18 @@ bad_string_format_character.py:19:1: PLE1300 Unsupported format character 'y'
 18 | "{:{s}}".format("hello", s="s")  # OK (nested replacement value not checked)
 19 | "{:{s:y}}".format("hello", s="s")  # [bad-format-character] (nested replacement format spec checked)
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLE1300
-20 | "{0:.{prec}g}".format(1.23, prec=15)  # OK (cannot validate after nested replacement)
+20 | "{0:.{prec}g}".format(1.23, prec=15)  # OK
+21 | "{0:.{foo}x{bar}y{foobar}g}".format(...)  # OK (all nested replacements are consumed without considering in between chars)
+   |
+
+bad_string_format_character.py:22:1: PLE1300 Unsupported format character 'y'
+   |
+20 | "{0:.{prec}g}".format(1.23, prec=15)  # OK
+21 | "{0:.{foo}x{bar}y{foobar}g}".format(...)  # OK (all nested replacements are consumed without considering in between chars)
+22 | "{0:.{foo}{bar}{foobar}y}".format(...)  # [bad-format-character] (check value after replacements)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLE1300
+23 | 
+24 | ## f-strings
    |
 
 

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -320,7 +320,7 @@ fn parse_precision(text: &str) -> Result<(Option<usize>, &str), FormatSpecError>
 
 /// Parses a format part within a format spec
 fn parse_nested_placeholder<'a>(
-    parts: &mut Vec<FormatPart>,
+    placeholders: &mut Vec<FormatPart>,
     text: &'a str,
 ) -> Result<&'a str, FormatSpecError> {
     match FormatString::parse_spec(text, AllowPlaceholderNesting::No) {
@@ -328,7 +328,7 @@ fn parse_nested_placeholder<'a>(
         Err(FormatParseError::MissingStartBracket) => Ok(text),
         Err(err) => Err(FormatSpecError::InvalidPlaceholder(err)),
         Ok((format_part, text)) => {
-            parts.push(format_part);
+            placeholders.push(format_part);
             Ok(text)
         }
     }
@@ -337,7 +337,6 @@ fn parse_nested_placeholder<'a>(
 impl FormatSpec {
     pub fn parse(text: &str) -> Result<Self, FormatSpecError> {
         let mut replacements = vec![];
-        // get_integer in CPython
         let text = parse_nested_placeholder(&mut replacements, text)?;
         let (conversion, text) = FormatConversion::parse(text);
         let text = parse_nested_placeholder(&mut replacements, text)?;

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -335,11 +335,7 @@ fn parse_nested_placeholder<'a>(
 }
 
 /// Parse and consume all placeholders in a format spec
-///
-/// This will also consume any intermediate characters such as `x` and `y` in
-/// ```
-/// "x{foo}y{bar}z"
-/// ```
+/// This will also consume any intermediate characters such as `x` and `y` in `"x{foo}y{bar}z"`
 fn consume_all_placeholders<'a>(
     placeholders: &mut Vec<FormatPart>,
     text: &'a str,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__with_statement.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__with_statement.snap
@@ -477,7 +477,7 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
             is_async: false,
             items: [
                 WithItem {
-                    range: 239..240,
+                    range: 239..243,
                     context_expr: Constant(
                         ExprConstant {
                             range: 239..240,
@@ -490,7 +490,7 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                     optional_vars: None,
                 },
                 WithItem {
-                    range: 242..243,
+                    range: 239..243,
                     context_expr: Constant(
                         ExprConstant {
                             range: 242..243,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__with_statement.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__with_statement.snap
@@ -477,7 +477,7 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
             is_async: false,
             items: [
                 WithItem {
-                    range: 239..243,
+                    range: 239..240,
                     context_expr: Constant(
                         ExprConstant {
                             range: 239..240,
@@ -490,7 +490,7 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                     optional_vars: None,
                 },
                 WithItem {
-                    range: 239..243,
+                    range: 242..243,
                     context_expr: Constant(
                         ExprConstant {
                             range: 242..243,


### PR DESCRIPTION
Closes #6767 

The presented false positive `"{0:.{prec}g}".format(1.23, prec=15)` occurs because we treated the entire format specification of `.{prec}g` as the format type (which is typically at the end of a format specification). The nested replacement was not detected because a leading `{` was not seen. Instead, `.` remained the leading character — it's the leading character for a precision clause but was not consumed since the replacement was not a valid number

One way to resolve this is to update parsing of every clause in a format specification to be replacement aware e.g. precision parsing would accept a replacement as well as a number. I determined that this is too complicated and provides little value for our current rules around format specifications.

Instead, after we've parsed most of the format specification parts, we will check for any remaining replacements (i.e. the presence of `{` anywhere in the remaining string) and consume them and any intermediate characters. This matches our existing intention of basically ignoring any replacements while retaining as much of the normal format specification linting as we can.