### PR TITLE
Truncate ecosystem comment when necessary

### DIFF
--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -47,19 +47,27 @@ jobs:
         id: generate-comment
         if: steps.download-ecosystem-result.outputs.found_artifact == 'true'
         run: |
-          echo 'comment<<EOF' >> $GITHUB_OUTPUT
-          echo '## PR Check Results' >> $GITHUB_OUTPUT
+          echo '## PR Check Results' >> comment.txt
 
-          echo "### Ecosystem" >> $GITHUB_OUTPUT
-          cat pr/ecosystem/ecosystem-result >> $GITHUB_OUTPUT
-          echo "" >> $GITHUB_OUTPUT
+          echo "### Ecosystem" >> comment.txt
+          cat pr/ecosystem/ecosystem-result >> comment.txt
+          echo "" >> comment.txt
+          cat comment.txt >> $GITHUB_OUTPUT
 
-          echo 'EOF' >> $GITHUB_OUTPUT
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        if: steps.generate-comment.outcome == 'success'
+        id: find-comment
+        with:
+          issue-number: ${{ steps.pr-number.outputs.pr-number }}
+          comment-author: "github-actions[bot]"
+          body-includes: PR Check Results
 
       - name: Create or update comment
-        if: steps.generate-comment.outputs.comment
-        uses: thollander/actions-comment-pull-request@v2
+        if: steps.find-comment.outcome == 'success'
+        uses: peter-evans/create-or-update-comment@v3
         with:
-          pr_number: ${{ steps.pr-number.outputs.pr-number }}
-          message: ${{ steps.generate-comment.outputs.comment }}
-          comment_tag: PR Check Results
+          comment-d: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.pr-number.outputs.pr-number }}
+          body-path: comment.txt
+          edit-mode: replace

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -52,7 +52,10 @@ jobs:
           echo "### Ecosystem" >> comment.txt
           cat pr/ecosystem/ecosystem-result >> comment.txt
           echo "" >> comment.txt
+
+          echo 'comment<<EOF' >> $GITHUB_OUTPUT
           cat comment.txt >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Find Comment
         uses: peter-evans/find-comment@v2
@@ -67,7 +70,7 @@ jobs:
         if: steps.find-comment.outcome == 'success'
         uses: peter-evans/create-or-update-comment@v3
         with:
-          comment-d: ${{ steps.find-comment.outputs.comment-id }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ steps.pr-number.outputs.pr-number }}
           body-path: comment.txt
           edit-mode: replace


### PR DESCRIPTION
## Summary

This PR ensures that the PR comment action always creates a comment, even if the ecosystem results are huge by:

* Testing on the outcome of the step rather the comment text to prevent an out of memory error
* Use another PR comment plugin that automatically truncates the text if it exceeds GitHubs limit of 65536 characters. 

It would be nice if we could add a custom message when the results are truncated but the plugin does not support that. I think this is already a huge improvement because it prevents that we loose the ecosystem result when it's most needed

## Test Plan

I commented out the traversal of the class body in checker to generate a large regression. 

* The [PR Comment run](https://github.com/astral-sh/ruff/actions/runs/5990006807) with the workflow from main fails 
* The manually scheduled [PR Comment run](https://github.com/astral-sh/ruff/actions/runs/5990009960/job/16246859872) on this branch succeeds

<!-- How was it tested? -->
