### PR TITLE
Update `Stylist` quote detection with new f-string token

### DIFF
--- a/crates/ruff_python_codegen/src/stylist.rs
+++ b/crates/ruff_python_codegen/src/stylist.rs
@@ -55,6 +55,9 @@ fn detect_quote(tokens: &[LexResult], locator: &Locator) -> Quote {
             triple_quoted: false,
             ..
         } => Some(*range),
+        // No need to check if it's triple-quoted as f-strings cannot be used
+        // as docstrings.
+        Tok::FStringStart => Some(*range),
         _ => None,
     });
 
@@ -248,7 +251,23 @@ x = (
             Quote::Single
         );
 
+        let contents = r#"x = f'1'"#;
+        let locator = Locator::new(contents);
+        let tokens: Vec<_> = lex(contents, Mode::Module).collect();
+        assert_eq!(
+            Stylist::from_tokens(&tokens, &locator).quote(),
+            Quote::Single
+        );
+
         let contents = r#"x = "1""#;
+        let locator = Locator::new(contents);
+        let tokens: Vec<_> = lex(contents, Mode::Module).collect();
+        assert_eq!(
+            Stylist::from_tokens(&tokens, &locator).quote(),
+            Quote::Double
+        );
+
+        let contents = r#"x = f"1""#;
         let locator = Locator::new(contents);
         let tokens: Vec<_> = lex(contents, Mode::Module).collect();
         assert_eq!(
@@ -300,6 +319,41 @@ a = "v"
         assert_eq!(
             Stylist::from_tokens(&tokens, &locator).quote(),
             Quote::Double
+        );
+
+        // Detect from f-string appearing after docstring
+        let contents = r#"
+"""Module docstring."""
+
+a = f'v'
+"#;
+        let locator = Locator::new(contents);
+        let tokens: Vec<_> = lex(contents, Mode::Module).collect();
+        assert_eq!(
+            Stylist::from_tokens(&tokens, &locator).quote(),
+            Quote::Single
+        );
+
+        let contents = r#"
+'''Module docstring.'''
+
+a = f"v"
+"#;
+        let locator = Locator::new(contents);
+        let tokens: Vec<_> = lex(contents, Mode::Module).collect();
+        assert_eq!(
+            Stylist::from_tokens(&tokens, &locator).quote(),
+            Quote::Double
+        );
+
+        let contents = r#"
+f'''Module docstring.'''
+"#;
+        let locator = Locator::new(contents);
+        let tokens: Vec<_> = lex(contents, Mode::Module).collect();
+        assert_eq!(
+            Stylist::from_tokens(&tokens, &locator).quote(),
+            Quote::Single
         );
     }
 


### PR DESCRIPTION
## Summary

This PR updates `Stylist` quote detection to include the f-string tokens.

As f-strings cannot be used as docstrings, we'll skip the check for triple-quoted f-strings.

## Test Plan

Add new test cases with f-strings.

fixes: #7293
