### PR TITLE
chore: Upgrade notify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,20 +1419,21 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.2.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729f63e1ca555a43fe3efa4f3efdf4801c479da85b432242a7b726f353c88486"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
+ "log",
  "mio",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -52,7 +52,7 @@ is-macro = { workspace = true }
 itertools = { workspace = true }
 itoa = { version = "1.0.6" }
 log = { workspace = true }
-notify = { version = "5.1.0" }
+notify = { version = "6.1.1" }
 path-absolutize = { workspace = true, features = ["once_cell_cache"] }
 rayon = { version = "1.7.0" }
 regex = { workspace = true }


### PR DESCRIPTION
## Summary

This PR updates notify from 5.x to 6.x

The license change to CC 1.0 (which it already was dual-licensed under before) is fine, IMO because it is a permissive license allowing any use. 

I verified that moving a file into a folder triggers a recheck.

## Test Plan

I used `ruff check . --watch` and I verified that the checks are executed again after changing a file. 