### PR TITLE
Clean up some misc. code in NamedTuple and TypedDict conversion

### DIFF
--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -1,16 +1,15 @@
-use anyhow::{bail, Result};
 use log::debug;
-use ruff_python_ast::{
-    self as ast, Arguments, Constant, Expr, ExprContext, Identifier, Keyword, Stmt,
-};
-use ruff_text_size::{Ranged, TextRange};
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::is_dunder;
+use ruff_python_ast::{
+    self as ast, Arguments, Constant, Expr, ExprContext, Identifier, Keyword, Stmt,
+};
 use ruff_python_codegen::Generator;
 use ruff_python_semantic::SemanticModel;
 use ruff_python_stdlib::identifiers::is_identifier;
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -66,6 +65,70 @@ impl Violation for ConvertNamedTupleFunctionalToClass {
     }
 }
 
+/// UP014
+pub(crate) fn convert_named_tuple_functional_to_class(
+    checker: &mut Checker,
+    stmt: &Stmt,
+    targets: &[Expr],
+    value: &Expr,
+) {
+    let Some((typename, args, keywords, base_class)) =
+        match_named_tuple_assign(targets, value, checker.semantic())
+    else {
+        return;
+    };
+
+    let fields = match (args, keywords) {
+        // Ex) `NamedTuple("MyType")`
+        ([_typename], []) => vec![Stmt::Pass(ast::StmtPass {
+            range: TextRange::default(),
+        })],
+        // Ex) `NamedTuple("MyType", [("a", int), ("b", str)])`
+        ([_typename, fields], []) => {
+            if let Some(fields) = create_fields_from_fields_arg(fields) {
+                fields
+            } else {
+                debug!("Skipping `NamedTuple` \"{typename}\": unable to parse fields");
+                return;
+            }
+        }
+        // Ex) `NamedTuple("MyType", a=int, b=str)`
+        ([_typename], keywords) => {
+            if let Some(fields) = create_fields_from_keywords(keywords) {
+                fields
+            } else {
+                debug!("Skipping `NamedTuple` \"{typename}\": unable to parse keywords");
+                return;
+            }
+        }
+        // Ex) `NamedTuple()`
+        _ => {
+            debug!("Skipping `NamedTuple` \"{typename}\": mixed fields and keywords");
+            return;
+        }
+    };
+
+    let mut diagnostic = Diagnostic::new(
+        ConvertNamedTupleFunctionalToClass {
+            name: typename.to_string(),
+        },
+        stmt.range(),
+    );
+    if checker.patch(diagnostic.kind.rule()) {
+        // TODO(charlie): Preserve indentation, to remove the first-column requirement.
+        if checker.locator().is_at_start_of_line(stmt.start()) {
+            diagnostic.set_fix(convert_to_class(
+                stmt,
+                typename,
+                fields,
+                base_class,
+                checker.generator(),
+            ));
+        }
+    }
+    checker.diagnostics.push(diagnostic);
+}
+
 /// Return the typename, args, keywords, and base class.
 fn match_named_tuple_assign<'a>(
     targets: &'a [Expr],
@@ -89,13 +152,12 @@ fn match_named_tuple_assign<'a>(
     Some((typename, args, keywords, func))
 }
 
