### PR TITLE
Move `ExprConstant::kind` to `StringConstant::unicode`

### DIFF
--- a/crates/ruff/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff/src/checkers/ast/analyze/expression.rs
@@ -1195,7 +1195,6 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
         }
         Expr::Constant(ast::ExprConstant {
             value: Constant::Int(_) | Constant::Float(_) | Constant::Complex { .. },
-            kind: _,
             range: _,
         }) => {
             if checker.source_type.is_stub() && checker.enabled(Rule::NumericLiteralTooLong) {
@@ -1204,7 +1203,6 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
         }
         Expr::Constant(ast::ExprConstant {
             value: Constant::Bytes(_),
-            kind: _,
             range: _,
         }) => {
             if checker.source_type.is_stub() && checker.enabled(Rule::StringOrBytesTooLong) {
@@ -1213,7 +1211,6 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
         }
         Expr::Constant(ast::ExprConstant {
             value: Constant::Str(value),
-            kind,
             range: _,
         }) => {
             if checker.enabled(Rule::HardcodedBindAllInterfaces) {
@@ -1227,7 +1224,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 flake8_bandit::rules::hardcoded_tmp_directory(checker, expr, value);
             }
             if checker.enabled(Rule::UnicodeKindPrefix) {
-                pyupgrade::rules::unicode_kind_prefix(checker, expr, kind.as_deref());
+                pyupgrade::rules::unicode_kind_prefix(checker, expr, value.unicode);
             }
             if checker.source_type.is_stub() {
                 if checker.enabled(Rule::StringOrBytesTooLong) {

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -1192,7 +1192,6 @@ where
             }
             Expr::Constant(ast::ExprConstant {
                 value: Constant::Str(value),
-                kind: _,
                 range: _,
             }) => {
                 if self.semantic.in_type_definition()

--- a/crates/ruff/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff/src/rules/flake8_annotations/rules/definition.rs
@@ -454,7 +454,6 @@ fn check_dynamically_typed<F>(
     if let Expr::Constant(ast::ExprConstant {
         range,
         value: Constant::Str(string),
-        ..
     }) = annotation
     {
         // Quoted annotations

--- a/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
@@ -77,7 +77,6 @@ pub(crate) fn call_datetime_strptime_without_zone(checker: &mut Checker, call: &
     // Does the `strptime` call contain a format string with a timezone specifier?
     if let Some(Expr::Constant(ast::ExprConstant {
         value: Constant::Str(format),
-        kind: None,
         range: _,
     })) = call.arguments.args.get(1).as_ref()
     {

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -278,8 +278,6 @@ fn elts_to_csv(elts: &[Expr], generator: Generator) -> Option<String> {
                 acc
             })
             .into(),
-
-        kind: None,
         range: TextRange::default(),
     });
     Some(generator.expr(&node))
@@ -340,7 +338,6 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                                     .map(|name| {
                                         Expr::Constant(ast::ExprConstant {
                                             value: (*name).to_string().into(),
-                                            kind: None,
                                             range: TextRange::default(),
                                         })
                                     })
@@ -375,7 +372,6 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                                     .map(|name| {
                                         Expr::Constant(ast::ExprConstant {
                                             value: (*name).to_string().into(),
-                                            kind: None,
                                             range: TextRange::default(),
                                         })
                                     })

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/unittest_assert.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/unittest_assert.rs
@@ -370,7 +370,6 @@ impl UnittestAssert {
                 };
                 let node = Expr::Constant(ast::ExprConstant {
                     value: Constant::None,
-                    kind: None,
                     range: TextRange::default(),
                 });
                 let expr = compare(expr, cmp_op, &node);

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -184,8 +184,12 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
         return;
     }
     let Expr::Constant(ast::ExprConstant {
-        value: Constant::Str(ast::StringConstant { value: env_var, .. }),
-        kind,
+        value:
+            Constant::Str(ast::StringConstant {
+                value: env_var,
+                unicode,
+                ..
+            }),
         range: _,
     }) = slice.as_ref()
     else {
@@ -205,8 +209,11 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
     );
     if checker.patch(diagnostic.kind.rule()) {
         let node = ast::ExprConstant {
-            value: capital_env_var.into(),
-            kind: kind.clone(),
+            value: ast::Constant::Str(ast::StringConstant {
+                value: capital_env_var,
+                unicode: *unicode,
+                implicit_concatenated: false,
+            }),
             range: TextRange::default(),
         };
         let new_env_var = node.into();

--- a/crates/ruff/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
+++ b/crates/ruff/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
@@ -68,7 +68,6 @@ pub(crate) fn path_constructor_current_directory(checker: &mut Checker, expr: &E
 
     let [Expr::Constant(ExprConstant {
         value: Constant::Str(ast::StringConstant { value, .. }),
-        kind: _,
         range,
     })] = args.as_slice()
     else {

--- a/crates/ruff/src/rules/flynt/helpers.rs
+++ b/crates/ruff/src/rules/flynt/helpers.rs
@@ -17,7 +17,6 @@ fn to_formatted_value_expr(inner: &Expr) -> Expr {
 pub(super) fn to_constant_string(s: &str) -> Expr {
     let node = ast::ExprConstant {
         value: s.to_owned().into(),
-        kind: None,
         range: TextRange::default(),
     };
     node.into()

--- a/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -86,7 +86,6 @@ fn build_fstring(joiner: &str, joinees: &[Expr]) -> Option<Expr> {
                 .join(joiner)
                 .into(),
             range: TextRange::default(),
-            kind: None,
         };
         return Some(node.into());
     }

--- a/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -172,7 +172,6 @@ pub(crate) fn literal_comparisons(checker: &mut Checker, compare: &ast::ExprComp
             if checker.enabled(Rule::TrueFalseComparison) {
                 if let Expr::Constant(ast::ExprConstant {
                     value: Constant::Bool(value),
-                    kind: None,
                     range: _,
                 }) = comparator
                 {
@@ -241,7 +240,6 @@ pub(crate) fn literal_comparisons(checker: &mut Checker, compare: &ast::ExprComp
         if checker.enabled(Rule::TrueFalseComparison) {
             if let Expr::Constant(ast::ExprConstant {
                 value: Constant::Bool(value),
-                kind: None,
                 range: _,
             }) = next
             {

--- a/crates/ruff/src/rules/pylint/rules/assert_on_string_literal.rs
+++ b/crates/ruff/src/rules/pylint/rules/assert_on_string_literal.rs
@@ -77,7 +77,7 @@ pub(crate) fn assert_on_string_literal(checker: &mut Checker, test: &Expr) {
                 AssertOnStringLiteral {
                     kind: if values.iter().all(|value| match value {
                         Expr::Constant(ast::ExprConstant { value, .. }) => match value {
-                            Constant::Str(value, ..) => value.is_empty(),
+                            Constant::Str(value) => value.is_empty(),
                             Constant::Bytes(value) => value.is_empty(),
                             _ => false,
                         },
@@ -86,7 +86,7 @@ pub(crate) fn assert_on_string_literal(checker: &mut Checker, test: &Expr) {
                         Kind::Empty
                     } else if values.iter().any(|value| match value {
                         Expr::Constant(ast::ExprConstant { value, .. }) => match value {
-                            Constant::Str(value, ..) => !value.is_empty(),
+                            Constant::Str(value) => !value.is_empty(),
                             Constant::Bytes(value) => !value.is_empty(),
                             _ => false,
                         },

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -40,6 +40,7 @@ impl From<LiteralType> for Constant {
         match value {
             LiteralType::Str => Constant::Str(ast::StringConstant {
                 value: String::new(),
+                unicode: false,
                 implicit_concatenated: false,
             }),
             LiteralType::Bytes => Constant::Bytes(ast::BytesConstant {

--- a/crates/ruff/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
@@ -40,8 +40,8 @@ impl AlwaysAutofixableViolation for UnicodeKindPrefix {
 }
 
 /// UP025
-pub(crate) fn unicode_kind_prefix(checker: &mut Checker, expr: &Expr, kind: Option<&str>) {
-    if matches!(kind, Some("u" | "U")) {
+pub(crate) fn unicode_kind_prefix(checker: &mut Checker, expr: &Expr, is_unicode: bool) {
+    if is_unicode {
         let mut diagnostic = Diagnostic::new(UnicodeKindPrefix, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.set_fix(Fix::automatic(Edit::range_deletion(TextRange::at(

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -121,7 +121,6 @@ fn optional(expr: &Expr) -> Expr {
         op: Operator::BitOr,
         right: Box::new(Expr::Constant(ast::ExprConstant {
             value: Constant::None,
-            kind: None,
             range: TextRange::default(),
         })),
         range: TextRange::default(),

--- a/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff/src/rules/ruff/rules/implicit_optional.rs
@@ -129,7 +129,6 @@ fn generate_fix(checker: &Checker, conversion_type: ConversionType, expr: &Expr)
                 op: Operator::BitOr,
                 right: Box::new(Expr::Constant(ast::ExprConstant {
                     value: Constant::None,
-                    kind: None,
                     range: TextRange::default(),
                 })),
                 range: TextRange::default(),
@@ -188,7 +187,6 @@ pub(crate) fn implicit_optional(checker: &mut Checker, parameters: &Parameters) 
         if let Expr::Constant(ast::ExprConstant {
             range,
             value: Constant::Str(string),
-            ..
         }) = annotation.as_ref()
         {
             // Quoted annotation.

--- a/crates/ruff/src/rules/ruff/typing.rs
+++ b/crates/ruff/src/rules/ruff/typing.rs
@@ -114,7 +114,6 @@ impl<'a> TypingTarget<'a> {
             Expr::Constant(ast::ExprConstant {
                 value: Constant::Str(string),
                 range,
-                ..
             }) => parse_type_annotation(string, *range, locator.contents())
                 .map_or(None, |(expr, _)| Some(TypingTarget::ForwardReference(expr))),
             _ => semantic.resolve_call_path(expr).map_or(

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -576,7 +576,6 @@ pub const fn is_const_none(expr: &Expr) -> bool {
         expr,
         Expr::Constant(ast::ExprConstant {
             value: Constant::None,
-            kind: None,
             ..
         }),
     )
@@ -588,7 +587,6 @@ pub const fn is_const_true(expr: &Expr) -> bool {
         expr,
         Expr::Constant(ast::ExprConstant {
             value: Constant::Bool(true),
-            kind: None,
             ..
         }),
     )
@@ -600,7 +598,6 @@ pub const fn is_const_false(expr: &Expr) -> bool {
         expr,
         Expr::Constant(ast::ExprConstant {
             value: Constant::Bool(false),
-            kind: None,
             ..
         }),
     )
@@ -1190,17 +1187,14 @@ mod tests {
         });
         let constant_one = Expr::Constant(ExprConstant {
             value: Constant::Int(1.into()),
-            kind: Some("x".to_string()),
             range: TextRange::default(),
         });
         let constant_two = Expr::Constant(ExprConstant {
             value: Constant::Int(2.into()),
-            kind: Some("y".to_string()),
             range: TextRange::default(),
         });
         let constant_three = Expr::Constant(ExprConstant {
             value: Constant::Int(3.into()),
-            kind: Some("z".to_string()),
             range: TextRange::default(),
         });
         let type_var_one = TypeParam::TypeVar(TypeParamTypeVar {
@@ -1243,7 +1237,6 @@ mod tests {
 
         let bound = Expr::Constant(ExprConstant {
             value: Constant::Int(1.into()),
-            kind: Some("x".to_string()),
             range: TextRange::default(),
         });
 

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -2682,11 +2682,7 @@ impl AstNode for ast::ExprConstant {
     where
         V: PreorderVisitor<'a> + ?Sized,
     {
-        let ast::ExprConstant {
-            value,
-            range: _,
-            kind: _,
-        } = self;
+        let ast::ExprConstant { value, range: _ } = self;
         visitor.visit_constant(value);
     }
 }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -945,7 +945,6 @@ impl From<ExprFString> for Expr {
 pub struct ExprConstant {
     pub range: TextRange,
     pub value: Constant,
-    pub kind: Option<String>,
 }
 
 impl From<ExprConstant> for Expr {
@@ -2559,6 +2558,8 @@ pub struct StringConstant {
     /// The string value as resolved by the parser (i.e., without quotes, or escape sequences, or
     /// implicit concatenations).
     pub value: String,
+    /// Whether the string is a Unicode string (i.e., `u"..."`).
+    pub unicode: bool,
     /// Whether the string contains multiple string tokens that were implicitly concatenated.
     pub implicit_concatenated: bool,
 }
@@ -2598,6 +2599,7 @@ impl From<String> for Constant {
     fn from(value: String) -> Constant {
         Self::Str(StringConstant {
             value,
+            unicode: false,
             implicit_concatenated: false,
         })
     }

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1078,14 +1078,7 @@ impl<'a> Generator<'a> {
             Expr::FString(ast::ExprFString { values, .. }) => {
                 self.unparse_f_string(values, false);
             }
-            Expr::Constant(ast::ExprConstant {
-                value,
-                kind,
-                range: _,
-            }) => {
-                if let Some(kind) = kind {
-                    self.p(kind);
-                }
+            Expr::Constant(ast::ExprConstant { value, range: _ }) => {
                 self.unparse_constant(value);
             }
             Expr::Attribute(ast::ExprAttribute { value, attr, .. }) => {
@@ -1168,7 +1161,10 @@ impl<'a> Generator<'a> {
             Constant::Bytes(b) => {
                 self.p_bytes_repr(b);
             }
-            Constant::Str(ast::StringConstant { value, .. }) => {
+            Constant::Str(ast::StringConstant { value, unicode, .. }) => {
+                if *unicode {
+                    self.p("u");
+                }
                 self.p_str_repr(value);
             }
             Constant::None => self.p("None"),

--- a/crates/ruff_python_formatter/src/expression/expr_constant.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_constant.rs
@@ -35,11 +35,7 @@ impl FormatRuleWithOptions<ExprConstant, PyFormatContext<'_>> for FormatExprCons
 
 impl FormatNodeRule<ExprConstant> for FormatExprConstant {
     fn fmt_fields(&self, item: &ExprConstant, f: &mut PyFormatter) -> FormatResult<()> {
-        let ExprConstant {
-            range: _,
-            value,
-            kind: _,
-        } = item;
+        let ExprConstant { range: _, value } = item;
 
         match value {
             Constant::Ellipsis => token("...").fmt(f),

--- a/crates/ruff_python_parser/src/python.lalrpop
+++ b/crates/ruff_python_parser/src/python.lalrpop
@@ -623,7 +623,7 @@ StarPattern: ast::Pattern = {
 
 ConstantAtom: ast::ParenthesizedExpr = {
     <location:@L> <value:Constant> <end_location:@R> => ast::Expr::Constant(
-        ast::ExprConstant { value, kind: None, range: (location..end_location).into() }
+        ast::ExprConstant { value, range: (location..end_location).into() }
     ).into(),
 }
 
@@ -716,17 +716,14 @@ MappingKey: ast::Expr = {
     <e:AddOpExpr> => e.into(),
     <location:@L> "None" <end_location:@R> => ast::ExprConstant {
         value: ast::Constant::None,
-        kind: None,
         range: (location..end_location).into()
     }.into(),
     <location:@L> "True" <end_location:@R> => ast::ExprConstant {
         value: true.into(),
-        kind: None,
         range: (location..end_location).into()
     }.into(),
     <location:@L> "False" <end_location:@R> => ast::ExprConstant {
         value: false.into(),
-        kind: None,
         range: (location..end_location).into()
     }.into(),
     <location:@L> <s:(@L string @R)+> =>? Ok(parse_strings(s)?),
@@ -1580,7 +1577,6 @@ Atom<Goal>: ast::ParenthesizedExpr = {
     <location:@L> <s:(@L string @R)+> =>? Ok(parse_strings(s)?.into()),
     <location:@L> <value:Constant> <end_location:@R> => ast::ExprConstant {
         value,
-        kind: None,
         range: (location..end_location).into(),
     }.into(),
     <location:@L> <id:Identifier> <end_location:@R> => ast::ExprName {
@@ -1671,10 +1667,10 @@ Atom<Goal>: ast::ParenthesizedExpr = {
         generators,
         range: (location..end_location).into(),
     }.into(),
-    <location:@L> "True" <end_location:@R> => ast::ExprConstant { value: true.into(), kind: None, range: (location..end_location).into() }.into(),
-    <location:@L> "False" <end_location:@R> => ast::ExprConstant { value: false.into(), kind: None, range: (location..end_location).into() }.into(),
-    <location:@L> "None" <end_location:@R> => ast::ExprConstant { value: ast::Constant::None, kind: None, range: (location..end_location).into() }.into(),
-    <location:@L> "..." <end_location:@R> => ast::ExprConstant { value: ast::Constant::Ellipsis, kind: None, range: (location..end_location).into() }.into(),
+    <location:@L> "True" <end_location:@R> => ast::ExprConstant { value: true.into(), range: (location..end_location).into() }.into(),
+    <location:@L> "False" <end_location:@R> => ast::ExprConstant { value: false.into(), range: (location..end_location).into() }.into(),
+    <location:@L> "None" <end_location:@R> => ast::ExprConstant { value: ast::Constant::None, range: (location..end_location).into() }.into(),
+    <location:@L> "..." <end_location:@R> => ast::ExprConstant { value: ast::Constant::Ellipsis, range: (location..end_location).into() }.into(),
 };
 
 ListLiteralValues: Vec<ast::ParenthesizedExpr> = {

--- a/crates/ruff_python_parser/src/python.rs
+++ b/crates/ruff_python_parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 516ee93137b3322a578922c24eb95daee3078883fdfa0c097268e64b78fcc54f
+// sha3: e8f3229288c1a13387ea6041355e2d8fe9ab788fbc7229032d2de92beb675944
 use num_bigint::BigInt;
 use ruff_text_size::{Ranged, TextSize};
 use ruff_python_ast::{self as ast, IpyEscapeKind};
@@ -32376,7 +32376,7 @@ fn __action111<
 ) -> ast::ParenthesizedExpr
 {
     ast::Expr::Constant(
-        ast::ExprConstant { value, kind: None, range: (location..end_location).into() }
+        ast::ExprConstant { value, range: (location..end_location).into() }
     ).into()
 }
 
@@ -32660,7 +32660,6 @@ fn __action129<
 {
     ast::ExprConstant {
         value: ast::Constant::None,
-        kind: None,
         range: (location..end_location).into()
     }.into()
 }
@@ -32677,7 +32676,6 @@ fn __action130<
 {
     ast::ExprConstant {
         value: true.into(),
-        kind: None,
         range: (location..end_location).into()
     }.into()
 }
@@ -32694,7 +32692,6 @@ fn __action131<
 {
     ast::ExprConstant {
         value: false.into(),
-        kind: None,
         range: (location..end_location).into()
     }.into()
 }
@@ -38353,7 +38350,6 @@ fn __action523<
 {
     ast::ExprConstant {
         value,
-        kind: None,
         range: (location..end_location).into(),
     }.into()
 }
@@ -38644,7 +38640,7 @@ fn __action537<
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::ParenthesizedExpr
 {
-    ast::ExprConstant { value: true.into(), kind: None, range: (location..end_location).into() }.into()
+    ast::ExprConstant { value: true.into(), range: (location..end_location).into() }.into()
 }
 
 #[allow(unused_variables)]
@@ -38657,7 +38653,7 @@ fn __action538<
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::ParenthesizedExpr
 {
-    ast::ExprConstant { value: false.into(), kind: None, range: (location..end_location).into() }.into()
+    ast::ExprConstant { value: false.into(), range: (location..end_location).into() }.into()
 }
 
 #[allow(unused_variables)]
@@ -38670,7 +38666,7 @@ fn __action539<
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::ParenthesizedExpr
 {
-    ast::ExprConstant { value: ast::Constant::None, kind: None, range: (location..end_location).into() }.into()
+    ast::ExprConstant { value: ast::Constant::None, range: (location..end_location).into() }.into()
 }
 
 #[allow(unused_variables)]
@@ -38683,7 +38679,7 @@ fn __action540<
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::ParenthesizedExpr
 {
-    ast::ExprConstant { value: ast::Constant::Ellipsis, kind: None, range: (location..end_location).into() }.into()
+    ast::ExprConstant { value: ast::Constant::Ellipsis, range: (location..end_location).into() }.into()
 }
 
 #[allow(unused_variables)]
@@ -39037,7 +39033,6 @@ fn __action566<
 {
     ast::ExprConstant {
         value,
-        kind: None,
         range: (location..end_location).into(),
     }.into()
 }
@@ -39302,7 +39297,7 @@ fn __action579<
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::ParenthesizedExpr
 {
-    ast::ExprConstant { value: true.into(), kind: None, range: (location..end_location).into() }.into()
+    ast::ExprConstant { value: true.into(), range: (location..end_location).into() }.into()
 }
 
 #[allow(unused_variables)]
@@ -39315,7 +39310,7 @@ fn __action580<
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::ParenthesizedExpr
 {
-    ast::ExprConstant { value: false.into(), kind: None, range: (location..end_location).into() }.into()
+    ast::ExprConstant { value: false.into(), range: (location..end_location).into() }.into()
 }
 
 #[allow(unused_variables)]
@@ -39328,7 +39323,7 @@ fn __action581<
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::ParenthesizedExpr
 {
-    ast::ExprConstant { value: ast::Constant::None, kind: None, range: (location..end_location).into() }.into()
+    ast::ExprConstant { value: ast::Constant::None, range: (location..end_location).into() }.into()
 }
 
 #[allow(unused_variables)]
@@ -39341,7 +39336,7 @@ fn __action582<
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::ParenthesizedExpr
 {
-    ast::ExprConstant { value: ast::Constant::Ellipsis, kind: None, range: (location..end_location).into() }.into()
+    ast::ExprConstant { value: ast::Constant::Ellipsis, range: (location..end_location).into() }.into()
 }
 
 #[allow(unused_variables)]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__ann_assign_name.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__ann_assign_name.snap
@@ -27,7 +27,6 @@ expression: parse_ast
                         value: Int(
                             1,
                         ),
-                        kind: None,
                     },
                 ),
             ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_attribute.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_attribute.snap
@@ -35,7 +35,6 @@ expression: parse_ast
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -44,7 +43,6 @@ expression: parse_ast
                                 value: Int(
                                     2,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -53,7 +51,6 @@ expression: parse_ast
                                 value: Int(
                                     3,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_for.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_for.snap
@@ -24,7 +24,6 @@ expression: parse_ast
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -33,7 +32,6 @@ expression: parse_ast
                                 value: Int(
                                     2,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -42,7 +40,6 @@ expression: parse_ast
                                 value: Int(
                                     3,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_list.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_list.snap
@@ -40,7 +40,6 @@ expression: parse_ast
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -49,7 +48,6 @@ expression: parse_ast
                                 value: Int(
                                     2,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -58,7 +56,6 @@ expression: parse_ast
                                 value: Int(
                                     3,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_list_comp.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_list_comp.snap
@@ -45,7 +45,6 @@ expression: parse_ast
                                                 value: Int(
                                                     1,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                         Constant(
@@ -54,7 +53,6 @@ expression: parse_ast
                                                 value: Int(
                                                     2,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                         Constant(
@@ -63,7 +61,6 @@ expression: parse_ast
                                                 value: Int(
                                                     3,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_name.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_name.snap
@@ -25,7 +25,6 @@ expression: parse_ast
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -34,7 +33,6 @@ expression: parse_ast
                                 value: Int(
                                     2,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -43,7 +41,6 @@ expression: parse_ast
                                 value: Int(
                                     3,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_named_expr.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_named_expr.snap
@@ -22,7 +22,6 @@ expression: parse_ast
                             value: Int(
                                 1,
                             ),
-                            kind: None,
                         },
                     ),
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_set_comp.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_set_comp.snap
@@ -45,7 +45,6 @@ expression: parse_ast
                                                 value: Int(
                                                     1,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                         Constant(
@@ -54,7 +53,6 @@ expression: parse_ast
                                                 value: Int(
                                                     2,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                         Constant(
@@ -63,7 +61,6 @@ expression: parse_ast
                                                 value: Int(
                                                     3,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_starred.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_starred.snap
@@ -46,7 +46,6 @@ expression: parse_ast
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -55,7 +54,6 @@ expression: parse_ast
                                 value: Int(
                                     2,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -64,7 +62,6 @@ expression: parse_ast
                                 value: Int(
                                     3,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_subscript.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_subscript.snap
@@ -38,7 +38,6 @@ expression: parse_ast
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -47,7 +46,6 @@ expression: parse_ast
                                 value: Int(
                                     2,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -56,7 +54,6 @@ expression: parse_ast
                                 value: Int(
                                     3,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_tuple.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_tuple.snap
@@ -40,7 +40,6 @@ expression: parse_ast
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -49,7 +48,6 @@ expression: parse_ast
                                 value: Int(
                                     2,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -58,7 +56,6 @@ expression: parse_ast
                                 value: Int(
                                     3,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_with.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__assign_with.snap
@@ -16,7 +16,6 @@ expression: parse_ast
                             value: Int(
                                 1,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: Some(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__aug_assign_attribute.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__aug_assign_attribute.snap
@@ -34,7 +34,6 @@ expression: parse_ast
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -43,7 +42,6 @@ expression: parse_ast
                                 value: Int(
                                     2,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -52,7 +50,6 @@ expression: parse_ast
                                 value: Int(
                                     3,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__aug_assign_name.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__aug_assign_name.snap
@@ -20,7 +20,6 @@ expression: parse_ast
                     value: Int(
                         1,
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__aug_assign_subscript.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__context__tests__aug_assign_subscript.snap
@@ -37,7 +37,6 @@ expression: parse_ast
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -46,7 +45,6 @@ expression: parse_ast
                                 value: Int(
                                     2,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -55,7 +53,6 @@ expression: parse_ast
                                 value: Int(
                                     3,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_kw_only_args_with_defaults.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_kw_only_args_with_defaults.snap
@@ -49,7 +49,6 @@ Ok(
                                         value: Int(
                                             20,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ),
@@ -71,7 +70,6 @@ Ok(
                                         value: Int(
                                             30,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_and_kw_only_args_with_defaults.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_and_kw_only_args_with_defaults.snap
@@ -86,7 +86,6 @@ Ok(
                                         value: Int(
                                             20,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ),
@@ -108,7 +107,6 @@ Ok(
                                         value: Int(
                                             30,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_and_kw_only_args_with_defaults_and_varargs.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_and_kw_only_args_with_defaults_and_varargs.snap
@@ -95,7 +95,6 @@ Ok(
                                         value: Int(
                                             20,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ),
@@ -117,7 +116,6 @@ Ok(
                                         value: Int(
                                             30,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_and_kw_only_args_with_defaults_and_varargs_and_kwargs.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_and_kw_only_args_with_defaults_and_varargs_and_kwargs.snap
@@ -95,7 +95,6 @@ Ok(
                                         value: Int(
                                             20,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ),
@@ -117,7 +116,6 @@ Ok(
                                         value: Int(
                                             30,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_args_with_defaults.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__function_pos_args_with_defaults.snap
@@ -47,7 +47,6 @@ Ok(
                                         value: Int(
                                             20,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ),
@@ -69,7 +68,6 @@ Ok(
                                         value: Int(
                                             30,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_kw_only_args.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_kw_only_args.snap
@@ -63,7 +63,6 @@ Ok(
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                     },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_kw_only_args_with_defaults.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_kw_only_args_with_defaults.snap
@@ -46,7 +46,6 @@ Ok(
                                                     value: Int(
                                                         20,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ),
@@ -68,7 +67,6 @@ Ok(
                                                     value: Int(
                                                         30,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ),
@@ -83,7 +81,6 @@ Ok(
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                     },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_no_args.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_no_args.snap
@@ -17,7 +17,6 @@ Ok(
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                     },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_pos_and_kw_only_args.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_pos_and_kw_only_args.snap
@@ -88,7 +88,6 @@ Ok(
                                 value: Int(
                                     0,
                                 ),
-                                kind: None,
                             },
                         ),
                     },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_pos_args.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_pos_args.snap
@@ -63,7 +63,6 @@ Ok(
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                     },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_pos_args_with_defaults.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__function__tests__lambda_pos_args_with_defaults.snap
@@ -44,7 +44,6 @@ Ok(
                                                     value: Int(
                                                         20,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ),
@@ -66,7 +65,6 @@ Ok(
                                                     value: Int(
                                                         30,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ),
@@ -83,7 +81,6 @@ Ok(
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                     },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__dict_unpacking.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__dict_unpacking.snap
@@ -13,10 +13,10 @@ Dict(
                         value: Str(
                             StringConstant {
                                 value: "a",
+                                unicode: false,
                                 implicit_concatenated: false,
                             },
                         ),
-                        kind: None,
                     },
                 ),
             ),
@@ -28,10 +28,10 @@ Dict(
                         value: Str(
                             StringConstant {
                                 value: "d",
+                                unicode: false,
                                 implicit_concatenated: false,
                             },
                         ),
-                        kind: None,
                     },
                 ),
             ),
@@ -43,10 +43,10 @@ Dict(
                     value: Str(
                         StringConstant {
                             value: "b",
+                            unicode: false,
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
             Name(
@@ -62,10 +62,10 @@ Dict(
                     value: Str(
                         StringConstant {
                             value: "e",
+                            unicode: false,
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__generator_expression_argument.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__generator_expression_argument.snap
@@ -14,10 +14,10 @@ Call(
                         value: Str(
                             StringConstant {
                                 value: " ",
+                                unicode: false,
                                 implicit_concatenated: false,
                             },
                         ),
-                        kind: None,
                     },
                 ),
                 attr: Identifier {
@@ -73,10 +73,10 @@ Call(
                                                                     value: Str(
                                                                         StringConstant {
                                                                             value: "LIMIT %d",
+                                                                            unicode: false,
                                                                             implicit_concatenated: false,
                                                                         },
                                                                     ),
-                                                                    kind: None,
                                                                 },
                                                             ),
                                                             op: Mod,
@@ -93,7 +93,6 @@ Call(
                                                         ExprConstant {
                                                             range: 76..80,
                                                             value: None,
-                                                            kind: None,
                                                         },
                                                     ),
                                                 },
@@ -117,10 +116,10 @@ Call(
                                                                     value: Str(
                                                                         StringConstant {
                                                                             value: "OFFSET %d",
+                                                                            unicode: false,
                                                                             implicit_concatenated: false,
                                                                         },
                                                                     ),
-                                                                    kind: None,
                                                                 },
                                                             ),
                                                             op: Mod,
@@ -137,7 +136,6 @@ Call(
                                                         ExprConstant {
                                                             range: 128..132,
                                                             value: None,
-                                                            kind: None,
                                                         },
                                                     ),
                                                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__ipython_escape_commands.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__ipython_escape_commands.snap
@@ -227,7 +227,6 @@ Module(
                                             value: Int(
                                                 5,
                                             ),
-                                            kind: None,
                                         },
                                     ),
                                 ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__match.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__match.snap
@@ -17,10 +17,10 @@ expression: parse_ast
                                     value: Str(
                                         StringConstant {
                                             value: "test",
+                                            unicode: false,
                                             implicit_concatenated: false,
                                         },
                                     ),
-                                    kind: None,
                                 },
                             ),
                         ),
@@ -32,7 +32,6 @@ expression: parse_ast
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],
@@ -105,10 +104,10 @@ expression: parse_ast
                                     value: Str(
                                         StringConstant {
                                             value: "label",
+                                            unicode: false,
                                             implicit_concatenated: false,
                                         },
                                     ),
-                                    kind: None,
                                 },
                             ),
                         ),
@@ -120,10 +119,10 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "test",
+                                        unicode: false,
                                         implicit_concatenated: false,
                                     },
                                 ),
-                                kind: None,
                             },
                         ),
                     ],
@@ -142,10 +141,10 @@ expression: parse_ast
                                         value: Str(
                                             StringConstant {
                                                 value: "label",
+                                                unicode: false,
                                                 implicit_concatenated: false,
                                             },
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ],
@@ -260,7 +259,6 @@ expression: parse_ast
                                                 value: Int(
                                                     0,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -274,7 +272,6 @@ expression: parse_ast
                                                 value: Int(
                                                     1,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -302,7 +299,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -338,7 +334,6 @@ expression: parse_ast
                                                 value: Int(
                                                     0,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -352,7 +347,6 @@ expression: parse_ast
                                                 value: Int(
                                                     1,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -380,7 +374,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -416,7 +409,6 @@ expression: parse_ast
                                                 value: Int(
                                                     0,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -444,7 +436,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__match_as_identifier.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__match_as_identifier.snap
@@ -633,7 +633,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 1,
                             ),
-                            kind: None,
                         },
                     ),
                 },
@@ -670,7 +669,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         1,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -695,7 +693,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         2,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -813,7 +810,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                                     value: Int(
                                                         12,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__numeric_literals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__numeric_literals.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ruff_python_parser/src/parser.rs
-expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
+expression: "parse_suite(source, \"<test>\").unwrap()"
 ---
 [
     Assign(
@@ -21,7 +21,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Int(
                         123456789,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -44,7 +43,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Int(
                         123456,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -67,7 +65,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Float(
                         0.1,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -90,7 +87,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Float(
                         1.0,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -113,7 +109,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Float(
                         10.0,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -136,7 +131,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Float(
                         0.1,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -159,7 +153,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Float(
                         1.00000001,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -182,7 +175,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Float(
                         123456789.12345679,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -205,7 +197,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Float(
                         inf,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -228,7 +219,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Float(
                         inf,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -252,7 +242,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                         real: 0.0,
                         imag: 123456789.0,
                     },
-                    kind: None,
                 },
             ),
         },
@@ -276,7 +265,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                         real: 0.0,
                         imag: 123456789.12345679,
                     },
-                    kind: None,
                 },
             ),
         },
@@ -299,7 +287,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Int(
                         727756,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -322,7 +309,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Int(
                         11,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -345,7 +331,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Int(
                         511,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -368,7 +353,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Float(
                         6e-9,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -391,7 +375,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Int(
                         10000,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -414,7 +397,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                     value: Int(
                         133333,
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__numeric_literals_attribute_access.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__numeric_literals_attribute_access.snap
@@ -27,7 +27,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Float(
                                         0.1,
                                     ),
-                                    kind: None,
                                 },
                             ),
                             attr: Identifier {
@@ -67,7 +66,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Float(
                                 1.0,
                             ),
-                            kind: None,
                         },
                     ),
                     attr: Identifier {
@@ -100,7 +98,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Float(
                                 10.0,
                             ),
-                            kind: None,
                         },
                     ),
                     attr: Identifier {
@@ -133,7 +130,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Float(
                                 0.1,
                             ),
-                            kind: None,
                         },
                     ),
                     attr: Identifier {
@@ -169,7 +165,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Float(
                                         123456789.12345679,
                                     ),
-                                    kind: None,
                                 },
                             ),
                             attr: Identifier {
@@ -209,7 +204,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Float(
                                 inf,
                             ),
-                            kind: None,
                         },
                     ),
                     attr: Identifier {
@@ -245,7 +239,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Float(
                                         inf,
                                     ),
-                                    kind: None,
                                 },
                             ),
                             attr: Identifier {
@@ -286,7 +279,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                 real: 0.0,
                                 imag: 123456789.0,
                             },
-                            kind: None,
                         },
                     ),
                     attr: Identifier {
@@ -323,7 +315,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                         real: 0.0,
                                         imag: 123456789.12345679,
                                     },
-                                    kind: None,
                                 },
                             ),
                             attr: Identifier {
@@ -348,7 +339,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                                     value: Int(
                                                         11,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                             attr: Identifier {
@@ -396,7 +386,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         727756,
                                     ),
-                                    kind: None,
                                 },
                             ),
                             attr: Identifier {
@@ -439,7 +428,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         11,
                                     ),
-                                    kind: None,
                                 },
                             ),
                             attr: Identifier {
@@ -479,7 +467,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 511,
                             ),
-                            kind: None,
                         },
                     ),
                     attr: Identifier {
@@ -515,7 +502,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Float(
                                         6e-9,
                                     ),
-                                    kind: None,
                                 },
                             ),
                             attr: Identifier {
@@ -557,7 +543,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                 real: 0.0,
                                 imag: 100.0,
                             },
-                            kind: None,
                         },
                     ),
                 },
@@ -576,7 +561,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 10,
                             ),
-                            kind: None,
                         },
                     ),
                     attr: Identifier {
@@ -594,7 +578,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             ExprConstant {
                                 range: 363..366,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },
@@ -624,7 +607,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 100,
                             ),
-                            kind: None,
                         },
                     ),
                     slice: Name(
@@ -660,7 +642,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 100,
                             ),
-                            kind: None,
                         },
                     ),
                     arguments: Arguments {

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parenthesized_with_statement.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parenthesized_with_statement.snap
@@ -325,7 +325,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         0,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -365,7 +364,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         0,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -439,7 +437,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         0,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -498,7 +495,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         0,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -549,7 +545,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         0,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_class.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_class.snap
@@ -119,10 +119,10 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                                 value: Str(
                                                     StringConstant {
                                                         value: "default",
+                                                        unicode: false,
                                                         implicit_concatenated: false,
                                                     },
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_class_generic_types.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_class_generic_types.snap
@@ -43,7 +43,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             ExprConstant {
                                 range: 26..29,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },
@@ -99,7 +98,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             ExprConstant {
                                 range: 73..76,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },
@@ -170,7 +168,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             ExprConstant {
                                 range: 135..138,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },
@@ -228,7 +225,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             ExprConstant {
                                 range: 178..181,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },
@@ -286,7 +282,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             ExprConstant {
                                 range: 220..223,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },
@@ -333,7 +328,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             ExprConstant {
                                 range: 258..261,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },
@@ -380,7 +374,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             ExprConstant {
                                 range: 293..296,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_double_list_comprehension.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_double_list_comprehension.snap
@@ -84,7 +84,6 @@ ListComp(
                                         value: Int(
                                             5,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ],
@@ -110,7 +109,6 @@ ListComp(
                                         value: Int(
                                             10,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_f_string.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_f_string.snap
@@ -16,10 +16,10 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "Hello world",
+                                        unicode: false,
                                         implicit_concatenated: false,
                                     },
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_function_definition.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_function_definition.snap
@@ -43,7 +43,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             ExprConstant {
                                 range: 17..20,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },
@@ -123,7 +122,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             ExprConstant {
                                 range: 50..53,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },
@@ -211,7 +209,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             ExprConstant {
                                 range: 88..91,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },
@@ -314,7 +311,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             ExprConstant {
                                 range: 135..138,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },
@@ -387,7 +383,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             ExprConstant {
                                 range: 168..171,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },
@@ -491,7 +486,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             ExprConstant {
                                 range: 227..230,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_if_elif_else.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_if_elif_else.snap
@@ -12,7 +12,6 @@ expression: parse_ast
                     value: Int(
                         1,
                     ),
-                    kind: None,
                 },
             ),
             body: [
@@ -25,7 +24,6 @@ expression: parse_ast
                                 value: Int(
                                     10,
                                 ),
-                                kind: None,
                             },
                         ),
                     },
@@ -41,7 +39,6 @@ expression: parse_ast
                                 value: Int(
                                     2,
                                 ),
-                                kind: None,
                             },
                         ),
                     ),
@@ -55,7 +52,6 @@ expression: parse_ast
                                         value: Int(
                                             20,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -75,7 +71,6 @@ expression: parse_ast
                                         value: Int(
                                             30,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_kwargs.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_kwargs.snap
@@ -25,10 +25,10 @@ expression: parse_ast
                                     value: Str(
                                         StringConstant {
                                             value: "positional",
+                                            unicode: false,
                                             implicit_concatenated: false,
                                         },
                                     ),
-                                    kind: None,
                                 },
                             ),
                         ],
@@ -47,7 +47,6 @@ expression: parse_ast
                                         value: Int(
                                             2,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_lambda_no_args.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_lambda_no_args.snap
@@ -16,7 +16,6 @@ expression: parse_ast
                             value: Int(
                                 1,
                             ),
-                            kind: None,
                         },
                     ),
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_named_expression_generator_comprehension.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_named_expression_generator_comprehension.snap
@@ -32,7 +32,6 @@ GeneratorExp(
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                     },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_print_2.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_print_2.snap
@@ -25,10 +25,10 @@ expression: parse_ast
                                     value: Str(
                                         StringConstant {
                                             value: "Hello world",
+                                            unicode: false,
                                             implicit_concatenated: false,
                                         },
                                     ),
-                                    kind: None,
                                 },
                             ),
                             Constant(
@@ -37,7 +37,6 @@ expression: parse_ast
                                     value: Int(
                                         2,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_print_hello.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_print_hello.snap
@@ -25,10 +25,10 @@ expression: parse_ast
                                     value: Str(
                                         StringConstant {
                                             value: "Hello world",
+                                            unicode: false,
                                             implicit_concatenated: false,
                                         },
                                     ),
-                                    kind: None,
                                 },
                             ),
                         ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_string.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_string.snap
@@ -12,10 +12,10 @@ expression: parse_ast
                     value: Str(
                         StringConstant {
                             value: "Hello world",
+                            unicode: false,
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_tuples.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_tuples.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ruff_python_parser/src/parser.rs
-expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
+expression: "parse_suite(source, \"<test>\").unwrap()"
 ---
 [
     Assign(
@@ -40,7 +40,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                                 value: Int(
                                     4,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -49,7 +48,6 @@ expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
                                 value: Int(
                                     5,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_type_declaration.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_type_declaration.snap
@@ -84,10 +84,10 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Str(
                                 StringConstant {
                                     value: "ForwardRefY",
+                                    unicode: false,
                                     implicit_concatenated: false,
                                 },
                             ),
-                            kind: None,
                         },
                     ),
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__patma.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__patma.snap
@@ -30,7 +30,6 @@ expression: parse_ast
                                                 real: 0.0,
                                                 imag: 0.0,
                                             },
-                                            kind: None,
                                         },
                                     ),
                                 },
@@ -57,7 +56,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -130,7 +128,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -162,7 +159,6 @@ expression: parse_ast
                                     value: Int(
                                         0,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -174,7 +170,6 @@ expression: parse_ast
                                 value: Int(
                                     0,
                                 ),
-                                kind: None,
                             },
                         ),
                     ),
@@ -197,7 +192,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -215,7 +209,6 @@ expression: parse_ast
                                     value: Int(
                                         0,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -227,7 +220,6 @@ expression: parse_ast
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                     ),
@@ -250,7 +242,6 @@ expression: parse_ast
                                         value: Int(
                                             1,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -269,7 +260,6 @@ expression: parse_ast
                     value: Int(
                         3,
                     ),
-                    kind: None,
                 },
             ),
             cases: [
@@ -288,7 +278,6 @@ expression: parse_ast
                                                 value: Int(
                                                     0,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -302,7 +291,6 @@ expression: parse_ast
                                                 value: Int(
                                                     1,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -316,7 +304,6 @@ expression: parse_ast
                                                 value: Int(
                                                     2,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -330,7 +317,6 @@ expression: parse_ast
                                                 value: Int(
                                                     3,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -358,7 +344,6 @@ expression: parse_ast
                                         value: Bool(
                                             true,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -398,7 +383,6 @@ expression: parse_ast
                                                             value: Int(
                                                                 0,
                                                             ),
-                                                            kind: None,
                                                         },
                                                     ),
                                                 },
@@ -412,7 +396,6 @@ expression: parse_ast
                                                             value: Int(
                                                                 1,
                                                             ),
-                                                            kind: None,
                                                         },
                                                     ),
                                                 },
@@ -433,7 +416,6 @@ expression: parse_ast
                                                             value: Int(
                                                                 1,
                                                             ),
-                                                            kind: None,
                                                         },
                                                     ),
                                                 },
@@ -447,7 +429,6 @@ expression: parse_ast
                                                             value: Int(
                                                                 0,
                                                             ),
-                                                            kind: None,
                                                         },
                                                     ),
                                                 },
@@ -478,7 +459,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -526,10 +506,10 @@ expression: parse_ast
                                             value: Str(
                                                 StringConstant {
                                                     value: "seq",
+                                                    unicode: false,
                                                     implicit_concatenated: false,
                                                 },
                                             ),
-                                            kind: None,
                                         },
                                     ),
                                 ),
@@ -559,10 +539,10 @@ expression: parse_ast
                                             value: Str(
                                                 StringConstant {
                                                     value: "map",
+                                                    unicode: false,
                                                     implicit_concatenated: false,
                                                 },
                                             ),
-                                            kind: None,
                                         },
                                     ),
                                 ),
@@ -596,7 +576,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ],
@@ -614,7 +593,6 @@ expression: parse_ast
                                                             value: Int(
                                                                 1,
                                                             ),
-                                                            kind: None,
                                                         },
                                                     ),
                                                 },
@@ -628,7 +606,6 @@ expression: parse_ast
                                                             value: Int(
                                                                 2,
                                                             ),
-                                                            kind: None,
                                                         },
                                                     ),
                                                 },
@@ -668,7 +645,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -691,7 +667,6 @@ expression: parse_ast
                                                     value: Int(
                                                         0,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ],
@@ -713,7 +688,6 @@ expression: parse_ast
                                                                                     value: Int(
                                                                                         1,
                                                                                     ),
-                                                                                    kind: None,
                                                                                 },
                                                                             ),
                                                                         },
@@ -727,7 +701,6 @@ expression: parse_ast
                                                                                     value: Int(
                                                                                         2,
                                                                                     ),
-                                                                                    kind: None,
                                                                                 },
                                                                             ),
                                                                         },
@@ -768,7 +741,6 @@ expression: parse_ast
                                                     value: Int(
                                                         1,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ],
@@ -800,7 +772,6 @@ expression: parse_ast
                                                     value: Int(
                                                         0,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ],
@@ -818,7 +789,6 @@ expression: parse_ast
                                                                         value: Int(
                                                                             1,
                                                                         ),
-                                                                        kind: None,
                                                                     },
                                                                 ),
                                                             },
@@ -832,7 +802,6 @@ expression: parse_ast
                                                                         value: Int(
                                                                             2,
                                                                         ),
-                                                                        kind: None,
                                                                     },
                                                                 ),
                                                             },
@@ -867,10 +836,10 @@ expression: parse_ast
                                                 value: Str(
                                                     StringConstant {
                                                         value: "X",
+                                                        unicode: false,
                                                         implicit_concatenated: false,
                                                     },
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -906,7 +875,6 @@ expression: parse_ast
                                         value: Int(
                                             1,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -941,7 +909,6 @@ expression: parse_ast
                                         value: Int(
                                             2,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -976,7 +943,6 @@ expression: parse_ast
                                             value: Float(
                                                 0.25,
                                             ),
-                                            kind: None,
                                         },
                                     ),
                                     op: Add,
@@ -987,7 +953,6 @@ expression: parse_ast
                                                 real: 0.0,
                                                 imag: 1.75,
                                             },
-                                            kind: None,
                                         },
                                     ),
                                 },
@@ -1014,7 +979,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -1051,7 +1015,6 @@ expression: parse_ast
                                                 real: 0.0,
                                                 imag: 0.0,
                                             },
-                                            kind: None,
                                         },
                                     ),
                                 },
@@ -1078,7 +1041,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -1097,7 +1059,6 @@ expression: parse_ast
                     value: Int(
                         4,
                     ),
-                    kind: None,
                 },
             ),
             cases: [
@@ -1116,7 +1077,6 @@ expression: parse_ast
                                                 value: Int(
                                                     0,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -1130,7 +1090,6 @@ expression: parse_ast
                                                 value: Int(
                                                     1,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -1144,7 +1103,6 @@ expression: parse_ast
                                                 value: Int(
                                                     2,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -1158,7 +1116,6 @@ expression: parse_ast
                                                 value: Int(
                                                     3,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -1186,7 +1143,6 @@ expression: parse_ast
                                         value: Bool(
                                             true,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -1218,7 +1174,6 @@ expression: parse_ast
                                     value: Int(
                                         0,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -1251,7 +1206,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -1284,7 +1238,6 @@ expression: parse_ast
                                         value: Int(
                                             1,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ],
@@ -1298,7 +1251,6 @@ expression: parse_ast
                                                 value: Int(
                                                     0,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -1327,7 +1279,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -1346,7 +1297,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ],
@@ -1360,7 +1310,6 @@ expression: parse_ast
                                                 value: Int(
                                                     0,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -1389,7 +1338,6 @@ expression: parse_ast
                                         value: Int(
                                             1,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -1431,7 +1379,6 @@ expression: parse_ast
                                         value: Int(
                                             2,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -1497,7 +1444,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -1529,7 +1475,6 @@ expression: parse_ast
                                     value: Int(
                                         1,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -1554,7 +1499,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -1572,7 +1516,6 @@ expression: parse_ast
                                     value: Int(
                                         1,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -1597,7 +1540,6 @@ expression: parse_ast
                                         value: Int(
                                             1,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -1630,10 +1572,10 @@ expression: parse_ast
                                         value: Str(
                                             StringConstant {
                                                 value: "foo",
+                                                unicode: false,
                                                 implicit_concatenated: false,
                                             },
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ],
@@ -1695,7 +1637,6 @@ expression: parse_ast
                                 value: Int(
                                     0,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -1704,7 +1645,6 @@ expression: parse_ast
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -1713,7 +1653,6 @@ expression: parse_ast
                                 value: Int(
                                     2,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],
@@ -1736,7 +1675,6 @@ expression: parse_ast
                                                 value: Int(
                                                     0,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -1750,7 +1688,6 @@ expression: parse_ast
                                                 value: Int(
                                                     1,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -1775,7 +1712,6 @@ expression: parse_ast
                                                 value: Int(
                                                     2,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -1803,7 +1739,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -1839,7 +1774,6 @@ expression: parse_ast
                                                 value: Int(
                                                     0,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -1867,7 +1801,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -1889,7 +1822,6 @@ expression: parse_ast
                                                 value: Int(
                                                     1,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -1903,7 +1835,6 @@ expression: parse_ast
                                                 value: Int(
                                                     0,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -1943,7 +1874,6 @@ expression: parse_ast
                                                             value: Int(
                                                                 0,
                                                             ),
-                                                            kind: None,
                                                         },
                                                     ),
                                                 ),
@@ -1975,7 +1905,6 @@ expression: parse_ast
                                         value: Int(
                                             1,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -1997,7 +1926,6 @@ expression: parse_ast
                                                 value: Int(
                                                     1,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -2011,7 +1939,6 @@ expression: parse_ast
                                                 value: Int(
                                                     0,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -2039,7 +1966,6 @@ expression: parse_ast
                                         value: Int(
                                             2,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -2119,7 +2045,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -2158,7 +2083,6 @@ expression: parse_ast
                                                     value: Float(
                                                         0.25,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         },
@@ -2171,7 +2095,6 @@ expression: parse_ast
                                                 real: 0.0,
                                                 imag: 1.75,
                                             },
-                                            kind: None,
                                         },
                                     ),
                                 },
@@ -2198,7 +2121,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -2268,7 +2190,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -2353,7 +2274,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -2402,7 +2322,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -2434,7 +2353,6 @@ expression: parse_ast
                                     value: Int(
                                         0,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -2459,7 +2377,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -2510,7 +2427,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -2559,7 +2475,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -2581,10 +2496,10 @@ expression: parse_ast
                                                 value: Str(
                                                     StringConstant {
                                                         value: "",
+                                                        unicode: false,
                                                         implicit_concatenated: false,
                                                     },
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -2612,7 +2527,6 @@ expression: parse_ast
                                         value: Int(
                                             1,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -2630,10 +2544,10 @@ expression: parse_ast
                                     value: Str(
                                         StringConstant {
                                             value: "",
+                                            unicode: false,
                                             implicit_concatenated: false,
                                         },
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -2658,7 +2572,6 @@ expression: parse_ast
                                         value: Int(
                                             2,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -2713,7 +2626,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -2798,7 +2710,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -2838,7 +2749,6 @@ expression: parse_ast
                                                             value: Int(
                                                                 0,
                                                             ),
-                                                            kind: None,
                                                         },
                                                     ),
                                                 },
@@ -2865,7 +2775,6 @@ expression: parse_ast
                                                             value: Int(
                                                                 1,
                                                             ),
-                                                            kind: None,
                                                         },
                                                     ),
                                                 },
@@ -2892,7 +2801,6 @@ expression: parse_ast
                                                             value: Int(
                                                                 2,
                                                             ),
-                                                            kind: None,
                                                         },
                                                     ),
                                                 },
@@ -2941,7 +2849,6 @@ expression: parse_ast
                                                     value: Int(
                                                         2,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         },
@@ -2969,7 +2876,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -3002,7 +2908,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ],
@@ -3020,7 +2925,6 @@ expression: parse_ast
                                                             value: Int(
                                                                 1,
                                                             ),
-                                                            kind: None,
                                                         },
                                                     ),
                                                 },
@@ -3034,7 +2938,6 @@ expression: parse_ast
                                                             value: Int(
                                                                 2,
                                                             ),
-                                                            kind: None,
                                                         },
                                                     ),
                                                 },
@@ -3074,7 +2977,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -3097,7 +2999,6 @@ expression: parse_ast
                                                     value: Int(
                                                         0,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ],
@@ -3119,7 +3020,6 @@ expression: parse_ast
                                                                                     value: Int(
                                                                                         1,
                                                                                     ),
-                                                                                    kind: None,
                                                                                 },
                                                                             ),
                                                                         },
@@ -3133,7 +3033,6 @@ expression: parse_ast
                                                                                     value: Int(
                                                                                         2,
                                                                                     ),
-                                                                                    kind: None,
                                                                                 },
                                                                             ),
                                                                         },
@@ -3174,7 +3073,6 @@ expression: parse_ast
                                                     value: Int(
                                                         1,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ],
@@ -3206,7 +3104,6 @@ expression: parse_ast
                                                     value: Int(
                                                         0,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ],
@@ -3224,7 +3121,6 @@ expression: parse_ast
                                                                         value: Int(
                                                                             1,
                                                                         ),
-                                                                        kind: None,
                                                                     },
                                                                 ),
                                                             },
@@ -3238,7 +3134,6 @@ expression: parse_ast
                                                                         value: Int(
                                                                             2,
                                                                         ),
-                                                                        kind: None,
                                                                     },
                                                                 ),
                                                             },
@@ -3273,10 +3168,10 @@ expression: parse_ast
                                                 value: Str(
                                                     StringConstant {
                                                         value: "X",
+                                                        unicode: false,
                                                         implicit_concatenated: false,
                                                     },
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -3312,7 +3207,6 @@ expression: parse_ast
                                         value: Int(
                                             1,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -3347,7 +3241,6 @@ expression: parse_ast
                                         value: Int(
                                             2,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -3370,7 +3263,6 @@ expression: parse_ast
                                 value: Int(
                                     0,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -3379,7 +3271,6 @@ expression: parse_ast
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -3388,7 +3279,6 @@ expression: parse_ast
                                 value: Int(
                                     2,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],
@@ -3411,7 +3301,6 @@ expression: parse_ast
                                                 value: Int(
                                                     0,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -3450,7 +3339,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -3473,7 +3361,6 @@ expression: parse_ast
                                 value: Int(
                                     0,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -3482,7 +3369,6 @@ expression: parse_ast
                                 value: Int(
                                     1,
                                 ),
-                                kind: None,
                             },
                         ),
                         Constant(
@@ -3491,7 +3377,6 @@ expression: parse_ast
                                 value: Int(
                                     2,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],
@@ -3525,7 +3410,6 @@ expression: parse_ast
                                                 value: Int(
                                                     2,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -3553,7 +3437,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -3615,7 +3498,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -3704,7 +3586,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },
@@ -3791,7 +3672,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__slice.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__slice.snap
@@ -22,7 +22,6 @@ Subscript(
                             value: Int(
                                 1,
                             ),
-                            kind: None,
                         },
                     ),
                 ),
@@ -33,7 +32,6 @@ Subscript(
                             value: Int(
                                 2,
                             ),
-                            kind: None,
                         },
                     ),
                 ),
@@ -44,7 +42,6 @@ Subscript(
                             value: Int(
                                 3,
                             ),
-                            kind: None,
                         },
                     ),
                 ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__star_index.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__star_index.snap
@@ -35,7 +35,6 @@ expression: parse_ast
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                                 Starred(
@@ -61,7 +60,6 @@ expression: parse_ast
                                                 value: Int(
                                                     1,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -99,7 +97,6 @@ expression: parse_ast
                                             value: Int(
                                                 0,
                                             ),
-                                            kind: None,
                                         },
                                     ),
                                     Starred(
@@ -125,7 +122,6 @@ expression: parse_ast
                                                     value: Int(
                                                         1,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         },
@@ -226,7 +222,6 @@ expression: parse_ast
                                                     value: Int(
                                                         3,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ),
@@ -237,7 +232,6 @@ expression: parse_ast
                                                     value: Int(
                                                         5,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__try.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__try.snap
@@ -30,7 +30,6 @@ expression: parse_ast
                                                     value: Int(
                                                         1,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ],
@@ -89,10 +88,10 @@ expression: parse_ast
                                                                         value: Str(
                                                                             StringConstant {
                                                                                 value: "caught ",
+                                                                                unicode: false,
                                                                                 implicit_concatenated: false,
                                                                             },
                                                                         ),
-                                                                        kind: None,
                                                                     },
                                                                 ),
                                                                 FormattedValue(
@@ -187,10 +186,10 @@ expression: parse_ast
                                                                         value: Str(
                                                                             StringConstant {
                                                                                 value: "caught ",
+                                                                                unicode: false,
                                                                                 implicit_concatenated: false,
                                                                             },
                                                                         ),
-                                                                        kind: None,
                                                                     },
                                                                 ),
                                                                 FormattedValue(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__try_star.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__try_star.snap
@@ -30,10 +30,10 @@ expression: parse_ast
                                                     value: Str(
                                                         StringConstant {
                                                             value: "eg",
+                                                            unicode: false,
                                                             implicit_concatenated: false,
                                                         },
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                             List(
@@ -59,7 +59,6 @@ expression: parse_ast
                                                                                 value: Int(
                                                                                     1,
                                                                                 ),
-                                                                                kind: None,
                                                                             },
                                                                         ),
                                                                     ],
@@ -86,7 +85,6 @@ expression: parse_ast
                                                                                 value: Int(
                                                                                     2,
                                                                                 ),
-                                                                                kind: None,
                                                                             },
                                                                         ),
                                                                     ],
@@ -113,7 +111,6 @@ expression: parse_ast
                                                                                 value: Int(
                                                                                     3,
                                                                                 ),
-                                                                                kind: None,
                                                                             },
                                                                         ),
                                                                     ],
@@ -140,7 +137,6 @@ expression: parse_ast
                                                                                 value: Int(
                                                                                     4,
                                                                                 ),
-                                                                                kind: None,
                                                                             },
                                                                         ),
                                                                     ],
@@ -208,10 +204,10 @@ expression: parse_ast
                                                                         value: Str(
                                                                             StringConstant {
                                                                                 value: "caught ",
+                                                                                unicode: false,
                                                                                 implicit_concatenated: false,
                                                                             },
                                                                         ),
-                                                                        kind: None,
                                                                     },
                                                                 ),
                                                                 FormattedValue(
@@ -253,10 +249,10 @@ expression: parse_ast
                                                                         value: Str(
                                                                             StringConstant {
                                                                                 value: " with nested ",
+                                                                                unicode: false,
                                                                                 implicit_concatenated: false,
                                                                             },
                                                                         ),
-                                                                        kind: None,
                                                                     },
                                                                 ),
                                                                 FormattedValue(
@@ -343,10 +339,10 @@ expression: parse_ast
                                                                         value: Str(
                                                                             StringConstant {
                                                                                 value: "caught ",
+                                                                                unicode: false,
                                                                                 implicit_concatenated: false,
                                                                             },
                                                                         ),
-                                                                        kind: None,
                                                                     },
                                                                 ),
                                                                 FormattedValue(
@@ -388,10 +384,10 @@ expression: parse_ast
                                                                         value: Str(
                                                                             StringConstant {
                                                                                 value: " with nested ",
+                                                                                unicode: false,
                                                                                 implicit_concatenated: false,
                                                                             },
                                                                         ),
-                                                                        kind: None,
                                                                     },
                                                                 ),
                                                                 FormattedValue(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__type_as_identifier.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__type_as_identifier.snap
@@ -633,7 +633,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 1,
                             ),
-                            kind: None,
                         },
                     ),
                 },
