### PR TITLE
Update `W605` to check in f-strings

### DIFF
--- a/crates/ruff/resources/test/fixtures/pycodestyle/W605_2.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/W605_2.py
@@ -44,8 +44,11 @@ regex = f'\\\_'
 value = f'\{{1}}'
 value = f'\{1}'
 value = f'{1:\}'
+value = f"{f"\{1}"}"
+value = rf"{f"\{1}"}"
 
 # Okay
 value = rf'\{{1}}'
 value = rf'\{1}'
 value = rf'{1:\}'
+value = f"{rf"\{1}"}"

--- a/crates/ruff/resources/test/fixtures/pycodestyle/W605_2.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/W605_2.py
@@ -1,0 +1,51 @@
+# Same as `W605_0.py` but using f-strings instead.
+
+#: W605:1:10
+regex = f'\.png$'
+
+#: W605:2:1
+regex = f'''
+\.png$
+'''
+
+#: W605:2:6
+f(
+    f'\_'
+)
+
+#: W605:4:6
+f"""
+multi-line
+literal
+with \_ somewhere
+in the middle
+"""
+
+#: W605:1:38
+value = f'new line\nand invalid escape \_ here'
+
+
+#: Okay
+regex = fr'\.png$'
+regex = f'\\.png$'
+regex = fr'''
+\.png$
+'''
+regex = fr'''
+\\.png$
+'''
+s = f'\\'
+regex = f'\w'  # noqa
+regex = f'''
+\w
+'''  # noqa
+
+regex = f'\\\_'
+value = f'\{{1}}'
+value = f'\{1}'
+value = f'{1:\}'
+
+# Okay
+value = rf'\{{1}}'
+value = rf'\{1}'
+value = rf'{1:\}'

