### PR TITLE
Avoid lexer infinite loop on invalid input

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -706,6 +706,8 @@ impl<'source> Lexer<'source> {
         // We reached end of file.
         // First of all, we need all nestings to be finished.
         if self.nesting > 0 {
+            // Reset the nesting to avoid going into infinite loop.
+            self.nesting = 0;
             return Err(LexicalError {
                 error: LexicalErrorType::Eof,
                 location: self.offset(),
@@ -1679,5 +1681,13 @@ def f(arg=%timeit a = b):
                 Tok::Newline,
             ]
         );
+    }
+
+    // This test case is to just make sure that the lexer doesn't go into
+    // inifite loop on invalid input.
+    #[test]
+    fn test_infite_loop() {
+        let source = "[1";
+        let _ = lex(source, Mode::Module).collect::<Vec<_>>();
     }
 }

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1684,7 +1684,7 @@ def f(arg=%timeit a = b):
     }
 
     // This test case is to just make sure that the lexer doesn't go into
-    // inifite loop on invalid input.
+    // infinite loop on invalid input.
     #[test]
     fn test_infite_loop() {
         let source = "[1";


### PR DESCRIPTION
## Summary

This PR fixes a bug which sends the lexer into infinite loop for an invalid input.
The code in question is `[1` where the nesting is never finished. This means
that the lexer will keep emitting the `Err` token forever.

## Test Plan

Add a test case which collects all the tokens from the lexer. This just makes
sure that it doesn't go into infinite loop.
