### PR TITLE
Unset `after_class_docstring` state on every iteration

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/class_definition.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/class_definition.py
@@ -206,3 +206,19 @@ class TestTypeParams[Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 class TestTypeParams[A, B, C](meta=Aaaaaaaaaaaaaaaaaaaaaa):
     pass
+
+
+# Regression test for: https://github.com/astral-sh/ruff/pull/7001
+class QuerySet(AltersData):
+    """Represent a lazy database lookup for a set of objects."""
+
+    def as_manager(cls):
+        # Address the circular dependency between `Queryset` and `Manager`.
+        from django.db.models.manager import Manager
+
+        manager = Manager.from_queryset(cls)()
+        manager._built_with_as_manager = True
+        return manager
+
+    as_manager.queryset_only = True
+    as_manager = classmethod(as_manager)

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -255,7 +255,6 @@ impl FormatRule<Suite, PyFormatContext<'_>> for FormatSuite {
                 //     ...
                 // ```
                 empty_line().fmt(f)?;
-                after_class_docstring = false;
             } else {
                 // Insert the appropriate number of empty lines based on the node level, e.g.:
                 // * [`NodeLevel::Module`]: Up to two empty lines
@@ -320,6 +319,7 @@ impl FormatRule<Suite, PyFormatContext<'_>> for FormatSuite {
                 following.format().fmt(f)?;
                 preceding = following;
             }
+            after_class_docstring = false;
         }
 
         Ok(())

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__class_definition.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__class_definition.py.snap
@@ -212,6 +212,22 @@ class TestTypeParams[Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 class TestTypeParams[A, B, C](meta=Aaaaaaaaaaaaaaaaaaaaaa):
     pass
+
+
+# Regression test for: https://github.com/astral-sh/ruff/pull/7001
+class QuerySet(AltersData):
+    """Represent a lazy database lookup for a set of objects."""
+
+    def as_manager(cls):
+        # Address the circular dependency between `Queryset` and `Manager`.
+        from django.db.models.manager import Manager
+
+        manager = Manager.from_queryset(cls)()
+        manager._built_with_as_manager = True
+        return manager
+
+    as_manager.queryset_only = True
+    as_manager = classmethod(as_manager)
 ```
 
 ## Output
@@ -459,6 +475,22 @@ class TestTypeParams[
 
 class TestTypeParams[A, B, C](meta=Aaaaaaaaaaaaaaaaaaaaaa):
     pass
+
+
+# Regression test for: https://github.com/astral-sh/ruff/pull/7001
+class QuerySet(AltersData):
+    """Represent a lazy database lookup for a set of objects."""
+
+    def as_manager(cls):
+        # Address the circular dependency between `Queryset` and `Manager`.
+        from django.db.models.manager import Manager
+
+        manager = Manager.from_queryset(cls)()
+        manager._built_with_as_manager = True
+        return manager
+
+    as_manager.queryset_only = True
+    as_manager = classmethod(as_manager)
 ```
 
 


### PR DESCRIPTION
## Summary

This PR fixes a small deviation in Django. Given:

```python
class QuerySet(AltersData):
    """Represent a lazy database lookup for a set of objects."""

    def as_manager(cls):
        # Address the circular dependency between `Queryset` and `Manager`.
        from django.db.models.manager import Manager

        manager = Manager.from_queryset(cls)()
        manager._built_with_as_manager = True
        return manager

    as_manager.queryset_only = True
    as_manager = classmethod(as_manager)
```

We weren't setting `after_class_docstring = false` on all branches, and so we were incorrectly inserting a blank line between the two statements at the end, like:

```python
class QuerySet(AltersData):
    """Represent a lazy database lookup for a set of objects."""

    def as_manager(cls):
        # Address the circular dependency between `Queryset` and `Manager`.
        from django.db.models.manager import Manager

        manager = Manager.from_queryset(cls)()
        manager._built_with_as_manager = True
        return manager

    as_manager.queryset_only = True

    as_manager = classmethod(as_manager)
```

## Test Plan

`cargo test`