--- a/crates/ruff/src/checkers/tokens.rs
+++ b/crates/ruff/src/checkers/tokens.rs
@@ -77,14 +77,14 @@ pub(crate) fn check_tokens(
 
     if settings.rules.enabled(Rule::InvalidEscapeSequence) {
         for (tok, range) in tokens.iter().flatten() {
-            if tok.is_string() {
-                pycodestyle::rules::invalid_escape_sequence(
-                    &mut diagnostics,
-                    locator,
-                    *range,
-                    settings.rules.should_fix(Rule::InvalidEscapeSequence),
-                );
-            }
+            pycodestyle::rules::invalid_escape_sequence(
+                &mut diagnostics,
+                locator,
+                indexer,
+                tok,
+                *range,
+                settings.rules.should_fix(Rule::InvalidEscapeSequence),
+            );
         }
     }
 

--- a/crates/ruff/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff/src/rules/pycodestyle/mod.rs
@@ -28,6 +28,7 @@ mod tests {
     #[test_case(Rule::BlankLineWithWhitespace, Path::new("W29.py"))]
     #[test_case(Rule::InvalidEscapeSequence, Path::new("W605_0.py"))]
     #[test_case(Rule::InvalidEscapeSequence, Path::new("W605_1.py"))]
+    #[test_case(Rule::InvalidEscapeSequence, Path::new("W605_2.py"))]
     #[test_case(Rule::LineTooLong, Path::new("E501.py"))]
     #[test_case(Rule::MixedSpacesAndTabs, Path::new("E101.py"))]
     #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E40.py"))]

--- a/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -47,36 +47,22 @@ pub(crate) fn invalid_escape_sequence(
     diagnostics: &mut Vec<Diagnostic>,
     locator: &Locator,
     indexer: &Indexer,
-    tok: &Tok,
-    tok_range: TextRange,
+    token: &Tok,
+    token_range: TextRange,
     autofix: bool,
 ) {
-    let (start_offset, body) = match tok {
+    let token_source_code = match token {
         Tok::FStringMiddle { value, is_raw } => {
             if *is_raw {
                 return;
             }
-            (tok_range.start(), value.as_str())
+            value.as_str()
         }
-        Tok::String {
-            value,
-            kind,
-            triple_quoted,
-        } => {
+        Tok::String { kind, .. } => {
             if kind.is_raw() {
                 return;
             }
-
-            let quote_len = if *triple_quoted {
-                TextSize::new(3)
-            } else {
-                TextSize::new(1)
-            };
-
-            (
-                tok_range.start() + kind.prefix_len() + quote_len,
-                value.as_str(),
-            )
+            locator.slice(token_range)
         }
         _ => return,
     };
@@ -85,7 +71,7 @@ pub(crate) fn invalid_escape_sequence(
     let mut invalid_escape_sequence = Vec::new();
 
     let mut prev = None;
-    let bytes = body.as_bytes();
+    let bytes = token_source_code.as_bytes();
     for i in memchr_iter(b'\\', bytes) {
         // If the previous character was also a backslash, skip.
         if prev.is_some_and(|prev| prev == i - 1) {
@@ -95,9 +81,9 @@ pub(crate) fn invalid_escape_sequence(
 
         prev = Some(i);
 
-        let next_char = match body[i + 1..].chars().next() {
+        let next_char = match token_source_code[i + 1..].chars().next() {
             Some(next_char) => next_char,
-            None if tok.is_f_string_middle() => {
+            None if token.is_f_string_middle() => {
                 // If we're at the end of a f-string middle token, the next character
                 // is actually emitted as a different token. For example,
                 //
@@ -105,8 +91,8 @@ pub(crate) fn invalid_escape_sequence(
                 // f"\{1}"
                 // ```
                 //
-                // is lexed as `FStringMiddle('\\')` and `LBrace`, so we need to check
-                // the next character in the source file.
+                // is lexed as `FStringMiddle('\\')` and `LBrace` (ignoring irrelevant
+                // tokens), so we need to check the next character in the source code.
                 //
                 // Now, if we're at the end of the f-string itself, the lexer wouldn't
                 // have emitted the `FStringMiddle` token in the first place. For example,
@@ -116,11 +102,14 @@ pub(crate) fn invalid_escape_sequence(
                 // ```
                 //
                 // Here, there won't be any `FStringMiddle` because it's an unterminated
-                // f-string.
-                let Some(next_char) = locator.after(tok_range.end()).chars().next() else {
+                // f-string. This means that if there's a `FStringMiddle` token and we
+                // encounter a `\` character, then the next character is always going to
+                // be part of the f-string.
+                if let Some(next_char) = locator.after(token_range.end()).chars().next() {
+                    next_char
+                } else {
                     continue;
-                };
-                next_char
+                }
             }
             // If we're at the end of the file, skip.
             None => continue,
@@ -164,7 +153,7 @@ pub(crate) fn invalid_escape_sequence(
             continue;
         }
 
-        let location = start_offset + TextSize::try_from(i).unwrap();
+        let location = token_range.start() + TextSize::try_from(i).unwrap();
         let range = TextRange::at(location, next_char.text_len() + TextSize::from(1));
         invalid_escape_sequence.push(Diagnostic::new(InvalidEscapeSequence(next_char), range));
     }
@@ -179,12 +168,16 @@ pub(crate) fn invalid_escape_sequence(
                 )));
             }
         } else {
-            let tok_start = if tok.is_f_string_middle() {
+            let tok_start = if token.is_f_string_middle() {
                 // SAFETY: If this is a `FStringMiddle` token, then the indexer
                 // must have the f-string range.
-                indexer.f_string_range(tok_range.start()).unwrap().start()
+                indexer
+                    .fstring_ranges()
+                    .innermost(token_range.start())
+                    .unwrap()
+                    .start()
             } else {
-                tok_range.start()
+                token_range.start()
             };
             // Turn into raw string.
             for diagnostic in &mut invalid_escape_sequence {

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_2.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_2.py.snap
@@ -139,7 +139,7 @@ W605_2.py:44:11: W605 [*] Invalid escape sequence: `\{`
    44 |+value = rf'\{{1}}'
 45 45 | value = f'\{1}'
 46 46 | value = f'{1:\}'
-47 47 | 
+47 47 | value = f"{f"\{1}"}"
 
 W605_2.py:45:11: W605 [*] Invalid escape sequence: `\{`
    |
@@ -148,6 +148,7 @@ W605_2.py:45:11: W605 [*] Invalid escape sequence: `\{`
 45 | value = f'\{1}'
    |           ^^ W605
 46 | value = f'{1:\}'
+47 | value = f"{f"\{1}"}"
    |
    = help: Add backslash to escape sequence
 
@@ -158,8 +159,8 @@ W605_2.py:45:11: W605 [*] Invalid escape sequence: `\{`
 45    |-value = f'\{1}'
    45 |+value = rf'\{1}'
 46 46 | value = f'{1:\}'
-47 47 | 
-48 48 | # Okay
+47 47 | value = f"{f"\{1}"}"
+48 48 | value = rf"{f"\{1}"}"
 
 W605_2.py:46:14: W605 [*] Invalid escape sequence: `\}`
    |
@@ -167,8 +168,8 @@ W605_2.py:46:14: W605 [*] Invalid escape sequence: `\}`
 45 | value = f'\{1}'
 46 | value = f'{1:\}'
    |              ^^ W605
-47 | 
-48 | # Okay
+47 | value = f"{f"\{1}"}"
+48 | value = rf"{f"\{1}"}"
    |
    = help: Add backslash to escape sequence
 
@@ -178,8 +179,49 @@ W605_2.py:46:14: W605 [*] Invalid escape sequence: `\}`
 45 45 | value = f'\{1}'
 46    |-value = f'{1:\}'
    46 |+value = rf'{1:\}'
-47 47 | 
-48 48 | # Okay
-49 49 | value = rf'\{{1}}'
+47 47 | value = f"{f"\{1}"}"
+48 48 | value = rf"{f"\{1}"}"
+49 49 | 
+
+W605_2.py:47:14: W605 [*] Invalid escape sequence: `\{`
+   |
+45 | value = f'\{1}'
+46 | value = f'{1:\}'
+47 | value = f"{f"\{1}"}"
+   |              ^^ W605
+48 | value = rf"{f"\{1}"}"
+   |
+   = help: Add backslash to escape sequence
+
+ℹ Fix
+44 44 | value = f'\{{1}}'
+45 45 | value = f'\{1}'
+46 46 | value = f'{1:\}'
+47    |-value = f"{f"\{1}"}"
+   47 |+value = f"{rf"\{1}"}"
+48 48 | value = rf"{f"\{1}"}"
+49 49 | 
+50 50 | # Okay
+
+W605_2.py:48:15: W605 [*] Invalid escape sequence: `\{`
+   |
+46 | value = f'{1:\}'
+47 | value = f"{f"\{1}"}"
+48 | value = rf"{f"\{1}"}"
+   |               ^^ W605
+49 | 
+50 | # Okay
+   |
+   = help: Add backslash to escape sequence
+
+ℹ Fix
+45 45 | value = f'\{1}'
+46 46 | value = f'{1:\}'
+47 47 | value = f"{f"\{1}"}"
+48    |-value = rf"{f"\{1}"}"
+   48 |+value = rf"{rf"\{1}"}"
+49 49 | 
+50 50 | # Okay
+51 51 | value = rf'\{{1}}'
 
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_2.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_2.py.snap
@@ -1,0 +1,185 @@
+---
+source: crates/ruff/src/rules/pycodestyle/mod.rs
+---
+W605_2.py:4:11: W605 [*] Invalid escape sequence: `\.`
+  |
+3 | #: W605:1:10
+4 | regex = f'\.png$'
+  |           ^^ W605
+5 | 
+6 | #: W605:2:1
+  |
+  = help: Add backslash to escape sequence
+
+ℹ Fix
+1 1 | # Same as `W605_0.py` but using f-strings instead.
+2 2 | 
+3 3 | #: W605:1:10
+4   |-regex = f'\.png$'
+  4 |+regex = rf'\.png$'
+5 5 | 
+6 6 | #: W605:2:1
+7 7 | regex = f'''
+
+W605_2.py:8:1: W605 [*] Invalid escape sequence: `\.`
+  |
+6 | #: W605:2:1
+7 | regex = f'''
+8 | \.png$
+  | ^^ W605
+9 | '''
+  |
+  = help: Add backslash to escape sequence
+
+ℹ Fix
+4 4 | regex = f'\.png$'
+5 5 | 
+6 6 | #: W605:2:1
+7   |-regex = f'''
+  7 |+regex = rf'''
+8 8 | \.png$
+9 9 | '''
+10 10 | 
+
+W605_2.py:13:7: W605 [*] Invalid escape sequence: `\_`
+   |
+11 | #: W605:2:6
+12 | f(
+13 |     f'\_'
+   |       ^^ W605
+14 | )
+   |
+   = help: Add backslash to escape sequence
+
+ℹ Fix
+10 10 | 
+11 11 | #: W605:2:6
+12 12 | f(
+13    |-    f'\_'
+   13 |+    rf'\_'
+14 14 | )
+15 15 | 
+16 16 | #: W605:4:6
+
+W605_2.py:20:6: W605 [*] Invalid escape sequence: `\_`
+   |
+18 | multi-line
+19 | literal
+20 | with \_ somewhere
+   |      ^^ W605
+21 | in the middle
+22 | """
+   |
+   = help: Add backslash to escape sequence
+
+ℹ Fix
+14 14 | )
+15 15 | 
+16 16 | #: W605:4:6
+17    |-f"""
+   17 |+rf"""
+18 18 | multi-line
+19 19 | literal
+20 20 | with \_ somewhere
+
+W605_2.py:25:40: W605 [*] Invalid escape sequence: `\_`
+   |
+24 | #: W605:1:38
+25 | value = f'new line\nand invalid escape \_ here'
+   |                                        ^^ W605
+   |
+   = help: Add backslash to escape sequence
+
+ℹ Fix
+22 22 | """
+23 23 | 
+24 24 | #: W605:1:38
+25    |-value = f'new line\nand invalid escape \_ here'
+   25 |+value = f'new line\nand invalid escape \\_ here'
+26 26 | 
+27 27 | 
+28 28 | #: Okay
+
+W605_2.py:43:13: W605 [*] Invalid escape sequence: `\_`
+   |
+41 | '''  # noqa
+42 | 
+43 | regex = f'\\\_'
+   |             ^^ W605
+44 | value = f'\{{1}}'
+45 | value = f'\{1}'
+   |
+   = help: Add backslash to escape sequence
+
+ℹ Fix
+40 40 | \w
+41 41 | '''  # noqa
+42 42 | 
+43    |-regex = f'\\\_'
+   43 |+regex = f'\\\\_'
+44 44 | value = f'\{{1}}'
+45 45 | value = f'\{1}'
+46 46 | value = f'{1:\}'
+
+W605_2.py:44:11: W605 [*] Invalid escape sequence: `\{`
+   |
+43 | regex = f'\\\_'
+44 | value = f'\{{1}}'
+   |           ^^ W605
+45 | value = f'\{1}'
+46 | value = f'{1:\}'
+   |
+   = help: Add backslash to escape sequence
+
+ℹ Fix
+41 41 | '''  # noqa
+42 42 | 
+43 43 | regex = f'\\\_'
+44    |-value = f'\{{1}}'
+   44 |+value = rf'\{{1}}'
+45 45 | value = f'\{1}'
+46 46 | value = f'{1:\}'
+47 47 | 
+
+W605_2.py:45:11: W605 [*] Invalid escape sequence: `\{`
+   |
+43 | regex = f'\\\_'
+44 | value = f'\{{1}}'
+45 | value = f'\{1}'
+   |           ^^ W605
+46 | value = f'{1:\}'
+   |
+   = help: Add backslash to escape sequence
+
+ℹ Fix
+42 42 | 
+43 43 | regex = f'\\\_'
+44 44 | value = f'\{{1}}'
+45    |-value = f'\{1}'
+   45 |+value = rf'\{1}'
+46 46 | value = f'{1:\}'
+47 47 | 
+48 48 | # Okay
+
+W605_2.py:46:14: W605 [*] Invalid escape sequence: `\}`
+   |
+44 | value = f'\{{1}}'
+45 | value = f'\{1}'
+46 | value = f'{1:\}'
+   |              ^^ W605
+47 | 
+48 | # Okay
+   |
+   = help: Add backslash to escape sequence
+
+ℹ Fix
+43 43 | regex = f'\\\_'
+44 44 | value = f'\{{1}}'
+45 45 | value = f'\{1}'
+46    |-value = f'{1:\}'
+   46 |+value = rf'{1:\}'
+47 47 | 
+48 48 | # Okay
+49 49 | value = rf'\{{1}}'
+
+


### PR DESCRIPTION
## Summary

This PR updates the `W605` (invalid-escape-sequence) to check inside f-strings. It also adds support to report violation on invalid escape sequence within f-strings w.r.t. the curly braces. So, the following cases will be identified:

```python
f"\{1}"
f"\{{1}}"
f"{1:\}"
```

The new CPython parser also gives out a syntax warning for such cases:

```
fstring.py:1: SyntaxWarning: invalid escape sequence '\{'
  f"\{1}"
fstring.py:2: SyntaxWarning: invalid escape sequence '\{'
  f"\{{1}}"
fstring.py:3: SyntaxWarning: invalid escape sequence '\}'
  f"{1:\}"
```

Nested f-strings are supported here, so the generated fix is aware of that and will create an edit for the proper f-string.

## Test Plan

Add new test cases for f-strings.

fixes: #7295
