### PR TITLE
Allow `tab_width` to be configable

### DIFF
--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -95,6 +95,12 @@ impl PyFormatOptions {
     }
 
     #[must_use]
+    pub fn with_tab_width(mut self, tab_width: TabWidth) -> Self {
+        self.tab_width = tab_width;
+        self
+    }
+
+    #[must_use]
     pub fn with_quote_style(mut self, style: QuoteStyle) -> Self {
         self.quote_style = style;
         self


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
It's impossible to change `tab_width` programmatically.
This PR adds a new method `with_tab_width` to allow it.

## Test Plan

<!-- How was it tested? -->
TBD