@@ -749,7 +748,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                                     value: Int(
                                                         12,
                                                     ),
-                                                    kind: None,
                                                 },
                                             ),
                                         ],
@@ -928,7 +926,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                     value: Int(
                         1,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -958,7 +955,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                     value: Int(
                         1,
                     ),
-                    kind: None,
                 },
             ),
         },
@@ -988,7 +984,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                     value: Int(
                         1,
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__variadic_generics.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__variadic_generics.snap
@@ -80,7 +80,6 @@ expression: parse_ast
                             ExprConstant {
                                 range: 46..49,
                                 value: Ellipsis,
-                                kind: None,
                             },
                         ),
                     },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__with_statement.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__with_statement.snap
@@ -16,7 +16,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 0,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: None,
@@ -44,7 +43,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 0,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: Some(
@@ -80,7 +78,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 0,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: None,
@@ -93,7 +90,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 1,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: None,
@@ -121,7 +117,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 0,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: Some(
@@ -142,7 +137,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 1,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: Some(
@@ -181,7 +175,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         1,
                                     ),
-                                    kind: None,
                                 },
                             ),
                             body: Constant(
@@ -190,7 +183,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         0,
                                     ),
-                                    kind: None,
                                 },
                             ),
                             orelse: Constant(
@@ -199,7 +191,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         2,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -232,7 +223,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         1,
                                     ),
