### PR TITLE
Parse human-readable names in noqa and rule selectors

### DIFF
--- a/crates/ruff/resources/test/fixtures/ruff/RUF100_3.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF100_3.py
@@ -3,23 +3,23 @@
 print()  # noqa
 print()  # noqa # comment
 print()  # noqa  # comment
-print()  # noqa comment
-print()  # noqa  comment
+print()  # noqa invalid-code
+print()  # noqa  invalid-code
 print(a)  # noqa
 print(a)  # noqa # comment
 print(a)  # noqa  # comment
-print(a)  # noqa comment
-print(a)  # noqa  comment
+print(a)  # noqa invalid-code
+print(a)  # noqa  invalid-code
 
 # noqa: E501, F821
 # noqa: E501, F821 # comment
 print()  # noqa: E501, F821
 print()  # noqa: E501, F821 # comment
 print()  # noqa: E501, F821  # comment
-print()  # noqa: E501, F821 comment
-print()  # noqa: E501, F821  comment
+print()  # noqa: E501, F821 invalid-code
+print()  # noqa: E501, F821  invalid-code
 print(a)  # noqa: E501, F821
 print(a)  # noqa: E501, F821 # comment
 print(a)  # noqa: E501, F821  # comment
-print(a)  # noqa: E501, F821 comment
-print(a)  # noqa: E501, F821  comment
+print(a)  # noqa: E501, F821 invalid-code
+print(a)  # noqa: E501, F821  invalid-code

--- a/crates/ruff/resources/test/fixtures/ruff/RUF100_3.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF100_3.py
@@ -3,13 +3,13 @@
 print()  # noqa
 print()  # noqa # comment
 print()  # noqa  # comment
-print()  # noqa invalid-code
-print()  # noqa  invalid-code
+print()  # noqa comment
+print()  # noqa  comment
 print(a)  # noqa
 print(a)  # noqa # comment
 print(a)  # noqa  # comment
-print(a)  # noqa invalid-code
-print(a)  # noqa  invalid-code
+print(a)  # noqa comment
+print(a)  # noqa  comment
 
 # noqa: E501, F821
 # noqa: E501, F821 # comment

--- a/crates/ruff/resources/test/fixtures/ruff/ruff_human_readable_noqa_codes.py
+++ b/crates/ruff/resources/test/fixtures/ruff/ruff_human_readable_noqa_codes.py
@@ -1,0 +1,8 @@
+# ruff: noqa: unused-import
+
+import os
+import foo
+
+
+def f():
+    x = 1

