### PR TITLE
Show header for formatter comment decoration info

### DIFF
--- a/crates/ruff_python_formatter/src/cli.rs
+++ b/crates/ruff_python_formatter/src/cli.rs
@@ -69,6 +69,9 @@ pub fn format_and_debug_print(input: &str, cli: &Cli, source_type: &Path) -> Res
         // Print preceding, following and enclosing nodes
         let source_code = SourceCode::new(input);
         let decorated_comments = collect_comments(&python_ast, source_code, &comment_ranges);
+        if !decorated_comments.is_empty() {
+            println!("# Comment decoration: Range Preceding Following Enclosing Comment");
+        }
         for comment in decorated_comments {
             println!(
                 "{:?} {:?} {:?} {:?} {:?}",

--- a/crates/ruff_python_formatter/src/cli.rs
+++ b/crates/ruff_python_formatter/src/cli.rs
@@ -70,11 +70,11 @@ pub fn format_and_debug_print(input: &str, cli: &Cli, source_type: &Path) -> Res
         let source_code = SourceCode::new(input);
         let decorated_comments = collect_comments(&python_ast, source_code, &comment_ranges);
         if !decorated_comments.is_empty() {
-            println!("# Comment decoration: Range Preceding Following Enclosing Comment");
+            println!("# Comment decoration: Range, Preceding, Following, Enclosing, Comment");
         }
         for comment in decorated_comments {
             println!(
-                "{:?} {:?} {:?} {:?} {:?}",
+                "{:?}, {:?}, {:?}, {:?}, {:?}",
                 comment.slice().range(),
                 comment
                     .preceding_node()


### PR DESCRIPTION
Show header for formatter comment decoration info

**Summary** Show a header in the formatter comment decoration debug output that shows which node is preceding/following/enclosing (https://github.com/astral-sh/ruff/pull/6813#issuecomment-1708119550). I kept this intentionally condensed to make it easy to use this is a small sidebar without vertical scrolling.

```console
$ cargo run --bin ruff_python_formatter -- --emit stdout --print-comments scratch.py
# Comment decoration: Range, Preceding, Following, Enclosing, Comment
17..20, Some((ParameterWithDefault, 6..10)), None, (Parameters, 5..22), "# a"
44..47, Some((StmtExpr, 28..39)), Some((StmtExpr, 52..60)), (StmtFunctionDef, 0..60), "# b"
77..80, None, None, (ExprList, 71..82), "# c"
{
    Node {
        kind: ParameterWithDefault,
        range: 6..10,
        source: `x=[]`,
    }: {
...
```

**Test Plan** It's debug output.
