### PR TITLE
Update ERA100 to apply to commented dictionary items with trailing comments

### DIFF
--- a/crates/ruff/resources/test/fixtures/eradicate/ERA001.py
+++ b/crates/ruff/resources/test/fixtures/eradicate/ERA001.py
@@ -19,3 +19,9 @@ def foo(x, y, z):
 class A():
     pass
     # b = c
+
+
+dictionary = {
+    # "key1": 123,  # noqa: ERA001
+    # "key2": 456,
+}

--- a/crates/ruff/resources/test/fixtures/eradicate/ERA001.py
+++ b/crates/ruff/resources/test/fixtures/eradicate/ERA001.py
@@ -25,3 +25,5 @@ dictionary = {
     # "key1": 123,  # noqa: ERA001
     # "key2": 456,
 }
+
+#import os  # noqa

--- a/crates/ruff/resources/test/fixtures/eradicate/ERA001.py
+++ b/crates/ruff/resources/test/fixtures/eradicate/ERA001.py
@@ -24,6 +24,7 @@ class A():
 dictionary = {
     # "key1": 123,  # noqa: ERA001
     # "key2": 456,
+    # "key3": 789,  # test
 }
 
 #import os  # noqa

--- a/crates/ruff/resources/test/fixtures/ruff/RUF100_5.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF100_5.py
@@ -1,8 +1,10 @@
+#import os  # noqa
 #import os  # noqa: ERA001
 
 dictionary = {
     # "key1": 123,  # noqa: ERA001
     # "key2": 456,
 }
+
 
 #import os  # noqa: E501

--- a/crates/ruff/resources/test/fixtures/ruff/RUF100_5.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF100_5.py
@@ -1,0 +1,8 @@
+#import os  # noqa: ERA001
+
+dictionary = {
+    # "key1": 123,  # noqa: ERA001
+    # "key2": 456,
+}
+
+#import os  # noqa: E501

--- a/crates/ruff/resources/test/fixtures/ruff/RUF100_5.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF100_5.py
@@ -3,7 +3,8 @@
 
 dictionary = {
     # "key1": 123,  # noqa: ERA001
-    # "key2": 456,
+    # "key2": 456,  # noqa
+    # "key3": 789,
 }
 
 

