### PR TITLE
Use dyn dispatch for `any_over_*`

### DIFF
--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -114,10 +114,7 @@ where
 
 /// Call `func` over every `Expr` in `expr`, returning `true` if any expression
 /// returns `true`..
-pub fn any_over_expr<F>(expr: &Expr, func: &F) -> bool
-where
-    F: Fn(&Expr) -> bool,
-{
+pub fn any_over_expr(expr: &Expr, func: &dyn Fn(&Expr) -> bool) -> bool {
     if func(expr) {
         return true;
     }
@@ -248,10 +245,7 @@ where
     }
 }
 
-pub fn any_over_type_param<F>(type_param: &TypeParam, func: &F) -> bool
-where
-    F: Fn(&Expr) -> bool,
-{
+pub fn any_over_type_param(type_param: &TypeParam, func: &dyn Fn(&Expr) -> bool) -> bool {
     match type_param {
         TypeParam::TypeVar(ast::TypeParamTypeVar { bound, .. }) => bound
             .as_ref()
@@ -261,10 +255,7 @@ where
     }
 }
 
-pub fn any_over_pattern<F>(pattern: &Pattern, func: &F) -> bool
-where
-    F: Fn(&Expr) -> bool,
-{
+pub fn any_over_pattern(pattern: &Pattern, func: &dyn Fn(&Expr) -> bool) -> bool {
     match pattern {
         Pattern::MatchValue(ast::PatternMatchValue { value, range: _ }) => {
             any_over_expr(value, func)
@@ -300,10 +291,7 @@ where
     }
 }
 
-pub fn any_over_stmt<F>(stmt: &Stmt, func: &F) -> bool
-where
-    F: Fn(&Expr) -> bool,
-{
+pub fn any_over_stmt(stmt: &Stmt, func: &dyn Fn(&Expr) -> bool) -> bool {
     match stmt {
         Stmt::FunctionDef(ast::StmtFunctionDef {
             parameters,
@@ -526,10 +514,7 @@ where
     }
 }
 
-pub fn any_over_body<F>(body: &[Stmt], func: &F) -> bool
-where
-    F: Fn(&Expr) -> bool,
-{
+pub fn any_over_body(body: &[Stmt], func: &dyn Fn(&Expr) -> bool) -> bool {
     body.iter().any(|stmt| any_over_stmt(stmt, func))
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR changes our `any_over_` functions to use dynamic dispatch over static dispatch because the use of `F: Fn(&Expr) -> bool` results in Rust monomorphizing the `any_over` function body for every passed closure. Resulting in `any_over_expr` being our 4th largest function in ruff:

```
Lines                  Copies               Function name
  -----                  ------               -------------
  1801126                36446                (TOTAL)
    33699 (1.9%,  1.9%)    141 (0.4%,  0.4%)  alloc::raw_vec::RawVec<T,A>::grow_amortized
    30284 (1.7%,  3.6%)    383 (1.1%,  1.4%)  core::iter::traits::iterator::Iterator::try_fold
    23751 (1.3%,  4.9%)      3 (0.0%,  1.4%)  <ruff::settings::options::_::<impl serde::de::Deserialize for ruff::settings::options::Options>::deserialize::__Visitor as serde::de::Visitor>::visit_map
    19173 (1.1%,  5.9%)     21 (0.1%,  1.5%)  ruff_python_ast::helpers::any_over_expr
```

The ideal solution would be inverse control by having an `expression` iterator. However, I haven't been able to come up with a fast implementation that doesn't require writing the child expressions to a temporary vec. 

## Test Plan

`cargo test`. This removes about 1% of llvm lines from the ruff crate. 

<!-- How was it tested? -->