-                                    kind: None,
                                 },
                             ),
                             body: Constant(
@@ -241,7 +231,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         0,
                                     ),
-                                    kind: None,
                                 },
                             ),
                             orelse: Constant(
@@ -250,7 +239,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         2,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -348,7 +336,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 0,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: None,
@@ -376,7 +363,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 0,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: Some(
@@ -412,7 +398,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 0,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: None,
@@ -444,7 +429,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ],
@@ -484,7 +468,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 0,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: None,
@@ -497,7 +480,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 1,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: None,
@@ -529,7 +511,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                                 Constant(
@@ -538,7 +519,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                         value: Int(
                                             1,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                             ],
@@ -670,7 +650,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                                 Starred(
@@ -719,7 +698,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                         value: Int(
                                             0,
                                         ),
-                                        kind: None,
                                     },
                                 ),
                                 Starred(
@@ -782,7 +760,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         0,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -822,7 +799,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                     value: Int(
                                         0,
                                     ),
-                                    kind: None,
                                 },
                             ),
                         },
@@ -874,7 +850,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                                 value: Int(
                                                     0,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -895,7 +870,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                                 value: Int(
                                                     1,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -943,7 +917,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                                 value: Int(
                                                     0,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -964,7 +937,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                                                 value: Int(
                                                     1,
                                                 ),
-                                                kind: None,
                                             },
                                         ),
                                     },
