### PR TITLE
Add TOML files to `SourceType`

### DIFF
--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -268,9 +268,12 @@ pub fn check_path(
 const MAX_ITERATIONS: usize = 100;
 
 /// Add any missing `# noqa` pragmas to the source code at the given `Path`.
-pub fn add_noqa_to_path(path: &Path, package: Option<&Path>, settings: &Settings) -> Result<usize> {
-    let source_type = PySourceType::from(path);
-
+pub fn add_noqa_to_path(
+    path: &Path,
+    package: Option<&Path>,
+    source_type: PySourceType,
+    settings: &Settings,
+) -> Result<usize> {
     // Read the file from disk.
     let contents = std::fs::read_to_string(path)?;
 

--- a/crates/ruff/src/source_kind.rs
+++ b/crates/ruff/src/source_kind.rs
@@ -3,7 +3,9 @@ use crate::jupyter::Notebook;
 
 #[derive(Clone, Debug, PartialEq, is_macro::Is)]
 pub enum SourceKind {
+    /// The source contains Python source code.
     Python(String),
+    /// The source contains a Jupyter notebook.
     IpyNotebook(Notebook),
 }
 

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -24,32 +24,63 @@ pub mod types;
 pub mod visitor;
 pub mod whitespace;
 
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum PySourceType {
-    #[default]
-    Python,
-    Stub,
-    Ipynb,
+/// The type of a source file.
+#[derive(Clone, Copy, Debug, PartialEq, is_macro::Is)]
+pub enum SourceType {
+    /// The file contains Python source code.
+    Python(PySourceType),
+    /// The file contains TOML.
+    Toml(TomlSourceType),
 }
 
-impl PySourceType {
-    pub const fn is_python(&self) -> bool {
-        matches!(self, PySourceType::Python)
+impl Default for SourceType {
+    fn default() -> Self {
+        Self::Python(PySourceType::Python)
     }
+}
 
-    pub const fn is_stub(&self) -> bool {
-        matches!(self, PySourceType::Stub)
+impl From<&Path> for SourceType {
+    fn from(path: &Path) -> Self {
+        match path.file_name() {
+            Some(filename) if filename == "pyproject.toml" => Self::Toml(TomlSourceType::Pyproject),
+            Some(filename) if filename == "Pipfile" => Self::Toml(TomlSourceType::Pipfile),
+            Some(filename) if filename == "poetry.lock" => Self::Toml(TomlSourceType::Poetry),
+            _ => match path.extension() {
+                Some(ext) if ext == "toml" => Self::Toml(TomlSourceType::Unrecognized),
+                _ => Self::Python(PySourceType::from(path)),
+            },
+        }
     }
+}
 
-    pub const fn is_ipynb(&self) -> bool {
-        matches!(self, PySourceType::Ipynb)
-    }
+#[derive(Clone, Copy, Debug, PartialEq, is_macro::Is)]
+pub enum TomlSourceType {
+    /// The source is a `pyproject.toml`.
+    Pyproject,
+    /// The source is a `Pipfile`.
+    Pipfile,
+    /// The source is a `poetry.lock`.
+    Poetry,
+    /// The source is an unrecognized TOML file.
+    Unrecognized,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, is_macro::Is)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum PySourceType {
+    /// The source is a Python file (`.py`).
+    #[default]
+    Python,
+    /// The source is a Python stub file (`.pyi`).
+    Stub,
+    /// The source is a Jupyter notebook (`.ipynb`).
+    Ipynb,
 }
 
 impl From<&Path> for PySourceType {
     fn from(path: &Path) -> Self {
         match path.extension() {
+            Some(ext) if ext == "py" => PySourceType::Python,
             Some(ext) if ext == "pyi" => PySourceType::Stub,
             Some(ext) if ext == "ipynb" => PySourceType::Ipynb,
             _ => PySourceType::Python,

--- a/crates/ruff_python_stdlib/src/path.rs
+++ b/crates/ruff_python_stdlib/src/path.rs
@@ -1,13 +1,7 @@
 use std::path::Path;
 
-/// Return `true` if the [`Path`] appears to be that of a Python file.
-pub fn is_python_file(path: &Path) -> bool {
-    path.extension()
-        .is_some_and(|ext| ext == "py" || ext == "pyi")
-}
-
 /// Return `true` if the [`Path`] is named `pyproject.toml`.
-pub fn is_project_toml(path: &Path) -> bool {
+pub fn is_pyproject_toml(path: &Path) -> bool {
     path.file_name()
         .is_some_and(|name| name == "pyproject.toml")
 }
@@ -26,22 +20,7 @@ pub fn is_jupyter_notebook(path: &Path) -> bool {
 mod tests {
     use std::path::Path;
 
-    use crate::path::{is_jupyter_notebook, is_python_file};
-
-    #[test]
-    fn inclusions() {
-        let path = Path::new("foo/bar/baz.py");
-        assert!(is_python_file(path));
-
-        let path = Path::new("foo/bar/baz.pyi");
-        assert!(is_python_file(path));
-
-        let path = Path::new("foo/bar/baz.js");
-        assert!(!is_python_file(path));
-
-        let path = Path::new("foo/bar/baz");
-        assert!(!is_python_file(path));
-    }
+    use crate::path::is_jupyter_notebook;
 
     #[test]
     fn test_is_jupyter_notebook() {


### PR DESCRIPTION
## Summary

This PR adds a higher-level enum (`SourceType`) around `PySourceType` to allow us to use the same detection path to handle TOML files. Right now, we have ad hoc `is_pyproject_toml` checks littered around, and some codepaths are omitting that logic altogether (like `add_noqa`). Instead, we should always be required to check the source type and handle TOML files as appropriate.

This PR will also help with our pre-commit capabilities. If we add `toml` to pre-commit (to support `pyproject.toml`), pre-commit will start to pass _other_ files to Ruff (along with `poetry.lock` and `Pipfile` -- see [identify](https://github.com/pre-commit/identify/blob/b59996304fea80025d32abc3ac8f7212a9e7380d/identify/extensions.py#L355)). By detecting those files and handling those cases, we avoid attempting to parse them as Python files, which would lead to pre-commit errors. (We tried to add `toml` to pre-commit here (https://github.com/astral-sh/ruff-pre-commit/pull/44), but had to revert here (https://github.com/astral-sh/ruff-pre-commit/pull/45) as it led to the pre-commit hook attempting to parse `poetry.lock` files as Python files.)
