### PR TITLE
Use symbol import for NPY003 replacement

### DIFF
--- a/crates/ruff/resources/test/fixtures/numpy/NPY003.py
+++ b/crates/ruff/resources/test/fixtures/numpy/NPY003.py
@@ -1,15 +1,18 @@
-import numpy as np
+def func():
+    import numpy as np
 
-np.round_(np.random.rand(5, 5), 2)
-np.product(np.random.rand(5, 5))
-np.cumproduct(np.random.rand(5, 5))
-np.sometrue(np.random.rand(5, 5))
-np.alltrue(np.random.rand(5, 5))
+    np.round_(np.random.rand(5, 5), 2)
+    np.product(np.random.rand(5, 5))
+    np.cumproduct(np.random.rand(5, 5))
+    np.sometrue(np.random.rand(5, 5))
+    np.alltrue(np.random.rand(5, 5))
 
-from numpy import round_, product, cumproduct, sometrue, alltrue
 
-round_(np.random.rand(5, 5), 2)
-product(np.random.rand(5, 5))
-cumproduct(np.random.rand(5, 5))
-sometrue(np.random.rand(5, 5))
-alltrue(np.random.rand(5, 5))
+def func():
+    from numpy import round_, product, cumproduct, sometrue, alltrue
+
+    round_(np.random.rand(5, 5), 2)
+    product(np.random.rand(5, 5))
+    cumproduct(np.random.rand(5, 5))
+    sometrue(np.random.rand(5, 5))
+    alltrue(np.random.rand(5, 5))

--- a/crates/ruff/src/rules/numpy/rules/deprecated_function.rs
+++ b/crates/ruff/src/rules/numpy/rules/deprecated_function.rs
@@ -1,10 +1,10 @@
-use ruff_python_ast::{self as ast, Expr};
-
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::Expr;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
+use crate::importer::ImportRequest;
 use crate::registry::AsRule;
 
 /// ## What it does
@@ -77,21 +77,15 @@ pub(crate) fn deprecated_function(checker: &mut Checker, expr: &Expr) {
             expr.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            match expr {
-                Expr::Name(_) => {
-                    diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
-                        replacement.to_string(),
-                        expr.range(),
-                    )));
-                }
-                Expr::Attribute(ast::ExprAttribute { attr, .. }) => {
-                    diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
-                        replacement.to_string(),
-                        attr.range(),
-                    )));
-                }
-                _ => {}
-            }
+            diagnostic.try_set_fix(|| {
+                let (import_edit, binding) = checker.importer().get_or_import_symbol(
+                    &ImportRequest::import_from("numpy", replacement),
+                    expr.start(),
+                    checker.semantic(),
+                )?;
+                let replacement_edit = Edit::range_replacement(binding, expr.range());
+                Ok(Fix::suggested_edits(import_edit, [replacement_edit]))
+            });
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/numpy/snapshots/ruff__rules__numpy__tests__numpy-deprecated-function_NPY003.py.snap
+++ b/crates/ruff/src/rules/numpy/snapshots/ruff__rules__numpy__tests__numpy-deprecated-function_NPY003.py.snap
@@ -1,201 +1,225 @@
 ---
 source: crates/ruff/src/rules/numpy/mod.rs
 ---
-NPY003.py:3:1: NPY003 [*] `np.round_` is deprecated; use `np.round` instead
+NPY003.py:4:5: NPY003 [*] `np.round_` is deprecated; use `np.round` instead
   |
-1 | import numpy as np
-2 | 
-3 | np.round_(np.random.rand(5, 5), 2)
-  | ^^^^^^^^^ NPY003
-4 | np.product(np.random.rand(5, 5))
-5 | np.cumproduct(np.random.rand(5, 5))
+2 |     import numpy as np
+3 | 
+4 |     np.round_(np.random.rand(5, 5), 2)
+  |     ^^^^^^^^^ NPY003
+5 |     np.product(np.random.rand(5, 5))
+6 |     np.cumproduct(np.random.rand(5, 5))
   |
   = help: Replace with `np.round`
 
 ℹ Suggested fix
