### PR TITLE
Implement ConfigProcessor on non-ref type

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -513,7 +513,7 @@ pub struct Overrides {
     pub show_fixes: Option<bool>,
 }
 
-impl ConfigProcessor for &Overrides {
+impl ConfigProcessor for Overrides {
     fn process_config(&self, config: &mut ruff::settings::configuration::Configuration) {
         if let Some(cache_dir) = &self.cache_dir {
             config.cache_dir = Some(cache_dir.clone());


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR implements `ConfigProcessor` on the `struct` itself rather than `&T`. 

It also changes the `resolve` functions to use dynamic dispatch rather than being generic over `ConfigProcessor`. 
Dynamic dispatch isn't a problem here as the `ConfigProcessor` isn't called in a hot code path

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

This PR removes about 13684 llvm lines (0.75%)

`cargo test`

<!-- How was it tested? -->
