### PR TITLE
Formatter: Detect line endings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,6 +2370,7 @@ dependencies = [
  "similar",
  "smallvec",
  "thiserror",
+ "tracing",
  "unicode-width",
 ]
 

--- a/crates/ruff_formatter/src/printer/printer_options/mod.rs
+++ b/crates/ruff_formatter/src/printer/printer_options/mod.rs
@@ -124,7 +124,8 @@ impl SourceMapGeneration {
 }
 
 #[allow(dead_code)]
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LineEnding {
     ///  Line Feed only (\n), common on Linux and macOS as well as inside git repos
     #[default]

--- a/crates/ruff_python_formatter/Cargo.toml
+++ b/crates/ruff_python_formatter/Cargo.toml
@@ -31,6 +31,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
 smallvec = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 unicode-width = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -1,4 +1,5 @@
 use thiserror::Error;
+use tracing::Level;
 
 use ruff_formatter::prelude::*;
 use ruff_formatter::{format, FormatError, Formatted, PrintError, Printed, SourceCode};
@@ -119,6 +120,7 @@ impl From<ParseError> for FormatModuleError {
     }
 }
 
+#[tracing::instrument(level=Level::TRACE, skip_all, err)]
 pub fn format_module(
     contents: &str,
     options: PyFormatOptions,

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -28,6 +28,8 @@ pub struct PyFormatOptions {
     #[cfg_attr(feature = "serde", serde(default = "default_tab_width"))]
     tab_width: TabWidth,
 
+    line_ending: LineEnding,
+
     /// The preferred quote style to use (single vs double quotes).
     quote_style: QuoteStyle,
 
@@ -59,6 +61,7 @@ impl Default for PyFormatOptions {
             line_width: default_line_width(),
             tab_width: default_tab_width(),
             quote_style: QuoteStyle::default(),
+            line_ending: LineEnding::default(),
             magic_trailing_comma: MagicTrailingComma::default(),
             source_map_generation: SourceMapGeneration::default(),
         }
@@ -94,6 +97,10 @@ impl PyFormatOptions {
         self.source_map_generation
     }
 
+    pub fn line_ending(&self) -> LineEnding {
+        self.line_ending
+    }
+
     #[must_use]
     pub fn with_tab_width(mut self, tab_width: TabWidth) -> Self {
         self.tab_width = tab_width;
@@ -123,6 +130,12 @@ impl PyFormatOptions {
         self.line_width = line_width;
         self
     }
+
+    #[must_use]
+    pub fn with_line_ending(mut self, line_ending: LineEnding) -> Self {
+        self.line_ending = line_ending;
+        self
+    }
 }
 
 impl FormatOptions for PyFormatOptions {
@@ -142,7 +155,7 @@ impl FormatOptions for PyFormatOptions {
         PrinterOptions {
             tab_width: self.tab_width,
             line_width: self.line_width,
-            line_ending: LineEnding::LineFeed,
+            line_ending: self.line_ending,
             indent_style: self.indent_style,
             source_map_generation: self.source_map_generation,
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR changes the ruff cli to detect the default line ending automatically. 

We should add a Cconfiguration option for the default line ending in the future (https://github.com/astral-sh/ruff/issues/7061) but until then, detect the first line ending and use it (to align with Black).

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I ran `ruff format --check` on the LSP project on windows (before charlie's commit to change to LN) and it doesn't reformat any files. 

But the LSP is a good example why detecting the default generally is not a good idea, because you end up with all kind of line endings in your project

```
[crates\ruff_cli\src\commands\format.rs:150] line_ending = LineFeed
[crates\ruff_cli\src\commands\format.rs:150] path = "C:\\Users\\Micha\\astral\\ruff-lsp\\ruff_lsp\\__init__.py"
[crates\ruff_cli\src\commands\format.rs:150] line_ending = LineFeed
[crates\ruff_cli\src\commands\format.rs:150] path = "C:\\Users\\Micha\\astral\\ruff-lsp\\ruff_lsp\\__main__.py"
[crates\ruff_cli\src\commands\format.rs:150] line_ending = CarriageReturnLineFeed
[crates\ruff_cli\src\commands\format.rs:150] path = "C:\\Users\\Micha\\astral\\ruff-lsp\\tests\\client\\defaults.py"
[crates\ruff_cli\src\commands\format.rs:150] line_ending = CarriageReturnLineFeed
[crates\ruff_cli\src\commands\format.rs:150] path = "C:\\Users\\Micha\\astral\\ruff-lsp\\tests\\test_format.py"
[crates\ruff_cli\src\commands\format.rs:150] line_ending = LineFeed
[crates\ruff_cli\src\commands\format.rs:150] path = "C:\\Users\\Micha\\astral\\ruff-lsp\\ruff_lsp\\settings.py"
[crates\ruff_cli\src\commands\format.rs:150] line_ending = LineFeed
[crates\ruff_cli\src\commands\format.rs:150] path = "C:\\Users\\Micha\\astral\\ruff-lsp\\tests\\client\\constants.py"
[crates\ruff_cli\src\commands\format.rs:150] line_ending = CarriageReturnLineFeed
[crates\ruff_cli\src\commands\format.rs:150] path = "C:\\Users\\Micha\\astral\\ruff-lsp\\tests\\client\\session.py"
[crates\ruff_cli\src\commands\format.rs:150] line_ending = LineFeed
[crates\ruff_cli\src\commands\format.rs:150] path = "C:\\Users\\Micha\\astral\\ruff-lsp\\tests\\client\\__init__.py"
[crates\ruff_cli\src\commands\format.rs:150] line_ending = LineFeed
[crates\ruff_cli\src\commands\format.rs:150] path = "C:\\Users\\Micha\\astral\\ruff-lsp\\tests\\client\\utils.py"
[crates\ruff_cli\src\commands\format.rs:150] line_ending = CarriageReturnLineFeed
```

<!-- How was it tested? -->
