### PR TITLE
Handle keyword comments between = and value

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/call.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/call.py
@@ -80,6 +80,21 @@ f(
     # oddly placed own line comment
     dict()
 )
+f(
+    session,
+    b=1,
+    **(# oddly placed own line comment
+    dict()
+    )
+)
+f(
+    session,
+    b=1,
+    **(
+        # oddly placed own line comment
+    dict()
+    )
+)
 
 # Don't add a magic trailing comma when there is only one entry
 # Minimized from https://github.com/django/django/blob/7eeadc82c2f7d7a778e3bb43c34d642e6275dacf/django/contrib/admin/checks.py#L674-L681
@@ -205,3 +220,25 @@ aaa = (
     ()
     .bbbbbbbbbbbbbbbb
 )
+
+# Comments around keywords
+f(x= # comment
+  1)
+
+f(x # comment
+ =
+  1)
+
+f(x=
+  # comment
+  1)
+
+f(x=(# comment
+  1
+))
+
+
+f(x=(
+  # comment
+  1
+))

--- a/crates/ruff_python_formatter/src/expression/expr_dict.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_dict.rs
@@ -40,6 +40,8 @@ impl Format<PyFormatContext<'_>> for KeyValuePair<'_> {
                 ])]
             )
         } else {
+            // TODO(charlie): Make these dangling comments on the `ExprDict`, and identify them
+            // dynamically, so as to avoid the parent rendering its child's comments.
             let comments = f.context().comments().clone();
             let leading_value_comments = comments.leading(self.value);
             write!(

--- a/crates/ruff_python_formatter/src/other/keyword.rs
+++ b/crates/ruff_python_formatter/src/other/keyword.rs
@@ -13,10 +13,10 @@ impl FormatNodeRule<Keyword> for FormatKeyword {
             arg,
             value,
         } = item;
+        // Comments after the `=` or `**` are reassigned as leading comments on the value.
         if let Some(arg) = arg {
             write!(f, [arg.format(), text("="), value.format()])
         } else {
-            // Comments after the stars are reassigned as trailing value comments
             write!(f, [text("**"), value.format()])
         }
     }

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__call.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__call.py.snap
@@ -86,6 +86,21 @@ f(
     # oddly placed own line comment
     dict()
 )
+f(
+    session,
+    b=1,
+    **(# oddly placed own line comment
+    dict()
+    )
+)
+f(
+    session,
+    b=1,
+    **(
+        # oddly placed own line comment
+    dict()
+    )
+)
 
 # Don't add a magic trailing comma when there is only one entry
 # Minimized from https://github.com/django/django/blob/7eeadc82c2f7d7a778e3bb43c34d642e6275dacf/django/contrib/admin/checks.py#L674-L681
@@ -211,6 +226,28 @@ aaa = (
     ()
     .bbbbbbbbbbbbbbbb
 )
+
+# Comments around keywords
+f(x= # comment
+  1)
+
+f(x # comment
+ =
+  1)
+
+f(x=
+  # comment
+  1)
+
+f(x=(# comment
+  1
+))
+
+
+f(x=(
+  # comment
+  1
+))
 ```
 
 ## Output
@@ -288,13 +325,29 @@ f("aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaa
 f(
     session,
     b=1,
-    **dict(),  # oddly placed end-of-line comment
+    # oddly placed end-of-line comment
+    **dict(),
 )
 f(
     session,
     b=1,
-    **dict(),
     # oddly placed own line comment
+    **dict(),
+)
+f(
+    session,
+    b=1,
+    **(  # oddly placed own line comment
+        dict()
+    ),
+)
+f(
+    session,
+    b=1,
+    **(
+        # oddly placed own line comment
+        dict()
+    ),
 )
 
 # Don't add a magic trailing comma when there is only one entry
@@ -408,6 +461,36 @@ aaa = (
     bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     # awkward comment
 )().bbbbbbbbbbbbbbbb
+
+# Comments around keywords
+f(
+    # comment
+    x=1
+)
+
+f(
+    # comment
+    x=1
+)
+
+f(
+    # comment
+    x=1
+)
+
+f(
+    x=(  # comment
+        1
+    )
+)
+
+
+f(
+    x=(
+        # comment
+        1
+    )
+)
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__dict.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__dict.py.snap
@@ -80,22 +80,26 @@ x={  # dangling end of line comment
 
 {
     **a,  #  leading
-    **b,  # middle  # trailing
+    # middle
+    **b,  # trailing
 }
 
 {
-    **b  # middle with single item
+    # middle with single item
+    **b
 }
 
 {
     # before
-    **b,  # between
+    # between
+    **b,
 }
 
 {
     **a,  # comment before preceding node's comma
     # before
-    **b,  # between
+    # between
+    **b,
 }
 
 {}

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -985,18 +985,18 @@ match pattern_match_class:
         ...
 
     case A(
-        b=# b
+        # b
         # c
-        2  # d
+        b=2  # d
         # e
     ):
         pass
 
     case A(
         # a
-        b=# b
+        # b
         # c
-        2  # d
+        b=2  # d
         # e
     ):
         pass


### PR DESCRIPTION
## Summary

This PR adds comment handling for comments between the `=` and the `value` for keywords, as in the following cases:

```python
func(
    x  # dangling
    =  # dangling
    # dangling
    1,
    **  # dangling
    y
)
```

(Comments after the `**` were already handled in some cases, but I've unified the handling with the `=` handling.)

Note that, previously, comments between the `**` and its value were rendered as trailing comments on the value (so they'd appear after `y`). This struck me as odd since it effectively re-ordered the comment with respect to its closest AST node (the value). I've made them leading comments, though I don't know that that's a significant improvement. I could also imagine us leaving them where they are.