--- a/crates/ruff/src/rules/eradicate/detection.rs
+++ b/crates/ruff/src/rules/eradicate/detection.rs
@@ -28,7 +28,7 @@ static HASH_NUMBER: Lazy<Regex> = Lazy::new(|| Regex::new(r"#\d").unwrap());
 static MULTILINE_ASSIGNMENT_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^\s*([(\[]\s*)?(\w+\s*,\s*)*\w+\s*([)\]]\s*)?=.*[(\[{]$").unwrap());
 static PARTIAL_DICTIONARY_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"^\s*['"]\w+['"]\s*:.+[,{]\s*$"#).unwrap());
+    Lazy::new(|| Regex::new(r#"^\s*['"]\w+['"]\s*:.+[,{]\s*(#.*)?$"#).unwrap());
 static PRINT_RETURN_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(print|return)\b\s*").unwrap());
 
 /// Returns `true` if a comment contains Python code.

--- a/crates/ruff/src/rules/eradicate/snapshots/ruff__rules__eradicate__tests__ERA001_ERA001.py.snap
+++ b/crates/ruff/src/rules/eradicate/snapshots/ruff__rules__eradicate__tests__ERA001_ERA001.py.snap
@@ -115,7 +115,8 @@ ERA001.py:26:5: ERA001 [*] Found commented-out code
 25 |     # "key1": 123,  # noqa: ERA001
 26 |     # "key2": 456,
    |     ^^^^^^^^^^^^^^ ERA001
-27 | }
+27 |     # "key3": 789,  # test
+28 | }
    |
    = help: Remove commented-out code
 
@@ -124,8 +125,27 @@ ERA001.py:26:5: ERA001 [*] Found commented-out code
 24 24 | dictionary = {
 25 25 |     # "key1": 123,  # noqa: ERA001
 26    |-    # "key2": 456,
-27 26 | }
-28 27 | 
-29 28 | #import os  # noqa
+27 26 |     # "key3": 789,  # test
+28 27 | }
+29 28 | 
+
+ERA001.py:27:5: ERA001 [*] Found commented-out code
+   |
+25 |     # "key1": 123,  # noqa: ERA001
+26 |     # "key2": 456,
+27 |     # "key3": 789,  # test
+   |     ^^^^^^^^^^^^^^^^^^^^^^ ERA001
+28 | }
+   |
+   = help: Remove commented-out code
+
+ℹ Possible fix
+24 24 | dictionary = {
+25 25 |     # "key1": 123,  # noqa: ERA001
+26 26 |     # "key2": 456,
+27    |-    # "key3": 789,  # test
+28 27 | }
+29 28 | 
+30 29 | #import os  # noqa
 
 

--- a/crates/ruff/src/rules/eradicate/snapshots/ruff__rules__eradicate__tests__ERA001_ERA001.py.snap
+++ b/crates/ruff/src/rules/eradicate/snapshots/ruff__rules__eradicate__tests__ERA001_ERA001.py.snap
@@ -105,5 +105,25 @@ ERA001.py:21:5: ERA001 [*] Found commented-out code
 19 19 | class A():
 20 20 |     pass
 21    |-    # b = c
+22 21 | 
+23 22 | 
+24 23 | dictionary = {
+
+ERA001.py:26:5: ERA001 [*] Found commented-out code
+   |
+24 | dictionary = {
+25 |     # "key1": 123,  # noqa: ERA001
+26 |     # "key2": 456,
+   |     ^^^^^^^^^^^^^^ ERA001
+27 | }
+   |
+   = help: Remove commented-out code
+
+ℹ Possible fix
+23 23 | 
+24 24 | dictionary = {
+25 25 |     # "key1": 123,  # noqa: ERA001
+26    |-    # "key2": 456,
+27 26 | }
 
 

--- a/crates/ruff/src/rules/eradicate/snapshots/ruff__rules__eradicate__tests__ERA001_ERA001.py.snap
+++ b/crates/ruff/src/rules/eradicate/snapshots/ruff__rules__eradicate__tests__ERA001_ERA001.py.snap
@@ -125,5 +125,7 @@ ERA001.py:26:5: ERA001 [*] Found commented-out code
 25 25 |     # "key1": 123,  # noqa: ERA001
 26    |-    # "key2": 456,
 27 26 | }
+28 27 | 
+29 28 | #import os  # noqa
 
 

--- a/crates/ruff/src/rules/ruff/mod.rs
+++ b/crates/ruff/src/rules/ruff/mod.rs
@@ -166,6 +166,21 @@ mod tests {
     }
 
     #[test]
+    fn ruf100_5() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("ruff/RUF100_5.py"),
+            &settings::Settings {
+                ..settings::Settings::for_rules(vec![
+                    Rule::UnusedNOQA,
+                    Rule::LineTooLong,
+                    Rule::CommentedOutCode,
+                ])
+            },
+        )?;
+        assert_messages!(diagnostics);
+        Ok(())
+    }
+    #[test]
     fn flake8_noqa() -> Result<()> {
         let diagnostics = test_path(
             Path::new("ruff/flake8_noqa.py"),

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_5.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_5.snap
@@ -1,47 +1,6 @@
 ---
 source: crates/ruff/src/rules/ruff/mod.rs
 ---
-RUF100_5.py:5:21: RUF100 [*] Unused `noqa` directive (unused: `ERA001`)
-  |
-4 | dictionary = {
-5 |     # "key1": 123,  # noqa: ERA001
-  |                     ^^^^^^^^^^^^^^ RUF100
-6 |     # "key2": 456,  # noqa
-7 |     # "key3": 789,
-  |
-  = help: Remove unused `noqa` directive
-
-ℹ Suggested fix
-2 2 | #import os  # noqa: ERA001
-3 3 | 
-4 4 | dictionary = {
-5   |-    # "key1": 123,  # noqa: ERA001
-  5 |+    # "key1": 123,
-6 6 |     # "key2": 456,  # noqa
-7 7 |     # "key3": 789,
-8 8 | }
-
-RUF100_5.py:6:21: RUF100 [*] Unused blanket `noqa` directive
-  |
-4 | dictionary = {
-5 |     # "key1": 123,  # noqa: ERA001
-6 |     # "key2": 456,  # noqa
-  |                     ^^^^^^ RUF100
-7 |     # "key3": 789,
-8 | }
-  |
-  = help: Remove unused `noqa` directive
-
-ℹ Suggested fix
-3 3 | 
-4 4 | dictionary = {
-5 5 |     # "key1": 123,  # noqa: ERA001
-6   |-    # "key2": 456,  # noqa
-  6 |+    # "key2": 456,
-7 7 |     # "key3": 789,
-8 8 | }
-9 9 | 
-
 RUF100_5.py:7:5: ERA001 [*] Found commented-out code
   |
 5 |     # "key1": 123,  # noqa: ERA001

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_5.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_5.snap
@@ -6,8 +6,8 @@ RUF100_5.py:5:21: RUF100 [*] Unused `noqa` directive (unused: `ERA001`)
 4 | dictionary = {
 5 |     # "key1": 123,  # noqa: ERA001
   |                     ^^^^^^^^^^^^^^ RUF100
-6 |     # "key2": 456,
-7 | }
+6 |     # "key2": 456,  # noqa
+7 |     # "key3": 789,
   |
   = help: Remove unused `noqa` directive
 
@@ -17,54 +17,75 @@ RUF100_5.py:5:21: RUF100 [*] Unused `noqa` directive (unused: `ERA001`)
 4 4 | dictionary = {
 5   |-    # "key1": 123,  # noqa: ERA001
   5 |+    # "key1": 123,
-6 6 |     # "key2": 456,
-7 7 | }
-8 8 | 
+6 6 |     # "key2": 456,  # noqa
+7 7 |     # "key3": 789,
+8 8 | }
 
-RUF100_5.py:6:5: ERA001 [*] Found commented-out code
+RUF100_5.py:6:21: RUF100 [*] Unused blanket `noqa` directive
   |
 4 | dictionary = {
 5 |     # "key1": 123,  # noqa: ERA001
-6 |     # "key2": 456,
+6 |     # "key2": 456,  # noqa
+  |                     ^^^^^^ RUF100
+7 |     # "key3": 789,
+8 | }
+  |
+  = help: Remove unused `noqa` directive
+
+ℹ Suggested fix
+3 3 | 
+4 4 | dictionary = {
+5 5 |     # "key1": 123,  # noqa: ERA001
+6   |-    # "key2": 456,  # noqa
+  6 |+    # "key2": 456,
+7 7 |     # "key3": 789,
+8 8 | }
+9 9 | 
+
+RUF100_5.py:7:5: ERA001 [*] Found commented-out code
+  |
+5 |     # "key1": 123,  # noqa: ERA001
+6 |     # "key2": 456,  # noqa
+7 |     # "key3": 789,
   |     ^^^^^^^^^^^^^^ ERA001
-7 | }
+8 | }
   |
   = help: Remove commented-out code
 
 ℹ Possible fix
