### PR TITLE
Better formatter CLI verbose output

### DIFF
--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -64,7 +64,7 @@ shellexpand = { workspace = true }
 similar = { workspace = true }
 strum = { workspace = true, features = [] }
 thiserror = { workspace = true }
-tracing = { workspace = true }
+tracing = { workspace = true, features = ["log"] }
 walkdir = { version = "2.3.2" }
 wild = { version = "2" }
 


### PR DESCRIPTION
**Summary** A bit of polishing for the formatter CLI verbose output. I'm trying to use more tracing in the main CLI without having to rewrite everything. I included the options for each file because we allow hierarchical configuration, for the formatter at least in theory.

```console
$ target/debug/ruff format -q scripts/
```

```console
$ target/debug/ruff format scripts/
warning: `ruff format` is a work-in-progress, subject to change at any time, and intended only for experimentation.
11 files left unchanged
```

```console
$ target/debug/ruff format -v scripts/
warning: `ruff format` is a work-in-progress, subject to change at any time, and intended only for experimentation.
[2023-09-04][13:37:26][ruff_cli::resolve][DEBUG] Using pyproject.toml (parent) at /home/konsti/ruff/pyproject.toml
[2023-09-04][13:37:26][ignore::walk][DEBUG] ignoring /home/konsti/ruff/scripts/__pycache__: Ignore(IgnoreMatch(Gitignore(Glob { from: Some("/home/konsti/ruff/.gitignore"), original: "__pycache__/", actual: "**/__pycache__", is_whitelist: false, is_only_dir: true })))
[2023-09-04][13:37:26][ruff_workspace::resolver][DEBUG] Included path via `include`: "/home/konsti/ruff/scripts/update_schemastore.py"
[2023-09-04][13:37:26][ruff_workspace::resolver][DEBUG] Included path via `include`: "/home/konsti/ruff/scripts/check_ecosystem.py"
[2023-09-04][13:37:26][ruff_workspace::resolver][DEBUG] Included path via `include`: "/home/konsti/ruff/scripts/transform_readme.py"
[2023-09-04][13:37:26][ruff_workspace::resolver][DEBUG] Included path via `include`: "/home/konsti/ruff/scripts/generate_known_standard_library.py"
[2023-09-04][13:37:26][ruff_workspace::resolver][DEBUG] Included path via `include`: "/home/konsti/ruff/scripts/ecosystem_all_check.py"
[2023-09-04][13:37:26][ruff_workspace::resolver][DEBUG] Included path via `include`: "/home/konsti/ruff/scripts/check_docs_formatted.py"
[2023-09-04][13:37:26][ruff_workspace::resolver][DEBUG] Included path via `include`: "/home/konsti/ruff/scripts/update_ambiguous_characters.py"
[2023-09-04][13:37:26][ruff_workspace::resolver][DEBUG] Included path via `include`: "/home/konsti/ruff/scripts/pyproject.toml"
[2023-09-04][13:37:26][ruff_workspace::resolver][DEBUG] Included path via `include`: "/home/konsti/ruff/scripts/generate_mkdocs.py"
[2023-09-04][13:37:26][ruff_workspace::resolver][DEBUG] Included path via `include`: "/home/konsti/ruff/scripts/_utils.py"
[2023-09-04][13:37:26][ruff_workspace::resolver][DEBUG] Ignored path via `exclude`: "/home/konsti/ruff/scripts/.ruff_cache"
[2023-09-04][13:37:26][ruff_workspace::resolver][DEBUG] Included path via `include`: "/home/konsti/ruff/scripts/add_rule.py"
[2023-09-04][13:37:26][ruff_workspace::resolver][DEBUG] Included path via `include`: "/home/konsti/ruff/scripts/add_plugin.py"
[2023-09-04][13:37:26][ruff_workspace::resolver][DEBUG] Included path via `include`: "/home/konsti/ruff/scripts/benchmarks/pyproject.toml"
[2023-09-04][13:37:26][ruff_cli::commands::format][DEBUG] Formatting /home/konsti/ruff/scripts/update_ambiguous_characters.py with PyFormatOptions { source_type: Python, indent_style: Space(4), line_width: LineWidth(88), tab_width: TabWidth(4), line_ending: LineFeed, quote_style: Double, magic_trailing_comma: Respect, source_map_generation: Disabled }
[2023-09-04][13:37:26][ruff_cli::commands::format][DEBUG] Formatting /home/konsti/ruff/scripts/check_ecosystem.py with PyFormatOptions { source_type: Python, indent_style: Space(4), line_width: LineWidth(88), tab_width: TabWidth(4), line_ending: LineFeed, quote_style: Double, magic_trailing_comma: Respect, source_map_generation: Disabled }
[2023-09-04][13:37:26][ruff_cli::commands::format][DEBUG] Formatting /home/konsti/ruff/scripts/_utils.py with PyFormatOptions { source_type: Python, indent_style: Space(4), line_width: LineWidth(88), tab_width: TabWidth(4), line_ending: LineFeed, quote_style: Double, magic_trailing_comma: Respect, source_map_generation: Disabled }
[2023-09-04][13:37:26][ruff_cli::commands::format][DEBUG] Formatting /home/konsti/ruff/scripts/update_schemastore.py with PyFormatOptions { source_type: Python, indent_style: Space(4), line_width: LineWidth(88), tab_width: TabWidth(4), line_ending: LineFeed, quote_style: Double, magic_trailing_comma: Respect, source_map_generation: Disabled }
[2023-09-04][13:37:26][ruff_cli::commands::format][DEBUG] Formatting /home/konsti/ruff/scripts/transform_readme.py with PyFormatOptions { source_type: Python, indent_style: Space(4), line_width: LineWidth(88), tab_width: TabWidth(4), line_ending: LineFeed, quote_style: Double, magic_trailing_comma: Respect, source_map_generation: Disabled }
[2023-09-04][13:37:26][ruff_cli::commands::format][DEBUG] Formatting /home/konsti/ruff/scripts/add_rule.py with PyFormatOptions { source_type: Python, indent_style: Space(4), line_width: LineWidth(88), tab_width: TabWidth(4), line_ending: LineFeed, quote_style: Double, magic_trailing_comma: Respect, source_map_generation: Disabled }
[2023-09-04][13:37:26][ruff_cli::commands::format][DEBUG] Formatting /home/konsti/ruff/scripts/ecosystem_all_check.py with PyFormatOptions { source_type: Python, indent_style: Space(4), line_width: LineWidth(88), tab_width: TabWidth(4), line_ending: LineFeed, quote_style: Double, magic_trailing_comma: Respect, source_map_generation: Disabled }
[2023-09-04][13:37:26][ruff_cli::commands::format][DEBUG] Formatting /home/konsti/ruff/scripts/generate_known_standard_library.py with PyFormatOptions { source_type: Python, indent_style: Space(4), line_width: LineWidth(88), tab_width: TabWidth(4), line_ending: LineFeed, quote_style: Double, magic_trailing_comma: Respect, source_map_generation: Disabled }
[2023-09-04][13:37:26][ruff_cli::commands::format][DEBUG] Formatting /home/konsti/ruff/scripts/check_docs_formatted.py with PyFormatOptions { source_type: Python, indent_style: Space(4), line_width: LineWidth(88), tab_width: TabWidth(4), line_ending: LineFeed, quote_style: Double, magic_trailing_comma: Respect, source_map_generation: Disabled }
[2023-09-04][13:37:26][ruff_cli::commands::format][DEBUG] Formatting /home/konsti/ruff/scripts/generate_mkdocs.py with PyFormatOptions { source_type: Python, indent_style: Space(4), line_width: LineWidth(88), tab_width: TabWidth(4), line_ending: LineFeed, quote_style: Double, magic_trailing_comma: Respect, source_map_generation: Disabled }
[2023-09-04][13:37:26][ruff_cli::commands::format][DEBUG] Formatting /home/konsti/ruff/scripts/add_plugin.py with PyFormatOptions { source_type: Python, indent_style: Space(4), line_width: LineWidth(88), tab_width: TabWidth(4), line_ending: LineFeed, quote_style: Double, magic_trailing_comma: Respect, source_map_generation: Disabled }
[2023-09-04][13:37:26][ruff_cli::commands::format][DEBUG] Formatted 11 files in 29.62ms
11 files left unchanged
```

**Test Plan** I don't think it makes sense to add tests for this
