### PR TITLE
Remove Comprehension priority

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/boolean_operation.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/boolean_operation.py
@@ -94,3 +94,11 @@ if not (
     isinstance(aaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbb) and (xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx + yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy) or isinstance(ccccccccccc, dddddd)
 ):
     pass
+
+
+def test():
+    return (
+        isinstance(other, Mapping)
+        and {k.lower(): v for k, v in self.items()}
+        == {k.lower(): v for k, v in other.items()}
+    )

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -434,14 +434,15 @@ impl<'input> CanOmitOptionalParenthesesVisitor<'input> {
     // Visits a subexpression, ignoring whether it is parenthesized or not
     fn visit_subexpression(&mut self, expr: &'input Expr) {
         match expr {
-            Expr::Dict(_) | Expr::List(_) | Expr::Tuple(_) | Expr::Set(_) => {
+            Expr::Dict(_)
+            | Expr::List(_)
+            | Expr::Tuple(_)
+            | Expr::Set(_)
+            | Expr::ListComp(_)
+            | Expr::SetComp(_)
+            | Expr::DictComp(_) => {
                 self.any_parenthesized_expressions = true;
                 // The values are always parenthesized, don't visit.
-                return;
-            }
-            Expr::ListComp(_) | Expr::SetComp(_) | Expr::DictComp(_) => {
-                self.any_parenthesized_expressions = true;
-                self.update_max_priority(OperatorPriority::Comprehension);
                 return;
             }
             // It's impossible for a file smaller or equal to 4GB to contain more than 2^32 comparisons
@@ -789,7 +790,6 @@ enum OperatorPriority {
     String,
     BooleanOperation,
     Conditional,
-    Comprehension,
 }
 
 impl From<ast::Operator> for OperatorPriority {

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__boolean_operation.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__boolean_operation.py.snap
@@ -100,6 +100,14 @@ if not (
     isinstance(aaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbb) and (xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx + yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy) or isinstance(ccccccccccc, dddddd)
 ):
     pass
+
+
+def test():
+    return (
+        isinstance(other, Mapping)
+        and {k.lower(): v for k, v in self.items()}
+        == {k.lower(): v for k, v in other.items()}
+    )
 ```
 
 ## Output
@@ -220,6 +228,12 @@ if not (
     or isinstance(ccccccccccc, dddddd)
 ):
     pass
+
+
+def test():
+    return isinstance(other, Mapping) and {k.lower(): v for k, v in self.items()} == {
+        k.lower(): v for k, v in other.items()
+    }
 ```
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR removes the `Comprehension` Priority from `can_omit_parentheses` because Black seems to omit parentheses even if there are multiple parentheses. 

I'm not entirely sure why. Or better, I'm not entirely sure what the following checks in Black are for

https://github.com/psf/black/blob/b4dca26c7d93f930bbd5a7b552807370b60d4298/src/black/brackets.py#L266-L283

But I suggest to remove the priority for now and re-introduce the priority when we come across some code that gets formatted incorrectly

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

* I added a new test
* I double checked that it doesn't introduce new regressions in the django project
* It improves the similarity overall

**This PR**

| project      | similarity index |
|--------------|------------------|
| cpython      | 0.76082          |
| **django**       | 0.99902          | 
| **transformers** | 0.99850          |
| **twine**        | 0.99982          |
| typeshed     | 0.99953          |
| **warehouse**    | 0.99648          |
| **zulip**        | 0.99924          |

**Main**

| project      | similarity index |
|--------------|------------------|
| cpython      | 0.76081          |
| django       | 0.99899          |
| transformers | 0.99842          |
| twine        | 0.99929          |
| typeshed     | 0.99953          |
| warehouse    | 0.99646          |
| zulip        | 0.99922          |


<!-- How was it tested? -->