-/// Generate a [`Stmt::AnnAssign`] representing the provided property
-/// definition.
-fn create_property_assignment_stmt(property: &str, annotation: &Expr) -> Stmt {
+/// Generate a [`Stmt::AnnAssign`] representing the provided field definition.
+fn create_field_assignment_stmt(field: &str, annotation: &Expr) -> Stmt {
     ast::StmtAnnAssign {
         target: Box::new(
             ast::ExprName {
-                id: property.into(),
+                id: field.into(),
                 ctx: ExprContext::Load,
                 range: TextRange::default(),
             }
@@ -109,56 +171,46 @@ fn create_property_assignment_stmt(property: &str, annotation: &Expr) -> Stmt {
     .into()
 }
 
-/// Create a list of property assignments from the `NamedTuple` fields argument.
-fn create_properties_from_fields_arg(fields: &Expr) -> Result<Vec<Stmt>> {
-    let Expr::List(ast::ExprList { elts, .. }) = &fields else {
-        bail!("Expected argument to be `Expr::List`");
-    };
+/// Create a list of field assignments from the `NamedTuple` fields argument.
+fn create_fields_from_fields_arg(fields: &Expr) -> Option<Vec<Stmt>> {
+    let ast::ExprList { elts, .. } = fields.as_list_expr()?;
     if elts.is_empty() {
         let node = Stmt::Pass(ast::StmtPass {
             range: TextRange::default(),
         });
-        return Ok(vec![node]);
+        Some(vec![node])
+    } else {
+        elts.iter()
+            .map(|field| {
+                let ast::ExprTuple { elts, .. } = field.as_tuple_expr()?;
+                let [field, annotation] = elts.as_slice() else {
+                    return None;
+                };
+                let field = field.as_constant_expr()?;
+                let Constant::Str(ast::StringConstant { value: field, .. }) = &field.value else {
+                    return None;
+                };
+                if !is_identifier(field) {
+                    return None;
+                }
+                if is_dunder(field) {
+                    return None;
+                }
+                Some(create_field_assignment_stmt(field, annotation))
+            })
+            .collect()
     }
-    elts.iter()
-        .map(|field| {
-            let Expr::Tuple(ast::ExprTuple { elts, .. }) = &field else {
-                bail!("Expected `field` to be `Expr::Tuple`")
-            };
-            let [field_name, annotation] = elts.as_slice() else {
-                bail!("Expected `elts` to have exactly two elements")
-            };
-            let Expr::Constant(ast::ExprConstant {
-                value:
-                    Constant::Str(ast::StringConstant {
-                        value: property, ..
-                    }),
-                ..
-            }) = &field_name
-            else {
-                bail!("Expected `field_name` to be `Constant::Str`")
-            };
-            if !is_identifier(property) {
-                bail!("Invalid property name: {}", property)
-            }
-            if is_dunder(property) {
-                bail!("Cannot use dunder property name: {}", property)
-            }
-            Ok(create_property_assignment_stmt(property, annotation))
-        })
-        .collect()
 }
 
-/// Create a list of property assignments from the `NamedTuple` keyword arguments.
-fn create_properties_from_keywords(keywords: &[Keyword]) -> Result<Vec<Stmt>> {
+/// Create a list of field assignments from the `NamedTuple` keyword arguments.
+fn create_fields_from_keywords(keywords: &[Keyword]) -> Option<Vec<Stmt>> {
     keywords
         .iter()
         .map(|keyword| {
-            let Keyword { arg, value, .. } = keyword;
-            let Some(arg) = arg else {
-                bail!("Expected `keyword` to have an `arg`")
-            };
-            Ok(create_property_assignment_stmt(arg.as_str(), value))
+            keyword
+                .arg
+                .as_ref()
+                .map(|field| create_field_assignment_stmt(field.as_str(), &keyword.value))
         })
         .collect()
 }
@@ -193,68 +245,4 @@ fn convert_to_class(
         generator.stmt(&create_class_def_stmt(typename, body, base_class)),
         stmt.range(),
     ))
-}
-
-/// UP014
-pub(crate) fn convert_named_tuple_functional_to_class(
-    checker: &mut Checker,
-    stmt: &Stmt,
-    targets: &[Expr],
-    value: &Expr,
-) {
-    let Some((typename, args, keywords, base_class)) =
-        match_named_tuple_assign(targets, value, checker.semantic())
-    else {
-        return;
-    };
-
-    let properties = match (args, keywords) {
-        // Ex) NamedTuple("MyType")
-        ([_typename], []) => vec![Stmt::Pass(ast::StmtPass {
-            range: TextRange::default(),
-        })],
-        // Ex) NamedTuple("MyType", [("a", int), ("b", str)])
-        ([_typename, fields], []) => {
-            if let Ok(properties) = create_properties_from_fields_arg(fields) {
-                properties
-            } else {
-                debug!("Skipping `NamedTuple` \"{typename}\": unable to parse fields");
-                return;
-            }
-        }
-        // Ex) NamedTuple("MyType", a=int, b=str)
-        ([_typename], keywords) => {
-            if let Ok(properties) = create_properties_from_keywords(keywords) {
-                properties
-            } else {
-                debug!("Skipping `NamedTuple` \"{typename}\": unable to parse keywords");
-                return;
-            }
-        }
-        // Unfixable
-        _ => {
-            debug!("Skipping `NamedTuple` \"{typename}\": mixed fields and keywords");
-            return;
-        }
-    };
-
-    let mut diagnostic = Diagnostic::new(
-        ConvertNamedTupleFunctionalToClass {
-            name: typename.to_string(),
-        },
-        stmt.range(),
-    );
-    if checker.patch(diagnostic.kind.rule()) {
-        // TODO(charlie): Preserve indentation, to remove the first-column requirement.
-        if checker.locator().is_at_start_of_line(stmt.start()) {
-            diagnostic.set_fix(convert_to_class(
-                stmt,
-                typename,
-                properties,
-                base_class,
-                checker.generator(),
-            ));
-        }
-    }
-    checker.diagnostics.push(diagnostic);
 }


### PR DESCRIPTION
- Use `Option` instead of `Result` everywhere.
- Use `field` instead of `property` (to match the nomenclature of `NamedTuple` and `TypedDict`).
- Put the violation function at the top of the file, rather than the bottom.