### PR TITLE
Treat whitespace-only line as blank for D411

### DIFF
--- a/crates/ruff/resources/test/fixtures/pydocstyle/sections.py
+++ b/crates/ruff/resources/test/fixtures/pydocstyle/sections.py
@@ -529,3 +529,16 @@ def replace_equals_with_dash2():
     Parameters
     ===========
     """
+
+
+@expect(_D213)
+def non_empty_blank_line_before_section():  # noqa: D416
+    """Toggle the gizmo.
+
+    The function's description.
+    
+    Returns
+    -------
+    A value of some sort.
+
+    """

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -1691,7 +1691,10 @@ fn common_section(
     }
 
     if checker.enabled(Rule::NoBlankLineBeforeSection) {
-        if !context.previous_line().is_some_and(str::is_empty) {
+        if !context
+            .previous_line()
+            .is_some_and(|line| line.trim().is_empty())
+        {
             let mut diagnostic = Diagnostic::new(
                 NoBlankLineBeforeSection {
                     name: context.section_name().to_string(),

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D407_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D407_sections.py.snap
@@ -496,5 +496,6 @@ sections.py:527:5: D407 [*] Missing dashed underline after section ("Parameters"
     530 |+    ----------
 530 531 |     ===========
 531 532 |     """
+532 533 | 
 
 


### PR DESCRIPTION
This better aligns with the definition of "blank line" that we use throughout the docstring rules.

Closes https://github.com/astral-sh/ruff/issues/7216.
