### PR TITLE
Remove comment lexing from isort

### DIFF
--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -721,10 +721,16 @@ pub(crate) fn if_with_same_arms(checker: &mut Checker, locator: &Locator, stmt_i
         // ...and the same comments
         let first_comments = checker
             .indexer()
-            .comments_in_range(body_range(&current_branch, locator), locator);
+            .comment_ranges()
+            .comments_in_range(body_range(&current_branch, locator))
+            .iter()
+            .map(|range| locator.slice(*range));
         let second_comments = checker
             .indexer()
-            .comments_in_range(body_range(following_branch, locator), locator);
+            .comment_ranges()
+            .comments_in_range(body_range(following_branch, locator))
+            .iter()
+            .map(|range| locator.slice(*range));
         if !first_comments.eq(second_comments) {
             continue;
         }

--- a/crates/ruff/src/rules/isort/comments.rs
+++ b/crates/ruff/src/rules/isort/comments.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use ruff_python_ast::{PySourceType, Ranged};
-use ruff_python_parser::{lexer, AsMode, Tok};
+use ruff_python_ast::Ranged;
+use ruff_python_index::Indexer;
 use ruff_source_file::Locator;
 use ruff_text_size::TextRange;
 
@@ -21,20 +21,15 @@ impl Ranged for Comment<'_> {
 pub(crate) fn collect_comments<'a>(
     range: TextRange,
     locator: &'a Locator,
-    source_type: PySourceType,
+    indexer: &'a Indexer,
 ) -> Vec<Comment<'a>> {
-    let contents = locator.slice(range);
-    lexer::lex_starts_at(contents, source_type.as_mode(), range.start())
-        .flatten()
-        .filter_map(|(tok, range)| {
-            if let Tok::Comment(value) = tok {
-                Some(Comment {
-                    value: value.into(),
-                    range,
-                })
-            } else {
-                None
-            }
+    indexer
+        .comment_ranges()
+        .comments_in_range(range)
+        .iter()
+        .map(|range| Comment {
+            value: locator.slice(*range).into(),
+            range: *range,
         })
         .collect()
 }

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -106,7 +106,7 @@ pub(crate) fn organize_imports(
     let comments = comments::collect_comments(
         TextRange::new(range.start(), locator.full_line_end(range.end())),
         locator,
-        source_type,
+        indexer,
     );
 
     let trailing_line_end = if block.trailer.is_none() {

--- a/crates/ruff_python_index/src/indexer.rs
+++ b/crates/ruff_python_index/src/indexer.rs
@@ -99,18 +99,6 @@ impl Indexer {
         &self.comment_ranges
     }
 
-    /// Returns the comments in the given range as source code slices
-    pub fn comments_in_range<'a>(
-        &'a self,
-        range: TextRange,
-        locator: &'a Locator,
-    ) -> impl Iterator<Item = &'a str> {
-        self.comment_ranges
-            .comments_in_range(range)
-            .iter()
-            .map(move |comment_range| locator.slice(*comment_range))
-    }
-
     /// Returns the line start positions of continuations (backslash).
     pub fn continuation_line_starts(&self) -> &[TextSize] {
         &self.continuation_lines


### PR DESCRIPTION
## Summary

No need to lex to find comments -- we already know their locations via `Indexer`.