### PR TITLE
Avoid triggering N806 on `TypeAlias` assignments

### DIFF
--- a/crates/ruff/resources/test/fixtures/pep8_naming/N806.py
+++ b/crates/ruff/resources/test/fixtures/pep8_naming/N806.py
@@ -1,8 +1,6 @@
 import collections
 from collections import namedtuple
-from typing import TypeVar
-from typing import NewType
-from typing import NamedTuple, TypedDict
+from typing import TypeAlias, TypeVar, NewType, NamedTuple, TypedDict
 
 GLOBAL: str = "foo"
 
@@ -21,9 +19,11 @@ def assign():
     T = TypeVar("T")
     UserId = NewType("UserId", int)
 
-    Employee = NamedTuple('Employee', [('name', str), ('id', int)])
+    Employee = NamedTuple("Employee", [("name", str), ("id", int)])
 
-    Point2D = TypedDict('Point2D', {'in': int, 'x-y': int})
+    Point2D = TypedDict("Point2D", {"in": int, "x-y": int})
+
+    IntOrStr: TypeAlias = int | str
 
 
 def aug_assign(rank, world_size):

--- a/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
@@ -70,6 +70,7 @@ pub(crate) fn non_lowercase_variable_in_function(checker: &mut Checker, expr: &E
     if helpers::is_named_tuple_assignment(parent, checker.semantic())
         || helpers::is_typed_dict_assignment(parent, checker.semantic())
         || helpers::is_type_var_assignment(parent, checker.semantic())
+        || helpers::is_type_alias_assignment(parent, checker.semantic())
     {
         return;
     }

--- a/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N806_N806.py.snap
+++ b/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N806_N806.py.snap
@@ -1,23 +1,23 @@
 ---
 source: crates/ruff/src/rules/pep8_naming/mod.rs
 ---
-N806.py:14:5: N806 Variable `Camel` in function should be lowercase
+N806.py:12:5: N806 Variable `Camel` in function should be lowercase
    |
-12 |     GLOBAL = "bar"
-13 |     lower = 0
-14 |     Camel = 0
+10 |     GLOBAL = "bar"
+11 |     lower = 0
+12 |     Camel = 0
    |     ^^^^^ N806
-15 |     CONSTANT = 0
-16 |     _ = 0
+13 |     CONSTANT = 0
+14 |     _ = 0
    |
 
-N806.py:15:5: N806 Variable `CONSTANT` in function should be lowercase
+N806.py:13:5: N806 Variable `CONSTANT` in function should be lowercase
    |
-13 |     lower = 0
-14 |     Camel = 0
-15 |     CONSTANT = 0
+11 |     lower = 0
+12 |     Camel = 0
+13 |     CONSTANT = 0
    |     ^^^^^^^^ N806
-16 |     _ = 0
+14 |     _ = 0
    |
 
 


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/7068, although note that this solution relies on assignments being marked as `TypeAlias`, which is the best we can do for now.

## Test Plan

`cargo test`
