### PR TITLE
Preserve parentheses around partial call chains

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/parentheses/call_chains.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/parentheses/call_chains.py
@@ -161,3 +161,58 @@ max_message_id = (
 max_message_id = (
     Message.objects.filter(recipient=recipient).order_by("id").reverse()[0].id()
 )
+
+# Parentheses with fluent style within and outside of the parentheses.
+(
+    (
+        df1_aaaaaaaaaaaa.merge()
+    )
+    .groupby(1,)
+    .sum()
+)
+
+(
+    ( # foo
+        df1_aaaaaaaaaaaa.merge()
+    )
+    .groupby(1,)
+    .sum()
+)
+
+(
+    (
+        df1_aaaaaaaaaaaa.merge()
+        .groupby(1,)
+    )
+    .sum()
+)
+
+
+(
+    (
+        df1_aaaaaaaaaaaa.merge()
+        .groupby(1,)
+    )
+    .sum()
+    .bar()
+)
+
+(
+    (
+        df1_aaaaaaaaaaaa.merge()
+        .groupby(1,)
+        .bar()
+    )
+    .sum()
+)
+
+(
+    (
+        df1_aaaaaaaaaaaa.merge()
+        .groupby(1,)
+        .bar()
+    )
+    .sum()
+    .baz()
+)
+

--- a/crates/ruff_python_formatter/tests/snapshots/format@parentheses__call_chains.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@parentheses__call_chains.py.snap
@@ -167,6 +167,61 @@ max_message_id = (
 max_message_id = (
     Message.objects.filter(recipient=recipient).order_by("id").reverse()[0].id()
 )
+
+# Parentheses with fluent style within and outside of the parentheses.
+(
+    (
+        df1_aaaaaaaaaaaa.merge()
+    )
+    .groupby(1,)
+    .sum()
+)
+
+(
+    ( # foo
+        df1_aaaaaaaaaaaa.merge()
+    )
+    .groupby(1,)
+    .sum()
+)
+
+(
+    (
+        df1_aaaaaaaaaaaa.merge()
+        .groupby(1,)
+    )
+    .sum()
+)
+
+
+(
+    (
+        df1_aaaaaaaaaaaa.merge()
+        .groupby(1,)
+    )
+    .sum()
+    .bar()
+)
+
+(
+    (
+        df1_aaaaaaaaaaaa.merge()
+        .groupby(1,)
+        .bar()
+    )
+    .sum()
+)
+
+(
+    (
+        df1_aaaaaaaaaaaa.merge()
+        .groupby(1,)
+        .bar()
+    )
+    .sum()
+    .baz()
+)
+
 ```
 
 ## Output
@@ -349,6 +404,66 @@ max_message_id = (
 
 max_message_id = (
     Message.objects.filter(recipient=recipient).order_by("id").reverse()[0].id()
+)
+
+# Parentheses with fluent style within and outside of the parentheses.
+(
+    (df1_aaaaaaaaaaaa.merge())
+    .groupby(
+        1,
+    )
+    .sum()
+)
+
+(
+    (  # foo
+        df1_aaaaaaaaaaaa.merge()
+    )
+    .groupby(
+        1,
+    )
+    .sum()
+)
+
+(
+    (
+        df1_aaaaaaaaaaaa.merge().groupby(
+            1,
+        )
+    ).sum()
+)
+
+
+(
+    (
+        df1_aaaaaaaaaaaa.merge().groupby(
+            1,
+        )
+    )
+    .sum()
+    .bar()
+)
+
+(
+    (
+        df1_aaaaaaaaaaaa.merge()
+        .groupby(
+            1,
+        )
+        .bar()
+    ).sum()
+)
+
+(
+    (
+        df1_aaaaaaaaaaaa.merge()
+        .groupby(
+            1,
+        )
+        .bar()
+    )
+    .sum()
+    .baz()
 )
 ```
 


### PR DESCRIPTION
## Summary

This PR fixes a subtle deviation in call chain formatting, the first being that we weren't preserving parentheses around parts of a call chain, and the second being that we were propagating call chain formatting incorrectly when part of the call chain was parenthesized.

Consider these two cases:

```python
(
    (
        df1_aaaaaaaaaaaa.merge()
        .groupby(1,)
    )
    .sum()
)


(
    (
        df1_aaaaaaaaaaaa.merge()
        .groupby(1,)
    )
    .sum()
    .bar()
)
```

In the former case, nothing should be call-chain formatted. In the latter, _only_ the `.sum().bar()` should be call-chain formatted. To implement this, we need to ensure that we (1) retain parentheses around the first part of the call chain, but also (2) avoid propagating the call chain formatting across the parenthesis boundary.

Closes https://github.com/astral-sh/ruff/issues/7050.

## Test Plan

`cargo test`

Small improvement in transformers (12 files went from changed to unchanged).

Before:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99957 |              2760 |                67 |
| transformers |           0.99927 |              2587 |               468 |
| twine        |           0.99982 |                33 |                 1 |
| typeshed     |           0.99978 |              3496 |              2173 |
| warehouse    |           0.99818 |               648 |                24 |
| zulip        |           0.99942 |              1437 |                32 |

After:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99957 |              2760 |                67 |
| **transformers** |           **0.99928** |              **2587** |               **456** |
| twine        |           0.99982 |                33 |                 1 |
| typeshed     |           0.99978 |              3496 |              2173 |
| warehouse    |           0.99818 |               648 |                24 |
| zulip        |           0.99942 |              1437 |                32 |
