### PR TITLE
Update release workflow to checkout the given sha

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -372,10 +372,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ebe9c03545a4496811efeee7a530a5632e48e7d2
+          ref: 57065ecff4937cd9be885fada6747eed79e769d8
       - name: Check main branch
         run: |
-          if git branch --contains ebe9c03545a4496811efeee7a530a5632e48e7d2 | grep -E '(^|\s)main$'; then
+          if git branch --contains 57065ecff4937cd9be885fada6747eed79e769d8 | grep -E '(^|\s)main$'; then
             echo "The specified sha is not on the main branch" >&2
             exit 1
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -374,7 +374,6 @@ jobs:
         with:
           ref: ebe9c03545a4496811efeee7a530a5632e48e7d2
       - name: Check main branch
-        if: ${{ inputs.sha }}
         run: |
           if git branch --contains ebe9c03545a4496811efeee7a530a5632e48e7d2 | grep -E '(^|\s)main$'; then
             echo "The specified sha is not on the main branch" >&2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -366,3 +366,17 @@ jobs:
         with:
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
+
+  validate-sha-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ebe9c03545a4496811efeee7a530a5632e48e7d2
+      - name: Check main branch
+        if: ${{ inputs.sha }}
+        run: |
+          if git branch --contains ebe9c03545a4496811efeee7a530a5632e48e7d2 | grep -E '(^|\s)main$'; then
+            echo "The specified sha is not on the main branch" >&2
+            exit 1
+          fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -366,16 +366,3 @@ jobs:
         with:
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
-
-  validate-sha-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: 57065ecff4937cd9be885fada6747eed79e769d8
-      - name: Check main branch
-        run: |
-          if git branch --contains 57065ecff4937cd9be885fada6747eed79e769d8 | grep -E '(^|\s)main$'; then
-            echo "The specified sha is not on the main branch" >&2
-            exit 1
-          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -434,7 +434,9 @@ jobs:
       - name: Check main branch
         if: ${{ inputs.sha }}
         run: |
-          if git branch --contains ${{ inputs.sha }} | grep -E '(^|\s)main$'; then
+          # Fetch the main branch since a shallow checkout is used by default
+          git fetch origin main --unshallow
+          if ! git branch --contains ${{ inputs.sha }} | grep -E '(^|\s)main$'; then
             echo "The specified sha is not on the main branch" >&2
             exit 1
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,8 @@ on:
         description: "The version to tag, without the leading 'v'. If omitted, will initiate a dry run (no uploads)."
         type: string
       sha:
-        description: "Optionally, the full sha of the commit to be released"
+        description: "The full sha of the commit to be released. If ommitted, the latest commit on the default branch will be used."
+        default: ""
         type: string
   pull_request:
     paths:
@@ -31,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -57,6 +60,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -95,6 +100,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -141,6 +148,8 @@ jobs:
             arch: x64
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -187,6 +196,8 @@ jobs:
           - i686-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -244,6 +255,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -297,6 +310,8 @@ jobs:
           - i686-unknown-linux-musl
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -351,6 +366,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -399,6 +416,8 @@ jobs:
     if: ${{ inputs.tag }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
       - name: Check tag consistency
         run: |
           version=$(grep "version = " pyproject.toml | sed -e 's/version = "\(.*\)"/\1/g')
@@ -465,6 +484,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
       - name: git tag
         run: |
           git config user.email "hey@astral.sh"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -431,6 +431,13 @@ jobs:
           else
             echo "Releasing ${version}"
           fi
+      - name: Check main branch
+        if: ${{ inputs.sha }}
+        run: |
+          if git branch --contains ${{ inputs.sha }} | grep -E '(^|\s)main$'; then
+            echo "The specified sha is not on the main branch" >&2
+            exit 1
+          fi
       - name: Check SHA consistency
         if: ${{ inputs.sha }}
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,8 @@ on:
     paths:
       # When we change pyproject.toml, we want to ensure that the maturin builds still work
       - pyproject.toml
+      # And when we change this workflow itself...
+      - .github/workflows/release.yaml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
         description: "The version to tag, without the leading 'v'. If omitted, will initiate a dry run (no uploads)."
         type: string
       sha:
-        description: "The full sha of the commit to be released. If ommitted, the latest commit on the default branch will be used."
+        description: "The full sha of the commit to be released. If omitted, the latest commit on the default branch will be used."
         default: ""
         type: string
   pull_request:


### PR DESCRIPTION
As far as I can tell, the release workflow would just run on the latest commit from `main` then crash and burn if that did not match the given SHA? It seems much clearer to actually checkout the given SHA so we can publish a release after making additional commits to `main`.