### PR TITLE
Remove autofix for ambiguous unicode rules

### DIFF
--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__confusables.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__confusables.snap
@@ -1,22 +1,14 @@
 ---
 source: crates/ruff/src/rules/ruff/mod.rs
 ---
-confusables.py:1:6: RUF001 [*] String contains ambiguous `𝐁` (MATHEMATICAL BOLD CAPITAL B). Did you mean `B` (LATIN CAPITAL LETTER B)?
+confusables.py:1:6: RUF001 String contains ambiguous `𝐁` (MATHEMATICAL BOLD CAPITAL B). Did you mean `B` (LATIN CAPITAL LETTER B)?
   |
 1 | x = "𝐁ad string"
   |      ^ RUF001
 2 | y = "−"
   |
-  = help: Replace `𝐁` (MATHEMATICAL BOLD CAPITAL B) with `B` (LATIN CAPITAL LETTER B)
 
-ℹ Possible fix
-1   |-x = "𝐁ad string"
-  1 |+x = "Bad string"
-2 2 | y = "−"
-3 3 | 
-4 4 | 
-
-confusables.py:6:56: RUF002 [*] Docstring contains ambiguous `）` (FULLWIDTH RIGHT PARENTHESIS). Did you mean `)` (RIGHT PARENTHESIS)?
+confusables.py:6:56: RUF002 Docstring contains ambiguous `）` (FULLWIDTH RIGHT PARENTHESIS). Did you mean `)` (RIGHT PARENTHESIS)?
   |
 5 | def f():
 6 |     """Here's a docstring with an unusual parenthesis: ）"""
