### PR TITLE
Avoid adding duplicate `capture_output` keyword to `subprocess.run`

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP022.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP022.py
@@ -35,6 +35,13 @@ if output:
         encoding="utf-8",
     )
 
+output = subprocess.run(
+    ["foo"], stdout=subprocess.PIPE, capture_output=True, stderr=subprocess.PIPE
+)
+
+output = subprocess.run(
+    ["foo"], stdout=subprocess.PIPE, capture_output=False, stderr=subprocess.PIPE
+)
 
 # Examples that should NOT trigger the rule
 from foo import PIPE

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP022.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP022.py.snap
@@ -157,6 +157,8 @@ UP022.py:29:14: UP022 [*] Sending `stdout` and `stderr` to `PIPE` is deprecated,
 35 | |         encoding="utf-8",
 36 | |     )
    | |_____^ UP022
+37 |   
+38 |   output = subprocess.run(
    |
    = help: Replace with `capture_output` keyword argument
 
@@ -171,5 +173,53 @@ UP022.py:29:14: UP022 [*] Sending `stdout` and `stderr` to `PIPE` is deprecated,
 34 33 |         text=True,
 35 34 |         encoding="utf-8",
 36 35 |     )
+
+UP022.py:38:10: UP022 [*] Sending `stdout` and `stderr` to `PIPE` is deprecated, use `capture_output`
+   |
+36 |       )
+37 |   
+38 |   output = subprocess.run(
+   |  __________^
+39 | |     ["foo"], stdout=subprocess.PIPE, capture_output=True, stderr=subprocess.PIPE
+40 | | )
+   | |_^ UP022
+41 |   
+42 |   output = subprocess.run(
+   |
+   = help: Replace with `capture_output` keyword argument
+
+ℹ Suggested fix
+36 36 |     )
+37 37 | 
+38 38 | output = subprocess.run(
+39    |-    ["foo"], stdout=subprocess.PIPE, capture_output=True, stderr=subprocess.PIPE
+   39 |+    ["foo"], capture_output=True
+40 40 | )
+41 41 | 
+42 42 | output = subprocess.run(
+
+UP022.py:42:10: UP022 [*] Sending `stdout` and `stderr` to `PIPE` is deprecated, use `capture_output`
+   |
+40 |   )
+41 |   
+42 |   output = subprocess.run(
+   |  __________^
+43 | |     ["foo"], stdout=subprocess.PIPE, capture_output=False, stderr=subprocess.PIPE
+44 | | )
+   | |_^ UP022
+45 |   
+46 |   # Examples that should NOT trigger the rule
+   |
+   = help: Replace with `capture_output` keyword argument
+
+ℹ Suggested fix
+40 40 | )
+41 41 | 
+42 42 | output = subprocess.run(
+43    |-    ["foo"], stdout=subprocess.PIPE, capture_output=False, stderr=subprocess.PIPE
+   43 |+    ["foo"], capture_output=False
+44 44 | )
+45 45 | 
+46 46 | # Examples that should NOT trigger the rule
 
 


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/7104.