-1 1 | import numpy as np
-2 2 | 
-3   |-np.round_(np.random.rand(5, 5), 2)
-  3 |+np.round(np.random.rand(5, 5), 2)
-4 4 | np.product(np.random.rand(5, 5))
-5 5 | np.cumproduct(np.random.rand(5, 5))
-6 6 | np.sometrue(np.random.rand(5, 5))
+1 1 | def func():
+2 2 |     import numpy as np
+3 3 | 
+4   |-    np.round_(np.random.rand(5, 5), 2)
+  4 |+    np.round(np.random.rand(5, 5), 2)
+5 5 |     np.product(np.random.rand(5, 5))
+6 6 |     np.cumproduct(np.random.rand(5, 5))
+7 7 |     np.sometrue(np.random.rand(5, 5))
 
-NPY003.py:4:1: NPY003 [*] `np.product` is deprecated; use `np.prod` instead
+NPY003.py:5:5: NPY003 [*] `np.product` is deprecated; use `np.prod` instead
   |
-3 | np.round_(np.random.rand(5, 5), 2)
-4 | np.product(np.random.rand(5, 5))
-  | ^^^^^^^^^^ NPY003
-5 | np.cumproduct(np.random.rand(5, 5))
-6 | np.sometrue(np.random.rand(5, 5))
+4 |     np.round_(np.random.rand(5, 5), 2)
+5 |     np.product(np.random.rand(5, 5))
+  |     ^^^^^^^^^^ NPY003
+6 |     np.cumproduct(np.random.rand(5, 5))
+7 |     np.sometrue(np.random.rand(5, 5))
   |
   = help: Replace with `np.prod`
 
 ℹ Suggested fix
-1 1 | import numpy as np
-2 2 | 
-3 3 | np.round_(np.random.rand(5, 5), 2)
-4   |-np.product(np.random.rand(5, 5))
-  4 |+np.prod(np.random.rand(5, 5))
-5 5 | np.cumproduct(np.random.rand(5, 5))
-6 6 | np.sometrue(np.random.rand(5, 5))
-7 7 | np.alltrue(np.random.rand(5, 5))
+2 2 |     import numpy as np
+3 3 | 
+4 4 |     np.round_(np.random.rand(5, 5), 2)
+5   |-    np.product(np.random.rand(5, 5))
+  5 |+    np.prod(np.random.rand(5, 5))
+6 6 |     np.cumproduct(np.random.rand(5, 5))
+7 7 |     np.sometrue(np.random.rand(5, 5))
+8 8 |     np.alltrue(np.random.rand(5, 5))
 
-NPY003.py:5:1: NPY003 [*] `np.cumproduct` is deprecated; use `np.cumprod` instead
+NPY003.py:6:5: NPY003 [*] `np.cumproduct` is deprecated; use `np.cumprod` instead
   |
-3 | np.round_(np.random.rand(5, 5), 2)
-4 | np.product(np.random.rand(5, 5))
-5 | np.cumproduct(np.random.rand(5, 5))
-  | ^^^^^^^^^^^^^ NPY003
-6 | np.sometrue(np.random.rand(5, 5))
-7 | np.alltrue(np.random.rand(5, 5))
+4 |     np.round_(np.random.rand(5, 5), 2)
+5 |     np.product(np.random.rand(5, 5))
+6 |     np.cumproduct(np.random.rand(5, 5))
+  |     ^^^^^^^^^^^^^ NPY003
+7 |     np.sometrue(np.random.rand(5, 5))
+8 |     np.alltrue(np.random.rand(5, 5))
   |
   = help: Replace with `np.cumprod`
 
 ℹ Suggested fix
-2 2 | 
-3 3 | np.round_(np.random.rand(5, 5), 2)
-4 4 | np.product(np.random.rand(5, 5))
-5   |-np.cumproduct(np.random.rand(5, 5))
-  5 |+np.cumprod(np.random.rand(5, 5))
-6 6 | np.sometrue(np.random.rand(5, 5))
-7 7 | np.alltrue(np.random.rand(5, 5))
-8 8 | 
+3 3 | 
+4 4 |     np.round_(np.random.rand(5, 5), 2)
+5 5 |     np.product(np.random.rand(5, 5))
+6   |-    np.cumproduct(np.random.rand(5, 5))
+  6 |+    np.cumprod(np.random.rand(5, 5))
+7 7 |     np.sometrue(np.random.rand(5, 5))
+8 8 |     np.alltrue(np.random.rand(5, 5))
+9 9 | 
 