@@ -24,19 +16,8 @@ confusables.py:6:56: RUF002 [*] Docstring contains ambiguous `）` (FULLWIDTH RI
 7 |     # And here's a comment with an unusual punctuation mark: ᜵
 8 |     ...
   |
-  = help: Replace `）` (FULLWIDTH RIGHT PARENTHESIS) with `)` (RIGHT PARENTHESIS)
 
-ℹ Possible fix
-3 3 | 
-4 4 | 
-5 5 | def f():
-6   |-    """Here's a docstring with an unusual parenthesis: ）"""
-  6 |+    """Here's a docstring with an unusual parenthesis: )"""
-7 7 |     # And here's a comment with an unusual punctuation mark: ᜵
-8 8 |     ...
-9 9 | 
-
-confusables.py:7:62: RUF003 [*] Comment contains ambiguous `᜵` (PHILIPPINE SINGLE PUNCTUATION). Did you mean `/` (SOLIDUS)?
+confusables.py:7:62: RUF003 Comment contains ambiguous `᜵` (PHILIPPINE SINGLE PUNCTUATION). Did you mean `/` (SOLIDUS)?
   |
 5 | def f():
 6 |     """Here's a docstring with an unusual parenthesis: ）"""
@@ -44,37 +25,15 @@ confusables.py:7:62: RUF003 [*] Comment contains ambiguous `᜵` (PHILIPPINE SIN
   |                                                              ^ RUF003
 8 |     ...
   |
-  = help: Replace `᜵` (PHILIPPINE SINGLE PUNCTUATION) with `/` (SOLIDUS)
 
-ℹ Possible fix
-4 4 | 
-5 5 | def f():
-6 6 |     """Here's a docstring with an unusual parenthesis: ）"""
-7   |-    # And here's a comment with an unusual punctuation mark: ᜵
-  7 |+    # And here's a comment with an unusual punctuation mark: /
-8 8 |     ...
-9 9 | 
-10 10 | 
-
-confusables.py:17:6: RUF001 [*] String contains ambiguous `𝐁` (MATHEMATICAL BOLD CAPITAL B). Did you mean `B` (LATIN CAPITAL LETTER B)?
+confusables.py:17:6: RUF001 String contains ambiguous `𝐁` (MATHEMATICAL BOLD CAPITAL B). Did you mean `B` (LATIN CAPITAL LETTER B)?
    |
 17 | x = "𝐁ad string"
    |      ^ RUF001
 18 | x = "−"
    |
-   = help: Replace `𝐁` (MATHEMATICAL BOLD CAPITAL B) with `B` (LATIN CAPITAL LETTER B)
 
-ℹ Possible fix
-14 14 |     ...
-15 15 | 
-16 16 | 
-17    |-x = "𝐁ad string"
-   17 |+x = "Bad string"
-18 18 | x = "−"
-19 19 | 
-20 20 | # This should be ignored, since it contains an unambiguous unicode character, and no
-
-confusables.py:26:10: RUF001 [*] String contains ambiguous `α` (GREEK SMALL LETTER ALPHA). Did you mean `a` (LATIN SMALL LETTER A)?
+confusables.py:26:10: RUF001 String contains ambiguous `α` (GREEK SMALL LETTER ALPHA). Did you mean `a` (LATIN SMALL LETTER A)?
    |
 24 | # The first word should be ignored, while the second should be included, since it
 25 | # contains ASCII.
@@ -83,48 +42,21 @@ confusables.py:26:10: RUF001 [*] String contains ambiguous `α` (GREEK SMALL LET
 27 | 
 28 | # The two characters should be flagged here. The first character is a "word"
    |
-   = help: Replace `α` (GREEK SMALL LETTER ALPHA) with `a` (LATIN SMALL LETTER A)
 
-ℹ Possible fix
-23 23 | 
-24 24 | # The first word should be ignored, while the second should be included, since it
-25 25 | # contains ASCII.
-26    |-x = "βα Bαd"
-   26 |+x = "βα Bad"
-27 27 | 
-28 28 | # The two characters should be flagged here. The first character is a "word"
-29 29 | # consisting of a single ambiguous character, while the second character is a "word
-
-confusables.py:31:6: RUF001 [*] String contains ambiguous `Р` (CYRILLIC CAPITAL LETTER ER). Did you mean `P` (LATIN CAPITAL LETTER P)?
+confusables.py:31:6: RUF001 String contains ambiguous `Р` (CYRILLIC CAPITAL LETTER ER). Did you mean `P` (LATIN CAPITAL LETTER P)?
    |
 29 | # consisting of a single ambiguous character, while the second character is a "word
 30 | # boundary" (whitespace) that it itself ambiguous.
 31 | x = "Р усский"
    |      ^ RUF001
    |
-   = help: Replace `Р` (CYRILLIC CAPITAL LETTER ER) with `P` (LATIN CAPITAL LETTER P)
 
-ℹ Possible fix
-28 28 | # The two characters should be flagged here. The first character is a "word"
-29 29 | # consisting of a single ambiguous character, while the second character is a "word
-30 30 | # boundary" (whitespace) that it itself ambiguous.
-31    |-x = "Р усский"
-   31 |+x = "P усский"
-
-confusables.py:31:7: RUF001 [*] String contains ambiguous ` ` (EN QUAD). Did you mean ` ` (SPACE)?
+confusables.py:31:7: RUF001 String contains ambiguous ` ` (EN QUAD). Did you mean ` ` (SPACE)?
    |
 29 | # consisting of a single ambiguous character, while the second character is a "word
 30 | # boundary" (whitespace) that it itself ambiguous.
 31 | x = "Р усский"
    |       ^ RUF001
    |
-   = help: Replace ` ` (EN QUAD) with ` ` (SPACE)
-
-ℹ Possible fix
-28 28 | # The two characters should be flagged here. The first character is a "word"
-29 29 | # consisting of a single ambiguous character, while the second character is a "word
-30 30 | # boundary" (whitespace) that it itself ambiguous.
-31    |-x = "Р усский"
-   31 |+x = "Р усский"
 
 


### PR DESCRIPTION
## Summary

This has been the source of many bugs (via fuzzing and in practice). They're marked as manual, and we can always restore them later on if we want them to appear in code frames, but for now, I'd rather remove.

Closes https://github.com/astral-sh/ruff/issues/7158.