### PR TITLE
Allow up to two empty lines after top-level imports

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/import.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/import.py
@@ -1,3 +1,58 @@
 from a import aksjdhflsakhdflkjsadlfajkslhfdkjsaldajlahflashdfljahlfksajlhfajfjfsaahflakjslhdfkjalhdskjfa
 from a import aksjdhflsakhdflkjsadlfajkslhfdkjsaldajlahflashdfljahlfksajlhfajfjfsaahflakjslhdfkjalhdskjfa, aksjdhflsakhdflkjsadlfajkslhfdkjsaldajlahflashdfljahlfksajlhfajfjfsaahflakjslhdfkjalhdskjfa
 from a import aksjdhflsakhdflkjsadlfajkslhfdkjsaldajlahflashdfljahlfksajlhfajfjfsaahflakjslhdfkjalhdskjfa as dfgsdfgsd, aksjdhflsakhdflkjsadlfajkslhfdkjsaldajlahflashdfljahlfksajlhfajfjfsaahflakjslhdfkjalhdskjfa as sdkjflsdjlahlfd
+
+# At the top-level, force one empty line after an import, but allow up to two empty
+# lines.
+import os
+import sys
+x = 1
+
+import os
+import sys
+
+x = 1
+
+import os
+import sys
+
+
+x = 1
+
+import os
+import sys
+
+
+
+x = 1
+
+
+# In a nested scope, force one empty line after an import.
+def func():
+    import os
+    import sys
+    x = 1
+
+
+def func():
+    import os
+    import sys
+
+    x = 1
+
+
+def func():
+    import os
+    import sys
+
+
+    x = 1
+
+
+def func():
+    import os
+    import sys
+
+
+
+    x = 1

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__import.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__import.py.snap
@@ -7,6 +7,61 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/
 from a import aksjdhflsakhdflkjsadlfajkslhfdkjsaldajlahflashdfljahlfksajlhfajfjfsaahflakjslhdfkjalhdskjfa
 from a import aksjdhflsakhdflkjsadlfajkslhfdkjsaldajlahflashdfljahlfksajlhfajfjfsaahflakjslhdfkjalhdskjfa, aksjdhflsakhdflkjsadlfajkslhfdkjsaldajlahflashdfljahlfksajlhfajfjfsaahflakjslhdfkjalhdskjfa
 from a import aksjdhflsakhdflkjsadlfajkslhfdkjsaldajlahflashdfljahlfksajlhfajfjfsaahflakjslhdfkjalhdskjfa as dfgsdfgsd, aksjdhflsakhdflkjsadlfajkslhfdkjsaldajlahflashdfljahlfksajlhfajfjfsaahflakjslhdfkjalhdskjfa as sdkjflsdjlahlfd
+
+# At the top-level, force one empty line after an import, but allow up to two empty
+# lines.
+import os
+import sys
+x = 1
+
+import os
+import sys
+
+x = 1
+
+import os
+import sys
+
+
+x = 1
+
+import os
+import sys
+
+
+
+x = 1
+
+
+# In a nested scope, force one empty line after an import.
+def func():
+    import os
+    import sys
+    x = 1
+
+
+def func():
+    import os
+    import sys
+
+    x = 1
+
+
+def func():
+    import os
+    import sys
+
+
+    x = 1
+
+
+def func():
+    import os
+    import sys
+
+
+
+    x = 1
 ```
 
 ## Output
@@ -22,6 +77,59 @@ from a import (
     aksjdhflsakhdflkjsadlfajkslhfdkjsaldajlahflashdfljahlfksajlhfajfjfsaahflakjslhdfkjalhdskjfa as dfgsdfgsd,
     aksjdhflsakhdflkjsadlfajkslhfdkjsaldajlahflashdfljahlfksajlhfajfjfsaahflakjslhdfkjalhdskjfa as sdkjflsdjlahlfd,
 )
+
+# At the top-level, force one empty line after an import, but allow up to two empty
+# lines.
+import os
+import sys
+
+x = 1
+
+import os
+import sys
+
+x = 1
+
+import os
+import sys
+
+
+x = 1
+
+import os
+import sys
+
+
+x = 1
+
+
+# In a nested scope, force one empty line after an import.
+def func():
+    import os
+    import sys
+
+    x = 1
+
+
+def func():
+    import os
+    import sys
+
+    x = 1
+
+
+def func():
+    import os
+    import sys
+
+    x = 1
+
+
+def func():
+    import os
+    import sys
+
+    x = 1
 ```
 
 


### PR DESCRIPTION
## Summary

For imports, we enforce that there's _at least_ one empty line after an import (assuming the next statement is _not_ an import), but allow up to two at the module level.

Closes https://github.com/astral-sh/ruff/issues/6760.

## Test Plan

`cargo test`
