### PR TITLE
fix: Group fluent subscript

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/slice.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/slice.py
@@ -98,3 +98,15 @@ def f():
         package_version is not None
         and package_version.split(".")[:2] == package_info.version.split(".")[:2]
     )
+
+
+# Group to ensure other arguments don't expand.
+self.assertEqual(
+    houses.all()[0].occupants.all()[0].houses.all()[1].rooms.all()[0],
+    self.room2_1,
+)
+
+self.assertEqual(
+    suite._tests[0].id().split(".")[0],
+    os.path.basename(os.getcwd()),
+)

--- a/crates/ruff_python_formatter/src/expression/binary_like.rs
+++ b/crates/ruff_python_formatter/src/expression/binary_like.rs
@@ -667,7 +667,10 @@ impl Format<PyFormatContext<'_>> for FlatBinaryExpressionSlice<'_> {
                     leading_comments(leading).fmt(f)?;
                 }
 
-                in_parentheses_only_group(&left).fmt(f)?;
+                match &left.0 {
+                    [OperandOrOperator::Operand(operand)] => operand.fmt(f)?,
+                    _ => in_parentheses_only_group(&left).fmt(f)?,
+                }
 
                 if let Some(trailing) = left.last_operand().trailing_binary_comments() {
                     trailing_comments(trailing).fmt(f)?;
@@ -708,7 +711,10 @@ impl Format<PyFormatContext<'_>> for FlatBinaryExpressionSlice<'_> {
             leading_comments(leading).fmt(f)?;
         }
 
-        in_parentheses_only_group(&right).fmt(f)
+        match &right.0 {
+            [OperandOrOperator::Operand(operand)] => operand.fmt(f),
+            _ => in_parentheses_only_group(&right).fmt(f),
+        }
     }
 }
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__slice.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__slice.py.snap
@@ -104,6 +104,18 @@ def f():
         package_version is not None
         and package_version.split(".")[:2] == package_info.version.split(".")[:2]
     )
+
+
+# Group to ensure other arguments don't expand.
+self.assertEqual(
+    houses.all()[0].occupants.all()[0].houses.all()[1].rooms.all()[0],
+    self.room2_1,
+)
+
+self.assertEqual(
+    suite._tests[0].id().split(".")[0],
+    os.path.basename(os.getcwd()),
+)
 ```
 
 ## Output
@@ -207,6 +219,18 @@ def f():
         package_version is not None
         and package_version.split(".")[:2] == package_info.version.split(".")[:2]
     )
+
+
+# Group to ensure other arguments don't expand.
+self.assertEqual(
+    houses.all()[0].occupants.all()[0].houses.all()[1].rooms.all()[0],
+    self.room2_1,
+)
+
+self.assertEqual(
+    suite._tests[0].id().split(".")[0],
+    os.path.basename(os.getcwd()),
+)
 ```
 
 


### PR DESCRIPTION
## Summary

Wrap fluent subscript calls in a group the same as for attributes or call expressions. This ensures that the chain only splits if it doesn't fit on a line and not if the enclosing group (e.g. all arguments) don't fit. 

This fixes a black deviation where 

```python
self.assertEqual(
    houses.all()[0].occupants.all()[0].houses.all()[1].rooms.all()[0],
    self.room2_1,
)


self.assertEqual(
    suite._tests[0].id().split(".")[0],
    os.path.basename(os.getcwd()),
)
```

was formatted as 

```python
self.assertEqual(
    houses.all()[0]
    .occupants.all()[0]
    .houses.all()[1]
    .rooms.all()[0],
    self.room2_1,
)


self.assertEqual(
    suite._tests[0]
    .id()
    .split(".")[0],
    os.path.basename(os.getcwd()),
)
```

because of the trailing comma. 


## Test Plan

Added test

**Base**

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99981 |              2760 |                39 |
| transformers |           0.99952 |              2587 |               408 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| warehouse    |           0.99923 |               648 |                18 |
| zulip        |           0.99962 |              1437 |                22 |


**This PR**

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| **django**       |           0.99982 |              2760 |                37 |
| transformers |           0.99952 |              2587 |               408 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| warehouse    |           0.99923 |               648 |                18 |
| zulip        |           0.99962 |              1437 |                22 |

