### PR TITLE
`should_use_best_fit with comments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/parentheses/best_fit.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/parentheses/best_fit.py
@@ -1,0 +1,14 @@
+UNUSABLE_PASSWORD_SUFFIX_LENGTH = 40  # number of random chars to add after UNUSABLE_PASSWORD_PREFIX
+
+
+UNUSABLE_PASSWORD_SUFFIX_LENGTH = (
+    40
+)  # number of random chars to add after UNUSABLE_PASSWORD_PREFIX
+
+
+
+UNUSABLE_PASSWORD_SUFFIX_LENGTH = (
+    40  # number of random chars to add after UNUSABLE_PASSWORD_PREFIX
+)
+
+

--- a/crates/ruff_python_formatter/src/expression/expr_constant.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_constant.rs
@@ -75,7 +75,7 @@ impl FormatNodeRule<ExprConstant> for FormatExprConstant {
 impl NeedsParentheses for ExprConstant {
     fn needs_parentheses(
         &self,
-        _parent: AnyNodeRef,
+        parent: AnyNodeRef,
         context: &PyFormatContext,
     ) -> OptionalParentheses {
         if self.value.is_implicit_concatenated() {
@@ -86,7 +86,7 @@ impl NeedsParentheses for ExprConstant {
             || self.value.is_ellipsis()
         {
             OptionalParentheses::Never
-        } else if should_use_best_fit(self, context) {
+        } else if should_use_best_fit(self, parent, context) {
             OptionalParentheses::BestFit
         } else {
             OptionalParentheses::Never

--- a/crates/ruff_python_formatter/src/expression/expr_f_string.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_f_string.rs
@@ -21,13 +21,13 @@ impl FormatNodeRule<ExprFString> for FormatExprFString {
 impl NeedsParentheses for ExprFString {
     fn needs_parentheses(
         &self,
-        _parent: AnyNodeRef,
+        parent: AnyNodeRef,
         context: &PyFormatContext,
     ) -> OptionalParentheses {
         if self.implicit_concatenated {
             OptionalParentheses::Multiline
         } else if memchr2(b'\n', b'\r', context.source()[self.range].as_bytes()).is_none()
-            && should_use_best_fit(self, context)
+            && should_use_best_fit(self, parent, context)
         {
             OptionalParentheses::BestFit
         } else {

--- a/crates/ruff_python_formatter/src/expression/expr_name.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_name.rs
@@ -37,10 +37,10 @@ impl FormatNodeRule<ExprName> for FormatExprName {
 impl NeedsParentheses for ExprName {
     fn needs_parentheses(
         &self,
-        _parent: AnyNodeRef,
+        parent: AnyNodeRef,
         context: &PyFormatContext,
     ) -> OptionalParentheses {
-        if should_use_best_fit(self, context) {
+        if should_use_best_fit(self, parent, context) {
             OptionalParentheses::BestFit
         } else {
             OptionalParentheses::Never

--- a/crates/ruff_python_formatter/tests/snapshots/format@parentheses__best_fit.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@parentheses__best_fit.py.snap
@@ -1,0 +1,30 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/parentheses/best_fit.py
+---
+## Input
+```py
+UNUSABLE_PASSWORD_SUFFIX_LENGTH = 40  # number of random chars to add after UNUSABLE_PASSWORD_PREFIX
+
+
+UNUSABLE_PASSWORD_SUFFIX_LENGTH = (
+    40
+)  # number of random chars to add after UNUSABLE_PASSWORD_PREFIX
+
+
+```
+
+## Output
+```py
+UNUSABLE_PASSWORD_SUFFIX_LENGTH = (
+    40
+)  # number of random chars to add after UNUSABLE_PASSWORD_PREFIX
+
+
+UNUSABLE_PASSWORD_SUFFIX_LENGTH = (
+    40
+)  # number of random chars to add after UNUSABLE_PASSWORD_PREFIX
+```
+
+
+


### PR DESCRIPTION
draft for discussion

also use trailing comment length in the `should_use_best_fit` text length heuristic

https://github.com/astral-sh/ruff/issues/5630#issuecomment-1700532155

currently unstable