### PR TITLE
Use `BestFit` layout even for attributes with a short name

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unsplittable.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unsplittable.py
@@ -65,3 +65,8 @@ def test():
 
 m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyField(Person, blank=True)
 m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyFieldAttributeChainFieeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeld
+
+def test():
+    if True:
+        VLM_m2m = VLM.m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.through
+        allows_group_by_select_index = self.connection.features.allows_group_by_select_index

--- a/crates/ruff_python_formatter/src/expression/expr_attribute.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_attribute.rs
@@ -153,6 +153,8 @@ impl NeedsParentheses for ExprAttribute {
             OptionalParentheses::Multiline
         } else if context.comments().has_dangling(self) {
             OptionalParentheses::Always
+        } else if self.value.is_name_expr() {
+            OptionalParentheses::BestFit
         } else {
             self.value.needs_parentheses(self.into(), context)
         }

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__unsplittable.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__unsplittable.py.snap
@@ -71,6 +71,11 @@ def test():
 
 m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyField(Person, blank=True)
 m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyFieldAttributeChainFieeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeld
+
+def test():
+    if True:
+        VLM_m2m = VLM.m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.through
+        allows_group_by_select_index = self.connection.features.allows_group_by_select_index
 ```
 
 ## Output
@@ -152,6 +157,16 @@ m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = (
     models.ManyToManyField(Person, blank=True)
 )
 m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyFieldAttributeChainFieeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeld
+
+
+def test():
+    if True:
+        VLM_m2m = (
+            VLM.m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.through
+        )
+        allows_group_by_select_index = (
+            self.connection.features.allows_group_by_select_index
+        )
 ```
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR fixes a bug where attribute chains starting with a name shorter than 5 characters didn't use the `BestFit` layout.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

This change Increases the similarity index for several projects

| project      | similarity index |
|--------------|------------------|
| cpython      | 0.76066          |
| django       | 0.99898          |
| transformers | 0.99842          |
| twine        | 0.99929          |
| typeshed     | 0.99953          |
| warehouse    | 0.99637          |
| zulip        | 0.99920          |


| project      | similarity index |
|--------------|------------------|
| cpython      | 0.76067          |
| **django**       | 0.99899          | 
| transformers | 0.99842          |
| twine        | 0.99929          |
| typeshed     | 0.99953          |
| **warehouse**    | 0.99646          | 
| **zulip**        | 0.99922          | 


<!-- How was it tested? -->
