### PR TITLE
Remove remaining usage of `set_fix_from_edit`

### DIFF
--- a/crates/ruff/src/checkers/noqa.rs
+++ b/crates/ruff/src/checkers/noqa.rs
@@ -110,8 +110,8 @@ pub(crate) fn check_noqa(
                         let mut diagnostic =
                             Diagnostic::new(UnusedNOQA { codes: None }, directive.range());
                         if settings.rules.should_fix(diagnostic.kind.rule()) {
-                            #[allow(deprecated)]
-                            diagnostic.set_fix_from_edit(delete_noqa(directive.range(), locator));
+                            diagnostic
+                                .set_fix(Fix::automatic(delete_noqa(directive.range(), locator)));
                         }
                         diagnostics.push(diagnostic);
                     }
@@ -175,12 +175,12 @@ pub(crate) fn check_noqa(
                         );
                         if settings.rules.should_fix(diagnostic.kind.rule()) {
                             if valid_codes.is_empty() {
-                                #[allow(deprecated)]
-                                diagnostic
-                                    .set_fix_from_edit(delete_noqa(directive.range(), locator));
+                                diagnostic.set_fix(Fix::automatic(delete_noqa(
+                                    directive.range(),
+                                    locator,
+                                )));
                             } else {
-                                #[allow(deprecated)]
-                                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
                                     format!("# noqa: {}", valid_codes.join(", ")),
                                     directive.range(),
                                 )));

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_0.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_0.snap
@@ -10,7 +10,7 @@ RUF100_0.py:9:12: RUF100 [*] Unused blanket `noqa` directive
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 6  6  |     b = 2  # noqa: F841
 7  7  | 
 8  8  |     # Invalid
@@ -30,7 +30,7 @@ RUF100_0.py:13:12: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 10 10 |     print(c)
 11 11 | 
 12 12 |     # Invalid
