### PR TITLE
Use snapshots for remaining lexer tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,7 +2400,6 @@ dependencies = [
  "ruff_text_size",
  "rustc-hash",
  "static_assertions",
- "test-case",
  "tiny-keccak",
  "unicode-ident",
  "unicode_names2",

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -30,7 +30,6 @@ static_assertions = "1.1.0"
 
 [dev-dependencies]
 insta = { workspace = true }
-test-case = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1266,7 +1266,6 @@ impl<'a> LexedText<'a> {
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;
-    use test_case::test_case;
 
     use super::*;
 
@@ -1284,23 +1283,50 @@ mod tests {
         lexer.map(|x| x.unwrap().0).collect()
     }
 
-    #[test_case(UNIX_EOL, "unix")]
-    #[test_case(MAC_EOL, "mac")]
-    #[test_case(WINDOWS_EOL, "windows")]
-    fn test_ipython_escape_command_line_continuation_eol(eol: &str, platform: &str) {
-        let snapshot = format!("ipython_escape_command_line_continuation_{platform}_eol");
+    fn ipython_escape_command_line_continuation_eol(eol: &str) -> Vec<Tok> {
         let source = format!("%matplotlib \\{eol}  --inline");
-        assert_debug_snapshot!(snapshot, lex_jupyter_source(&source));
+        lex_jupyter_source(&source)
     }
 
-    #[test_case(UNIX_EOL, "unix")]
-    #[test_case(MAC_EOL, "mac")]
-    #[test_case(WINDOWS_EOL, "windows")]
-    fn test_ipython_escape_command_line_continuation_with_eol_and_eof(eol: &str, platform: &str) {
-        let snapshot =
-            format!("ipython_escape_command_line_continuation_with_{platform}_eol_and_eof",);
+    #[test]
+    fn test_ipython_escape_command_line_continuation_unix_eol() {
+        assert_debug_snapshot!(ipython_escape_command_line_continuation_eol(UNIX_EOL));
+    }
+
+    #[test]
+    fn test_ipython_escape_command_line_continuation_mac_eol() {
+        assert_debug_snapshot!(ipython_escape_command_line_continuation_eol(MAC_EOL));
+    }
+
+    #[test]
+    fn test_ipython_escape_command_line_continuation_windows_eol() {
+        assert_debug_snapshot!(ipython_escape_command_line_continuation_eol(WINDOWS_EOL));
+    }
+
+    fn ipython_escape_command_line_continuation_with_eol_and_eof(eol: &str) -> Vec<Tok> {
         let source = format!("%matplotlib \\{eol}");
-        assert_debug_snapshot!(snapshot, lex_jupyter_source(&source));
+        lex_jupyter_source(&source)
+    }
+
+    #[test]
+    fn test_ipython_escape_command_line_continuation_with_unix_eol_and_eof() {
+        assert_debug_snapshot!(ipython_escape_command_line_continuation_with_eol_and_eof(
+            UNIX_EOL
+        ));
+    }
+
+    #[test]
+    fn test_ipython_escape_command_line_continuation_with_mac_eol_and_eof() {
+        assert_debug_snapshot!(ipython_escape_command_line_continuation_with_eol_and_eof(
+            MAC_EOL
+        ));
+    }
+
+    #[test]
+    fn test_ipython_escape_command_line_continuation_with_windows_eol_and_eof() {
+        assert_debug_snapshot!(ipython_escape_command_line_continuation_with_eol_and_eof(
+            WINDOWS_EOL
+        ));
     }
 
     #[test]
@@ -1432,13 +1458,24 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(lex_source(&source));
     }
 
-    #[test_case(UNIX_EOL, "unix")]
-    #[test_case(MAC_EOL, "mac")]
-    #[test_case(WINDOWS_EOL, "windows")]
-    fn test_comment_until_eol(eol: &str, platform: &str) {
-        let snapshot = format!("comment_until_{platform}_eol");
+    fn comment_until_eol(eol: &str) -> Vec<Tok> {
         let source = format!("123  # Foo{eol}456");
-        assert_debug_snapshot!(snapshot, lex_source(&source));
+        lex_source(&source)
+    }
+
+    #[test]
+    fn test_comment_until_unix_eol() {
+        assert_debug_snapshot!(comment_until_eol(UNIX_EOL));
+    }
+
+    #[test]
+    fn test_comment_until_mac_eol() {
+        assert_debug_snapshot!(comment_until_eol(MAC_EOL));
+    }
+
+    #[test]
+    fn test_comment_until_windows_eol() {
+        assert_debug_snapshot!(comment_until_eol(WINDOWS_EOL));
     }
 
     #[test]
@@ -1447,38 +1484,67 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(lex_source(source));
     }
 
-    #[test_case(UNIX_EOL, "unix")]
-    #[test_case(MAC_EOL, "mac")]
-    #[test_case(WINDOWS_EOL, "windows")]
-    fn test_indentation_with_eol(eol: &str, platform: &str) {
-        let snapshot = format!("indentation_with_{platform}_eol");
+    fn indentation_with_eol(eol: &str) -> Vec<Tok> {
         let source = format!("def foo():{eol}    return 99{eol}{eol}");
-        assert_debug_snapshot!(snapshot, lex_source(&source));
+        lex_source(&source)
     }
 
-    #[test_case(UNIX_EOL, "unix")]
-    #[test_case(MAC_EOL, "mac")]
-    #[test_case(WINDOWS_EOL, "windows")]
-    fn test_double_dedent_with_eol(eol: &str, platform: &str) {
-        let snapshot = format!("double_dedent_with_{platform}_eol");
+    #[test]
+    fn test_indentation_with_unix_eol() {
+        assert_debug_snapshot!(indentation_with_eol(UNIX_EOL));
+    }
+
+    #[test]
+    fn test_indentation_with_mac_eol() {
+        assert_debug_snapshot!(indentation_with_eol(MAC_EOL));
+    }
+
+    #[test]
+    fn test_indentation_with_windows_eol() {
+        assert_debug_snapshot!(indentation_with_eol(WINDOWS_EOL));
+    }
+
+    fn double_dedent_with_eol(eol: &str) -> Vec<Tok> {
         let source = format!("def foo():{eol} if x:{eol}{eol}  return 99{eol}{eol}");
-        assert_debug_snapshot!(snapshot, lex_source(&source));
+        lex_source(&source)
     }
 
-    #[test_case(UNIX_EOL, "unix")]
-    #[test_case(MAC_EOL, "mac")]
-    #[test_case(WINDOWS_EOL, "windows")]
-    fn test_double_dedent_with_tabs(eol: &str, platform: &str) {
-        let snapshot = format!("double_dedent_with_tabs_{platform}_eol");
+    #[test]
+    fn test_double_dedent_with_unix_eol() {
+        assert_debug_snapshot!(double_dedent_with_eol(UNIX_EOL));
+    }
+
+    #[test]
+    fn test_double_dedent_with_mac_eol() {
+        assert_debug_snapshot!(double_dedent_with_eol(MAC_EOL));
+    }
+
+    #[test]
+    fn test_double_dedent_with_windows_eol() {
+        assert_debug_snapshot!(double_dedent_with_eol(WINDOWS_EOL));
+    }
+
+    fn double_dedent_with_tabs_eol(eol: &str) -> Vec<Tok> {
         let source = format!("def foo():{eol}\tif x:{eol}{eol}\t\t return 99{eol}{eol}");
-        assert_debug_snapshot!(snapshot, lex_source(&source));
+        lex_source(&source)
     }
 
-    #[test_case(UNIX_EOL, "unix")]
-    #[test_case(MAC_EOL, "mac")]
-    #[test_case(WINDOWS_EOL, "windows")]
-    fn test_newline_in_brackets(eol: &str, platform: &str) {
-        let snapshot = format!("newline_in_brackets_{platform}_eol");
+    #[test]
+    fn test_double_dedent_with_tabs_unix_eol() {
+        assert_debug_snapshot!(double_dedent_with_tabs_eol(UNIX_EOL));
+    }
+
+    #[test]
+    fn test_double_dedent_with_tabs_mac_eol() {
+        assert_debug_snapshot!(double_dedent_with_tabs_eol(MAC_EOL));
+    }
+
+    #[test]
+    fn test_double_dedent_with_tabs_windows_eol() {
+        assert_debug_snapshot!(double_dedent_with_tabs_eol(WINDOWS_EOL));
+    }
+
+    fn newline_in_brackets_eol(eol: &str) -> Vec<Tok> {
         let source = r"x = [
 
     1,2
@@ -1490,7 +1556,22 @@ def f(arg=%timeit a = b):
 7}]
 "
         .replace('\n', eol);
-        assert_debug_snapshot!(snapshot, lex_source(&source));
+        lex_source(&source)
+    }
+
+    #[test]
+    fn test_newline_in_brackets_unix_eol() {
+        assert_debug_snapshot!(newline_in_brackets_eol(UNIX_EOL));
+    }
+
+    #[test]
+    fn test_newline_in_brackets_mac_eol() {
+        assert_debug_snapshot!(newline_in_brackets_eol(MAC_EOL));
+    }
+
+    #[test]
+    fn test_newline_in_brackets_windows_eol() {
+        assert_debug_snapshot!(newline_in_brackets_eol(WINDOWS_EOL));
     }
 
     #[test]
@@ -1523,13 +1604,24 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(lex_source(source));
     }
 
-    #[test_case(UNIX_EOL, "unix")]
-    #[test_case(MAC_EOL, "mac")]
-    #[test_case(WINDOWS_EOL, "windows")]
-    fn test_string_continuation_with_eol(eol: &str, platform: &str) {
-        let snapshot = format!("string_continuation_with_{platform}_eol");
+    fn string_continuation_with_eol(eol: &str) -> Vec<Tok> {
         let source = format!("\"abc\\{eol}def\"");
-        assert_debug_snapshot!(snapshot, lex_source(&source));
+        lex_source(&source)
+    }
+
+    #[test]
+    fn test_string_continuation_with_unix_eol() {
+        assert_debug_snapshot!(string_continuation_with_eol(UNIX_EOL));
+    }
+
+    #[test]
+    fn test_string_continuation_with_mac_eol() {
+        assert_debug_snapshot!(string_continuation_with_eol(MAC_EOL));
+    }
+
+    #[test]
+    fn test_string_continuation_with_windows_eol() {
+        assert_debug_snapshot!(string_continuation_with_eol(WINDOWS_EOL));
     }
 
     #[test]
@@ -1538,13 +1630,24 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(lex_source(source));
     }
 
-    #[test_case(UNIX_EOL, "unix")]
-    #[test_case(MAC_EOL, "mac")]
-    #[test_case(WINDOWS_EOL, "windows")]
-    fn test_triple_quoted(eol: &str, platform: &str) {
-        let snapshot = format!("triple_quoted_{platform}_eol");
+    fn triple_quoted_eol(eol: &str) -> Vec<Tok> {
         let source = format!("\"\"\"{eol} test string{eol} \"\"\"");
-        assert_debug_snapshot!(snapshot, lex_source(&source));
+        lex_source(&source)
+    }
+
+    #[test]
+    fn test_triple_quoted_unix_eol() {
+        assert_debug_snapshot!(triple_quoted_eol(UNIX_EOL));
+    }
+
+    #[test]
+    fn test_triple_quoted_mac_eol() {
+        assert_debug_snapshot!(triple_quoted_eol(MAC_EOL));
+    }
+
+    #[test]
+    fn test_triple_quoted_windows_eol() {
+        assert_debug_snapshot!(triple_quoted_eol(WINDOWS_EOL));
     }
 
     // This test case is to just make sure that the lexer doesn't go into

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_mac_eol.snap
@@ -1,0 +1,17 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Int {
+        value: 123,
+    },
+    Comment(
+        "# Foo",
+    ),
+    Newline,
+    Int {
+        value: 456,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_unix_eol.snap
@@ -1,0 +1,17 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Int {
+        value: 123,
+    },
+    Comment(
+        "# Foo",
+    ),
+    Newline,
+    Int {
+        value: 456,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_windows_eol.snap
@@ -1,0 +1,17 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Int {
+        value: 123,
+    },
+    Comment(
+        "# Foo",
+    ),
+    Newline,
+    Int {
+        value: 456,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_mac_eol.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Def,
+    Name {
+        name: "foo",
+    },
+    Lpar,
+    Rpar,
+    Colon,
+    Newline,
+    Indent,
+    If,
+    Name {
+        name: "x",
+    },
+    Colon,
+    Newline,
+    NonLogicalNewline,
+    Indent,
+    Return,
+    Int {
+        value: 99,
+    },
+    Newline,
+    NonLogicalNewline,
+    Dedent,
+    Dedent,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_mac_eol.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Def,
+    Name {
+        name: "foo",
+    },
+    Lpar,
+    Rpar,
+    Colon,
+    Newline,
+    Indent,
+    If,
+    Name {
+        name: "x",
+    },
+    Colon,
+    Newline,
+    NonLogicalNewline,
+    Indent,
+    Return,
+    Int {
+        value: 99,
+    },
+    Newline,
+    NonLogicalNewline,
+    Dedent,
+    Dedent,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_unix_eol.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Def,
+    Name {
+        name: "foo",
+    },
+    Lpar,
+    Rpar,
+    Colon,
+    Newline,
+    Indent,
+    If,
+    Name {
+        name: "x",
+    },
+    Colon,
+    Newline,
+    NonLogicalNewline,
+    Indent,
+    Return,
+    Int {
+        value: 99,
+    },
+    Newline,
+    NonLogicalNewline,
+    Dedent,
+    Dedent,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_windows_eol.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Def,
+    Name {
+        name: "foo",
+    },
+    Lpar,
+    Rpar,
+    Colon,
+    Newline,
+    Indent,
+    If,
+    Name {
+        name: "x",
+    },
+    Colon,
+    Newline,
+    NonLogicalNewline,
+    Indent,
+    Return,
+    Int {
+        value: 99,
+    },
+    Newline,
+    NonLogicalNewline,
+    Dedent,
+    Dedent,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_unix_eol.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Def,
+    Name {
+        name: "foo",
+    },
+    Lpar,
+    Rpar,
+    Colon,
+    Newline,
+    Indent,
+    If,
+    Name {
+        name: "x",
+    },
+    Colon,
+    Newline,
+    NonLogicalNewline,
+    Indent,
+    Return,
+    Int {
+        value: 99,
+    },
+    Newline,
+    NonLogicalNewline,
+    Dedent,
+    Dedent,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_windows_eol.snap
@@ -1,0 +1,31 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Def,
+    Name {
+        name: "foo",
+    },
+    Lpar,
+    Rpar,
+    Colon,
+    Newline,
+    Indent,
+    If,
+    Name {
+        name: "x",
+    },
+    Colon,
+    Newline,
+    NonLogicalNewline,
+    Indent,
+    Return,
+    Int {
+        value: 99,
+    },
+    Newline,
+    NonLogicalNewline,
+    Dedent,
+    Dedent,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__escape_unicode_name.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__escape_unicode_name.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(source)
+---
+[
+    String {
+        value: "\\N{EN SPACE}",
+        kind: String,
+        triple_quoted: false,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_mac_eol.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Def,
+    Name {
+        name: "foo",
+    },
+    Lpar,
+    Rpar,
+    Colon,
+    Newline,
+    Indent,
+    Return,
+    Int {
+        value: 99,
+    },
+    Newline,
+    NonLogicalNewline,
+    Dedent,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_unix_eol.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Def,
+    Name {
+        name: "foo",
+    },
+    Lpar,
+    Rpar,
+    Colon,
+    Newline,
+    Indent,
+    Return,
+    Int {
+        value: 99,
+    },
+    Newline,
+    NonLogicalNewline,
+    Dedent,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_windows_eol.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Def,
+    Name {
+        name: "foo",
+    },
+    Lpar,
+    Rpar,
+    Colon,
+    Newline,
+    Indent,
+    Return,
+    Int {
+        value: 99,
+    },
+    Newline,
+    NonLogicalNewline,
+    Dedent,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_mac_eol.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_jupyter_source(&source)
+---
+[
+    IpyEscapeCommand {
+        value: "matplotlib   --inline",
+        kind: Magic,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_unix_eol.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_jupyter_source(&source)
+---
+[
+    IpyEscapeCommand {
+        value: "matplotlib   --inline",
+        kind: Magic,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_windows_eol.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_jupyter_source(&source)
+---
+[
+    IpyEscapeCommand {
+        value: "matplotlib   --inline",
+        kind: Magic,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_mac_eol_and_eof.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_mac_eol_and_eof.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_jupyter_source(&source)
+---
+[
+    IpyEscapeCommand {
+        value: "matplotlib ",
+        kind: Magic,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_unix_eol_and_eof.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_unix_eol_and_eof.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_jupyter_source(&source)
+---
+[
+    IpyEscapeCommand {
+        value: "matplotlib ",
+        kind: Magic,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_windows_eol_and_eof.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_windows_eol_and_eof.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_jupyter_source(&source)
+---
+[
+    IpyEscapeCommand {
+        value: "matplotlib ",
+        kind: Magic,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_empty.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_empty.snap
@@ -1,0 +1,13 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Int {
+        value: 99232,
+    },
+    Comment(
+        "#",
+    ),
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_long.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_long.snap
@@ -1,0 +1,13 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Int {
+        value: 99232,
+    },
+    Comment(
+        "# foo",
+    ),
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_single_whitespace.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_single_whitespace.snap
@@ -1,0 +1,13 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Int {
+        value: 99232,
+    },
+    Comment(
+        "# ",
+    ),
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_whitespace.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_whitespace.snap
@@ -1,0 +1,13 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Int {
+        value: 99232,
+    },
+    Comment(
+        "#  ",
+    ),
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_mac_eol.snap
@@ -1,0 +1,52 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Name {
+        name: "x",
+    },
+    Equal,
+    Lsqb,
+    NonLogicalNewline,
+    NonLogicalNewline,
+    Int {
+        value: 1,
+    },
+    Comma,
+    Int {
+        value: 2,
+    },
+    NonLogicalNewline,
+    Comma,
+    Lpar,
+    Int {
+        value: 3,
+    },
+    Comma,
+    NonLogicalNewline,
+    Int {
+        value: 4,
+    },
+    Comma,
+    NonLogicalNewline,
+    Rpar,
+    Comma,
+    Lbrace,
+    NonLogicalNewline,
+    Int {
+        value: 5,
+    },
+    Comma,
+    NonLogicalNewline,
+    Int {
+        value: 6,
+    },
+    Comma,
+    Int {
+        value: 7,
+    },
+    Rbrace,
+    Rsqb,
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_unix_eol.snap
@@ -1,0 +1,52 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Name {
+        name: "x",
+    },
+    Equal,
+    Lsqb,
+    NonLogicalNewline,
+    NonLogicalNewline,
+    Int {
+        value: 1,
+    },
+    Comma,
+    Int {
+        value: 2,
+    },
+    NonLogicalNewline,
+    Comma,
+    Lpar,
+    Int {
+        value: 3,
+    },
+    Comma,
+    NonLogicalNewline,
+    Int {
+        value: 4,
+    },
+    Comma,
+    NonLogicalNewline,
+    Rpar,
+    Comma,
+    Lbrace,
+    NonLogicalNewline,
+    Int {
+        value: 5,
+    },
+    Comma,
+    NonLogicalNewline,
+    Int {
+        value: 6,
+    },
+    Comma,
+    Int {
+        value: 7,
+    },
+    Rbrace,
+    Rsqb,
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_windows_eol.snap
@@ -1,0 +1,52 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    Name {
+        name: "x",
+    },
+    Equal,
+    Lsqb,
+    NonLogicalNewline,
+    NonLogicalNewline,
+    Int {
+        value: 1,
+    },
+    Comma,
+    Int {
+        value: 2,
+    },
+    NonLogicalNewline,
+    Comma,
+    Lpar,
+    Int {
+        value: 3,
+    },
+    Comma,
+    NonLogicalNewline,
+    Int {
+        value: 4,
+    },
+    Comma,
+    NonLogicalNewline,
+    Rpar,
+    Comma,
+    Lbrace,
+    NonLogicalNewline,
+    Int {
+        value: 5,
+    },
+    Comma,
+    NonLogicalNewline,
+    Int {
+        value: 6,
+    },
+    Comma,
+    Int {
+        value: 7,
+    },
+    Rbrace,
+    Rsqb,
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_mac_eol.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    String {
+        value: "abc\\\rdef",
+        kind: String,
+        triple_quoted: false,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_unix_eol.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    String {
+        value: "abc\\\ndef",
+        kind: String,
+        triple_quoted: false,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_windows_eol.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    String {
+        value: "abc\\\r\ndef",
+        kind: String,
+        triple_quoted: false,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_mac_eol.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    String {
+        value: "\r test string\r ",
+        kind: String,
+        triple_quoted: true,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_unix_eol.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    String {
+        value: "\n test string\n ",
+        kind: String,
+        triple_quoted: true,
+    },
+    Newline,
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_windows_eol.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(&source)
+---
+[
+    String {
+        value: "\r\n test string\r\n ",
+        kind: String,
+        triple_quoted: true,
+    },
+    Newline,
+]


### PR DESCRIPTION
## Summary

This PR updates the remaining lexer test cases to use the snapshots. This is
mainly a mechanical refactor.

## Motivation

The main motivation is so that when we add the token range values to the test
case output, it's easier to update the test cases.

The reason they were not using the snapshots before was because of the usage of
`test_case` macro. The macros is mainly used for different EOL test cases. If we
just generate the snapshots directly, then the snapshot name would be suffixed
with `-1`, `-2`, etc. as the test function is still the same. So, we'll create
the snapshot ourselves with the platform name for the respective EOL test cases.

## Test Plan

`cargo test`
