### PR TITLE
Use the unicode-ident crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,8 +2432,7 @@ dependencies = [
  "static_assertions",
  "test-case",
  "tiny-keccak",
- "unic-emoji-char",
- "unic-ucd-ident",
+ "unicode-ident",
  "unicode_names2",
 ]
 
@@ -2468,7 +2467,7 @@ dependencies = [
 name = "ruff_python_stdlib"
 version = "0.0.0"
 dependencies = [
- "unic-ucd-ident",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2482,7 +2481,7 @@ dependencies = [
  "ruff_source_file",
  "ruff_text_size",
  "smallvec",
- "unic-ucd-ident",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3281,34 +3280,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
 
 [[package]]
-name = "unic-emoji-char"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b07221e68897210270a38bde4babb655869637af0f69407f96053a34f76494d"
-dependencies = [
- "unic-char-property",
- "unic-char-range",
- "unic-ucd-version",
-]
-
-[[package]]
 name = "unic-ucd-category"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8d4591f5fcfe1bd4453baaf803c40e1b1e69ff8455c47620440b46efef91c0"
 dependencies = [
  "matches",
- "unic-char-property",
- "unic-char-range",
- "unic-ucd-version",
-]
-
-[[package]]
-name = "unic-ucd-ident"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987"
-dependencies = [
  "unic-char-property",
  "unic-char-range",
  "unic-ucd-version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ toml = { version = "0.7.2" }
 tracing = "0.1.37"
 tracing-indicatif = "0.3.4"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-unic-ucd-ident = "0.9.0"
+unicode-ident = "1.0.11"
 unicode-width = "0.1.10"
 uuid = { version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics", "js"] }
 wsl = { version = "0.1.0" }

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -23,8 +23,7 @@ itertools = { workspace = true }
 lalrpop-util = { version = "0.20.0", default-features = false }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
-unic-emoji-char = "0.9.0"
-unic-ucd-ident = {  workspace = true }
+unicode-ident = { workspace = true }
 unicode_names2 = { version = "0.6.0", git = "https://github.com/youknowone/unicode_names2.git", rev = "4ce16aa85cbcdd9cc830410f1a72ef9a235f2fde" }
 rustc-hash = { workspace = true }
 static_assertions = "1.1.0"

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -36,8 +36,7 @@ use num_bigint::BigInt;
 use num_traits::{Num, Zero};
 use ruff_python_ast::IpyEscapeKind;
 use ruff_text_size::{TextLen, TextRange, TextSize};
-use unic_emoji_char::is_emoji_presentation;
-use unic_ucd_ident::{is_xid_continue, is_xid_start};
+use unicode_ident::{is_xid_continue, is_xid_start};
 
 use crate::lexer::cursor::{Cursor, EOF_CHAR};
 use crate::lexer::indentation::{Indentation, Indentations};
@@ -597,15 +596,6 @@ impl<'source> Lexer<'source> {
                 self.state = State::Other;
 
                 Ok((identifier, self.token_range()))
-            } else if is_emoji_presentation(c) {
-                self.state = State::Other;
-
-                Ok((
-                    Tok::Name {
-                        name: c.to_string(),
-                    },
-                    self.token_range(),
-                ))
             } else {
                 Err(LexicalError {
                     error: LexicalErrorType::UnrecognizedToken { tok: c },

--- a/crates/ruff_python_stdlib/Cargo.toml
+++ b/crates/ruff_python_stdlib/Cargo.toml
@@ -13,4 +13,4 @@ license = { workspace = true }
 [lib]
 
 [dependencies]
-unic-ucd-ident = { workspace = true }
+unicode-ident = { workspace = true }

--- a/crates/ruff_python_stdlib/src/identifiers.rs
+++ b/crates/ruff_python_stdlib/src/identifiers.rs
@@ -1,4 +1,4 @@
-use unic_ucd_ident::{is_xid_continue, is_xid_start};
+use unicode_ident::{is_xid_continue, is_xid_start};
 
 use crate::keyword::is_keyword;
 

--- a/crates/ruff_python_trivia/Cargo.toml
+++ b/crates/ruff_python_trivia/Cargo.toml
@@ -18,7 +18,7 @@ ruff_source_file = { path = "../ruff_source_file" }
 
 memchr = { workspace = true }
 smallvec = { workspace = true }
-unic-ucd-ident = { workspace = true }
+unicode-ident = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -1,5 +1,5 @@
 use memchr::{memchr2, memchr3, memrchr3_iter};
-use unic_ucd_ident::{is_xid_continue, is_xid_start};
+use unicode_ident::{is_xid_continue, is_xid_start};
 
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR replaces the `unic-ucd-ident` with the much faster and smaller `unicode-ident` crate. 

I don't expect this PR to improve performance in our benchmarks because

a) We have no test files with unicode identifiers
b) Our lexer has a fast path that bypasses the `is_identifier_start` for ascii characters. 

This PR further removes the emoji identifier support which is not part of [Python's identifier specification](https://docs.python.org/3/reference/lexical_analysis.html#identifiers)

## Test Plan

`cargo test`

Wait for the ecosystem check

## Performance

I extended the `unicode-ident` 's benchmark to also include `unic-ucd-ident` . `unicode-ident` outperforms it significantly

```
Running benches/ident.rs (target/release/deps/ident-ad9d9d2d593f7661)
Gnuplot not found, using plotters backend
0%-nonascii/baseline    time:   [217.56 µs 217.84 µs 218.14 µs]
0%-nonascii/unicode-ident
                        time:   [417.51 µs 418.02 µs 418.55 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
0%-nonascii/unicode-xid time:   [1.5056 ms 1.5061 ms 1.5066 ms]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
0%-nonascii/unic-ucd-ident
                        time:   [9.8530 ms 9.8653 ms 9.8804 ms]
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

1%-nonascii/baseline    time:   [239.63 µs 240.05 µs 240.60 µs]
1%-nonascii/unicode-ident
                        time:   [442.01 µs 443.87 µs 446.10 µs]
1%-nonascii/unicode-xid time:   [1.5937 ms 1.5941 ms 1.5946 ms]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
1%-nonascii/unic-ucd-ident
                        time:   [10.102 ms 10.145 ms 10.187 ms]

10%-nonascii/baseline   time:   [493.61 µs 493.94 µs 494.35 µs]
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low mild
  9 (9.00%) high mild
  4 (4.00%) high severe
10%-nonascii/unicode-ident
                        time:   [671.83 µs 672.38 µs 673.02 µs]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
Benchmarking 10%-nonascii/unicode-xid: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 10.0s. You may wish to increase target time to 13.7s, enable flat sampling, or reduce sample count to 60.
10%-nonascii/unicode-xid
                        time:   [2.6001 ms 2.6043 ms 2.6094 ms]
10%-nonascii/unic-ucd-ident
                        time:   [10.434 ms 10.448 ms 10.460 ms]
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) low severe
  1 (1.00%) high mild
  2 (2.00%) high severe

100%-nonascii/baseline  time:   [609.36 µs 611.90 µs 614.95 µs]
Found 25 outliers among 100 measurements (25.00%)
  25 (25.00%) low mild
100%-nonascii/unicode-ident
                        time:   [1.4087 ms 1.4127 ms 1.4161 ms]
Found 14 outliers among 100 measurements (14.00%)
  12 (12.00%) low severe
  2 (2.00%) low mild
100%-nonascii/unicode-xid
                        time:   [11.733 ms 11.742 ms 11.754 ms]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
100%-nonascii/unic-ucd-ident
                        time:   [10.895 ms 10.897 ms 10.900 ms]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild
```
