### PR TITLE
BestFitting: Reduce allocations

### DIFF
--- a/crates/ruff_formatter/src/arguments.rs
+++ b/crates/ruff_formatter/src/arguments.rs
@@ -129,7 +129,7 @@ mod tests {
 
     #[test]
     fn test_nesting() {
-        let mut context = FormatState::new(());
+        let mut context = FormatState::new(SimpleFormatContext::default());
         let mut buffer = VecBuffer::new(&mut context);
 
         write!(

--- a/crates/ruff_formatter/src/format_element.rs
+++ b/crates/ruff_formatter/src/format_element.rs
@@ -3,12 +3,14 @@ pub mod tag;
 
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
+use std::num::NonZeroU32;
 use std::ops::Deref;
 use std::rc::Rc;
+use unicode_width::UnicodeWidthChar;
 
 use crate::format_element::tag::{GroupMode, LabelId, Tag};
 use crate::source_code::SourceCodeSlice;
-use crate::TagKind;
+use crate::{TabWidth, TagKind};
 use ruff_text_size::TextSize;
 
 /// Language agnostic IR for formatting source code.
@@ -37,13 +39,13 @@ pub enum FormatElement {
     Text {
         /// There's no need for the text to be mutable, using `Box<str>` safes 8 bytes over `String`.
         text: Box<str>,
+        text_width: TextWidth,
     },
 
     /// Text that gets emitted as it is in the source code. Optimized to avoid any allocations.
     SourceCodeSlice {
         slice: SourceCodeSlice,
-        /// Whether the string contains any new line characters
-        contains_newlines: bool,
+        text_width: TextWidth,
     },
 
     /// Prevents that line suffixes move past this boundary. Forces the printer to print any pending
@@ -73,13 +75,10 @@ impl std::fmt::Debug for FormatElement {
             FormatElement::ExpandParent => write!(fmt, "ExpandParent"),
             FormatElement::Token { text } => fmt.debug_tuple("Token").field(text).finish(),
             FormatElement::Text { text, .. } => fmt.debug_tuple("DynamicText").field(text).finish(),
-            FormatElement::SourceCodeSlice {
-                slice,
-                contains_newlines,
-            } => fmt
+            FormatElement::SourceCodeSlice { slice, text_width } => fmt
                 .debug_tuple("Text")
                 .field(slice)
-                .field(contains_newlines)
+                .field(text_width)
                 .finish(),
             FormatElement::LineSuffixBoundary => write!(fmt, "LineSuffixBoundary"),
             FormatElement::BestFitting { variants, mode } => fmt
@@ -255,11 +254,8 @@ impl FormatElements for FormatElement {
             FormatElement::ExpandParent => true,
             FormatElement::Tag(Tag::StartGroup(group)) => !group.mode().is_flat(),
             FormatElement::Line(line_mode) => matches!(line_mode, LineMode::Hard | LineMode::Empty),
-
-            FormatElement::Text { text, .. } => text.contains('\n'),
-            FormatElement::SourceCodeSlice {
-                contains_newlines, ..
-            } => *contains_newlines,
+            FormatElement::Text { text_width, .. } => text_width.is_multiline(),
+            FormatElement::SourceCodeSlice { text_width, .. } => text_width.is_multiline(),
             FormatElement::Interned(interned) => interned.will_break(),
             // Traverse into the most flat version because the content is guaranteed to expand when even
             // the most flat version contains some content that forces a break.
@@ -401,6 +397,47 @@ pub trait FormatElements {
     /// Returns the end tag if:
     /// - the last element is an end tag of `kind`
     fn end_tag(&self, kind: TagKind) -> Option<&Tag>;
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum TextWidth {
+    Width(NonZeroU32),
+    Multiline,
+}
+
+impl TextWidth {
+    pub(crate) const fn new_width(width: u32) -> Self {
+        // SAFETY: 1 + x is guaranteed to be non zero
+        #[allow(unsafe_code)]
+        TextWidth::Width(unsafe { NonZeroU32::new_unchecked(width.saturating_add(1)) })
+    }
+
+    pub fn from_text(text: &str, tab_width: TabWidth) -> TextWidth {
+        let mut width = 0u32;
+
+        for c in text.chars() {
+            let char_width = match c {
+                '\t' => tab_width.value(),
+                '\n' => return TextWidth::Multiline,
+                #[allow(clippy::cast_possible_truncation)]
+                c => c.width().unwrap_or(0) as u32,
+            };
+            width += char_width;
+        }
+
+        Self::new_width(width)
+    }
+
+    pub const fn width(self) -> Option<u32> {
+        match self {
+            TextWidth::Width(width) => Some(width.get() - 1),
+            TextWidth::Multiline => None,
+        }
+    }
+
+    pub(crate) const fn is_multiline(self) -> bool {
+        matches!(self, TextWidth::Multiline)
+    }
 }
 
 #[cfg(test)]

--- a/crates/ruff_formatter/src/format_element/tag.rs
+++ b/crates/ruff_formatter/src/format_element/tag.rs
@@ -83,6 +83,11 @@ pub enum Tag {
 
     StartFitsExpanded(FitsExpanded),
     EndFitsExpanded,
+
+    StartBestFittingEntry {
+        length: usize,
+    },
+    EndBestFittingEntry,
 }
 
 impl Tag {
@@ -103,6 +108,7 @@ impl Tag {
                 | Tag::StartVerbatim(_)
                 | Tag::StartLabelled(_)
                 | Tag::StartFitsExpanded(_)
+                | Tag::StartBestFittingEntry { .. },
         )
     }
 
@@ -129,6 +135,7 @@ impl Tag {
             StartVerbatim(_) | EndVerbatim => TagKind::Verbatim,
             StartLabelled(_) | EndLabelled => TagKind::Labelled,
             StartFitsExpanded { .. } | EndFitsExpanded => TagKind::FitsExpanded,
+            StartBestFittingEntry { .. } | EndBestFittingEntry => TagKind::BestFittingEntry,
         }
     }
 }
@@ -152,6 +159,7 @@ pub enum TagKind {
     Verbatim,
     Labelled,
     FitsExpanded,
+    BestFittingEntry,
 }
 
 #[derive(Debug, Copy, Default, Clone, Eq, PartialEq)]

--- a/crates/ruff_formatter/src/macros.rs
+++ b/crates/ruff_formatter/src/macros.rs
@@ -343,15 +343,15 @@ mod tests {
 
     struct TestFormat;
 
-    impl Format<()> for TestFormat {
-        fn fmt(&self, f: &mut Formatter<()>) -> FormatResult<()> {
+    impl Format<SimpleFormatContext> for TestFormat {
+        fn fmt(&self, f: &mut Formatter<SimpleFormatContext>) -> FormatResult<()> {
             write!(f, [token("test")])
         }
     }
 
     #[test]
     fn test_single_element() {
-        let mut state = FormatState::new(());
+        let mut state = FormatState::new(SimpleFormatContext::default());
         let mut buffer = VecBuffer::new(&mut state);
 
         write![&mut buffer, [TestFormat]].unwrap();
@@ -364,7 +364,7 @@ mod tests {
 
     #[test]
     fn test_multiple_elements() {
-        let mut state = FormatState::new(());
+        let mut state = FormatState::new(SimpleFormatContext::default());
         let mut buffer = VecBuffer::new(&mut state);
 
         write![

--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-use unicode_width::UnicodeWidthChar;
-
 use ruff_formatter::{format_args, write, FormatError, FormatOptions, SourceCode};
 use ruff_python_ast::node::{AnyNodeRef, AstNode};
 use ruff_python_trivia::{lines_after, lines_after_ignoring_trivia, lines_before};
@@ -371,16 +369,10 @@ impl Format<PyFormatContext<'_>> for FormatTrailingEndOfLineComment<'_> {
             0
         } else {
             // Start with 2 because of the two leading spaces.
-            let mut width = 2;
-
-            // SAFETY: The formatted file is <= 4GB, and each comment should as well.
-            #[allow(clippy::cast_possible_truncation)]
-            for c in normalized_comment.chars() {
-                width += match c {
-                    '\t' => f.options().tab_width().value(),
-                    c => c.width().unwrap_or(0) as u32,
-                }
-            }
+            let width = TextWidth::from_text(&normalized_comment, f.options().tab_width())
+                .width()
+                .expect("Expected comment not to contain any newlines")
+                + 2;
 
             width
         };
@@ -424,11 +416,9 @@ pub(crate) struct FormatNormalizedComment<'a> {
 impl Format<PyFormatContext<'_>> for FormatNormalizedComment<'_> {
     fn fmt(&self, f: &mut Formatter<PyFormatContext>) -> FormatResult<()> {
         match self.comment {
-            Cow::Borrowed(borrowed) => source_text_slice(
-                TextRange::at(self.range.start(), borrowed.text_len()),
-                ContainsNewlines::No,
-            )
-            .fmt(f),
+            Cow::Borrowed(borrowed) => {
+                source_text_slice(TextRange::at(self.range.start(), borrowed.text_len())).fmt(f)
+            }
 
             Cow::Owned(ref owned) => {
                 write!(

--- a/crates/ruff_python_formatter/src/expression/expr_ipy_escape_command.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_ipy_escape_command.rs
@@ -8,6 +8,6 @@ pub struct FormatExprIpyEscapeCommand;
 
 impl FormatNodeRule<ExprIpyEscapeCommand> for FormatExprIpyEscapeCommand {
     fn fmt_fields(&self, item: &ExprIpyEscapeCommand, f: &mut PyFormatter) -> FormatResult<()> {
-        source_text_slice(item.range(), ContainsNewlines::No).fmt(f)
+        source_text_slice(item.range()).fmt(f)
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_name.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_name.rs
@@ -21,7 +21,7 @@ impl FormatNodeRule<ExprName> for FormatExprName {
                 .text(f.context().source_code())
         );
 
-        write!(f, [source_text_slice(*range, ContainsNewlines::No)])
+        write!(f, [source_text_slice(*range)])
     }
 
     fn fmt_dangling_comments(

--- a/crates/ruff_python_formatter/src/expression/number.rs
+++ b/crates/ruff_python_formatter/src/expression/number.rs
@@ -24,7 +24,7 @@ impl Format<PyFormatContext<'_>> for FormatInt<'_> {
         let normalized = normalize_integer(content);
 
         match normalized {
-            Cow::Borrowed(_) => source_text_slice(range, ContainsNewlines::No).fmt(f),
+            Cow::Borrowed(_) => source_text_slice(range).fmt(f),
             Cow::Owned(normalized) => text(&normalized, Some(range.start())).fmt(f),
         }
     }
@@ -49,7 +49,7 @@ impl Format<PyFormatContext<'_>> for FormatFloat<'_> {
         let normalized = normalize_floating_number(content);
 
         match normalized {
-            Cow::Borrowed(_) => source_text_slice(range, ContainsNewlines::No).fmt(f),
+            Cow::Borrowed(_) => source_text_slice(range).fmt(f),
             Cow::Owned(normalized) => text(&normalized, Some(range.start())).fmt(f),
         }
     }
@@ -75,7 +75,7 @@ impl Format<PyFormatContext<'_>> for FormatComplex<'_> {
 
         match normalized {
             Cow::Borrowed(_) => {
-                source_text_slice(range.sub_end(TextSize::from(1)), ContainsNewlines::No).fmt(f)?;
+                source_text_slice(range.sub_end(TextSize::from(1))).fmt(f)?;
             }
             Cow::Owned(normalized) => {
                 text(&normalized, Some(range.start())).fmt(f)?;

--- a/crates/ruff_python_formatter/src/other/identifier.rs
+++ b/crates/ruff_python_formatter/src/other/identifier.rs
@@ -8,7 +8,7 @@ pub struct FormatIdentifier;
 
 impl FormatRule<Identifier, PyFormatContext<'_>> for FormatIdentifier {
     fn fmt(&self, item: &Identifier, f: &mut PyFormatter) -> FormatResult<()> {
-        source_text_slice(item.range(), ContainsNewlines::No).fmt(f)
+        source_text_slice(item.range()).fmt(f)
     }
 }
 

--- a/crates/ruff_python_formatter/src/statement/stmt_ipy_escape_command.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_ipy_escape_command.rs
@@ -9,7 +9,7 @@ pub struct FormatStmtIpyEscapeCommand;
 
 impl FormatNodeRule<StmtIpyEscapeCommand> for FormatStmtIpyEscapeCommand {
     fn fmt_fields(&self, item: &StmtIpyEscapeCommand, f: &mut PyFormatter) -> FormatResult<()> {
-        source_text_slice(item.range(), ContainsNewlines::No).fmt(f)
+        source_text_slice(item.range()).fmt(f)
     }
 
     fn is_suppressed(

--- a/crates/ruff_python_formatter/src/verbatim.rs
+++ b/crates/ruff_python_formatter/src/verbatim.rs
@@ -709,7 +709,7 @@ impl Format<PyFormatContext<'_>> for FormatVerbatimStatementRange {
                 }
             } else {
                 // Non empty line, write the text of the line
-                verbatim_text(trimmed_line_range, logical_line.contains_newlines).fmt(f)?;
+                verbatim_text(trimmed_line_range).fmt(f)?;
 
                 // Write the line separator that terminates the line, except if it is the last line (that isn't separated by a hard line break).
                 if logical_line.has_trailing_newline {
@@ -760,7 +760,6 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut parens = 0u32;
-        let mut contains_newlines = ContainsNewlines::No;
 
         let (content_end, full_end) = loop {
             match self.lexer.next() {
@@ -768,17 +767,11 @@ where
                     Tok::Newline => break (range.start(), range.end()),
                     // Ignore if inside an expression
                     Tok::NonLogicalNewline if parens == 0 => break (range.start(), range.end()),
-                    Tok::NonLogicalNewline => {
-                        contains_newlines = ContainsNewlines::Yes;
-                    }
                     Tok::Lbrace | Tok::Lpar | Tok::Lsqb => {
                         parens = parens.saturating_add(1);
                     }
                     Tok::Rbrace | Tok::Rpar | Tok::Rsqb => {
                         parens = parens.saturating_sub(1);
-                    }
-                    Tok::String { value, .. } if value.contains(['\n', '\r']) => {
-                        contains_newlines = ContainsNewlines::Yes;
                     }
                     _ => {}
                 },
@@ -790,7 +783,6 @@ where
                         self.last_line_end = self.content_end;
                         Some(Ok(LogicalLine {
                             content_range: TextRange::new(content_start, self.content_end),
-                            contains_newlines: ContainsNewlines::No,
                             has_trailing_newline: false,
                         }))
                     } else {
@@ -810,7 +802,6 @@ where
 
         Some(Ok(LogicalLine {
             content_range: TextRange::new(line_start, content_end),
-            contains_newlines,
             has_trailing_newline: true,
         }))
     }
@@ -822,8 +813,6 @@ impl<I> FusedIterator for LogicalLinesIter<I> where I: Iterator<Item = LexResult
 struct LogicalLine {
     /// The range of this lines content (excluding the trailing newline)
     content_range: TextRange,
-    /// Whether the content in `content_range` contains any newlines.
-    contains_newlines: ContainsNewlines,
     /// Does this logical line have a trailing newline or does it just happen to be the last line.
     has_trailing_newline: bool,
 }
@@ -836,16 +825,14 @@ impl Ranged for LogicalLine {
 
 struct VerbatimText {
     verbatim_range: TextRange,
-    contains_newlines: ContainsNewlines,
 }
 
-fn verbatim_text<T>(item: T, contains_newlines: ContainsNewlines) -> VerbatimText
+fn verbatim_text<T>(item: T) -> VerbatimText
 where
     T: Ranged,
 {
     VerbatimText {
         verbatim_range: item.range(),
-        contains_newlines,
     }
 }
 
@@ -859,13 +846,7 @@ impl Format<PyFormatContext<'_>> for VerbatimText {
 
         match normalize_newlines(f.context().locator().slice(self.verbatim_range), ['\r']) {
             Cow::Borrowed(_) => {
-                write!(
-                    f,
-                    [source_text_slice(
-                        self.verbatim_range,
-                        self.contains_newlines
-                    )]
-                )?;
+                write!(f, [source_text_slice(self.verbatim_range,)])?;
             }
             Cow::Owned(cleaned) => {
                 write!(
@@ -924,7 +905,7 @@ impl Format<PyFormatContext<'_>> for FormatSuppressedNode<'_> {
             f,
             [
                 leading_comments(node_comments.leading),
-                verbatim_text(self.node, ContainsNewlines::Detect),
+                verbatim_text(self.node),
                 trailing_comments(node_comments.trailing)
             ]
         )
@@ -937,13 +918,7 @@ pub(crate) fn write_suppressed_clause_header(
     f: &mut PyFormatter,
 ) -> FormatResult<()> {
     // Write the outer comments and format the node as verbatim
-    write!(
-        f,
-        [verbatim_text(
-            header.range(f.context().source())?,
-            ContainsNewlines::Detect
-        )]
-    )?;
+    write!(f, [verbatim_text(header.range(f.context().source())?)])?;
 
     let comments = f.context().comments();
     header.visit(&mut |child| {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR aims to reduce the allocations necessary for `best_fitting`. 

Today:

* One allocation for interning the object that should be formatted with different variants (outside of best fitting, avoids formatting the same content multiple times)
* One allocation for the `Vec` that stores all variants
* One allocation per variant that stores the format elements for that variant


This PR removes the allocations per variant and instead writes all variants into a single buffer stored on `BestFitting`. 
The downside of this is that resolving the most-flat or most-expanded variants now requires a search for the `StartBestFittingEntry` or `EndBestFittingEntry` . I don't expect this to be significant because best-fitting entries tend to be small (<16 entries). 

## Performance

This gives us a 2% improvement for most files, except the large/dataset.py. I need to dig deeper to understand why only large data set is regressing. This is especially surprising because I would have expected the performance to improve the most for large files that make heavy use of best fitting.

## Test Plan

`cargo test`
