### PR TITLE
Printer: Slice based queue and stack

### DIFF
--- a/crates/ruff_formatter/src/printer/queue.rs
+++ b/crates/ruff_formatter/src/printer/queue.rs
@@ -1,6 +1,5 @@
 use crate::format_element::tag::TagKind;
 use crate::prelude::Tag;
-use crate::printer::stack::{Stack, StackedStack};
 use crate::printer::{invalid_end_tag, invalid_start_tag};
 use crate::{FormatElement, PrintResult};
 use std::fmt::Debug;
@@ -9,43 +8,11 @@ use std::marker::PhantomData;
 
 /// Queue of [`FormatElement`]s.
 pub(super) trait Queue<'a> {
-    type Stack: Stack<&'a [FormatElement]>;
-
-    fn stack(&self) -> &Self::Stack;
-
-    fn stack_mut(&mut self) -> &mut Self::Stack;
-
-    fn next_index(&self) -> usize;
-
-    fn set_next_index(&mut self, index: usize);
-
     /// Pops the element at the end of the queue.
-    fn pop(&mut self) -> Option<&'a FormatElement> {
-        match self.stack().top() {
-            Some(top_slice) => {
-                // SAFETY: Safe because queue ensures that slices inside `slices` are never empty.
-                let next_index = self.next_index();
-                let element = &top_slice[next_index];
-
-                if next_index + 1 == top_slice.len() {
-                    self.stack_mut().pop().unwrap();
-                    self.set_next_index(0);
-                } else {
-                    self.set_next_index(next_index + 1);
-                }
-
-                Some(element)
-            }
-            None => None,
-        }
-    }
+    fn pop(&mut self) -> Option<&'a FormatElement>;
 
     /// Returns the next element, not traversing into [`FormatElement::Interned`].
-    fn top_with_interned(&self) -> Option<&'a FormatElement> {
-        self.stack()
-            .top()
-            .map(|top_slice| &top_slice[self.next_index()])
-    }
+    fn top_with_interned(&self) -> Option<&'a FormatElement>;
 
     /// Returns the next element, recursively resolving the first element of [`FormatElement::Interned`].
     fn top(&self) -> Option<&'a FormatElement> {
@@ -64,29 +31,10 @@ pub(super) trait Queue<'a> {
     }
 
     /// Queues a slice of elements to process before the other elements in this queue.
-    fn extend_back(&mut self, elements: &'a [FormatElement]) {
-        match elements {
-            [] => {
-                // Don't push empty slices
-            }
-            slice => {
-                let next_index = self.next_index();
-                let stack = self.stack_mut();
-                if let Some(top) = stack.pop() {
-                    stack.push(&top[next_index..]);
-                }
-
-                stack.push(slice);
-                self.set_next_index(0);
-            }
-        }
-    }
+    fn extend_back(&mut self, elements: &'a [FormatElement]);
 
     /// Removes top slice.
-    fn pop_slice(&mut self) -> Option<&'a [FormatElement]> {
-        self.set_next_index(0);
-        self.stack_mut().pop()
-    }
+    fn pop_slice(&mut self) -> Option<&'a [FormatElement]>;
 
     /// Skips all content until it finds the corresponding end tag with the given kind.
     fn skip_content(&mut self, kind: TagKind)
@@ -112,45 +60,58 @@ pub(super) trait Queue<'a> {
 /// Queue with the elements to print.
 #[derive(Debug, Default, Clone)]
 pub(super) struct PrintQueue<'a> {
-    slices: Vec<&'a [FormatElement]>,
-    next_index: usize,
+    element_slices: Vec<std::slice::Iter<'a, FormatElement>>,
 }
 
 impl<'a> PrintQueue<'a> {
     pub(super) fn new(slice: &'a [FormatElement]) -> Self {
-        let slices = match slice {
-            [] => Vec::default(),
-            slice => vec![slice],
-        };
-
         Self {
-            slices,
-            next_index: 0,
+            element_slices: if slice.is_empty() {
+                Vec::new()
+            } else {
+                vec![slice.iter()]
+            },
         }
-    }
-
-    pub(super) fn is_empty(&self) -> bool {
-        self.slices.is_empty()
     }
 }
 
 impl<'a> Queue<'a> for PrintQueue<'a> {
-    type Stack = Vec<&'a [FormatElement]>;
-
-    fn stack(&self) -> &Self::Stack {
-        &self.slices
+    fn pop(&mut self) -> Option<&'a FormatElement> {
+        let elements = self.element_slices.last_mut()?;
+        elements.next().or_else(|| {
+            self.element_slices.pop();
+            let elements = self.element_slices.last_mut()?;
+            elements.next()
+        })
     }
 
