### PR TITLE
Use `SourceCodeSnippet` for more diagnostic messages

### DIFF
--- a/crates/ruff/src/autofix/snippet.rs
+++ b/crates/ruff/src/autofix/snippet.rs
@@ -9,6 +9,10 @@ impl SourceCodeSnippet {
         Self(source_code)
     }
 
+    pub(crate) fn from_str(source_code: &str) -> Self {
+        Self(source_code.to_string())
+    }
+
     /// Return the full snippet for user-facing display, or `None` if the snippet should be
     /// truncated.
     pub(crate) fn full_display(&self) -> Option<&str> {

--- a/crates/ruff/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff/src/checkers/ast/analyze/expression.rs
@@ -1039,12 +1039,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                     }
                 }
                 if checker.enabled(Rule::PrintfStringFormatting) {
-                    pyupgrade::rules::printf_string_formatting(
-                        checker,
-                        expr,
-                        right,
-                        checker.locator,
-                    );
+                    pyupgrade::rules::printf_string_formatting(checker, expr, right);
                 }
                 if checker.enabled(Rule::BadStringFormatCharacter) {
                     pylint::rules::bad_string_format_character::percent(checker, expr);

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -3,6 +3,7 @@ use std::hash::BuildHasherDefault;
 use ruff_python_ast::Expr;
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use crate::autofix::snippet::SourceCodeSnippet;
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::ComparableExpr;
@@ -43,7 +44,7 @@ use crate::registry::{AsRule, Rule};
 /// - [Python documentation: Dictionaries](https://docs.python.org/3/tutorial/datastructures.html#dictionaries)
 #[violation]
 pub struct MultiValueRepeatedKeyLiteral {
-    name: String,
+    name: SourceCodeSnippet,
 }
 
 impl Violation for MultiValueRepeatedKeyLiteral {
@@ -52,12 +53,20 @@ impl Violation for MultiValueRepeatedKeyLiteral {
     #[derive_message_formats]
     fn message(&self) -> String {
         let MultiValueRepeatedKeyLiteral { name } = self;
-        format!("Dictionary key literal `{name}` repeated")
+        if let Some(name) = name.full_display() {
+            format!("Dictionary key literal `{name}` repeated")
+        } else {
+            format!("Dictionary key literal repeated")
+        }
     }
 
     fn autofix_title(&self) -> Option<String> {
         let MultiValueRepeatedKeyLiteral { name } = self;
-        Some(format!("Remove repeated key literal `{name}`"))
+        if let Some(name) = name.full_display() {
+            Some(format!("Remove repeated key literal `{name}`"))
+        } else {
+            Some(format!("Remove repeated key literal"))
+        }
     }
 }
 
@@ -92,7 +101,7 @@ impl Violation for MultiValueRepeatedKeyLiteral {
 /// - [Python documentation: Dictionaries](https://docs.python.org/3/tutorial/datastructures.html#dictionaries)
 #[violation]
 pub struct MultiValueRepeatedKeyVariable {
-    name: String,
+    name: SourceCodeSnippet,
 }
 
 impl Violation for MultiValueRepeatedKeyVariable {
@@ -101,12 +110,20 @@ impl Violation for MultiValueRepeatedKeyVariable {
     #[derive_message_formats]
     fn message(&self) -> String {
         let MultiValueRepeatedKeyVariable { name } = self;
-        format!("Dictionary key `{name}` repeated")
+        if let Some(name) = name.full_display() {
+            format!("Dictionary key `{name}` repeated")
+        } else {
+            format!("Dictionary key repeated")
+        }
     }
 
     fn autofix_title(&self) -> Option<String> {
         let MultiValueRepeatedKeyVariable { name } = self;
-        Some(format!("Remove repeated key `{name}`"))
+        if let Some(name) = name.full_display() {
+            Some(format!("Remove repeated key `{name}`"))
+        } else {
+            Some(format!("Remove repeated key"))
+        }
     }
 }
 
@@ -135,7 +152,7 @@ pub(crate) fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values
                 if checker.enabled(Rule::MultiValueRepeatedKeyLiteral) {
                     let mut diagnostic = Diagnostic::new(
                         MultiValueRepeatedKeyLiteral {
-                            name: checker.locator().slice(key).to_string(),
+                            name: SourceCodeSnippet::from_str(checker.locator().slice(key)),
                         },
                         key.range(),
                     );
@@ -154,7 +171,7 @@ pub(crate) fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values
                 if checker.enabled(Rule::MultiValueRepeatedKeyVariable) {
                     let mut diagnostic = Diagnostic::new(
                         MultiValueRepeatedKeyVariable {
-                            name: checker.locator().slice(key).to_string(),
+                            name: SourceCodeSnippet::from_str(checker.locator().slice(key)),
                         },
                         key.range(),
                     );

--- a/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
@@ -46,8 +46,10 @@ impl Violation for NestedMinMax {
     const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
+
     fn message(&self) -> String {
-        format!("Nested `{}` calls can be flattened", self.func)
+        let NestedMinMax { func } = self;
+        format!("Nested `{func}` calls can be flattened")
     }
 
     fn autofix_title(&self) -> Option<String> {

--- a/crates/ruff/src/rules/pylint/rules/repeated_isinstance_calls.rs
+++ b/crates/ruff/src/rules/pylint/rules/repeated_isinstance_calls.rs
@@ -2,6 +2,7 @@ use itertools::Itertools;
 use ruff_python_ast::{self as ast, Arguments, BoolOp, Expr};
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use crate::autofix::snippet::SourceCodeSnippet;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::hashable::HashableExpr;
@@ -44,19 +45,27 @@ use crate::settings::types::PythonVersion;
 /// - [Python documentation: `isinstance`](https://docs.python.org/3/library/functions.html#isinstance)
 #[violation]
 pub struct RepeatedIsinstanceCalls {
-    expr: String,
+    expression: SourceCodeSnippet,
 }
 
 impl AlwaysAutofixableViolation for RepeatedIsinstanceCalls {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let RepeatedIsinstanceCalls { expr } = self;
-        format!("Merge `isinstance` calls: `{expr}`")
+        let RepeatedIsinstanceCalls { expression } = self;
+        if let Some(expression) = expression.full_display() {
+            format!("Merge `isinstance` calls: `{expression}`")
+        } else {
+            format!("Merge `isinstance` calls")
+        }
     }
 
     fn autofix_title(&self) -> String {
-        let RepeatedIsinstanceCalls { expr } = self;
-        format!("Replace with `{expr}`")
+        let RepeatedIsinstanceCalls { expression } = self;
+        if let Some(expression) = expression.full_display() {
+            format!("Replace with `{expression}`")
+        } else {
+            format!("Replace with merged `isinstance` call")
+        }
     }
 }
 
@@ -117,8 +126,12 @@ pub(crate) fn repeated_isinstance_calls(
                     .sorted(),
                 checker.settings.target_version,
             );
-            let mut diagnostic =
-                Diagnostic::new(RepeatedIsinstanceCalls { expr: call.clone() }, expr.range());
+            let mut diagnostic = Diagnostic::new(
+                RepeatedIsinstanceCalls {
+                    expression: SourceCodeSnippet::new(call.clone()),
+                },
+                expr.range(),
+            );
             if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.set_fix(Fix::automatic(Edit::range_replacement(call, expr.range())));
             }

--- a/crates/ruff/src/rules/ruff/rules/static_key_dict_comprehension.rs
+++ b/crates/ruff/src/rules/ruff/rules/static_key_dict_comprehension.rs
@@ -1,5 +1,6 @@
 use ruff_python_ast::Expr;
 
+use crate::autofix::snippet::SourceCodeSnippet;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::is_constant;
@@ -29,14 +30,18 @@ use crate::checkers::ast::Checker;
 /// ```
 #[violation]
 pub struct StaticKeyDictComprehension {
-    key: String,
+    key: SourceCodeSnippet,
 }
 
 impl Violation for StaticKeyDictComprehension {
     #[derive_message_formats]
     fn message(&self) -> String {
         let StaticKeyDictComprehension { key } = self;
-        format!("Dictionary comprehension uses static key: `{key}`")
+        if let Some(key) = key.full_display() {
+            format!("Dictionary comprehension uses static key: `{key}`")
+        } else {
+            format!("Dictionary comprehension uses static key")
+        }
     }
 }
 
@@ -45,7 +50,7 @@ pub(crate) fn static_key_dict_comprehension(checker: &mut Checker, key: &Expr) {
     if is_constant(key) {
         checker.diagnostics.push(Diagnostic::new(
             StaticKeyDictComprehension {
-                key: checker.locator().slice(key).to_string(),
+                key: SourceCodeSnippet::from_str(checker.locator().slice(key)),
             },
             key.range(),
         ));


### PR DESCRIPTION
## Summary

This ensures that we truncate the messages when they break over multiple lines, etc.