### PR TITLE
Respect own-line leading comments before parenthesized nodes

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/list.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/list.py
@@ -50,3 +50,11 @@ c1 = [ # trailing open bracket
     second,
     third
 ]  # outer comment
+
+[  # inner comment
+    # own-line comment
+    (  # end-of-line comment
+        # own-line comment
+        first,
+    ),
+]  # outer comment

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__call.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__call.py.snap
@@ -331,9 +331,8 @@ func(
 )
 
 func(
-    (
-        # outer comment
-        # inner comment
+    # outer comment
+    (  # inner comment
         []
     )
 )

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__list.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__list.py.snap
@@ -56,6 +56,14 @@ c1 = [ # trailing open bracket
     second,
     third
 ]  # outer comment
+
+[  # inner comment
+    # own-line comment
+    (  # end-of-line comment
+        # own-line comment
+        first,
+    ),
+]  # outer comment
 ```
 
 ## Output
@@ -109,6 +117,14 @@ c1 = [  # trailing open bracket
     first,
     second,
     third,
+]  # outer comment
+
+[  # inner comment
+    # own-line comment
+    (  # end-of-line comment
+        # own-line comment
+        first,
+    ),
 ]  # outer comment
 ```
 


### PR DESCRIPTION
## Summary

This PR ensures that if an expression has an own-line leading comment _before_ its open parentheses, we render it as such.

For example, given:

```python
[ # foo
    # bar
    ( # baz
        1
    )
]
```

On `main`, we format as:

```python
[  # foo
    (
        # bar
        # baz
        1
    )
]
```

As of this PR, we format as:

```python
[  # foo
    # bar
    (  # baz
        1
    )
]
```

## Test Plan

`cargo test`
