### PR TITLE
Add FString support to binary like formatting

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary_implicit_string.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary_implicit_string.py
@@ -85,6 +85,15 @@ self._assert_skipping(
 )
 
 (
+    b + c + d +
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    f"bbbbbb{z}bbbbbbbbbbbbbbbbbbbbbbb"
+    "cccccccccccccccccccccccccc"
+    % aaaaaaaaaaaa
+    + x
+)
+
+(
     b < c > d <
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/compare.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/compare.py
@@ -131,6 +131,15 @@ assert (
     in caplog.messages
 )
 
+(
+    b < c > d <
+    f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "cccccccccccccccccccccccccc"
+    % aaaaaaaaaaaa
+    > x
+)
+
 c = (a >
      # test leading binary comment
      "a" "b" * b

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__binary_implicit_string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__binary_implicit_string.py.snap
@@ -91,6 +91,15 @@ self._assert_skipping(
 )
 
 (
+    b + c + d +
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    f"bbbbbb{z}bbbbbbbbbbbbbbbbbbbbbbb"
+    "cccccccccccccccccccccccccc"
+    % aaaaaaaaaaaa
+    + x
+)
+
+(
     b < c > d <
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -263,6 +272,12 @@ self._assert_skipping(
 (
     b + c + d + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "cccccccccccccccccccccccccc" % aaaaaaaaaaaa + x
+)
+
+(
+    b + c + d + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    f"bbbbbb{z}bbbbbbbbbbbbbbbbbbbbbbb"
     "cccccccccccccccccccccccccc" % aaaaaaaaaaaa + x
 )
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__compare.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__compare.py.snap
@@ -137,6 +137,15 @@ assert (
     in caplog.messages
 )
 
+(
+    b < c > d <
+    f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "cccccccccccccccccccccccccc"
+    % aaaaaaaaaaaa
+    > x
+)
+
 c = (a >
      # test leading binary comment
      "a" "b" * b
@@ -354,6 +363,12 @@ c = (
 assert (
     "One or more packages has an associated PGP signature; these will "
     "be silently ignored by the index" in caplog.messages
+)
+
+(
+    b < c > d < f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "cccccccccccccccccccccccccc" % aaaaaaaaaaaa > x
 )
 
 c = (


### PR DESCRIPTION
## Summary

This is the last part of the string - binary like formatting. It adds support for handling fstrings the same as "regular" strings.


## Test Plan

I added a test for both binary and comparison. 

Small improvements across several projects

**This PR**
| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99966 |              2760 |                58 |
| **transformers** |           0.99929 |              2587 |               454 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99978 |              3496 |              2173 |
| **warehouse**    |           0.99825 |               648 |                22 |
| **zulip**        |           0.99950 |              1437 |                27 |


**Base**

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99966 |              2760 |                58 |
| transformers |           0.99928 |              2587 |               454 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99978 |              3496 |              2173 |
| warehouse    |           0.99824 |               648 |                22 |
| zulip        |           0.99948 |              1437 |                28 |


<!-- How was it tested? -->
