### PR TITLE
Display the `--preview` option in the CLI help menu

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -116,7 +116,7 @@ pub struct CheckCommand {
     #[arg(long, value_enum)]
     pub target_version: Option<PythonVersion>,
     /// Enable preview mode; checks will include unstable rules and fixes.
-    #[arg(long, overrides_with("no_preview"), hide = true)]
+    #[arg(long, overrides_with("no_preview"))]
     preview: bool,
     #[clap(long, overrides_with("preview"), hide = true)]
     no_preview: bool,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -212,6 +212,8 @@ Options:
           Specify file to write the linter output to (default: stdout)
       --target-version <TARGET_VERSION>
           The minimum Python version that should be supported [possible values: py37, py38, py39, py310, py311, py312]
+      --preview
+          Enable preview mode; checks will include unstable rules and fixes
       --config <CONFIG>
           Path to the `pyproject.toml` or `ruff.toml` file to use for configuration
       --statistics


### PR DESCRIPTION
If we're going to warn on use of NURSERY in #7210 we probably ought to show the `--preview` option in our help menus.