### PR TITLE
Fix: Re-add missing node start positions

### DIFF
--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -54,7 +54,13 @@ where
         if self.is_suppressed(node_comments.trailing, f.context()) {
             suppressed_node(node.as_any_node_ref()).fmt(f)
         } else {
-            leading_comments(node_comments.leading).fmt(f)?;
+            write!(
+                f,
+                [
+                    leading_comments(node_comments.leading),
+                    source_position(node.start())
+                ]
+            )?;
             self.fmt_fields(node, f)?;
             self.fmt_dangling_comments(node_comments.dangling, f)?;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I accidentally removed the write of the start position in #6561

This PR adds the position again. 

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

We'll have tests for this once we implement range formatting

<!-- How was it tested? -->
