### PR TITLE
Update LibCST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,12 +1269,11 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 [[package]]
 name = "libcst"
 version = "0.1.0"
-source = "git+https://github.com/Instagram/LibCST.git?rev=3cacca1a1029f05707e50703b49fe3dd860aa839#3cacca1a1029f05707e50703b49fe3dd860aa839"
+source = "git+https://github.com/Instagram/LibCST.git?rev=9c263aa8977962a870ce2770d2aa18ee0dacb344#9c263aa8977962a870ce2770d2aa18ee0dacb344"
 dependencies = [
  "chic",
- "itertools",
  "libcst_derive",
- "once_cell",
+ "memchr",
  "paste",
  "peg",
  "regex",
@@ -1284,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "libcst_derive"
 version = "0.1.0"
-source = "git+https://github.com/Instagram/LibCST.git?rev=3cacca1a1029f05707e50703b49fe3dd860aa839#3cacca1a1029f05707e50703b49fe3dd860aa839"
+source = "git+https://github.com/Instagram/LibCST.git?rev=9c263aa8977962a870ce2770d2aa18ee0dacb344#9c263aa8977962a870ce2770d2aa18ee0dacb344"
 dependencies = [
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ uuid = { version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics", "
 wsl = { version = "0.1.0" }
 
 # v1.0.1
-libcst = { git = "https://github.com/Instagram/LibCST.git", rev = "3cacca1a1029f05707e50703b49fe3dd860aa839", default-features = false }
+libcst = { git = "https://github.com/Instagram/LibCST.git", rev = "9c263aa8977962a870ce2770d2aa18ee0dacb344", default-features = false }
 
 [profile.release]
 lto = "fat"

--- a/crates/ruff/resources/test/fixtures/pyflakes/F504.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F504.py
@@ -9,3 +9,8 @@ hidden = {"a": "!"}
 "%(a)s" % {'a': 1, u"b": "!"}  # F504 ("b" not used)
 
 '' % {'a''b' : ''}  # F504 ("ab" not used)
+
+# https://github.com/astral-sh/ruff/issues/4899
+"" % {
+  'test1': '',  'test2': '',
+}

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F504_F504.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F504_F504.py.snap
@@ -59,6 +59,7 @@ F504.py:9:1: F504 [*] `%`-format string has unused named argument(s): b
    9  |+"%(a)s" % {'a': 1, }  # F504 ("b" not used)
 10 10 | 
 11 11 | '' % {'a''b' : ''}  # F504 ("ab" not used)
+12 12 | 
 
 F504.py:11:1: F504 [*] `%`-format string has unused named argument(s): ab
    |
@@ -66,6 +67,8 @@ F504.py:11:1: F504 [*] `%`-format string has unused named argument(s): ab
 10 | 
 11 | '' % {'a''b' : ''}  # F504 ("ab" not used)
    | ^^^^^^^^^^^^^^^^^^ F504
+12 | 
+13 | # https://github.com/astral-sh/ruff/issues/4899
    |
    = help: Remove extra named arguments: ab
 
@@ -75,5 +78,26 @@ F504.py:11:1: F504 [*] `%`-format string has unused named argument(s): ab
 10 10 | 
 11    |-'' % {'a''b' : ''}  # F504 ("ab" not used)
    11 |+'' % {}  # F504 ("ab" not used)
+12 12 | 
+13 13 | # https://github.com/astral-sh/ruff/issues/4899
+14 14 | "" % {
+
+F504.py:14:1: F504 [*] `%`-format string has unused named argument(s): test1, test2
+   |
+13 |   # https://github.com/astral-sh/ruff/issues/4899
+14 | / "" % {
+15 | |   'test1': '',  'test2': '',
+16 | | }
+   | |_^ F504
+   |
+   = help: Remove extra named arguments: test1, test2
+
+ℹ Fix
+12 12 | 
+13 13 | # https://github.com/astral-sh/ruff/issues/4899
+14 14 | "" % {
+15    |-  'test1': '',16    |-  'test2': '',
+   15 |+  
+17 16 | }
 
 


### PR DESCRIPTION
## Summary

This PR updates the revision of `LibCST` dependency to https://github.com/Instagram/LibCST/commit/9c263aa8977962a870ce2770d2aa18ee0dacb344
inorder to fix https://github.com/astral-sh/ruff/issues/4899

## Test Plan

The test case including the carriage return (`\r`) character was added for
`F504` and then `cargo test`.

fixes: #4899
