### PR TITLE
Detect `noqa` directives for multi-line f-strings

### DIFF
--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -122,6 +122,9 @@ fn extract_noqa_line_for(lxr: &[LexResult], locator: &Locator, indexer: &Indexer
     // the inner f-strings.
     let mut last_fstring_range: TextRange = TextRange::default();
     for fstring_range in indexer.fstring_ranges().values() {
+        if !locator.contains_line_break(*fstring_range) {
+            continue;
+        }
         if last_fstring_range.contains_range(*fstring_range) {
             continue;
         }
@@ -513,6 +516,12 @@ end'''
             noqa_mappings(contents),
             NoqaMapping::from_iter([TextRange::new(TextSize::from(6), TextSize::from(70))])
         );
+
+        let contents = "x = 1
+y = f'normal'
+z = f'another but {f'nested but {f'still single line'} nested'}'
+";
+        assert_eq!(noqa_mappings(contents), NoqaMapping::default());
 
         let contents = r"x = \
     1";

--- a/crates/ruff_python_index/src/fstring_ranges.rs
+++ b/crates/ruff_python_index/src/fstring_ranges.rs
@@ -50,9 +50,20 @@ impl FStringRanges {
             .map(|(_, range)| *range)
     }
 
-    #[cfg(test)]
-    pub(crate) fn ranges(&self) -> impl Iterator<Item = TextRange> + '_ {
-        self.raw.values().copied()
+    /// Returns an iterator over all f-string [`TextRange`] sorted by their
+    /// start location.
+    ///
+    /// For nested f-strings, the outermost f-string is yielded first, moving
+    /// inwards with each iteration.
+    #[inline]
+    pub fn values(&self) -> impl Iterator<Item = &TextRange> + '_ {
+        self.raw.values()
+    }
+
+    /// Returns the number of f-string ranges stored.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.raw.len()
     }
 }
 

--- a/crates/ruff_python_index/src/indexer.rs
+++ b/crates/ruff_python_index/src/indexer.rs
@@ -353,7 +353,11 @@ f"implicit " f"concatenation"
         let lxr: Vec<LexResult> = lexer::lex(contents, Mode::Module).collect();
         let indexer = Indexer::from_tokens(lxr.as_slice(), &Locator::new(contents));
         assert_eq!(
-            indexer.fstring_ranges().ranges().collect::<Vec<_>>(),
+            indexer
+                .fstring_ranges()
+                .values()
+                .copied()
+                .collect::<Vec<_>>(),
             &[
                 TextRange::new(TextSize::from(0), TextSize::from(18)),
                 TextRange::new(TextSize::from(19), TextSize::from(55)),
@@ -385,7 +389,11 @@ f-string"""}
         let lxr: Vec<LexResult> = lexer::lex(contents, Mode::Module).collect();
         let indexer = Indexer::from_tokens(lxr.as_slice(), &Locator::new(contents));
         assert_eq!(
-            indexer.fstring_ranges().ranges().collect::<Vec<_>>(),
+            indexer
+                .fstring_ranges()
+                .values()
+                .copied()
+                .collect::<Vec<_>>(),
             &[
                 TextRange::new(TextSize::from(0), TextSize::from(39)),
                 TextRange::new(TextSize::from(40), TextSize::from(68)),


### PR DESCRIPTION
## Summary

This PR updates the NoQA directive detection to consider the new f-string tokens.

The reason being that now there can be multi-line f-strings without triple-quotes:

```python
f"{
x
	*
		y
}"
```

Here, the `noqa` directive should go at the end of the last line.

## Test Plan

* Add new test cases for f-strings
* Tested with `--add-noqa` using the following command with the above code snippet:
	```console
	$ cargo run --bin ruff -- check --select=F821 --no-cache --isolated ~/playground/ruff/fstring.py --add-noqa
	Added 1 noqa directive.
	```

	Output:
	```python
	f"{
	x
    	*
        	y
	}"  # noqa: F821
	```
	Running the same command again doesn't add `noqa` directive and without the `--add-noqa` flag, the violation isn't reported.

fixes: #7291
