### PR TITLE
Add internal rules for testing

### DIFF
--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -89,3 +89,5 @@ default = []
 schemars = ["dep:schemars"]
 # Enables the UnreachableCode rule
 unreachable-code = []
+# Enables rules for internal integration tests
+test-rules = []

--- a/crates/ruff/src/codes.rs
+++ b/crates/ruff/src/codes.rs
@@ -865,11 +865,11 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Ruff, "017") => (RuleGroup::Nursery, rules::ruff::rules::QuadraticListSummation),
         (Ruff, "100") => (RuleGroup::Unspecified, rules::ruff::rules::UnusedNOQA),
         (Ruff, "200") => (RuleGroup::Unspecified, rules::ruff::rules::InvalidPyprojectToml),
-        #[cfg(test)]
+        #[cfg(feature = "test-rules")]
         (Ruff, "900") => (RuleGroup::Unspecified, rules::ruff::rules::StableTestRule),
-        #[cfg(test)]
+        #[cfg(feature = "test-rules")]
         (Ruff, "901") => (RuleGroup::Nursery, rules::ruff::rules::NurseryTestRule),
-        #[cfg(test)]
+        #[cfg(feature = "test-rules")]
         (Ruff, "902") => (RuleGroup::Preview, rules::ruff::rules::PreviewTestRule),
 
         // flake8-django

--- a/crates/ruff/src/codes.rs
+++ b/crates/ruff/src/codes.rs
@@ -868,10 +868,10 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         #[cfg(feature = "test-rules")]
         (Ruff, "900") => (RuleGroup::Unspecified, rules::ruff::rules::StableTestRule),
         #[cfg(feature = "test-rules")]
-        (Ruff, "901") => (RuleGroup::Preview, rules::ruff::rules::PreviewTestRule),
+        (Ruff, "911") => (RuleGroup::Preview, rules::ruff::rules::PreviewTestRule),
         #[cfg(feature = "test-rules")]
         #[allow(deprecated)]
-        (Ruff, "902") => (RuleGroup::Nursery, rules::ruff::rules::NurseryTestRule),
+        (Ruff, "912") => (RuleGroup::Nursery, rules::ruff::rules::NurseryTestRule),
 
         // flake8-django
         (Flake8Django, "001") => (RuleGroup::Unspecified, rules::flake8_django::rules::DjangoNullableModelStringField),

--- a/crates/ruff/src/codes.rs
+++ b/crates/ruff/src/codes.rs
@@ -868,6 +868,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         #[cfg(feature = "test-rules")]
         (Ruff, "900") => (RuleGroup::Unspecified, rules::ruff::rules::StableTestRule),
         #[cfg(feature = "test-rules")]
+        #[allow(deprecated)]
         (Ruff, "901") => (RuleGroup::Nursery, rules::ruff::rules::NurseryTestRule),
         #[cfg(feature = "test-rules")]
         (Ruff, "902") => (RuleGroup::Preview, rules::ruff::rules::PreviewTestRule),

--- a/crates/ruff/src/codes.rs
+++ b/crates/ruff/src/codes.rs
@@ -868,10 +868,10 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         #[cfg(feature = "test-rules")]
         (Ruff, "900") => (RuleGroup::Unspecified, rules::ruff::rules::StableTestRule),
         #[cfg(feature = "test-rules")]
-        #[allow(deprecated)]
-        (Ruff, "901") => (RuleGroup::Nursery, rules::ruff::rules::NurseryTestRule),
+        (Ruff, "901") => (RuleGroup::Preview, rules::ruff::rules::PreviewTestRule),
         #[cfg(feature = "test-rules")]
-        (Ruff, "902") => (RuleGroup::Preview, rules::ruff::rules::PreviewTestRule),
+        #[allow(deprecated)]
+        (Ruff, "902") => (RuleGroup::Nursery, rules::ruff::rules::NurseryTestRule),
 
         // flake8-django
         (Flake8Django, "001") => (RuleGroup::Unspecified, rules::flake8_django::rules::DjangoNullableModelStringField),