@@ -1006,7 +978,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 0,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: Some(
@@ -1042,7 +1013,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 0,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: Some(
@@ -1078,7 +1048,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 0,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: Some(
@@ -1099,7 +1068,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 1,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: Some(
@@ -1135,7 +1103,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 0,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: Some(
@@ -1156,7 +1123,6 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
                             value: Int(
                                 1,
                             ),
-                            kind: None,
                         },
                     ),
                     optional_vars: Some(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__backspace_alias.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__backspace_alias.snap
@@ -12,10 +12,10 @@ expression: parse_ast
                     value: Str(
                         StringConstant {
                             value: "\u{8}",
+                            unicode: false,
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__bell_alias.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__bell_alias.snap
@@ -12,10 +12,10 @@ expression: parse_ast
                     value: Str(
                         StringConstant {
                             value: "\u{7}",
+                            unicode: false,
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__carriage_return_alias.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__carriage_return_alias.snap
@@ -12,10 +12,10 @@ expression: parse_ast
                     value: Str(
                         StringConstant {
                             value: "\r",
+                            unicode: false,
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__character_tabulation_with_justification_alias.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__character_tabulation_with_justification_alias.snap
@@ -12,10 +12,10 @@ expression: parse_ast
                     value: Str(
                         StringConstant {
                             value: "\u{89}",
+                            unicode: false,
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__delete_alias.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__delete_alias.snap
@@ -12,10 +12,10 @@ expression: parse_ast
                     value: Str(
                         StringConstant {
                             value: "\u{7f}",
+                            unicode: false,
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__double_quoted_byte.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__double_quoted_byte.snap
@@ -272,7 +272,6 @@ expression: parse_ast
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__escape_alias.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__escape_alias.snap
@@ -12,10 +12,10 @@ expression: parse_ast
                     value: Str(
                         StringConstant {
                             value: "\u{1b}",
+                            unicode: false,
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__escape_char_in_byte_literal.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__escape_char_in_byte_literal.snap
@@ -26,7 +26,6 @@ expression: parse_ast
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__escape_octet.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__escape_octet.snap
@@ -21,7 +21,6 @@ expression: parse_ast
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__form_feed_alias.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__form_feed_alias.snap
@@ -12,10 +12,10 @@ expression: parse_ast
                     value: Str(
                         StringConstant {
                             value: "\u{c}",
+                            unicode: false,
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_constant_range.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_constant_range.snap
@@ -16,10 +16,10 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "aaa",
+                                        unicode: false,
                                         implicit_concatenated: false,
                                     },
                                 ),
-                                kind: None,
                             },
                         ),
                         FormattedValue(
@@ -43,10 +43,10 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "ccc",
+                                        unicode: false,
                                         implicit_concatenated: false,
                                     },
                                 ),
-                                kind: None,
                             },
                         ),
                         FormattedValue(
@@ -70,10 +70,10 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "eee",
+                                        unicode: false,
                                         implicit_concatenated: false,
                                     },
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_character.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_character.snap
@@ -16,10 +16,10 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "\\",
+                                        unicode: false,
                                         implicit_concatenated: false,
                                     },
                                 ),
-                                kind: None,
                             },
                         ),
                         FormattedValue(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_newline.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_newline.snap
@@ -16,10 +16,10 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "\n",
+                                        unicode: false,
                                         implicit_concatenated: false,
                                     },
                                 ),
-                                kind: None,
                             },
                         ),
                         FormattedValue(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_line_continuation.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_line_continuation.snap
@@ -16,10 +16,10 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "\\\n",
+                                        unicode: false,
                                         implicit_concatenated: false,
                                     },
                                 ),
-                                kind: None,
                             },
                         ),
                         FormattedValue(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_base_more.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_base_more.snap
@@ -9,10 +9,10 @@ expression: parse_ast
             value: Str(
                 StringConstant {
                     value: "mix ",
+                    unicode: false,
                     implicit_concatenated: false,
                 },
             ),
-            kind: None,
         },
     ),
     FormattedValue(
@@ -41,10 +41,10 @@ expression: parse_ast
             value: Str(
                 StringConstant {
                     value: " with text and ",
+                    unicode: false,
                     implicit_concatenated: false,
                 },
             ),
-            kind: None,
         },
     ),
     FormattedValue(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_format.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_format.snap
@@ -31,10 +31,10 @@ expression: parse_ast
                                     value: Str(
                                         StringConstant {
                                             value: ">10",
+                                            unicode: false,
                                             implicit_concatenated: false,
                                         },
                                     ),
-                                    kind: None,
                                 },
                             ),
                         ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_unescaped_newline.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_unescaped_newline.snap