-NPY003.py:6:1: NPY003 [*] `np.sometrue` is deprecated; use `np.any` instead
+NPY003.py:7:5: NPY003 [*] `np.sometrue` is deprecated; use `np.any` instead
   |
-4 | np.product(np.random.rand(5, 5))
-5 | np.cumproduct(np.random.rand(5, 5))
-6 | np.sometrue(np.random.rand(5, 5))
-  | ^^^^^^^^^^^ NPY003
-7 | np.alltrue(np.random.rand(5, 5))
+5 |     np.product(np.random.rand(5, 5))
+6 |     np.cumproduct(np.random.rand(5, 5))
+7 |     np.sometrue(np.random.rand(5, 5))
+  |     ^^^^^^^^^^^ NPY003
+8 |     np.alltrue(np.random.rand(5, 5))
   |
   = help: Replace with `np.any`
 
 ℹ Suggested fix
-3 3 | np.round_(np.random.rand(5, 5), 2)
-4 4 | np.product(np.random.rand(5, 5))
-5 5 | np.cumproduct(np.random.rand(5, 5))
-6   |-np.sometrue(np.random.rand(5, 5))
-  6 |+np.any(np.random.rand(5, 5))
-7 7 | np.alltrue(np.random.rand(5, 5))
-8 8 | 
-9 9 | from numpy import round_, product, cumproduct, sometrue, alltrue
+4 4 |     np.round_(np.random.rand(5, 5), 2)
+5 5 |     np.product(np.random.rand(5, 5))
+6 6 |     np.cumproduct(np.random.rand(5, 5))
+7   |-    np.sometrue(np.random.rand(5, 5))
+  7 |+    np.any(np.random.rand(5, 5))
+8 8 |     np.alltrue(np.random.rand(5, 5))
+9 9 | 
+10 10 | 
 
-NPY003.py:7:1: NPY003 [*] `np.alltrue` is deprecated; use `np.all` instead
+NPY003.py:8:5: NPY003 [*] `np.alltrue` is deprecated; use `np.all` instead
   |
-5 | np.cumproduct(np.random.rand(5, 5))
-6 | np.sometrue(np.random.rand(5, 5))
-7 | np.alltrue(np.random.rand(5, 5))
-  | ^^^^^^^^^^ NPY003
-8 | 
-9 | from numpy import round_, product, cumproduct, sometrue, alltrue
+6 |     np.cumproduct(np.random.rand(5, 5))
+7 |     np.sometrue(np.random.rand(5, 5))
+8 |     np.alltrue(np.random.rand(5, 5))
+  |     ^^^^^^^^^^ NPY003
   |
   = help: Replace with `np.all`
 
 ℹ Suggested fix
-4 4 | np.product(np.random.rand(5, 5))
-5 5 | np.cumproduct(np.random.rand(5, 5))
-6 6 | np.sometrue(np.random.rand(5, 5))
-7   |-np.alltrue(np.random.rand(5, 5))
-  7 |+np.all(np.random.rand(5, 5))
-8 8 | 
-9 9 | from numpy import round_, product, cumproduct, sometrue, alltrue
+5 5 |     np.product(np.random.rand(5, 5))
+6 6 |     np.cumproduct(np.random.rand(5, 5))
+7 7 |     np.sometrue(np.random.rand(5, 5))
+8   |-    np.alltrue(np.random.rand(5, 5))
+  8 |+    np.all(np.random.rand(5, 5))
+9 9 | 
 10 10 | 
+11 11 | def func():
 
-NPY003.py:11:1: NPY003 [*] `np.round_` is deprecated; use `np.round` instead
+NPY003.py:14:5: NPY003 [*] `np.round_` is deprecated; use `np.round` instead
    |
- 9 | from numpy import round_, product, cumproduct, sometrue, alltrue
-10 | 
-11 | round_(np.random.rand(5, 5), 2)
-   | ^^^^^^ NPY003
-12 | product(np.random.rand(5, 5))
-13 | cumproduct(np.random.rand(5, 5))
+12 |     from numpy import round_, product, cumproduct, sometrue, alltrue
+13 | 
+14 |     round_(np.random.rand(5, 5), 2)
+   |     ^^^^^^ NPY003
+15 |     product(np.random.rand(5, 5))
+16 |     cumproduct(np.random.rand(5, 5))
    |
    = help: Replace with `np.round`
 
 ℹ Suggested fix
