### PR TITLE
Restructure signatures of `flake8_comprehensions` fixers

### DIFF
--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
@@ -85,9 +85,9 @@ pub(crate) fn unnecessary_call_around_sorted(
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
             let edit = fixes::fix_unnecessary_call_around_sorted(
+                expr,
                 checker.locator(),
                 checker.stylist(),
-                expr,
             )?;
             if outer.id == "reversed" {
                 Ok(Fix::suggested(edit))

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
@@ -88,7 +88,7 @@ pub(crate) fn unnecessary_collection_call(
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            fixes::fix_unnecessary_collection_call(checker, expr).map(Fix::suggested)
+            fixes::fix_unnecessary_collection_call(expr, checker).map(Fix::suggested)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -65,7 +65,7 @@ fn add_diagnostic(checker: &mut Checker, expr: &Expr) {
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            fixes::fix_unnecessary_comprehension(checker.locator(), checker.stylist(), expr)
+            fixes::fix_unnecessary_comprehension(expr, checker.locator(), checker.stylist())
                 .map(Fix::suggested)
         });
     }

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_any_all.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_any_all.rs
@@ -91,7 +91,7 @@ pub(crate) fn unnecessary_comprehension_any_all(
     let mut diagnostic = Diagnostic::new(UnnecessaryComprehensionAnyAll, arg.range());
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            fixes::fix_unnecessary_comprehension_any_all(checker.locator(), checker.stylist(), expr)
+            fixes::fix_unnecessary_comprehension_any_all(expr, checker.locator(), checker.stylist())
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
@@ -133,9 +133,9 @@ pub(crate) fn unnecessary_double_cast_or_process(
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
                 fixes::fix_unnecessary_double_cast_or_process(
+                    expr,
                     checker.locator(),
                     checker.stylist(),
-                    expr,
                 )
                 .map(Fix::suggested)
             });

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
@@ -60,7 +60,7 @@ pub(crate) fn unnecessary_generator_dict(
                 let mut diagnostic = Diagnostic::new(UnnecessaryGeneratorDict, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.try_set_fix(|| {
-                        fixes::fix_unnecessary_generator_dict(checker, expr).map(Fix::suggested)
+                        fixes::fix_unnecessary_generator_dict(expr, checker).map(Fix::suggested)
                     });
                 }
                 checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
@@ -62,7 +62,7 @@ pub(crate) fn unnecessary_generator_list(
         let mut diagnostic = Diagnostic::new(UnnecessaryGeneratorList, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
-                fixes::fix_unnecessary_generator_list(checker.locator(), checker.stylist(), expr)
+                fixes::fix_unnecessary_generator_list(expr, checker.locator(), checker.stylist())
                     .map(Fix::suggested)
             });
         }

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
@@ -62,7 +62,7 @@ pub(crate) fn unnecessary_generator_set(
         let mut diagnostic = Diagnostic::new(UnnecessaryGeneratorSet, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
-                fixes::fix_unnecessary_generator_set(checker, expr).map(Fix::suggested)
+                fixes::fix_unnecessary_generator_set(expr, checker).map(Fix::suggested)
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
@@ -58,7 +58,7 @@ pub(crate) fn unnecessary_list_call(
     let mut diagnostic = Diagnostic::new(UnnecessaryListCall, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            fixes::fix_unnecessary_list_call(checker.locator(), checker.stylist(), expr)
+            fixes::fix_unnecessary_list_call(expr, checker.locator(), checker.stylist())
                 .map(Fix::suggested)
         });
     }

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
@@ -67,7 +67,7 @@ pub(crate) fn unnecessary_list_comprehension_dict(
     let mut diagnostic = Diagnostic::new(UnnecessaryListComprehensionDict, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            fixes::fix_unnecessary_list_comprehension_dict(checker, expr).map(Fix::suggested)
+            fixes::fix_unnecessary_list_comprehension_dict(expr, checker).map(Fix::suggested)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
@@ -60,7 +60,7 @@ pub(crate) fn unnecessary_list_comprehension_set(
         let mut diagnostic = Diagnostic::new(UnnecessaryListComprehensionSet, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
-                fixes::fix_unnecessary_list_comprehension_set(checker, expr).map(Fix::suggested)
+                fixes::fix_unnecessary_list_comprehension_set(expr, checker).map(Fix::suggested)
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
@@ -82,7 +82,7 @@ pub(crate) fn unnecessary_literal_dict(
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic
-            .try_set_fix(|| fixes::fix_unnecessary_literal_dict(checker, expr).map(Fix::suggested));
+            .try_set_fix(|| fixes::fix_unnecessary_literal_dict(expr, checker).map(Fix::suggested));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
@@ -77,7 +77,7 @@ pub(crate) fn unnecessary_literal_set(
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic
-            .try_set_fix(|| fixes::fix_unnecessary_literal_set(checker, expr).map(Fix::suggested));
+            .try_set_fix(|| fixes::fix_unnecessary_literal_set(expr, checker).map(Fix::suggested));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_dict_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_dict_call.rs
@@ -94,9 +94,9 @@ pub(crate) fn unnecessary_literal_within_dict_call(
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
             fixes::fix_unnecessary_literal_within_dict_call(
+                expr,
                 checker.locator(),
                 checker.stylist(),
-                expr,
             )
             .map(Fix::suggested)
         });

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
@@ -96,9 +96,9 @@ pub(crate) fn unnecessary_literal_within_list_call(
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
             fixes::fix_unnecessary_literal_within_list_call(
+                expr,
                 checker.locator(),
                 checker.stylist(),
-                expr,
             )
             .map(Fix::suggested)
         });

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
@@ -98,9 +98,9 @@ pub(crate) fn unnecessary_literal_within_tuple_call(
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
             fixes::fix_unnecessary_literal_within_tuple_call(
+                expr,
                 checker.locator(),
                 checker.stylist(),
-                expr,
             )
             .map(Fix::suggested)
         });

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -224,11 +224,11 @@ pub(crate) fn unnecessary_map(
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
             fixes::fix_unnecessary_map(
-                checker.locator(),
-                checker.stylist(),
                 expr,
                 parent,
                 object_type,
+                checker.locator(),
+                checker.stylist(),
             )
             .map(Fix::suggested)
         });


### PR DESCRIPTION
The `expr` should always be first, with any "global" structs like the locator and semantic model coming last. (No behavior changes, just changing the order of arguments.)