### PR TITLE
Introduce `ArgOrKeyword` to keep call parameter order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,6 +2303,7 @@ dependencies = [
  "bitflags 2.4.0",
  "insta",
  "is-macro",
+ "itertools",
  "memchr",
  "num-bigint",
  "num-traits",

--- a/crates/ruff/src/autofix/edits.rs
+++ b/crates/ruff/src/autofix/edits.rs
@@ -92,7 +92,7 @@ pub(crate) fn remove_argument<T: Ranged>(
 ) -> Result<Edit> {
     // Partition into arguments before and after the argument to remove.
     let (before, after): (Vec<_>, Vec<_>) = arguments
-        .arguments_as_declared()
+        .arguments_source_order()
         .map(|arg| arg.range())
         .filter(|range| argument.range() != *range)
         .partition(|range| range.start() < argument.start());

--- a/crates/ruff/src/autofix/edits.rs
+++ b/crates/ruff/src/autofix/edits.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result};
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::{self as ast, Arguments, ExceptHandler, Expr, Keyword, Stmt};
+use ruff_python_ast::{self as ast, Arguments, ExceptHandler, Stmt};
 use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;
 use ruff_python_trivia::{
@@ -92,10 +92,8 @@ pub(crate) fn remove_argument<T: Ranged>(
 ) -> Result<Edit> {
     // Partition into arguments before and after the argument to remove.
     let (before, after): (Vec<_>, Vec<_>) = arguments
-        .args
-        .iter()
-        .map(Expr::range)
-        .chain(arguments.keywords.iter().map(Keyword::range))
+        .arguments_as_declared()
+        .map(|arg| arg.range())
         .filter(|range| argument.range() != *range)
         .partition(|range| range.start() < argument.start());
 

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -19,6 +19,7 @@ ruff_text_size = { path = "../ruff_text_size" }
 
 bitflags = { workspace = true }
 is-macro = { workspace = true }
+itertools = { workspace = true }
 memchr = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -9,8 +9,7 @@ use ruff_text_size::{Ranged, TextRange};
 use crate::call_path::CallPath;
 use crate::statement_visitor::{walk_body, walk_stmt, StatementVisitor};
 use crate::{
-    self as ast, ArgOrKeyword, Arguments, Constant, ExceptHandler, Expr, MatchCase, Pattern, Stmt,
-    TypeParam,
+    self as ast, Arguments, Constant, ExceptHandler, Expr, MatchCase, Pattern, Stmt, TypeParam,
 };
 
 /// Return `true` if the `Stmt` is a compound statement (as opposed to a simple statement).
@@ -204,16 +203,16 @@ pub fn any_over_expr(expr: &Expr, func: &dyn Fn(&Expr) -> bool) -> bool {
         }) => any_over_expr(left, func) || comparators.iter().any(|expr| any_over_expr(expr, func)),
         Expr::Call(ast::ExprCall {
             func: call_func,
-            arguments,
+            arguments: Arguments { args, keywords, .. },
             range: _,
         }) => {
             any_over_expr(call_func, func)
-                || arguments
-                    .arguments_as_declared()
-                    .any(|arg_or_keyword| match arg_or_keyword {
-                        ArgOrKeyword::Arg(arg) => any_over_expr(arg, func),
-                        ArgOrKeyword::Keyword(keyword) => any_over_expr(&keyword.value, func),
-                    })
+                // Note that this is the evaluation order but not necessarily the declaration order
+                // (e.g. for `f(*args, a=2, *args2, **kwargs)` it's not)
+                || args.iter().any(|expr| any_over_expr(expr, func))
+                || keywords
+                    .iter()
+                    .any(|keyword| any_over_expr(&keyword.value, func))
         }
         Expr::FormattedValue(ast::ExprFormattedValue {
             value, format_spec, ..
@@ -352,18 +351,20 @@ pub fn any_over_stmt(stmt: &Stmt, func: &dyn Fn(&Expr) -> bool) -> bool {
         }) => {
             // Note that e.g. `class A(*args, a=2, *args2, **kwargs): pass` is a valid class
             // definition
-            arguments.as_deref().is_some_and(|arguments| {
-                arguments
-                    .arguments_as_declared()
-                    .any(|arg_or_keyword| match arg_or_keyword {
-                        ArgOrKeyword::Arg(arg) => any_over_expr(arg, func),
-                        ArgOrKeyword::Keyword(keyword) => any_over_expr(&keyword.value, func),
-                    })
-            }) || type_params.as_ref().is_some_and(|type_params| {
-                type_params
-                    .iter()
-                    .any(|type_param| any_over_type_param(type_param, func))
-            }) || body.iter().any(|stmt| any_over_stmt(stmt, func))
+            arguments
+                .as_deref()
+                .is_some_and(|Arguments { args, keywords, .. }| {
+                    args.iter().any(|expr| any_over_expr(expr, func))
+                        || keywords
+                            .iter()
+                            .any(|keyword| any_over_expr(&keyword.value, func))
+                })
+                || type_params.as_ref().is_some_and(|type_params| {
+                    type_params
+                        .iter()
+                        .any(|type_param| any_over_type_param(type_param, func))
+                })
+                || body.iter().any(|stmt| any_over_stmt(stmt, func))
                 || decorator_list
                     .iter()
                     .any(|decorator| any_over_expr(&decorator.expression, func))

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -3549,7 +3549,7 @@ impl AstNode for Arguments {
     where
         V: PreorderVisitor<'a> + ?Sized,
     {
-        for arg_or_keyword in self.arguments_as_declared() {
+        for arg_or_keyword in self.arguments_source_order() {
             match arg_or_keyword {
                 ArgOrKeyword::Arg(arg) => visitor.visit_expr(arg),
                 ArgOrKeyword::Keyword(keyword) => visitor.visit_keyword(keyword),

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -1,9 +1,9 @@
 use crate::visitor::preorder::PreorderVisitor;
 use crate::{
-    self as ast, Alias, Arguments, Comprehension, Decorator, ExceptHandler, Expr, Keyword,
-    MatchCase, Mod, Parameter, ParameterWithDefault, Parameters, Pattern, PatternArguments,
-    PatternKeyword, Stmt, TypeParam, TypeParamParamSpec, TypeParamTypeVar, TypeParamTypeVarTuple,
-    TypeParams, WithItem,
+    self as ast, Alias, ArgOrKeyword, Arguments, Comprehension, Decorator, ExceptHandler, Expr,
+    Keyword, MatchCase, Mod, Parameter, ParameterWithDefault, Parameters, Pattern,
+    PatternArguments, PatternKeyword, Stmt, TypeParam, TypeParamParamSpec, TypeParamTypeVar,
+    TypeParamTypeVarTuple, TypeParams, WithItem,
 };
 use ruff_text_size::{Ranged, TextRange};
 use std::ptr::NonNull;
@@ -3549,18 +3549,11 @@ impl AstNode for Arguments {
     where
         V: PreorderVisitor<'a> + ?Sized,
     {
-        let ast::Arguments {
-            range: _,
-            args,
-            keywords,
-        } = self;
-
-        for arg in args {
-            visitor.visit_expr(arg);
-        }
-
-        for keyword in keywords {
-            visitor.visit_keyword(keyword);
+        for arg_or_keyword in self.arguments_as_declared() {
+            match arg_or_keyword {
+                ArgOrKeyword::Arg(arg) => visitor.visit_expr(arg),
+                ArgOrKeyword::Keyword(keyword) => visitor.visit_keyword(keyword),
+            }
         }
     }
 }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2276,7 +2276,7 @@ impl Arguments {
     /// 2
     /// {'4': 5}
     /// ```
-    pub fn arguments_as_declared(&self) -> impl Iterator<Item = ArgOrKeyword<'_>> {
+    pub fn arguments_source_order(&self) -> impl Iterator<Item = ArgOrKeyword<'_>> {
         let args = self.args.iter().map(ArgOrKeyword::Arg);
         let keywords = self.keywords.iter().map(ArgOrKeyword::Keyword);
         args.merge_by(keywords, |left, right| left.start() < right.start())

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+use itertools::Itertools;
 use std::fmt;
 use std::fmt::Debug;
 use std::ops::Deref;
@@ -2177,6 +2178,34 @@ pub struct Arguments {
     pub keywords: Vec<Keyword>,
 }
 
+/// An entry in the argument list of a function call.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ArgOrKeyword<'a> {
+    Arg(&'a Expr),
+    Keyword(&'a Keyword),
+}
+
+impl<'a> From<&'a Expr> for ArgOrKeyword<'a> {
+    fn from(arg: &'a Expr) -> Self {
+        Self::Arg(arg)
+    }
+}
+
+impl<'a> From<&'a Keyword> for ArgOrKeyword<'a> {
+    fn from(keyword: &'a Keyword) -> Self {
+        Self::Keyword(keyword)
+    }
+}
+
+impl Ranged for ArgOrKeyword<'_> {
+    fn range(&self) -> TextRange {
+        match self {
+            Self::Arg(arg) => arg.range(),
+            Self::Keyword(keyword) => keyword.range(),
+        }
+    }
+}
+
 impl Arguments {
     /// Return the number of positional and keyword arguments.
     pub fn len(&self) -> usize {
@@ -2211,6 +2240,46 @@ impl Arguments {
         self.find_keyword(name)
             .map(|keyword| &keyword.value)
             .or_else(|| self.find_positional(position))
+    }
+
+    /// Return the positional and keyword arguments in the order of declaration.
+    ///
+    /// Positional arguments are generally before keyword arguments, but star arguments are an
+    /// exception:
+    /// ```python
+    /// class A(*args, a=2, *args2, **kwargs):
+    ///     pass
+    ///
+    /// f(*args, a=2, *args2, **kwargs)
+    /// ```
+    /// where `*args` and `args2` are `args` while `a=1` and `kwargs` are `keywords`.
+    ///
+    /// If you would just chain `args` and `keywords` the call would get reordered which we don't
+    /// want. This function instead "merge sorts" them into the correct order.
+    ///
+    /// Note that the order of evaluation is always first `args`, then `keywords`:
+    /// ```python
+    /// def f(*args, **kwargs):
+    ///     pass
+    ///
+    /// def g(x):
+    ///     print(x)
+    ///     return x
+    ///
+    ///
+    /// f(*g([1]), a=g(2), *g([3]), **g({"4": 5}))
+    /// ```
+    /// Output:
+    /// ```text
+    /// [1]
+    /// [3]
+    /// 2
+    /// {'4': 5}
+    /// ```
+    pub fn arguments_as_declared(&self) -> impl Iterator<Item = ArgOrKeyword<'_>> {
+        let args = self.args.iter().map(ArgOrKeyword::Arg);
+        let keywords = self.keywords.iter().map(ArgOrKeyword::Keyword);
+        args.merge_by(keywords, |left, right| left.start() < right.start())
     }
 }
 

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -573,6 +573,9 @@ pub fn walk_format_spec<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, format_spe
 }
 
 pub fn walk_arguments<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, arguments: &'a Arguments) {
+    // Note that the there might be keywords before the last arg, e.g. in
+    // f(*args, a=2, *args2, **kwargs)`, but we follow Python in evaluating first `args` and then
+    // `keywords`. See also [Arguments::arguments_as_declared`].
     for arg in &arguments.args {
         visitor.visit_expr(arg);
     }

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -266,7 +266,7 @@ impl<'a> Generator<'a> {
                     if let Some(arguments) = arguments {
                         self.p("(");
                         let mut first = true;
-                        for arg_or_keyword in arguments.arguments_as_declared() {
+                        for arg_or_keyword in arguments.arguments_source_order() {
                             match arg_or_keyword {
                                 ArgOrKeyword::Arg(arg) => {
                                     self.p_delim(&mut first, ", ");
@@ -1051,7 +1051,7 @@ impl<'a> Generator<'a> {
                 } else {
                     let mut first = true;
 
-                    for arg_or_keyword in arguments.arguments_as_declared() {
+                    for arg_or_keyword in arguments.arguments_source_order() {
                         match arg_or_keyword {
                             ArgOrKeyword::Arg(arg) => {
                                 self.p_delim(&mut first, ", ");


### PR DESCRIPTION
## Motivation

The `ast::Arguments` for call argument are split into positional arguments (args) and keywords arguments (keywords). We currently assume that call consists of first args and then keywords, which is generally the case, but not always:

```python
f(*args, a=2, *args2, **kwargs)

class A(*args, a=2, *args2, **kwargs):
    pass
```

The consequence is accidentally reordering arguments (https://github.com/astral-sh/ruff/pull/7268).

## Summary

`Arguments::args_and_keywords` returns an iterator of an `ArgOrKeyword` enum that yields args and keywords in the correct order. I've fixed the obvious `args` and `keywords` usages, but there might be some cases with wrong assumptions remaining.

## Test Plan

The generator got new test cases, otherwise the stacked PR (https://github.com/astral-sh/ruff/pull/7268) which uncovered this.
