### PR TITLE
Use BestFits for non-fluent attribute chains

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unsplittable.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unsplittable.py
@@ -52,3 +52,8 @@ for converter in connection.ops.get_db_converters(
     expression
 ) + expression.get_db_converters(connection):
     ...
+
+
+aaa = (
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb # awkward comment
+)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unsplittable.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unsplittable.py
@@ -57,3 +57,11 @@ for converter in connection.ops.get_db_converters(
 aaa = (
     bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb # awkward comment
 )
+
+def test():
+    m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyField(Person, blank=True)
+
+    m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyFieldAttributeChainField
+
+m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyField(Person, blank=True)
+m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyFieldAttributeChainFieeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeld

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/yield.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/yield.py
@@ -66,6 +66,13 @@ def foo():
         1
     )
 
+    yield (
+        "#   * Make sure each ForeignKey and OneToOneField has `on_delete` set "
+        "to the desired behavior"
+    )
+
+    yield aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb + ccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
 yield ("Cache key will cause errors if used with memcached: %r " "(longer than %s)" % (
     key,
     MEMCACHE_MAX_KEY_LENGTH,

--- a/crates/ruff_python_formatter/src/expression/expr_call.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_call.rs
@@ -66,10 +66,7 @@ impl NeedsParentheses for ExprCall {
         {
             OptionalParentheses::Multiline
         } else {
-            match self.func.needs_parentheses(self.into(), context) {
-                OptionalParentheses::BestFit => OptionalParentheses::IfFits,
-                parentheses => parentheses,
-            }
+            self.func.needs_parentheses(self.into(), context)
         }
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_call.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_call.rs
@@ -1,5 +1,6 @@
 use crate::expression::CallChainLayout;
-use ruff_formatter::FormatRuleWithOptions;
+
+use ruff_formatter::{format_args, write, FormatRuleWithOptions};
 use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::{Expr, ExprCall};
 
@@ -31,15 +32,11 @@ impl FormatNodeRule<ExprCall> for FormatExprCall {
 
         let call_chain_layout = self.call_chain_layout.apply_in_node(item, f);
 
-        let fmt_inner = format_with(|f| {
-            match func.as_ref() {
-                Expr::Attribute(expr) => expr.format().with_options(call_chain_layout).fmt(f)?,
-                Expr::Call(expr) => expr.format().with_options(call_chain_layout).fmt(f)?,
-                Expr::Subscript(expr) => expr.format().with_options(call_chain_layout).fmt(f)?,
-                _ => func.format().fmt(f)?,
-            }
-
-            arguments.format().fmt(f)
+        let fmt_func = format_with(|f| match func.as_ref() {
+            Expr::Attribute(expr) => expr.format().with_options(call_chain_layout).fmt(f),
+            Expr::Call(expr) => expr.format().with_options(call_chain_layout).fmt(f),
+            Expr::Subscript(expr) => expr.format().with_options(call_chain_layout).fmt(f),
+            _ => func.format().fmt(f),
         });
 
         // Allow to indent the parentheses while
@@ -51,9 +48,9 @@ impl FormatNodeRule<ExprCall> for FormatExprCall {
         if call_chain_layout == CallChainLayout::Fluent
             && self.call_chain_layout == CallChainLayout::Default
         {
-            group(&fmt_inner).fmt(f)
+            group(&format_args![fmt_func, arguments.format()]).fmt(f)
         } else {
-            fmt_inner.fmt(f)
+            write!(f, [fmt_func, arguments.format()])
         }
     }
 }
@@ -70,7 +67,7 @@ impl NeedsParentheses for ExprCall {
             OptionalParentheses::Multiline
         } else {
             match self.func.needs_parentheses(self.into(), context) {
-                OptionalParentheses::BestFit => OptionalParentheses::Never,
+                OptionalParentheses::BestFit => OptionalParentheses::IfFits,
                 parentheses => parentheses,
             }
         }

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 use thiserror::Error;
 
 use ruff_formatter::format_element::tag;

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 use thiserror::Error;
 
 use ruff_formatter::format_element::tag;

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__trailing_commas_in_leading_parts.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__trailing_commas_in_leading_parts.py.snap
@@ -56,6 +56,18 @@ assert xxxxxxxxx.xxxxxxxxx.xxxxxxxxx(
  
  
  # Example from https://github.com/psf/black/issues/3229
+@@ -43,8 +41,6 @@
+ )
+ 
+ # Regression test for https://github.com/psf/black/issues/3414.
+-assert xxxxxxxxx.xxxxxxxxx.xxxxxxxxx(
+-    xxxxxxxxx
+-).xxxxxxxxxxxxxxxxxx(), (
+-    "xxx {xxxxxxxxx} xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+-)
++assert (
++    xxxxxxxxx.xxxxxxxxx.xxxxxxxxx(xxxxxxxxx).xxxxxxxxxxxxxxxxxx()
++), "xxx {xxxxxxxxx} xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
 
 ## Ruff Output
@@ -104,11 +116,9 @@ assert (
 )
 
 # Regression test for https://github.com/psf/black/issues/3414.
-assert xxxxxxxxx.xxxxxxxxx.xxxxxxxxx(
-    xxxxxxxxx
-).xxxxxxxxxxxxxxxxxx(), (
-    "xxx {xxxxxxxxx} xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-)
+assert (
+    xxxxxxxxx.xxxxxxxxx.xxxxxxxxx(xxxxxxxxx).xxxxxxxxxxxxxxxxxx()
+), "xxx {xxxxxxxxx} xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
 
 ## Black Output

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__unsplittable.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__unsplittable.py.snap
@@ -63,6 +63,14 @@ for converter in connection.ops.get_db_converters(
 aaa = (
     bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb # awkward comment
 )
+
+def test():
+    m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyField(Person, blank=True)
+
+    m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyFieldAttributeChainField
+
+m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyField(Person, blank=True)
+m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyFieldAttributeChainFieeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeld
 ```
 
 ## Output
@@ -128,6 +136,22 @@ for converter in connection.ops.get_db_converters(
 
 
 aaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  # awkward comment
+
+
+def test():
+    m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = (
+        models.ManyToManyField(Person, blank=True)
+    )
+
+    m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = (
+        models.ManyToManyFieldAttributeChainField
+    )
+
+
+m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = (
+    models.ManyToManyField(Person, blank=True)
+)
+m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyFieldAttributeChainFieeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeld
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__unsplittable.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__unsplittable.py.snap
@@ -58,6 +58,11 @@ for converter in connection.ops.get_db_converters(
     expression
 ) + expression.get_db_converters(connection):
     ...
+
+
+aaa = (
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb # awkward comment
+)
 ```
 
 ## Output
@@ -120,6 +125,9 @@ for converter in connection.ops.get_db_converters(
     expression
 ) + expression.get_db_converters(connection):
     ...
+
+
+aaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  # awkward comment
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__yield.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__yield.py.snap
@@ -72,6 +72,13 @@ def foo():
         1
     )
 
+    yield (
+        "#   * Make sure each ForeignKey and OneToOneField has `on_delete` set "
+        "to the desired behavior"
+    )
+
+    yield aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb + ccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
 yield ("Cache key will cause errors if used with memcached: %r " "(longer than %s)" % (
     key,
     MEMCACHE_MAX_KEY_LENGTH,
@@ -166,6 +173,17 @@ def foo():
                 1,
             )
         )
+    )
+
+    yield (
+        "#   * Make sure each ForeignKey and OneToOneField has `on_delete` set "
+        "to the desired behavior"
+    )
+
+    yield (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+        + ccccccccccccccccccccccccccccccccccccccccccccccccccccccc
     )
 
 


### PR DESCRIPTION
## Summary

This is the last part of #6271. It implements the overlong parenthesizing for attribute chains (and call expressions). 

The code changes are minimal. The main reason for this being its own PR is to assess the performance implication (and compatibility win)

Closes #6271

## Test Plan

**Base**


project | similarity index
-- | --
cpython | 0.76058
django | 0.99894
transformers | 0.99842
twine | 0.99929
typeshed | 0.99953
warehouse | 0.99632
zulip | 0.99909



**This PR**
| project      | similarity index |
|--------------|------------------|
| cpython      | 0.76061          |
| django       | 0.99898          |
| transformers | 0.99842          |
| twine        | 0.99929          |
| typeshed     | 0.99953          |
| warehouse    | 0.99637          |
| zulip        | 0.99920          |


<!-- How was it tested? -->
