### PR TITLE
Update RUF100 test to reflect applicability

### DIFF
--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_5.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_5.snap
@@ -40,7 +40,7 @@ RUF100_5.py:11:13: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 8  8  | }
 9  9  | 
 10 10 | 


### PR DESCRIPTION
Broken on merge of #6822 due to new test cases conflicting with the addition of an applicability to RUF100 in #6827