### PR TITLE
fix is_raw_string for multiple prefixes

### DIFF
--- a/crates/ruff_python_formatter/src/expression/string.rs
+++ b/crates/ruff_python_formatter/src/expression/string.rs
@@ -377,7 +377,7 @@ impl StringPrefix {
     }
 
     pub(super) const fn is_raw_string(self) -> bool {
-        matches!(self, StringPrefix::RAW | StringPrefix::RAW_UPPER)
+        self.contains(StringPrefix::RAW) || self.contains(StringPrefix::RAW_UPPER)
     }
 }
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -46,7 +46,7 @@ result_f = (
 (f"{one}" f"{two}")
 
 
-rf'Not-so-tricky "quote'
+rf"Not-so-tricky \"quote"
 
 # Regression test for fstrings dropping comments
 result_f = (


### PR DESCRIPTION
fix `is_raw_string` in the presence of other prefixes (like `rb"foo"`)

fixes #6864