-    fn stack_mut(&mut self) -> &mut Self::Stack {
-        &mut self.slices
+    fn top_with_interned(&self) -> Option<&'a FormatElement> {
+        let mut slices = self.element_slices.iter().rev();
+        let slice = slices.next()?;
+
+        match slice.as_slice().first() {
+            Some(element) => Some(element),
+            None => {
+                if let Some(next_elements) = slices.next() {
+                    next_elements.as_slice().first()
+                } else {
+                    None
+                }
+            }
+        }
     }
 
-    fn next_index(&self) -> usize {
-        self.next_index
+    fn extend_back(&mut self, elements: &'a [FormatElement]) {
+        if !elements.is_empty() {
+            self.element_slices.push(elements.iter());
+        }
     }
 
-    fn set_next_index(&mut self, index: usize) {
-        self.next_index = index;
+    /// Removes top slice.
+    fn pop_slice(&mut self) -> Option<&'a [FormatElement]> {
+        self.element_slices
+            .pop()
+            .map(|elements| elements.as_slice())
     }
 }
 
@@ -161,45 +122,63 @@ impl<'a> Queue<'a> for PrintQueue<'a> {
 #[must_use]
 #[derive(Debug)]
 pub(super) struct FitsQueue<'a, 'print> {
-    stack: StackedStack<'print, &'a [FormatElement]>,
-    next_index: usize,
+    queue: PrintQueue<'a>,
+    rest_elements: std::slice::Iter<'print, std::slice::Iter<'a, FormatElement>>,
 }
 
 impl<'a, 'print> FitsQueue<'a, 'print> {
     pub(super) fn new(
-        print_queue: &'print PrintQueue<'a>,
-        saved: Vec<&'a [FormatElement]>,
+        rest_queue: &'print PrintQueue<'a>,
+        queue_vec: Vec<std::slice::Iter<'a, FormatElement>>,
     ) -> Self {
-        let stack = StackedStack::with_vec(&print_queue.slices, saved);
-
         Self {
-            stack,
-            next_index: print_queue.next_index,
+            queue: PrintQueue {
+                element_slices: queue_vec,
+            },
+            rest_elements: rest_queue.element_slices.iter(),
         }
     }
 
-    pub(super) fn finish(self) -> Vec<&'a [FormatElement]> {
-        self.stack.into_vec()
+    pub(super) fn finish(self) -> Vec<std::slice::Iter<'a, FormatElement>> {
+        self.queue.element_slices
     }
 }
 
 impl<'a, 'print> Queue<'a> for FitsQueue<'a, 'print> {
-    type Stack = StackedStack<'print, &'a [FormatElement]>;
-
-    fn stack(&self) -> &Self::Stack {
-        &self.stack
+    fn pop(&mut self) -> Option<&'a FormatElement> {
+        self.queue.pop().or_else(|| {
+            if let Some(next_slice) = self.rest_elements.next_back() {
+                self.queue.extend_back(next_slice.as_slice());
+                self.queue.pop()
+            } else {
+                None
+            }
+        })
     }
 
-    fn stack_mut(&mut self) -> &mut Self::Stack {
-        &mut self.stack
+    fn top_with_interned(&self) -> Option<&'a FormatElement> {
+        self.queue.top_with_interned().or_else(|| {
+            if let Some(next_elements) = self.rest_elements.as_slice().last() {
+                next_elements.as_slice().first()
+            } else {
+                None
+            }
+        })
     }
 
-    fn next_index(&self) -> usize {
-        self.next_index
+    fn extend_back(&mut self, elements: &'a [FormatElement]) {
+        if !elements.is_empty() {
+            self.queue.extend_back(elements);
+        }
     }
 
-    fn set_next_index(&mut self, index: usize) {
-        self.next_index = index;
+    /// Removes top slice.
+    fn pop_slice(&mut self) -> Option<&'a [FormatElement]> {
+        self.queue.pop_slice().or_else(|| {
+            self.rest_elements
+                .next_back()
+                .map(std::slice::Iter::as_slice)
+        })
     }
 }
 

