### PR TITLE
 Formatter: Show preceding, following and enclosing nodes of comments, Attempt 2

### DIFF
--- a/crates/ruff_python_formatter/src/cli.rs
+++ b/crates/ruff_python_formatter/src/cli.rs
@@ -9,7 +9,9 @@ use ruff_formatter::SourceCode;
 use ruff_python_index::CommentRangesBuilder;
 use ruff_python_parser::lexer::lex;
 use ruff_python_parser::{parse_tokens, Mode};
+use ruff_text_size::Ranged;
 
+use crate::comments::collect_comments;
 use crate::{format_node, PyFormatOptions};
 
 #[derive(ValueEnum, Clone, Debug)]
@@ -64,6 +66,26 @@ pub fn format_and_debug_print(input: &str, cli: &Cli, source_type: &Path) -> Res
         println!("{}", formatted.document().display(SourceCode::new(input)));
     }
     if cli.print_comments {
+        // Print preceding, following and enclosing nodes
+        let source_code = SourceCode::new(input);
+        let decorated_comments = collect_comments(&python_ast, source_code, &comment_ranges);
+        for comment in decorated_comments {
+            println!(
+                "{:?} {:?} {:?} {:?} {:?}",
+                comment.slice().range(),
+                comment
+                    .preceding_node()
+                    .map(|node| (node.kind(), node.range())),
+                comment
+                    .following_node()
+                    .map(|node| (node.kind(), node.range())),
+                (
+                    comment.enclosing_node().kind(),
+                    comment.enclosing_node().range()
+                ),
+                comment.slice().text(SourceCode::new(input)),
+            );
+        }
         println!(
             "{:#?}",
             formatted.context().comments().debug(SourceCode::new(input))

--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -108,7 +108,8 @@ use ruff_python_trivia::PythonWhitespace;
 use crate::comments::debug::{DebugComment, DebugComments};
 use crate::comments::map::{LeadingDanglingTrailing, MultiMap};
 use crate::comments::node_key::NodeRefEqualityKey;
-use crate::comments::visitor::CommentsVisitor;
+use crate::comments::visitor::{CommentsMapBuilder, CommentsVisitor};
+pub(crate) use visitor::collect_comments;
 
 mod debug;
 pub(crate) mod format;
@@ -324,7 +325,9 @@ impl<'a> Comments<'a> {
         let map = if comment_ranges.is_empty() {
             CommentsMap::new()
         } else {
-            CommentsVisitor::new(source_code, comment_ranges).visit(root)
+            let mut builder = CommentsMapBuilder::default();
+            CommentsVisitor::new(source_code, comment_ranges, &mut builder).visit(root);
+            builder.finish()
         };
 
         Self::new(map)


### PR DESCRIPTION
This is a new attempt after https://github.com/astral-sh/ruff/pull/6337.

**Summary** I used to always add `dbg!` for the preceding, following and enclosing node. With this change `--print-comments` can do this instead.

```python
match foo: # a
    # b
    case [1, 2, * # c
    rest]:
        pass
    # d
    case [1, 2, * #e
    _]:
        pass
    case [
        1,
        2,
        *rest,
    ]:
        pass
```
Additional `--print-comments` Output:
```
11..14 Some((ExprName, 6..9)) Some((MatchCase, 27..68)) (StmtMatch, 0..186) "# a"
19..22 Some((ExprName, 6..9)) Some((MatchCase, 27..68)) (StmtMatch, 0..186) "# b"
41..44 None None (PatternMatchStar, 39..53) "# c"
73..76 Some((MatchCase, 27..68)) Some((MatchCase, 81..118)) (StmtMatch, 0..186) "# d"
95..97 None None (PatternMatchStar, 93..103) "#e"
```

**Test Plan** n/a