### PR TITLE
Add hidden `--preview` / `--no-preview` options to `ruff check`

### DIFF
--- a/crates/ruff/src/settings/defaults.rs
+++ b/crates/ruff/src/settings/defaults.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 use rustc_hash::FxHashSet;
 use std::collections::HashSet;
 
-use super::types::{FilePattern, PythonVersion};
+use super::types::{FilePattern, PreviewMode, PythonVersion};
 use super::Settings;
 use crate::codes::{self, RuleCodePrefix};
 use crate::line_width::{LineLength, TabSize};
@@ -84,7 +84,7 @@ impl Default for Settings {
             line_length: LineLength::default(),
             logger_objects: vec![],
             namespace_packages: vec![],
-            preview: false,
+            preview: PreviewMode::default(),
             per_file_ignores: vec![],
             project_root: path_dedot::CWD.clone(),
             respect_gitignore: true,

--- a/crates/ruff/src/settings/defaults.rs
+++ b/crates/ruff/src/settings/defaults.rs
@@ -84,7 +84,7 @@ impl Default for Settings {
             line_length: LineLength::default(),
             logger_objects: vec![],
             namespace_packages: vec![],
-            preview_mode: false,
+            preview: false,
             per_file_ignores: vec![],
             project_root: path_dedot::CWD.clone(),
             respect_gitignore: true,

--- a/crates/ruff/src/settings/defaults.rs
+++ b/crates/ruff/src/settings/defaults.rs
@@ -84,6 +84,7 @@ impl Default for Settings {
             line_length: LineLength::default(),
             logger_objects: vec![],
             namespace_packages: vec![],
+            preview_mode: false,
             per_file_ignores: vec![],
             project_root: path_dedot::CWD.clone(),
             respect_gitignore: true,

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -24,6 +24,7 @@ use crate::settings::types::{FilePatternSet, PerFileIgnore, PythonVersion, Seria
 use super::line_width::{LineLength, TabSize};
 
 use self::rule_table::RuleTable;
+use self::types::PreviewMode;
 
 pub mod defaults;
 pub mod flags;
@@ -55,7 +56,7 @@ pub struct Settings {
     pub per_file_ignores: Vec<(GlobMatcher, GlobMatcher, RuleSet)>,
 
     pub target_version: PythonVersion,
-    pub preview: bool,
+    pub preview: PreviewMode,
 
     // Resolver settings
     pub exclude: FilePatternSet,

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -55,7 +55,7 @@ pub struct Settings {
     pub per_file_ignores: Vec<(GlobMatcher, GlobMatcher, RuleSet)>,
 
     pub target_version: PythonVersion,
-    pub preview_mode: bool,
+    pub preview: bool,
 
     // Resolver settings
     pub exclude: FilePatternSet,

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -55,6 +55,7 @@ pub struct Settings {
     pub per_file_ignores: Vec<(GlobMatcher, GlobMatcher, RuleSet)>,
 
     pub target_version: PythonVersion,
+    pub preview_mode: bool,
 
     // Resolver settings
     pub exclude: FilePatternSet,

--- a/crates/ruff/src/settings/types.rs
+++ b/crates/ruff/src/settings/types.rs
@@ -101,9 +101,10 @@ pub enum PreviewMode {
 
 impl From<bool> for PreviewMode {
     fn from(version: bool) -> Self {
-        match version {
-            true => PreviewMode::Enabled,
-            false => PreviewMode::Disabled,
+        if version {
+            PreviewMode::Enabled
+        } else {
+            PreviewMode::Disabled
         }
     }
 }

--- a/crates/ruff/src/settings/types.rs
+++ b/crates/ruff/src/settings/types.rs
@@ -92,11 +92,11 @@ impl PythonVersion {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Default, CacheKey, is_macro::Is)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, CacheKey, is_macro::Is)]
 pub enum PreviewMode {
-    Enabled,
     #[default]
     Disabled,
+    Enabled,
 }
 
 impl From<bool> for PreviewMode {

--- a/crates/ruff/src/settings/types.rs
+++ b/crates/ruff/src/settings/types.rs
@@ -92,6 +92,22 @@ impl PythonVersion {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Default, CacheKey, is_macro::Is)]
+pub enum PreviewMode {
+    Enabled,
+    #[default]
+    Disabled,
+}
+
+impl From<bool> for PreviewMode {
+    fn from(version: bool) -> Self {
+        match version {
+            true => PreviewMode::Enabled,
+            false => PreviewMode::Disabled,
+        }
+    }
+}
+
 #[derive(Debug, Clone, CacheKey, PartialEq, PartialOrd, Eq, Ord)]
 pub enum FilePattern {
     Builtin(&'static str),

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -115,6 +115,11 @@ pub struct CheckCommand {
     /// The minimum Python version that should be supported.
     #[arg(long, value_enum)]
     pub target_version: Option<PythonVersion>,
+    /// Enable preview mode
+    #[arg(long, overrides_with("no_preview"))]
+    preview: bool,
+    #[clap(long, overrides_with("preview"), hide = true)]
+    no_preview: bool,
     /// Path to the `pyproject.toml` or `ruff.toml` file to use for
     /// configuration.
     #[arg(long, conflicts_with = "isolated")]
@@ -458,6 +463,7 @@ impl CheckCommand {
                 ignore: self.ignore,
                 line_length: self.line_length,
                 per_file_ignores: self.per_file_ignores,
+                preview_mode: resolve_bool_arg(self.preview, self.no_preview),
                 respect_gitignore: resolve_bool_arg(
                     self.respect_gitignore,
                     self.no_respect_gitignore,
@@ -569,6 +575,7 @@ pub struct Overrides {
     pub ignore: Option<Vec<RuleSelector>>,
     pub line_length: Option<LineLength>,
     pub per_file_ignores: Option<Vec<PatternPrefixPair>>,
+    pub preview_mode: Option<bool>,
     pub respect_gitignore: Option<bool>,
     pub select: Option<Vec<RuleSelector>>,
     pub show_source: Option<bool>,
@@ -631,6 +638,9 @@ impl ConfigProcessor for Overrides {
         }
         if let Some(line_length) = &self.line_length {
             config.line_length = Some(*line_length);
+        }
+        if let Some(preview_mode) = &self.preview_mode {
+            config.preview_mode = Some(*preview_mode);
         }
         if let Some(per_file_ignores) = &self.per_file_ignores {
             config.per_file_ignores = Some(collect_per_file_ignores(per_file_ignores.clone()));

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -9,7 +9,7 @@ use rustc_hash::FxHashMap;
 use ruff::logging::LogLevel;
 use ruff::registry::Rule;
 use ruff::settings::types::{
-    FilePattern, PatternPrefixPair, PerFileIgnore, PythonVersion, SerializationFormat,
+    FilePattern, PatternPrefixPair, PerFileIgnore, PreviewMode, PythonVersion, SerializationFormat,
 };
 use ruff::RuleSelector;
 use ruff_workspace::configuration::{Configuration, RuleSelection};
@@ -463,7 +463,7 @@ impl CheckCommand {
                 ignore: self.ignore,
                 line_length: self.line_length,
                 per_file_ignores: self.per_file_ignores,
-                preview: resolve_bool_arg(self.preview, self.no_preview),
+                preview: resolve_bool_arg(self.preview, self.no_preview).map(PreviewMode::from),
                 respect_gitignore: resolve_bool_arg(
                     self.respect_gitignore,
                     self.no_respect_gitignore,
@@ -575,7 +575,7 @@ pub struct Overrides {
     pub ignore: Option<Vec<RuleSelector>>,
     pub line_length: Option<LineLength>,
     pub per_file_ignores: Option<Vec<PatternPrefixPair>>,
-    pub preview: Option<bool>,
+    pub preview: Option<PreviewMode>,
     pub respect_gitignore: Option<bool>,
     pub select: Option<Vec<RuleSelector>>,
     pub show_source: Option<bool>,

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -115,7 +115,7 @@ pub struct CheckCommand {
     /// The minimum Python version that should be supported.
     #[arg(long, value_enum)]
     pub target_version: Option<PythonVersion>,
-    /// Enable preview mode
+    /// Enable preview mode; checks will include unstable rules and fixes.
     #[arg(long, overrides_with("no_preview"), hide = true)]
     preview: bool,
     #[clap(long, overrides_with("preview"), hide = true)]
@@ -463,7 +463,7 @@ impl CheckCommand {
                 ignore: self.ignore,
                 line_length: self.line_length,
                 per_file_ignores: self.per_file_ignores,
-                preview_mode: resolve_bool_arg(self.preview, self.no_preview),
+                preview: resolve_bool_arg(self.preview, self.no_preview),
                 respect_gitignore: resolve_bool_arg(
                     self.respect_gitignore,
                     self.no_respect_gitignore,
@@ -575,7 +575,7 @@ pub struct Overrides {
     pub ignore: Option<Vec<RuleSelector>>,
     pub line_length: Option<LineLength>,
     pub per_file_ignores: Option<Vec<PatternPrefixPair>>,
-    pub preview_mode: Option<bool>,
+    pub preview: Option<bool>,
     pub respect_gitignore: Option<bool>,
     pub select: Option<Vec<RuleSelector>>,
     pub show_source: Option<bool>,
@@ -639,8 +639,8 @@ impl ConfigProcessor for Overrides {
         if let Some(line_length) = &self.line_length {
             config.line_length = Some(*line_length);
         }
-        if let Some(preview_mode) = &self.preview_mode {
-            config.preview_mode = Some(*preview_mode);
+        if let Some(preview) = &self.preview {
+            config.preview = Some(*preview);
         }
         if let Some(per_file_ignores) = &self.per_file_ignores {
             config.per_file_ignores = Some(collect_per_file_ignores(per_file_ignores.clone()));

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -116,7 +116,7 @@ pub struct CheckCommand {
     #[arg(long, value_enum)]
     pub target_version: Option<PythonVersion>,
     /// Enable preview mode
-    #[arg(long, overrides_with("no_preview"))]
+    #[arg(long, overrides_with("no_preview"), hide = true)]
     preview: bool,
     #[clap(long, overrides_with("preview"), hide = true)]
     no_preview: bool,

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -8,7 +8,7 @@ use ruff::directives;
 use ruff::line_width::{LineLength, TabSize};
 use ruff::linter::{check_path, LinterResult};
 use ruff::registry::AsRule;
-use ruff::settings::types::PythonVersion;
+use ruff::settings::types::{PythonVersion};
 use ruff::settings::{defaults, flags, Settings};
 use ruff_formatter::{FormatResult, Formatted};
 use ruff_python_ast::{Mod, PySourceType};

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -128,6 +128,7 @@ impl Workspace {
             external: Some(Vec::default()),
             ignore: Some(Vec::default()),
             line_length: Some(LineLength::default()),
+            preview_mode: Some(false),
             select: Some(defaults::PREFIXES.to_vec()),
             tab_size: Some(TabSize::default()),
             target_version: Some(PythonVersion::default()),

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -8,7 +8,7 @@ use ruff::directives;
 use ruff::line_width::{LineLength, TabSize};
 use ruff::linter::{check_path, LinterResult};
 use ruff::registry::AsRule;
-use ruff::settings::types::{PythonVersion};
+use ruff::settings::types::PythonVersion;
 use ruff::settings::{defaults, flags, Settings};
 use ruff_formatter::{FormatResult, Formatted};
 use ruff_python_ast::{Mod, PySourceType};

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -128,7 +128,7 @@ impl Workspace {
             external: Some(Vec::default()),
             ignore: Some(Vec::default()),
             line_length: Some(LineLength::default()),
-            preview_mode: Some(false),
+            preview: Some(false),
             select: Some(defaults::PREFIXES.to_vec()),
             tab_size: Some(TabSize::default()),
             target_version: Some(PythonVersion::default()),

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -67,7 +67,7 @@ pub struct Configuration {
     pub line_length: Option<LineLength>,
     pub logger_objects: Option<Vec<String>>,
     pub namespace_packages: Option<Vec<PathBuf>>,
-    pub preview_mode: Option<bool>,
+    pub preview: Option<bool>,
     pub required_version: Option<Version>,
     pub respect_gitignore: Option<bool>,
     pub show_fixes: Option<bool>,
@@ -175,7 +175,7 @@ impl Configuration {
                     .collect()
             }),
             logger_objects: self.logger_objects.unwrap_or_default(),
-            preview_mode: self.preview_mode.unwrap_or_default(),
+            preview: self.preview.unwrap_or_default(),
             typing_modules: self.typing_modules.unwrap_or_default(),
             // Plugins
             flake8_annotations: self
@@ -389,7 +389,7 @@ impl Configuration {
                 .namespace_packages
                 .map(|namespace_package| resolve_src(&namespace_package, project_root))
                 .transpose()?,
-            preview_mode: options.preview_mode,
+            preview: options.preview,
             per_file_ignores: options.per_file_ignores.map(|per_file_ignores| {
                 per_file_ignores
                     .into_iter()
@@ -679,7 +679,7 @@ impl Configuration {
             show_fixes: self.show_fixes.or(config.show_fixes),
             src: self.src.or(config.src),
             target_version: self.target_version.or(config.target_version),
-            preview_mode: self.preview_mode.or(config.preview_mode),
+            preview: self.preview.or(config.preview),
             task_tags: self.task_tags.or(config.task_tags),
             typing_modules: self.typing_modules.or(config.typing_modules),
             // Plugins

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -23,7 +23,8 @@ use ruff::registry::{Rule, RuleSet, INCOMPATIBLE_CODES};
 use ruff::rule_selector::Specificity;
 use ruff::settings::rule_table::RuleTable;
 use ruff::settings::types::{
-    FilePattern, FilePatternSet, PerFileIgnore, PythonVersion, SerializationFormat, Version,
+    FilePattern, FilePatternSet, PerFileIgnore, PreviewMode, PythonVersion, SerializationFormat,
+    Version,
 };
 use ruff::settings::{defaults, resolve_per_file_ignores, AllSettings, CliSettings, Settings};
 use ruff::{fs, warn_user_once_by_id, RuleSelector, RUFF_PKG_VERSION};
@@ -67,7 +68,7 @@ pub struct Configuration {
     pub line_length: Option<LineLength>,
     pub logger_objects: Option<Vec<String>>,
     pub namespace_packages: Option<Vec<PathBuf>>,
-    pub preview: Option<bool>,
+    pub preview: Option<PreviewMode>,
     pub required_version: Option<Version>,
     pub respect_gitignore: Option<bool>,
     pub show_fixes: Option<bool>,
@@ -389,7 +390,7 @@ impl Configuration {
                 .namespace_packages
                 .map(|namespace_package| resolve_src(&namespace_package, project_root))
                 .transpose()?,
-            preview: options.preview,
+            preview: options.preview.map(PreviewMode::from),
             per_file_ignores: options.per_file_ignores.map(|per_file_ignores| {
                 per_file_ignores
                     .into_iter()

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -67,6 +67,7 @@ pub struct Configuration {
     pub line_length: Option<LineLength>,
     pub logger_objects: Option<Vec<String>>,
     pub namespace_packages: Option<Vec<PathBuf>>,
+    pub preview_mode: Option<bool>,
     pub required_version: Option<Version>,
     pub respect_gitignore: Option<bool>,
     pub show_fixes: Option<bool>,
@@ -174,6 +175,7 @@ impl Configuration {
                     .collect()
             }),
             logger_objects: self.logger_objects.unwrap_or_default(),
+            preview_mode: self.preview_mode.unwrap_or_default(),
             typing_modules: self.typing_modules.unwrap_or_default(),
             // Plugins
             flake8_annotations: self
@@ -387,6 +389,7 @@ impl Configuration {
                 .namespace_packages
                 .map(|namespace_package| resolve_src(&namespace_package, project_root))
                 .transpose()?,
+            preview_mode: options.preview_mode,
             per_file_ignores: options.per_file_ignores.map(|per_file_ignores| {
                 per_file_ignores
                     .into_iter()
@@ -676,6 +679,7 @@ impl Configuration {
             show_fixes: self.show_fixes.or(config.show_fixes),
             src: self.src.or(config.src),
             target_version: self.target_version.or(config.target_version),
+            preview_mode: self.preview_mode.or(config.preview_mode),
             task_tags: self.task_tags.or(config.task_tags),
             typing_modules: self.typing_modules.or(config.typing_modules),
             // Plugins

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -483,6 +483,17 @@ pub struct Options {
     /// `ruff.toml` or `.ruff.toml`, no such inference will be performed.
     pub target_version: Option<PythonVersion>,
     #[option(
+        default = "false",
+        value_type = "bool",
+        example = r#"
+            # Enable preview mode
+            preview-mode = true
+        "#
+    )]
+    /// Whether to enable preview mode. When preview mode is enabled, Ruff will
+    /// use unstable rules and fixes.
+    pub preview_mode: Option<bool>,
+    #[option(
         default = r#"["TODO", "FIXME", "XXX"]"#,
         value_type = "list[str]",
         example = r#"task-tags = ["HACK"]"#

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -486,13 +486,13 @@ pub struct Options {
         default = "false",
         value_type = "bool",
         example = r#"
-            # Enable preview mode
-            preview-mode = true
+            # Enable preview features
+            preview = true
         "#
     )]
     /// Whether to enable preview mode. When preview mode is enabled, Ruff will
     /// use unstable rules and fixes.
-    pub preview_mode: Option<bool>,
+    pub preview: Option<bool>,
     #[option(
         default = r#"["TODO", "FIXME", "XXX"]"#,
         value_type = "list[str]",

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -441,6 +441,13 @@
         }
       }
     },
+    "preview-mode": {
+      "description": "Whether to enable preview mode. When preview mode is enabled, Ruff will use unstable rules and fixes.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "pycodestyle": {
       "description": "Options for the `pycodestyle` plugin.",
       "anyOf": [

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -441,7 +441,7 @@
         }
       }
     },
-    "preview-mode": {
+    "preview": {
       "description": "Whether to enable preview mode. When preview mode is enabled, Ruff will use unstable rules and fixes.",
       "type": [
         "boolean",


### PR DESCRIPTION
Per discussion at https://github.com/astral-sh/ruff/discussions/6998

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Adds a `--preview` and `--no-preview` option to the CLI for `ruff check` and corresponding settings. The CLI options are hidden for now.

Available in the settings as `preview = true` or `preview = false`.

Does not include environment variable configuration, although we may add it in the future.

## Test Plan

<!-- How was it tested? -->

`cargo build`

Future work will build on this setting, such as toggling the mode during a test.
