### PR TITLE
Update `dynamic_text` builder doc comment

### DIFF
--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -334,7 +334,8 @@ impl<Context> Format<Context> for SourcePosition {
     }
 }
 
-/// Creates a text from a dynamic string with its optional start-position in the source document
+/// Creates a text from a dynamic string with its optional start-position in the source document.
+/// This is done by allocating a new string internally.
 pub fn dynamic_text(text: &str, position: Option<TextSize>) -> DynamicText {
     debug_assert_no_newlines(text);
 


### PR DESCRIPTION
This PR adds a little more detail to `dynamic_text`'s documentation.

This isn't *really* necessary since I'm sure 'dynamic' implies this logic in some way that I'm not familiar with yet, but I'm always looking for even subtle improvements to help the next reader.

Since I didn't read the implementation I failed to realize that this builder allocates a new string -- which would have influenced my decision using it for some use cases. See https://github.com/astral-sh/ruff/pull/6901#discussion_r1308276680 for more context.

Idk if this is just me, but I tend to start out by running `cargo doc -p ruff_formatter --open` to gain some familiarity with the project (I should start using the `source` button in addition to reading the documentation lol :)).