### PR TITLE
Rename `run.rs` command to `check.rs`

### DIFF
--- a/crates/ruff_cli/src/commands/check.rs
+++ b/crates/ruff_cli/src/commands/check.rs
@@ -28,7 +28,7 @@ use crate::diagnostics::Diagnostics;
 use crate::panic::catch_unwind;
 
 /// Run the linter over a collection of files.
-pub(crate) fn run(
+pub(crate) fn check(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
     overrides: &Overrides,
@@ -245,7 +245,7 @@ mod test {
 
     use crate::args::Overrides;
 
-    use super::run;
+    use super::check;
 
     /// We check that regular python files, pyproject.toml and jupyter notebooks all handle io
     /// errors gracefully
@@ -278,7 +278,7 @@ mod test {
             PyprojectConfig::new(PyprojectDiscoveryStrategy::Fixed, settings, None);
 
         // Run
-        let diagnostics = run(
+        let diagnostics = check(
             // Notebooks are not included by default
             &[tempdir.path().to_path_buf(), notebook],
             &pyproject_config,

--- a/crates/ruff_cli/src/commands/check_stdin.rs
+++ b/crates/ruff_cli/src/commands/check_stdin.rs
@@ -18,7 +18,7 @@ pub(crate) fn read_from_stdin() -> Result<String> {
 }
 
 /// Run the linter over a single file, read from `stdin`.
-pub(crate) fn run_stdin(
+pub(crate) fn check_stdin(
     filename: Option<&Path>,
     pyproject_config: &PyprojectConfig,
     overrides: &Overrides,

--- a/crates/ruff_cli/src/commands/mod.rs
+++ b/crates/ruff_cli/src/commands/mod.rs
@@ -1,10 +1,10 @@
 pub(crate) mod add_noqa;
+pub(crate) mod check;
+pub(crate) mod check_stdin;
 pub(crate) mod clean;
 pub(crate) mod config;
 pub(crate) mod format;
 pub(crate) mod linter;
 pub(crate) mod rule;
-pub(crate) mod run;
-pub(crate) mod run_stdin;
 pub(crate) mod show_files;
 pub(crate) mod show_settings;

--- a/crates/ruff_cli/src/commands/snapshots/ruff_cli__commands__check__test__E902_E902.py.snap
+++ b/crates/ruff_cli/src/commands/snapshots/ruff_cli__commands__check__test__E902_E902.py.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ruff_cli/src/commands/run.rs
+source: crates/ruff_cli/src/commands/check.rs
 ---
 /home/ferris/project/code.py:1:1: E902 Permission denied (os error 13)
 /home/ferris/project/notebook.ipynb:1:1: E902 Permission denied (os error 13)

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -16,7 +16,7 @@ use ruff::{fs, warn_user_once};
 use ruff_python_formatter::{format_module, PyFormatOptions};
 
 use crate::args::{Args, CheckCommand, Command, FormatCommand};
-use crate::commands::run_stdin::read_from_stdin;
+use crate::commands::check_stdin::read_from_stdin;
 use crate::printer::{Flags as PrinterFlags, Printer};
 
 pub mod args;
@@ -300,7 +300,7 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
         Printer::clear_screen()?;
         printer.write_to_user("Starting linter in watch mode...\n");
 
-        let messages = commands::run::run(
+        let messages = commands::check::check(
             &cli.files,
             &pyproject_config,
             &overrides,
@@ -332,7 +332,7 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
                     Printer::clear_screen()?;
                     printer.write_to_user("File change detected...\n");
 
-                    let messages = commands::run::run(
+                    let messages = commands::check::check(
                         &cli.files,
                         &pyproject_config,
                         &overrides,
@@ -350,7 +350,7 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
 
         // Generate lint violations.
         let diagnostics = if is_stdin {
-            commands::run_stdin::run_stdin(
+            commands::check_stdin::check_stdin(
                 cli.stdin_filename.map(fs::normalize_path).as_deref(),
                 &pyproject_config,
                 &overrides,
@@ -358,7 +358,7 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
                 autofix,
             )?
         } else {
-            commands::run::run(
+            commands::check::check(
                 &cli.files,
                 &pyproject_config,
                 &overrides,


### PR DESCRIPTION
The CLI command is called "check", so this is more consistent (and consistent with the pattern used in other commands).
