### PR TITLE
Refactor ruff_cli's run method to return on each branch

### DIFF
--- a/crates/ruff_cli/src/commands/config.rs
+++ b/crates/ruff_cli/src/commands/config.rs
@@ -1,19 +1,19 @@
-use crate::ExitStatus;
+use anyhow::{anyhow, Result};
+
 use ruff_workspace::options::Options;
 
 #[allow(clippy::print_stdout)]
-pub(crate) fn config(key: Option<&str>) -> ExitStatus {
+pub(crate) fn config(key: Option<&str>) -> Result<()> {
     match key {
         None => print!("{}", Options::metadata()),
         Some(key) => match Options::metadata().get(key) {
             None => {
-                println!("Unknown option");
-                return ExitStatus::Error;
+                return Err(anyhow!("Unknown option: {key}"));
             }
             Some(entry) => {
                 print!("{entry}");
             }
         },
     }
-    ExitStatus::Success
+    Ok(())
 }

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -139,18 +139,27 @@ quoting the executed command, along with the relevant file contents and `pyproje
             if let Some(rule) = rule {
                 commands::rule::rule(rule, format)?;
             }
+            Ok(ExitStatus::Success)
         }
-        Command::Config { option } => return Ok(commands::config::config(option.as_deref())),
-        Command::Linter { format } => commands::linter::linter(format)?,
-        Command::Clean => commands::clean::clean(log_level)?,
+        Command::Config { option } => {
+            commands::config::config(option.as_deref())?;
+            Ok(ExitStatus::Success)
+        }
+        Command::Linter { format } => {
+            commands::linter::linter(format)?;
+            Ok(ExitStatus::Success)
+        }
+        Command::Clean => {
+            commands::clean::clean(log_level)?;
+            Ok(ExitStatus::Success)
+        }
         Command::GenerateShellCompletion { shell } => {
             shell.generate(&mut Args::command(), &mut stdout());
+            Ok(ExitStatus::Success)
         }
-        Command::Check(args) => return check(args, log_level),
-        Command::Format(args) => return format(args, log_level),
+        Command::Check(args) => check(args, log_level),
+        Command::Format(args) => format(args, log_level),
     }
-
-    Ok(ExitStatus::Success)
 }
 
 fn format(args: FormatCommand, log_level: LogLevel) -> Result<ExitStatus> {


### PR DESCRIPTION
## Summary

I think the fallthrough here for some branches is a little confusing. Now each branch either runs a command that returns `Result<ExitStatus>`, or runs a command that returns `Result<()>` and then explicitly returns `Ok(ExitStatus::SUCCESS)`.