@@ -16,10 +16,10 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "\n",
+                                        unicode: false,
                                         implicit_concatenated: false,
                                     },
                                 ),
-                                kind: None,
                             },
                         ),
                         FormattedValue(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__hts_alias.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__hts_alias.snap
@@ -12,10 +12,10 @@ expression: parse_ast
                     value: Str(
                         StringConstant {
                             value: "\u{88}",
+                            unicode: false,
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_1.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_1.snap
@@ -16,10 +16,10 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "Hello world",
+                                        unicode: false,
                                         implicit_concatenated: true,
                                     },
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_2.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_2.snap
@@ -16,10 +16,10 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "Hello world",
+                                        unicode: false,
                                         implicit_concatenated: true,
                                     },
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_3.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_3.snap
@@ -16,10 +16,10 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "Hello world",
+                                        unicode: false,
                                         implicit_concatenated: true,
                                     },
                                 ),
-                                kind: None,
                             },
                         ),
                         FormattedValue(
@@ -31,10 +31,10 @@ expression: parse_ast
                                         value: Str(
                                             StringConstant {
                                                 value: "!",
+                                                unicode: false,
                                                 implicit_concatenated: false,
                                             },
                                         ),
-                                        kind: None,
                                     },
                                 ),
                                 debug_text: None,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_4.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_4.snap
