### PR TITLE
Avoid duplicate fixes for multi-import imports in RUF017

### DIFF
--- a/crates/ruff/resources/test/fixtures/ruff/RUF017.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF017.py
@@ -12,3 +12,10 @@ sum([[1, 2, 3], [4, 5, 6]],
 # OK
 sum([x, y])
 sum([[1, 2, 3], [4, 5, 6]])
+
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/7059
+def func():
+    import functools, operator
+
+    sum([x, y], [])

--- a/crates/ruff/src/rules/ruff/rules/quadratic_list_summation.rs
+++ b/crates/ruff/src/rules/ruff/rules/quadratic_list_summation.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use itertools::Itertools;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -106,7 +107,7 @@ fn convert_to_reduce(iterable: &Expr, call: &ast::ExprCall, checker: &Checker) -
             format!("{reduce_binding}({iadd_binding}, {iterable}, [])"),
             call.range(),
         ),
-        [reduce_edit, iadd_edit],
+        [reduce_edit, iadd_edit].into_iter().dedup(),
     ))
 }
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF017_RUF017.py.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF017_RUF017.py.snap
@@ -131,4 +131,20 @@ RUF017.py:9:1: RUF017 [*] Avoid quadratic list summation
 12 13 | # OK
 13 14 | sum([x, y])
 
+RUF017.py:21:5: RUF017 [*] Avoid quadratic list summation
+   |
+19 |     import functools, operator
+20 | 
+21 |     sum([x, y], [])
+   |     ^^^^^^^^^^^^^^^ RUF017
+   |
+   = help: Replace with `functools.reduce`
+
+ℹ Suggested fix
+18 18 | def func():
+19 19 |     import functools, operator
+20 20 | 
+21    |-    sum([x, y], [])
+   21 |+    functools.reduce(operator.iadd, [x, y], [])
+
 


### PR DESCRIPTION
If a user has `import collections, functools, operator`, and we try to import from `functools` and `operator`, we end up adding two identical synthetic edits to preserve that import statement. We need to dedupe them.

Closes https://github.com/astral-sh/ruff/issues/7059.