-8  8  | 
-9  9  | from numpy import round_, product, cumproduct, sometrue, alltrue
-10 10 | 
-11    |-round_(np.random.rand(5, 5), 2)
-   11 |+round(np.random.rand(5, 5), 2)
-12 12 | product(np.random.rand(5, 5))
-13 13 | cumproduct(np.random.rand(5, 5))
-14 14 | sometrue(np.random.rand(5, 5))
+   1  |+from numpy import round
+1  2  | def func():
+2  3  |     import numpy as np
+3  4  | 
+--------------------------------------------------------------------------------
+11 12 | def func():
+12 13 |     from numpy import round_, product, cumproduct, sometrue, alltrue
+13 14 | 
+14    |-    round_(np.random.rand(5, 5), 2)
+   15 |+    round(np.random.rand(5, 5), 2)
+15 16 |     product(np.random.rand(5, 5))
+16 17 |     cumproduct(np.random.rand(5, 5))
+17 18 |     sometrue(np.random.rand(5, 5))
 
-NPY003.py:12:1: NPY003 [*] `np.product` is deprecated; use `np.prod` instead
+NPY003.py:15:5: NPY003 [*] `np.product` is deprecated; use `np.prod` instead
    |
-11 | round_(np.random.rand(5, 5), 2)
-12 | product(np.random.rand(5, 5))
-   | ^^^^^^^ NPY003
-13 | cumproduct(np.random.rand(5, 5))
-14 | sometrue(np.random.rand(5, 5))
+14 |     round_(np.random.rand(5, 5), 2)
+15 |     product(np.random.rand(5, 5))
+   |     ^^^^^^^ NPY003
+16 |     cumproduct(np.random.rand(5, 5))
+17 |     sometrue(np.random.rand(5, 5))
    |
    = help: Replace with `np.prod`
 
 ℹ Suggested fix
-9  9  | from numpy import round_, product, cumproduct, sometrue, alltrue
-10 10 | 
-11 11 | round_(np.random.rand(5, 5), 2)
-12    |-product(np.random.rand(5, 5))
-   12 |+prod(np.random.rand(5, 5))
-13 13 | cumproduct(np.random.rand(5, 5))
-14 14 | sometrue(np.random.rand(5, 5))
-15 15 | alltrue(np.random.rand(5, 5))
+   1  |+from numpy import prod
+1  2  | def func():
+2  3  |     import numpy as np
+3  4  | 
+--------------------------------------------------------------------------------
+12 13 |     from numpy import round_, product, cumproduct, sometrue, alltrue
+13 14 | 
+14 15 |     round_(np.random.rand(5, 5), 2)
+15    |-    product(np.random.rand(5, 5))
+   16 |+    prod(np.random.rand(5, 5))
+16 17 |     cumproduct(np.random.rand(5, 5))
+17 18 |     sometrue(np.random.rand(5, 5))
+18 19 |     alltrue(np.random.rand(5, 5))
 
-NPY003.py:13:1: NPY003 [*] `np.cumproduct` is deprecated; use `np.cumprod` instead
+NPY003.py:16:5: NPY003 [*] `np.cumproduct` is deprecated; use `np.cumprod` instead
    |
-11 | round_(np.random.rand(5, 5), 2)
-12 | product(np.random.rand(5, 5))
-13 | cumproduct(np.random.rand(5, 5))
-   | ^^^^^^^^^^ NPY003
-14 | sometrue(np.random.rand(5, 5))
-15 | alltrue(np.random.rand(5, 5))
+14 |     round_(np.random.rand(5, 5), 2)
+15 |     product(np.random.rand(5, 5))
+16 |     cumproduct(np.random.rand(5, 5))
+   |     ^^^^^^^^^^ NPY003
+17 |     sometrue(np.random.rand(5, 5))
+18 |     alltrue(np.random.rand(5, 5))
    |
    = help: Replace with `np.cumprod`
 
 ℹ Suggested fix
