### PR TITLE
Add a --check flag to the formatter CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,6 +2210,7 @@ dependencies = [
  "glob",
  "ignore",
  "insta",
+ "is-macro",
  "itertools",
  "itoa",
  "log",

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -47,6 +47,7 @@ colored = { workspace = true }
 filetime = { workspace = true }
 glob = { workspace = true }
 ignore = { workspace = true }
+is-macro = { workspace = true }
 itertools = { workspace = true }
 itoa = { version = "1.0.6" }
 log = { workspace = true }

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -329,6 +329,10 @@ pub struct CheckCommand {
 pub struct FormatCommand {
     /// List of files or directories to format.
     pub files: Vec<PathBuf>,
+    /// Avoid writing any formatted files back; instead, exit with a non-zero status code if any
+    /// files would have been modified, and zero otherwise.
+    #[arg(long)]
+    pub check: bool,
     /// Specify file to write the linter output to (default: stdout).
     #[arg(short, long)]
     pub output_file: Option<PathBuf>,
@@ -480,6 +484,7 @@ impl FormatCommand {
     pub fn partition(self) -> (FormatArguments, Overrides) {
         (
             FormatArguments {
+                check: self.check,
                 config: self.config,
                 files: self.files,
                 isolated: self.isolated,
@@ -541,6 +546,7 @@ pub struct CheckArguments {
 /// etc.).
 #[allow(clippy::struct_excessive_bools)]
 pub struct FormatArguments {
+    pub check: bool,
     pub config: Option<PathBuf>,
     pub files: Vec<PathBuf>,
     pub isolated: bool,

--- a/crates/ruff_cli/src/commands/format_stdin.rs
+++ b/crates/ruff_cli/src/commands/format_stdin.rs
@@ -6,6 +6,7 @@ use ruff_python_formatter::{format_module, PyFormatOptions};
 use ruff_workspace::resolver::python_file_at_path;
 
 use crate::args::{FormatArguments, Overrides};
+use crate::commands::format::FormatMode;
 use crate::resolve::resolve;
 use crate::stdin::read_from_stdin;
 use crate::ExitStatus;
@@ -18,6 +19,11 @@ pub(crate) fn format_stdin(cli: &FormatArguments, overrides: &Overrides) -> Resu
         overrides,
         cli.stdin_filename.as_deref(),
     )?;
+    let mode = if cli.check {
+        FormatMode::Check
+    } else {
+        FormatMode::Write
+    };
 
     if let Some(filename) = cli.stdin_filename.as_deref() {
         if !python_file_at_path(filename, &pyproject_config, overrides)? {
@@ -25,13 +31,27 @@ pub(crate) fn format_stdin(cli: &FormatArguments, overrides: &Overrides) -> Resu
         }
     }
 
-    let stdin = read_from_stdin()?;
+    // Format the file.
+    let unformatted = read_from_stdin()?;
     let options = cli
         .stdin_filename
         .as_deref()
         .map(PyFormatOptions::from_extension)
         .unwrap_or_default();
-    let formatted = format_module(&stdin, options)?;
-    stdout().lock().write_all(formatted.as_code().as_bytes())?;
-    Ok(ExitStatus::Success)
+    let formatted = format_module(&unformatted, options)?;
+
+    match mode {
+        FormatMode::Write => {
+            stdout().lock().write_all(formatted.as_code().as_bytes())?;
+            Ok(ExitStatus::Success)
+        }
+        FormatMode::Check => {
+            if formatted.as_code().len() == unformatted.len() && formatted.as_code() == unformatted
+            {
+                Ok(ExitStatus::Success)
+            } else {
+                Ok(ExitStatus::Failure)
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Returns an exit code of 1 if any files would be reformatted:

```
ruff on  charlie/format-check:main [$?⇡] is 📦 v0.0.286 via 🐍 v3.11.2 via 🦀 v1.72.0
❯ cargo run -p ruff_cli -- format foo.py --check
   Compiling ruff_cli v0.0.286 (/Users/crmarsh/workspace/ruff/crates/ruff_cli)
    Finished dev [unoptimized + debuginfo] target(s) in 1.69s
     Running `target/debug/ruff format foo.py --check`
warning: `ruff format` is a work-in-progress, subject to change at any time, and intended only for experimentation.
1 file would be reformatted
ruff on  charlie/format-check:main [$?⇡] is 📦 v0.0.286 via 🐍 v3.11.2 via 🦀 v1.72.0 took 2s
❯ echo $?
1
```

Closes #6966.
