### PR TITLE
Use generator for UP007 autofix

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP007.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP007.py
@@ -95,3 +95,11 @@ def f(x: Optional[str, int : float]) -> None:
 
 def f(x: Optional[int, float]) -> None:
     ...
+
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/7131
+class ServiceRefOrValue:
+    service_specification: Optional[
+        list[ServiceSpecificationRef]
+        | list[ServiceSpecification]
+    ] = None

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -1,12 +1,8 @@
-use itertools::Either::{Left, Right};
-use itertools::Itertools;
-use ruff_python_ast::{self as ast, Expr};
-
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::{self as ast, Constant, Expr, ExprContext, Operator};
 use ruff_python_semantic::analyze::typing::Pep604Operator;
-use ruff_source_file::Locator;
-use ruff_text_size::Ranged;
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -83,7 +79,7 @@ pub(crate) fn use_pep604_annotation(
                     }
                     _ => {
                         diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
-                            optional(slice, checker.locator()),
+                            checker.generator().expr(&optional(slice)),
                             expr.range(),
                         )));
                     }
@@ -100,7 +96,7 @@ pub(crate) fn use_pep604_annotation(
                     }
                     Expr::Tuple(ast::ExprTuple { elts, .. }) => {
                         diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
-                            union(elts, checker.locator()),
+                            checker.generator().expr(&union(elts)),
                             expr.range(),
                         )));
                     }
@@ -119,23 +115,36 @@ pub(crate) fn use_pep604_annotation(
 }
 
 /// Format the expression as a PEP 604-style optional.
-fn optional(expr: &Expr, locator: &Locator) -> String {
-    format!("{} | None", locator.slice(expr))
+fn optional(expr: &Expr) -> Expr {
+    ast::ExprBinOp {
+        left: Box::new(expr.clone()),
+        op: Operator::BitOr,
+        right: Box::new(Expr::Constant(ast::ExprConstant {
+            value: Constant::None,
+            kind: None,
+            range: TextRange::default(),
+        })),
+        range: TextRange::default(),
+    }
+    .into()
 }
 
 /// Format the expressions as a PEP 604-style union.
-fn union(elts: &[Expr], locator: &Locator) -> String {
-    let mut elts = elts
-        .iter()
-        .flat_map(|expr| match expr {
-            Expr::Tuple(ast::ExprTuple { elts, .. }) => Left(elts.iter()),
-            _ => Right(std::iter::once(expr)),
-        })
-        .peekable();
-    if elts.peek().is_none() {
-        "()".to_string()
-    } else {
-        elts.map(|expr| locator.slice(expr)).join(" | ")
+fn union(elts: &[Expr]) -> Expr {
+    match elts {
+        [] => Expr::Tuple(ast::ExprTuple {
+            elts: vec![],
+            ctx: ExprContext::Load,
+            range: TextRange::default(),
+        }),
+        [Expr::Tuple(ast::ExprTuple { elts, .. })] => union(elts),
+        [elt] => elt.clone(),
+        [elt, rest @ ..] => Expr::BinOp(ast::ExprBinOp {
+            left: Box::new(union(&[elt.clone()])),
+            op: Operator::BitOr,
+            right: Box::new(union(rest)),
+            range: TextRange::default(),
+        }),
     }
 }
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP007.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP007.py.snap
@@ -50,7 +50,7 @@ UP007.py:14:10: UP007 [*] Use `X | Y` for type annotations
 12 12 | 
 13 13 | 
 14    |-def f(x: Union[str, int, Union[float, bytes]]) -> None:
-   14 |+def f(x: str | int | Union[float, bytes]) -> None:
+   14 |+def f(x: str | (int | Union[float, bytes])) -> None:
 15 15 |     ...
 16 16 | 
 17 17 | 
@@ -176,7 +176,7 @@ UP007.py:38:11: UP007 [*] Use `X | Y` for type annotations
 36 36 | 
 37 37 | 
 38    |-def f(x: "Union[str, int, Union[float, bytes]]") -> None:
-   38 |+def f(x: "str | int | Union[float, bytes]") -> None:
+   38 |+def f(x: "str | (int | Union[float, bytes])") -> None:
 39 39 |     ...
 40 40 | 
 41 41 | 
@@ -368,5 +368,28 @@ UP007.py:96:10: UP007 Use `X | Y` for type annotations
 97 |     ...
    |
    = help: Convert to `X | Y`
+
+UP007.py:102:28: UP007 [*] Use `X | Y` for type annotations
+    |
+100 |   # Regression test for: https://github.com/astral-sh/ruff/issues/7131
+101 |   class ServiceRefOrValue:
+102 |       service_specification: Optional[
+    |  ____________________________^
+103 | |         list[ServiceSpecificationRef]
+104 | |         | list[ServiceSpecification]
+105 | |     ] = None
+    | |_____^ UP007
+    |
+    = help: Convert to `X | Y`
+
+ℹ Suggested fix
+99  99  | 
+100 100 | # Regression test for: https://github.com/astral-sh/ruff/issues/7131
+101 101 | class ServiceRefOrValue:
+102     |-    service_specification: Optional[
+103     |-        list[ServiceSpecificationRef]
+104     |-        | list[ServiceSpecification]
+105     |-    ] = None
+    102 |+    service_specification: list[ServiceSpecificationRef] | list[ServiceSpecification] | None = None
 
 


### PR DESCRIPTION
## Summary

Ensures that we generate syntactically valid code, at the cost of lower fidelity. For example, we might collapse implicitly concatenated strings, or add unnecessary parentheses (although the latter is solvable by improving the generator).

Closes https://github.com/astral-sh/ruff/issues/7131.

## Test Plan

`cargo test`