-10 10 | 
-11 11 | round_(np.random.rand(5, 5), 2)
-12 12 | product(np.random.rand(5, 5))
-13    |-cumproduct(np.random.rand(5, 5))
-   13 |+cumprod(np.random.rand(5, 5))
-14 14 | sometrue(np.random.rand(5, 5))
-15 15 | alltrue(np.random.rand(5, 5))
+   1  |+from numpy import cumprod
+1  2  | def func():
+2  3  |     import numpy as np
+3  4  | 
+--------------------------------------------------------------------------------
+13 14 | 
+14 15 |     round_(np.random.rand(5, 5), 2)
+15 16 |     product(np.random.rand(5, 5))
+16    |-    cumproduct(np.random.rand(5, 5))
+   17 |+    cumprod(np.random.rand(5, 5))
+17 18 |     sometrue(np.random.rand(5, 5))
+18 19 |     alltrue(np.random.rand(5, 5))
 
-NPY003.py:14:1: NPY003 [*] `np.sometrue` is deprecated; use `np.any` instead
+NPY003.py:17:5: NPY003 [*] `np.sometrue` is deprecated; use `np.any` instead
    |
-12 | product(np.random.rand(5, 5))
-13 | cumproduct(np.random.rand(5, 5))
-14 | sometrue(np.random.rand(5, 5))
-   | ^^^^^^^^ NPY003
-15 | alltrue(np.random.rand(5, 5))
+15 |     product(np.random.rand(5, 5))
+16 |     cumproduct(np.random.rand(5, 5))
+17 |     sometrue(np.random.rand(5, 5))
+   |     ^^^^^^^^ NPY003
+18 |     alltrue(np.random.rand(5, 5))
    |
    = help: Replace with `np.any`
 
 ℹ Suggested fix
-11 11 | round_(np.random.rand(5, 5), 2)
-12 12 | product(np.random.rand(5, 5))
-13 13 | cumproduct(np.random.rand(5, 5))
-14    |-sometrue(np.random.rand(5, 5))
-   14 |+any(np.random.rand(5, 5))
-15 15 | alltrue(np.random.rand(5, 5))
+   1  |+from numpy import any
+1  2  | def func():
+2  3  |     import numpy as np
+3  4  | 
+--------------------------------------------------------------------------------
+14 15 |     round_(np.random.rand(5, 5), 2)
+15 16 |     product(np.random.rand(5, 5))
+16 17 |     cumproduct(np.random.rand(5, 5))
+17    |-    sometrue(np.random.rand(5, 5))
+   18 |+    any(np.random.rand(5, 5))
+18 19 |     alltrue(np.random.rand(5, 5))
 
-NPY003.py:15:1: NPY003 [*] `np.alltrue` is deprecated; use `np.all` instead
+NPY003.py:18:5: NPY003 [*] `np.alltrue` is deprecated; use `np.all` instead
    |
-13 | cumproduct(np.random.rand(5, 5))
-14 | sometrue(np.random.rand(5, 5))
-15 | alltrue(np.random.rand(5, 5))
-   | ^^^^^^^ NPY003
+16 |     cumproduct(np.random.rand(5, 5))
+17 |     sometrue(np.random.rand(5, 5))
+18 |     alltrue(np.random.rand(5, 5))
+   |     ^^^^^^^ NPY003
    |
    = help: Replace with `np.all`
 
 ℹ Suggested fix
-12 12 | product(np.random.rand(5, 5))
-13 13 | cumproduct(np.random.rand(5, 5))
-14 14 | sometrue(np.random.rand(5, 5))
-15    |-alltrue(np.random.rand(5, 5))
-   15 |+all(np.random.rand(5, 5))
+   1  |+from numpy import all
+1  2  | def func():
+2  3  |     import numpy as np
+3  4  | 
+--------------------------------------------------------------------------------
+15 16 |     product(np.random.rand(5, 5))
+16 17 |     cumproduct(np.random.rand(5, 5))
+17 18 |     sometrue(np.random.rand(5, 5))
+18    |-    alltrue(np.random.rand(5, 5))
+   19 |+    all(np.random.rand(5, 5))
 
 


### PR DESCRIPTION
## Summary

This moves the `NPY003` autofix to our symbol import infrastructure. It closes https://github.com/astral-sh/ruff/issues/7077, or at least, means we can merge that issue with https://github.com/astral-sh/ruff/issues/6842. It also ensures that if the symbol is imported using `from numpy import round_`, we don't _assume_ that `round` is bound to `np.round` as we did before.
