### PR TITLE
Show rule codes in shell tab completion

### DIFF
--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -5,6 +5,8 @@
 //!
 //! [Ruff]: https://github.com/astral-sh/ruff
 
+#[cfg(feature = "clap")]
+pub use rule_selector::clap_completion::RuleSelectorParser;
 pub use rule_selector::RuleSelector;
 pub use rules::pycodestyle::rules::{IOError, SyntaxError};
 

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -1,17 +1,16 @@
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use clap::{command, Parser};
 use regex::Regex;
-use ruff::line_width::LineLength;
 use rustc_hash::FxHashMap;
 
+use ruff::line_width::LineLength;
 use ruff::logging::LogLevel;
 use ruff::registry::Rule;
 use ruff::settings::types::{
     FilePattern, PatternPrefixPair, PerFileIgnore, PreviewMode, PythonVersion, SerializationFormat,
 };
-use ruff::RuleSelector;
+use ruff::{RuleSelector, RuleSelectorParser};
 use ruff_workspace::configuration::{Configuration, RuleSelection};
 use ruff_workspace::resolver::ConfigProcessor;
 
@@ -129,7 +128,7 @@ pub struct CheckCommand {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
-        value_parser = parse_rule_selector,
+        value_parser = RuleSelectorParser,
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
@@ -139,7 +138,7 @@ pub struct CheckCommand {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
-        value_parser = parse_rule_selector,
+        value_parser = RuleSelectorParser,
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
@@ -149,7 +148,7 @@ pub struct CheckCommand {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
-        value_parser = parse_rule_selector,
+        value_parser = RuleSelectorParser,
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
@@ -159,7 +158,7 @@ pub struct CheckCommand {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
-        value_parser = parse_rule_selector,
+        value_parser = RuleSelectorParser,
         help_heading = "Rule selection",
         hide = true
     )]
@@ -191,7 +190,7 @@ pub struct CheckCommand {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
-        value_parser = parse_rule_selector,
+        value_parser = RuleSelectorParser,
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
@@ -201,7 +200,7 @@ pub struct CheckCommand {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
-        value_parser = parse_rule_selector,
+        value_parser = RuleSelectorParser,
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
@@ -211,7 +210,7 @@ pub struct CheckCommand {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
-        value_parser = parse_rule_selector,
+        value_parser = RuleSelectorParser,
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
@@ -221,7 +220,7 @@ pub struct CheckCommand {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
-        value_parser = parse_rule_selector,
+        value_parser = RuleSelectorParser,
         help_heading = "Rule selection",
         hide = true
     )]
@@ -509,11 +508,6 @@ impl FormatCommand {
             },
         )
     }
-}
-
-fn parse_rule_selector(env: &str) -> Result<RuleSelector, std::io::Error> {
-    RuleSelector::from_str(env)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
 }
 
 fn resolve_bool_arg(yes: bool, no: bool) -> Option<bool> {

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -451,7 +451,7 @@ fn preview_group_selector() {
     ----- stdout -----
 
     ----- stderr -----
-    error: invalid value 'PREVIEW' for '--select <RULE_CODE>': Unknown rule selector: `PREVIEW`
+    error: invalid value 'PREVIEW' for '--select <RULE_CODE>'
 
     For more information, try '--help'.
     "###);
@@ -470,7 +470,7 @@ fn preview_enabled_group_ignore() {
     ----- stdout -----
 
     ----- stderr -----
-    error: invalid value 'PREVIEW' for '--ignore <RULE_CODE>': Unknown rule selector: `PREVIEW`
+    error: invalid value 'PREVIEW' for '--ignore <RULE_CODE>'
 
     For more information, try '--help'.
     "###);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -476,7 +476,7 @@ Ruff supports two command-line flags that alter its exit code behavior:
     `--exit-non-zero-on-fix` can result in a non-zero exit code even if no violations remain after
     autofixing.
 
-## Autocompletion
+## Shell autocompletion
 
 Ruff supports autocompletion for most shells. A shell-specific completion script can be generated
 by `ruff generate-shell-completion <SHELL>`, where `<SHELL>` is one of `bash`, `elvish`, `fig`, `fish`,


### PR DESCRIPTION
## Summary

I noticed that we have a custom parser for rule selectors, but it wasn't actually being used? This PR adds it back to our Clap setup and changes the parser to only show full categories and individual rules when tab-completing:

<img width="1792" alt="Screen Shot 2023-09-13 at 9 13 38 PM" src="https://github.com/astral-sh/ruff/assets/1309177/028b18d2-8c92-49c1-b781-f24c9ae310f7">

<img width="1792" alt="Screen Shot 2023-09-13 at 9 13 40 PM" src="https://github.com/astral-sh/ruff/assets/1309177/fd598da5-78fb-412d-a69e-2a0963d479cd">

<img width="1792" alt="Screen Shot 2023-09-13 at 9 13 58 PM" src="https://github.com/astral-sh/ruff/assets/1309177/7c482b90-6e54-425c-ae23-fb50496a177a">

The previous implementation showed all codes, which I found too noisy:

<img width="1792" alt="Screen Shot 2023-09-13 at 8 57 09 PM" src="https://github.com/astral-sh/ruff/assets/1309177/db370a0e-2a9f-4acd-b1e3-224a1f8e9ce5">
