### PR TITLE
Update `F541` to use new f-string tokens

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyflakes/F541.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F541.py
@@ -40,6 +40,7 @@ f"{{{{x}}}}"
 ""f""
 ''f""
 (""f""r"")
+f"{v:{f"0.2f"}}"
 
 # To be fixed
 # Error: f-string: single '}' is not allowed at line 41 column 8

--- a/crates/ruff/resources/test/fixtures/pyflakes/F541.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F541.py
@@ -41,7 +41,4 @@ f"{{{{x}}}}"
 ''f""
 (""f""r"")
 f"{v:{f"0.2f"}}"
-
-# To be fixed
-# Error: f-string: single '}' is not allowed at line 41 column 8
-# f"\{{x}}"
+f"\{{x}}"

--- a/crates/ruff/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff/src/checkers/ast/analyze/expression.rs
@@ -946,9 +946,9 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 pylint::rules::await_outside_async(checker, expr);
             }
         }
-        Expr::FString(ast::ExprFString { values, .. }) => {
+        Expr::FString(fstring @ ast::ExprFString { values, .. }) => {
             if checker.enabled(Rule::FStringMissingPlaceholders) {
-                pyflakes::rules::f_string_missing_placeholders(expr, values, checker);
+                pyflakes::rules::f_string_missing_placeholders(fstring, checker);
             }
             if checker.enabled(Rule::HardcodedSQLExpression) {
                 flake8_bandit::rules::hardcoded_sql_expression(checker, expr);

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F541_F541.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F541_F541.py.snap
@@ -332,7 +332,7 @@ F541.py:40:3: F541 [*] f-string without any placeholders
    40 |+"" ""
 41 41 | ''f""
 42 42 | (""f""r"")
-43 43 | 
+43 43 | f"{v:{f"0.2f"}}"
 
 F541.py:41:3: F541 [*] f-string without any placeholders
    |
@@ -341,6 +341,7 @@ F541.py:41:3: F541 [*] f-string without any placeholders
 41 | ''f""
    |   ^^^ F541
 42 | (""f""r"")
+43 | f"{v:{f"0.2f"}}"
    |
    = help: Remove extraneous `f` prefix
 
@@ -351,8 +352,8 @@ F541.py:41:3: F541 [*] f-string without any placeholders
 41    |-''f""
    41 |+''""
 42 42 | (""f""r"")
-43 43 | 
-44 44 | # To be fixed
+43 43 | f"{v:{f"0.2f"}}"
+44 44 | 
 
 F541.py:42:4: F541 [*] f-string without any placeholders
    |
@@ -360,8 +361,7 @@ F541.py:42:4: F541 [*] f-string without any placeholders
 41 | ''f""
 42 | (""f""r"")
    |    ^^^ F541
-43 | 
-44 | # To be fixed
+43 | f"{v:{f"0.2f"}}"
    |
    = help: Remove extraneous `f` prefix
 
@@ -371,8 +371,29 @@ F541.py:42:4: F541 [*] f-string without any placeholders
 41 41 | ''f""
 42    |-(""f""r"")
    42 |+("" ""r"")
-43 43 | 
-44 44 | # To be fixed
-45 45 | # Error: f-string: single '}' is not allowed at line 41 column 8
+43 43 | f"{v:{f"0.2f"}}"
+44 44 | 
+45 45 | # To be fixed
+
+F541.py:43:7: F541 [*] f-string without any placeholders
+   |
+41 | ''f""
+42 | (""f""r"")
+43 | f"{v:{f"0.2f"}}"
+   |       ^^^^^^^ F541
+44 | 
+45 | # To be fixed
+   |
+   = help: Remove extraneous `f` prefix
+
+ℹ Fix
+40 40 | ""f""
+41 41 | ''f""
+42 42 | (""f""r"")
+43    |-f"{v:{f"0.2f"}}"
+   43 |+f"{v:{"0.2f"}}"
+44 44 | 
+45 45 | # To be fixed
+46 46 | # Error: f-string: single '}' is not allowed at line 41 column 8
 
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F541_F541.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F541_F541.py.snap
@@ -353,7 +353,7 @@ F541.py:41:3: F541 [*] f-string without any placeholders
    41 |+''""
 42 42 | (""f""r"")
 43 43 | f"{v:{f"0.2f"}}"
-44 44 | 
+44 44 | f"\{{x}}"
 
 F541.py:42:4: F541 [*] f-string without any placeholders
    |
@@ -362,6 +362,7 @@ F541.py:42:4: F541 [*] f-string without any placeholders
 42 | (""f""r"")
    |    ^^^ F541
 43 | f"{v:{f"0.2f"}}"
+44 | f"\{{x}}"
    |
    = help: Remove extraneous `f` prefix
 
@@ -372,8 +373,7 @@ F541.py:42:4: F541 [*] f-string without any placeholders
 42    |-(""f""r"")
    42 |+("" ""r"")
 43 43 | f"{v:{f"0.2f"}}"
-44 44 | 
-45 45 | # To be fixed
+44 44 | f"\{{x}}"
 
 F541.py:43:7: F541 [*] f-string without any placeholders
    |
@@ -381,8 +381,7 @@ F541.py:43:7: F541 [*] f-string without any placeholders
 42 | (""f""r"")
 43 | f"{v:{f"0.2f"}}"
    |       ^^^^^^^ F541
-44 | 
-45 | # To be fixed
+44 | f"\{{x}}"
    |
    = help: Remove extraneous `f` prefix
 
@@ -392,8 +391,22 @@ F541.py:43:7: F541 [*] f-string without any placeholders
 42 42 | (""f""r"")
 43    |-f"{v:{f"0.2f"}}"
    43 |+f"{v:{"0.2f"}}"
-44 44 | 
-45 45 | # To be fixed
-46 46 | # Error: f-string: single '}' is not allowed at line 41 column 8
+44 44 | f"\{{x}}"
+
+F541.py:44:1: F541 [*] f-string without any placeholders
+   |
+42 | (""f""r"")
+43 | f"{v:{f"0.2f"}}"
+44 | f"\{{x}}"
+   | ^^^^^^^^^ F541
+   |
+   = help: Remove extraneous `f` prefix
+
+ℹ Fix
+41 41 | ''f""
+42 42 | (""f""r"")
+43 43 | f"{v:{f"0.2f"}}"
+44    |-f"\{{x}}"
+   44 |+"\{x}"
 
 


### PR DESCRIPTION
## Summary

This PR updates the `F541` rule to use the new f-string tokens.

## Test Plan

Add new test case and uncomment a broken test case.

fixes: #7292
