### PR TITLE
Fix test that checks for black and linter compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,10 +106,9 @@ jobs:
         shell: bash
         # We can't reject unreferenced snapshots on windows because flake8_executable can't run on windows
         run: cargo insta test --all --all-features
-      - run: cargo test --package ruff_cli --test black_compatibility_test -- --ignored
-        # TODO: Skipped as it's currently broken. The resource were moved from the
-        # ruff_cli to ruff crate, but this test was not updated.
-        if: false
+      # Check linter fix compatibility with Black
+      - name: "Check Black compatibility"
+        run: cargo test --package ruff_cli --test black_compatibility_test -- --ignored
       # Check for broken links in the documentation.
       - run: cargo doc --all --no-deps
         env:

--- a/crates/ruff_cli/tests/black_compatibility_test.rs
+++ b/crates/ruff_cli/tests/black_compatibility_test.rs
@@ -192,8 +192,8 @@ fn test_ruff_black_compatibility() -> Result<()> {
         // Exclude ruff codes, specifically RUF100, because it causes differences that are not a
         // problem. Ruff would add a `# noqa: W292`  after the first run, black introduces a
         // newline, and ruff removes the `# noqa: W292` again.
-        // "--ignore",
-        // "RUF",
+        "--ignore",
+        "RUF",
     ];
 
     let mut results = vec![];


### PR DESCRIPTION
This test was disabled because the fixture files moved; here I enable the test again and update the directory to cover our the correct Python fixtures.

I also updated the output to be usable and display all mismatches on failure instead of just the first one.

Before
```
thread 'test_ruff_black_compatibility' panicked at 'assertion failed: `(left == right)`
  left: `Ok("# Errors\nprint(\"foo %(foo)d bar %(bar)d\" % {\"foo\": \"1\", \"bar\": \"2\"})\n\n\"foo {:e} bar {}\".format(\"1\", 2)\n\n\"%d\" % \"1\"\n\"{:o}\".format(\"1\")\n\"%(key)d\" % {\"key\": \"1\"}\nf\"{1.1:x}\"\nf\"{1.1:x}\"\n\"%d\" % []\n\"%d\" % ([],)\n\"%(key)d\" % {\"key\": []}\nprint(\"%d\" % (\"{}\".format(\"nested\"),))\n\"%d\" % ((1, 2, 3),)\n\"%d\" % (1 if x > 0 else [])\n\n# False negatives\nWORD = \"abc\"\n\"%d\" % WORD\n\"%d %s\" % (WORD, WORD)\nVALUES_TO_FORMAT = (1, \"2\", 3.0)\n\"%d %d %f\" % VALUES_TO_FORMAT\n\n# OK\n\"%d %s %f\" % VALUES_TO_FORMAT\n\"{}\".format(\"1\")\n\"{} {} {}\".format(\"1\", 2, 3.5)\nprint(\"%d %d\" % (1, 1.1))\nf\"{1}\"\n\"%d\" % 1\nf\"{1:f}\"\nf\"{1}\"\nf\"{1}\"\n\"%d\" % 1\n\"%(key)d\" % {\"key\": 1}\nf\"{1:f}\"\nf\"{1:f}\"\n\"%d\" % 1.1\n\"%(key)d\" % {\"key\": 1.1}\n\"%s\" % []\nf\"{[]}\"\nf\"{None}\"\nf\"{None}\"\nprint(\"{}\".format(\"{}\".format(\"nested\")))\nprint(\"{}\".format(\"%d\" % (5,)))\n\"%d %d\" % \"1\"\n\"%d%d\" % \"1\"\n\"-%f\" % time.time()\n\"{!r}\".format(object[\"dn\"])\nrf\"\\{ord(c):03o}\"\n(\"%02X\" % int(_) for _ in o)\n\"%s;range=%d-*\" % (attr, upper + 1)\n\"%d\" % (len(foo),)\n\"({!r}, {!r}, {!r}, {!r})\".format(hostname, address, username, \"$PASSWORD\")\n\"{!r}\".format(\n    {\n        \"server_school_roles\": server_school_roles,\n        \"is_school_multiserver_domain\": is_school_multiserver_domain,\n    }\n)\n\"%d\" % (1 if x > 0 else 2)\n")`,
 right: `Ok("# Errors\nprint(\"foo %(foo)d bar %(bar)d\" % {\"foo\": \"1\", \"bar\": \"2\"})\n\n\"foo {:e} bar {}\".format(\"1\", 2)\n\n\"%d\" % \"1\"\n\"{:o}\".format(\"1\")\n\"%(key)d\" % {\"key\": \"1\"}\nf\"{1.1:x}\"\nf\"{1.1:x}\"\n\"%d\" % []\n\"%d\" % ([],)\n\"%(key)d\" % {\"key\": []}\nprint(\"%d\" % (\"{}\".format(\"nested\"),))\n\"%d\" % ((1, 2, 3),)\n\"%d\" % (1 if x > 0 else [])\n\n# False negatives\nWORD = \"abc\"\n\"%d\" % WORD\n\"%d %s\" % (WORD, WORD)\nVALUES_TO_FORMAT = (1, \"2\", 3.0)\n\"%d %d %f\" % VALUES_TO_FORMAT\n\n# OK\n\"%d %s %f\" % VALUES_TO_FORMAT\n\"{}\".format(\"1\")\n\"{} {} {}\".format(\"1\", 2, 3.5)\nprint(\"%d %d\" % (1, 1.1))\nf\"{1}\"\n\"%d\" % 1\nf\"{1:f}\"\nf\"{1}\"\nf\"{1}\"\n\"%d\" % 1\n\"%(key)d\" % {\"key\": 1}\nf\"{1:f}\"\nf\"{1:f}\"\n\"%d\" % 1.1\n\"%(key)d\" % {\"key\": 1.1}\n\"%s\" % []\nf\"{[]}\"\nf\"{None}\"\nf\"{None}\"\nprint(\"{}\".format(\"{}\".format(\"nested\")))\nprint(\"{}\".format(\"%d\" % (5,)))\n\"%d %d\" % \"1\"\n\"%d%d\" % \"1\"\n\"-%f\" % time.time()\n\"{!r}\".format(object[\"dn\"])\nrf\"\\{ord(c):03o}\"\n(\"%02X\" % int(_) for _ in o)\n\"%s;range=%d-*\" % (attr, upper + 1)\n\"%d\" % (len(foo),)\n\"({!r}, {!r}, {!r}, {!r})\".format(hostname, address, username, \"$PASSWORD\")\n\"{!r}\".format(\n    {\n        \"server_school_roles\": server_school_roles,\n        \"is_school_multiserver_domain\": is_school_multiserver_domain,\n    },\n)\n\"%d\" % (1 if x > 0 else 2)\n")`: Mismatch found for /Users/mz/eng/src/astral-sh/ruff/crates/ruff/resources/test/fixtures/pylint/bad_string_format_type.py', crates/ruff_cli/tests/black_compatibility_test.rs:136:5
```