-3 3 | 
 4 4 | dictionary = {
 5 5 |     # "key1": 123,  # noqa: ERA001
-6   |-    # "key2": 456,
-7 6 | }
-8 7 | 
+6 6 |     # "key2": 456,  # noqa
+7   |-    # "key3": 789,
+8 7 | }
 9 8 | 
+10 9 | 
 
-RUF100_5.py:10:1: ERA001 [*] Found commented-out code
+RUF100_5.py:11:1: ERA001 [*] Found commented-out code
    |
-10 | #import os  # noqa: E501
+11 | #import os  # noqa: E501
    | ^^^^^^^^^^^^^^^^^^^^^^^^ ERA001
    |
    = help: Remove commented-out code
 
 ℹ Possible fix
-7  7  | }
-8  8  | 
+8  8  | }
 9  9  | 
-10    |-#import os  # noqa: E501
+10 10 | 
+11    |-#import os  # noqa: E501
 
-RUF100_5.py:10:13: RUF100 [*] Unused `noqa` directive (unused: `E501`)
+RUF100_5.py:11:13: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
-10 | #import os  # noqa: E501
+11 | #import os  # noqa: E501
    |             ^^^^^^^^^^^^ RUF100
    |
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-7  7  | }
-8  8  | 
+8  8  | }
 9  9  | 
