### PR TITLE
Add a `NotebookError` type to avoid returning `Diagnostics` on error

### DIFF
--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -6,7 +6,7 @@
 //! [Ruff]: https://github.com/astral-sh/ruff
 
 pub use rule_selector::RuleSelector;
-pub use rules::pycodestyle::rules::IOError;
+pub use rules::pycodestyle::rules::{IOError, SyntaxError};
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/crates/ruff/src/rules/pycodestyle/rules/mod.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/mod.rs
@@ -4,8 +4,8 @@ pub(crate) use ambiguous_variable_name::*;
 pub(crate) use bare_except::*;
 pub(crate) use compound_statements::*;
 pub(crate) use doc_line_too_long::*;
-pub use errors::IOError;
 pub(crate) use errors::*;
+pub use errors::{IOError, SyntaxError};
 pub(crate) use imports::*;
 
 pub(crate) use invalid_escape_sequence::*;

--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -21,7 +21,7 @@ use ruff_text_size::Ranged;
 
 use crate::autofix::{fix_file, FixResult};
 use crate::directives;
-use crate::jupyter::Notebook;
+use crate::jupyter::{Notebook, NotebookError};
 use crate::linter::{check_path, LinterResult};
 use crate::message::{Emitter, EmitterContext, Message, TextEmitter};
 use crate::packaging::detect_package_root;
@@ -29,18 +29,6 @@ use crate::registry::AsRule;
 use crate::rules::pycodestyle::rules::syntax_error;
 use crate::settings::{flags, Settings};
 use crate::source_kind::SourceKind;
-
-#[cfg(not(fuzzing))]
-pub(crate) fn read_jupyter_notebook(path: &Path) -> Result<Notebook> {
-    let path = test_resource_path("fixtures/jupyter").join(path);
-    Notebook::from_path(&path).map_err(|err| {
-        anyhow::anyhow!(
-            "Failed to read notebook file `{}`: {:?}",
-            path.display(),
-            err
-        )
-    })
-}
 
 #[cfg(not(fuzzing))]
 pub(crate) fn test_resource_path(path: impl AsRef<Path>) -> std::path::PathBuf {
@@ -67,12 +55,12 @@ pub(crate) fn test_notebook_path(
     path: impl AsRef<Path>,
     expected: impl AsRef<Path>,
     settings: &Settings,
-) -> Result<TestedNotebook> {
-    let source_notebook = read_jupyter_notebook(path.as_ref())?;
+) -> Result<TestedNotebook, NotebookError> {
+    let source_notebook = Notebook::from_path(path.as_ref())?;
 
     let source_kind = SourceKind::IpyNotebook(source_notebook);
     let (messages, transformed) = test_contents(&source_kind, path.as_ref(), settings);
-    let expected_notebook = read_jupyter_notebook(expected.as_ref())?;
+    let expected_notebook = Notebook::from_path(expected.as_ref())?;
     let linted_notebook = transformed.into_owned().expect_ipy_notebook();
 
     assert_eq!(
@@ -273,12 +261,8 @@ Source with applied fixes:
     (messages, transformed)
 }
 
-fn print_diagnostics(
-    diagnostics: Vec<Diagnostic>,
-    file_path: &Path,
-    source: &SourceKind,
-) -> String {
-    let filename = file_path.file_name().unwrap().to_string_lossy();
+fn print_diagnostics(diagnostics: Vec<Diagnostic>, path: &Path, source: &SourceKind) -> String {
+    let filename = path.file_name().unwrap().to_string_lossy();
     let source_file = SourceFileBuilder::new(filename.as_ref(), source.source_code()).finish();
 
     let messages: Vec<_> = diagnostics
@@ -291,7 +275,7 @@ fn print_diagnostics(
         .collect();
 
     if let Some(notebook) = source.notebook() {
-        print_jupyter_messages(&messages, &filename, notebook)
+        print_jupyter_messages(&messages, path, notebook)
     } else {
         print_messages(&messages)
     }
@@ -299,7 +283,7 @@ fn print_diagnostics(
 
 pub(crate) fn print_jupyter_messages(
     messages: &[Message],
-    filename: &str,
+    path: &Path,
     notebook: &Notebook,
 ) -> String {
     let mut output = Vec::new();
@@ -312,7 +296,7 @@ pub(crate) fn print_jupyter_messages(
             &mut output,
             messages,
             &EmitterContext::new(&FxHashMap::from_iter([(
-                filename.to_string(),
+                path.file_name().unwrap().to_string_lossy().to_string(),
                 notebook.clone(),
             )])),
         )


### PR DESCRIPTION
## Summary

This PR refactors the error-handling cases around Jupyter notebooks to use errors rather than `Box<Diagnostics>`, which creates some oddities in the downstream handling. So, instead of formatting errors as diagnostics _eagerly_ (in the notebook methods), we now return errors and convert those errors to diagnostics at the last possible moment (in `diagnostics.rs`). This is more ergonomic, as errors can be composed and reported-on in different ways, whereas diagnostics require a `Printer`, etc.

See, e.g., https://github.com/astral-sh/ruff/pull/7013#discussion_r1311136301.

## Test Plan

Ran `cargo run` over a Python file labeled with a `.ipynb` suffix, and saw:

```
foo.ipynb:1:1: E999 SyntaxError: Expected a Jupyter Notebook, which must be internally stored as JSON, but found a Python source file: expected value at line 1 column 1
```