After
```
Mismatch found for /Users/mz/eng/src/astral-sh/ruff/crates/ruff/resources/test/fixtures/pyflakes/F541.py
---------- FIRST ----------
# OK
a = "abc"
b = f"ghi{'jkl'}"

# Errors
c = "def"
d = "def" + "ghi"
e = "def" + "ghi"
f = "a" "b" "c" r"d" r"e"
g = ""

# OK
g = f"ghi{123:{45}}"

# Error
h = "xyz"

v = 23.234234

# OK
f"{v:0.2f}"
f"{f'{v:0.2f}'}"

# Errors
f"{v:{'0.2f'}}"
f"{''}"
"{test}"
"{ 40 }"
"{a {x}"
"{{x}}"
""
""
("" r"")

# To be fixed
# Error: f-string: single '}' is not allowed at line 41 column 8
# f"\{{x}}"


---------- SECOND ----------
# OK
a = "abc"
b = f"ghi{'jkl'}"

# Errors
c = "def"
d = "def" + "ghi"
e = "def" + "ghi"
f = "abc" r"de"
g = ""

# OK
g = f"ghi{123:{45}}"

# Error
h = "xyz"

v = 23.234234

# OK
f"{v:0.2f}"
f"{f'{v:0.2f}'}"

# Errors
f"{v:{'0.2f'}}"
f"{''}"
"{test}"
"{ 40 }"
"{a {x}"
"{{x}}"
""
""
("" r"")

# To be fixed
# Error: f-string: single '}' is not allowed at line 41 column 8
# f"\{{x}}"


---------- DIFF ----------
@@ -6,7 +6,7 @@
 c = "def"
 d = "def" + "ghi"
 e = "def" + "ghi"
-f = "a" "b" "c" r"d" r"e"
+f = "abc" r"de"
 g = ""
 
 # OK


Error: 30 mismatches found
```

