### PR TITLE
Fix Printer group modes

### DIFF
--- a/crates/ruff_formatter/src/diagnostics.rs
+++ b/crates/ruff_formatter/src/diagnostics.rs
@@ -1,4 +1,5 @@
 use crate::prelude::TagKind;
+use crate::GroupId;
 use ruff_text_size::TextRange;
 use std::error::Error;
 
@@ -86,7 +87,9 @@ pub enum InvalidDocumentError {
     /// Text
     /// EndGroup
     /// ```
-    StartTagMissing { kind: TagKind },
+    StartTagMissing {
+        kind: TagKind,
+    },
 
     /// Expected a specific start tag but instead is:
     /// - at the end of the document
@@ -95,6 +98,10 @@ pub enum InvalidDocumentError {
     ExpectedStart {
         expected_start: TagKind,
         actual: ActualStart,
+    },
+
+    UnknownGroupId {
+        group_id: GroupId,
     },
 }
 
@@ -147,6 +154,9 @@ impl std::fmt::Display for InvalidDocumentError {
                         std::write!(f, "Expected start tag of kind {expected_start:?} but found non-tag element.")
                     }
                 }
+            }
+            InvalidDocumentError::UnknownGroupId { group_id } => {
+                std::write!(f, "Encountered unknown group id {group_id:?}. Ensure that the group with the id {group_id:?} exists and that the group is a parent of or comes before the element referring to it.")
             }
         }
     }

--- a/crates/ruff_formatter/src/group_id.rs
+++ b/crates/ruff_formatter/src/group_id.rs
@@ -1,9 +1,11 @@
 use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicU32, Ordering};
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
 pub struct DebugGroupId {
     value: NonZeroU32,
+    #[cfg_attr(feature = "serde", serde(skip))]
     name: &'static str,
 }
 
@@ -28,6 +30,7 @@ impl std::fmt::Debug for DebugGroupId {
 /// See [`crate::Formatter::group_id`] on how to get a unique id.
 #[repr(transparent)]
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReleaseGroupId {
     value: NonZeroU32,
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This fixes a bug in the Printer where the mode for a group was stale when testing if some content fits. 

The input must have been of the form

```
group(1, 
	...
)
... (as long as no line break)
group(2, 
	if_group_breaks(2, text("()),
	...
)
```

What happened is:

* The printer measured if group 1 fits
	* The printer sees no line break up to group 2 and, therefore, starts measuring group 2
	* But the printer first writes that the group 2 is printed in `Expanded` mode to the `print_modes` state that is shared between printing and measuring
	* The printer return `Fits::No`, because the line ultimately doesn't fit, but it doesn't undo the written `group_modes[2] = Expand`
* The printer now tests if at least the group 2 fits
	* The `if_group_breaks` looks up the value of group `2` in `group_modes` which still contains the stale `Expand` entry (it breaks)
	* The printer, incorrectly assumes that it will have to print the `(`. It won't print the `(`, but it assumes the layout as if group 2 breaks when measuring if it fits
	* The printer decides that the group fits (when it shouldn't), and renders it in flat mode

This PR implements a fix by always writing `group_modes[group_id] = Flat` of the current group that should be measured. We already do this **after** measuring and inside of `fits_groups`. This only extends it to override any stale entry for the outermost group too. 

This seems to come at a performance cost because there's now one additional write for every group (and there are many!). What would be nice is if there's a cheap way to restore `group_modes` after measuring fits but that would require that the group ids in the document are monotonic. While it's true that group ids are always increasing, it isn't guaranteed that their groups are written in the same order as the ids have been created. 

I used the chance to remove the (last?) `unwrap` in the `Printer` by returning gan `Err` if a document uses a `group_id` that hasn't been seen to this point.