@@ -16,10 +16,10 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "Hello world",
+                                        unicode: false,
                                         implicit_concatenated: true,
                                     },
                                 ),
-                                kind: None,
                             },
                         ),
                         FormattedValue(
@@ -31,10 +31,10 @@ expression: parse_ast
                                         value: Str(
                                             StringConstant {
                                                 value: "!",
+                                                unicode: false,
                                                 implicit_concatenated: false,
                                             },
                                         ),
-                                        kind: None,
                                     },
                                 ),
                                 debug_text: None,
@@ -48,10 +48,10 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "again!",
+                                        unicode: false,
                                         implicit_concatenated: true,
                                     },
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring.snap
@@ -39,10 +39,10 @@ expression: parse_ast
             value: Str(
                 StringConstant {
                     value: "{foo}",
+                    unicode: false,
                     implicit_concatenated: false,
                 },
             ),
-            kind: None,
         },
     ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_equals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_equals.snap
@@ -15,7 +15,6 @@ expression: parse_ast
                             value: Int(
                                 42,
                             ),
-                            kind: None,
                         },
                     ),
                     ops: [
@@ -28,7 +27,6 @@ expression: parse_ast
                                 value: Int(
                                     42,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_concatenation_string_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_concatenation_string_spec.snap
@@ -29,10 +29,10 @@ expression: parse_ast
                                             value: Str(
                                                 StringConstant {
                                                     value: "",
+                                                    unicode: false,
                                                     implicit_concatenated: true,
                                                 },
                                             ),
-                                            kind: None,
                                         },
                                     ),
                                     debug_text: None,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_string_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_string_spec.snap
