### PR TITLE
Base parameter-find lookup on range, rather than name

### DIFF
--- a/crates/ruff/src/rules/refurb/rules/check_and_remove_from_set.rs
+++ b/crates/ruff/src/rules/refurb/rules/check_and_remove_from_set.rs
@@ -95,9 +95,7 @@ pub(crate) fn check_and_remove_from_set(checker: &mut Checker, if_stmt: &ast::St
         .semantic()
         .resolve_name(check_set)
         .map(|binding_id| checker.semantic().binding(binding_id))
-        .map_or(false, |binding| {
-            is_set(binding, &check_set.id, checker.semantic())
-        })
+        .map_or(false, |binding| is_set(binding, checker.semantic()))
     {
         return;
     };

--- a/crates/ruff/src/rules/refurb/rules/delete_full_slice.rs
+++ b/crates/ruff/src/rules/refurb/rules/delete_full_slice.rs
@@ -111,9 +111,7 @@ fn match_full_slice<'a>(expr: &'a Expr, semantic: &SemanticModel) -> Option<&'a 
     };
 
     // It should only apply to variables that are known to be lists or dicts.
-    if binding.source.is_none()
-        || !(is_dict(binding, name, semantic) || is_list(binding, name, semantic))
-    {
+    if !(is_dict(binding, semantic) || is_list(binding, semantic)) {
         return None;
     }
 

--- a/crates/ruff/src/rules/refurb/rules/repeated_append.rs
+++ b/crates/ruff/src/rules/refurb/rules/repeated_append.rs
@@ -299,7 +299,7 @@ fn match_append<'a>(semantic: &'a SemanticModel, stmt: &'a Stmt) -> Option<Appen
     let binding = semantic.binding(*binding_id);
 
     // ...and whether this something is a list.
-    if binding.source.is_none() || !is_list(binding, name, semantic) {
+    if !is_list(binding, semantic) {
         return None;
     }
 


### PR DESCRIPTION
## Summary

This simplifies the signature a bit and is more reliable in the (unusual? invalid?) case of duplicate parameters.