### PR TITLE
Optional source map generation

### DIFF
--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -1,15 +1,16 @@
+use std::cell::Cell;
+use std::marker::PhantomData;
+use std::num::NonZeroU8;
+
+use ruff_text_size::TextRange;
+#[allow(clippy::enum_glob_use)]
+use Tag::*;
+
 use crate::format_element::tag::{Condition, Tag};
 use crate::prelude::tag::{DedentMode, GroupMode, LabelId};
 use crate::prelude::*;
 use crate::{format_element, write, Argument, Arguments, FormatContext, GroupId, TextSize};
 use crate::{Buffer, VecBuffer};
-
-use ruff_text_size::TextRange;
-use std::cell::Cell;
-use std::marker::PhantomData;
-use std::num::NonZeroU8;
-#[allow(clippy::enum_glob_use)]
-use Tag::*;
 
 /// A line break that only gets printed if the enclosing `Group` doesn't fit on a single line.
 /// It's omitted if the enclosing `Group` fits on a single line.
@@ -283,7 +284,6 @@ impl std::fmt::Debug for StaticText {
 /// ## Examples
 ///
 /// ```
-/// /// ```
 /// use ruff_formatter::format;
 /// use ruff_formatter::prelude::*;
 ///
@@ -329,6 +329,7 @@ pub struct SourcePosition(TextSize);
 impl<Context> Format<Context> for SourcePosition {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         f.write_element(FormatElement::SourcePosition(self.0));
+
         Ok(())
     }
 }

--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -1,17 +1,19 @@
-use super::tag::Tag;
+use std::collections::HashMap;
+use std::ops::Deref;
+
+use rustc_hash::FxHashMap;
+
 use crate::format_element::tag::{Condition, DedentMode};
 use crate::prelude::tag::GroupMode;
 use crate::prelude::*;
-use crate::printer::LineEnding;
 use crate::source_code::SourceCode;
 use crate::{format, write, TabWidth};
 use crate::{
     BufferExtensions, Format, FormatContext, FormatElement, FormatOptions, FormatResult, Formatter,
     IndentStyle, LineWidth, PrinterOptions,
 };
-use rustc_hash::FxHashMap;
-use std::collections::HashMap;
-use std::ops::Deref;
+
+use super::tag::Tag;
 
 /// A formatted document.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
@@ -225,10 +227,9 @@ impl FormatOptions for IrFormatOptions {
 
     fn as_print_options(&self) -> PrinterOptions {
         PrinterOptions {
-            tab_width: TabWidth::default(),
             print_width: self.line_width().into(),
-            line_ending: LineEnding::LineFeed,
             indent_style: IndentStyle::Space(2),
+            ..PrinterOptions::default()
         }
     }
 }
