### PR TITLE
Fix placement for comments within f-strings concatenations

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -33,3 +33,27 @@ result_f = (
     # comment
     ''
 )
+
+(
+    f'{1}'  # comment
+    f'{2}'
+)
+
+(
+    f'{1}'
+    f'{2}'  # comment
+)
+
+(
+    1, (  # comment
+        f'{2}'
+    )
+)
+
+(
+    (
+        f'{1}'
+        # comment
+    ),
+    2
+)

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -70,6 +70,20 @@ fn handle_parenthesized_comment<'a>(
     comment: DecoratedComment<'a>,
     locator: &Locator,
 ) -> CommentPlacement<'a> {
+    // As a special-case, ignore comments within f-strings, like:
+    // ```python
+    // (
+    //     f'{1}' # comment
+    //     f'{2}'
+    // )
+    // ```
+    // These can't be parenthesized, as they must fall between two string tokens in an implicit
+    // concatenation. But the expression ranges only include the `1` and `2` above, so we also
+    // can't lex the contents between them.
+    if comment.enclosing_node().is_expr_f_string() {
+        return CommentPlacement::Default(comment);
+    }
+
     let Some(preceding) = comment.preceding_node() else {
         return CommentPlacement::Default(comment);
     };

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -39,6 +39,30 @@ result_f = (
     # comment
     ''
 )
+
+(
+    f'{1}'  # comment
+    f'{2}'
+)
+
+(
+    f'{1}'
+    f'{2}'  # comment
+)
+
+(
+    1, (  # comment
+        f'{2}'
+    )
+)
+
+(
+    (
+        f'{1}'
+        # comment
+    ),
+    2
+)
 ```
 
 ## Output
@@ -75,6 +99,30 @@ result_f = (
     f"{1}"
     # comment
     ""
+)
+
+(
+    f"{1}"  # comment
+    f"{2}"
+)
+
+(
+    f"{1}" f"{2}"  # comment
+)
+
+(
+    1,
+    (  # comment
+        f"{2}"
+    ),
+)
+
+(
+    (
+        f"{1}"
+        # comment
+    ),
+    2,
 )
 ```
 


### PR DESCRIPTION
## Summary

Restores the dangling comment handling for f-strings, which broke with the parenthesized expression code.

Closes https://github.com/astral-sh/ruff/issues/6898.

## Test Plan

`cargo test`

No change in any of the similarity indexes or changed file counts:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99957 |              2760 |                67 |
| transformers |           0.99927 |              2587 |               468 |
| twine        |           0.99982 |                33 |                 1 |
| typeshed     |           0.99978 |              3496 |              2173 |
| warehouse    |           0.99818 |               648 |                24 |
| zulip        |           0.99942 |              1437 |                32 |