### PR TITLE
Break before slice colon

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/slice.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/slice.py
@@ -91,3 +91,18 @@ f = "f"[:,]
 g1 = "g"[(1):(2)]
 g2 = "g"[(1):(2):(3)]
 
+# https://github.com/astral-sh/ruff/issues/7316
+section_header_data = byte_array[
+    byte_begin_index
+    + byte_step_index * event_index : byte_begin_index
+    + byte_step_index * (event_index + 1)
+]
+
+section_header_data2 = byte_array[
+    byte_begin_index
+    + byte_step_index * event_index : byte_begin_index
+    + byte_step_index : section_size
+]
+
+
+

--- a/crates/ruff_python_formatter/src/expression/expr_slice.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_slice.rs
@@ -91,7 +91,7 @@ impl FormatNodeRule<ExprSlice> for FormatExprSlice {
         if !all_simple && lower.is_some() {
             space().fmt(f)?;
         }
-        token(":").fmt(f)?;
+        write!(f, [soft_line_break(), token(":")])?;
         // No upper node, no need for a space, e.g. `x[a() :]`
         if !all_simple && upper.is_some() {
             space().fmt(f)?;
@@ -125,7 +125,7 @@ impl FormatNodeRule<ExprSlice> for FormatExprSlice {
             if !all_simple && (upper.is_some() || step.is_none()) {
                 space().fmt(f)?;
             }
-            token(":").fmt(f)?;
+            write!(f, [soft_line_break(), token(":")])?;
             // No step node, no need for a space
             if !all_simple && step.is_some() {
                 space().fmt(f)?;

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__slice.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__slice.py.snap
@@ -97,6 +97,21 @@ f = "f"[:,]
 g1 = "g"[(1):(2)]
 g2 = "g"[(1):(2):(3)]
 
+# https://github.com/astral-sh/ruff/issues/7316
+section_header_data = byte_array[
+    byte_begin_index
+    + byte_step_index * event_index : byte_begin_index
+    + byte_step_index * (event_index + 1)
+]
+
+section_header_data2 = byte_array[
+    byte_begin_index
+    + byte_step_index * event_index : byte_begin_index
+    + byte_step_index : section_size
+]
+
+
+
 ```
 
 ## Output
@@ -132,21 +147,25 @@ b1 = "b"[  # a
 
 # Handle the spacing from the colon correctly with upper leading comments
 c1 = "c"[
-    1:  # e
+    1
+    :  # e
     # f
     2
 ]
 c2 = "c"[
-    1:  # e
+    1
+    :  # e
     2
 ]
 c3 = "c"[
-    1:
+    1
+    :
     # f
     2
 ]
 c4 = "c"[
-    1:  # f
+    1
+    :  # f
     2
 ]
 
@@ -155,7 +174,8 @@ d1 = "d"[  # comment
     :
 ]
 d2 = "d"[  # comment
-    1:
+    1
+    :
 ]
 d3 = "d"[
     1  # comment
@@ -191,6 +211,18 @@ f = "f"[:,]
 # Regression test for https://github.com/astral-sh/ruff/issues/5733
 g1 = "g"[(1):(2)]
 g2 = "g"[(1):(2):(3)]
+
+# https://github.com/astral-sh/ruff/issues/7316
+section_header_data = byte_array[
+    byte_begin_index + byte_step_index * event_index 
+    : byte_begin_index + byte_step_index * (event_index + 1)
+]
+
+section_header_data2 = byte_array[
+    byte_begin_index + byte_step_index * event_index 
+    : byte_begin_index + byte_step_index 
+    : section_size
+]
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__raise.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__raise.py.snap
@@ -175,7 +175,8 @@ raise (  # hey 2
 
 # some comment
 raise aksjdhflsakhdflkjsadlfajkslhfdkjsaldajlahflashdfljahlfksajlhfajfjfsaahflakjslhdfkjalhdskjfa[
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbb
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    :bbbbbbbbbbbbbbbbbbbbbbbbbb
 ]
 
 raise (


### PR DESCRIPTION
**Summary** Break slices at the colon first, since the colon is separator with the lowest precedence and we're in a parenthesized context.

**Input**
```python
section_header_data = byte_array[byte_begin_index + byte_step_index * event_index : byte_begin_index + byte_step_index * (event_index + 1)]
```
**Black**
```python
section_header_data = byte_array[
    byte_begin_index
    + byte_step_index * event_index : byte_begin_index
    + byte_step_index * (event_index + 1)
]
```
**Current formatting**
```python
section_header_data = byte_array[
    byte_begin_index + byte_step_index * event_index : byte_begin_index
    + byte_step_index * (event_index + 1)
]
```
**Proposed formatting**
```python
section_header_data = byte_array[
    byte_begin_index + byte_step_index * event_index 
    : byte_begin_index + byte_step_index * (event_index + 1)
]
```

This is another intentional black deviation, but i find it a clear style improvement.

This is consistent with adding a step:
```python
section_header_data2 = byte_array[
    byte_begin_index + byte_step_index * event_index 
    : byte_begin_index + byte_step_index 
    : section_size
]
```

As-is, this regresses trailing colon comments:

**in**
```python
c1 = "c"[
    1:  # e
    # f
    2
]
```
**out**
```python
c1 = "c"[
    1
    :  # e
    # f
    2
]
```

**main**

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| **django**       |           0.99981 |              2760 |                40 |
| **transformers** |           0.99944 |              2587 |               413 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| warehouse    |           0.99834 |               648 |                20 |
| **zulip**        |           0.99956 |              1437 |                23 |

**PR**

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| **django**       |           0.99981 |              2760 |                41 |
| **transformers** |           0.99942 |              2587 |               430 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| warehouse    |           0.99834 |               648 |                20 |
| **zulip**        |           0.99956 |              1437 |                24 |

For the similarity index, this is a regression.

Fixes #7316

**Test Plan** Added the fixtures above.