--- a/crates/ruff/src/codes.rs
+++ b/crates/ruff/src/codes.rs
@@ -865,6 +865,12 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Ruff, "017") => (RuleGroup::Nursery, rules::ruff::rules::QuadraticListSummation),
         (Ruff, "100") => (RuleGroup::Unspecified, rules::ruff::rules::UnusedNOQA),
         (Ruff, "200") => (RuleGroup::Unspecified, rules::ruff::rules::InvalidPyprojectToml),
+        #[cfg(test)]
+        (Ruff, "900") => (RuleGroup::Unspecified, rules::ruff::rules::StableTestRule),
+        #[cfg(test)]
+        (Ruff, "901") => (RuleGroup::Nursery, rules::ruff::rules::NurseryTestRule),
+        #[cfg(test)]
+        (Ruff, "902") => (RuleGroup::Preview, rules::ruff::rules::PreviewTestRule),
 
         // flake8-django
         (Flake8Django, "001") => (RuleGroup::Unspecified, rules::flake8_django::rules::DjangoNullableModelStringField),

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -214,7 +214,7 @@ pub fn check_path(
     }
 
     // Raise violations for internal test rules
-    #[cfg(test)]
+    #[cfg(feature = "test-rules")]
     {
         if settings.rules.enabled(Rule::StableTestRule) {
             diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -8,16 +8,6 @@ use itertools::Itertools;
 use log::error;
 use rustc_hash::FxHashMap;
 
-use ruff_diagnostics::Diagnostic;
-use ruff_python_ast::imports::ImportMap;
-use ruff_python_ast::PySourceType;
-use ruff_python_codegen::Stylist;
-use ruff_python_index::Indexer;
-use ruff_python_parser::lexer::LexResult;
-use ruff_python_parser::{AsMode, ParseError};
-use ruff_source_file::{Locator, SourceFileBuilder};
-use ruff_text_size::Ranged;
-
 use crate::autofix::{fix_file, FixResult};
 use crate::checkers::ast::check_ast;
 use crate::checkers::filesystem::check_file_path;
@@ -35,6 +25,15 @@ use crate::rules::pycodestyle;
 use crate::settings::{flags, Settings};
 use crate::source_kind::SourceKind;
 use crate::{directives, fs};
+use ruff_diagnostics::Diagnostic;
+use ruff_python_ast::imports::ImportMap;
+use ruff_python_ast::PySourceType;
+use ruff_python_codegen::Stylist;
+use ruff_python_index::Indexer;
+use ruff_python_parser::lexer::LexResult;
+use ruff_python_parser::{AsMode, ParseError};
+use ruff_source_file::{Locator, SourceFileBuilder};
+use ruff_text_size::Ranged;
 
 const CARGO_PKG_NAME: &str = env!("CARGO_PKG_NAME");
 const CARGO_PKG_REPOSITORY: &str = env!("CARGO_PKG_REPOSITORY");
@@ -218,21 +217,21 @@ pub fn check_path(
     {
         if settings.rules.enabled(Rule::StableTestRule) {
             diagnostics.push(Diagnostic::new(
-                Rule::StableTestRule,
+                crate::rules::ruff::rules::StableTestRule,
                 ruff_text_size::TextRange::default(),
             ));
         }
 
         if settings.rules.enabled(Rule::PreviewTestRule) {
             diagnostics.push(Diagnostic::new(
-                Rule::PreviewTestRule,
+                crate::rules::ruff::rules::PreviewTestRule,
                 ruff_text_size::TextRange::default(),
             ));
         }
 
         if settings.rules.enabled(Rule::NurseryTestRule) {
             diagnostics.push(Diagnostic::new(
-                Rule::NurseryTestRule,
+                crate::rules::ruff::rules::NurseryTestRule,
                 ruff_text_size::TextRange::default(),
             ));
         }

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -213,6 +213,31 @@ pub fn check_path(
         ));
     }
 
+    // Raise violations for internal test rules
+    #[cfg(test)]
+    {
+        if settings.rules.enabled(Rule::StableTestRule) {
+            diagnostics.push(Diagnostic::new(
+                Rule::StableTestRule,
+                ruff_text_size::TextRange::default(),
+            ));
+        }
+
+        if settings.rules.enabled(Rule::PreviewTestRule) {
+            diagnostics.push(Diagnostic::new(
+                Rule::PreviewTestRule,
+                ruff_text_size::TextRange::default(),
+            ));
+        }
+
+        if settings.rules.enabled(Rule::NurseryTestRule) {
+            diagnostics.push(Diagnostic::new(
+                Rule::NurseryTestRule,
+                ruff_text_size::TextRange::default(),
+            ));
+        }
+    }
+
     // Ignore diagnostics based on per-file-ignores.
     if !diagnostics.is_empty() && !settings.per_file_ignores.is_empty() {
         let ignores = fs::ignores_from_path(path, &settings.per_file_ignores);

--- a/crates/ruff/src/rules/ruff/rules/mod.rs
+++ b/crates/ruff/src/rules/ruff/rules/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use mutable_class_default::*;
 pub(crate) use mutable_dataclass_default::*;
 pub(crate) use pairwise_over_zipped::*;
 pub(crate) use static_key_dict_comprehension::*;
-#[cfg(test)]
+#[cfg(feature = "test-rules")]
 pub(crate) use test_rules::*;
 pub(crate) use unnecessary_iterable_allocation_for_first_element::*;
 #[cfg(feature = "unreachable-code")]
@@ -31,7 +31,7 @@ mod mutable_class_default;
 mod mutable_dataclass_default;
 mod pairwise_over_zipped;
 mod static_key_dict_comprehension;
-#[cfg(test)]
+#[cfg(feature = "test-rules")]
 mod test_rules;
 mod unnecessary_iterable_allocation_for_first_element;
 #[cfg(feature = "unreachable-code")]

--- a/crates/ruff/src/rules/ruff/rules/mod.rs
+++ b/crates/ruff/src/rules/ruff/rules/mod.rs
@@ -10,6 +10,8 @@ pub(crate) use mutable_class_default::*;
 pub(crate) use mutable_dataclass_default::*;
 pub(crate) use pairwise_over_zipped::*;
 pub(crate) use static_key_dict_comprehension::*;
+#[cfg(test)]
+pub(crate) use test_rules::*;
 pub(crate) use unnecessary_iterable_allocation_for_first_element::*;
 #[cfg(feature = "unreachable-code")]
 pub(crate) use unreachable::*;
@@ -29,6 +31,8 @@ mod mutable_class_default;
 mod mutable_dataclass_default;
 mod pairwise_over_zipped;
 mod static_key_dict_comprehension;
+#[cfg(test)]
+mod test_rules;
 mod unnecessary_iterable_allocation_for_first_element;
 #[cfg(feature = "unreachable-code")]
 pub(crate) mod unreachable;

--- a/crates/ruff/src/rules/ruff/rules/test_rules.rs
+++ b/crates/ruff/src/rules/ruff/rules/test_rules.rs
@@ -1,0 +1,83 @@
+use ruff_diagnostics::{AutofixKind, Violation};
+use ruff_macros::{derive_message_formats, violation};
+
+/// ## What it does
+/// Fake rule for testing.
+///
+/// ## Why is this bad?
+/// Tests must pass!
+///
+/// ## Example
+/// ```python
+/// foo
+/// ```
+///
+/// Use instead:
+/// ```python
+/// bar
+/// ```
+#[violation]
+pub struct StableTestRule;
+
+impl Violation for StableTestRule {
+    const AUTOFIX: AutofixKind = AutofixKind::None;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Hey this is a stable test rule.")
+    }
+}
+
+/// ## What it does
+/// Fake rule for testing.
+///
+/// ## Why is this bad?
+/// Tests must pass!
+///
+/// ## Example
+/// ```python
+/// foo
+/// ```
+///
+/// Use instead:
+/// ```python
+/// bar
+/// ```
+#[violation]
+pub struct PreviewTestRule;
+
+impl Violation for PreviewTestRule {
+    const AUTOFIX: AutofixKind = AutofixKind::None;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Hey this is a preview test rule.")
+    }
+}
+
+/// ## What it does
+/// Fake rule for testing.
+///
+/// ## Why is this bad?
+/// Tests must pass!
+///
+/// ## Example
+/// ```python
+/// foo
+/// ```
+///
+/// Use instead:
+/// ```python
+/// bar
+/// ```
+#[violation]
+pub struct NurseryTestRule;
+
+impl Violation for NurseryTestRule {
+    const AUTOFIX: AutofixKind = AutofixKind::None;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Hey this is a nursery test rule.")
+    }
+}

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -69,6 +69,7 @@ walkdir = { version = "2.3.2" }
 wild = { version = "2" }
 
 [dev-dependencies]
