### PR TITLE
Added simple docs for argfile

### DIFF
--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -389,3 +389,45 @@ fn unreadable_dir() -> Result<()> {
     );
     Ok(())
 }
+
+/// Read input using argfile
+#[cfg(unix)]
+#[test]
+fn check_input_from_argfile() -> Result<()> {
+    let tempdir = TempDir::new()?;
+
+    // Create python files
+    let file_a_path = tempdir.path().join("a.py");
+    let file_b_path = tempdir.path().join("b.py");
+    fs::write(&file_a_path, b"import os")?;
+    fs::write(&file_b_path, b"print('hello, world!')")?;
+
+    // Create a the input file for argfile to expand
+    let input_file_path = tempdir.path().join("file_paths.txt");
+    let input_file_path_string = &input_file_path.display();
+    fs::write(
+        &input_file_path,
+        format!("{}\n{}", file_a_path.display(), file_b_path.display()),
+    )?;
+
+    // Generate the args with the argfile notation
+    let args = vec![
+        "check".to_string(),
+        "--no-cache".to_string(),
+        format!("@{}", input_file_path_string),
+    ];
+
+    let mut cmd = Command::cargo_bin(BIN_NAME)?;
+    let output = cmd.args(args).write_stdin("").assert().failure();
+    assert_eq!(
+        str::from_utf8(&output.get_output().stdout)?,
+        format!(
+            "{}:1:8: F401 [*] `os` imported but unused
+Found 1 error.
+[*] 1 potentially fixable with the --fix option.
+",
+            file_a_path.display()
+        )
+    );
+    Ok(())
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,6 +7,7 @@ ruff check .                        # Lint all files in the current directory (a
 ruff check path/to/code/            # Lint all files in `/path/to/code` (and any subdirectories)
 ruff check path/to/code/*.py        # Lint all `.py` files in `/path/to/code`
 ruff check path/to/code/to/file.py  # Lint `file.py`
+ruff check @file_paths.txt          # Lint using an input file and treat its contents as command-line arguments (whitespace delimiter)
 ```
 
 You can run Ruff in `--watch` mode to automatically re-run on-change:


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Adding documentation and test for argfile support https://github.com/astral-sh/ruff/pull/4087

## Test Plan

Integration test `check_input_from_argfile` passes in CI. This test uses [argfile](https://docs.rs/argfile/latest/argfile/index.html) to expand CLI arguments.
