### PR TITLE
Add range to lexer test snapshots

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1275,7 +1275,7 @@ mod tests {
 
     fn lex_source_with_mode(source: &str, mode: Mode) -> Vec<Spanned> {
         let lexer = lex(source, mode);
-        lexer.map(|result| result.unwrap()).collect()
+        lexer.map(std::result::Result::unwrap).collect()
     }
 
     fn lex_source(source: &str) -> Vec<Spanned> {
@@ -1409,7 +1409,7 @@ baz = %matplotlib \
     fn assert_no_ipython_escape_command(tokens: &[Spanned]) {
         for (tok, _) in tokens {
             if let Tok::IpyEscapeCommand { .. } = tok {
-                panic!("Unexpected escape command token: {:?}", tok)
+                panic!("Unexpected escape command token: {tok:?}")
             }
         }
     }

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1273,17 +1273,32 @@ mod tests {
     const MAC_EOL: &str = "\r";
     const UNIX_EOL: &str = "\n";
 
-    fn lex_source(source: &str) -> Vec<Tok> {
-        let lexer = lex(source, Mode::Module);
-        lexer.map(|result| result.unwrap().0).collect()
+    #[derive(Debug, PartialEq)]
+    struct Token {
+        value: Tok,
+        range: TextRange,
     }
 
-    fn lex_jupyter_source(source: &str) -> Vec<Tok> {
-        let lexer = lex(source, Mode::Ipython);
-        lexer.map(|x| x.unwrap().0).collect()
+    impl From<Spanned> for Token {
+        fn from((value, range): Spanned) -> Self {
+            Self { value, range }
+        }
     }
 
-    fn ipython_escape_command_line_continuation_eol(eol: &str) -> Vec<Tok> {
+    fn lex_source_with_mode(source: &str, mode: Mode) -> Vec<Token> {
+        let lexer = lex(source, mode);
+        lexer.map(|result| Token::from(result.unwrap())).collect()
+    }
+
+    fn lex_source(source: &str) -> Vec<Token> {
+        lex_source_with_mode(source, Mode::Module)
+    }
+
+    fn lex_jupyter_source(source: &str) -> Vec<Token> {
+        lex_source_with_mode(source, Mode::Ipython)
+    }
+
+    fn ipython_escape_command_line_continuation_eol(eol: &str) -> Vec<Token> {
         let source = format!("%matplotlib \\{eol}  --inline");
         lex_jupyter_source(&source)
     }
@@ -1303,7 +1318,7 @@ mod tests {
         assert_debug_snapshot!(ipython_escape_command_line_continuation_eol(WINDOWS_EOL));
     }
 
-    fn ipython_escape_command_line_continuation_with_eol_and_eof(eol: &str) -> Vec<Tok> {
+    fn ipython_escape_command_line_continuation_with_eol_and_eof(eol: &str) -> Vec<Token> {
         let source = format!("%matplotlib \\{eol}");
         lex_jupyter_source(&source)
     }
@@ -1403,10 +1418,10 @@ baz = %matplotlib \
         assert_debug_snapshot!(lex_jupyter_source(source));
     }
 
-    fn assert_no_ipython_escape_command(tokens: &[Tok]) {
-        for tok in tokens {
-            if let Tok::IpyEscapeCommand { .. } = tok {
-                panic!("Unexpected escape command token: {tok:?}")
+    fn assert_no_ipython_escape_command(tokens: &[Token]) {
+        for token in tokens {
+            if let Tok::IpyEscapeCommand { .. } = token.value {
+                panic!("Unexpected escape command token: {:?}", token.value)
             }
         }
     }
@@ -1458,7 +1473,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(lex_source(&source));
     }
 
-    fn comment_until_eol(eol: &str) -> Vec<Tok> {
+    fn comment_until_eol(eol: &str) -> Vec<Token> {
         let source = format!("123  # Foo{eol}456");
         lex_source(&source)
     }
@@ -1484,7 +1499,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(lex_source(source));
     }
 
-    fn indentation_with_eol(eol: &str) -> Vec<Tok> {
+    fn indentation_with_eol(eol: &str) -> Vec<Token> {
         let source = format!("def foo():{eol}    return 99{eol}{eol}");
         lex_source(&source)
     }
@@ -1504,7 +1519,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(indentation_with_eol(WINDOWS_EOL));
     }
 
-    fn double_dedent_with_eol(eol: &str) -> Vec<Tok> {
+    fn double_dedent_with_eol(eol: &str) -> Vec<Token> {
         let source = format!("def foo():{eol} if x:{eol}{eol}  return 99{eol}{eol}");
         lex_source(&source)
     }
@@ -1524,7 +1539,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(double_dedent_with_eol(WINDOWS_EOL));
     }
 
-    fn double_dedent_with_tabs_eol(eol: &str) -> Vec<Tok> {
+    fn double_dedent_with_tabs_eol(eol: &str) -> Vec<Token> {
         let source = format!("def foo():{eol}\tif x:{eol}{eol}\t\t return 99{eol}{eol}");
         lex_source(&source)
     }
@@ -1544,7 +1559,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(double_dedent_with_tabs_eol(WINDOWS_EOL));
     }
 
-    fn newline_in_brackets_eol(eol: &str) -> Vec<Tok> {
+    fn newline_in_brackets_eol(eol: &str) -> Vec<Token> {
         let source = r"x = [
 
     1,2
@@ -1604,7 +1619,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(lex_source(source));
     }
 
-    fn string_continuation_with_eol(eol: &str) -> Vec<Tok> {
+    fn string_continuation_with_eol(eol: &str) -> Vec<Token> {
         let source = format!("\"abc\\{eol}def\"");
         lex_source(&source)
     }
@@ -1630,7 +1645,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(lex_source(source));
     }
 
-    fn triple_quoted_eol(eol: &str) -> Vec<Tok> {
+    fn triple_quoted_eol(eol: &str) -> Vec<Token> {
         let source = format!("\"\"\"{eol} test string{eol} \"\"\"");
         lex_source(&source)
     }

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1273,32 +1273,20 @@ mod tests {
     const MAC_EOL: &str = "\r";
     const UNIX_EOL: &str = "\n";
 
-    #[derive(Debug, PartialEq)]
-    struct Token {
-        value: Tok,
-        range: TextRange,
-    }
-
-    impl From<Spanned> for Token {
-        fn from((value, range): Spanned) -> Self {
-            Self { value, range }
-        }
-    }
-
-    fn lex_source_with_mode(source: &str, mode: Mode) -> Vec<Token> {
+    fn lex_source_with_mode(source: &str, mode: Mode) -> Vec<Spanned> {
         let lexer = lex(source, mode);
-        lexer.map(|result| Token::from(result.unwrap())).collect()
+        lexer.map(|result| result.unwrap()).collect()
     }
 
-    fn lex_source(source: &str) -> Vec<Token> {
+    fn lex_source(source: &str) -> Vec<Spanned> {
         lex_source_with_mode(source, Mode::Module)
     }
 
-    fn lex_jupyter_source(source: &str) -> Vec<Token> {
+    fn lex_jupyter_source(source: &str) -> Vec<Spanned> {
         lex_source_with_mode(source, Mode::Ipython)
     }
 
-    fn ipython_escape_command_line_continuation_eol(eol: &str) -> Vec<Token> {
+    fn ipython_escape_command_line_continuation_eol(eol: &str) -> Vec<Spanned> {
         let source = format!("%matplotlib \\{eol}  --inline");
         lex_jupyter_source(&source)
     }
@@ -1318,7 +1306,7 @@ mod tests {
         assert_debug_snapshot!(ipython_escape_command_line_continuation_eol(WINDOWS_EOL));
     }
 
-    fn ipython_escape_command_line_continuation_with_eol_and_eof(eol: &str) -> Vec<Token> {
+    fn ipython_escape_command_line_continuation_with_eol_and_eof(eol: &str) -> Vec<Spanned> {
         let source = format!("%matplotlib \\{eol}");
         lex_jupyter_source(&source)
     }
@@ -1418,10 +1406,10 @@ baz = %matplotlib \
         assert_debug_snapshot!(lex_jupyter_source(source));
     }
 
-    fn assert_no_ipython_escape_command(tokens: &[Token]) {
-        for token in tokens {
-            if let Tok::IpyEscapeCommand { .. } = token.value {
-                panic!("Unexpected escape command token: {:?}", token.value)
+    fn assert_no_ipython_escape_command(tokens: &[Spanned]) {
+        for (tok, _) in tokens {
+            if let Tok::IpyEscapeCommand { .. } = tok {
+                panic!("Unexpected escape command token: {:?}", tok)
             }
         }
     }
@@ -1473,7 +1461,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(lex_source(&source));
     }
 
-    fn comment_until_eol(eol: &str) -> Vec<Token> {
+    fn comment_until_eol(eol: &str) -> Vec<Spanned> {
         let source = format!("123  # Foo{eol}456");
         lex_source(&source)
     }
@@ -1499,7 +1487,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(lex_source(source));
     }
 
-    fn indentation_with_eol(eol: &str) -> Vec<Token> {
+    fn indentation_with_eol(eol: &str) -> Vec<Spanned> {
         let source = format!("def foo():{eol}    return 99{eol}{eol}");
         lex_source(&source)
     }
@@ -1519,7 +1507,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(indentation_with_eol(WINDOWS_EOL));
     }
 
-    fn double_dedent_with_eol(eol: &str) -> Vec<Token> {
+    fn double_dedent_with_eol(eol: &str) -> Vec<Spanned> {
         let source = format!("def foo():{eol} if x:{eol}{eol}  return 99{eol}{eol}");
         lex_source(&source)
     }
@@ -1539,7 +1527,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(double_dedent_with_eol(WINDOWS_EOL));
     }
 
-    fn double_dedent_with_tabs_eol(eol: &str) -> Vec<Token> {
+    fn double_dedent_with_tabs_eol(eol: &str) -> Vec<Spanned> {
         let source = format!("def foo():{eol}\tif x:{eol}{eol}\t\t return 99{eol}{eol}");
         lex_source(&source)
     }
@@ -1559,7 +1547,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(double_dedent_with_tabs_eol(WINDOWS_EOL));
     }
 
-    fn newline_in_brackets_eol(eol: &str) -> Vec<Token> {
+    fn newline_in_brackets_eol(eol: &str) -> Vec<Spanned> {
         let source = r"x = [
 
     1,2
@@ -1619,7 +1607,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(lex_source(source));
     }
 
-    fn string_continuation_with_eol(eol: &str) -> Vec<Token> {
+    fn string_continuation_with_eol(eol: &str) -> Vec<Spanned> {
         let source = format!("\"abc\\{eol}def\"");
         lex_source(&source)
     }
@@ -1645,7 +1633,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(lex_source(source));
     }
 
-    fn triple_quoted_eol(eol: &str) -> Vec<Token> {
+    fn triple_quoted_eol(eol: &str) -> Vec<Spanned> {
         let source = format!("\"\"\"{eol} test string{eol} \"\"\"");
         lex_source(&source)
     }

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__assignment.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__assignment.snap
@@ -3,20 +3,44 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(source)
 ---
 [
-    Name {
-        name: "a_variable",
+    Token {
+        value: Name {
+            name: "a_variable",
+        },
+        range: 0..10,
     },
-    Equal,
-    Int {
-        value: 99,
+    Token {
+        value: Equal,
+        range: 11..12,
     },
-    Plus,
-    Int {
-        value: 2,
+    Token {
+        value: Int {
+            value: 99,
+        },
+        range: 13..15,
     },
-    Minus,
-    Int {
-        value: 0,
+    Token {
+        value: Plus,
+        range: 16..17,
     },
-    Newline,
+    Token {
+        value: Int {
+            value: 2,
+        },
+        range: 18..19,
+    },
+    Token {
+        value: Minus,
+        range: 19..20,
+    },
+    Token {
+        value: Int {
+            value: 0,
+        },
+        range: 20..21,
+    },
+    Token {
+        value: Newline,
+        range: 21..21,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__assignment.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__assignment.snap
@@ -3,44 +3,44 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(source)
 ---
 [
-    Token {
-        value: Name {
+    (
+        Name {
             name: "a_variable",
         },
-        range: 0..10,
-    },
-    Token {
-        value: Equal,
-        range: 11..12,
-    },
-    Token {
-        value: Int {
+        0..10,
+    ),
+    (
+        Equal,
+        11..12,
+    ),
+    (
+        Int {
             value: 99,
         },
-        range: 13..15,
-    },
-    Token {
-        value: Plus,
-        range: 16..17,
-    },
-    Token {
-        value: Int {
+        13..15,
+    ),
+    (
+        Plus,
+        16..17,
+    ),
+    (
+        Int {
             value: 2,
         },
-        range: 18..19,
-    },
-    Token {
-        value: Minus,
-        range: 19..20,
-    },
-    Token {
-        value: Int {
+        18..19,
+    ),
+    (
+        Minus,
+        19..20,
+    ),
+    (
+        Int {
             value: 0,
         },
-        range: 20..21,
-    },
-    Token {
-        value: Newline,
-        range: 21..21,
-    },
+        20..21,
+    ),
+    (
+        Newline,
+        21..21,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_mac_eol.snap
@@ -3,15 +3,30 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Int {
-        value: 123,
+    Token {
+        value: Int {
+            value: 123,
+        },
+        range: 0..3,
     },
-    Comment(
-        "# Foo",
-    ),
-    Newline,
-    Int {
-        value: 456,
+    Token {
+        value: Comment(
+            "# Foo",
+        ),
+        range: 5..10,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 10..11,
+    },
+    Token {
+        value: Int {
+            value: 456,
+        },
+        range: 11..14,
+    },
+    Token {
+        value: Newline,
+        range: 14..14,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_mac_eol.snap
@@ -1,32 +1,32 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: comment_until_eol(MAC_EOL)
 ---
 [
-    Token {
-        value: Int {
+    (
+        Int {
             value: 123,
         },
-        range: 0..3,
-    },
-    Token {
-        value: Comment(
+        0..3,
+    ),
+    (
+        Comment(
             "# Foo",
         ),
-        range: 5..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..11,
-    },
-    Token {
-        value: Int {
+        5..10,
+    ),
+    (
+        Newline,
+        10..11,
+    ),
+    (
+        Int {
             value: 456,
         },
-        range: 11..14,
-    },
-    Token {
-        value: Newline,
-        range: 14..14,
-    },
+        11..14,
+    ),
+    (
+        Newline,
+        14..14,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_unix_eol.snap
@@ -3,15 +3,30 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Int {
-        value: 123,
+    Token {
+        value: Int {
+            value: 123,
+        },
+        range: 0..3,
     },
-    Comment(
-        "# Foo",
-    ),
-    Newline,
-    Int {
-        value: 456,
+    Token {
+        value: Comment(
+            "# Foo",
+        ),
+        range: 5..10,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 10..11,
+    },
+    Token {
+        value: Int {
+            value: 456,
+        },
+        range: 11..14,
+    },
+    Token {
+        value: Newline,
+        range: 14..14,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_unix_eol.snap
@@ -1,32 +1,32 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: comment_until_eol(UNIX_EOL)
 ---
 [
-    Token {
-        value: Int {
+    (
+        Int {
             value: 123,
         },
-        range: 0..3,
-    },
-    Token {
-        value: Comment(
+        0..3,
+    ),
+    (
+        Comment(
             "# Foo",
         ),
-        range: 5..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..11,
-    },
-    Token {
-        value: Int {
+        5..10,
+    ),
+    (
+        Newline,
+        10..11,
+    ),
+    (
+        Int {
             value: 456,
         },
-        range: 11..14,
-    },
-    Token {
-        value: Newline,
-        range: 14..14,
-    },
+        11..14,
+    ),
+    (
+        Newline,
+        14..14,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_windows_eol.snap
@@ -1,32 +1,32 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: comment_until_eol(WINDOWS_EOL)
 ---
 [
-    Token {
-        value: Int {
+    (
+        Int {
             value: 123,
         },
-        range: 0..3,
-    },
-    Token {
-        value: Comment(
+        0..3,
+    ),
+    (
+        Comment(
             "# Foo",
         ),
-        range: 5..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..12,
-    },
-    Token {
-        value: Int {
+        5..10,
+    ),
+    (
+        Newline,
+        10..12,
+    ),
+    (
+        Int {
             value: 456,
         },
-        range: 12..15,
-    },
-    Token {
-        value: Newline,
-        range: 15..15,
-    },
+        12..15,
+    ),
+    (
+        Newline,
+        15..15,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__comment_until_windows_eol.snap
@@ -3,15 +3,30 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Int {
-        value: 123,
+    Token {
+        value: Int {
+            value: 123,
+        },
+        range: 0..3,
     },
-    Comment(
-        "# Foo",
-    ),
-    Newline,
-    Int {
-        value: 456,
+    Token {
+        value: Comment(
+            "# Foo",
+        ),
+        range: 5..10,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 10..12,
+    },
+    Token {
+        value: Int {
+            value: 456,
+        },
+        range: 12..15,
+    },
+    Token {
+        value: Newline,
+        range: 15..15,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_mac_eol.snap
@@ -1,88 +1,88 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: double_dedent_with_eol(MAC_EOL)
 ---
 [
-    Token {
-        value: Def,
-        range: 0..3,
-    },
-    Token {
-        value: Name {
+    (
+        Def,
+        0..3,
+    ),
+    (
+        Name {
             name: "foo",
         },
-        range: 4..7,
-    },
-    Token {
-        value: Lpar,
-        range: 7..8,
-    },
-    Token {
-        value: Rpar,
-        range: 8..9,
-    },
-    Token {
-        value: Colon,
-        range: 9..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..11,
-    },
-    Token {
-        value: Indent,
-        range: 11..12,
-    },
-    Token {
-        value: If,
-        range: 12..14,
-    },
-    Token {
-        value: Name {
+        4..7,
+    ),
+    (
+        Lpar,
+        7..8,
+    ),
+    (
+        Rpar,
+        8..9,
+    ),
+    (
+        Colon,
+        9..10,
+    ),
+    (
+        Newline,
+        10..11,
+    ),
+    (
+        Indent,
+        11..12,
+    ),
+    (
+        If,
+        12..14,
+    ),
+    (
+        Name {
             name: "x",
         },
-        range: 15..16,
-    },
-    Token {
-        value: Colon,
-        range: 16..17,
-    },
-    Token {
-        value: Newline,
-        range: 17..18,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 18..19,
-    },
-    Token {
-        value: Indent,
-        range: 19..21,
-    },
-    Token {
-        value: Return,
-        range: 21..27,
-    },
-    Token {
-        value: Int {
+        15..16,
+    ),
+    (
+        Colon,
+        16..17,
+    ),
+    (
+        Newline,
+        17..18,
+    ),
+    (
+        NonLogicalNewline,
+        18..19,
+    ),
+    (
+        Indent,
+        19..21,
+    ),
+    (
+        Return,
+        21..27,
+    ),
+    (
+        Int {
             value: 99,
         },
-        range: 28..30,
-    },
-    Token {
-        value: Newline,
-        range: 30..31,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 31..32,
-    },
-    Token {
-        value: Dedent,
-        range: 32..32,
-    },
-    Token {
-        value: Dedent,
-        range: 32..32,
-    },
+        28..30,
+    ),
+    (
+        Newline,
+        30..31,
+    ),
+    (
+        NonLogicalNewline,
+        31..32,
+    ),
+    (
+        Dedent,
+        32..32,
+    ),
+    (
+        Dedent,
+        32..32,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_mac_eol.snap
@@ -3,29 +3,86 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Def,
-    Name {
-        name: "foo",
+    Token {
+        value: Def,
+        range: 0..3,
     },
-    Lpar,
-    Rpar,
-    Colon,
-    Newline,
-    Indent,
-    If,
-    Name {
-        name: "x",
+    Token {
+        value: Name {
+            name: "foo",
+        },
+        range: 4..7,
     },
-    Colon,
-    Newline,
-    NonLogicalNewline,
-    Indent,
-    Return,
-    Int {
-        value: 99,
+    Token {
+        value: Lpar,
+        range: 7..8,
     },
-    Newline,
-    NonLogicalNewline,
-    Dedent,
-    Dedent,
+    Token {
+        value: Rpar,
+        range: 8..9,
+    },
+    Token {
+        value: Colon,
+        range: 9..10,
+    },
+    Token {
+        value: Newline,
+        range: 10..11,
+    },
+    Token {
+        value: Indent,
+        range: 11..12,
+    },
+    Token {
+        value: If,
+        range: 12..14,
+    },
+    Token {
+        value: Name {
+            name: "x",
+        },
+        range: 15..16,
+    },
+    Token {
+        value: Colon,
+        range: 16..17,
+    },
+    Token {
+        value: Newline,
+        range: 17..18,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 18..19,
+    },
+    Token {
+        value: Indent,
+        range: 19..21,
+    },
+    Token {
+        value: Return,
+        range: 21..27,
+    },
+    Token {
+        value: Int {
+            value: 99,
+        },
+        range: 28..30,
+    },
+    Token {
+        value: Newline,
+        range: 30..31,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 31..32,
+    },
+    Token {
+        value: Dedent,
+        range: 32..32,
+    },
+    Token {
+        value: Dedent,
+        range: 32..32,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_mac_eol.snap
@@ -3,29 +3,86 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Def,
-    Name {
-        name: "foo",
+    Token {
+        value: Def,
+        range: 0..3,
     },
-    Lpar,
-    Rpar,
-    Colon,
-    Newline,
-    Indent,
-    If,
-    Name {
-        name: "x",
+    Token {
+        value: Name {
+            name: "foo",
+        },
+        range: 4..7,
     },
-    Colon,
-    Newline,
-    NonLogicalNewline,
-    Indent,
-    Return,
-    Int {
-        value: 99,
+    Token {
+        value: Lpar,
+        range: 7..8,
     },
-    Newline,
-    NonLogicalNewline,
-    Dedent,
-    Dedent,
+    Token {
+        value: Rpar,
+        range: 8..9,
+    },
+    Token {
+        value: Colon,
+        range: 9..10,
+    },
+    Token {
+        value: Newline,
+        range: 10..11,
+    },
+    Token {
+        value: Indent,
+        range: 11..12,
+    },
+    Token {
+        value: If,
+        range: 12..14,
+    },
+    Token {
+        value: Name {
+            name: "x",
+        },
+        range: 15..16,
+    },
+    Token {
+        value: Colon,
+        range: 16..17,
+    },
+    Token {
+        value: Newline,
+        range: 17..18,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 18..19,
+    },
+    Token {
+        value: Indent,
+        range: 19..22,
+    },
+    Token {
+        value: Return,
+        range: 22..28,
+    },
+    Token {
+        value: Int {
+            value: 99,
+        },
+        range: 29..31,
+    },
+    Token {
+        value: Newline,
+        range: 31..32,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 32..33,
+    },
+    Token {
+        value: Dedent,
+        range: 33..33,
+    },
+    Token {
+        value: Dedent,
+        range: 33..33,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_mac_eol.snap
@@ -1,88 +1,88 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: double_dedent_with_tabs_eol(MAC_EOL)
 ---
 [
-    Token {
-        value: Def,
-        range: 0..3,
-    },
-    Token {
-        value: Name {
+    (
+        Def,
+        0..3,
+    ),
+    (
+        Name {
             name: "foo",
         },
-        range: 4..7,
-    },
-    Token {
-        value: Lpar,
-        range: 7..8,
-    },
-    Token {
-        value: Rpar,
-        range: 8..9,
-    },
-    Token {
-        value: Colon,
-        range: 9..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..11,
-    },
-    Token {
-        value: Indent,
-        range: 11..12,
-    },
-    Token {
-        value: If,
-        range: 12..14,
-    },
-    Token {
-        value: Name {
+        4..7,
+    ),
+    (
+        Lpar,
+        7..8,
+    ),
+    (
+        Rpar,
+        8..9,
+    ),
+    (
+        Colon,
+        9..10,
+    ),
+    (
+        Newline,
+        10..11,
+    ),
+    (
+        Indent,
+        11..12,
+    ),
+    (
+        If,
+        12..14,
+    ),
+    (
+        Name {
             name: "x",
         },
-        range: 15..16,
-    },
-    Token {
-        value: Colon,
-        range: 16..17,
-    },
-    Token {
-        value: Newline,
-        range: 17..18,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 18..19,
-    },
-    Token {
-        value: Indent,
-        range: 19..22,
-    },
-    Token {
-        value: Return,
-        range: 22..28,
-    },
-    Token {
-        value: Int {
+        15..16,
+    ),
+    (
+        Colon,
+        16..17,
+    ),
+    (
+        Newline,
+        17..18,
+    ),
+    (
+        NonLogicalNewline,
+        18..19,
+    ),
+    (
+        Indent,
+        19..22,
+    ),
+    (
+        Return,
+        22..28,
+    ),
+    (
+        Int {
             value: 99,
         },
-        range: 29..31,
-    },
-    Token {
-        value: Newline,
-        range: 31..32,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 32..33,
-    },
-    Token {
-        value: Dedent,
-        range: 33..33,
-    },
-    Token {
-        value: Dedent,
-        range: 33..33,
-    },
+        29..31,
+    ),
+    (
+        Newline,
+        31..32,
+    ),
+    (
+        NonLogicalNewline,
+        32..33,
+    ),
+    (
+        Dedent,
+        33..33,
+    ),
+    (
+        Dedent,
+        33..33,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_unix_eol.snap
@@ -3,29 +3,86 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Def,
-    Name {
-        name: "foo",
+    Token {
+        value: Def,
+        range: 0..3,
     },
-    Lpar,
-    Rpar,
-    Colon,
-    Newline,
-    Indent,
-    If,
-    Name {
-        name: "x",
+    Token {
+        value: Name {
+            name: "foo",
+        },
+        range: 4..7,
     },
-    Colon,
-    Newline,
-    NonLogicalNewline,
-    Indent,
-    Return,
-    Int {
-        value: 99,
+    Token {
+        value: Lpar,
+        range: 7..8,
     },
-    Newline,
-    NonLogicalNewline,
-    Dedent,
-    Dedent,
+    Token {
+        value: Rpar,
+        range: 8..9,
+    },
+    Token {
+        value: Colon,
+        range: 9..10,
+    },
+    Token {
+        value: Newline,
+        range: 10..11,
+    },
+    Token {
+        value: Indent,
+        range: 11..12,
+    },
+    Token {
+        value: If,
+        range: 12..14,
+    },
+    Token {
+        value: Name {
+            name: "x",
+        },
+        range: 15..16,
+    },
+    Token {
+        value: Colon,
+        range: 16..17,
+    },
+    Token {
+        value: Newline,
+        range: 17..18,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 18..19,
+    },
+    Token {
+        value: Indent,
+        range: 19..22,
+    },
+    Token {
+        value: Return,
+        range: 22..28,
+    },
+    Token {
+        value: Int {
+            value: 99,
+        },
+        range: 29..31,
+    },
+    Token {
+        value: Newline,
+        range: 31..32,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 32..33,
+    },
+    Token {
+        value: Dedent,
+        range: 33..33,
+    },
+    Token {
+        value: Dedent,
+        range: 33..33,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_unix_eol.snap
@@ -1,88 +1,88 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: double_dedent_with_tabs_eol(UNIX_EOL)
 ---
 [
-    Token {
-        value: Def,
-        range: 0..3,
-    },
-    Token {
-        value: Name {
+    (
+        Def,
+        0..3,
+    ),
+    (
+        Name {
             name: "foo",
         },
-        range: 4..7,
-    },
-    Token {
-        value: Lpar,
-        range: 7..8,
-    },
-    Token {
-        value: Rpar,
-        range: 8..9,
-    },
-    Token {
-        value: Colon,
-        range: 9..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..11,
-    },
-    Token {
-        value: Indent,
-        range: 11..12,
-    },
-    Token {
-        value: If,
-        range: 12..14,
-    },
-    Token {
-        value: Name {
+        4..7,
+    ),
+    (
+        Lpar,
+        7..8,
+    ),
+    (
+        Rpar,
+        8..9,
+    ),
+    (
+        Colon,
+        9..10,
+    ),
+    (
+        Newline,
+        10..11,
+    ),
+    (
+        Indent,
+        11..12,
+    ),
+    (
+        If,
+        12..14,
+    ),
+    (
+        Name {
             name: "x",
         },
-        range: 15..16,
-    },
-    Token {
-        value: Colon,
-        range: 16..17,
-    },
-    Token {
-        value: Newline,
-        range: 17..18,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 18..19,
-    },
-    Token {
-        value: Indent,
-        range: 19..22,
-    },
-    Token {
-        value: Return,
-        range: 22..28,
-    },
-    Token {
-        value: Int {
+        15..16,
+    ),
+    (
+        Colon,
+        16..17,
+    ),
+    (
+        Newline,
+        17..18,
+    ),
+    (
+        NonLogicalNewline,
+        18..19,
+    ),
+    (
+        Indent,
+        19..22,
+    ),
+    (
+        Return,
+        22..28,
+    ),
+    (
+        Int {
             value: 99,
         },
-        range: 29..31,
-    },
-    Token {
-        value: Newline,
-        range: 31..32,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 32..33,
-    },
-    Token {
-        value: Dedent,
-        range: 33..33,
-    },
-    Token {
-        value: Dedent,
-        range: 33..33,
-    },
+        29..31,
+    ),
+    (
+        Newline,
+        31..32,
+    ),
+    (
+        NonLogicalNewline,
+        32..33,
+    ),
+    (
+        Dedent,
+        33..33,
+    ),
+    (
+        Dedent,
+        33..33,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_windows_eol.snap
@@ -1,88 +1,88 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: double_dedent_with_tabs_eol(WINDOWS_EOL)
 ---
 [
-    Token {
-        value: Def,
-        range: 0..3,
-    },
-    Token {
-        value: Name {
+    (
+        Def,
+        0..3,
+    ),
+    (
+        Name {
             name: "foo",
         },
-        range: 4..7,
-    },
-    Token {
-        value: Lpar,
-        range: 7..8,
-    },
-    Token {
-        value: Rpar,
-        range: 8..9,
-    },
-    Token {
-        value: Colon,
-        range: 9..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..12,
-    },
-    Token {
-        value: Indent,
-        range: 12..13,
-    },
-    Token {
-        value: If,
-        range: 13..15,
-    },
-    Token {
-        value: Name {
+        4..7,
+    ),
+    (
+        Lpar,
+        7..8,
+    ),
+    (
+        Rpar,
+        8..9,
+    ),
+    (
+        Colon,
+        9..10,
+    ),
+    (
+        Newline,
+        10..12,
+    ),
+    (
+        Indent,
+        12..13,
+    ),
+    (
+        If,
+        13..15,
+    ),
+    (
+        Name {
             name: "x",
         },
-        range: 16..17,
-    },
-    Token {
-        value: Colon,
-        range: 17..18,
-    },
-    Token {
-        value: Newline,
-        range: 18..20,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 20..22,
-    },
-    Token {
-        value: Indent,
-        range: 22..25,
-    },
-    Token {
-        value: Return,
-        range: 25..31,
-    },
-    Token {
-        value: Int {
+        16..17,
+    ),
+    (
+        Colon,
+        17..18,
+    ),
+    (
+        Newline,
+        18..20,
+    ),
+    (
+        NonLogicalNewline,
+        20..22,
+    ),
+    (
+        Indent,
+        22..25,
+    ),
+    (
+        Return,
+        25..31,
+    ),
+    (
+        Int {
             value: 99,
         },
-        range: 32..34,
-    },
-    Token {
-        value: Newline,
-        range: 34..36,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 36..38,
-    },
-    Token {
-        value: Dedent,
-        range: 38..38,
-    },
-    Token {
-        value: Dedent,
-        range: 38..38,
-    },
+        32..34,
+    ),
+    (
+        Newline,
+        34..36,
+    ),
+    (
+        NonLogicalNewline,
+        36..38,
+    ),
+    (
+        Dedent,
+        38..38,
+    ),
+    (
+        Dedent,
+        38..38,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_tabs_windows_eol.snap
@@ -3,29 +3,86 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Def,
-    Name {
-        name: "foo",
+    Token {
+        value: Def,
+        range: 0..3,
     },
-    Lpar,
-    Rpar,
-    Colon,
-    Newline,
-    Indent,
-    If,
-    Name {
-        name: "x",
+    Token {
+        value: Name {
+            name: "foo",
+        },
+        range: 4..7,
     },
-    Colon,
-    Newline,
-    NonLogicalNewline,
-    Indent,
-    Return,
-    Int {
-        value: 99,
+    Token {
+        value: Lpar,
+        range: 7..8,
     },
-    Newline,
-    NonLogicalNewline,
-    Dedent,
-    Dedent,
+    Token {
+        value: Rpar,
+        range: 8..9,
+    },
+    Token {
+        value: Colon,
+        range: 9..10,
+    },
+    Token {
+        value: Newline,
+        range: 10..12,
+    },
+    Token {
+        value: Indent,
+        range: 12..13,
+    },
+    Token {
+        value: If,
+        range: 13..15,
+    },
+    Token {
+        value: Name {
+            name: "x",
+        },
+        range: 16..17,
+    },
+    Token {
+        value: Colon,
+        range: 17..18,
+    },
+    Token {
+        value: Newline,
+        range: 18..20,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 20..22,
+    },
+    Token {
+        value: Indent,
+        range: 22..25,
+    },
+    Token {
+        value: Return,
+        range: 25..31,
+    },
+    Token {
+        value: Int {
+            value: 99,
+        },
+        range: 32..34,
+    },
+    Token {
+        value: Newline,
+        range: 34..36,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 36..38,
+    },
+    Token {
+        value: Dedent,
+        range: 38..38,
+    },
+    Token {
+        value: Dedent,
+        range: 38..38,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_unix_eol.snap
@@ -1,88 +1,88 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: double_dedent_with_eol(UNIX_EOL)
 ---
 [
-    Token {
-        value: Def,
-        range: 0..3,
-    },
-    Token {
-        value: Name {
+    (
+        Def,
+        0..3,
+    ),
+    (
+        Name {
             name: "foo",
         },
-        range: 4..7,
-    },
-    Token {
-        value: Lpar,
-        range: 7..8,
-    },
-    Token {
-        value: Rpar,
-        range: 8..9,
-    },
-    Token {
-        value: Colon,
-        range: 9..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..11,
-    },
-    Token {
-        value: Indent,
-        range: 11..12,
-    },
-    Token {
-        value: If,
-        range: 12..14,
-    },
-    Token {
-        value: Name {
+        4..7,
+    ),
+    (
+        Lpar,
+        7..8,
+    ),
+    (
+        Rpar,
+        8..9,
+    ),
+    (
+        Colon,
+        9..10,
+    ),
+    (
+        Newline,
+        10..11,
+    ),
+    (
+        Indent,
+        11..12,
+    ),
+    (
+        If,
+        12..14,
+    ),
+    (
+        Name {
             name: "x",
         },
-        range: 15..16,
-    },
-    Token {
-        value: Colon,
-        range: 16..17,
-    },
-    Token {
-        value: Newline,
-        range: 17..18,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 18..19,
-    },
-    Token {
-        value: Indent,
-        range: 19..21,
-    },
-    Token {
-        value: Return,
-        range: 21..27,
-    },
-    Token {
-        value: Int {
+        15..16,
+    ),
+    (
+        Colon,
+        16..17,
+    ),
+    (
+        Newline,
+        17..18,
+    ),
+    (
+        NonLogicalNewline,
+        18..19,
+    ),
+    (
+        Indent,
+        19..21,
+    ),
+    (
+        Return,
+        21..27,
+    ),
+    (
+        Int {
             value: 99,
         },
-        range: 28..30,
-    },
-    Token {
-        value: Newline,
-        range: 30..31,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 31..32,
-    },
-    Token {
-        value: Dedent,
-        range: 32..32,
-    },
-    Token {
-        value: Dedent,
-        range: 32..32,
-    },
+        28..30,
+    ),
+    (
+        Newline,
+        30..31,
+    ),
+    (
+        NonLogicalNewline,
+        31..32,
+    ),
+    (
+        Dedent,
+        32..32,
+    ),
+    (
+        Dedent,
+        32..32,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_unix_eol.snap
@@ -3,29 +3,86 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Def,
-    Name {
-        name: "foo",
+    Token {
+        value: Def,
+        range: 0..3,
     },
-    Lpar,
-    Rpar,
-    Colon,
-    Newline,
-    Indent,
-    If,
-    Name {
-        name: "x",
+    Token {
+        value: Name {
+            name: "foo",
+        },
+        range: 4..7,
     },
-    Colon,
-    Newline,
-    NonLogicalNewline,
-    Indent,
-    Return,
-    Int {
-        value: 99,
+    Token {
+        value: Lpar,
+        range: 7..8,
     },
-    Newline,
-    NonLogicalNewline,
-    Dedent,
-    Dedent,
+    Token {
+        value: Rpar,
+        range: 8..9,
+    },
+    Token {
+        value: Colon,
+        range: 9..10,
+    },
+    Token {
+        value: Newline,
+        range: 10..11,
+    },
+    Token {
+        value: Indent,
+        range: 11..12,
+    },
+    Token {
+        value: If,
+        range: 12..14,
+    },
+    Token {
+        value: Name {
+            name: "x",
+        },
+        range: 15..16,
+    },
+    Token {
+        value: Colon,
+        range: 16..17,
+    },
+    Token {
+        value: Newline,
+        range: 17..18,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 18..19,
+    },
+    Token {
+        value: Indent,
+        range: 19..21,
+    },
+    Token {
+        value: Return,
+        range: 21..27,
+    },
+    Token {
+        value: Int {
+            value: 99,
+        },
+        range: 28..30,
+    },
+    Token {
+        value: Newline,
+        range: 30..31,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 31..32,
+    },
+    Token {
+        value: Dedent,
+        range: 32..32,
+    },
+    Token {
+        value: Dedent,
+        range: 32..32,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_windows_eol.snap
@@ -1,88 +1,88 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: double_dedent_with_eol(WINDOWS_EOL)
 ---
 [
-    Token {
-        value: Def,
-        range: 0..3,
-    },
-    Token {
-        value: Name {
+    (
+        Def,
+        0..3,
+    ),
+    (
+        Name {
             name: "foo",
         },
-        range: 4..7,
-    },
-    Token {
-        value: Lpar,
-        range: 7..8,
-    },
-    Token {
-        value: Rpar,
-        range: 8..9,
-    },
-    Token {
-        value: Colon,
-        range: 9..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..12,
-    },
-    Token {
-        value: Indent,
-        range: 12..13,
-    },
-    Token {
-        value: If,
-        range: 13..15,
-    },
-    Token {
-        value: Name {
+        4..7,
+    ),
+    (
+        Lpar,
+        7..8,
+    ),
+    (
+        Rpar,
+        8..9,
+    ),
+    (
+        Colon,
+        9..10,
+    ),
+    (
+        Newline,
+        10..12,
+    ),
+    (
+        Indent,
+        12..13,
+    ),
+    (
+        If,
+        13..15,
+    ),
+    (
+        Name {
             name: "x",
         },
-        range: 16..17,
-    },
-    Token {
-        value: Colon,
-        range: 17..18,
-    },
-    Token {
-        value: Newline,
-        range: 18..20,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 20..22,
-    },
-    Token {
-        value: Indent,
-        range: 22..24,
-    },
-    Token {
-        value: Return,
-        range: 24..30,
-    },
-    Token {
-        value: Int {
+        16..17,
+    ),
+    (
+        Colon,
+        17..18,
+    ),
+    (
+        Newline,
+        18..20,
+    ),
+    (
+        NonLogicalNewline,
+        20..22,
+    ),
+    (
+        Indent,
+        22..24,
+    ),
+    (
+        Return,
+        24..30,
+    ),
+    (
+        Int {
             value: 99,
         },
-        range: 31..33,
-    },
-    Token {
-        value: Newline,
-        range: 33..35,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 35..37,
-    },
-    Token {
-        value: Dedent,
-        range: 37..37,
-    },
-    Token {
-        value: Dedent,
-        range: 37..37,
-    },
+        31..33,
+    ),
+    (
+        Newline,
+        33..35,
+    ),
+    (
+        NonLogicalNewline,
+        35..37,
+    ),
+    (
+        Dedent,
+        37..37,
+    ),
+    (
+        Dedent,
+        37..37,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__double_dedent_with_windows_eol.snap
@@ -3,29 +3,86 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Def,
-    Name {
-        name: "foo",
+    Token {
+        value: Def,
+        range: 0..3,
     },
-    Lpar,
-    Rpar,
-    Colon,
-    Newline,
-    Indent,
-    If,
-    Name {
-        name: "x",
+    Token {
+        value: Name {
+            name: "foo",
+        },
+        range: 4..7,
     },
-    Colon,
-    Newline,
-    NonLogicalNewline,
-    Indent,
-    Return,
-    Int {
-        value: 99,
+    Token {
+        value: Lpar,
+        range: 7..8,
     },
-    Newline,
-    NonLogicalNewline,
-    Dedent,
-    Dedent,
+    Token {
+        value: Rpar,
+        range: 8..9,
+    },
+    Token {
+        value: Colon,
+        range: 9..10,
+    },
+    Token {
+        value: Newline,
+        range: 10..12,
+    },
+    Token {
+        value: Indent,
+        range: 12..13,
+    },
+    Token {
+        value: If,
+        range: 13..15,
+    },
+    Token {
+        value: Name {
+            name: "x",
+        },
+        range: 16..17,
+    },
+    Token {
+        value: Colon,
+        range: 17..18,
+    },
+    Token {
+        value: Newline,
+        range: 18..20,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 20..22,
+    },
+    Token {
+        value: Indent,
+        range: 22..24,
+    },
+    Token {
+        value: Return,
+        range: 24..30,
+    },
+    Token {
+        value: Int {
+            value: 99,
+        },
+        range: 31..33,
+    },
+    Token {
+        value: Newline,
+        range: 33..35,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 35..37,
+    },
+    Token {
+        value: Dedent,
+        range: 37..37,
+    },
+    Token {
+        value: Dedent,
+        range: 37..37,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__empty_ipython_escape_command.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__empty_ipython_escape_command.snap
@@ -3,103 +3,103 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(source)
 ---
 [
-    Token {
-        value: IpyEscapeCommand {
+    (
+        IpyEscapeCommand {
             value: "",
             kind: Magic,
         },
-        range: 0..1,
-    },
-    Token {
-        value: Newline,
-        range: 1..2,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        0..1,
+    ),
+    (
+        Newline,
+        1..2,
+    ),
+    (
+        IpyEscapeCommand {
             value: "",
             kind: Magic2,
         },
-        range: 2..4,
-    },
-    Token {
-        value: Newline,
-        range: 4..5,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        2..4,
+    ),
+    (
+        Newline,
+        4..5,
+    ),
+    (
+        IpyEscapeCommand {
             value: "",
             kind: Shell,
         },
-        range: 5..6,
-    },
-    Token {
-        value: Newline,
-        range: 6..7,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        5..6,
+    ),
+    (
+        Newline,
+        6..7,
+    ),
+    (
+        IpyEscapeCommand {
             value: "",
             kind: ShCap,
         },
-        range: 7..9,
-    },
-    Token {
-        value: Newline,
-        range: 9..10,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        7..9,
+    ),
+    (
+        Newline,
+        9..10,
+    ),
+    (
+        IpyEscapeCommand {
             value: "",
             kind: Help,
         },
-        range: 10..11,
-    },
-    Token {
-        value: Newline,
-        range: 11..12,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        10..11,
+    ),
+    (
+        Newline,
+        11..12,
+    ),
+    (
+        IpyEscapeCommand {
             value: "",
             kind: Help2,
         },
-        range: 12..14,
-    },
-    Token {
-        value: Newline,
-        range: 14..15,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        12..14,
+    ),
+    (
+        Newline,
+        14..15,
+    ),
+    (
+        IpyEscapeCommand {
             value: "",
             kind: Paren,
         },
-        range: 15..16,
-    },
-    Token {
-        value: Newline,
-        range: 16..17,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        15..16,
+    ),
+    (
+        Newline,
+        16..17,
+    ),
+    (
+        IpyEscapeCommand {
             value: "",
             kind: Quote,
         },
-        range: 17..18,
-    },
-    Token {
-        value: Newline,
-        range: 18..19,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        17..18,
+    ),
+    (
+        Newline,
+        18..19,
+    ),
+    (
+        IpyEscapeCommand {
             value: "",
             kind: Quote2,
         },
-        range: 19..20,
-    },
-    Token {
-        value: Newline,
-        range: 20..20,
-    },
+        19..20,
+    ),
+    (
+        Newline,
+        20..20,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__empty_ipython_escape_command.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__empty_ipython_escape_command.snap
@@ -3,49 +3,103 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(source)
 ---
 [
-    IpyEscapeCommand {
-        value: "",
-        kind: Magic,
+    Token {
+        value: IpyEscapeCommand {
+            value: "",
+            kind: Magic,
+        },
+        range: 0..1,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "",
-        kind: Magic2,
+    Token {
+        value: Newline,
+        range: 1..2,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "",
-        kind: Shell,
+    Token {
+        value: IpyEscapeCommand {
+            value: "",
+            kind: Magic2,
+        },
+        range: 2..4,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "",
-        kind: ShCap,
+    Token {
+        value: Newline,
+        range: 4..5,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "",
-        kind: Help,
+    Token {
+        value: IpyEscapeCommand {
+            value: "",
+            kind: Shell,
+        },
+        range: 5..6,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "",
-        kind: Help2,
+    Token {
+        value: Newline,
+        range: 6..7,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "",
-        kind: Paren,
+    Token {
+        value: IpyEscapeCommand {
+            value: "",
+            kind: ShCap,
+        },
+        range: 7..9,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "",
-        kind: Quote,
+    Token {
+        value: Newline,
+        range: 9..10,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "",
-        kind: Quote2,
+    Token {
+        value: IpyEscapeCommand {
+            value: "",
+            kind: Help,
+        },
+        range: 10..11,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 11..12,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "",
+            kind: Help2,
+        },
+        range: 12..14,
+    },
+    Token {
+        value: Newline,
+        range: 14..15,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "",
+            kind: Paren,
+        },
+        range: 15..16,
+    },
+    Token {
+        value: Newline,
+        range: 16..17,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "",
+            kind: Quote,
+        },
+        range: 17..18,
+    },
+    Token {
+        value: Newline,
+        range: 18..19,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "",
+            kind: Quote2,
+        },
+        range: 19..20,
+    },
+    Token {
+        value: Newline,
+        range: 20..20,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__escape_unicode_name.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__escape_unicode_name.snap
@@ -3,10 +3,16 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(source)
 ---
 [
-    String {
-        value: "\\N{EN SPACE}",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: String {
+            value: "\\N{EN SPACE}",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 0..14,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 14..14,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__escape_unicode_name.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__escape_unicode_name.snap
@@ -3,16 +3,16 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(source)
 ---
 [
-    Token {
-        value: String {
+    (
+        String {
             value: "\\N{EN SPACE}",
             kind: String,
             triple_quoted: false,
         },
-        range: 0..14,
-    },
-    Token {
-        value: Newline,
-        range: 14..14,
-    },
+        0..14,
+    ),
+    (
+        Newline,
+        14..14,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_mac_eol.snap
@@ -1,58 +1,58 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: indentation_with_eol(MAC_EOL)
 ---
 [
-    Token {
-        value: Def,
-        range: 0..3,
-    },
-    Token {
-        value: Name {
+    (
+        Def,
+        0..3,
+    ),
+    (
+        Name {
             name: "foo",
         },
-        range: 4..7,
-    },
-    Token {
-        value: Lpar,
-        range: 7..8,
-    },
-    Token {
-        value: Rpar,
-        range: 8..9,
-    },
-    Token {
-        value: Colon,
-        range: 9..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..11,
-    },
-    Token {
-        value: Indent,
-        range: 11..15,
-    },
-    Token {
-        value: Return,
-        range: 15..21,
-    },
-    Token {
-        value: Int {
+        4..7,
+    ),
+    (
+        Lpar,
+        7..8,
+    ),
+    (
+        Rpar,
+        8..9,
+    ),
+    (
+        Colon,
+        9..10,
+    ),
+    (
+        Newline,
+        10..11,
+    ),
+    (
+        Indent,
+        11..15,
+    ),
+    (
+        Return,
+        15..21,
+    ),
+    (
+        Int {
             value: 99,
         },
-        range: 22..24,
-    },
-    Token {
-        value: Newline,
-        range: 24..25,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 25..26,
-    },
-    Token {
-        value: Dedent,
-        range: 26..26,
-    },
+        22..24,
+    ),
+    (
+        Newline,
+        24..25,
+    ),
+    (
+        NonLogicalNewline,
+        25..26,
+    ),
+    (
+        Dedent,
+        26..26,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_mac_eol.snap
@@ -3,20 +3,56 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Def,
-    Name {
-        name: "foo",
+    Token {
+        value: Def,
+        range: 0..3,
     },
-    Lpar,
-    Rpar,
-    Colon,
-    Newline,
-    Indent,
-    Return,
-    Int {
-        value: 99,
+    Token {
+        value: Name {
+            name: "foo",
+        },
+        range: 4..7,
     },
-    Newline,
-    NonLogicalNewline,
-    Dedent,
+    Token {
+        value: Lpar,
+        range: 7..8,
+    },
+    Token {
+        value: Rpar,
+        range: 8..9,
+    },
+    Token {
+        value: Colon,
+        range: 9..10,
+    },
+    Token {
+        value: Newline,
+        range: 10..11,
+    },
+    Token {
+        value: Indent,
+        range: 11..15,
+    },
+    Token {
+        value: Return,
+        range: 15..21,
+    },
+    Token {
+        value: Int {
+            value: 99,
+        },
+        range: 22..24,
+    },
+    Token {
+        value: Newline,
+        range: 24..25,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 25..26,
+    },
+    Token {
+        value: Dedent,
+        range: 26..26,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_unix_eol.snap
@@ -1,58 +1,58 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: indentation_with_eol(UNIX_EOL)
 ---
 [
-    Token {
-        value: Def,
-        range: 0..3,
-    },
-    Token {
-        value: Name {
+    (
+        Def,
+        0..3,
+    ),
+    (
+        Name {
             name: "foo",
         },
-        range: 4..7,
-    },
-    Token {
-        value: Lpar,
-        range: 7..8,
-    },
-    Token {
-        value: Rpar,
-        range: 8..9,
-    },
-    Token {
-        value: Colon,
-        range: 9..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..11,
-    },
-    Token {
-        value: Indent,
-        range: 11..15,
-    },
-    Token {
-        value: Return,
-        range: 15..21,
-    },
-    Token {
-        value: Int {
+        4..7,
+    ),
+    (
+        Lpar,
+        7..8,
+    ),
+    (
+        Rpar,
+        8..9,
+    ),
+    (
+        Colon,
+        9..10,
+    ),
+    (
+        Newline,
+        10..11,
+    ),
+    (
+        Indent,
+        11..15,
+    ),
+    (
+        Return,
+        15..21,
+    ),
+    (
+        Int {
             value: 99,
         },
-        range: 22..24,
-    },
-    Token {
-        value: Newline,
-        range: 24..25,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 25..26,
-    },
-    Token {
-        value: Dedent,
-        range: 26..26,
-    },
+        22..24,
+    ),
+    (
+        Newline,
+        24..25,
+    ),
+    (
+        NonLogicalNewline,
+        25..26,
+    ),
+    (
+        Dedent,
+        26..26,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_unix_eol.snap
@@ -3,20 +3,56 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Def,
-    Name {
-        name: "foo",
+    Token {
+        value: Def,
+        range: 0..3,
     },
-    Lpar,
-    Rpar,
-    Colon,
-    Newline,
-    Indent,
-    Return,
-    Int {
-        value: 99,
+    Token {
+        value: Name {
+            name: "foo",
+        },
+        range: 4..7,
     },
-    Newline,
-    NonLogicalNewline,
-    Dedent,
+    Token {
+        value: Lpar,
+        range: 7..8,
+    },
+    Token {
+        value: Rpar,
+        range: 8..9,
+    },
+    Token {
+        value: Colon,
+        range: 9..10,
+    },
+    Token {
+        value: Newline,
+        range: 10..11,
+    },
+    Token {
+        value: Indent,
+        range: 11..15,
+    },
+    Token {
+        value: Return,
+        range: 15..21,
+    },
+    Token {
+        value: Int {
+            value: 99,
+        },
+        range: 22..24,
+    },
+    Token {
+        value: Newline,
+        range: 24..25,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 25..26,
+    },
+    Token {
+        value: Dedent,
+        range: 26..26,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_windows_eol.snap
@@ -1,58 +1,58 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: indentation_with_eol(WINDOWS_EOL)
 ---
 [
-    Token {
-        value: Def,
-        range: 0..3,
-    },
-    Token {
-        value: Name {
+    (
+        Def,
+        0..3,
+    ),
+    (
+        Name {
             name: "foo",
         },
-        range: 4..7,
-    },
-    Token {
-        value: Lpar,
-        range: 7..8,
-    },
-    Token {
-        value: Rpar,
-        range: 8..9,
-    },
-    Token {
-        value: Colon,
-        range: 9..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..12,
-    },
-    Token {
-        value: Indent,
-        range: 12..16,
-    },
-    Token {
-        value: Return,
-        range: 16..22,
-    },
-    Token {
-        value: Int {
+        4..7,
+    ),
+    (
+        Lpar,
+        7..8,
+    ),
+    (
+        Rpar,
+        8..9,
+    ),
+    (
+        Colon,
+        9..10,
+    ),
+    (
+        Newline,
+        10..12,
+    ),
+    (
+        Indent,
+        12..16,
+    ),
+    (
+        Return,
+        16..22,
+    ),
+    (
+        Int {
             value: 99,
         },
-        range: 23..25,
-    },
-    Token {
-        value: Newline,
-        range: 25..27,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 27..29,
-    },
-    Token {
-        value: Dedent,
-        range: 29..29,
-    },
+        23..25,
+    ),
+    (
+        Newline,
+        25..27,
+    ),
+    (
+        NonLogicalNewline,
+        27..29,
+    ),
+    (
+        Dedent,
+        29..29,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__indentation_with_windows_eol.snap
@@ -3,20 +3,56 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Def,
-    Name {
-        name: "foo",
+    Token {
+        value: Def,
+        range: 0..3,
     },
-    Lpar,
-    Rpar,
-    Colon,
-    Newline,
-    Indent,
-    Return,
-    Int {
-        value: 99,
+    Token {
+        value: Name {
+            name: "foo",
+        },
+        range: 4..7,
     },
-    Newline,
-    NonLogicalNewline,
-    Dedent,
+    Token {
+        value: Lpar,
+        range: 7..8,
+    },
+    Token {
+        value: Rpar,
+        range: 8..9,
+    },
+    Token {
+        value: Colon,
+        range: 9..10,
+    },
+    Token {
+        value: Newline,
+        range: 10..12,
+    },
+    Token {
+        value: Indent,
+        range: 12..16,
+    },
+    Token {
+        value: Return,
+        range: 16..22,
+    },
+    Token {
+        value: Int {
+            value: 99,
+        },
+        range: 23..25,
+    },
+    Token {
+        value: Newline,
+        range: 25..27,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 27..29,
+    },
+    Token {
+        value: Dedent,
+        range: 29..29,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command.snap
@@ -3,59 +3,125 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(source)
 ---
 [
-    IpyEscapeCommand {
-        value: "foo",
-        kind: Help,
+    Token {
+        value: IpyEscapeCommand {
+            value: "foo",
+            kind: Help,
+        },
+        range: 0..4,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "foo",
-        kind: Help2,
+    Token {
+        value: Newline,
+        range: 4..5,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "timeit a = b",
-        kind: Magic,
+    Token {
+        value: IpyEscapeCommand {
+            value: "foo",
+            kind: Help2,
+        },
+        range: 5..10,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "timeit a % 3",
-        kind: Magic,
+    Token {
+        value: Newline,
+        range: 10..11,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "matplotlib     --inline",
-        kind: Magic,
+    Token {
+        value: IpyEscapeCommand {
+            value: "timeit a = b",
+            kind: Magic,
+        },
+        range: 11..24,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "pwd   && ls -a | sed 's/^/\\\\    /'",
-        kind: Shell,
+    Token {
+        value: Newline,
+        range: 24..25,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "cd /Users/foo/Library/Application\\ Support/",
-        kind: ShCap,
+    Token {
+        value: IpyEscapeCommand {
+            value: "timeit a % 3",
+            kind: Magic,
+        },
+        range: 25..38,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "foo 1 2",
-        kind: Paren,
+    Token {
+        value: Newline,
+        range: 38..39,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "foo 1 2",
-        kind: Quote,
+    Token {
+        value: IpyEscapeCommand {
+            value: "matplotlib     --inline",
+            kind: Magic,
+        },
+        range: 39..65,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "foo 1 2",
-        kind: Quote2,
+    Token {
+        value: Newline,
+        range: 65..66,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "ls",
-        kind: Shell,
+    Token {
+        value: IpyEscapeCommand {
+            value: "pwd   && ls -a | sed 's/^/\\\\    /'",
+            kind: Shell,
+        },
+        range: 66..103,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 103..104,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "cd /Users/foo/Library/Application\\ Support/",
+            kind: ShCap,
+        },
+        range: 104..149,
+    },
+    Token {
+        value: Newline,
+        range: 149..150,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "foo 1 2",
+            kind: Paren,
+        },
+        range: 150..158,
+    },
+    Token {
+        value: Newline,
+        range: 158..159,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "foo 1 2",
+            kind: Quote,
+        },
+        range: 159..167,
+    },
+    Token {
+        value: Newline,
+        range: 167..168,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "foo 1 2",
+            kind: Quote2,
+        },
+        range: 168..176,
+    },
+    Token {
+        value: Newline,
+        range: 176..177,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "ls",
+            kind: Shell,
+        },
+        range: 177..180,
+    },
+    Token {
+        value: Newline,
+        range: 180..180,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command.snap
@@ -3,125 +3,125 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(source)
 ---
 [
-    Token {
-        value: IpyEscapeCommand {
+    (
+        IpyEscapeCommand {
             value: "foo",
             kind: Help,
         },
-        range: 0..4,
-    },
-    Token {
-        value: Newline,
-        range: 4..5,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        0..4,
+    ),
+    (
+        Newline,
+        4..5,
+    ),
+    (
+        IpyEscapeCommand {
             value: "foo",
             kind: Help2,
         },
-        range: 5..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..11,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        5..10,
+    ),
+    (
+        Newline,
+        10..11,
+    ),
+    (
+        IpyEscapeCommand {
             value: "timeit a = b",
             kind: Magic,
         },
-        range: 11..24,
-    },
-    Token {
-        value: Newline,
-        range: 24..25,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        11..24,
+    ),
+    (
+        Newline,
+        24..25,
+    ),
+    (
+        IpyEscapeCommand {
             value: "timeit a % 3",
             kind: Magic,
         },
-        range: 25..38,
-    },
-    Token {
-        value: Newline,
-        range: 38..39,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        25..38,
+    ),
+    (
+        Newline,
+        38..39,
+    ),
+    (
+        IpyEscapeCommand {
             value: "matplotlib     --inline",
             kind: Magic,
         },
-        range: 39..65,
-    },
-    Token {
-        value: Newline,
-        range: 65..66,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        39..65,
+    ),
+    (
+        Newline,
+        65..66,
+    ),
+    (
+        IpyEscapeCommand {
             value: "pwd   && ls -a | sed 's/^/\\\\    /'",
             kind: Shell,
         },
-        range: 66..103,
-    },
-    Token {
-        value: Newline,
-        range: 103..104,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        66..103,
+    ),
+    (
+        Newline,
+        103..104,
+    ),
+    (
+        IpyEscapeCommand {
             value: "cd /Users/foo/Library/Application\\ Support/",
             kind: ShCap,
         },
-        range: 104..149,
-    },
-    Token {
-        value: Newline,
-        range: 149..150,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        104..149,
+    ),
+    (
+        Newline,
+        149..150,
+    ),
+    (
+        IpyEscapeCommand {
             value: "foo 1 2",
             kind: Paren,
         },
-        range: 150..158,
-    },
-    Token {
-        value: Newline,
-        range: 158..159,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        150..158,
+    ),
+    (
+        Newline,
+        158..159,
+    ),
+    (
+        IpyEscapeCommand {
             value: "foo 1 2",
             kind: Quote,
         },
-        range: 159..167,
-    },
-    Token {
-        value: Newline,
-        range: 167..168,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        159..167,
+    ),
+    (
+        Newline,
+        167..168,
+    ),
+    (
+        IpyEscapeCommand {
             value: "foo 1 2",
             kind: Quote2,
         },
-        range: 168..176,
-    },
-    Token {
-        value: Newline,
-        range: 176..177,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        168..176,
+    ),
+    (
+        Newline,
+        176..177,
+    ),
+    (
+        IpyEscapeCommand {
             value: "ls",
             kind: Shell,
         },
-        range: 177..180,
-    },
-    Token {
-        value: Newline,
-        range: 180..180,
-    },
+        177..180,
+    ),
+    (
+        Newline,
+        180..180,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_assignment.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_assignment.snap
@@ -3,88 +3,88 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(source)
 ---
 [
-    Token {
-        value: Name {
+    (
+        Name {
             name: "pwd",
         },
-        range: 0..3,
-    },
-    Token {
-        value: Equal,
-        range: 4..5,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        0..3,
+    ),
+    (
+        Equal,
+        4..5,
+    ),
+    (
+        IpyEscapeCommand {
             value: "pwd",
             kind: Shell,
         },
-        range: 6..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..11,
-    },
-    Token {
-        value: Name {
+        6..10,
+    ),
+    (
+        Newline,
+        10..11,
+    ),
+    (
+        Name {
             name: "foo",
         },
-        range: 11..14,
-    },
-    Token {
-        value: Equal,
-        range: 15..16,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        11..14,
+    ),
+    (
+        Equal,
+        15..16,
+    ),
+    (
+        IpyEscapeCommand {
             value: "timeit a = b",
             kind: Magic,
         },
-        range: 17..30,
-    },
-    Token {
-        value: Newline,
-        range: 30..31,
-    },
-    Token {
-        value: Name {
+        17..30,
+    ),
+    (
+        Newline,
+        30..31,
+    ),
+    (
+        Name {
             name: "bar",
         },
-        range: 31..34,
-    },
-    Token {
-        value: Equal,
-        range: 35..36,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        31..34,
+    ),
+    (
+        Equal,
+        35..36,
+    ),
+    (
+        IpyEscapeCommand {
             value: "timeit a % 3",
             kind: Magic,
         },
-        range: 37..50,
-    },
-    Token {
-        value: Newline,
-        range: 50..51,
-    },
-    Token {
-        value: Name {
+        37..50,
+    ),
+    (
+        Newline,
+        50..51,
+    ),
+    (
+        Name {
             name: "baz",
         },
-        range: 51..54,
-    },
-    Token {
-        value: Equal,
-        range: 55..56,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        51..54,
+    ),
+    (
+        Equal,
+        55..56,
+    ),
+    (
+        IpyEscapeCommand {
             value: "matplotlib         inline",
             kind: Magic,
         },
-        range: 57..85,
-    },
-    Token {
-        value: Newline,
-        range: 85..85,
-    },
+        57..85,
+    ),
+    (
+        Newline,
+        85..85,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_assignment.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_assignment.snap
@@ -3,40 +3,88 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(source)
 ---
 [
-    Name {
-        name: "pwd",
+    Token {
+        value: Name {
+            name: "pwd",
+        },
+        range: 0..3,
     },
-    Equal,
-    IpyEscapeCommand {
-        value: "pwd",
-        kind: Shell,
+    Token {
+        value: Equal,
+        range: 4..5,
     },
-    Newline,
-    Name {
-        name: "foo",
+    Token {
+        value: IpyEscapeCommand {
+            value: "pwd",
+            kind: Shell,
+        },
+        range: 6..10,
     },
-    Equal,
-    IpyEscapeCommand {
-        value: "timeit a = b",
-        kind: Magic,
+    Token {
+        value: Newline,
+        range: 10..11,
     },
-    Newline,
-    Name {
-        name: "bar",
+    Token {
+        value: Name {
+            name: "foo",
+        },
+        range: 11..14,
     },
-    Equal,
-    IpyEscapeCommand {
-        value: "timeit a % 3",
-        kind: Magic,
+    Token {
+        value: Equal,
+        range: 15..16,
     },
-    Newline,
-    Name {
-        name: "baz",
+    Token {
+        value: IpyEscapeCommand {
+            value: "timeit a = b",
+            kind: Magic,
+        },
+        range: 17..30,
     },
-    Equal,
-    IpyEscapeCommand {
-        value: "matplotlib         inline",
-        kind: Magic,
+    Token {
+        value: Newline,
+        range: 30..31,
     },
-    Newline,
+    Token {
+        value: Name {
+            name: "bar",
+        },
+        range: 31..34,
+    },
+    Token {
+        value: Equal,
+        range: 35..36,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "timeit a % 3",
+            kind: Magic,
+        },
+        range: 37..50,
+    },
+    Token {
+        value: Newline,
+        range: 50..51,
+    },
+    Token {
+        value: Name {
+            name: "baz",
+        },
+        range: 51..54,
+    },
+    Token {
+        value: Equal,
+        range: 55..56,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "matplotlib         inline",
+            kind: Magic,
+        },
+        range: 57..85,
+    },
+    Token {
+        value: Newline,
+        range: 85..85,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_indentation.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_indentation.snap
@@ -3,39 +3,39 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(source)
 ---
 [
-    Token {
-        value: If,
-        range: 0..2,
-    },
-    Token {
-        value: True,
-        range: 3..7,
-    },
-    Token {
-        value: Colon,
-        range: 7..8,
-    },
-    Token {
-        value: Newline,
-        range: 8..9,
-    },
-    Token {
-        value: Indent,
-        range: 9..13,
-    },
-    Token {
-        value: IpyEscapeCommand {
+    (
+        If,
+        0..2,
+    ),
+    (
+        True,
+        3..7,
+    ),
+    (
+        Colon,
+        7..8,
+    ),
+    (
+        Newline,
+        8..9,
+    ),
+    (
+        Indent,
+        9..13,
+    ),
+    (
+        IpyEscapeCommand {
             value: "matplotlib         --inline",
             kind: Magic,
         },
-        range: 13..43,
-    },
-    Token {
-        value: Newline,
-        range: 43..43,
-    },
-    Token {
-        value: Dedent,
-        range: 43..43,
-    },
+        13..43,
+    ),
+    (
+        Newline,
+        43..43,
+    ),
+    (
+        Dedent,
+        43..43,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_indentation.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_indentation.snap
@@ -3,15 +3,39 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(source)
 ---
 [
-    If,
-    True,
-    Colon,
-    Newline,
-    Indent,
-    IpyEscapeCommand {
-        value: "matplotlib         --inline",
-        kind: Magic,
+    Token {
+        value: If,
+        range: 0..2,
     },
-    Newline,
-    Dedent,
+    Token {
+        value: True,
+        range: 3..7,
+    },
+    Token {
+        value: Colon,
+        range: 7..8,
+    },
+    Token {
+        value: Newline,
+        range: 8..9,
+    },
+    Token {
+        value: Indent,
+        range: 9..13,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "matplotlib         --inline",
+            kind: Magic,
+        },
+        range: 13..43,
+    },
+    Token {
+        value: Newline,
+        range: 43..43,
+    },
+    Token {
+        value: Dedent,
+        range: 43..43,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_mac_eol.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_jupyter_source(&source)
+expression: ipython_escape_command_line_continuation_eol(MAC_EOL)
 ---
 [
-    Token {
-        value: IpyEscapeCommand {
+    (
+        IpyEscapeCommand {
             value: "matplotlib   --inline",
             kind: Magic,
         },
-        range: 0..24,
-    },
-    Token {
-        value: Newline,
-        range: 24..24,
-    },
+        0..24,
+    ),
+    (
+        Newline,
+        24..24,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_mac_eol.snap
@@ -3,9 +3,15 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(&source)
 ---
 [
-    IpyEscapeCommand {
-        value: "matplotlib   --inline",
-        kind: Magic,
+    Token {
+        value: IpyEscapeCommand {
+            value: "matplotlib   --inline",
+            kind: Magic,
+        },
+        range: 0..24,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 24..24,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_unix_eol.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_jupyter_source(&source)
+expression: ipython_escape_command_line_continuation_eol(UNIX_EOL)
 ---
 [
-    Token {
-        value: IpyEscapeCommand {
+    (
+        IpyEscapeCommand {
             value: "matplotlib   --inline",
             kind: Magic,
         },
-        range: 0..24,
-    },
-    Token {
-        value: Newline,
-        range: 24..24,
-    },
+        0..24,
+    ),
+    (
+        Newline,
+        24..24,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_unix_eol.snap
@@ -3,9 +3,15 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(&source)
 ---
 [
-    IpyEscapeCommand {
-        value: "matplotlib   --inline",
-        kind: Magic,
+    Token {
+        value: IpyEscapeCommand {
+            value: "matplotlib   --inline",
+            kind: Magic,
+        },
+        range: 0..24,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 24..24,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_windows_eol.snap
@@ -3,9 +3,15 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(&source)
 ---
 [
-    IpyEscapeCommand {
-        value: "matplotlib   --inline",
-        kind: Magic,
+    Token {
+        value: IpyEscapeCommand {
+            value: "matplotlib   --inline",
+            kind: Magic,
+        },
+        range: 0..25,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 25..25,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_windows_eol.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_jupyter_source(&source)
+expression: ipython_escape_command_line_continuation_eol(WINDOWS_EOL)
 ---
 [
-    Token {
-        value: IpyEscapeCommand {
+    (
+        IpyEscapeCommand {
             value: "matplotlib   --inline",
             kind: Magic,
         },
-        range: 0..25,
-    },
-    Token {
-        value: Newline,
-        range: 25..25,
-    },
+        0..25,
+    ),
+    (
+        Newline,
+        25..25,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_mac_eol_and_eof.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_mac_eol_and_eof.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_jupyter_source(&source)
+expression: ipython_escape_command_line_continuation_with_eol_and_eof(MAC_EOL)
 ---
 [
-    Token {
-        value: IpyEscapeCommand {
+    (
+        IpyEscapeCommand {
             value: "matplotlib ",
             kind: Magic,
         },
-        range: 0..14,
-    },
-    Token {
-        value: Newline,
-        range: 14..14,
-    },
+        0..14,
+    ),
+    (
+        Newline,
+        14..14,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_mac_eol_and_eof.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_mac_eol_and_eof.snap
@@ -3,9 +3,15 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(&source)
 ---
 [
-    IpyEscapeCommand {
-        value: "matplotlib ",
-        kind: Magic,
+    Token {
+        value: IpyEscapeCommand {
+            value: "matplotlib ",
+            kind: Magic,
+        },
+        range: 0..14,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 14..14,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_unix_eol_and_eof.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_unix_eol_and_eof.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_jupyter_source(&source)
+expression: ipython_escape_command_line_continuation_with_eol_and_eof(UNIX_EOL)
 ---
 [
-    Token {
-        value: IpyEscapeCommand {
+    (
+        IpyEscapeCommand {
             value: "matplotlib ",
             kind: Magic,
         },
-        range: 0..14,
-    },
-    Token {
-        value: Newline,
-        range: 14..14,
-    },
+        0..14,
+    ),
+    (
+        Newline,
+        14..14,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_unix_eol_and_eof.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_unix_eol_and_eof.snap
@@ -3,9 +3,15 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(&source)
 ---
 [
-    IpyEscapeCommand {
-        value: "matplotlib ",
-        kind: Magic,
+    Token {
+        value: IpyEscapeCommand {
+            value: "matplotlib ",
+            kind: Magic,
+        },
+        range: 0..14,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 14..14,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_windows_eol_and_eof.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_windows_eol_and_eof.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_jupyter_source(&source)
+expression: ipython_escape_command_line_continuation_with_eol_and_eof(WINDOWS_EOL)
 ---
 [
-    Token {
-        value: IpyEscapeCommand {
+    (
+        IpyEscapeCommand {
             value: "matplotlib ",
             kind: Magic,
         },
-        range: 0..15,
-    },
-    Token {
-        value: Newline,
-        range: 15..15,
-    },
+        0..15,
+    ),
+    (
+        Newline,
+        15..15,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_windows_eol_and_eof.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_escape_command_line_continuation_with_windows_eol_and_eof.snap
@@ -3,9 +3,15 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(&source)
 ---
 [
-    IpyEscapeCommand {
-        value: "matplotlib ",
-        kind: Magic,
+    Token {
+        value: IpyEscapeCommand {
+            value: "matplotlib ",
+            kind: Magic,
+        },
+        range: 0..15,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 15..15,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_help_end_escape_command.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_help_end_escape_command.snap
@@ -3,84 +3,180 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(source)
 ---
 [
-    IpyEscapeCommand {
-        value: "foo",
-        kind: Help,
+    Token {
+        value: IpyEscapeCommand {
+            value: "foo",
+            kind: Help,
+        },
+        range: 0..5,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "foo",
-        kind: Help,
+    Token {
+        value: Newline,
+        range: 5..6,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "   foo  ?",
-        kind: Help2,
+    Token {
+        value: IpyEscapeCommand {
+            value: "foo",
+            kind: Help,
+        },
+        range: 6..15,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "foo",
-        kind: Help2,
+    Token {
+        value: Newline,
+        range: 15..16,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "foo",
-        kind: Help2,
+    Token {
+        value: IpyEscapeCommand {
+            value: "   foo  ?",
+            kind: Help2,
+        },
+        range: 16..27,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "foo",
-        kind: Help,
+    Token {
+        value: Newline,
+        range: 27..28,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "foo",
-        kind: Help2,
+    Token {
+        value: IpyEscapeCommand {
+            value: "foo",
+            kind: Help2,
+        },
+        range: 28..34,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "foo???",
-        kind: Help2,
+    Token {
+        value: Newline,
+        range: 34..35,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "?foo???",
-        kind: Help2,
+    Token {
+        value: IpyEscapeCommand {
+            value: "foo",
+            kind: Help2,
+        },
+        range: 35..42,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "foo",
-        kind: Help,
+    Token {
+        value: Newline,
+        range: 42..43,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: " ?",
-        kind: Help2,
+    Token {
+        value: IpyEscapeCommand {
+            value: "foo",
+            kind: Help,
+        },
+        range: 43..50,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "??",
-        kind: Help2,
+    Token {
+        value: Newline,
+        range: 50..51,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "%foo",
-        kind: Help,
+    Token {
+        value: IpyEscapeCommand {
+            value: "foo",
+            kind: Help2,
+        },
+        range: 51..59,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "%foo",
-        kind: Help2,
+    Token {
+        value: Newline,
+        range: 59..60,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "foo???",
-        kind: Magic2,
+    Token {
+        value: IpyEscapeCommand {
+            value: "foo???",
+            kind: Help2,
+        },
+        range: 60..68,
     },
-    Newline,
-    IpyEscapeCommand {
-        value: "pwd",
-        kind: Help,
+    Token {
+        value: Newline,
+        range: 68..69,
     },
-    Newline,
+    Token {
+        value: IpyEscapeCommand {
+            value: "?foo???",
+            kind: Help2,
+        },
+        range: 69..78,
+    },
+    Token {
+        value: Newline,
+        range: 78..79,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "foo",
+            kind: Help,
+        },
+        range: 79..92,
+    },
+    Token {
+        value: Newline,
+        range: 92..93,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: " ?",
+            kind: Help2,
+        },
+        range: 93..99,
+    },
+    Token {
+        value: Newline,
+        range: 99..100,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "??",
+            kind: Help2,
+        },
+        range: 100..104,
+    },
+    Token {
+        value: Newline,
+        range: 104..105,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "%foo",
+            kind: Help,
+        },
+        range: 105..110,
+    },
+    Token {
+        value: Newline,
+        range: 110..111,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "%foo",
+            kind: Help2,
+        },
+        range: 111..117,
+    },
+    Token {
+        value: Newline,
+        range: 117..118,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "foo???",
+            kind: Magic2,
+        },
+        range: 118..126,
+    },
+    Token {
+        value: Newline,
+        range: 126..127,
+    },
+    Token {
+        value: IpyEscapeCommand {
+            value: "pwd",
+            kind: Help,
+        },
+        range: 127..132,
+    },
+    Token {
+        value: Newline,
+        range: 132..132,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_help_end_escape_command.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__ipython_help_end_escape_command.snap
@@ -3,180 +3,180 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_jupyter_source(source)
 ---
 [
-    Token {
-        value: IpyEscapeCommand {
+    (
+        IpyEscapeCommand {
             value: "foo",
             kind: Help,
         },
-        range: 0..5,
-    },
-    Token {
-        value: Newline,
-        range: 5..6,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        0..5,
+    ),
+    (
+        Newline,
+        5..6,
+    ),
+    (
+        IpyEscapeCommand {
             value: "foo",
             kind: Help,
         },
-        range: 6..15,
-    },
-    Token {
-        value: Newline,
-        range: 15..16,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        6..15,
+    ),
+    (
+        Newline,
+        15..16,
+    ),
+    (
+        IpyEscapeCommand {
             value: "   foo  ?",
             kind: Help2,
         },
-        range: 16..27,
-    },
-    Token {
-        value: Newline,
-        range: 27..28,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        16..27,
+    ),
+    (
+        Newline,
+        27..28,
+    ),
+    (
+        IpyEscapeCommand {
             value: "foo",
             kind: Help2,
         },
-        range: 28..34,
-    },
-    Token {
-        value: Newline,
-        range: 34..35,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        28..34,
+    ),
+    (
+        Newline,
+        34..35,
+    ),
+    (
+        IpyEscapeCommand {
             value: "foo",
             kind: Help2,
         },
-        range: 35..42,
-    },
-    Token {
-        value: Newline,
-        range: 42..43,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        35..42,
+    ),
+    (
+        Newline,
+        42..43,
+    ),
+    (
+        IpyEscapeCommand {
             value: "foo",
             kind: Help,
         },
-        range: 43..50,
-    },
-    Token {
-        value: Newline,
-        range: 50..51,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        43..50,
+    ),
+    (
+        Newline,
+        50..51,
+    ),
+    (
+        IpyEscapeCommand {
             value: "foo",
             kind: Help2,
         },
-        range: 51..59,
-    },
-    Token {
-        value: Newline,
-        range: 59..60,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        51..59,
+    ),
+    (
+        Newline,
+        59..60,
+    ),
+    (
+        IpyEscapeCommand {
             value: "foo???",
             kind: Help2,
         },
-        range: 60..68,
-    },
-    Token {
-        value: Newline,
-        range: 68..69,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        60..68,
+    ),
+    (
+        Newline,
+        68..69,
+    ),
+    (
+        IpyEscapeCommand {
             value: "?foo???",
             kind: Help2,
         },
-        range: 69..78,
-    },
-    Token {
-        value: Newline,
-        range: 78..79,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        69..78,
+    ),
+    (
+        Newline,
+        78..79,
+    ),
+    (
+        IpyEscapeCommand {
             value: "foo",
             kind: Help,
         },
-        range: 79..92,
-    },
-    Token {
-        value: Newline,
-        range: 92..93,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        79..92,
+    ),
+    (
+        Newline,
+        92..93,
+    ),
+    (
+        IpyEscapeCommand {
             value: " ?",
             kind: Help2,
         },
-        range: 93..99,
-    },
-    Token {
-        value: Newline,
-        range: 99..100,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        93..99,
+    ),
+    (
+        Newline,
+        99..100,
+    ),
+    (
+        IpyEscapeCommand {
             value: "??",
             kind: Help2,
         },
-        range: 100..104,
-    },
-    Token {
-        value: Newline,
-        range: 104..105,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        100..104,
+    ),
+    (
+        Newline,
+        104..105,
+    ),
+    (
+        IpyEscapeCommand {
             value: "%foo",
             kind: Help,
         },
-        range: 105..110,
-    },
-    Token {
-        value: Newline,
-        range: 110..111,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        105..110,
+    ),
+    (
+        Newline,
+        110..111,
+    ),
+    (
+        IpyEscapeCommand {
             value: "%foo",
             kind: Help2,
         },
-        range: 111..117,
-    },
-    Token {
-        value: Newline,
-        range: 117..118,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        111..117,
+    ),
+    (
+        Newline,
+        117..118,
+    ),
+    (
+        IpyEscapeCommand {
             value: "foo???",
             kind: Magic2,
         },
-        range: 118..126,
-    },
-    Token {
-        value: Newline,
-        range: 126..127,
-    },
-    Token {
-        value: IpyEscapeCommand {
+        118..126,
+    ),
+    (
+        Newline,
+        126..127,
+    ),
+    (
+        IpyEscapeCommand {
             value: "pwd",
             kind: Help,
         },
-        range: 127..132,
-    },
-    Token {
-        value: Newline,
-        range: 132..132,
-    },
+        127..132,
+    ),
+    (
+        Newline,
+        132..132,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_empty.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_empty.snap
@@ -3,11 +3,20 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Int {
-        value: 99232,
+    Token {
+        value: Int {
+            value: 99232,
+        },
+        range: 0..5,
     },
-    Comment(
-        "#",
-    ),
-    Newline,
+    Token {
+        value: Comment(
+            "#",
+        ),
+        range: 7..8,
+    },
+    Token {
+        value: Newline,
+        range: 8..8,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_empty.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_empty.snap
@@ -3,20 +3,20 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Token {
-        value: Int {
+    (
+        Int {
             value: 99232,
         },
-        range: 0..5,
-    },
-    Token {
-        value: Comment(
+        0..5,
+    ),
+    (
+        Comment(
             "#",
         ),
-        range: 7..8,
-    },
-    Token {
-        value: Newline,
-        range: 8..8,
-    },
+        7..8,
+    ),
+    (
+        Newline,
+        8..8,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_long.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_long.snap
@@ -3,11 +3,20 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Int {
-        value: 99232,
+    Token {
+        value: Int {
+            value: 99232,
+        },
+        range: 0..5,
     },
-    Comment(
-        "# foo",
-    ),
-    Newline,
+    Token {
+        value: Comment(
+            "# foo",
+        ),
+        range: 7..12,
+    },
+    Token {
+        value: Newline,
+        range: 12..12,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_long.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_long.snap
@@ -3,20 +3,20 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Token {
-        value: Int {
+    (
+        Int {
             value: 99232,
         },
-        range: 0..5,
-    },
-    Token {
-        value: Comment(
+        0..5,
+    ),
+    (
+        Comment(
             "# foo",
         ),
-        range: 7..12,
-    },
-    Token {
-        value: Newline,
-        range: 12..12,
-    },
+        7..12,
+    ),
+    (
+        Newline,
+        12..12,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_single_whitespace.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_single_whitespace.snap
@@ -3,11 +3,20 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Int {
-        value: 99232,
+    Token {
+        value: Int {
+            value: 99232,
+        },
+        range: 0..5,
     },
-    Comment(
-        "# ",
-    ),
-    Newline,
+    Token {
+        value: Comment(
+            "# ",
+        ),
+        range: 7..9,
+    },
+    Token {
+        value: Newline,
+        range: 9..9,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_single_whitespace.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_single_whitespace.snap
@@ -3,20 +3,20 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Token {
-        value: Int {
+    (
+        Int {
             value: 99232,
         },
-        range: 0..5,
-    },
-    Token {
-        value: Comment(
+        0..5,
+    ),
+    (
+        Comment(
             "# ",
         ),
-        range: 7..9,
-    },
-    Token {
-        value: Newline,
-        range: 9..9,
-    },
+        7..9,
+    ),
+    (
+        Newline,
+        9..9,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_whitespace.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_whitespace.snap
@@ -3,11 +3,20 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Int {
-        value: 99232,
+    Token {
+        value: Int {
+            value: 99232,
+        },
+        range: 0..5,
     },
-    Comment(
-        "#  ",
-    ),
-    Newline,
+    Token {
+        value: Comment(
+            "#  ",
+        ),
+        range: 7..10,
+    },
+    Token {
+        value: Newline,
+        range: 10..10,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_whitespace.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__line_comment_whitespace.snap
@@ -3,20 +3,20 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Token {
-        value: Int {
+    (
+        Int {
             value: 99232,
         },
-        range: 0..5,
-    },
-    Token {
-        value: Comment(
+        0..5,
+    ),
+    (
+        Comment(
             "#  ",
         ),
-        range: 7..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..10,
-    },
+        7..10,
+    ),
+    (
+        Newline,
+        10..10,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__logical_newline_line_comment.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__logical_newline_line_comment.snap
@@ -3,24 +3,24 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(source)
 ---
 [
-    Token {
-        value: Comment(
+    (
+        Comment(
             "#Hello",
         ),
-        range: 0..6,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 6..7,
-    },
-    Token {
-        value: Comment(
+        0..6,
+    ),
+    (
+        NonLogicalNewline,
+        6..7,
+    ),
+    (
+        Comment(
             "#World",
         ),
-        range: 7..13,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 13..14,
-    },
+        7..13,
+    ),
+    (
+        NonLogicalNewline,
+        13..14,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__logical_newline_line_comment.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__logical_newline_line_comment.snap
@@ -3,12 +3,24 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(source)
 ---
 [
-    Comment(
-        "#Hello",
-    ),
-    NonLogicalNewline,
-    Comment(
-        "#World",
-    ),
-    NonLogicalNewline,
+    Token {
+        value: Comment(
+            "#Hello",
+        ),
+        range: 0..6,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 6..7,
+    },
+    Token {
+        value: Comment(
+            "#World",
+        ),
+        range: 7..13,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 13..14,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_mac_eol.snap
@@ -1,142 +1,142 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: newline_in_brackets_eol(MAC_EOL)
 ---
 [
-    Token {
-        value: Name {
+    (
+        Name {
             name: "x",
         },
-        range: 0..1,
-    },
-    Token {
-        value: Equal,
-        range: 2..3,
-    },
-    Token {
-        value: Lsqb,
-        range: 4..5,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 5..6,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 6..7,
-    },
-    Token {
-        value: Int {
+        0..1,
+    ),
+    (
+        Equal,
+        2..3,
+    ),
+    (
+        Lsqb,
+        4..5,
+    ),
+    (
+        NonLogicalNewline,
+        5..6,
+    ),
+    (
+        NonLogicalNewline,
+        6..7,
+    ),
+    (
+        Int {
             value: 1,
         },
-        range: 11..12,
-    },
-    Token {
-        value: Comma,
-        range: 12..13,
-    },
-    Token {
-        value: Int {
+        11..12,
+    ),
+    (
+        Comma,
+        12..13,
+    ),
+    (
+        Int {
             value: 2,
         },
-        range: 13..14,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 14..15,
-    },
-    Token {
-        value: Comma,
-        range: 15..16,
-    },
-    Token {
-        value: Lpar,
-        range: 16..17,
-    },
-    Token {
-        value: Int {
+        13..14,
+    ),
+    (
+        NonLogicalNewline,
+        14..15,
+    ),
+    (
+        Comma,
+        15..16,
+    ),
+    (
+        Lpar,
+        16..17,
+    ),
+    (
+        Int {
             value: 3,
         },
-        range: 17..18,
-    },
-    Token {
-        value: Comma,
-        range: 18..19,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 19..20,
-    },
-    Token {
-        value: Int {
+        17..18,
+    ),
+    (
+        Comma,
+        18..19,
+    ),
+    (
+        NonLogicalNewline,
+        19..20,
+    ),
+    (
+        Int {
             value: 4,
         },
-        range: 20..21,
-    },
-    Token {
-        value: Comma,
-        range: 21..22,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 22..23,
-    },
-    Token {
-        value: Rpar,
-        range: 23..24,
-    },
-    Token {
-        value: Comma,
-        range: 24..25,
-    },
-    Token {
-        value: Lbrace,
-        range: 26..27,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 27..28,
-    },
-    Token {
-        value: Int {
+        20..21,
+    ),
+    (
+        Comma,
+        21..22,
+    ),
+    (
+        NonLogicalNewline,
+        22..23,
+    ),
+    (
+        Rpar,
+        23..24,
+    ),
+    (
+        Comma,
+        24..25,
+    ),
+    (
+        Lbrace,
+        26..27,
+    ),
+    (
+        NonLogicalNewline,
+        27..28,
+    ),
+    (
+        Int {
             value: 5,
         },
-        range: 28..29,
-    },
-    Token {
-        value: Comma,
-        range: 29..30,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 30..31,
-    },
-    Token {
-        value: Int {
+        28..29,
+    ),
+    (
+        Comma,
+        29..30,
+    ),
+    (
+        NonLogicalNewline,
+        30..31,
+    ),
+    (
+        Int {
             value: 6,
         },
-        range: 31..32,
-    },
-    Token {
-        value: Comma,
-        range: 32..33,
-    },
-    Token {
-        value: Int {
+        31..32,
+    ),
+    (
+        Comma,
+        32..33,
+    ),
+    (
+        Int {
             value: 7,
         },
-        range: 35..36,
-    },
-    Token {
-        value: Rbrace,
-        range: 36..37,
-    },
-    Token {
-        value: Rsqb,
-        range: 37..38,
-    },
-    Token {
-        value: Newline,
-        range: 38..39,
-    },
+        35..36,
+    ),
+    (
+        Rbrace,
+        36..37,
+    ),
+    (
+        Rsqb,
+        37..38,
+    ),
+    (
+        Newline,
+        38..39,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_mac_eol.snap
@@ -3,50 +3,140 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Name {
-        name: "x",
+    Token {
+        value: Name {
+            name: "x",
+        },
+        range: 0..1,
     },
-    Equal,
-    Lsqb,
-    NonLogicalNewline,
-    NonLogicalNewline,
-    Int {
-        value: 1,
+    Token {
+        value: Equal,
+        range: 2..3,
     },
-    Comma,
-    Int {
-        value: 2,
+    Token {
+        value: Lsqb,
+        range: 4..5,
     },
-    NonLogicalNewline,
-    Comma,
-    Lpar,
-    Int {
-        value: 3,
+    Token {
+        value: NonLogicalNewline,
+        range: 5..6,
     },
-    Comma,
-    NonLogicalNewline,
-    Int {
-        value: 4,
+    Token {
+        value: NonLogicalNewline,
+        range: 6..7,
     },
-    Comma,
-    NonLogicalNewline,
-    Rpar,
-    Comma,
-    Lbrace,
-    NonLogicalNewline,
-    Int {
-        value: 5,
+    Token {
+        value: Int {
+            value: 1,
+        },
+        range: 11..12,
     },
-    Comma,
-    NonLogicalNewline,
-    Int {
-        value: 6,
+    Token {
+        value: Comma,
+        range: 12..13,
     },
-    Comma,
-    Int {
-        value: 7,
+    Token {
+        value: Int {
+            value: 2,
+        },
+        range: 13..14,
     },
-    Rbrace,
-    Rsqb,
-    Newline,
+    Token {
+        value: NonLogicalNewline,
+        range: 14..15,
+    },
+    Token {
+        value: Comma,
+        range: 15..16,
+    },
+    Token {
+        value: Lpar,
+        range: 16..17,
+    },
+    Token {
+        value: Int {
+            value: 3,
+        },
+        range: 17..18,
+    },
+    Token {
+        value: Comma,
+        range: 18..19,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 19..20,
+    },
+    Token {
+        value: Int {
+            value: 4,
+        },
+        range: 20..21,
+    },
+    Token {
+        value: Comma,
+        range: 21..22,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 22..23,
+    },
+    Token {
+        value: Rpar,
+        range: 23..24,
+    },
+    Token {
+        value: Comma,
+        range: 24..25,
+    },
+    Token {
+        value: Lbrace,
+        range: 26..27,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 27..28,
+    },
+    Token {
+        value: Int {
+            value: 5,
+        },
+        range: 28..29,
+    },
+    Token {
+        value: Comma,
+        range: 29..30,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 30..31,
+    },
+    Token {
+        value: Int {
+            value: 6,
+        },
+        range: 31..32,
+    },
+    Token {
+        value: Comma,
+        range: 32..33,
+    },
+    Token {
+        value: Int {
+            value: 7,
+        },
+        range: 35..36,
+    },
+    Token {
+        value: Rbrace,
+        range: 36..37,
+    },
+    Token {
+        value: Rsqb,
+        range: 37..38,
+    },
+    Token {
+        value: Newline,
+        range: 38..39,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_unix_eol.snap
@@ -1,142 +1,142 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: newline_in_brackets_eol(UNIX_EOL)
 ---
 [
-    Token {
-        value: Name {
+    (
+        Name {
             name: "x",
         },
-        range: 0..1,
-    },
-    Token {
-        value: Equal,
-        range: 2..3,
-    },
-    Token {
-        value: Lsqb,
-        range: 4..5,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 5..6,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 6..7,
-    },
-    Token {
-        value: Int {
+        0..1,
+    ),
+    (
+        Equal,
+        2..3,
+    ),
+    (
+        Lsqb,
+        4..5,
+    ),
+    (
+        NonLogicalNewline,
+        5..6,
+    ),
+    (
+        NonLogicalNewline,
+        6..7,
+    ),
+    (
+        Int {
             value: 1,
         },
-        range: 11..12,
-    },
-    Token {
-        value: Comma,
-        range: 12..13,
-    },
-    Token {
-        value: Int {
+        11..12,
+    ),
+    (
+        Comma,
+        12..13,
+    ),
+    (
+        Int {
             value: 2,
         },
-        range: 13..14,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 14..15,
-    },
-    Token {
-        value: Comma,
-        range: 15..16,
-    },
-    Token {
-        value: Lpar,
-        range: 16..17,
-    },
-    Token {
-        value: Int {
+        13..14,
+    ),
+    (
+        NonLogicalNewline,
+        14..15,
+    ),
+    (
+        Comma,
+        15..16,
+    ),
+    (
+        Lpar,
+        16..17,
+    ),
+    (
+        Int {
             value: 3,
         },
-        range: 17..18,
-    },
-    Token {
-        value: Comma,
-        range: 18..19,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 19..20,
-    },
-    Token {
-        value: Int {
+        17..18,
+    ),
+    (
+        Comma,
+        18..19,
+    ),
+    (
+        NonLogicalNewline,
+        19..20,
+    ),
+    (
+        Int {
             value: 4,
         },
-        range: 20..21,
-    },
-    Token {
-        value: Comma,
-        range: 21..22,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 22..23,
-    },
-    Token {
-        value: Rpar,
-        range: 23..24,
-    },
-    Token {
-        value: Comma,
-        range: 24..25,
-    },
-    Token {
-        value: Lbrace,
-        range: 26..27,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 27..28,
-    },
-    Token {
-        value: Int {
+        20..21,
+    ),
+    (
+        Comma,
+        21..22,
+    ),
+    (
+        NonLogicalNewline,
+        22..23,
+    ),
+    (
+        Rpar,
+        23..24,
+    ),
+    (
+        Comma,
+        24..25,
+    ),
+    (
+        Lbrace,
+        26..27,
+    ),
+    (
+        NonLogicalNewline,
+        27..28,
+    ),
+    (
+        Int {
             value: 5,
         },
-        range: 28..29,
-    },
-    Token {
-        value: Comma,
-        range: 29..30,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 30..31,
-    },
-    Token {
-        value: Int {
+        28..29,
+    ),
+    (
+        Comma,
+        29..30,
+    ),
+    (
+        NonLogicalNewline,
+        30..31,
+    ),
+    (
+        Int {
             value: 6,
         },
-        range: 31..32,
-    },
-    Token {
-        value: Comma,
-        range: 32..33,
-    },
-    Token {
-        value: Int {
+        31..32,
+    ),
+    (
+        Comma,
+        32..33,
+    ),
+    (
+        Int {
             value: 7,
         },
-        range: 35..36,
-    },
-    Token {
-        value: Rbrace,
-        range: 36..37,
-    },
-    Token {
-        value: Rsqb,
-        range: 37..38,
-    },
-    Token {
-        value: Newline,
-        range: 38..39,
-    },
+        35..36,
+    ),
+    (
+        Rbrace,
+        36..37,
+    ),
+    (
+        Rsqb,
+        37..38,
+    ),
+    (
+        Newline,
+        38..39,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_unix_eol.snap
@@ -3,50 +3,140 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Name {
-        name: "x",
+    Token {
+        value: Name {
+            name: "x",
+        },
+        range: 0..1,
     },
-    Equal,
-    Lsqb,
-    NonLogicalNewline,
-    NonLogicalNewline,
-    Int {
-        value: 1,
+    Token {
+        value: Equal,
+        range: 2..3,
     },
-    Comma,
-    Int {
-        value: 2,
+    Token {
+        value: Lsqb,
+        range: 4..5,
     },
-    NonLogicalNewline,
-    Comma,
-    Lpar,
-    Int {
-        value: 3,
+    Token {
+        value: NonLogicalNewline,
+        range: 5..6,
     },
-    Comma,
-    NonLogicalNewline,
-    Int {
-        value: 4,
+    Token {
+        value: NonLogicalNewline,
+        range: 6..7,
     },
-    Comma,
-    NonLogicalNewline,
-    Rpar,
-    Comma,
-    Lbrace,
-    NonLogicalNewline,
-    Int {
-        value: 5,
+    Token {
+        value: Int {
+            value: 1,
+        },
+        range: 11..12,
     },
-    Comma,
-    NonLogicalNewline,
-    Int {
-        value: 6,
+    Token {
+        value: Comma,
+        range: 12..13,
     },
-    Comma,
-    Int {
-        value: 7,
+    Token {
+        value: Int {
+            value: 2,
+        },
+        range: 13..14,
     },
-    Rbrace,
-    Rsqb,
-    Newline,
+    Token {
+        value: NonLogicalNewline,
+        range: 14..15,
+    },
+    Token {
+        value: Comma,
+        range: 15..16,
+    },
+    Token {
+        value: Lpar,
+        range: 16..17,
+    },
+    Token {
+        value: Int {
+            value: 3,
+        },
+        range: 17..18,
+    },
+    Token {
+        value: Comma,
+        range: 18..19,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 19..20,
+    },
+    Token {
+        value: Int {
+            value: 4,
+        },
+        range: 20..21,
+    },
+    Token {
+        value: Comma,
+        range: 21..22,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 22..23,
+    },
+    Token {
+        value: Rpar,
+        range: 23..24,
+    },
+    Token {
+        value: Comma,
+        range: 24..25,
+    },
+    Token {
+        value: Lbrace,
+        range: 26..27,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 27..28,
+    },
+    Token {
+        value: Int {
+            value: 5,
+        },
+        range: 28..29,
+    },
+    Token {
+        value: Comma,
+        range: 29..30,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 30..31,
+    },
+    Token {
+        value: Int {
+            value: 6,
+        },
+        range: 31..32,
+    },
+    Token {
+        value: Comma,
+        range: 32..33,
+    },
+    Token {
+        value: Int {
+            value: 7,
+        },
+        range: 35..36,
+    },
+    Token {
+        value: Rbrace,
+        range: 36..37,
+    },
+    Token {
+        value: Rsqb,
+        range: 37..38,
+    },
+    Token {
+        value: Newline,
+        range: 38..39,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_windows_eol.snap
@@ -3,50 +3,140 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    Name {
-        name: "x",
+    Token {
+        value: Name {
+            name: "x",
+        },
+        range: 0..1,
     },
-    Equal,
-    Lsqb,
-    NonLogicalNewline,
-    NonLogicalNewline,
-    Int {
-        value: 1,
+    Token {
+        value: Equal,
+        range: 2..3,
     },
-    Comma,
-    Int {
-        value: 2,
+    Token {
+        value: Lsqb,
+        range: 4..5,
     },
-    NonLogicalNewline,
-    Comma,
-    Lpar,
-    Int {
-        value: 3,
+    Token {
+        value: NonLogicalNewline,
+        range: 5..7,
     },
-    Comma,
-    NonLogicalNewline,
-    Int {
-        value: 4,
+    Token {
+        value: NonLogicalNewline,
+        range: 7..9,
     },
-    Comma,
-    NonLogicalNewline,
-    Rpar,
-    Comma,
-    Lbrace,
-    NonLogicalNewline,
-    Int {
-        value: 5,
+    Token {
+        value: Int {
+            value: 1,
+        },
+        range: 13..14,
     },
-    Comma,
-    NonLogicalNewline,
-    Int {
-        value: 6,
+    Token {
+        value: Comma,
+        range: 14..15,
     },
-    Comma,
-    Int {
-        value: 7,
+    Token {
+        value: Int {
+            value: 2,
+        },
+        range: 15..16,
     },
-    Rbrace,
-    Rsqb,
-    Newline,
+    Token {
+        value: NonLogicalNewline,
+        range: 16..18,
+    },
+    Token {
+        value: Comma,
+        range: 18..19,
+    },
+    Token {
+        value: Lpar,
+        range: 19..20,
+    },
+    Token {
+        value: Int {
+            value: 3,
+        },
+        range: 20..21,
+    },
+    Token {
+        value: Comma,
+        range: 21..22,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 22..24,
+    },
+    Token {
+        value: Int {
+            value: 4,
+        },
+        range: 24..25,
+    },
+    Token {
+        value: Comma,
+        range: 25..26,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 26..28,
+    },
+    Token {
+        value: Rpar,
+        range: 28..29,
+    },
+    Token {
+        value: Comma,
+        range: 29..30,
+    },
+    Token {
+        value: Lbrace,
+        range: 31..32,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 32..34,
+    },
+    Token {
+        value: Int {
+            value: 5,
+        },
+        range: 34..35,
+    },
+    Token {
+        value: Comma,
+        range: 35..36,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 36..38,
+    },
+    Token {
+        value: Int {
+            value: 6,
+        },
+        range: 38..39,
+    },
+    Token {
+        value: Comma,
+        range: 39..40,
+    },
+    Token {
+        value: Int {
+            value: 7,
+        },
+        range: 43..44,
+    },
+    Token {
+        value: Rbrace,
+        range: 44..45,
+    },
+    Token {
+        value: Rsqb,
+        range: 45..46,
+    },
+    Token {
+        value: Newline,
+        range: 46..48,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__newline_in_brackets_windows_eol.snap
@@ -1,142 +1,142 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: newline_in_brackets_eol(WINDOWS_EOL)
 ---
 [
-    Token {
-        value: Name {
+    (
+        Name {
             name: "x",
         },
-        range: 0..1,
-    },
-    Token {
-        value: Equal,
-        range: 2..3,
-    },
-    Token {
-        value: Lsqb,
-        range: 4..5,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 5..7,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 7..9,
-    },
-    Token {
-        value: Int {
+        0..1,
+    ),
+    (
+        Equal,
+        2..3,
+    ),
+    (
+        Lsqb,
+        4..5,
+    ),
+    (
+        NonLogicalNewline,
+        5..7,
+    ),
+    (
+        NonLogicalNewline,
+        7..9,
+    ),
+    (
+        Int {
             value: 1,
         },
-        range: 13..14,
-    },
-    Token {
-        value: Comma,
-        range: 14..15,
-    },
-    Token {
-        value: Int {
+        13..14,
+    ),
+    (
+        Comma,
+        14..15,
+    ),
+    (
+        Int {
             value: 2,
         },
-        range: 15..16,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 16..18,
-    },
-    Token {
-        value: Comma,
-        range: 18..19,
-    },
-    Token {
-        value: Lpar,
-        range: 19..20,
-    },
-    Token {
-        value: Int {
+        15..16,
+    ),
+    (
+        NonLogicalNewline,
+        16..18,
+    ),
+    (
+        Comma,
+        18..19,
+    ),
+    (
+        Lpar,
+        19..20,
+    ),
+    (
+        Int {
             value: 3,
         },
-        range: 20..21,
-    },
-    Token {
-        value: Comma,
-        range: 21..22,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 22..24,
-    },
-    Token {
-        value: Int {
+        20..21,
+    ),
+    (
+        Comma,
+        21..22,
+    ),
+    (
+        NonLogicalNewline,
+        22..24,
+    ),
+    (
+        Int {
             value: 4,
         },
-        range: 24..25,
-    },
-    Token {
-        value: Comma,
-        range: 25..26,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 26..28,
-    },
-    Token {
-        value: Rpar,
-        range: 28..29,
-    },
-    Token {
-        value: Comma,
-        range: 29..30,
-    },
-    Token {
-        value: Lbrace,
-        range: 31..32,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 32..34,
-    },
-    Token {
-        value: Int {
+        24..25,
+    ),
+    (
+        Comma,
+        25..26,
+    ),
+    (
+        NonLogicalNewline,
+        26..28,
+    ),
+    (
+        Rpar,
+        28..29,
+    ),
+    (
+        Comma,
+        29..30,
+    ),
+    (
+        Lbrace,
+        31..32,
+    ),
+    (
+        NonLogicalNewline,
+        32..34,
+    ),
+    (
+        Int {
             value: 5,
         },
-        range: 34..35,
-    },
-    Token {
-        value: Comma,
-        range: 35..36,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 36..38,
-    },
-    Token {
-        value: Int {
+        34..35,
+    ),
+    (
+        Comma,
+        35..36,
+    ),
+    (
+        NonLogicalNewline,
+        36..38,
+    ),
+    (
+        Int {
             value: 6,
         },
-        range: 38..39,
-    },
-    Token {
-        value: Comma,
-        range: 39..40,
-    },
-    Token {
-        value: Int {
+        38..39,
+    ),
+    (
+        Comma,
+        39..40,
+    ),
+    (
+        Int {
             value: 7,
         },
-        range: 43..44,
-    },
-    Token {
-        value: Rbrace,
-        range: 44..45,
-    },
-    Token {
-        value: Rsqb,
-        range: 45..46,
-    },
-    Token {
-        value: Newline,
-        range: 46..48,
-    },
+        43..44,
+    ),
+    (
+        Rbrace,
+        44..45,
+    ),
+    (
+        Rsqb,
+        45..46,
+    ),
+    (
+        Newline,
+        46..48,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__non_logical_newline_in_string_continuation.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__non_logical_newline_in_string_continuation.snap
@@ -3,68 +3,68 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(source)
 ---
 [
-    Token {
-        value: Lpar,
-        range: 0..1,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 1..2,
-    },
-    Token {
-        value: String {
+    (
+        Lpar,
+        0..1,
+    ),
+    (
+        NonLogicalNewline,
+        1..2,
+    ),
+    (
+        String {
             value: "a",
             kind: String,
             triple_quoted: false,
         },
-        range: 6..9,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 9..10,
-    },
-    Token {
-        value: String {
+        6..9,
+    ),
+    (
+        NonLogicalNewline,
+        9..10,
+    ),
+    (
+        String {
             value: "b",
             kind: String,
             triple_quoted: false,
         },
-        range: 14..17,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 17..18,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 18..19,
-    },
-    Token {
-        value: String {
+        14..17,
+    ),
+    (
+        NonLogicalNewline,
+        17..18,
+    ),
+    (
+        NonLogicalNewline,
+        18..19,
+    ),
+    (
+        String {
             value: "c",
             kind: String,
             triple_quoted: false,
         },
-        range: 23..26,
-    },
-    Token {
-        value: String {
+        23..26,
+    ),
+    (
+        String {
             value: "d",
             kind: String,
             triple_quoted: false,
         },
-        range: 33..36,
-    },
-    Token {
-        value: NonLogicalNewline,
-        range: 36..37,
-    },
-    Token {
-        value: Rpar,
-        range: 37..38,
-    },
-    Token {
-        value: Newline,
-        range: 38..38,
-    },
+        33..36,
+    ),
+    (
+        NonLogicalNewline,
+        36..37,
+    ),
+    (
+        Rpar,
+        37..38,
+    ),
+    (
+        Newline,
+        38..38,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__non_logical_newline_in_string_continuation.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__non_logical_newline_in_string_continuation.snap
@@ -3,32 +3,68 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(source)
 ---
 [
-    Lpar,
-    NonLogicalNewline,
-    String {
-        value: "a",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: Lpar,
+        range: 0..1,
     },
-    NonLogicalNewline,
-    String {
-        value: "b",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: NonLogicalNewline,
+        range: 1..2,
     },
-    NonLogicalNewline,
-    NonLogicalNewline,
-    String {
-        value: "c",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: String {
+            value: "a",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 6..9,
     },
-    String {
-        value: "d",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: NonLogicalNewline,
+        range: 9..10,
     },
-    NonLogicalNewline,
-    Rpar,
-    Newline,
+    Token {
+        value: String {
+            value: "b",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 14..17,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 17..18,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 18..19,
+    },
+    Token {
+        value: String {
+            value: "c",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 23..26,
+    },
+    Token {
+        value: String {
+            value: "d",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 33..36,
+    },
+    Token {
+        value: NonLogicalNewline,
+        range: 36..37,
+    },
+    Token {
+        value: Rpar,
+        range: 37..38,
+    },
+    Token {
+        value: Newline,
+        range: 38..38,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__numbers.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__numbers.snap
@@ -3,76 +3,76 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(source)
 ---
 [
-    Token {
-        value: Int {
+    (
+        Int {
             value: 47,
         },
-        range: 0..4,
-    },
-    Token {
-        value: Int {
+        0..4,
+    ),
+    (
+        Int {
             value: 10,
         },
-        range: 5..9,
-    },
-    Token {
-        value: Int {
+        5..9,
+    ),
+    (
+        Int {
             value: 13,
         },
-        range: 10..16,
-    },
-    Token {
-        value: Int {
+        10..16,
+    ),
+    (
+        Int {
             value: 0,
         },
-        range: 17..18,
-    },
-    Token {
-        value: Int {
+        17..18,
+    ),
+    (
+        Int {
             value: 123,
         },
-        range: 19..22,
-    },
-    Token {
-        value: Int {
+        19..22,
+    ),
+    (
+        Int {
             value: 1234567890,
         },
-        range: 23..36,
-    },
-    Token {
-        value: Float {
+        23..36,
+    ),
+    (
+        Float {
             value: 0.2,
         },
-        range: 37..40,
-    },
-    Token {
-        value: Float {
+        37..40,
+    ),
+    (
+        Float {
             value: 100.0,
         },
-        range: 41..45,
-    },
-    Token {
-        value: Float {
+        41..45,
+    ),
+    (
+        Float {
             value: 2100.0,
         },
-        range: 46..51,
-    },
-    Token {
-        value: Complex {
+        46..51,
+    ),
+    (
+        Complex {
             real: 0.0,
             imag: 2.0,
         },
-        range: 52..54,
-    },
-    Token {
-        value: Complex {
+        52..54,
+    ),
+    (
+        Complex {
             real: 0.0,
             imag: 2.2,
         },
-        range: 55..59,
-    },
-    Token {
-        value: Newline,
-        range: 59..59,
-    },
+        55..59,
+    ),
+    (
+        Newline,
+        59..59,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__numbers.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__numbers.snap
@@ -3,40 +3,76 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(source)
 ---
 [
-    Int {
-        value: 47,
+    Token {
+        value: Int {
+            value: 47,
+        },
+        range: 0..4,
     },
-    Int {
-        value: 10,
+    Token {
+        value: Int {
+            value: 10,
+        },
+        range: 5..9,
     },
-    Int {
-        value: 13,
+    Token {
+        value: Int {
+            value: 13,
+        },
+        range: 10..16,
     },
-    Int {
-        value: 0,
+    Token {
+        value: Int {
+            value: 0,
+        },
+        range: 17..18,
     },
-    Int {
-        value: 123,
+    Token {
+        value: Int {
+            value: 123,
+        },
+        range: 19..22,
     },
-    Int {
-        value: 1234567890,
+    Token {
+        value: Int {
+            value: 1234567890,
+        },
+        range: 23..36,
     },
-    Float {
-        value: 0.2,
+    Token {
+        value: Float {
+            value: 0.2,
+        },
+        range: 37..40,
     },
-    Float {
-        value: 100.0,
+    Token {
+        value: Float {
+            value: 100.0,
+        },
+        range: 41..45,
     },
-    Float {
-        value: 2100.0,
+    Token {
+        value: Float {
+            value: 2100.0,
+        },
+        range: 46..51,
     },
-    Complex {
-        real: 0.0,
-        imag: 2.0,
+    Token {
+        value: Complex {
+            real: 0.0,
+            imag: 2.0,
+        },
+        range: 52..54,
     },
-    Complex {
-        real: 0.0,
-        imag: 2.2,
+    Token {
+        value: Complex {
+            real: 0.0,
+            imag: 2.2,
+        },
+        range: 55..59,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 59..59,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__operators.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__operators.snap
@@ -3,10 +3,28 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(source)
 ---
 [
-    DoubleSlash,
-    DoubleSlash,
-    DoubleSlashEqual,
-    Slash,
-    Slash,
-    Newline,
+    Token {
+        value: DoubleSlash,
+        range: 0..2,
+    },
+    Token {
+        value: DoubleSlash,
+        range: 2..4,
+    },
+    Token {
+        value: DoubleSlashEqual,
+        range: 4..7,
+    },
+    Token {
+        value: Slash,
+        range: 7..8,
+    },
+    Token {
+        value: Slash,
+        range: 9..10,
+    },
+    Token {
+        value: Newline,
+        range: 10..10,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__operators.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__operators.snap
@@ -3,28 +3,28 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(source)
 ---
 [
-    Token {
-        value: DoubleSlash,
-        range: 0..2,
-    },
-    Token {
-        value: DoubleSlash,
-        range: 2..4,
-    },
-    Token {
-        value: DoubleSlashEqual,
-        range: 4..7,
-    },
-    Token {
-        value: Slash,
-        range: 7..8,
-    },
-    Token {
-        value: Slash,
-        range: 9..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..10,
-    },
+    (
+        DoubleSlash,
+        0..2,
+    ),
+    (
+        DoubleSlash,
+        2..4,
+    ),
+    (
+        DoubleSlashEqual,
+        4..7,
+    ),
+    (
+        Slash,
+        7..8,
+    ),
+    (
+        Slash,
+        9..10,
+    ),
+    (
+        Newline,
+        10..10,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string.snap
@@ -3,50 +3,80 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(source)
 ---
 [
-    String {
-        value: "double",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: String {
+            value: "double",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 0..8,
     },
-    String {
-        value: "single",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: String {
+            value: "single",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 9..17,
     },
-    String {
-        value: "can\\'t",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: String {
+            value: "can\\'t",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 18..26,
     },
-    String {
-        value: "\\\\\\\"",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: String {
+            value: "\\\\\\\"",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 27..33,
     },
-    String {
-        value: "\\t\\r\\n",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: String {
+            value: "\\t\\r\\n",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 34..42,
     },
-    String {
-        value: "\\g",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: String {
+            value: "\\g",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 43..47,
     },
-    String {
-        value: "raw\\'",
-        kind: RawString,
-        triple_quoted: false,
+    Token {
+        value: String {
+            value: "raw\\'",
+            kind: RawString,
+            triple_quoted: false,
+        },
+        range: 48..56,
     },
-    String {
-        value: "\\420",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: String {
+            value: "\\420",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 57..63,
     },
-    String {
-        value: "\\200\\0a",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: String {
+            value: "\\200\\0a",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 64..73,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 73..73,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string.snap
@@ -3,80 +3,80 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(source)
 ---
 [
-    Token {
-        value: String {
+    (
+        String {
             value: "double",
             kind: String,
             triple_quoted: false,
         },
-        range: 0..8,
-    },
-    Token {
-        value: String {
+        0..8,
+    ),
+    (
+        String {
             value: "single",
             kind: String,
             triple_quoted: false,
         },
-        range: 9..17,
-    },
-    Token {
-        value: String {
+        9..17,
+    ),
+    (
+        String {
             value: "can\\'t",
             kind: String,
             triple_quoted: false,
         },
-        range: 18..26,
-    },
-    Token {
-        value: String {
+        18..26,
+    ),
+    (
+        String {
             value: "\\\\\\\"",
             kind: String,
             triple_quoted: false,
         },
-        range: 27..33,
-    },
-    Token {
-        value: String {
+        27..33,
+    ),
+    (
+        String {
             value: "\\t\\r\\n",
             kind: String,
             triple_quoted: false,
         },
-        range: 34..42,
-    },
-    Token {
-        value: String {
+        34..42,
+    ),
+    (
+        String {
             value: "\\g",
             kind: String,
             triple_quoted: false,
         },
-        range: 43..47,
-    },
-    Token {
-        value: String {
+        43..47,
+    ),
+    (
+        String {
             value: "raw\\'",
             kind: RawString,
             triple_quoted: false,
         },
-        range: 48..56,
-    },
-    Token {
-        value: String {
+        48..56,
+    ),
+    (
+        String {
             value: "\\420",
             kind: String,
             triple_quoted: false,
         },
-        range: 57..63,
-    },
-    Token {
-        value: String {
+        57..63,
+    ),
+    (
+        String {
             value: "\\200\\0a",
             kind: String,
             triple_quoted: false,
         },
-        range: 64..73,
-    },
-    Token {
-        value: Newline,
-        range: 73..73,
-    },
+        64..73,
+    ),
+    (
+        Newline,
+        73..73,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_mac_eol.snap
@@ -3,10 +3,16 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    String {
-        value: "abc\\\rdef",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: String {
+            value: "abc\\\rdef",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 0..10,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 10..10,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_mac_eol.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: string_continuation_with_eol(MAC_EOL)
 ---
 [
-    Token {
-        value: String {
+    (
+        String {
             value: "abc\\\rdef",
             kind: String,
             triple_quoted: false,
         },
-        range: 0..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..10,
-    },
+        0..10,
+    ),
+    (
+        Newline,
+        10..10,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_unix_eol.snap
@@ -3,10 +3,16 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    String {
-        value: "abc\\\ndef",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: String {
+            value: "abc\\\ndef",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 0..10,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 10..10,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_unix_eol.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: string_continuation_with_eol(UNIX_EOL)
 ---
 [
-    Token {
-        value: String {
+    (
+        String {
             value: "abc\\\ndef",
             kind: String,
             triple_quoted: false,
         },
-        range: 0..10,
-    },
-    Token {
-        value: Newline,
-        range: 10..10,
-    },
+        0..10,
+    ),
+    (
+        Newline,
+        10..10,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_windows_eol.snap
@@ -3,10 +3,16 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    String {
-        value: "abc\\\r\ndef",
-        kind: String,
-        triple_quoted: false,
+    Token {
+        value: String {
+            value: "abc\\\r\ndef",
+            kind: String,
+            triple_quoted: false,
+        },
+        range: 0..11,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 11..11,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__string_continuation_with_windows_eol.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: string_continuation_with_eol(WINDOWS_EOL)
 ---
 [
-    Token {
-        value: String {
+    (
+        String {
             value: "abc\\\r\ndef",
             kind: String,
             triple_quoted: false,
         },
-        range: 0..11,
-    },
-    Token {
-        value: Newline,
-        range: 11..11,
-    },
+        0..11,
+    ),
+    (
+        Newline,
+        11..11,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_mac_eol.snap
@@ -3,10 +3,16 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    String {
-        value: "\r test string\r ",
-        kind: String,
-        triple_quoted: true,
+    Token {
+        value: String {
+            value: "\r test string\r ",
+            kind: String,
+            triple_quoted: true,
+        },
+        range: 0..21,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 21..21,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_mac_eol.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: triple_quoted_eol(MAC_EOL)
 ---
 [
-    Token {
-        value: String {
+    (
+        String {
             value: "\r test string\r ",
             kind: String,
             triple_quoted: true,
         },
-        range: 0..21,
-    },
-    Token {
-        value: Newline,
-        range: 21..21,
-    },
+        0..21,
+    ),
+    (
+        Newline,
+        21..21,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_unix_eol.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: triple_quoted_eol(UNIX_EOL)
 ---
 [
-    Token {
-        value: String {
+    (
+        String {
             value: "\n test string\n ",
             kind: String,
             triple_quoted: true,
         },
-        range: 0..21,
-    },
-    Token {
-        value: Newline,
-        range: 21..21,
-    },
+        0..21,
+    ),
+    (
+        Newline,
+        21..21,
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_unix_eol.snap
@@ -3,10 +3,16 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    String {
-        value: "\n test string\n ",
-        kind: String,
-        triple_quoted: true,
+    Token {
+        value: String {
+            value: "\n test string\n ",
+            kind: String,
+            triple_quoted: true,
+        },
+        range: 0..21,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 21..21,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_windows_eol.snap
@@ -3,10 +3,16 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: lex_source(&source)
 ---
 [
-    String {
-        value: "\r\n test string\r\n ",
-        kind: String,
-        triple_quoted: true,
+    Token {
+        value: String {
+            value: "\r\n test string\r\n ",
+            kind: String,
+            triple_quoted: true,
+        },
+        range: 0..23,
     },
-    Newline,
+    Token {
+        value: Newline,
+        range: 23..23,
+    },
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__triple_quoted_windows_eol.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/ruff_python_parser/src/lexer.rs
-expression: lex_source(&source)
+expression: triple_quoted_eol(WINDOWS_EOL)
 ---
 [
-    Token {
-        value: String {
+    (
+        String {
             value: "\r\n test string\r\n ",
             kind: String,
             triple_quoted: true,
         },
-        range: 0..23,
-    },
-    Token {
-        value: Newline,
-        range: 23..23,
-    },
+        0..23,
+    ),
+    (
+        Newline,
+        23..23,
+    ),
 ]


### PR DESCRIPTION
## Summary

This PR updates the lexer test snapshots to include the range value as well.
This is mainly a mechanical refactor.

### Motivation

The main motivation is so that we can verify that the ranges are valid and do
not overlap.

## Test Plan

`cargo test`
