### PR TITLE
Rename Notebook related symbols

### DIFF
--- a/crates/ruff/src/jupyter/index.rs
+++ b/crates/ruff/src/jupyter/index.rs
@@ -3,14 +3,14 @@
 /// When we lint a jupyter notebook, we have to translate the row/column based on
 /// [`ruff_text_size::TextSize`] to jupyter notebook cell/row/column.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct JupyterIndex {
+pub struct NotebookIndex {
     /// Enter a row (1-based), get back the cell (1-based)
     pub(super) row_to_cell: Vec<u32>,
     /// Enter a row (1-based), get back the row in cell (1-based)
     pub(super) row_to_row_in_cell: Vec<u32>,
 }
 
-impl JupyterIndex {
+impl NotebookIndex {
     /// Returns the cell number (1-based) for the given row (1-based).
     pub fn cell(&self, row: usize) -> Option<u32> {
         self.row_to_cell.get(row).copied()

--- a/crates/ruff/src/jupyter/notebook.rs
+++ b/crates/ruff/src/jupyter/notebook.rs
@@ -666,7 +666,7 @@ print("after empty cells")
     fn test_no_cell_id() -> Result<()> {
         let path = "no_cell_id.ipynb".to_string();
         let source_notebook = read_jupyter_notebook(path.as_ref())?;
-        let source_kind = SourceKind::Jupyter(source_notebook);
+        let source_kind = SourceKind::IpyNotebook(source_notebook);
         let (_, transformed) = test_contents(
             &source_kind,
             path.as_ref(),

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -147,7 +147,7 @@ pub fn check_path(
         match ruff_python_parser::parse_program_tokens(
             tokens,
             &path.to_string_lossy(),
-            source_type.is_jupyter(),
+            source_type.is_ipynb(),
         ) {
             Ok(python_ast) => {
                 if use_ast {

--- a/crates/ruff/src/message/grouped.rs
+++ b/crates/ruff/src/message/grouped.rs
@@ -7,7 +7,7 @@ use colored::Colorize;
 use ruff_source_file::OneIndexed;
 
 use crate::fs::relativize_path;
-use crate::jupyter::{JupyterIndex, Notebook};
+use crate::jupyter::{Notebook, NotebookIndex};
 use crate::message::diff::calculate_print_width;
 use crate::message::text::{MessageCodeFrame, RuleCodeAndBody};
 use crate::message::{
@@ -92,7 +92,7 @@ struct DisplayGroupedMessage<'a> {
     show_source: bool,
     row_length: NonZeroUsize,
     column_length: NonZeroUsize,
-    jupyter_index: Option<&'a JupyterIndex>,
+    jupyter_index: Option<&'a NotebookIndex>,
 }
 
 impl Display for DisplayGroupedMessage<'_> {

--- a/crates/ruff/src/message/text.rs
+++ b/crates/ruff/src/message/text.rs
@@ -11,7 +11,7 @@ use ruff_source_file::{OneIndexed, SourceLocation};
 use ruff_text_size::{TextRange, TextSize};
 
 use crate::fs::relativize_path;
-use crate::jupyter::{JupyterIndex, Notebook};
+use crate::jupyter::{Notebook, NotebookIndex};
 use crate::line_width::{LineWidth, TabSize};
 use crate::message::diff::Diff;
 use crate::message::{Emitter, EmitterContext, Message};
@@ -161,7 +161,7 @@ impl Display for RuleCodeAndBody<'_> {
 
 pub(super) struct MessageCodeFrame<'a> {
     pub(crate) message: &'a Message,
-    pub(crate) jupyter_index: Option<&'a JupyterIndex>,
+    pub(crate) jupyter_index: Option<&'a NotebookIndex>,
 }
 
 impl Display for MessageCodeFrame<'_> {

--- a/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
@@ -70,7 +70,7 @@ pub(crate) fn yield_outside_function(checker: &mut Checker, expr: &Expr) {
         // `await` is allowed at the top level of a Jupyter notebook.
         // See: https://ipython.readthedocs.io/en/stable/interactive/autoawait.html.
         if scope.kind.is_module()
-            && checker.source_type.is_jupyter()
+            && checker.source_type.is_ipynb()
             && keyword == DeferralKeyword::Await
         {
             return;

--- a/crates/ruff/src/source_kind.rs
+++ b/crates/ruff/src/source_kind.rs
@@ -4,13 +4,13 @@ use crate::jupyter::Notebook;
 #[derive(Clone, Debug, PartialEq, is_macro::Is)]
 pub enum SourceKind {
     Python(String),
-    Jupyter(Notebook),
+    IpyNotebook(Notebook),
 }
 
 impl SourceKind {
-    /// Return the [`Notebook`] if the source kind is [`SourceKind::Jupyter`].
+    /// Return the [`Notebook`] if the source kind is [`SourceKind::IpyNotebook`].
     pub fn notebook(&self) -> Option<&Notebook> {
-        if let Self::Jupyter(notebook) = self {
+        if let Self::IpyNotebook(notebook) = self {
             Some(notebook)
         } else {
             None
@@ -20,10 +20,10 @@ impl SourceKind {
     #[must_use]
     pub(crate) fn updated(&self, new_source: String, source_map: &SourceMap) -> Self {
         match self {
-            SourceKind::Jupyter(notebook) => {
+            SourceKind::IpyNotebook(notebook) => {
                 let mut cloned = notebook.clone();
                 cloned.update(source_map, new_source);
-                SourceKind::Jupyter(cloned)
+                SourceKind::IpyNotebook(cloned)
             }
             SourceKind::Python(_) => SourceKind::Python(new_source),
         }
@@ -32,7 +32,7 @@ impl SourceKind {
     pub fn source_code(&self) -> &str {
         match self {
             SourceKind::Python(source) => source,
-            SourceKind::Jupyter(notebook) => notebook.source_code(),
+            SourceKind::IpyNotebook(notebook) => notebook.source_code(),
         }
     }
 }

--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -69,7 +69,7 @@ pub(crate) fn test_notebook_path(
 ) -> Result<TestedNotebook> {
     let source_notebook = read_jupyter_notebook(path.as_ref())?;
 
-    let source_kind = SourceKind::Jupyter(source_notebook);
+    let source_kind = SourceKind::IpyNotebook(source_notebook);
     let (messages, transformed) = test_contents(&source_kind, path.as_ref(), settings);
     let expected_notebook = read_jupyter_notebook(expected.as_ref())?;
     let linted_notebook = transformed.into_owned().expect_jupyter();

--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -72,7 +72,7 @@ pub(crate) fn test_notebook_path(
     let source_kind = SourceKind::IpyNotebook(source_notebook);
     let (messages, transformed) = test_contents(&source_kind, path.as_ref(), settings);
     let expected_notebook = read_jupyter_notebook(expected.as_ref())?;
-    let linted_notebook = transformed.into_owned().expect_jupyter();
+    let linted_notebook = transformed.into_owned().expect_ipy_notebook();
 
     assert_eq!(
         linted_notebook.cell_offsets(),
@@ -86,7 +86,7 @@ pub(crate) fn test_notebook_path(
 
     Ok(TestedNotebook {
         messages,
-        source_notebook: source_kind.expect_jupyter(),
+        source_notebook: source_kind.expect_ipy_notebook(),
         linted_notebook,
     })
 }

--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -293,7 +293,7 @@ pub(crate) fn lint_path(
                         SourceKind::Python(transformed) => {
                             write(path, transformed.as_bytes())?;
                         }
-                        SourceKind::Jupyter(notebook) => {
+                        SourceKind::IpyNotebook(notebook) => {
                             notebook.write(path)?;
                         }
                     },
@@ -308,10 +308,10 @@ pub(crate) fn lint_path(
                                 stdout.write_all(b"\n")?;
                                 stdout.flush()?;
                             }
-                            SourceKind::Jupyter(dest_notebook) => {
+                            SourceKind::IpyNotebook(dest_notebook) => {
                                 // We need to load the notebook again, since we might've
                                 // mutated it.
-                                let src_notebook = source_kind.as_jupyter().unwrap();
+                                let src_notebook = source_kind.as_ipy_notebook().unwrap();
                                 let mut stdout = io::stdout().lock();
                                 for ((idx, src_cell), dest_cell) in src_notebook
                                     .cells()
@@ -409,7 +409,7 @@ pub(crate) fn lint_path(
         );
     }
 
-    let notebooks = if let SourceKind::Jupyter(notebook) = source_kind {
+    let notebooks = if let SourceKind::IpyNotebook(notebook) = source_kind {
         FxHashMap::from_iter([(
             path.to_str()
                 .ok_or_else(|| anyhow!("Unable to parse filename: {:?}", path))?
@@ -567,9 +567,9 @@ impl LintSources {
         let source_type = PySourceType::from(path);
 
         // Read the file from disk.
-        if source_type.is_jupyter() {
+        if source_type.is_ipynb() {
             let notebook = notebook_from_path(path).map_err(SourceExtractionError::Diagnostics)?;
-            let source_kind = SourceKind::Jupyter(notebook);
+            let source_kind = SourceKind::IpyNotebook(notebook);
             Ok(LintSources {
                 source_type,
                 source_kind,
@@ -593,10 +593,10 @@ impl LintSources {
     ) -> Result<LintSources, SourceExtractionError> {
         let source_type = path.map(PySourceType::from).unwrap_or_default();
 
-        if source_type.is_jupyter() {
+        if source_type.is_ipynb() {
             let notebook = notebook_from_source_code(&source_code, path)
                 .map_err(SourceExtractionError::Diagnostics)?;
-            let source_kind = SourceKind::Jupyter(notebook);
+            let source_kind = SourceKind::IpyNotebook(notebook);
             Ok(LintSources {
                 source_type,
                 source_kind,

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -58,7 +58,7 @@ pub enum PySourceType {
     #[default]
     Python,
     Stub,
-    Jupyter,
+    Ipynb,
 }
 
 impl PySourceType {
@@ -70,8 +70,8 @@ impl PySourceType {
         matches!(self, PySourceType::Stub)
     }
 
-    pub const fn is_jupyter(&self) -> bool {
-        matches!(self, PySourceType::Jupyter)
+    pub const fn is_ipynb(&self) -> bool {
+        matches!(self, PySourceType::Ipynb)
     }
 }
 
@@ -79,7 +79,7 @@ impl From<&Path> for PySourceType {
     fn from(path: &Path) -> Self {
         match path.extension() {
             Some(ext) if ext == "pyi" => PySourceType::Stub,
-            Some(ext) if ext == "ipynb" => PySourceType::Jupyter,
+            Some(ext) if ext == "ipynb" => PySourceType::Ipynb,
             _ => PySourceType::Python,
         }
     }

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -313,7 +313,7 @@ impl AsMode for PySourceType {
     fn as_mode(&self) -> Mode {
         match self {
             PySourceType::Python | PySourceType::Stub => Mode::Module,
-            PySourceType::Jupyter => Mode::Jupyter,
+            PySourceType::Ipynb => Mode::Jupyter,
         }
     }
 }


### PR DESCRIPTION
This PR renames the following symbols:

* `PySourceType::Jupyter` -> `PySourceType::Ipynb`
* `SourceKind::Jupyter` -> `SourceKind::IpyNotebook`
* `JupyterIndex` -> `NotebookIndex`
