### PR TITLE
Add warnings for nursery and preview rule selection

### DIFF
--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -405,6 +405,23 @@ fn preview_enabled_direct() {
 }
 
 #[test]
+fn preview_disabled_direct() {
+    // FURB145 is preview not nursery so selecting should be empty
+    let args = ["--select", "FURB145"];
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .args(STDIN_BASE_OPTIONS)
+        .args(args)
+        .pass_stdin("a = l[:]\n"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Selection `FURB145` has no effect because the `--preview` flag was not included.
+    "###);
+}
+
+#[test]
 fn preview_disabled_prefix_empty() {
     // Warns that the selection is empty since all of the CPY rules are in preview
     let args = ["--select", "CPY"];

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -301,6 +301,7 @@ fn nursery_direct() {
     Found 1 error.
 
     ----- stderr -----
+    warning: Selection of nursery rule `E225` without the `--preview` flag is deprecated.
     "###);
 }
 

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -585,6 +585,7 @@ impl Configuration {
                 .chain(selection.unfixable.iter())
                 .chain(selection.extend_fixable.iter())
             {
+                #[allow(deprecated)]
                 if matches!(selector, RuleSelector::Nursery) {
                     let suggestion = if preview.is_disabled() {
                         "Use the `--preview` flag instead."

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -460,9 +460,9 @@ impl Configuration {
         let mut carryover_ignores: Option<&[RuleSelector]> = None;
         let mut carryover_unfixables: Option<&[RuleSelector]> = None;
 
-        // Store redirects for displaying warnings
+        // Store selectors for displaying warnings
         let mut redirects = FxHashMap::default();
-        let mut backwards_compat_nursery_rules = FxHashSet::default();
+        let mut deprecated_nursery_selectors = FxHashSet::default();
         let mut ignored_preview_selectors = FxHashSet::default();
 
         for selection in &self.rule_selections {
@@ -597,7 +597,7 @@ impl Configuration {
                 if preview.is_disabled() {
                     if let RuleSelector::Rule { prefix, .. } = selector {
                         if prefix.rules().any(|rule| rule.is_nursery()) {
-                            backwards_compat_nursery_rules.insert(selector);
+                            deprecated_nursery_selectors.insert(selector);
                         }
                     }
 
@@ -627,7 +627,7 @@ impl Configuration {
             );
         }
 
-        for selection in backwards_compat_nursery_rules {
+        for selection in deprecated_nursery_selectors {
             let (prefix, code) = selection.prefix_and_code();
             warn_user!("Selection of nursery rule `{prefix}{code}` without the `--preview` flag is deprecated.",);
         }

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -592,7 +592,7 @@ impl Configuration {
                     } else {
                         "Use the `PREVIEW` selector instead."
                     };
-                    warn_user_once!("The `NURSERY` selector has been deprecated. {}", suggestion);
+                    warn_user_once!("The `NURSERY` selector has been deprecated. {suggestion}");
                 }
 
                 if preview.is_disabled() {

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -27,7 +27,7 @@ use ruff::settings::types::{
     Version,
 };
 use ruff::settings::{defaults, resolve_per_file_ignores, AllSettings, CliSettings, Settings};
-use ruff::{fs, warn_user_once_by_id, RuleSelector, RUFF_PKG_VERSION};
+use ruff::{fs, warn_user, warn_user_once, warn_user_once_by_id, RuleSelector, RUFF_PKG_VERSION};
 use ruff_cache::cache_dir;
 use rustc_hash::{FxHashMap, FxHashSet};
 use shellexpand;
@@ -460,7 +460,10 @@ impl Configuration {
         let mut carryover_ignores: Option<&[RuleSelector]> = None;
         let mut carryover_unfixables: Option<&[RuleSelector]> = None;
 
+        // Store redirects for displaying warnings
         let mut redirects = FxHashMap::default();
+        let mut backwards_compat_nursery_rules = FxHashSet::default();
+        let mut ignored_preview_selectors = FxHashSet::default();
 
         for selection in &self.rule_selections {
             // If a selection only specifies extend-select we cannot directly
@@ -571,8 +574,7 @@ impl Configuration {
                 }
             }
 
-            // We insert redirects into the hashmap so that we
-            // can warn the users about remapped rule codes.
+            // Check for selections that require a warning
             for selector in selection
                 .select
                 .iter()
@@ -583,6 +585,28 @@ impl Configuration {
                 .chain(selection.unfixable.iter())
                 .chain(selection.extend_fixable.iter())
             {
+                if matches!(selector, RuleSelector::Nursery) {
+                    let suggestion = if preview.is_disabled() {
+                        "Use the `--preview` flag instead."
+                    } else {
+                        "Use the `PREVIEW` selector instead."
+                    };
+                    warn_user_once!("The `NURSERY` selector has been deprecated. {}", suggestion);
+                }
+
+                if preview.is_disabled() {
+                    if let RuleSelector::Rule { prefix, .. } = selector {
+                        if prefix.rules().any(|rule| rule.is_nursery()) {
+                            backwards_compat_nursery_rules.insert(selector);
+                        }
+                    }
+
+                    // Check if the selector is empty because preview mode is disabled
+                    if selector.rules(PreviewMode::Disabled).next().is_none() {
+                        ignored_preview_selectors.insert(selector);
+                    }
+                }
+
                 if let RuleSelector::Prefix {
                     prefix,
                     redirected_from: Some(redirect_from),
@@ -600,6 +624,18 @@ impl Configuration {
                 "`{from}` has been remapped to `{}{}`.",
                 target.linter().common_prefix(),
                 target.short_code()
+            );
+        }
+
+        for selection in backwards_compat_nursery_rules {
+            let (prefix, code) = selection.prefix_and_code();
+            warn_user!("Selection of nursery rule `{prefix}{code}` without the `--preview` flag is deprecated.",);
+        }
+
+        for selection in ignored_preview_selectors {
+            let (prefix, code) = selection.prefix_and_code();
+            warn_user!(
+                "Selection `{prefix}{code}` has no effect because the `--preview` flag was not included.",
             );
         }
 


### PR DESCRIPTION
## Summary

Adds warnings for cases where:
- A selector does not include any rules because preview is disabled
- A nursery rule is selected without the preview flag

## Test plan

Add integration tests