### PR TITLE
Add dependabot for `cargo` dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
-      time: "12:00"
-      timezone: "America/New_York"
-    commit-message:
-      prefix: "ci(deps)"
+    labels: ["internal"]
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels: ["internal"]


### PR DESCRIPTION
Ideally we shouldn't have to run `cargo update` manually — it requires us to remember to do so and groups all updates into a single pull request making it challenging to determine which upgrade introduces regressions e.g. #6964. Here we add daily checks for cargo dependency updates.

This pull request also simplifies dependabot configuration for GitHub Actions versions.


