### PR TITLE
Handle pattern parentheses in `FormatPattern`

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
@@ -263,6 +263,7 @@ match foo:
     ):
         y = 1
 
+
 match foo:
     case [1, 2, *rest]:
         pass
@@ -299,3 +300,47 @@ match foo:
         _, 1, 2]:
         pass
 
+
+match foo:
+    case (1):
+        pass
+    case ((1)):
+        pass
+    case [(1), 2]:
+        pass
+    case [(  # comment
+        1
+      ), 2]:
+        pass
+    case [  # outer
+        (  # inner
+        1
+      ), 2]:
+        pass
+    case [
+		( # outer
+			[ # inner
+				1,
+			]
+		)
+	]:
+        pass
+    case [ # outer
+		( # inner outer
+			[ # inner
+				1,
+			]
+		)
+	]:
+        pass
+    case [ # outer
+        # own line
+		( # inner outer
+			[ # inner
+				1,
+			]
+		)
+	]:
+        pass
+    case [(*rest), (a as b)]:
+        pass

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -212,7 +212,6 @@ fn handle_enclosed_comment<'a>(
             handle_leading_class_with_decorators_comment(comment, class_def)
         }
         AnyNodeRef::StmtImportFrom(import_from) => handle_import_from_comment(comment, import_from),
-        AnyNodeRef::MatchCase(match_case) => handle_match_case_comment(comment, match_case),
         AnyNodeRef::StmtWith(with_) => handle_with_comment(comment, with_),
         AnyNodeRef::ExprConstant(_) => {
             if let Some(AnyNodeRef::ExprFString(fstring)) = comment.enclosing_parent() {
@@ -1355,28 +1354,6 @@ fn handle_import_from_comment<'a>(
             import_from.start() < comment.start() && comment.start() < first_name.start()
         })
     {
-        CommentPlacement::dangling(comment.enclosing_node(), comment)
-    } else {
-        CommentPlacement::Default(comment)
-    }
-}
-
-/// Attach an enclosed end-of-line comment to a [`MatchCase`].
-///
-/// For example, given:
-/// ```python
-/// case (  # comment
-///    pattern
-/// ):
-///     ...
-/// ```
-///
-/// The comment will be attached to the [`MatchCase`] node as a dangling comment.
-fn handle_match_case_comment<'a>(
-    comment: DecoratedComment<'a>,
-    match_case: &'a MatchCase,
-) -> CommentPlacement<'a> {
-    if comment.line_position().is_end_of_line() && comment.start() < match_case.pattern.start() {
         CommentPlacement::dangling(comment.enclosing_node(), comment)
     } else {
         CommentPlacement::Default(comment)

--- a/crates/ruff_python_formatter/src/other/match_case.rs
+++ b/crates/ruff_python_formatter/src/other/match_case.rs
@@ -1,13 +1,13 @@
 use ruff_formatter::{write, Buffer, FormatResult};
-use ruff_python_ast::{MatchCase, Pattern, Ranged};
-use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
-use ruff_text_size::TextRange;
+use ruff_python_ast::node::AstNode;
+use ruff_python_ast::MatchCase;
 
+use crate::builders::parenthesize_if_expands;
 use crate::comments::SourceComment;
-use crate::expression::parentheses::{parenthesized, Parentheses};
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses, Parentheses};
 use crate::prelude::*;
 use crate::statement::clause::{clause_body, clause_header, ClauseHeader};
-use crate::{FormatError, FormatNodeRule, PyFormatter};
+use crate::{FormatNodeRule, PyFormatter};
 
 #[derive(Default)]
 pub struct FormatMatchCase;
@@ -21,13 +21,8 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
             body,
         } = item;
 
-        // Distinguish dangling comments that appear on the open parenthesis from those that
-        // appear on the trailing colon.
         let comments = f.context().comments().clone();
         let dangling_item_comments = comments.dangling(item);
