### PR TITLE
Move stdin formatting to its own command file

### DIFF
--- a/crates/ruff_cli/src/commands/check_stdin.rs
+++ b/crates/ruff_cli/src/commands/check_stdin.rs
@@ -1,4 +1,3 @@
-use std::io::{self, Read};
 use std::path::Path;
 
 use anyhow::Result;
@@ -9,13 +8,7 @@ use ruff_workspace::resolver::{python_file_at_path, PyprojectConfig};
 
 use crate::args::Overrides;
 use crate::diagnostics::{lint_stdin, Diagnostics};
-
-/// Read a `String` from `stdin`.
-pub(crate) fn read_from_stdin() -> Result<String> {
-    let mut buffer = String::new();
-    io::stdin().lock().read_to_string(&mut buffer)?;
-    Ok(buffer)
-}
+use crate::stdin::read_from_stdin;
 
 /// Run the linter over a single file, read from `stdin`.
 pub(crate) fn check_stdin(

--- a/crates/ruff_cli/src/commands/format_stdin.rs
+++ b/crates/ruff_cli/src/commands/format_stdin.rs
@@ -1,0 +1,37 @@
+use std::io::{stdout, Write};
+
+use anyhow::Result;
+
+use ruff_python_formatter::{format_module, PyFormatOptions};
+use ruff_workspace::resolver::python_file_at_path;
+
+use crate::args::{FormatArguments, Overrides};
+use crate::resolve::resolve;
+use crate::stdin::read_from_stdin;
+use crate::ExitStatus;
+
+/// Run the formatter over a single file, read from `stdin`.
+pub(crate) fn format_stdin(cli: &FormatArguments, overrides: &Overrides) -> Result<ExitStatus> {
+    let pyproject_config = resolve(
+        cli.isolated,
+        cli.config.as_deref(),
+        overrides,
+        cli.stdin_filename.as_deref(),
+    )?;
+
+    if let Some(filename) = cli.stdin_filename.as_deref() {
+        if !python_file_at_path(filename, &pyproject_config, overrides)? {
+            return Ok(ExitStatus::Success);
+        }
+    }
+
+    let stdin = read_from_stdin()?;
+    let options = cli
+        .stdin_filename
+        .as_deref()
+        .map(PyFormatOptions::from_extension)
+        .unwrap_or_default();
+    let formatted = format_module(&stdin, options)?;
+    stdout().lock().write_all(formatted.as_code().as_bytes())?;
+    Ok(ExitStatus::Success)
+}

--- a/crates/ruff_cli/src/commands/mod.rs
+++ b/crates/ruff_cli/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod check_stdin;
 pub(crate) mod clean;
 pub(crate) mod config;
 pub(crate) mod format;
+pub(crate) mod format_stdin;
 pub(crate) mod linter;
 pub(crate) mod rule;
 pub(crate) mod show_files;

--- a/crates/ruff_cli/src/stdin.rs
+++ b/crates/ruff_cli/src/stdin.rs
@@ -1,0 +1,9 @@
+use std::io;
+use std::io::Read;
+
+/// Read a string from `stdin`.
+pub(crate) fn read_from_stdin() -> Result<String, io::Error> {
+    let mut buffer = String::new();
+    io::stdin().lock().read_to_string(&mut buffer)?;
+    Ok(buffer)
+}


### PR DESCRIPTION
## Summary

This is similar to `commands::check` vs. `commands::check_stdin`, and gets the logic out of the parent file (`lib.rs`). It also ensures that we avoid formatting files that should be excluded when `--force-exclude` is provided.