--- a/crates/ruff/src/noqa.rs
+++ b/crates/ruff/src/noqa.rs
@@ -169,7 +169,7 @@ impl<'a> Directive<'a> {
         // According to https://beta.ruff.rs/docs/rules/, all rule names are lowercase + at least 1 dash
         let length = line
             .chars()
-            .take_while(|c| c.is_ascii_alphanumeric() || *c == '-')
+            .take_while(|c| c.is_ascii_lowercase() || *c == '-')
             .count();
         let has_dash = line[..length].chars().any(|c| c == '-');
         if has_dash && length > 0 {
@@ -449,7 +449,7 @@ impl<'a> ParsedFileExemption<'a> {
         // According to https://beta.ruff.rs/docs/rules/, all rule names are lowercase + at least 1 dash
         let length = line
             .chars()
-            .take_while(|c| c.is_ascii_alphanumeric() || *c == '-')
+            .take_while(|c| c.is_ascii_lowercase() || *c == '-')
             .count();
         let has_dash = line[..length].chars().any(|c| c == '-');
         if has_dash && length > 0 {

--- a/crates/ruff/src/noqa.rs
+++ b/crates/ruff/src/noqa.rs
@@ -267,6 +267,8 @@ impl FileExemption {
                                 if let Ok(rule) = Rule::from_code(get_redirect_target(code).unwrap_or(code))
                                 {
                                     Some(rule.noqa_code())
+                                } else if let Ok(rule) = Rule::from_name(code) {
+                                    Some(rule.noqa_code())
                                 } else {
                                     #[allow(deprecated)]
                                     let line = locator.compute_line_index(range.start());
@@ -430,7 +432,7 @@ impl<'a> ParsedFileExemption<'a> {
 /// The result of an [`Importer::get_or_import_symbol`] call.
 #[derive(Debug)]
 pub(crate) enum ParseError {
-    /// The `noqa` directive was missing valid codes (e.g., `# noqa: unused-import` instead of `# noqa: F401`).
+    /// The `noqa` directive was missing valid codes (e.g., `# noqa: _F401_` instead of `# noqa: F401`).
     MissingCodes,
     /// The `noqa` directive used an invalid suffix (e.g., `# noqa; F401` instead of `# noqa: F401`).
     InvalidSuffix,

--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -9,6 +9,7 @@ use ruff_macros::RuleNamespace;
 pub use rule_set::{RuleSet, RuleSetIterator};
 
 use crate::codes::{self};
+use crate::rule_redirects;
 
 mod rule_set;
 
@@ -29,6 +30,25 @@ impl Rule {
         Self::iter()
             .find(|rule| rule.as_ref() == name)
             .ok_or(FromCodeError::Unknown)
+    }
+
+    /// Convert a code or name to a rule
+    pub fn from_code_or_name(
+        code_or_name: &str,
+        check_redirects: bool,
+    ) -> Result<Self, FromCodeError> {
+        Rule::from_code(if check_redirects {
+            rule_redirects::get_code_redirect_target(code_or_name).unwrap_or(code_or_name)
+        } else {
+            code_or_name
+        })
+        .or_else(|_| {
+            Rule::from_name(if check_redirects {
+                rule_redirects::get_name_redirect_target(code_or_name).unwrap_or(code_or_name)
+            } else {
+                code_or_name
+            })
+        })
     }
 }
 

--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -1,6 +1,7 @@
 //! Remnant of the registry of all [`Rule`] implementations, now it's reexporting from codes.rs
 //! with some helper symbols
 
+use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 pub use codes::Rule;
@@ -21,6 +22,12 @@ impl Rule {
         linter
             .all_rules()
             .find(|rule| rule.noqa_code().suffix() == code)
+            .ok_or(FromCodeError::Unknown)
+    }
+
+    pub fn from_name(name: &str) -> Result<Self, FromCodeError> {
+        Self::iter()
+            .find(|rule| rule.as_ref() == name)
             .ok_or(FromCodeError::Unknown)
     }
 }

--- a/crates/ruff/src/rule_redirects.rs
+++ b/crates/ruff/src/rule_redirects.rs
@@ -3,17 +3,28 @@ use std::collections::HashMap;
 use once_cell::sync::Lazy;
 
 /// Returns the redirect target for the given code.
-pub(crate) fn get_redirect_target(code: &str) -> Option<&'static str> {
-    REDIRECTS.get(code).copied()
+pub(crate) fn get_code_redirect_target(code: &str) -> Option<&'static str> {
+    CODE_REDIRECTS.get(code).copied()
 }
 
 /// Returns the code and the redirect target if the given code is a redirect.
 /// (The same code is returned to obtain it with a static lifetime).
-pub(crate) fn get_redirect(code: &str) -> Option<(&'static str, &'static str)> {
-    REDIRECTS.get_key_value(code).map(|(k, v)| (*k, *v))
+pub(crate) fn get_code_redirect(code: &str) -> Option<(&'static str, &'static str)> {
+    CODE_REDIRECTS.get_key_value(code).map(|(k, v)| (*k, *v))
 }
 
-static REDIRECTS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
+/// Returns the redirect target for the given rule name.
+pub(crate) fn get_name_redirect_target(name: &str) -> Option<&'static str> {
+    NAME_REDIRECTS.get(name).copied()
+}
+
+/// Returns the name and the redirect target if the given rule name is a redirect.
+/// (The same name is returned to obtain it with a static lifetime).
+pub(crate) fn get_name_redirect(name: &str) -> Option<(&'static str, &'static str)> {
+    NAME_REDIRECTS.get_key_value(name).map(|(k, v)| (*k, *v))
+}
+
+static CODE_REDIRECTS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     HashMap::from_iter([
         // The following are here because we don't yet have the many-to-one mapping enabled.
         ("SIM111", "SIM110"),
@@ -100,3 +111,5 @@ static REDIRECTS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
         ("T004", "FIX004"),
     ])
 });
+
+static NAME_REDIRECTS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(HashMap::new);

--- a/crates/ruff/src/rule_selector.rs
+++ b/crates/ruff/src/rule_selector.rs
@@ -52,8 +52,17 @@ impl FromStr for RuleSelector {
                     None => (s, None),
                 };
 
+                let mut s = String::from(s);
+                // If a human-readable name is provided, convert it back to a structude code
+                if let Ok(rule) = Rule::from_name(&s) {
+                    s.clear();
+                    let noqa_code = rule.noqa_code();
+                    s.push_str(noqa_code.prefix());
+                    s.push_str(noqa_code.suffix());
+                }
+
                 let (linter, code) =
-                    Linter::parse_code(s).ok_or_else(|| ParseError::Unknown(s.to_string()))?;
+                    Linter::parse_code(&s).ok_or_else(|| ParseError::Unknown(s.to_string()))?;
 
                 if code.is_empty() {
                     return Ok(Self::Linter(linter));

--- a/crates/ruff/src/rules/ruff/mod.rs
+++ b/crates/ruff/src/rules/ruff/mod.rs
@@ -211,6 +211,16 @@ mod tests {
     }
 
     #[test]
+    fn ruff_human_readable_noqa_codes() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("ruff/ruff_human_readable_noqa_codes.py"),
+            &settings::Settings::for_rules(vec![Rule::UnusedImport, Rule::UnusedVariable]),
+        )?;
+        assert_messages!(diagnostics);
+        Ok(())
+    }
+
+    #[test]
     fn ruff_noqa_invalid() -> Result<()> {
         let diagnostics = test_path(
             Path::new("ruff/ruff_noqa_invalid.py"),

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_3.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_3.snap
@@ -52,7 +52,7 @@ RUF100_3.py:3:10: RUF100 [*] Unused blanket `noqa` directive
   3 |+print()
 4 4 | print()  # noqa # comment
 5 5 | print()  # noqa  # comment
-6 6 | print()  # noqa comment
+6 6 | print()  # noqa invalid-code
 
 RUF100_3.py:4:10: RUF100 [*] Unused blanket `noqa` directive
   |
@@ -61,7 +61,7 @@ RUF100_3.py:4:10: RUF100 [*] Unused blanket `noqa` directive
 4 | print()  # noqa # comment
   |          ^^^^^^ RUF100
 5 | print()  # noqa  # comment
-6 | print()  # noqa comment
+6 | print()  # noqa invalid-code
   |
   = help: Remove unused `noqa` directive
 
@@ -72,8 +72,8 @@ RUF100_3.py:4:10: RUF100 [*] Unused blanket `noqa` directive
 4   |-print()  # noqa # comment
   4 |+print()  # comment
 5 5 | print()  # noqa  # comment
-6 6 | print()  # noqa comment
-7 7 | print()  # noqa  comment
+6 6 | print()  # noqa invalid-code
+7 7 | print()  # noqa  invalid-code
 
 RUF100_3.py:5:10: RUF100 [*] Unused blanket `noqa` directive
   |
@@ -81,8 +81,8 @@ RUF100_3.py:5:10: RUF100 [*] Unused blanket `noqa` directive
 4 | print()  # noqa # comment
 5 | print()  # noqa  # comment
   |          ^^^^^^ RUF100
-6 | print()  # noqa comment
-7 | print()  # noqa  comment
+6 | print()  # noqa invalid-code
+7 | print()  # noqa  invalid-code
   |
   = help: Remove unused `noqa` directive
 
@@ -92,17 +92,17 @@ RUF100_3.py:5:10: RUF100 [*] Unused blanket `noqa` directive
 4 4 | print()  # noqa # comment
 5   |-print()  # noqa  # comment
   5 |+print()  # comment
-6 6 | print()  # noqa comment
-7 7 | print()  # noqa  comment
+6 6 | print()  # noqa invalid-code
+7 7 | print()  # noqa  invalid-code
 8 8 | print(a)  # noqa
 
 RUF100_3.py:6:10: RUF100 [*] Unused blanket `noqa` directive
   |
 4 | print()  # noqa # comment
 5 | print()  # noqa  # comment
-6 | print()  # noqa comment
+6 | print()  # noqa invalid-code
   |          ^^^^^^ RUF100
-7 | print()  # noqa  comment
+7 | print()  # noqa  invalid-code
 8 | print(a)  # noqa
   |
   = help: Remove unused `noqa` directive
@@ -111,17 +111,17 @@ RUF100_3.py:6:10: RUF100 [*] Unused blanket `noqa` directive
 3 3 | print()  # noqa
 4 4 | print()  # noqa # comment
 5 5 | print()  # noqa  # comment
-6   |-print()  # noqa comment
-  6 |+print()  # comment
-7 7 | print()  # noqa  comment
+6   |-print()  # noqa invalid-code
+  6 |+print()  # invalid-code
+7 7 | print()  # noqa  invalid-code
 8 8 | print(a)  # noqa
 9 9 | print(a)  # noqa # comment
 
 RUF100_3.py:7:10: RUF100 [*] Unused blanket `noqa` directive
   |
 5 | print()  # noqa  # comment
-6 | print()  # noqa comment
-7 | print()  # noqa  comment
+6 | print()  # noqa invalid-code
+7 | print()  # noqa  invalid-code
   |          ^^^^^^ RUF100
 8 | print(a)  # noqa
 9 | print(a)  # noqa # comment
@@ -131,16 +131,16 @@ RUF100_3.py:7:10: RUF100 [*] Unused blanket `noqa` directive
 ℹ Suggested fix
 4 4 | print()  # noqa # comment
 5 5 | print()  # noqa  # comment
-6 6 | print()  # noqa comment
-7   |-print()  # noqa  comment
-  7 |+print()  # comment
+6 6 | print()  # noqa invalid-code
+7   |-print()  # noqa  invalid-code
+  7 |+print()  # invalid-code
 8 8 | print(a)  # noqa
 9 9 | print(a)  # noqa # comment
 10 10 | print(a)  # noqa  # comment
 
 RUF100_3.py:14:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
-12 | print(a)  # noqa  comment
+12 | print(a)  # noqa  invalid-code
 13 | 
 14 | # noqa: E501, F821
    | ^^^^^^^^^^^^^^^^^^ RUF100
@@ -150,8 +150,8 @@ RUF100_3.py:14:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-11 11 | print(a)  # noqa comment
-12 12 | print(a)  # noqa  comment
+11 11 | print(a)  # noqa invalid-code
+12 12 | print(a)  # noqa  invalid-code
 13 13 | 
 14    |-# noqa: E501, F821
 15 14 | # noqa: E501, F821 # comment
@@ -169,7 +169,7 @@ RUF100_3.py:15:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-12 12 | print(a)  # noqa  comment
+12 12 | print(a)  # noqa  invalid-code
 13 13 | 
 14 14 | # noqa: E501, F821
 15    |-# noqa: E501, F821 # comment
@@ -197,7 +197,7 @@ RUF100_3.py:16:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    16 |+print()
 17 17 | print()  # noqa: E501, F821 # comment
 18 18 | print()  # noqa: E501, F821  # comment
-19 19 | print()  # noqa: E501, F821 comment
+19 19 | print()  # noqa: E501, F821 invalid-code
 
 RUF100_3.py:17:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
@@ -206,7 +206,7 @@ RUF100_3.py:17:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 17 | print()  # noqa: E501, F821 # comment
    |          ^^^^^^^^^^^^^^^^^^ RUF100
 18 | print()  # noqa: E501, F821  # comment
-19 | print()  # noqa: E501, F821 comment
+19 | print()  # noqa: E501, F821 invalid-code
    |
    = help: Remove unused `noqa` directive
 
@@ -217,8 +217,8 @@ RUF100_3.py:17:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 17    |-print()  # noqa: E501, F821 # comment
    17 |+print()  # comment
 18 18 | print()  # noqa: E501, F821  # comment
-19 19 | print()  # noqa: E501, F821 comment
-20 20 | print()  # noqa: E501, F821  comment
+19 19 | print()  # noqa: E501, F821 invalid-code
+20 20 | print()  # noqa: E501, F821  invalid-code
 
 RUF100_3.py:18:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
@@ -226,8 +226,8 @@ RUF100_3.py:18:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 17 | print()  # noqa: E501, F821 # comment
 18 | print()  # noqa: E501, F821  # comment
    |          ^^^^^^^^^^^^^^^^^^ RUF100
-19 | print()  # noqa: E501, F821 comment
-20 | print()  # noqa: E501, F821  comment
+19 | print()  # noqa: E501, F821 invalid-code
+20 | print()  # noqa: E501, F821  invalid-code
    |
    = help: Remove unused `noqa` directive
 
@@ -237,17 +237,17 @@ RUF100_3.py:18:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 17 17 | print()  # noqa: E501, F821 # comment
 18    |-print()  # noqa: E501, F821  # comment
    18 |+print()  # comment
-19 19 | print()  # noqa: E501, F821 comment
-20 20 | print()  # noqa: E501, F821  comment
+19 19 | print()  # noqa: E501, F821 invalid-code
+20 20 | print()  # noqa: E501, F821  invalid-code
 21 21 | print(a)  # noqa: E501, F821
 
-RUF100_3.py:19:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
+RUF100_3.py:19:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`; unknown: `invalid-code`)
    |
 17 | print()  # noqa: E501, F821 # comment
 18 | print()  # noqa: E501, F821  # comment
-19 | print()  # noqa: E501, F821 comment
-   |          ^^^^^^^^^^^^^^^^^^ RUF100
-20 | print()  # noqa: E501, F821  comment
+19 | print()  # noqa: E501, F821 invalid-code
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF100
+20 | print()  # noqa: E501, F821  invalid-code
 21 | print(a)  # noqa: E501, F821
    |
    = help: Remove unused `noqa` directive
@@ -256,18 +256,18 @@ RUF100_3.py:19:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 16 16 | print()  # noqa: E501, F821
 17 17 | print()  # noqa: E501, F821 # comment
 18 18 | print()  # noqa: E501, F821  # comment
-19    |-print()  # noqa: E501, F821 comment
-   19 |+print()  # comment
-20 20 | print()  # noqa: E501, F821  comment
+19    |-print()  # noqa: E501, F821 invalid-code
+   19 |+print()
+20 20 | print()  # noqa: E501, F821  invalid-code
 21 21 | print(a)  # noqa: E501, F821
 22 22 | print(a)  # noqa: E501, F821 # comment
 
-RUF100_3.py:20:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
+RUF100_3.py:20:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`; unknown: `invalid-code`)
    |
 18 | print()  # noqa: E501, F821  # comment
-19 | print()  # noqa: E501, F821 comment
-20 | print()  # noqa: E501, F821  comment
-   |          ^^^^^^^^^^^^^^^^^^ RUF100
+19 | print()  # noqa: E501, F821 invalid-code
+20 | print()  # noqa: E501, F821  invalid-code
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF100
 21 | print(a)  # noqa: E501, F821
 22 | print(a)  # noqa: E501, F821 # comment
    |
@@ -276,17 +276,17 @@ RUF100_3.py:20:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
 ℹ Suggested fix
 17 17 | print()  # noqa: E501, F821 # comment
 18 18 | print()  # noqa: E501, F821  # comment
-19 19 | print()  # noqa: E501, F821 comment
-20    |-print()  # noqa: E501, F821  comment
-   20 |+print()  # comment
+19 19 | print()  # noqa: E501, F821 invalid-code
+20    |-print()  # noqa: E501, F821  invalid-code
+   20 |+print()
 21 21 | print(a)  # noqa: E501, F821
 22 22 | print(a)  # noqa: E501, F821 # comment
 23 23 | print(a)  # noqa: E501, F821  # comment
 
 RUF100_3.py:21:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
-19 | print()  # noqa: E501, F821 comment
-20 | print()  # noqa: E501, F821  comment
+19 | print()  # noqa: E501, F821 invalid-code
+20 | print()  # noqa: E501, F821  invalid-code
 21 | print(a)  # noqa: E501, F821
    |           ^^^^^^^^^^^^^^^^^^ RUF100
 22 | print(a)  # noqa: E501, F821 # comment
@@ -296,34 +296,34 @@ RUF100_3.py:21:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
 
 ℹ Suggested fix
 18 18 | print()  # noqa: E501, F821  # comment
-19 19 | print()  # noqa: E501, F821 comment
-20 20 | print()  # noqa: E501, F821  comment
+19 19 | print()  # noqa: E501, F821 invalid-code
+20 20 | print()  # noqa: E501, F821  invalid-code
 21    |-print(a)  # noqa: E501, F821
    21 |+print(a)  # noqa: F821
 22 22 | print(a)  # noqa: E501, F821 # comment
 23 23 | print(a)  # noqa: E501, F821  # comment
-24 24 | print(a)  # noqa: E501, F821 comment
+24 24 | print(a)  # noqa: E501, F821 invalid-code
 
 RUF100_3.py:22:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
-20 | print()  # noqa: E501, F821  comment
+20 | print()  # noqa: E501, F821  invalid-code
 21 | print(a)  # noqa: E501, F821
 22 | print(a)  # noqa: E501, F821 # comment
    |           ^^^^^^^^^^^^^^^^^^ RUF100
 23 | print(a)  # noqa: E501, F821  # comment
-24 | print(a)  # noqa: E501, F821 comment
+24 | print(a)  # noqa: E501, F821 invalid-code
    |
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-19 19 | print()  # noqa: E501, F821 comment
-20 20 | print()  # noqa: E501, F821  comment
+19 19 | print()  # noqa: E501, F821 invalid-code
+20 20 | print()  # noqa: E501, F821  invalid-code
 21 21 | print(a)  # noqa: E501, F821
 22    |-print(a)  # noqa: E501, F821 # comment
    22 |+print(a)  # noqa: F821 # comment
 23 23 | print(a)  # noqa: E501, F821  # comment
-24 24 | print(a)  # noqa: E501, F821 comment
-25 25 | print(a)  # noqa: E501, F821  comment
+24 24 | print(a)  # noqa: E501, F821 invalid-code
+25 25 | print(a)  # noqa: E501, F821  invalid-code
 
 RUF100_3.py:23:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
@@ -331,27 +331,27 @@ RUF100_3.py:23:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
 22 | print(a)  # noqa: E501, F821 # comment
 23 | print(a)  # noqa: E501, F821  # comment
    |           ^^^^^^^^^^^^^^^^^^ RUF100
-24 | print(a)  # noqa: E501, F821 comment
-25 | print(a)  # noqa: E501, F821  comment
+24 | print(a)  # noqa: E501, F821 invalid-code
+25 | print(a)  # noqa: E501, F821  invalid-code
    |
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-20 20 | print()  # noqa: E501, F821  comment
+20 20 | print()  # noqa: E501, F821  invalid-code
 21 21 | print(a)  # noqa: E501, F821
 22 22 | print(a)  # noqa: E501, F821 # comment
 23    |-print(a)  # noqa: E501, F821  # comment
    23 |+print(a)  # noqa: F821  # comment
-24 24 | print(a)  # noqa: E501, F821 comment
-25 25 | print(a)  # noqa: E501, F821  comment
+24 24 | print(a)  # noqa: E501, F821 invalid-code
+25 25 | print(a)  # noqa: E501, F821  invalid-code
 
-RUF100_3.py:24:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
+RUF100_3.py:24:11: RUF100 [*] Unused `noqa` directive (unused: `E501`; unknown: `invalid-code`)
    |
 22 | print(a)  # noqa: E501, F821 # comment
 23 | print(a)  # noqa: E501, F821  # comment
-24 | print(a)  # noqa: E501, F821 comment
-   |           ^^^^^^^^^^^^^^^^^^ RUF100
-25 | print(a)  # noqa: E501, F821  comment
+24 | print(a)  # noqa: E501, F821 invalid-code
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF100
+25 | print(a)  # noqa: E501, F821  invalid-code
    |
    = help: Remove unused `noqa` directive
 
@@ -359,24 +359,24 @@ RUF100_3.py:24:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
 21 21 | print(a)  # noqa: E501, F821
 22 22 | print(a)  # noqa: E501, F821 # comment
 23 23 | print(a)  # noqa: E501, F821  # comment
-24    |-print(a)  # noqa: E501, F821 comment
-   24 |+print(a)  # noqa: F821 comment
-25 25 | print(a)  # noqa: E501, F821  comment
+24    |-print(a)  # noqa: E501, F821 invalid-code
+   24 |+print(a)  # noqa: F821
+25 25 | print(a)  # noqa: E501, F821  invalid-code
 
-RUF100_3.py:25:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
+RUF100_3.py:25:11: RUF100 [*] Unused `noqa` directive (unused: `E501`; unknown: `invalid-code`)
    |
 23 | print(a)  # noqa: E501, F821  # comment
-24 | print(a)  # noqa: E501, F821 comment
-25 | print(a)  # noqa: E501, F821  comment
-   |           ^^^^^^^^^^^^^^^^^^ RUF100
+24 | print(a)  # noqa: E501, F821 invalid-code
+25 | print(a)  # noqa: E501, F821  invalid-code
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF100
    |
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
 22 22 | print(a)  # noqa: E501, F821 # comment
 23 23 | print(a)  # noqa: E501, F821  # comment
-24 24 | print(a)  # noqa: E501, F821 comment
-25    |-print(a)  # noqa: E501, F821  comment
-   25 |+print(a)  # noqa: F821  comment
+24 24 | print(a)  # noqa: E501, F821 invalid-code
+25    |-print(a)  # noqa: E501, F821  invalid-code
+   25 |+print(a)  # noqa: F821
 
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_3.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_3.snap
@@ -52,7 +52,7 @@ RUF100_3.py:3:10: RUF100 [*] Unused blanket `noqa` directive
   3 |+print()
 4 4 | print()  # noqa # comment
 5 5 | print()  # noqa  # comment
-6 6 | print()  # noqa invalid-code
+6 6 | print()  # noqa comment
 
 RUF100_3.py:4:10: RUF100 [*] Unused blanket `noqa` directive
   |
@@ -61,7 +61,7 @@ RUF100_3.py:4:10: RUF100 [*] Unused blanket `noqa` directive
 4 | print()  # noqa # comment
   |          ^^^^^^ RUF100
 5 | print()  # noqa  # comment
-6 | print()  # noqa invalid-code
+6 | print()  # noqa comment
   |
   = help: Remove unused `noqa` directive
 
@@ -72,8 +72,8 @@ RUF100_3.py:4:10: RUF100 [*] Unused blanket `noqa` directive
 4   |-print()  # noqa # comment
   4 |+print()  # comment
 5 5 | print()  # noqa  # comment
-6 6 | print()  # noqa invalid-code
-7 7 | print()  # noqa  invalid-code
+6 6 | print()  # noqa comment
+7 7 | print()  # noqa  comment
 
 RUF100_3.py:5:10: RUF100 [*] Unused blanket `noqa` directive
   |
@@ -81,8 +81,8 @@ RUF100_3.py:5:10: RUF100 [*] Unused blanket `noqa` directive
 4 | print()  # noqa # comment
 5 | print()  # noqa  # comment
   |          ^^^^^^ RUF100
-6 | print()  # noqa invalid-code
-7 | print()  # noqa  invalid-code
+6 | print()  # noqa comment
+7 | print()  # noqa  comment
   |
   = help: Remove unused `noqa` directive
 
@@ -92,17 +92,17 @@ RUF100_3.py:5:10: RUF100 [*] Unused blanket `noqa` directive
 4 4 | print()  # noqa # comment
 5   |-print()  # noqa  # comment
   5 |+print()  # comment
-6 6 | print()  # noqa invalid-code
-7 7 | print()  # noqa  invalid-code
+6 6 | print()  # noqa comment
+7 7 | print()  # noqa  comment
 8 8 | print(a)  # noqa
 
 RUF100_3.py:6:10: RUF100 [*] Unused blanket `noqa` directive
   |
 4 | print()  # noqa # comment
 5 | print()  # noqa  # comment
-6 | print()  # noqa invalid-code
+6 | print()  # noqa comment
   |          ^^^^^^ RUF100
-7 | print()  # noqa  invalid-code
+7 | print()  # noqa  comment
 8 | print(a)  # noqa
   |
   = help: Remove unused `noqa` directive
@@ -111,17 +111,17 @@ RUF100_3.py:6:10: RUF100 [*] Unused blanket `noqa` directive
 3 3 | print()  # noqa
 4 4 | print()  # noqa # comment
 5 5 | print()  # noqa  # comment
-6   |-print()  # noqa invalid-code
-  6 |+print()  # invalid-code
-7 7 | print()  # noqa  invalid-code
+6   |-print()  # noqa comment
+  6 |+print()  # comment
+7 7 | print()  # noqa  comment
 8 8 | print(a)  # noqa
 9 9 | print(a)  # noqa # comment
 
 RUF100_3.py:7:10: RUF100 [*] Unused blanket `noqa` directive
   |
 5 | print()  # noqa  # comment
-6 | print()  # noqa invalid-code
-7 | print()  # noqa  invalid-code
+6 | print()  # noqa comment
+7 | print()  # noqa  comment
   |          ^^^^^^ RUF100
 8 | print(a)  # noqa
 9 | print(a)  # noqa # comment
@@ -131,16 +131,16 @@ RUF100_3.py:7:10: RUF100 [*] Unused blanket `noqa` directive
 ℹ Suggested fix
 4 4 | print()  # noqa # comment
 5 5 | print()  # noqa  # comment
-6 6 | print()  # noqa invalid-code
-7   |-print()  # noqa  invalid-code
-  7 |+print()  # invalid-code
+6 6 | print()  # noqa comment
+7   |-print()  # noqa  comment
+  7 |+print()  # comment
 8 8 | print(a)  # noqa
 9 9 | print(a)  # noqa # comment
 10 10 | print(a)  # noqa  # comment
 
 RUF100_3.py:14:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
-12 | print(a)  # noqa  invalid-code
+12 | print(a)  # noqa  comment
 13 | 
 14 | # noqa: E501, F821
    | ^^^^^^^^^^^^^^^^^^ RUF100
@@ -150,8 +150,8 @@ RUF100_3.py:14:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-11 11 | print(a)  # noqa invalid-code
-12 12 | print(a)  # noqa  invalid-code
+11 11 | print(a)  # noqa comment
+12 12 | print(a)  # noqa  comment
 13 13 | 
 14    |-# noqa: E501, F821
 15 14 | # noqa: E501, F821 # comment
@@ -169,7 +169,7 @@ RUF100_3.py:15:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    = help: Remove unused `noqa` directive
 
 ℹ Suggested fix
-12 12 | print(a)  # noqa  invalid-code
+12 12 | print(a)  # noqa  comment
 13 13 | 
 14 14 | # noqa: E501, F821
 15    |-# noqa: E501, F821 # comment

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruff_human_readable_noqa_codes.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruff_human_readable_noqa_codes.snap
@@ -1,0 +1,19 @@
+---
+source: crates/ruff/src/rules/ruff/mod.rs
+---
+ruff_human_readable_noqa_codes.py:8:5: F841 [*] Local variable `x` is assigned to but never used
+  |
+7 | def f():
+8 |     x = 1
+  |     ^ F841
+  |
+  = help: Remove assignment to unused variable `x`
+
+ℹ Suggested fix
+5 5 | 
+6 6 | 
+7 7 | def f():
+8   |-    x = 1
+  8 |+    pass
+
+

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_invalid_codes.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_invalid_codes.snap
@@ -6,13 +6,10 @@ Ok(
     Some(
         Codes(
             Codes {
-                range: 0..52,
+                range: 0..35,
                 codes: [
                     "unused-import-invalid",
                     "F401",
-                    "some",
-                    "other",
-                    "code",
                 ],
             },
         ),

--- a/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_invalid_codes.snap
+++ b/crates/ruff/src/snapshots/ruff__noqa__tests__noqa_invalid_codes.snap
@@ -2,6 +2,19 @@
 source: crates/ruff/src/noqa.rs
 expression: "Directive::try_extract(source, TextSize::default())"
 ---
-Err(
-    MissingCodes,
+Ok(
+    Some(
+        Codes(
+            Codes {
+                range: 0..52,
+                codes: [
+                    "unused-import-invalid",
+                    "F401",
+                    "some",
+                    "other",
+                    "code",
+                ],
+            },
+        ),
+    ),
 )


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Allow using human-readable rule names in `noqa` and rule selectors
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

- ran `cargo test`
- manually tested putting human-readable rule name as `noqa` code 
- manually tested rule selector on the command line
<!-- How was it tested? -->