+ruff = { path = "../ruff", features = ["clap", "test-rules"] }
 assert_cmd = { version = "2.0.8" }
 # Avoid writing colored snapshots when running tests from the terminal
 colored = { workspace = true, features = ["no-color"]}

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -278,7 +278,8 @@ fn nursery_all() {
     ----- stdout -----
     -:1:1: E741 Ambiguous variable name: `I`
     -:1:1: D100 Missing docstring in public module
-    Found 2 errors.
+    -:1:1: RUF900 Hey this is a stable test rule.
+    Found 3 errors.
 
     ----- stderr -----
     warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Ignoring `one-blank-line-before-class`.
@@ -317,8 +318,9 @@ fn nursery_group_selector() {
     exit_code: 1
     ----- stdout -----
     -:1:1: CPY001 Missing copyright notice at top of file
+    -:1:1: RUF902 Hey this is a nursery test rule.
     -:1:2: E225 Missing whitespace around operator
-    Found 2 errors.
+    Found 3 errors.
 
     ----- stderr -----
     warning: The `NURSERY` selector has been deprecated. Use the `--preview` flag instead.
@@ -337,8 +339,9 @@ fn nursery_group_selector_preview_enabled() {
     exit_code: 1
     ----- stdout -----
     -:1:1: CPY001 Missing copyright notice at top of file
+    -:1:1: RUF902 Hey this is a nursery test rule.
     -:1:2: E225 Missing whitespace around operator
-    Found 2 errors.
+    Found 3 errors.
 
     ----- stderr -----
     warning: The `NURSERY` selector has been deprecated. Use the `PREVIEW` selector instead.
@@ -377,8 +380,11 @@ fn preview_enabled_all() {
     -:1:1: E741 Ambiguous variable name: `I`
     -:1:1: D100 Missing docstring in public module
     -:1:1: CPY001 Missing copyright notice at top of file
+    -:1:1: RUF900 Hey this is a stable test rule.
+    -:1:1: RUF901 Hey this is a preview test rule.
+    -:1:1: RUF902 Hey this is a nursery test rule.
     -:1:2: E225 Missing whitespace around operator
-    Found 4 errors.
+    Found 7 errors.
 
     ----- stderr -----
     warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Ignoring `one-blank-line-before-class`.
@@ -467,8 +473,10 @@ fn preview_enabled_group_selector() {
     exit_code: 1
     ----- stdout -----
     -:1:1: CPY001 Missing copyright notice at top of file
+    -:1:1: RUF901 Hey this is a preview test rule.
+    -:1:1: RUF902 Hey this is a nursery test rule.
     -:1:2: E225 Missing whitespace around operator
-    Found 2 errors.
+    Found 4 errors.
 
     ----- stderr -----
     "###);


### PR DESCRIPTION
Follow-up to discussion in #7210

Moves integration tests from using rules that are transitively in nursery / preview groups to dedicated test rules that only exist during development. These rules _always_ raise violations (they do not require specific file behavior).

Uses features instead of `cfg(test)` for cross-crate support per https://github.com/rust-lang/cargo/issues/8379