### PR TITLE
Expand if-expressions with leading and trailing comments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/if.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/if.py
@@ -108,3 +108,60 @@ def something():
         if flat
         else ValuesListIterable)
     )
+
+
+# Expanding leading and trailing comments.
+before = (
+    # comment
+    0
+    if self.thing is None
+    else before - after
+)
+
+before = (
+    0
+    if self.thing is None
+    else before - after
+    # comment
+)
+
+before = (  # comment
+    0
+    if self.thing is None
+    else before - after
+)
+
+before = (
+    # comment
+    (0
+     if self.thing is None
+     else before - after
+     ))
+
+before = [
+    # comment
+    0
+    if self.thing is None
+    else before - after
+]
+
+before = (
+    # comment
+    0
+    if self.thing is None
+    else before - after
+)
+
+before = [
+    # comment
+    0
+    if self.thing is None
+    else before - after,
+    2
+]
+
+before = (
+    0
+    if self.thing is None
+    else before - after  # comment
+)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/if.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/if.py
@@ -149,7 +149,8 @@ before = (
     # comment
     0
     if self.thing is None
-    else before - after
+    else before - after,
+    2
 )
 
 before = [

--- a/crates/ruff_python_formatter/src/expression/expr_if_exp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_if_exp.rs
@@ -53,9 +53,22 @@ impl FormatNodeRule<ExprIfExp> for FormatExprIfExp {
         let comments = f.context().comments().clone();
 
         let inner = format_with(|f: &mut PyFormatter| {
-            // We place `if test` and `else orelse` on a single line, so the `test` and `orelse` leading
-            // comments go on the line before the `if` or `else` instead of directly ahead `test` or
-            // `orelse`
+            // If the expression has any leading or trailing comments, always expand it, as in:
+            // ```
+            // (
+            //     # comment
+            //     0
+            //     if self.thing is None
+            //     else before - after
+            // )
+            // ```
+            if comments.has_leading(item) || comments.has_trailing(item) {
+                expand_parent().fmt(f)?;
+            }
+
+            // We place `if test` and `else orelse` on a single line, so the `test` and `orelse`
+            // leading comments go on the line before the `if` or `else` instead of directly ahead
+            // `test` or `orelse`.
             write!(
                 f,
                 [

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__if.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__if.py.snap
@@ -155,7 +155,8 @@ before = (
     # comment
     0
     if self.thing is None
-    else before - after
+    else before - after,
+    2
 )
 
 before = [
@@ -336,16 +337,13 @@ before = [
 
 before = (
     # comment
-    0
-    if self.thing is None
-    else before - after
+    0 if self.thing is None else before - after,
+    2,
 )
 
 before = [
     # comment
-    0
-    if self.thing is None
-    else before - after,
+    0 if self.thing is None else before - after,
     2,
 ]
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__if.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__if.py.snap
@@ -114,6 +114,63 @@ def something():
         if flat
         else ValuesListIterable)
     )
+
+
+# Expanding leading and trailing comments.
+before = (
+    # comment
+    0
+    if self.thing is None
+    else before - after
+)
+
+before = (
+    0
+    if self.thing is None
+    else before - after
+    # comment
+)
+
+before = (  # comment
+    0
+    if self.thing is None
+    else before - after
+)
+
+before = (
+    # comment
+    (0
+     if self.thing is None
+     else before - after
+     ))
+
+before = [
+    # comment
+    0
+    if self.thing is None
+    else before - after
+]
+
+before = (
+    # comment
+    0
+    if self.thing is None
+    else before - after
+)
+
+before = [
+    # comment
+    0
+    if self.thing is None
+    else before - after,
+    2
+]
+
+before = (
+    0
+    if self.thing is None
+    else before - after  # comment
+)
 ```
 
 ## Output
@@ -240,6 +297,63 @@ def something():
             else ValuesListIterable
         )
     )
+
+
+# Expanding leading and trailing comments.
+before = (
+    # comment
+    0
+    if self.thing is None
+    else before - after
+)
+
+before = (
+    0
+    if self.thing is None
+    else before - after
+    # comment
+)
+
+before = (  # comment
+    0
+    if self.thing is None
+    else before - after
+)
+
+before = (
+    # comment
+    0
+    if self.thing is None
+    else before - after
+)
+
+before = [
+    # comment
+    0
+    if self.thing is None
+    else before - after
+]
+
+before = (
+    # comment
+    0
+    if self.thing is None
+    else before - after
+)
+
+before = [
+    # comment
+    0
+    if self.thing is None
+    else before - after,
+    2,
+]
+
+before = (
+    0
+    if self.thing is None
+    else before - after  # comment
+)
 ```
 
 


### PR DESCRIPTION
## Summary

Black appears to expand if-expressions when they contain leading or trailing own-line comments, if they're the only expression in a set of brackets (parenthesized, or the only element in a list or tuple) -- see the [playground](https://black.vercel.app/?version=main&state=_Td6WFoAAATm1rRGAgAhARYAAAB0L-Wj4ALtAKtdAD2IimZxl1N_WlTWs6ra1iDKWjAPAF8A1eA3JJuhoRcrxg1GcFUyUKdBgvXAKf9vb2b2GNeOKaqRVL99qLhz_7CFFeh2p2wszSTX0xlzDVNKB5fS1mxpy8SWRl56WbjlWd1hmvliVVZomrrTLj3M3Xyu0RL7AZkbyqHEmsw9aiZ62mj0ufah9LqO-SCSCXgKLE-XDbDdUO1w3hw8Ou6v1uLDy_tFArdKueDmAAAAbEf-eL11oJwAAccB7gUAAIEns8KxxGf7AgAAAAAEWVo=).

This PR applies the same logic to our own if-expression formatting.

Closes https://github.com/astral-sh/ruff/issues/7066.

No change in similarity:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99957 |              2760 |                67 |
| transformers |           0.99927 |              2587 |               468 |
| twine        |           0.99982 |                33 |                 1 |
| typeshed     |           0.99978 |              3496 |              2173 |
| warehouse    |           0.99818 |               648 |                24 |
| zulip        |           0.99942 |              1437 |                32 |
