### PR TITLE
Fix panic when formatting binary expression with two implicit concatenated string operands

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary_implicit_string.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary_implicit_string.py
@@ -169,3 +169,23 @@ c = (a
      # test trailing operator comment
      b
      )
+
+c = ("a" "b" +
+     # test leading binary comment
+     "a" "b"
+ )
+
+(
+    b + c + d +
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+    "cccccccccccccccccccccccccc"
+    "dddddddddddddddddddddddddd"
+    % aaaaaaaaaaaa
+    + x
+)
+
+"a" "b" "c" + "d" "e" + "f" "g" + "h" "i" "j"
+class EC2REPATH:
+    f.write ("Pathway name" + "\t" "Database Identifier" + "\t" "Source database" + "\n")
+

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__binary_implicit_string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__binary_implicit_string.py.snap
@@ -175,6 +175,26 @@ c = (a
      # test trailing operator comment
      b
      )
+
+c = ("a" "b" +
+     # test leading binary comment
+     "a" "b"
+ )
+
+(
+    b + c + d +
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+    "cccccccccccccccccccccccccc"
+    "dddddddddddddddddddddddddd"
+    % aaaaaaaaaaaa
+    + x
+)
+
+"a" "b" "c" + "d" "e" + "f" "g" + "h" "i" "j"
+class EC2REPATH:
+    f.write ("Pathway name" + "\t" "Database Identifier" + "\t" "Source database" + "\n")
+
 ```
 
 ## Output
@@ -363,6 +383,26 @@ c = (
     # test trailing operator comment
     b
 )
+
+c = (
+    "a"
+    "b" +
+    # test leading binary comment
+    "a"
+    "b"
+)
+
+(
+    b + c + d + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" + "cccccccccccccccccccccccccc"
+    "dddddddddddddddddddddddddd" % aaaaaaaaaaaa + x
+)
+
+"a" "b" "c" + "d" "e" + "f" "g" + "h" "i" "j"
+
+
+class EC2REPATH:
+    f.write("Pathway name" + "\t" "Database Identifier" + "\t" "Source database" + "\n")
 ```
 
 


### PR DESCRIPTION

## Summary

This PR fixes a panic when formatting a binary like expression where both operands are implicit concatenated strings: `"a" "b" + "c" "d"`

The implementation formats the implicit concatenated string together with the right operator and than continues with the expressions to the right. 
The next iteration then tried to format the expressions between the last formatted right operator (`+`) and the next string concatenation, assuming that it would never be empty. 
This assumption was incorrect as the above example demonstrates. There's no other binary like expression between the `+` and `"c" "d"`. 

This PR fixes this by skipping the formatting of the left side if the last operator is the same as the left operator of this implicit concatenated string. 

Closes #7245


## Test Plan

Added tests