@@ -29,10 +29,10 @@ expression: parse_ast
                                             value: Str(
                                                 StringConstant {
                                                     value: "",
+                                                    unicode: false,
                                                     implicit_concatenated: false,
                                                 },
                                             ),
-                                            kind: None,
                                         },
                                     ),
                                     debug_text: None,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_equals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_equals.snap
@@ -15,7 +15,6 @@ expression: parse_ast
                             value: Int(
                                 1,
                             ),
-                            kind: None,
                         },
                     ),
                     ops: [
@@ -28,7 +27,6 @@ expression: parse_ast
                                 value: Int(
                                     2,
                                 ),
-                                kind: None,
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_nested_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_nested_spec.snap
@@ -26,10 +26,10 @@ expression: parse_ast
                                     value: Str(
                                         StringConstant {
                                             value: "spec",
+                                            unicode: false,
                                             implicit_concatenated: false,
                                         },
                                     ),
-                                    kind: None,
                                 },
                             ),
                         ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_string_concat.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_string_concat.snap
@@ -12,10 +12,10 @@ expression: parse_ast
                     value: Str(
                         StringConstant {
                             value: "Hello world",
+                            unicode: false,
                             implicit_concatenated: true,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_string_triple_quotes_with_kind.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_string_triple_quotes_with_kind.snap
@@ -12,11 +12,9 @@ expression: parse_ast
                     value: Str(
                         StringConstant {
                             value: "Hello, world!",
+                            unicode: true,
                             implicit_concatenated: false,
                         },
-                    ),
-                    kind: Some(
-                        "u",
                     ),
                 },
             ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_f_string_concat_1.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_f_string_concat_1.snap
@@ -16,11 +16,9 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "Hello world",
+                                        unicode: true,
                                         implicit_concatenated: true,
                                     },
