### PR TITLE
Remove the `PREVIEW` rule selector

### DIFF
--- a/crates/ruff/src/rule_selector.rs
+++ b/crates/ruff/src/rule_selector.rs
@@ -15,10 +15,8 @@ use crate::settings::types::PreviewMode;
 pub enum RuleSelector {
     /// Select all rules (includes rules in preview if enabled)
     All,
-    /// Category to select all rules in preview (includes legacy nursery rules)
-    Preview,
     /// Legacy category to select all rules in the "nursery" which predated preview mode
-    #[deprecated(note = "Use `RuleSelector::Preview` for new rules instead")]
+    #[deprecated(note = "The nursery was replaced with 'preview mode' which has no selector")]
     Nursery,
     /// Legacy category to select both the `mccabe` and `flake8-comprehensions` linters
     /// via a single selector.
@@ -54,7 +52,6 @@ impl FromStr for RuleSelector {
             "ALL" => Ok(Self::All),
             #[allow(deprecated)]
             "NURSERY" => Ok(Self::Nursery),
-            "PREVIEW" => Ok(Self::Preview),
             "C" => Ok(Self::C),
             "T" => Ok(Self::T),
             _ => {
@@ -121,7 +118,6 @@ impl RuleSelector {
             RuleSelector::All => ("", "ALL"),
             #[allow(deprecated)]
             RuleSelector::Nursery => ("", "NURSERY"),
-            RuleSelector::Preview => ("", "PREVIEW"),
             RuleSelector::C => ("", "C"),
             RuleSelector::T => ("", "T"),
             RuleSelector::Prefix { prefix, .. } | RuleSelector::Rule { prefix, .. } => {
@@ -185,9 +181,6 @@ impl RuleSelector {
             RuleSelector::Nursery => {
                 RuleSelectorIter::Nursery(Rule::iter().filter(Rule::is_nursery))
             }
-            RuleSelector::Preview => RuleSelectorIter::Nursery(
-                Rule::iter().filter(|rule| rule.is_preview() || rule.is_nursery()),
-            ),
             RuleSelector::C => RuleSelectorIter::Chain(
                 Linter::Flake8Comprehensions
                     .rules()
@@ -301,7 +294,6 @@ impl RuleSelector {
     pub fn specificity(&self) -> Specificity {
         match self {
             RuleSelector::All => Specificity::All,
-            RuleSelector::Preview => Specificity::All,
             #[allow(deprecated)]
             RuleSelector::Nursery => Specificity::All,
             RuleSelector::T => Specificity::LinterGroup,

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -341,7 +341,7 @@ fn nursery_group_selector_preview_enabled() {
     Found 2 errors.
 
     ----- stderr -----
-    warning: The `NURSERY` selector has been deprecated. Use the `PREVIEW` selector instead.
+    warning: The `NURSERY` selector has been deprecated.
     "###);
 }
 
@@ -439,38 +439,21 @@ fn preview_disabled_prefix_empty() {
 }
 
 #[test]
-fn preview_disabled_group_selector() {
-    // `--select PREVIEW` should warn without the `--preview` flag
-    let args = ["--select", "PREVIEW"];
-    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-        .args(STDIN_BASE_OPTIONS)
-        .args(args)
-        .pass_stdin("I=42\n"), @r###"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    warning: Selection `PREVIEW` has no effect because the `--preview` flag was not included.
-    "###);
-}
-
-#[test]
-fn preview_enabled_group_selector() {
-    // `--select PREVIEW` is okay with the `--preview` flag and shouldn't warn
+fn preview_group_selector() {
+    // `--select PREVIEW` should error (selector was removed)
     let args = ["--select", "PREVIEW", "--preview"];
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(STDIN_BASE_OPTIONS)
         .args(args)
         .pass_stdin("I=42\n"), @r###"
     success: false
-    exit_code: 1
+    exit_code: 2
     ----- stdout -----
-    -:1:1: CPY001 Missing copyright notice at top of file
-    -:1:2: E225 Missing whitespace around operator
-    Found 2 errors.
 
     ----- stderr -----
+    error: invalid value 'PREVIEW' for '--select <RULE_CODE>': Unknown rule selector: `PREVIEW`
+
+    For more information, try '--help'.
     "###);
 }
 
@@ -483,13 +466,13 @@ fn preview_enabled_group_ignore() {
         .args(args)
         .pass_stdin("I=42\n"), @r###"
     success: false
-    exit_code: 1
+    exit_code: 2
     ----- stdout -----
-    -:1:1: E741 Ambiguous variable name: `I`
-    -:1:2: E225 Missing whitespace around operator
-    Found 2 errors.
 
     ----- stderr -----
+    error: invalid value 'PREVIEW' for '--ignore <RULE_CODE>': Unknown rule selector: `PREVIEW`
+
+    For more information, try '--help'.
     "###);
 }
 

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -588,11 +588,12 @@ impl Configuration {
                 #[allow(deprecated)]
                 if matches!(selector, RuleSelector::Nursery) {
                     let suggestion = if preview.is_disabled() {
-                        "Use the `--preview` flag instead."
+                        " Use the `--preview` flag instead."
                     } else {
-                        "Use the `PREVIEW` selector instead."
+                        // We have no suggested alternative since there is intentionally no "PREVIEW" selector
+                        ""
                     };
-                    warn_user_once!("The `NURSERY` selector has been deprecated. {suggestion}");
+                    warn_user_once!("The `NURSERY` selector has been deprecated.{suggestion}");
                 }
 
                 if preview.is_disabled() {
@@ -1093,6 +1094,27 @@ mod tests {
     }
 
     #[test]
+    fn select_all_preview() {
+        let actual = resolve_rules(
+            [RuleSelection {
+                select: Some(vec![RuleSelector::All]),
+                ..RuleSelection::default()
+            }],
+            Some(PreviewMode::Disabled),
+        );
+        assert!(!actual.intersects(&RuleSet::from_rules(PREVIEW_RULES)));
+
+        let actual = resolve_rules(
+            [RuleSelection {
+                select: Some(vec![RuleSelector::All]),
+                ..RuleSelection::default()
+            }],
+            Some(PreviewMode::Enabled),
+        );
+        assert!(actual.intersects(&RuleSet::from_rules(PREVIEW_RULES)));
+    }
+
+    #[test]
     fn select_linter_preview() {
         let actual = resolve_rules(
             [RuleSelection {
@@ -1158,31 +1180,6 @@ mod tests {
             Some(PreviewMode::Enabled),
         );
         let expected = RuleSet::from_rule(Rule::SliceCopy);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn select_preview() {
-        let actual = resolve_rules(
-            [RuleSelection {
-                select: Some(vec![RuleSelector::Preview]),
-                ..RuleSelection::default()
-            }],
-            Some(PreviewMode::Disabled),
-        );
-        let expected = RuleSet::empty();
-        assert_eq!(actual, expected);
-
-        let actual = resolve_rules(
-            [RuleSelection {
-                select: Some(vec![RuleSelector::Preview]),
-                ..RuleSelection::default()
-            }],
-            Some(PreviewMode::Enabled),
-        );
-
-        let expected =
-            RuleSet::from_rules(NURSERY_RULES).union(&RuleSet::from_rules(PREVIEW_RULES));
         assert_eq!(actual, expected);
     }
 


### PR DESCRIPTION
The rule selector is not useful because `--select PREVIEW` only targets Ruff developers and `--ignore PREVIEW` has no effect due to its low specificity. We may restore it later if useful.