### PR TITLE
Move `FURB145` from nursery to preview

### DIFF
--- a/crates/ruff/src/codes.rs
+++ b/crates/ruff/src/codes.rs
@@ -916,8 +916,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Refurb, "131") => (RuleGroup::Nursery, rules::refurb::rules::DeleteFullSlice),
         #[allow(deprecated)]
         (Refurb, "132") => (RuleGroup::Nursery, rules::refurb::rules::CheckAndRemoveFromSet),
-        #[allow(deprecated)]
-        (Refurb, "145") => (RuleGroup::Nursery, rules::refurb::rules::SliceCopy),
+        (Refurb, "145") => (RuleGroup::Preview, rules::refurb::rules::SliceCopy),
 
         _ => return None,
     })

--- a/crates/ruff/src/rule_selector.rs
+++ b/crates/ruff/src/rule_selector.rs
@@ -212,7 +212,7 @@ impl RuleSelector {
             // Always include rules that are not in preview or the nursery
             !(rule.is_preview() || rule.is_nursery())
             // Backwards compatibility allows selection of nursery rules by exact code or dedicated group
-            || (matches!(self, RuleSelector::Rule { .. }) || matches!(self, RuleSelector::Nursery { .. }) && rule.is_nursery())
+            || ((matches!(self, RuleSelector::Rule { .. }) || matches!(self, RuleSelector::Nursery { .. })) && rule.is_nursery())
             // Enabling preview includes all preview or nursery rules
             || preview.is_enabled()
         })


### PR DESCRIPTION
Moves the new rule from nursery to preview for the upcoming release.

Adds new test coverage for selection of a single preview rule and fixes a bug where preview rules were incorrectly selectable with exact codes.