### PR TITLE
Allow `NUL` character in f-strings

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -552,7 +552,10 @@ impl<'source> Lexer<'source> {
 
         loop {
             match self.cursor.first() {
-                EOF_CHAR => {
+                // The condition is to differentiate between the `NUL` (`\0`) character
+                // in the source code and the one returned by `self.cursor.first()` when
+                // we reach the end of the source code.
+                EOF_CHAR if self.cursor.is_eof() => {
                     let error = if fstring.is_triple_quoted() {
                         FStringErrorType::UnterminatedTripleQuotedString
                     } else {
@@ -2017,6 +2020,12 @@ f"{lambda x:{x}}"
 f"{(lambda x:{x})}"
 "#
         .trim();
+        assert_debug_snapshot!(lex_source(source));
+    }
+
+    #[test]
+    fn test_fstring_with_nul_char() {
+        let source = r"f'\0'";
         assert_debug_snapshot!(lex_source(source));
     }
 

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_nul_char.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_with_nul_char.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: lex_source(source)
+---
+[
+    (
+        FStringStart,
+        0..2,
+    ),
+    (
+        FStringMiddle {
+            value: "\\0",
+            is_raw: false,
+        },
+        2..4,
+    ),
+    (
+        FStringEnd,
+        4..5,
+    ),
+    (
+        Newline,
+        5..5,
+    ),
+]


### PR DESCRIPTION
## Summary

This PR fixes the bug to allow `NUL` (`\0`) character inside f-strings.

## Test Plan

Add test case with `NUL` character inside f-string.
