### PR TITLE
fix D417 error with function docstrings with dashed lines

### DIFF
--- a/crates/ruff/resources/test/fixtures/pydocstyle/D417.py
+++ b/crates/ruff/resources/test/fixtures/pydocstyle/D417.py
@@ -128,6 +128,19 @@ def f(x, *, y, z):
     """
     return x, y, z
 
+def f(x):
+    """Do something with valid description.
+
+    Args:
+    ----
+        x: the value
+
+    Returns:
+    -------
+        the value
+    """
+    return x
+
 
 class Test:
     def f(self, /, arg1: int) -> None:

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -1377,9 +1377,7 @@ fn blanks_and_section_underline(
     }
 
     if let Some(non_blank_line) = following_lines.next() {
-        let dash_line_found = non_blank_line
-            .chars()
-            .all(|char| char.is_whitespace() || char == '-');
+        let dash_line_found = is_dashed_underline(&non_blank_line);
 
         if dash_line_found {
             if blank_lines_after_header > 0 {
@@ -1798,7 +1796,9 @@ fn args_section(context: &SectionContext) -> FxHashSet<String> {
     let relevant_lines = std::iter::once(first_line)
         .chain(following_lines)
         .map(|l| l.as_str())
-        .filter(|line| line.starts_with(leading_space) || line.is_empty())
+        .filter(|line| {
+            line.is_empty() || (line.starts_with(leading_space) && !is_dashed_underline(line))
+        })
         .join("\n");
     let args_content = dedent(&relevant_lines);
 
@@ -1988,4 +1988,9 @@ fn parse_google_sections(
             missing_args(checker, docstring, &documented_args);
         }
     }
+}
+
+fn is_dashed_underline(line: &str) -> bool {
+    let trimmed_line = line.trim();
+    !trimmed_line.is_empty() && trimmed_line.chars().all(|char| char == '-')
 }


### PR DESCRIPTION


## Summary

Fix https://github.com/astral-sh/ruff/issues/7250, False positive D417 for docstrings with dashed lines.

## Test Plan

Tested on the example in https://github.com/astral-sh/ruff/issues/7250
