### PR TITLE
Group binary operators with same precedence only

### DIFF
--- a/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
@@ -17,6 +17,7 @@ use crate::expression::parentheses::{
     NeedsParentheses, OptionalParentheses,
 };
 use crate::expression::string::StringLayout;
+use crate::expression::OperatorPrecedence;
 use crate::prelude::*;
 
 #[derive(Default)]
@@ -66,10 +67,13 @@ impl FormatNodeRule<ExprBinOp> for FormatExprBinOp {
             BinOpLayout::Default => {
                 let format_inner = format_with(|f: &mut PyFormatter| {
                     let source = f.context().source();
+                    let precedence = OperatorPrecedence::from(item.op);
                     let binary_chain: SmallVec<[&ExprBinOp; 4]> =
                         iter::successors(Some(item), |parent| {
                             parent.left.as_bin_op_expr().and_then(|bin_expression| {
-                                if is_expression_parenthesized(bin_expression.into(), source) {
+                                if OperatorPrecedence::from(bin_expression.op) != precedence
+                                    || is_expression_parenthesized(bin_expression.into(), source)
+                                {
                                     None
                                 } else {
                                     Some(bin_expression)

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__expression.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__expression.py.snap
@@ -311,38 +311,6 @@ last_call()
      sync(async_xxxx_xxx_xxxx_xxxxx_xxxx_xxx.__func__)
  )
  xxxx_xxx_xxxx_xxxxx_xxxx_xxx: Callable[..., List[SomeClass]] = classmethod(
-@@ -328,13 +331,18 @@
- ):
-     return True
- if (
--    ~aaaa.a + aaaa.b - aaaa.c * aaaa.d / aaaa.e
-+    ~aaaa.a
-+    + aaaa.b
-+    - aaaa.c * aaaa.d / aaaa.e
-     | aaaa.f & aaaa.g % aaaa.h ^ aaaa.i << aaaa.k >> aaaa.l**aaaa.m // aaaa.n
- ):
-     return True
- if (
--    ~aaaaaaaa.a + aaaaaaaa.b - aaaaaaaa.c @ aaaaaaaa.d / aaaaaaaa.e
--    | aaaaaaaa.f & aaaaaaaa.g % aaaaaaaa.h
-+    ~aaaaaaaa.a
-+    + aaaaaaaa.b
-+    - aaaaaaaa.c @ aaaaaaaa.d / aaaaaaaa.e
-+    | aaaaaaaa.f
-+    & aaaaaaaa.g % aaaaaaaa.h
-     ^ aaaaaaaa.i << aaaaaaaa.k >> aaaaaaaa.l**aaaaaaaa.m // aaaaaaaa.n
- ):
-     return True
-@@ -342,7 +350,8 @@
-     ~aaaaaaaaaaaaaaaa.a
-     + aaaaaaaaaaaaaaaa.b
-     - aaaaaaaaaaaaaaaa.c * aaaaaaaaaaaaaaaa.d @ aaaaaaaaaaaaaaaa.e
--    | aaaaaaaaaaaaaaaa.f & aaaaaaaaaaaaaaaa.g % aaaaaaaaaaaaaaaa.h
-+    | aaaaaaaaaaaaaaaa.f
-+    & aaaaaaaaaaaaaaaa.g % aaaaaaaaaaaaaaaa.h
-     ^ aaaaaaaaaaaaaaaa.i
-     << aaaaaaaaaaaaaaaa.k
-     >> aaaaaaaaaaaaaaaa.l**aaaaaaaaaaaaaaaa.m // aaaaaaaaaaaaaaaa.n
 ```
 
 ## Ruff Output
@@ -681,18 +649,13 @@ if (
 ):
     return True
 if (
-    ~aaaa.a
-    + aaaa.b
-    - aaaa.c * aaaa.d / aaaa.e
+    ~aaaa.a + aaaa.b - aaaa.c * aaaa.d / aaaa.e
     | aaaa.f & aaaa.g % aaaa.h ^ aaaa.i << aaaa.k >> aaaa.l**aaaa.m // aaaa.n
 ):
     return True
 if (
-    ~aaaaaaaa.a
-    + aaaaaaaa.b
-    - aaaaaaaa.c @ aaaaaaaa.d / aaaaaaaa.e
-    | aaaaaaaa.f
-    & aaaaaaaa.g % aaaaaaaa.h
+    ~aaaaaaaa.a + aaaaaaaa.b - aaaaaaaa.c @ aaaaaaaa.d / aaaaaaaa.e
+    | aaaaaaaa.f & aaaaaaaa.g % aaaaaaaa.h
     ^ aaaaaaaa.i << aaaaaaaa.k >> aaaaaaaa.l**aaaaaaaa.m // aaaaaaaa.n
 ):
     return True
@@ -700,8 +663,7 @@ if (
     ~aaaaaaaaaaaaaaaa.a
     + aaaaaaaaaaaaaaaa.b
     - aaaaaaaaaaaaaaaa.c * aaaaaaaaaaaaaaaa.d @ aaaaaaaaaaaaaaaa.e
-    | aaaaaaaaaaaaaaaa.f
-    & aaaaaaaaaaaaaaaa.g % aaaaaaaaaaaaaaaa.h
+    | aaaaaaaaaaaaaaaa.f & aaaaaaaaaaaaaaaa.g % aaaaaaaaaaaaaaaa.h
     ^ aaaaaaaaaaaaaaaa.i
     << aaaaaaaaaaaaaaaa.k
     >> aaaaaaaaaaaaaaaa.l**aaaaaaaaaaaaaaaa.m // aaaaaaaaaaaaaaaa.n

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__binary_implicit_string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__binary_implicit_string.py.snap
@@ -215,8 +215,7 @@ self._assert_skipping(
 (
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-    "cccccccccccccccccccccccccc"
-    % aaaaaaaaaaaa
+    "cccccccccccccccccccccccccc" % aaaaaaaaaaaa
     + x
 )
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR fixes a deviation from Black where Ruff expanded all binary expressions with the same or a higher precedence to the left of a binary expression.

This PR changes the binary expression formatting to only group operators with the same precedence. 

This PR also fixes the priority/precedence of the Comparator operators.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

See fixed snapshots. 

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76079 |              1789 |              1634 |
| django       |           0.99948 |              2760 |                85 |
| transformers |           0.99926 |              2587 |               491 |
| twine        |           0.99965 |                33 |                 3 |
| typeshed     |           0.99947 |              3496 |              2173 |
| warehouse    |           0.99659 |               648 |                41 |
| zulip        |           0.99938 |              1437 |                47 |


| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76079 |              1789 |              1634 |
| django       |           0.99948 |              2760 |                85 |
| **transformers** |           0.99927 |              2587 |               487 | 
| twine        |           0.99965 |                33 |                 3 |
| typeshed     |           0.99947 |              3496 |              2173 |
| **warehouse**    |           0.99820 |               648 |                39 |
| zulip        |           0.99938 |              1437 |                47 |