-        let (open_parenthesis_comments, trailing_colon_comments) = dangling_item_comments.split_at(
-            dangling_item_comments.partition_point(|comment| comment.start() < pattern.start()),
-        );
 
         write!(
             f,
@@ -38,16 +33,29 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
                     &format_with(|f| {
                         write!(f, [text("case"), space()])?;
 
-                        if is_match_case_pattern_parenthesized(item, pattern, f.context())? {
-                            parenthesized(
-                                "(",
-                                &pattern.format().with_options(Parentheses::Never),
-                                ")",
-                            )
-                            .with_dangling_comments(open_parenthesis_comments)
-                            .fmt(f)?;
+                        let has_comments = comments.has_leading(pattern)
+                            || comments.has_trailing_own_line(pattern);
+
+                        if has_comments {
+                            pattern.format().with_options(Parentheses::Always).fmt(f)?;
                         } else {
-                            pattern.format().fmt(f)?;
+                            match pattern.needs_parentheses(item.as_any_node_ref(), f.context()) {
+                                OptionalParentheses::Multiline => {
+                                    parenthesize_if_expands(
+                                        &pattern.format().with_options(Parentheses::Never),
+                                    )
+                                    .fmt(f)?;
+                                }
+                                OptionalParentheses::Always => {
+                                    pattern.format().with_options(Parentheses::Always).fmt(f)?;
+                                }
+                                OptionalParentheses::Never => {
+                                    pattern.format().with_options(Parentheses::Never).fmt(f)?;
+                                }
+                                OptionalParentheses::BestFit => {
+                                    pattern.format().with_options(Parentheses::Never).fmt(f)?;
+                                }
+                            }
                         }
 
                         if let Some(guard) = guard {
@@ -57,7 +65,7 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
                         Ok(())
                     }),
                 ),
-                clause_body(body, trailing_colon_comments),
+                clause_body(body, dangling_item_comments),
             ]
         )
     }
@@ -69,35 +77,5 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
     ) -> FormatResult<()> {
         // Handled as part of `fmt_fields`
         Ok(())
-    }
-}
-
-fn is_match_case_pattern_parenthesized(
-    case: &MatchCase,
-    pattern: &Pattern,
-    context: &PyFormatContext,
-) -> FormatResult<bool> {
-    let mut tokenizer = SimpleTokenizer::new(
-        context.source(),
-        TextRange::new(case.start(), pattern.start()),
-    )
-    .skip_trivia();
-
-    let case_keyword = tokenizer.next().ok_or(FormatError::syntax_error(
-        "Expected a `case` keyword, didn't find any token",
-    ))?;
-
-    debug_assert_eq!(
-        case_keyword.kind(),
-        SimpleTokenKind::Case,
-        "Expected `case` keyword but at {case_keyword:?}"
-    );
-
-    match tokenizer.next() {
-        Some(left_paren) => {
-            debug_assert_eq!(left_paren.kind(), SimpleTokenKind::LParen);
-            Ok(true)
-        }
-        None => Ok(false),
     }
 }

--- a/crates/ruff_python_formatter/src/other/match_case.rs
+++ b/crates/ruff_python_formatter/src/other/match_case.rs
@@ -4,7 +4,7 @@ use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
 use ruff_text_size::TextRange;
 
 use crate::comments::SourceComment;
-use crate::expression::parentheses::parenthesized;
+use crate::expression::parentheses::{parenthesized, Parentheses};
 use crate::prelude::*;
 use crate::statement::clause::{clause_body, clause_header, ClauseHeader};
 use crate::{FormatError, FormatNodeRule, PyFormatter};
@@ -39,9 +39,13 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
                         write!(f, [text("case"), space()])?;
 
                         if is_match_case_pattern_parenthesized(item, pattern, f.context())? {
-                            parenthesized("(", &pattern.format(), ")")
-                                .with_dangling_comments(open_parenthesis_comments)
-                                .fmt(f)?;
+                            parenthesized(
+                                "(",
+                                &pattern.format().with_options(Parentheses::Never),
+                                ")",
+                            )
+                            .with_dangling_comments(open_parenthesis_comments)
+                            .fmt(f)?;
                         } else {
                             pattern.format().fmt(f)?;
                         }

--- a/crates/ruff_python_formatter/src/pattern/mod.rs
+++ b/crates/ruff_python_formatter/src/pattern/mod.rs
@@ -1,8 +1,11 @@
 use ruff_formatter::{FormatOwnedWithRule, FormatRefWithRule, FormatRule, FormatRuleWithOptions};
+use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::{Pattern, Ranged};
 use ruff_python_trivia::{first_non_trivia_token, SimpleToken, SimpleTokenKind, SimpleTokenizer};
 
