### PR TITLE
Add `explicit-preview-rules` to toggle explicit selection of preview rules

### DIFF
--- a/crates/flake8_to_ruff/src/plugin.rs
+++ b/crates/flake8_to_ruff/src/plugin.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use anyhow::anyhow;
 use ruff_linter::registry::Linter;
-use ruff_linter::settings::types::PreviewMode;
+use ruff_linter::rule_selector::PreviewOptions;
 use ruff_linter::RuleSelector;
 
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
@@ -332,7 +332,7 @@ pub(crate) fn infer_plugins_from_codes(selectors: &HashSet<RuleSelector>) -> Vec
     .filter(|plugin| {
         for selector in selectors {
             if selector
-                .rules(PreviewMode::Disabled)
+                .rules(&PreviewOptions::default())
                 .any(|rule| Linter::from(plugin).rules().any(|r| r == rule))
             {
                 return true;

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -30,6 +30,7 @@ use super::line_width::{LineLength, TabSize};
 
 use self::rule_table::RuleTable;
 use self::types::PreviewMode;
+use crate::rule_selector::PreviewOptions;
 
 pub mod flags;
 pub mod rule_table;
@@ -44,6 +45,7 @@ pub struct LinterSettings {
 
     pub target_version: PythonVersion,
     pub preview: PreviewMode,
+    pub explicit_preview_rules: bool,
 
     // Rule-specific settings
     pub allowed_confusables: FxHashSet<char>,
@@ -121,7 +123,7 @@ impl LinterSettings {
             project_root: project_root.to_path_buf(),
             rules: PREFIXES
                 .iter()
-                .flat_map(|selector| selector.rules(PreviewMode::default()))
+                .flat_map(|selector| selector.rules(&PreviewOptions::default()))
                 .collect(),
             allowed_confusables: FxHashSet::from_iter([]),
 
@@ -168,6 +170,7 @@ impl LinterSettings {
             pylint: pylint::settings::Settings::default(),
             pyupgrade: pyupgrade::settings::Settings::default(),
             preview: PreviewMode::default(),
+            explicit_preview_rules: false,
         }
     }
 

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -570,6 +570,19 @@ pub struct LintOptions {
     )]
     pub select: Option<Vec<RuleSelector>>,
 
+    /// Whether to require exact codes to select preview rules. When enabled,
+    /// preview rules will not be selected by prefixes — the full code of each
+    /// preview rule will be required to enable the rule.
+    #[option(
+        default = "false",
+        value_type = "bool",
+        example = r#"
+            # Require explicit selection of preview rules
+            explicit-preview-rules = true
+        "#
+    )]
+    pub explicit_preview_rules: Option<bool>,
+
     /// A list of task tags to recognize (e.g., "TODO", "FIXME", "XXX").
     ///
     /// Comments starting with these tags will be ignored by commented-out code

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -47,11 +47,28 @@ Or, if you provided the `--preview` CLI flag.
 
 To see which rules are currently in preview, visit the [rules reference](rules.md).
 
+## Selecting single preview rules
+
+When preview mode is enabled, selecting rule categories or prefixes will include all preview rules that match.
+If you would prefer to opt-in to each preview rule individually, you can toggle the `explicit-preview-rules`
+setting in your `pyproject.toml`:
+
+```toml
+[tool.ruff]
+preview = true
+explicit-preview-rules = true
+```
+
+In our previous example, `--select` with `ALL` `HYP`, `HYP0`, or `HYP00` would not enable `HYP001`. Each preview
+rule will need to be selected with its exact code, e.g. `--select ALL,HYP001`.
+
+If preview mode is not enabled, this setting has no effect.
+
 ## Legacy behavior
 
 Before the preview mode was introduced, new rules were added in a "nursery" category that required selection of
-rules with their exact code.
+rules with their exact codes — similar to if `explicit-preview-rules` is enabled.
 
-The nursery category has been deprecated and all rules in the nursery are now considered to be in preview. For backwards
-compatibility, nursery rules are selectable with their exact codes without enabling preview mode but a warning will
-be displayed.
+The nursery category has been deprecated and all rules in the nursery are now considered to be in preview.
+For backwards compatibility, nursery rules are selectable with their exact codes without enabling preview mode.
+However, this behavior will display a warning and support will be removed in a future release.

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -50,6 +50,13 @@
         "type": "string"
       }
     },
+    "explicit-preview-rules": {
+      "description": "Whether to require exact codes to select preview rules. When enabled, preview rules will not be selected by prefixes — the full code of each preview rule will be required to enable the rule.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "extend": {
       "description": "A path to a local `pyproject.toml` file to merge into this configuration. User home directory and environment variables will be expanded.\n\nTo resolve the current `pyproject.toml` file, Ruff will first resolve this base configuration file, then merge in any properties defined in the current configuration file.",
       "type": [
@@ -1566,6 +1573,13 @@
           "description": "A regular expression used to identify \"dummy\" variables, or those which should be ignored when enforcing (e.g.) unused-variable rules. The default expression matches `_`, `__`, and `_var`, but not `_var_`.",
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "explicit-preview-rules": {
+          "description": "Whether to require exact codes to select preview rules. When enabled, preview rules will not be selected by prefixes — the full code of each preview rule will be required to enable the rule.",
+          "type": [
+            "boolean",
             "null"
           ]
         },


### PR DESCRIPTION
Closes #7434 

Replaces the `PREVIEW` selector (removed in #7389) with a configuration option `explicit-preview-rules` which requires selectors to use exact rule codes for all preview rules. This allows users to enable preview without opting into all preview rules at once.

## Test plan

Unit tests