### PR TITLE
fix: Don't omit optional parentheses for subscripts

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/slice.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/slice.py
@@ -91,3 +91,10 @@ f = "f"[:,]
 g1 = "g"[(1):(2)]
 g2 = "g"[(1):(2):(3)]
 
+# Don't omit optional parentheses for subscripts
+# https://github.com/astral-sh/ruff/issues/7319
+def f():
+    return (
+        package_version is not None
+        and package_version.split(".")[:2] == package_info.version.split(".")[:2]
+    )

--- a/crates/ruff_python_formatter/src/expression/expr_subscript.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_subscript.rs
@@ -57,8 +57,6 @@ impl FormatNodeRule<ExprSubscript> for FormatExprSubscript {
         }
 
         let format_slice = format_with(|f: &mut PyFormatter| {
-            let mut f = WithNodeLevel::new(NodeLevel::ParenthesizedExpression, f);
-
             if let Expr::Tuple(tuple) = slice.as_ref() {
                 write!(f, [tuple.format().with_options(TupleParentheses::Preserve)])
             } else {

--- a/crates/ruff_python_formatter/src/expression/expr_subscript.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_subscript.rs
@@ -3,7 +3,6 @@ use ruff_python_ast::node::{AnyNodeRef, AstNode};
 use ruff_python_ast::{Expr, ExprSubscript};
 
 use crate::comments::SourceComment;
-use crate::context::{NodeLevel, WithNodeLevel};
 use crate::expression::expr_tuple::TupleParentheses;
 use crate::expression::parentheses::{parenthesized, NeedsParentheses, OptionalParentheses};
 use crate::expression::CallChainLayout;
@@ -41,19 +40,11 @@ impl FormatNodeRule<ExprSubscript> for FormatExprSubscript {
             "A subscript expression can only have a single dangling comment, the one after the bracket"
         );
 
-        let format_value = format_with(|f| match value.as_ref() {
-            Expr::Attribute(expr) => expr.format().with_options(call_chain_layout).fmt(f),
-            Expr::Call(expr) => expr.format().with_options(call_chain_layout).fmt(f),
-            Expr::Subscript(expr) => expr.format().with_options(call_chain_layout).fmt(f),
-            _ => value.format().fmt(f),
-        });
-
-        if let NodeLevel::Expression(Some(_)) = f.context().node_level() {
-            // Enforce the optional parentheses for parenthesized values.
-            let mut f = WithNodeLevel::new(NodeLevel::Expression(None), f);
-            write!(f, [format_value])?;
-        } else {
-            format_value.fmt(f)?;
+        match value.as_ref() {
+            Expr::Attribute(expr) => expr.format().with_options(call_chain_layout).fmt(f)?,
+            Expr::Call(expr) => expr.format().with_options(call_chain_layout).fmt(f)?,
+            Expr::Subscript(expr) => expr.format().with_options(call_chain_layout).fmt(f)?,
+            _ => value.format().fmt(f)?,
         }
 
         let format_slice = format_with(|f: &mut PyFormatter| {

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__expression.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__expression.py.snap
@@ -275,23 +275,7 @@ last_call()
  flags & ~select.EPOLLIN and waiters.write_task is not None
  lambda arg: None
  lambda a=True: a
-@@ -39,10 +39,11 @@
- lambda a, b, c=True, *, d=(1 << v2), e="str": a
- lambda a, b, c=True, *vararg, d=(v1 << 2), e="str", **kwargs: a + b
- manylambdas = lambda x=lambda y=lambda z=1: z: y(): x()
--foo = lambda port_id, ignore_missing: {
--    "port1": port1_resource,
--    "port2": port2_resource,
--}[port_id]
-+foo = (
-+    lambda port_id, ignore_missing: {"port1": port1_resource, "port2": port2_resource}[
-+        port_id
-+    ]
-+)
- 1 if True else 2
- str or None if True else str or bytes or None
- (str or None) if True else (str or bytes or None)
-@@ -115,7 +116,7 @@
+@@ -115,7 +115,7 @@
      arg,
      another,
      kwarg="hey",
@@ -346,11 +330,10 @@ lambda a, b, c=True: a
 lambda a, b, c=True, *, d=(1 << v2), e="str": a
 lambda a, b, c=True, *vararg, d=(v1 << 2), e="str", **kwargs: a + b
 manylambdas = lambda x=lambda y=lambda z=1: z: y(): x()
-foo = (
-    lambda port_id, ignore_missing: {"port1": port1_resource, "port2": port2_resource}[
-        port_id
-    ]
-)
+foo = lambda port_id, ignore_missing: {
+    "port1": port1_resource,
+    "port2": port2_resource,
+}[port_id]
 1 if True else 2
 str or None if True else str or bytes or None
 (str or None) if True else (str or bytes or None)

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__compare.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__compare.py.snap
@@ -324,13 +324,13 @@ ct_match = (
     aaaaaaaaaaact_id == self.get_content_type(obj=rel_obj, using=instance._state.db)[id]
 )
 
-ct_match = {
-    aaaaaaaaaaaaaaaa
-} == self.get_content_type(obj=rel_obj, using=instance._state.db)[id]
+ct_match = {aaaaaaaaaaaaaaaa} == self.get_content_type(
+    obj=rel_obj, using=instance._state.db
+)[id]
 
-ct_match = (
-    aaaaaaaaaaaaaaaa
-) == self.get_content_type(obj=rel_obj, using=instance._state.db)[id]
+ct_match = (aaaaaaaaaaaaaaaa) == self.get_content_type(
+    obj=rel_obj, using=instance._state.db
+)[id]
 
 # Subscripts expressions with trailing attributes.
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__slice.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__slice.py.snap
@@ -97,6 +97,13 @@ f = "f"[:,]
 g1 = "g"[(1):(2)]
 g2 = "g"[(1):(2):(3)]
 
+# Don't omit optional parentheses for subscripts
+# https://github.com/astral-sh/ruff/issues/7319
+def f():
+    return (
+        package_version is not None
+        and package_version.split(".")[:2] == package_info.version.split(".")[:2]
+    )
 ```
 
 ## Output
@@ -191,6 +198,15 @@ f = "f"[:,]
 # Regression test for https://github.com/astral-sh/ruff/issues/5733
 g1 = "g"[(1):(2)]
 g2 = "g"[(1):(2):(3)]
+
+
+# Don't omit optional parentheses for subscripts
+# https://github.com/astral-sh/ruff/issues/7319
+def f():
+    return (
+        package_version is not None
+        and package_version.split(".")[:2] == package_info.version.split(".")[:2]
+    )
 ```
 
 


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/7319

Ruff formatted

```python
def f():
    return (
        package_version is not None
        and package_version.split(".")[:2] == package_info.version.split(".")[:2]
    )
```

as 

```python
def f():
    return package_version is not None and package_version.split(".")[
        :2
    ] == package_info.version.split(".")[:2]
```

Because our `can_omit_parentheses` returned `true` when an expression starts or ends with a subscript whereas Black's does not. 

https://github.com/psf/black/blob/c160e4b7ce30c661ac4f2dfa5038becf1b8c5c33/src/black/lines.py#L969-L973

This PR excludes Subscript from `can_omit_parentheses`.

## Test Plan

Added test plan

**Base**
| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99981 |              2760 |                40 |
| transformers |           0.99944 |              2587 |               413 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| warehouse    |           0.99834 |               648 |                20 |
| zulip        |           0.99956 |              1437 |                23 |


**This PR**
| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| **django**       |           0.99981 |              2760 |                39 |
| **transformers** |           0.99952 |              2587 |               408 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| **warehouse**    |           0.99923 |               648 |                18 |
| zulip        |           0.99956 |              1437 |                23 |