-                                ),
-                                kind: Some(
-                                    "u",
                                 ),
                             },
                         ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_f_string_concat_2.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_f_string_concat_2.snap
@@ -16,11 +16,9 @@ expression: parse_ast
                                 value: Str(
                                     StringConstant {
                                         value: "Hello world!",
+                                        unicode: true,
                                         implicit_concatenated: true,
                                     },
-                                ),
-                                kind: Some(
-                                    "u",
                                 ),
                             },
                         ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_string_concat_1.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_string_concat_1.snap
@@ -12,10 +12,10 @@ expression: parse_ast
                     value: Str(
                         StringConstant {
                             value: "Hello world",
+                            unicode: false,
                             implicit_concatenated: true,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_string_concat_2.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_string_concat_2.snap
@@ -12,11 +12,9 @@ expression: parse_ast
                     value: Str(
                         StringConstant {
                             value: "Hello world",
+                            unicode: true,
                             implicit_concatenated: true,
                         },
-                    ),
-                    kind: Some(
-                        "u",
                     ),
                 },
             ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__raw_byte_literal_1.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__raw_byte_literal_1.snap
@@ -20,7 +20,6 @@ expression: parse_ast
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__raw_byte_literal_2.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__raw_byte_literal_2.snap
@@ -18,7 +18,6 @@ expression: parse_ast
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__single_quoted_byte.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__single_quoted_byte.snap
@@ -272,7 +272,6 @@ expression: parse_ast
                             implicit_concatenated: false,
                         },
                     ),
-                    kind: None,
                 },
             ),
         },


### PR DESCRIPTION
## Summary

This PR refactors the `ExprConstant::kind` field to instead use
`StringConstant::unicode` to indicate a unicode string literal. The `kind`
field serves no other purpose, and is not used in any other way. This means
allocating a string to store `u`/`U` seems unnecessary.

The new field is similar to `implicit_concatenated`. It is a `bool` that
indicates whether the string literal is a unicode string literal.

This will also be useful in the f-string parsing to create an enum for possible
string literal types in implicit concatenation which are strings, bytes or
f-strings.

## Test Plan

```
cargo test --workspace --all-features
```