@@ -781,10 +782,11 @@ impl Format<IrFormatContext<'_>> for Condition {
 
 #[cfg(test)]
 mod tests {
+    use ruff_text_size::{TextRange, TextSize};
+
     use crate::prelude::*;
     use crate::{format, format_args, write};
     use crate::{SimpleFormatContext, SourceCode};
-    use ruff_text_size::{TextRange, TextSize};
 
     #[test]
     fn display_elements() {

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -39,7 +39,7 @@ use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 
 use crate::format_element::document::Document;
-use crate::printer::{Printer, PrinterOptions};
+use crate::printer::{Printer, PrinterOptions, SourceMapGeneration};
 pub use arguments::{Argument, Arguments};
 pub use buffer::{
     Buffer, BufferExtensions, BufferSnapshot, Inspect, RemoveSoftLinesBuffer, VecBuffer,
@@ -311,10 +311,12 @@ impl FormatOptions for SimpleFormatOptions {
     }
 
     fn as_print_options(&self) -> PrinterOptions {
-        PrinterOptions::default()
-            .with_indent(self.indent_style)
-            .with_tab_width(self.tab_width())
-            .with_print_width(self.line_width.into())
+        PrinterOptions {
+            print_width: self.line_width.into(),
+            indent_style: self.indent_style,
+            source_map_generation: SourceMapGeneration::Enabled,
+            ..PrinterOptions::default()
+        }
     }
 }
 

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -396,6 +396,10 @@ impl<'a> Printer<'a> {
     }
 
     fn push_marker(&mut self) {
+        if self.options.source_map_generation.is_disabled() {
+            return;
+        }
+
         let marker = SourceMarker {
             source: self.state.source_position,
             dest: self.state.buffer.text_len(),

--- a/crates/ruff_formatter/src/printer/printer_options/mod.rs
+++ b/crates/ruff_formatter/src/printer/printer_options/mod.rs
@@ -14,39 +14,10 @@ pub struct PrinterOptions {
 
     /// Whether the printer should use tabs or spaces to indent code and if spaces, by how many.
     pub indent_style: IndentStyle,
-}
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct PrintWidth(u32);
-
-impl PrintWidth {
-    pub fn new(width: u32) -> Self {
-        Self(width)
-    }
-}
-
-impl Default for PrintWidth {
-    fn default() -> Self {
-        LineWidth::default().into()
-    }
-}
-
-impl From<LineWidth> for PrintWidth {
-    fn from(width: LineWidth) -> Self {
-        Self(u32::from(u16::from(width)))
-    }
-}
-
-impl From<PrintWidth> for usize {
-    fn from(width: PrintWidth) -> Self {
-        width.0 as usize
-    }
-}
-
-impl From<PrintWidth> for u32 {
-    fn from(width: PrintWidth) -> Self {
-        width.0
-    }
+    /// Whether the printer should build a source map that allows mapping positions in the source document
+    /// to positions in the formatted document.
+    pub source_map_generation: SourceMapGeneration,
 }
 
 impl<'a, O> From<&'a O> for PrinterOptions
@@ -91,6 +62,64 @@ impl PrinterOptions {
             IndentStyle::Tab => self.tab_width.value(),
             IndentStyle::Space(count) => count as u32,
         }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct PrintWidth(u32);
+
+impl PrintWidth {
+    pub fn new(width: u32) -> Self {
+        Self(width)
+    }
+}
+
+impl Default for PrintWidth {
+    fn default() -> Self {
+        LineWidth::default().into()
+    }
+}
+
+impl From<LineWidth> for PrintWidth {
+    fn from(width: LineWidth) -> Self {
+        Self(u32::from(u16::from(width)))
+    }
+}
+
+impl From<PrintWidth> for usize {
+    fn from(width: PrintWidth) -> Self {
+        width.0 as usize
+    }
+}
+
+impl From<PrintWidth> for u32 {
+    fn from(width: PrintWidth) -> Self {
+        width.0
+    }
+}
+
+/// Configures whether the formatter and printer generate a source map that allows mapping
+/// positions in the source document to positions in the formatted code.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SourceMapGeneration {
+    /// The formatter generates no source map.
+    #[default]
+    Disabled,
+
+    /// The formatter generates a source map that allows mapping positions in the source document
+    /// to positions in the formatted document. The ability to map positions is useful for range formatting
+    /// or when trying to identify where to move the cursor so that it matches its position in the source document.
+    Enabled,
+}
+
+impl SourceMapGeneration {
+    pub const fn is_enabled(self) -> bool {
+        matches!(self, SourceMapGeneration::Enabled)
+    }
+
+    pub const fn is_disabled(self) -> bool {
+        matches!(self, SourceMapGeneration::Disabled)
     }
 }
 

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -1,4 +1,4 @@
-use ruff_formatter::printer::{LineEnding, PrinterOptions};
+use ruff_formatter::printer::{LineEnding, PrinterOptions, SourceMapGeneration};
 use ruff_formatter::{FormatOptions, IndentStyle, LineWidth, TabWidth};
 use ruff_python_ast::PySourceType;
 use std::path::Path;
@@ -33,6 +33,10 @@ pub struct PyFormatOptions {
 
     /// Whether to expand lists or elements if they have a trailing comma such as `(a, b,)`.
     magic_trailing_comma: MagicTrailingComma,
+
+    /// Should the formatter generate a source map that allows mapping source positions to positions
+    /// in the formatted document.
+    source_map_generation: SourceMapGeneration,
 }
 
 fn default_line_width() -> LineWidth {
@@ -56,6 +60,7 @@ impl Default for PyFormatOptions {
             tab_width: default_tab_width(),
             quote_style: QuoteStyle::default(),
             magic_trailing_comma: MagicTrailingComma::default(),
+            source_map_generation: SourceMapGeneration::default(),
         }
     }
 }
@@ -83,6 +88,10 @@ impl PyFormatOptions {
 
     pub fn source_type(&self) -> PySourceType {
         self.source_type
+    }
+
+    pub fn source_map_generation(&self) -> SourceMapGeneration {
+        self.source_map_generation
     }
 
     #[must_use]
@@ -129,6 +138,7 @@ impl FormatOptions for PyFormatOptions {
             print_width: self.line_width.into(),
             line_ending: LineEnding::LineFeed,
             indent_style: self.indent_style,
+            source_map_generation: self.source_map_generation,
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR makes the formatter's source map generation optional. 

Source mapping informatin is useful to implement range formatting or to move the cursor to the same position in the formatted document. But it comes at the cost of a much larger `Document` (one each at the start and end of every node) and a large source map created by writting source markers in the Printer (one marker at the start and end of every text). 
This PR makes the source map generation option so that we don't pay the overhead when it isn't needed.


## Test Plan

```
cargo test
```

Performance improves locally by about 16%

```
formatter/numpy/globals.py
                        time:   [36.860 µs 36.908 µs 36.971 µs]
                        thrpt:  [79.811 MiB/s 79.946 MiB/s 80.050 MiB/s]
                 change:
                        time:   [-16.602% -16.431% -16.245%] (p = 0.00 < 0.05)
                        thrpt:  [+19.396% +19.662% +19.907%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
formatter/pydantic/types.py
                        time:   [771.54 µs 773.43 µs 775.26 µs]
                        thrpt:  [32.896 MiB/s 32.974 MiB/s 33.055 MiB/s]
                 change:
                        time:   [-17.740% -17.519% -17.303%] (p = 0.00 < 0.05)
                        thrpt:  [+20.923% +21.240% +21.566%]
                        Performance has improved.
formatter/numpy/ctypeslib.py
                        time:   [408.12 µs 408.48 µs 408.90 µs]
                        thrpt:  [40.722 MiB/s 40.763 MiB/s 40.799 MiB/s]
                 change:
                        time:   [-16.845% -15.595% -14.821%] (p = 0.00 < 0.05)
                        thrpt:  [+17.400% +18.476% +20.257%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
formatter/large/dataset.py
                        time:   [2.1040 ms 2.1059 ms 2.1084 ms]
                        thrpt:  [19.295 MiB/s 19.318 MiB/s 19.336 MiB/s]
                 change:
                        time:   [-14.956% -14.812% -14.648%] (p = 0.00 < 0.05)
                        thrpt:  [+17.162% +17.387% +17.586%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

```