### PR TITLE
Add `eat_char2` for the lexer

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -515,13 +515,7 @@ impl<'source> Lexer<'source> {
 
         // If the next two characters are also the quote character, then we have a triple-quoted
         // string; consume those two characters and ensure that we require a triple-quote to close
-        let triple_quoted = if self.cursor.first() == quote && self.cursor.second() == quote {
-            self.cursor.bump();
-            self.cursor.bump();
-            true
-        } else {
-            false
-        };
+        let triple_quoted = self.cursor.eat_char2(quote, quote);
 
         let value_start = self.offset();
 
@@ -544,9 +538,7 @@ impl<'source> Lexer<'source> {
                 }
                 Some(c) if c == quote => {
                     if triple_quoted {
-                        if self.cursor.first() == quote && self.cursor.second() == quote {
-                            self.cursor.bump();
-                            self.cursor.bump();
+                        if self.cursor.eat_char2(quote, quote) {
                             break self.offset() - TextSize::new(3);
                         }
                     } else {
@@ -918,9 +910,7 @@ impl<'source> Lexer<'source> {
             '.' => {
                 if self.cursor.first().is_ascii_digit() {
                     self.lex_decimal_number('.')?
-                } else if self.cursor.first() == '.' && self.cursor.second() == '.' {
-                    self.cursor.bump();
-                    self.cursor.bump();
+                } else if self.cursor.eat_char2('.', '.') {
                     Tok::Ellipsis
                 } else {
                     Tok::Dot

--- a/crates/ruff_python_parser/src/lexer/cursor.rs
+++ b/crates/ruff_python_parser/src/lexer/cursor.rs
@@ -85,6 +85,17 @@ impl<'a> Cursor<'a> {
         }
     }
 
+    pub(super) fn eat_char2(&mut self, c1: char, c2: char) -> bool {
+        let mut chars = self.chars.clone();
+        if chars.next() == Some(c1) && chars.next() == Some(c2) {
+            self.bump();
+            self.bump();
+            true
+        } else {
+            false
+        }
+    }
+
     pub(super) fn eat_if<F>(&mut self, mut predicate: F) -> Option<char>
     where
         F: FnMut(char) -> bool,


### PR DESCRIPTION
## Summary

This PR adds a new helper method on the `Cursor` called `eat_char2` which is
similar to `eat_char` but accepts 2 characters instead of 1. It'll `bump` the
cursor twice if both characters are found on lookahead.

## Test Plan

`cargo test`