-use crate::expression::parentheses::{parenthesized, Parentheses};
+use crate::expression::parentheses::{
+    parenthesized, NeedsParentheses, OptionalParentheses, Parentheses,
+};
 use crate::prelude::*;
 
 pub(crate) mod pattern_match_as;
@@ -113,5 +116,24 @@ fn is_pattern_parenthesized(pattern: &Pattern, contents: &str) -> bool {
         )
     } else {
         false
+    }
+}
+
+impl NeedsParentheses for Pattern {
+    fn needs_parentheses(
+        &self,
+        parent: AnyNodeRef,
+        context: &PyFormatContext,
+    ) -> OptionalParentheses {
+        match self {
+            Pattern::MatchValue(pattern) => pattern.needs_parentheses(parent, context),
+            Pattern::MatchSingleton(pattern) => pattern.needs_parentheses(parent, context),
+            Pattern::MatchSequence(pattern) => pattern.needs_parentheses(parent, context),
+            Pattern::MatchMapping(pattern) => pattern.needs_parentheses(parent, context),
+            Pattern::MatchClass(pattern) => pattern.needs_parentheses(parent, context),
+            Pattern::MatchStar(pattern) => pattern.needs_parentheses(parent, context),
+            Pattern::MatchAs(pattern) => pattern.needs_parentheses(parent, context),
+            Pattern::MatchOr(pattern) => pattern.needs_parentheses(parent, context),
+        }
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_as.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_as.rs
@@ -1,8 +1,7 @@
 use ruff_formatter::{write, Buffer, FormatResult};
-use ruff_python_ast::{Pattern, PatternMatchAs};
+use ruff_python_ast::PatternMatchAs;
 
 use crate::comments::{dangling_comments, SourceComment};
-use crate::expression::parentheses::parenthesized;
 use crate::prelude::*;
 use crate::{FormatNodeRule, PyFormatter};
 
@@ -21,18 +20,7 @@ impl FormatNodeRule<PatternMatchAs> for FormatPatternMatchAs {
 
         if let Some(name) = name {
             if let Some(pattern) = pattern {
-                // Parenthesize nested `PatternMatchAs` like `(a as b) as c`.
-                if matches!(
-                    pattern.as_ref(),
-                    Pattern::MatchAs(PatternMatchAs {
-                        pattern: Some(_),
-                        ..
-                    })
-                ) {
-                    parenthesized("(", &pattern.format(), ")").fmt(f)?;
-                } else {
-                    pattern.format().fmt(f)?;
-                }
+                pattern.format().fmt(f)?;
 
                 if comments.has_trailing(pattern.as_ref()) {
                     write!(f, [hard_line_break()])?;

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_as.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_as.rs
@@ -1,7 +1,9 @@
 use ruff_formatter::{write, Buffer, FormatResult};
+use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::PatternMatchAs;
 
 use crate::comments::{dangling_comments, SourceComment};
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 use crate::{FormatNodeRule, PyFormatter};
 
@@ -54,5 +56,15 @@ impl FormatNodeRule<PatternMatchAs> for FormatPatternMatchAs {
         _f: &mut PyFormatter,
     ) -> FormatResult<()> {
         Ok(())
+    }
+}
+
+impl NeedsParentheses for PatternMatchAs {
+    fn needs_parentheses(
+        &self,
+        _parent: AnyNodeRef,
+        _context: &PyFormatContext,
+    ) -> OptionalParentheses {
+        OptionalParentheses::Multiline
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_class.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_class.rs
@@ -1,6 +1,9 @@
 use ruff_formatter::{write, Buffer, FormatResult};
+use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::PatternMatchClass;
 
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
+use crate::prelude::*;
 use crate::{not_yet_implemented_custom_text, FormatNodeRule, PyFormatter};
 
 #[derive(Default)]
@@ -15,5 +18,15 @@ impl FormatNodeRule<PatternMatchClass> for FormatPatternMatchClass {
                 item
             )]
         )
+    }
+}
+
+impl NeedsParentheses for PatternMatchClass {
+    fn needs_parentheses(
+        &self,
+        _parent: AnyNodeRef,
+        _context: &PyFormatContext,
+    ) -> OptionalParentheses {
+        OptionalParentheses::Never
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_mapping.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_mapping.rs
@@ -1,6 +1,9 @@
 use ruff_formatter::{write, Buffer, FormatResult};
+use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::PatternMatchMapping;
 
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
+use crate::prelude::*;
 use crate::{not_yet_implemented_custom_text, FormatNodeRule, PyFormatter};
 
 #[derive(Default)]
@@ -15,5 +18,15 @@ impl FormatNodeRule<PatternMatchMapping> for FormatPatternMatchMapping {
                 item
             )]
         )
+    }
+}
+
+impl NeedsParentheses for PatternMatchMapping {
+    fn needs_parentheses(
+        &self,
+        _parent: AnyNodeRef,
+        _context: &PyFormatContext,
+    ) -> OptionalParentheses {
+        OptionalParentheses::Never
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_or.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_or.rs
@@ -1,6 +1,9 @@
 use ruff_formatter::{write, Buffer, FormatResult};
+use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::PatternMatchOr;
 
+use crate::context::PyFormatContext;
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::{not_yet_implemented_custom_text, FormatNodeRule, PyFormatter};
 
 #[derive(Default)]
@@ -15,5 +18,15 @@ impl FormatNodeRule<PatternMatchOr> for FormatPatternMatchOr {
                 item
             )]
         )
+    }
+}
+
+impl NeedsParentheses for PatternMatchOr {
+    fn needs_parentheses(
+        &self,
+        _parent: AnyNodeRef,
+        _context: &PyFormatContext,
+    ) -> OptionalParentheses {
+        OptionalParentheses::Multiline
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_sequence.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_sequence.rs
@@ -1,9 +1,13 @@
 use ruff_formatter::prelude::format_with;
 use ruff_formatter::{Format, FormatResult};
+use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::PatternMatchSequence;
 
 use crate::builders::PyFormatterExtensions;
-use crate::expression::parentheses::{empty_parenthesized, optional_parentheses, parenthesized};
+use crate::context::PyFormatContext;
+use crate::expression::parentheses::{
+    empty_parenthesized, optional_parentheses, parenthesized, NeedsParentheses, OptionalParentheses,
+};
 use crate::{FormatNodeRule, PyFormatter};
 
 #[derive(Default)]
@@ -49,5 +53,15 @@ impl FormatNodeRule<PatternMatchSequence> for FormatPatternMatchSequence {
                 .fmt(f),
             SequenceType::TupleNoParens => optional_parentheses(&items).fmt(f),
         }
+    }
+}
+
+impl NeedsParentheses for PatternMatchSequence {
+    fn needs_parentheses(
+        &self,
+        _parent: AnyNodeRef,
+        _context: &PyFormatContext,
+    ) -> OptionalParentheses {
+        OptionalParentheses::Never
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_singleton.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_singleton.rs
@@ -1,6 +1,8 @@
 use crate::prelude::*;
+use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::{Constant, PatternMatchSingleton};
 
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::{FormatNodeRule, PyFormatter};
 
 #[derive(Default)]
@@ -14,5 +16,15 @@ impl FormatNodeRule<PatternMatchSingleton> for FormatPatternMatchSingleton {
             Constant::Bool(false) => text("False").fmt(f),
             _ => unreachable!(),
         }
+    }
+}
+
+impl NeedsParentheses for PatternMatchSingleton {
+    fn needs_parentheses(
+        &self,
+        _parent: AnyNodeRef,
+        _context: &PyFormatContext,
+    ) -> OptionalParentheses {
+        OptionalParentheses::Never
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_star.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_star.rs
@@ -1,9 +1,10 @@
-use ruff_formatter::{prelude::text, write, Buffer, FormatResult};
+use ruff_formatter::{write, Buffer, FormatResult};
+use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::PatternMatchStar;
 
 use crate::comments::{dangling_comments, SourceComment};
-use crate::AsFormat;
-use crate::{FormatNodeRule, PyFormatter};
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
+use crate::prelude::*;
 
 #[derive(Default)]
 pub struct FormatPatternMatchStar;
@@ -30,5 +31,15 @@ impl FormatNodeRule<PatternMatchStar> for FormatPatternMatchStar {
     ) -> FormatResult<()> {
         // Handled by `fmt_fields`
         Ok(())
+    }
+}
+
+impl NeedsParentheses for PatternMatchStar {
+    fn needs_parentheses(
+        &self,
+        _parent: AnyNodeRef,
+        _context: &PyFormatContext,
+    ) -> OptionalParentheses {
+        OptionalParentheses::Never
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_value.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_value.rs
@@ -1,6 +1,7 @@
+use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::PatternMatchValue;
 
-use crate::expression::parentheses::Parentheses;
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses, Parentheses};
 use crate::prelude::*;
 use crate::{AsFormat, FormatNodeRule, PyFormatter};
 
@@ -11,5 +12,15 @@ impl FormatNodeRule<PatternMatchValue> for FormatPatternMatchValue {
     fn fmt_fields(&self, item: &PatternMatchValue, f: &mut PyFormatter) -> FormatResult<()> {
         let PatternMatchValue { value, range: _ } = item;
         value.format().with_options(Parentheses::Never).fmt(f)
+    }
+}
+
+impl NeedsParentheses for PatternMatchValue {
+    fn needs_parentheses(
+        &self,
+        _parent: AnyNodeRef,
+        _context: &PyFormatContext,
+    ) -> OptionalParentheses {
+        OptionalParentheses::Never
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_value.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_value.rs
@@ -1,14 +1,15 @@
 use ruff_python_ast::PatternMatchValue;
 
+use crate::expression::parentheses::Parentheses;
 use crate::prelude::*;
+use crate::{AsFormat, FormatNodeRule, PyFormatter};
 
 #[derive(Default)]
 pub struct FormatPatternMatchValue;
 
 impl FormatNodeRule<PatternMatchValue> for FormatPatternMatchValue {
     fn fmt_fields(&self, item: &PatternMatchValue, f: &mut PyFormatter) -> FormatResult<()> {
-        // TODO(charlie): Avoid double parentheses for parenthesized top-level `PatternMatchValue`.
         let PatternMatchValue { value, range: _ } = item;
-        value.format().fmt(f)
+        value.format().with_options(Parentheses::Never).fmt(f)
     }
 }

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_extras.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_extras.py.snap
@@ -231,7 +231,7 @@ match bar1:
          pass
  
 -    case 4 as d, (5 as e), (6 | 7 as g), *h:
-+    case 4 as d, 5 as e, NOT_YET_IMPLEMENTED_PatternMatchOf | (y) as g, *h:
++    case 4 as d, (5 as e), (NOT_YET_IMPLEMENTED_PatternMatchOf | (y) as g), *h:
          pass
  
  
@@ -358,7 +358,7 @@ match something:
     case 2 as b, 3 as c:
         pass
 
-    case 4 as d, 5 as e, NOT_YET_IMPLEMENTED_PatternMatchOf | (y) as g, *h:
+    case 4 as d, (5 as e), (NOT_YET_IMPLEMENTED_PatternMatchOf | (y) as g), *h:
         pass
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_simple.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@py_310__pattern_matching_simple.py.snap
@@ -117,13 +117,13 @@ def where_is(point):
  
  match command.split():
 -    case ["go", ("north" | "south" | "east" | "west")]:
-+    case ["go", NOT_YET_IMPLEMENTED_PatternMatchOf | (y)]:
++    case ["go", (NOT_YET_IMPLEMENTED_PatternMatchOf | (y))]:
          current_room = current_room.neighbor(...)
          # how do I know which direction to go?
  
  match command.split():
 -    case ["go", ("north" | "south" | "east" | "west") as direction]:
-+    case ["go", NOT_YET_IMPLEMENTED_PatternMatchOf | (y) as direction]:
++    case ["go", (NOT_YET_IMPLEMENTED_PatternMatchOf | (y)) as direction]:
          current_room = current_room.neighbor(direction)
  
  match command.split():
@@ -223,12 +223,12 @@ match command.split():
         ...  # Code for picking up the given object
 
 match command.split():
-    case ["go", NOT_YET_IMPLEMENTED_PatternMatchOf | (y)]:
+    case ["go", (NOT_YET_IMPLEMENTED_PatternMatchOf | (y))]:
         current_room = current_room.neighbor(...)
         # how do I know which direction to go?
 
 match command.split():
-    case ["go", NOT_YET_IMPLEMENTED_PatternMatchOf | (y) as direction]:
+    case ["go", (NOT_YET_IMPLEMENTED_PatternMatchOf | (y)) as direction]:
         current_room = current_room.neighbor(direction)
 
 match command.split():

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -269,6 +269,7 @@ match foo:
     ):
         y = 1
 
+
 match foo:
     case [1, 2, *rest]:
         pass
@@ -305,6 +306,50 @@ match foo:
         _, 1, 2]:
         pass
 
+
+match foo:
+    case (1):
+        pass
+    case ((1)):
+        pass
+    case [(1), 2]:
+        pass
+    case [(  # comment
+        1
+      ), 2]:
+        pass
+    case [  # outer
+        (  # inner
+        1
+      ), 2]:
+        pass
+    case [
+		( # outer
+			[ # inner
+				1,
+			]
+		)
+	]:
+        pass
+    case [ # outer
+		( # inner outer
+			[ # inner
+				1,
+			]
+		)
+	]:
+        pass
+    case [ # outer
+        # own line
+		( # inner outer
+			[ # inner
+				1,
+			]
+		)
+	]:
+        pass
+    case [(*rest), (a as b)]:
+        pass
 ```
 
 ## Output
@@ -545,28 +590,29 @@ match foo:
 match foo:
     case 1:
         y = 0
-    case ((1)):
+    case (1):
         y = 1
-    case (("a")):
+    case ("a"):
         y = 1
     case (  # comment
-        (1)
+        1
     ):
         y = 1
     case (
         # comment
-        (1)
+        1
     ):
         y = 1
     case (
-        (1)  # comment
+        1  # comment
     ):
         y = 1
     case (
-        (1)
+        1
         # comment
     ):
         y = 1
+
 
 match foo:
     case [1, 2, *rest]:
@@ -626,6 +672,62 @@ match foo:
         1,
         2,
     ]:
+        pass
+
+
+match foo:
+    case (1):
+        pass
+    case (1):
+        pass
+    case [(1), 2]:
+        pass
+    case [
+        (  # comment
+            1
+        ),
+        2,
+    ]:
+        pass
+    case [
+        (  # outer
+            # inner
+            1
+        ),
+        2,
+    ]:
+        pass
+    case [
+        (  # outer
+            [
+                # inner
+                1,
+            ]
+        )
+    ]:
+        pass
+    case [
+        (  # outer
+            # inner outer
+            [
+                # inner
+                1,
+            ]
+        )
+    ]:
+        pass
+    case [
+        (  # outer
+            # own line
+            # inner outer
+            [
+                # inner
+                1,
+            ]
+        )
+    ]:
+        pass
+    case [(*rest), (a as b)]:
         pass
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -485,7 +485,7 @@ match pattern_comments:
 
 
 match pattern_comments:
-    case (no_comments):
+    case no_comments:
         pass
 
 
@@ -549,9 +549,7 @@ match pattern_singleton:
         # trailing own 2
     ):
         pass
-    case (
-        True  # trailing
-    ):
+    case True:  # trailing
         ...
     case False:
         ...
@@ -569,7 +567,7 @@ match foo:
         pass
     case ["a", "b"]:
         pass
-    case (["a", "b"]):
+    case ["a", "b"]:
         pass
 
 
@@ -590,9 +588,9 @@ match foo:
 match foo:
     case 1:
         y = 0
-    case (1):
+    case 1:
         y = 1
-    case ("a"):
+    case "a":
         y = 1
     case (  # comment
         1
@@ -603,9 +601,7 @@ match foo:
         1
     ):
         y = 1
-    case (
-        1  # comment
-    ):
+    case 1:  # comment
         y = 1
     case (
         1
@@ -676,9 +672,9 @@ match foo:
 
 
 match foo:
-    case (1):
+    case 1:
         pass
-    case (1):
+    case 1:
         pass
     case [(1), 2]:
         pass


### PR DESCRIPTION
## Summary

This PR fixes the duplicate-parenthesis problem that's visible in the tests from https://github.com/astral-sh/ruff/pull/6799. The issue is that we might have parentheses around the entire match-case pattern, like in `(1)` here:

```python
match foo:
    case (1):
        y = 0
```

In this case, the inner expression (`1`) will _think_ it's parenthesized, but we'll _also_ detect the parentheses at the case level -- so they get rendered by the case, then again by the expression. Instead, if we detect parentheses at the case level, we can force-off the parentheses for the pattern using a design similar to the way we handle parentheses on expressions.

Closes https://github.com/astral-sh/ruff/issues/6753.

## Test Plan

`cargo test`