--- a/crates/ruff_formatter/src/printer/stack.rs
+++ b/crates/ruff_formatter/src/printer/stack.rs
@@ -35,7 +35,7 @@ impl<T> Stack<T> for Vec<T> {
 #[derive(Debug, Clone)]
 pub(super) struct StackedStack<'a, T> {
     /// The content of the original stack.
-    original: &'a [T],
+    original: std::slice::Iter<'a, T>,
 
     /// Items that have been pushed since the creation of this stack and aren't part of the `original` stack.
     stack: Vec<T>,
@@ -49,7 +49,10 @@ impl<'a, T> StackedStack<'a, T> {
 
     /// Creates a new stack that uses `stack` for storing its elements.
     pub(super) fn with_vec(original: &'a [T], stack: Vec<T>) -> Self {
-        Self { original, stack }
+        Self {
+            original: original.iter(),
+            stack,
+        }
     }
 
     /// Returns the underlying `stack` vector.
@@ -63,13 +66,9 @@ where
     T: Copy,
 {
     fn pop(&mut self) -> Option<T> {
-        self.stack.pop().or_else(|| match self.original {
-            [rest @ .., last] => {
-                self.original = rest;
-                Some(*last)
-            }
-            _ => None,
-        })
+        self.stack
+            .pop()
+            .or_else(|| self.original.next_back().copied())
     }
 
     fn push(&mut self, value: T) {
@@ -77,11 +76,13 @@ where
     }
 
     fn top(&self) -> Option<&T> {
-        self.stack.last().or_else(|| self.original.last())
+        self.stack
+            .last()
+            .or_else(|| self.original.as_slice().last())
     }
 
     fn is_empty(&self) -> bool {
-        self.original.is_empty() && self.stack.is_empty()
+        self.stack.is_empty() && self.original.len() == 0
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR refactors the `Stack` and `Queue` implementations in the Printer to use `std::slice::Iter` instead of a `slice` + offset pointer. 

This results in a 3%  size reduction:

* Increase in `print_element` -> more aggressive inlining
* `ruff_formatter ruff_formatter::printer::call_stack::CallStack::top_kind` 7 byte reduction (relatively hot)
* `ruff_formatter ruff_formatter::printer::queue::Queue::extend_back` down to a single item and 78 bytes

**Main**
```
File .text    Size           Crate Name
0.0%  0.2%  2.8KiB  ruff_formatter ruff_formatter::printer::Printer::print_element
0.0%  0.1%  2.6KiB  ruff_formatter ruff_formatter::printer::Printer::print_fill_entries
0.0%  0.1%  2.0KiB  ruff_formatter ruff_formatter::printer::FitsMeasurer::fits_element
0.0%  0.1%  1.3KiB  ruff_formatter ruff_formatter::printer::FitsMeasurer::fill_entry_fits
0.0%  0.1%  1.2KiB  ruff_formatter ruff_formatter::printer::Printer::print_with_indent
0.0%  0.0%    891B  ruff_formatter ruff_formatter::printer::queue::Queue::skip_content
0.0%  0.0%    792B  ruff_formatter ruff_formatter::printer::Printer::print_entry
0.0%  0.0%    740B  ruff_formatter ruff_formatter::printer::Printer::fits
0.0%  0.0%    674B  ruff_formatter ruff_formatter::printer::Printer::flat_group_print_mode
0.0%  0.0%    595B  ruff_formatter ruff_formatter::printer::FitsMeasurer::fits_text
0.0%  0.0%    508B  ruff_formatter ruff_formatter::printer::Printer::print_text
0.0%  0.0%    458B  ruff_formatter ruff_formatter::printer::Printer::flush_line_suffixes
0.0%  0.0%    364B  ruff_formatter ruff_formatter::printer::FitsMeasurer::fits_group
0.0%  0.0%    361B  ruff_formatter ruff_formatter::printer::Printer::print_char
0.0%  0.0%    291B  ruff_formatter ruff_formatter::printer::queue::Queue::extend_back
0.0%  0.0%    289B ruff_formatter? <ruff_formatter::printer::queue::QueueContentIterator<Q> as core::iter::traits::iterator::Iterator>::next
0.0%  0.0%    223B  ruff_formatter ruff_formatter::printer::queue::Queue::extend_back
0.0%  0.0%    189B  ruff_formatter ruff_formatter::printer::line_suffixes::LineSuffixes::extend
0.0%  0.0%    179B  ruff_formatter ruff_formatter::printer::GroupModes::insert_print_mode
0.0%  0.0%    165B  ruff_formatter ruff_formatter::printer::Printer::push_marker
0.0%  0.0%    144B  ruff_formatter ruff_formatter::printer::FitsMeasurer::finish
0.0%  0.0%    138B             std core::ptr::drop_in_place<ruff_formatter::printer::Printer>
0.0%  0.0%    132B  ruff_formatter ruff_formatter::printer::Printer::print_str
0.0%  0.0%    101B             std core::ptr::drop_in_place<alloc::vec::drain::Drain<ruff_formatter::printer::line_suffixes::LineSuffixEntry>>
0.0%  0.0%    101B             std core::ptr::drop_in_place<core::iter::adapters::rev::Rev<alloc::vec::drain::Drain<ruff_formatter::printer::line_suffixes::LineSuffixEntry>>>
0.0%  0.0%     79B  ruff_formatter ruff_formatter::printer::call_stack::CallStack::push
0.0%  0.0%     77B  ruff_formatter ruff_formatter::printer::call_stack::CallStack::push
0.0%  0.0%     75B  ruff_formatter ruff_formatter::printer::call_stack::CallStack::top_kind
0.0%  0.0%     62B  ruff_formatter ruff_formatter::printer::invalid_start_tag
0.0%  0.0%     62B  ruff_formatter ruff_formatter::printer::invalid_start_tag
0.0%  0.0%     62B  ruff_formatter ruff_formatter::printer::invalid_start_tag
0.0%  0.0%     41B             std core::ptr::drop_in_place<ruff_formatter::printer::FitsMeasurer>
0.0%  0.0%      0B                 And 0 smaller methods. Use -n N to show more.
0.3%  1.0% 17.4KiB                 filtered data size, the file size is 5.5MiB
```

**This PR**

```
0.1%  0.2%  3.0KiB  ruff_formatter ruff_formatter::printer::Printer::print_element
0.0%  0.1%  2.4KiB  ruff_formatter ruff_formatter::printer::Printer::print_fill_entries
0.0%  0.1%  2.0KiB  ruff_formatter ruff_formatter::printer::FitsMeasurer::fits_element
0.0%  0.1%  1.1KiB  ruff_formatter ruff_formatter::printer::Printer::print_with_indent
0.0%  0.1%  1.0KiB  ruff_formatter ruff_formatter::printer::FitsMeasurer::fill_entry_fits
0.0%  0.0%    719B  ruff_formatter ruff_formatter::printer::Printer::print_entry
0.0%  0.0%    700B  ruff_formatter ruff_formatter::printer::Printer::flat_group_print_mode
0.0%  0.0%    634B  ruff_formatter ruff_formatter::printer::Printer::flush_line_suffixes
0.0%  0.0%    595B  ruff_formatter ruff_formatter::printer::FitsMeasurer::fits_text
0.0%  0.0%    583B  ruff_formatter ruff_formatter::printer::queue::Queue::skip_content
0.0%  0.0%    522B  ruff_formatter ruff_formatter::printer::Printer::fits
0.0%  0.0%    508B  ruff_formatter ruff_formatter::printer::Printer::print_text
0.0%  0.0%    433B ruff_formatter? <ruff_formatter::printer::queue::QueueContentIterator<Q> as core::iter::traits::iterator::Iterator>::next
0.0%  0.0%    364B  ruff_formatter ruff_formatter::printer::FitsMeasurer::fits_group
0.0%  0.0%    361B  ruff_formatter ruff_formatter::printer::Printer::print_char
0.0%  0.0%    271B  ruff_formatter <ruff_formatter::printer::queue::FitsQueue as ruff_formatter::printer::queue::Queue>::pop
0.0%  0.0%    189B  ruff_formatter ruff_formatter::printer::line_suffixes::LineSuffixes::extend
0.0%  0.0%    179B  ruff_formatter ruff_formatter::printer::GroupModes::insert_print_mode
0.0%  0.0%    165B  ruff_formatter ruff_formatter::printer::Printer::push_marker
0.0%  0.0%    138B             std core::ptr::drop_in_place<ruff_formatter::printer::Printer>
0.0%  0.0%    135B  ruff_formatter ruff_formatter::printer::FitsMeasurer::finish
0.0%  0.0%    132B  ruff_formatter ruff_formatter::printer::Printer::print_str
0.0%  0.0%    101B             std core::ptr::drop_in_place<alloc::vec::drain::Drain<ruff_formatter::printer::line_suffixes::LineSuffixEntry>>
0.0%  0.0%    101B             std core::ptr::drop_in_place<core::iter::adapters::rev::Rev<alloc::vec::drain::Drain<ruff_formatter::printer::line_suffixes::LineSuffixEntry>>>
0.0%  0.0%     79B  ruff_formatter ruff_formatter::printer::call_stack::CallStack::push
0.0%  0.0%     78B  ruff_formatter <ruff_formatter::printer::queue::PrintQueue as ruff_formatter::printer::queue::Queue>::extend_back
0.0%  0.0%     77B  ruff_formatter ruff_formatter::printer::call_stack::CallStack::push
0.0%  0.0%     68B  ruff_formatter ruff_formatter::printer::call_stack::CallStack::top_kind
0.0%  0.0%     62B  ruff_formatter ruff_formatter::printer::invalid_start_tag
0.0%  0.0%     62B  ruff_formatter ruff_formatter::printer::invalid_start_tag
0.0%  0.0%     62B  ruff_formatter ruff_formatter::printer::invalid_start_tag
0.0%  0.0%     40B             std core::ptr::drop_in_place<ruff_formatter::printer::FitsMeasurer>
0.0%  0.0%      0B                 And 0 smaller methods. Use -n N to show more.
0.3%  1.0% 16.9KiB                 filtered data size, the file size is 5.5MiB
```

## Test Plan

`cargo test`