-10    |-#import os  # noqa: E501
-   10 |+#import os
+10 10 | 
+11    |-#import os  # noqa: E501
+   11 |+#import os
 
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_5.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_5.snap
@@ -1,74 +1,70 @@
 ---
 source: crates/ruff/src/rules/ruff/mod.rs
 ---
-RUF100_5.py:4:21: RUF100 [*] Unused `noqa` directive (unused: `ERA001`)
+RUF100_5.py:5:21: RUF100 [*] Unused `noqa` directive (unused: `ERA001`)
   |
-3 | dictionary = {
-4 |     # "key1": 123,  # noqa: ERA001
+4 | dictionary = {
+5 |     # "key1": 123,  # noqa: ERA001
   |                     ^^^^^^^^^^^^^^ RUF100
-5 |     # "key2": 456,
-6 | }
+6 |     # "key2": 456,
+7 | }
   |
   = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-1 1 | #import os  # noqa: ERA001
-2 2 | 
-3 3 | dictionary = {
-4   |-    # "key1": 123,  # noqa: ERA001
-  4 |+    # "key1": 123,
-5 5 |     # "key2": 456,
-6 6 | }
-7 7 | 
+2 2 | #import os  # noqa: ERA001
+3 3 | 
+4 4 | dictionary = {
+5   |-    # "key1": 123,  # noqa: ERA001
+  5 |+    # "key1": 123,
+6 6 |     # "key2": 456,
+7 7 | }
+8 8 | 
 
-RUF100_5.py:5:5: ERA001 [*] Found commented-out code
+RUF100_5.py:6:5: ERA001 [*] Found commented-out code
   |
-3 | dictionary = {
-4 |     # "key1": 123,  # noqa: ERA001
-5 |     # "key2": 456,
+4 | dictionary = {
+5 |     # "key1": 123,  # noqa: ERA001
+6 |     # "key2": 456,
   |     ^^^^^^^^^^^^^^ ERA001
-6 | }
+7 | }
   |
   = help: Remove commented-out code
 
 ℹ Possible fix
-2 2 | 
-3 3 | dictionary = {
-4 4 |     # "key1": 123,  # noqa: ERA001
-5   |-    # "key2": 456,
-6 5 | }
-7 6 | 
-8 7 | #import os  # noqa: E501
+3 3 | 
+4 4 | dictionary = {
+5 5 |     # "key1": 123,  # noqa: ERA001
+6   |-    # "key2": 456,
+7 6 | }
+8 7 | 
+9 8 | 
 
-RUF100_5.py:8:1: ERA001 [*] Found commented-out code
-  |
-6 | }
-7 | 
-8 | #import os  # noqa: E501
-  | ^^^^^^^^^^^^^^^^^^^^^^^^ ERA001
-  |
-  = help: Remove commented-out code
+RUF100_5.py:10:1: ERA001 [*] Found commented-out code
+   |
+10 | #import os  # noqa: E501
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ ERA001
+   |
+   = help: Remove commented-out code
 
 ℹ Possible fix
