### PR TITLE
Improve comment handling around `PatternMatchAs`

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
@@ -168,6 +168,27 @@ match pattern_comments:
         pass
 
 
+match pattern_comments:
+    case (
+        pattern
+        # 1
+		as
+        # 2
+		name
+        # 3
+    ):
+        pass
+
+
+match subject:
+    case (
+        pattern # 1
+        as # 2
+        name # 3
+    ):
+        pass
+
+
 match x:
     case (a as b) as c:
         pass

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -205,6 +205,7 @@ fn handle_enclosed_comment<'a>(
             handle_module_level_own_line_comment_before_class_or_function_comment(comment, locator)
         }
         AnyNodeRef::WithItem(_) => handle_with_item_comment(comment, locator),
+        AnyNodeRef::PatternMatchAs(_) => handle_pattern_match_as_comment(comment, locator),
         AnyNodeRef::StmtFunctionDef(_) => handle_leading_function_with_decorators_comment(comment),
         AnyNodeRef::StmtClassDef(class_def) => {
             handle_leading_class_with_decorators_comment(comment, class_def)
@@ -1141,6 +1142,47 @@ fn handle_with_item_comment<'a>(
         CommentPlacement::dangling(comment.enclosing_node(), comment)
     } else {
         CommentPlacement::leading(optional_vars, comment)
+    }
+}
+
+/// Handles trailing comments after the `as` keyword of a pattern match item:
+///
+/// ```python
+/// case (
+///     pattern
+///     as # dangling end of line comment
+///     # dangling own line comment
+///     name
+/// ): ...
+/// ```
+fn handle_pattern_match_as_comment<'a>(
+    comment: DecoratedComment<'a>,
+    locator: &Locator,
+) -> CommentPlacement<'a> {
+    debug_assert!(comment.enclosing_node().is_pattern_match_as());
+
+    let Some(pattern) = comment.preceding_node() else {
+        return CommentPlacement::Default(comment);
+    };
+
+    let mut tokens = SimpleTokenizer::starts_at(pattern.end(), locator.contents())
+        .skip_trivia()
+        .skip_while(|token| token.kind == SimpleTokenKind::RParen);
+
+    let Some(as_token) = tokens
+        .next()
+        .filter(|token| token.kind == SimpleTokenKind::As)
+    else {
+        return CommentPlacement::Default(comment);
+    };
+
+    if comment.end() < as_token.start() {
+        // If before the `as` keyword, then it must be a trailing comment of the pattern.
+        CommentPlacement::trailing(pattern, comment)
+    } else {
+        // Otherwise, must be a dangling comment. (Any comments that follow the name will be
+        // trailing comments on the pattern match item, rather than enclosed by it.)
+        CommentPlacement::dangling(comment.enclosing_node(), comment)
     }
 }
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -174,6 +174,27 @@ match pattern_comments:
         pass
 
 
+match pattern_comments:
+    case (
+        pattern
+        # 1
+		as
+        # 2
+		name
+        # 3
+    ):
+        pass
+
+
+match subject:
+    case (
+        pattern # 1
+        as # 2
+        name # 3
+    ):
+        pass
+
+
 match x:
     case (a as b) as c:
         pass
@@ -379,10 +400,11 @@ match pattern_comments:
 match pattern_comments:
     case (
         # 1
-        pattern as name  # 2
+        pattern  # 2
         # 3
-        # 4
-        # 5  # 6
+        as  # 4
+        # 5
+        name  # 6
         # 7
     ):
         pass
@@ -390,11 +412,33 @@ match pattern_comments:
 
 match pattern_comments:
     case (
-        pattern as name
+        pattern
         # 1
-        # 2
-        # 3  # 4
+        as  # 2
+        # 3
+        name  # 4
         # 5
+    ):
+        pass
+
+
+match pattern_comments:
+    case (
+        pattern
+        # 1
+        as
+        # 2
+        name
+        # 3
+    ):
+        pass
+
+
+match subject:
+    case (
+        pattern  # 1
+        as  # 2
+        name  # 3
     ):
         pass
 


### PR DESCRIPTION
## Summary

Follows up on https://github.com/astral-sh/ruff/pull/6652#discussion_r1300871033 with some modifications to the `PatternMatchAs` comment handling. Specifically, any comments between the `as` and the end are now formatted as dangling, and we now insert some newlines in the appropriate places.

## Test Plan

`cargo test`
