### PR TITLE
Fix incorrect flake8-copyright link in faq

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -145,7 +145,7 @@ Today, Ruff can be used to replace Flake8 when used with any of the following pl
 - [flake8-builtins](https://pypi.org/project/flake8-builtins/)
 - [flake8-commas](https://pypi.org/project/flake8-commas/)
 - [flake8-comprehensions](https://pypi.org/project/flake8-comprehensions/)
-- [flake8-copyright](https://pypi.org/project/flake8-comprehensions/)
+- [flake8-copyright](https://pypi.org/project/flake8-copyright/)
 - [flake8-datetimez](https://pypi.org/project/flake8-datetimez/)
 - [flake8-debugger](https://pypi.org/project/flake8-debugger/)
 - [flake8-django](https://pypi.org/project/flake8-django/)


### PR DESCRIPTION
## Summary

One of the links to `flake8-copyright` points to the PyPI page for `flake8-comprehension`- let's make that link point to the correct page.

## Test Plan

Spun up a local instance of the docs and confirmed that the new link goes to the right page. I also did a quick spot-check to make sure the other links in that section point to the right places.
