### PR TITLE
Avoid parenthesizing multiline strings in binary expressions

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
@@ -222,3 +222,66 @@ x = (
 x = (
     () - ()  #
 )
+
+
+# Avoid unnecessary parentheses around multiline strings.
+expected_content = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+""" % (
+    self.base_url,
+    date.today(),
+)
+
+expected_content = (
+    """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+"""
+    # Needs parentheses
+    % (
+    self.base_url,
+    date.today(),
+    )
+)
+
+expected_content = (
+    """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+"""
+    %
+    # Needs parentheses
+    (
+        self.base_url,
+        date.today(),
+    )
+)
+
+
+expected_content = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+""" + a.call.expression(
+    self.base_url,
+    date.today(),
+)
+
+expected_content = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+""" + sssssssssssssssssssssssssssssssssssssssssooooo * looooooooooooooooooooooooooooooongggggggggggg
+
+call(arg1, arg2, """
+short
+""", arg3=True)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
@@ -285,3 +285,31 @@ expected_content = """<?xml version="1.0" encoding="UTF-8"?>
 call(arg1, arg2, """
 short
 """, arg3=True)
+
+expected_content = (
+    """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+"""
+    %
+    (
+        self.base_url
+    )
+)
+
+
+expected_content = (
+    """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+"""
+    %
+    (
+        # Needs parentheses
+        self.base_url
+    )
+)

--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -330,6 +330,17 @@ impl<'a> Comments<'a> {
         Self::new(map)
     }
 
+    /// Returns `true` if the given `node` has any comments.
+    #[inline]
+    pub(crate) fn has<T>(&self, node: T) -> bool
+    where
+        T: Into<AnyNodeRef<'a>>,
+    {
+        self.data
+            .comments
+            .has(&NodeRefEqualityKey::from_ref(node.into()))
+    }
+
     /// Returns `true` if the given `node` has any [leading comments](self#leading-comments).
     #[inline]
     pub(crate) fn has_leading<T>(&self, node: T) -> bool

--- a/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
@@ -11,7 +11,7 @@ use ruff_python_ast::{
 
 use crate::comments::{trailing_comments, trailing_node_comments, SourceComment};
 use crate::expression::expr_constant::{is_multiline_string, ExprConstantLayout};
-use crate::expression::has_own_parentheses;
+use crate::expression::has_parentheses;
 use crate::expression::parentheses::{
     in_parentheses_only_group, in_parentheses_only_soft_line_break,
     in_parentheses_only_soft_line_break_or_space, is_expression_parenthesized, parenthesized,
@@ -272,7 +272,7 @@ impl NeedsParentheses for ExprBinOp {
             // Multiline strings are guaranteed to never fit, avoid adding unnecessary parentheses
             if !constant.value.is_implicit_concatenated()
                 && is_multiline_string(constant, context.source())
-                && has_own_parentheses(&self.right, context).is_some()
+                && has_parentheses(&self.right, context).is_some()
                 && !context.comments().has_dangling(self)
                 && !context.comments().has(self.left.as_ref())
                 && !context.comments().has(self.right.as_ref())

--- a/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
@@ -10,7 +10,8 @@ use ruff_python_ast::{
 };
 
 use crate::comments::{trailing_comments, trailing_node_comments, SourceComment};
-use crate::expression::expr_constant::ExprConstantLayout;
+use crate::expression::expr_constant::{is_multiline_string, ExprConstantLayout};
+use crate::expression::has_own_parentheses;
 use crate::expression::parentheses::{
     in_parentheses_only_group, in_parentheses_only_soft_line_break,
     in_parentheses_only_soft_line_break_or_space, is_expression_parenthesized, parenthesized,
@@ -263,10 +264,23 @@ impl NeedsParentheses for ExprBinOp {
     fn needs_parentheses(
         &self,
         parent: AnyNodeRef,
-        _context: &PyFormatContext,
+        context: &PyFormatContext,
     ) -> OptionalParentheses {
         if parent.is_expr_await() && !self.op.is_pow() {
             OptionalParentheses::Always
+        } else if let Expr::Constant(constant) = self.left.as_ref() {
+            // Multiline strings are guaranteed to never fit, avoid adding unnecessary parentheses
+            if !constant.value.is_implicit_concatenated()
+                && is_multiline_string(constant, context.source())
+                && has_own_parentheses(&self.right, context).is_some()
+                && !context.comments().has_dangling(self)
+                && !context.comments().has(self.left.as_ref())
+                && !context.comments().has(self.right.as_ref())
+            {
+                OptionalParentheses::Never
+            } else {
+                OptionalParentheses::Multiline
+            }
         } else {
             OptionalParentheses::Multiline
         }

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__composition.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__composition.py.snap
@@ -227,27 +227,17 @@ class C:
  
          assert expected(
              value, is_going_to_be="too long to fit in a single line", srsly=True
-@@ -153,7 +154,8 @@
-             " because it's too long"
-         )
- 
--        dis_c_instance_method = """\
-+        dis_c_instance_method = (
-+            """\
-         %3d           0 LOAD_FAST                1 (x)
-                       2 LOAD_CONST               1 (1)
-                       4 COMPARE_OP               2 (==)
-@@ -161,8 +163,8 @@
+@@ -161,9 +162,7 @@
                        8 STORE_ATTR               0 (x)
                       10 LOAD_CONST               0 (None)
                       12 RETURN_VALUE
 -        """ % (
 -            _C.__init__.__code__.co_firstlineno + 1,
-+        """
-+            % (_C.__init__.__code__.co_firstlineno + 1,)
-         )
+-        )
++        """ % (_C.__init__.__code__.co_firstlineno + 1,)
  
          assert (
+             expectedexpectedexpectedexpectedexpectedexpectedexpectedexpectedexpect
 ```
 
 ## Ruff Output
@@ -409,8 +399,7 @@ class C:
             " because it's too long"
         )
 
-        dis_c_instance_method = (
-            """\
+        dis_c_instance_method = """\
         %3d           0 LOAD_FAST                1 (x)
                       2 LOAD_CONST               1 (1)
                       4 COMPARE_OP               2 (==)
@@ -418,9 +407,7 @@ class C:
                       8 STORE_ATTR               0 (x)
                      10 LOAD_CONST               0 (None)
                      12 RETURN_VALUE
-        """
-            % (_C.__init__.__code__.co_firstlineno + 1,)
-        )
+        """ % (_C.__init__.__code__.co_firstlineno + 1,)
 
         assert (
             expectedexpectedexpectedexpectedexpectedexpectedexpectedexpectedexpect

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__composition_no_trailing_comma.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__composition_no_trailing_comma.py.snap
@@ -227,27 +227,17 @@ class C:
  
          assert expected(
              value, is_going_to_be="too long to fit in a single line", srsly=True
-@@ -153,7 +154,8 @@
-             " because it's too long"
-         )
- 
--        dis_c_instance_method = """\
-+        dis_c_instance_method = (
-+            """\
-         %3d           0 LOAD_FAST                1 (x)
-                       2 LOAD_CONST               1 (1)
-                       4 COMPARE_OP               2 (==)
-@@ -161,8 +163,8 @@
+@@ -161,9 +162,7 @@
                        8 STORE_ATTR               0 (x)
                       10 LOAD_CONST               0 (None)
                       12 RETURN_VALUE
 -        """ % (
 -            _C.__init__.__code__.co_firstlineno + 1,
-+        """
-+            % (_C.__init__.__code__.co_firstlineno + 1,)
-         )
+-        )
++        """ % (_C.__init__.__code__.co_firstlineno + 1,)
  
          assert (
+             expectedexpectedexpectedexpectedexpectedexpectedexpectedexpectedexpect
 ```
 
 ## Ruff Output
@@ -409,8 +399,7 @@ class C:
             " because it's too long"
         )
 
-        dis_c_instance_method = (
-            """\
+        dis_c_instance_method = """\
         %3d           0 LOAD_FAST                1 (x)
                       2 LOAD_CONST               1 (1)
                       4 COMPARE_OP               2 (==)
@@ -418,9 +407,7 @@ class C:
                       8 STORE_ATTR               0 (x)
                      10 LOAD_CONST               0 (None)
                      12 RETURN_VALUE
-        """
-            % (_C.__init__.__code__.co_firstlineno + 1,)
-        )
+        """ % (_C.__init__.__code__.co_firstlineno + 1,)
 
         assert (
             expectedexpectedexpectedexpectedexpectedexpectedexpectedexpectedexpect

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
@@ -228,6 +228,69 @@ x = (
 x = (
     () - ()  #
 )
+
+
+# Avoid unnecessary parentheses around multiline strings.
+expected_content = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+""" % (
+    self.base_url,
+    date.today(),
+)
+
+expected_content = (
+    """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+"""
+    # Needs parentheses
+    % (
+    self.base_url,
+    date.today(),
+    )
+)
+
+expected_content = (
+    """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+"""
+    %
+    # Needs parentheses
+    (
+        self.base_url,
+        date.today(),
+    )
+)
+
+
+expected_content = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+""" + a.call.expression(
+    self.base_url,
+    date.today(),
+)
+
+expected_content = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+""" + sssssssssssssssssssssssssssssssssssssssssooooo * looooooooooooooooooooooooooooooongggggggggggg
+
+call(arg1, arg2, """
+short
+""", arg3=True)
 ```
 
 ## Output
@@ -511,6 +574,78 @@ x = (
 )
 x = (
     () - ()  #
+)
+
+
+# Avoid unnecessary parentheses around multiline strings.
+expected_content = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+""" % (
+    self.base_url,
+    date.today(),
+)
+
+expected_content = (
+    """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+"""
+    # Needs parentheses
+    % (
+        self.base_url,
+        date.today(),
+    )
+)
+
+expected_content = (
+    """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+"""
+    %
+    # Needs parentheses
+    (
+        self.base_url,
+        date.today(),
+    )
+)
+
+
+expected_content = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+""" + a.call.expression(
+    self.base_url,
+    date.today(),
+)
+
+expected_content = (
+    """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+"""
+    + sssssssssssssssssssssssssssssssssssssssssooooo
+    * looooooooooooooooooooooooooooooongggggggggggg
+)
+
+call(
+    arg1,
+    arg2,
+    """
+short
+""",
+    arg3=True,
 )
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
@@ -291,6 +291,34 @@ expected_content = """<?xml version="1.0" encoding="UTF-8"?>
 call(arg1, arg2, """
 short
 """, arg3=True)
+
+expected_content = (
+    """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+"""
+    %
+    (
+        self.base_url
+    )
+)
+
+
+expected_content = (
+    """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+"""
+    %
+    (
+        # Needs parentheses
+        self.base_url
+    )
+)
 ```
 
 ## Output
@@ -646,6 +674,28 @@ call(
 short
 """,
     arg3=True,
+)
+
+expected_content = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+""" % (self.base_url)
+
+
+expected_content = (
+    """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>%s/simple/sitemap-simple.xml</loc><lastmod>%s</lastmod>
+</sitemap>
+</sitemapindex>
+"""
+    %
+    (
+        # Needs parentheses
+        self.base_url
+    )
 )
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Avoid parenthesizing binary expressions that have a left multiline string and a parenthesized right side because the multiline string is guarnateed not to fit. 

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Added unit tests. 

The similarity index for django increases from 0.99948 to 0.99957 (one file less with changes). This change does not impact the other projects. 

<!-- How was it tested? -->