-5 5 |     # "key2": 456,
-6 6 | }
-7 7 | 
-8   |-#import os  # noqa: E501
+7  7  | }
+8  8  | 
+9  9  | 
+10    |-#import os  # noqa: E501
 
-RUF100_5.py:8:13: RUF100 [*] Unused `noqa` directive (unused: `E501`)
-  |
-6 | }
-7 | 
-8 | #import os  # noqa: E501
-  |             ^^^^^^^^^^^^ RUF100
-  |
-  = help: Remove unused `noqa` directive
+RUF100_5.py:10:13: RUF100 [*] Unused `noqa` directive (unused: `E501`)
+   |
+10 | #import os  # noqa: E501
+   |             ^^^^^^^^^^^^ RUF100
+   |
+   = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-5 5 |     # "key2": 456,
-6 6 | }
-7 7 | 
-8   |-#import os  # noqa: E501
-  8 |+#import os
+7  7  | }
+8  8  | 
+9  9  | 
+10    |-#import os  # noqa: E501
+   10 |+#import os
 
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_5.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_5.snap
@@ -1,0 +1,74 @@
+---
+source: crates/ruff/src/rules/ruff/mod.rs
+---
+RUF100_5.py:4:21: RUF100 [*] Unused `noqa` directive (unused: `ERA001`)
+  |
+3 | dictionary = {
+4 |     # "key1": 123,  # noqa: ERA001
+  |                     ^^^^^^^^^^^^^^ RUF100
+5 |     # "key2": 456,
+6 | }
+  |
+  = help: Remove unused `noqa` directive
+
+ℹ Suggested fix
+1 1 | #import os  # noqa: ERA001
+2 2 | 
+3 3 | dictionary = {
+4   |-    # "key1": 123,  # noqa: ERA001
+  4 |+    # "key1": 123,
+5 5 |     # "key2": 456,
+6 6 | }
+7 7 | 
+
+RUF100_5.py:5:5: ERA001 [*] Found commented-out code
+  |
+3 | dictionary = {
+4 |     # "key1": 123,  # noqa: ERA001
+5 |     # "key2": 456,
+  |     ^^^^^^^^^^^^^^ ERA001
+6 | }
+  |
+  = help: Remove commented-out code
+
+ℹ Possible fix
+2 2 | 
+3 3 | dictionary = {
+4 4 |     # "key1": 123,  # noqa: ERA001
+5   |-    # "key2": 456,
+6 5 | }
+7 6 | 
+8 7 | #import os  # noqa: E501
+
+RUF100_5.py:8:1: ERA001 [*] Found commented-out code
+  |
+6 | }
+7 | 
+8 | #import os  # noqa: E501
+  | ^^^^^^^^^^^^^^^^^^^^^^^^ ERA001
+  |
+  = help: Remove commented-out code
+
+ℹ Possible fix
+5 5 |     # "key2": 456,
+6 6 | }
+7 7 | 
+8   |-#import os  # noqa: E501
+
+RUF100_5.py:8:13: RUF100 [*] Unused `noqa` directive (unused: `E501`)
+  |
+6 | }
+7 | 
+8 | #import os  # noqa: E501
+  |             ^^^^^^^^^^^^ RUF100
+  |
+  = help: Remove unused `noqa` directive
+
+ℹ Suggested fix
+5 5 |     # "key2": 456,
+6 6 | }
+7 7 | 
+8   |-#import os  # noqa: E501
+  8 |+#import os
+
+


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/6821

ERA100 was not raising on commented parts of dictionaries if it included another comment (such as a noqa clause). In cases where this comment was a noqa clause, RUF100 to be emitted since the noqa would have no effect. Here, we update ERA100 to raise even when there are trailing comments. This resolves the linked issue _and_ increases the scope of ERA100. We could narrow the regular expression to only apply to noqa comments if we do not want to expand ERA100 however I think this change is within the spirit of the rule.