### PR TITLE
Handle open-parenthesis comments on match case

### DIFF
--- a/crates/ruff_python_formatter/tests/snapshots/format@parentheses__opening_parentheses_comment_value.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@parentheses__opening_parentheses_comment_value.py.snap
@@ -222,8 +222,7 @@ match (  # d 2
     case d2:
         pass
 match d3:
-    case (
-        # d 3
+    case (  # d 3
         x
     ):
         pass

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -354,8 +354,7 @@ match pattern_comments:
 
 
 match pattern_comments:
-    case (
-        # leading
+    case (  # leading
         only_leading
     ):
         pass


### PR DESCRIPTION
## Summary

Ensures that we retain the open-parenthesis comment in cases like:
```python
match pattern_comments:
    case (  # leading
        only_leading
    ):
        ...
```

Previously, this was treated as a leading comment on `only_leading`.

## Test Plan

`cargo test`
