### PR TITLE
Copy the starred argument as is for `PLW3301` autofix

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/nested_min_max.py
+++ b/crates/ruff/resources/test/fixtures/pylint/nested_min_max.py
@@ -36,3 +36,6 @@ tuples_list = [
 
 min(min(tuples_list))
 max(max(tuples_list))
+
+# Starred argument should be copied as it is.
+max(1, max(*a))

--- a/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
@@ -106,14 +106,16 @@ fn collect_nested_args(min_max: MinMax, args: &[Expr], semantic: &SemanticModel)
                 range: _,
             }) = arg
             {
-                if args.len() == 1 {
-                    let new_arg = Expr::Starred(ast::ExprStarred {
-                        value: Box::new(args[0].clone()),
-                        ctx: ast::ExprContext::Load,
-                        range: TextRange::default(),
-                    });
-                    new_args.push(new_arg);
-                    continue;
+                if let [arg] = args.as_slice() {
+                    if arg.as_starred_expr().is_none() {
+                        let new_arg = Expr::Starred(ast::ExprStarred {
+                            value: Box::new(arg.clone()),
+                            ctx: ast::ExprContext::Load,
+                            range: TextRange::default(),
+                        });
+                        new_args.push(new_arg);
+                        continue;
+                    }
                 }
                 if MinMax::try_from_call(func, keywords, semantic) == Some(min_max) {
                     inner(min_max, args, semantic, new_args);
@@ -129,7 +131,7 @@ fn collect_nested_args(min_max: MinMax, args: &[Expr], semantic: &SemanticModel)
     new_args
 }
 
-/// W3301
+/// PLW3301
 pub(crate) fn nested_min_max(
     checker: &mut Checker,
     expr: &Expr,

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLW3301_nested_min_max.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLW3301_nested_min_max.py.snap
@@ -278,4 +278,19 @@ nested_min_max.py:27:1: PLW3301 [*] Nested `max` calls can be flattened
 29 29 | tuples_list = [
 30 30 |     (1, 2),
 
+nested_min_max.py:41:1: PLW3301 [*] Nested `max` calls can be flattened
+   |
+40 | # Starred argument should be copied as it is.
+41 | max(1, max(*a))
+   | ^^^^^^^^^^^^^^^ PLW3301
+   |
+   = help: Flatten nested `max` calls
+
+ℹ Suggested fix
+38 38 | max(max(tuples_list))
+39 39 | 
+40 40 | # Starred argument should be copied as it is.
+41    |-max(1, max(*a))
+   41 |+max(1, *a)
+
 


### PR DESCRIPTION
## Summary

This PR fixes the bug where the autofix for `PLE3301` would _unconditionally_
use the starred argument is there was only a single argument to a `min`/`max`
call. This is incorrect as it would add an additional star making it a keyword
argument.

```diff
- min(min(*arg), 1)
+ min(**arg, 1)
```

The fix is to only use the starred argument node if it isn't already a starred
argument.

## Test Plan

Add a new test case to verify the fix.

fixes: #7142