@@ -50,7 +50,7 @@ RUF100_0.py:16:12: RUF100 [*] Unused `noqa` directive (unused: `F841`, `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 13 13 |     d = 1  # noqa: E501
 14 14 | 
 15 15 |     # Invalid
@@ -70,7 +70,7 @@ RUF100_0.py:19:12: RUF100 [*] Unused `noqa` directive (unused: `F841`, `W191`; n
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 16 16 |     d = 1  # noqa: F841, E501
 17 17 | 
 18 18 |     # Invalid (and unimplemented or not enabled)
@@ -90,7 +90,7 @@ RUF100_0.py:22:12: RUF100 [*] Unused `noqa` directive (unused: `F841`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 19 19 |     d = 1  # noqa: F841, W191, F821
 20 20 | 
 21 21 |     # Invalid (but external)
@@ -111,7 +111,7 @@ RUF100_0.py:26:10: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 23 23 | 
 24 24 |     # fmt: off
 25 25 |     # Invalid - no space before #
@@ -148,7 +148,7 @@ RUF100_0.py:29:33: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 26 26 |     d = 1# noqa: E501
 27 27 | 
 28 28 |     # Invalid - many spaces before #
@@ -168,7 +168,7 @@ RUF100_0.py:55:6: RUF100 [*] Unused `noqa` directive (unused: `F841`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 52 52 |     https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533
 53 53 | 
 54 54 | Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -188,7 +188,7 @@ RUF100_0.py:63:6: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 60 60 |     https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533
 61 61 | 
 62 62 | Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.
@@ -208,7 +208,7 @@ RUF100_0.py:71:6: RUF100 [*] Unused blanket `noqa` directive
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 68 68 |     https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533
 69 69 | 
 70 70 | Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.
@@ -254,7 +254,7 @@ RUF100_0.py:90:92: RUF100 [*] Unused `noqa` directive (unused: `F401`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 87 87 | 
 88 88 | print(sys.path)
 89 89 | 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_1.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_1.snap
@@ -32,7 +32,7 @@ RUF100_1.py:52:20: RUF100 [*] Unused `noqa` directive (unused: `F401`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 49 49 | def f():
 50 50 |     # This should ignore the error, but the inner noqa should be marked as unused.
 51 51 |     from typing import (  # noqa: F401
@@ -52,7 +52,7 @@ RUF100_1.py:59:20: RUF100 [*] Unused `noqa` directive (unused: `F401`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 56 56 | def f():
 57 57 |     # This should ignore the error, but the inner noqa should be marked as unused.
 58 58 |     from typing import (  # noqa
@@ -72,7 +72,7 @@ RUF100_1.py:66:16: RUF100 [*] Unused `noqa` directive (non-enabled: `F501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 63 63 | def f():
 64 64 |     # This should ignore the error, but mark F501 as unused.
 65 65 |     from typing import (  # noqa: F401
@@ -93,7 +93,7 @@ RUF100_1.py:72:27: RUF100 [*] Unused `noqa` directive (non-enabled: `F501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 69 69 | 
 70 70 | def f():
 71 71 |     # This should ignore the error, but mark F501 as unused.
@@ -144,7 +144,7 @@ RUF100_1.py:89:55: RUF100 [*] Unused `noqa` directive (non-enabled: `F501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 86 86 | 
 87 87 | def f():
 88 88 |     # This should mark F501 as unused.

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_2.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_2.snap
@@ -8,7 +8,7 @@ RUF100_2.py:1:19: RUF100 [*] Unused `noqa` directive (unused: `F401`)
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 1   |-import itertools  # noqa: F401
   1 |+import itertools
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_3.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_3.snap
@@ -10,7 +10,7 @@ RUF100_3.py:1:1: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 1   |-# noqa
 2 1 | # noqa # comment
 3 2 | print()  # noqa
@@ -26,7 +26,7 @@ RUF100_3.py:2:1: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # noqa
 2   |-# noqa # comment
   2 |+# comment
@@ -45,7 +45,7 @@ RUF100_3.py:3:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # noqa
 2 2 | # noqa # comment
 3   |-print()  # noqa
@@ -65,7 +65,7 @@ RUF100_3.py:4:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # noqa
 2 2 | # noqa # comment
 3 3 | print()  # noqa
@@ -86,7 +86,7 @@ RUF100_3.py:5:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 2 2 | # noqa # comment
 3 3 | print()  # noqa
 4 4 | print()  # noqa # comment
@@ -107,7 +107,7 @@ RUF100_3.py:6:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 3 3 | print()  # noqa
 4 4 | print()  # noqa # comment
 5 5 | print()  # noqa  # comment
@@ -128,7 +128,7 @@ RUF100_3.py:7:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 4 4 | print()  # noqa # comment
 5 5 | print()  # noqa  # comment
 6 6 | print()  # noqa comment
@@ -149,7 +149,7 @@ RUF100_3.py:14:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 11 11 | print(a)  # noqa comment
 12 12 | print(a)  # noqa  comment
 13 13 | 
@@ -168,7 +168,7 @@ RUF100_3.py:15:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 12 12 | print(a)  # noqa  comment
 13 13 | 
 14 14 | # noqa: E501, F821
@@ -189,7 +189,7 @@ RUF100_3.py:16:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 13 13 | 
 14 14 | # noqa: E501, F821
 15 15 | # noqa: E501, F821 # comment
@@ -210,7 +210,7 @@ RUF100_3.py:17:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 14 14 | # noqa: E501, F821
 15 15 | # noqa: E501, F821 # comment
 16 16 | print()  # noqa: E501, F821
@@ -231,7 +231,7 @@ RUF100_3.py:18:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 15 15 | # noqa: E501, F821 # comment
 16 16 | print()  # noqa: E501, F821
 17 17 | print()  # noqa: E501, F821 # comment
@@ -252,7 +252,7 @@ RUF100_3.py:19:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 16 16 | print()  # noqa: E501, F821
 17 17 | print()  # noqa: E501, F821 # comment
 18 18 | print()  # noqa: E501, F821  # comment
@@ -273,7 +273,7 @@ RUF100_3.py:20:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 17 17 | print()  # noqa: E501, F821 # comment
 18 18 | print()  # noqa: E501, F821  # comment
 19 19 | print()  # noqa: E501, F821 comment
@@ -294,7 +294,7 @@ RUF100_3.py:21:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 18 18 | print()  # noqa: E501, F821  # comment
 19 19 | print()  # noqa: E501, F821 comment
 20 20 | print()  # noqa: E501, F821  comment
@@ -315,7 +315,7 @@ RUF100_3.py:22:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 19 19 | print()  # noqa: E501, F821 comment
 20 20 | print()  # noqa: E501, F821  comment
 21 21 | print(a)  # noqa: E501, F821
@@ -336,7 +336,7 @@ RUF100_3.py:23:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 20 20 | print()  # noqa: E501, F821  comment
 21 21 | print(a)  # noqa: E501, F821
 22 22 | print(a)  # noqa: E501, F821 # comment
@@ -355,7 +355,7 @@ RUF100_3.py:24:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 21 21 | print(a)  # noqa: E501, F821
 22 22 | print(a)  # noqa: E501, F821 # comment
 23 23 | print(a)  # noqa: E501, F821  # comment
@@ -372,7 +372,7 @@ RUF100_3.py:25:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 22 22 | print(a)  # noqa: E501, F821 # comment
 23 23 | print(a)  # noqa: E501, F821  # comment
 24 24 | print(a)  # noqa: E501, F821 comment

--- a/crates/ruff_diagnostics/src/diagnostic.rs
+++ b/crates/ruff_diagnostics/src/diagnostic.rs
@@ -41,14 +41,6 @@ impl Diagnostic {
         self.fix = Some(fix);
     }
 
-    /// Set the [`Fix`] used to fix the diagnostic.
-    #[inline]
-    #[deprecated(note = "Use `Diagnostic::set_fix` instead.")]
-    #[allow(deprecated)]
-    pub fn set_fix_from_edit(&mut self, edit: Edit) {
-        self.fix = Some(Fix::unspecified(edit));
-    }
-
     /// Consumes `self` and returns a new `Diagnostic` with the given `fix`.
     #[inline]
     #[must_use]
@@ -60,7 +52,6 @@ impl Diagnostic {
     /// Set the [`Fix`] used to fix the diagnostic, if the provided function returns `Ok`.
     /// Otherwise, log the error.
     #[inline]
-    #[allow(deprecated)]
     pub fn try_set_fix(&mut self, func: impl FnOnce() -> Result<Fix>) {
         match func() {
             Ok(fix) => self.fix = Some(fix),


### PR DESCRIPTION
This method is deprecated; we have one last usage, so removing it.