### PR TITLE
Use dot references in docs for methods

### DIFF
--- a/crates/ruff/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
@@ -17,8 +17,8 @@ use crate::checkers::ast::Checker;
 /// contains multiple characters, the reader may be misled into thinking that
 /// a prefix or suffix is being removed, rather than a set of characters.
 ///
-/// In Python 3.9 and later, you can use `str#removeprefix` and
-/// `str#removesuffix` to remove an exact prefix or suffix from a string,
+/// In Python 3.9 and later, you can use `str.removeprefix` and
+/// `str.removesuffix` to remove an exact prefix or suffix from a string,
 /// respectively, which should be preferred when possible.
 ///
 /// ## Example

--- a/crates/ruff/src/rules/flake8_builtins/rules/builtin_attribute_shadowing.rs
+++ b/crates/ruff/src/rules/flake8_builtins/rules/builtin_attribute_shadowing.rs
@@ -137,13 +137,13 @@ fn is_standard_library_override(
         return false;
     };
     match name {
-        // Ex) `Event#set`
+        // Ex) `Event.set`
         "set" => bases.iter().any(|base| {
             semantic
                 .resolve_call_path(base)
                 .is_some_and(|call_path| matches!(call_path.as_slice(), ["threading", "Event"]))
         }),
-        // Ex) `Filter#filter`
+        // Ex) `Filter.filter`
         "filter" => bases.iter().any(|base| {
             semantic
                 .resolve_call_path(base)

--- a/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -12,10 +12,10 @@ use crate::registry::AsRule;
 use crate::rules::flynt::helpers;
 
 /// ## What it does
-/// Checks for `str#join` calls that can be replaced with f-strings.
+/// Checks for `str.join` calls that can be replaced with f-strings.
 ///
 /// ## Why is this bad?
-/// f-strings are more readable and generally preferred over `str#join` calls.
+/// f-strings are more readable and generally preferred over `str.join` calls.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/pylint/rules/bad_str_strip_call.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_str_strip_call.rs
@@ -11,15 +11,15 @@ use crate::checkers::ast::Checker;
 use crate::settings::types::PythonVersion;
 
 /// ## What it does
-/// Checks duplicate characters in `str#strip` calls.
+/// Checks duplicate characters in `str.strip` calls.
 ///
 /// ## Why is this bad?
-/// All characters in `str#strip` calls are removed from both the leading and
+/// All characters in `str.strip` calls are removed from both the leading and
 /// trailing ends of the string. Including duplicate characters in the call
 /// is redundant and often indicative of a mistake.
 ///
-/// In Python 3.9 and later, you can use `str#removeprefix` and
-/// `str#removesuffix` to remove an exact prefix or suffix from a string,
+/// In Python 3.9 and later, you can use `str.removeprefix` and
+/// `str.removesuffix` to remove an exact prefix or suffix from a string,
 /// respectively, which should be preferred when possible.
 ///
 /// ## Example

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -22,10 +22,10 @@ use crate::rules::pyflakes::format::FormatSummary;
 use crate::rules::pyupgrade::helpers::curly_escape;
 
 /// ## What it does
-/// Checks for `str#format` calls that can be replaced with f-strings.
+/// Checks for `str.format` calls that can be replaced with f-strings.
 ///
 /// ## Why is this bad?
-/// f-strings are more readable and generally preferred over `str#format`
+/// f-strings are more readable and generally preferred over `str.format`
 /// calls.
 ///
 /// ## Example

--- a/crates/ruff/src/rules/refurb/rules/check_and_remove_from_set.rs
+++ b/crates/ruff/src/rules/refurb/rules/check_and_remove_from_set.rs
@@ -12,7 +12,7 @@ use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 
 /// ## What it does
-/// Checks for uses of `set#remove` that can be replaced with `set#discard`.
+/// Checks for uses of `set.remove` that can be replaced with `set.discard`.
 ///
 /// ## Why is this bad?
 /// If an element should be removed from a set if it is present, it is more

--- a/crates/ruff/src/rules/refurb/rules/slice_copy.rs
+++ b/crates/ruff/src/rules/refurb/rules/slice_copy.rs
@@ -13,7 +13,7 @@ use crate::rules::refurb::helpers::generate_method_call;
 /// Checks for unbounded slice expressions to copy a list.
 ///
 /// ## Why is this bad?
-/// The `list#copy` method is more readable and consistent with copying other
+/// The `list.copy` method is more readable and consistent with copying other
 /// types.
 ///
 /// ## Known problems

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -545,7 +545,7 @@ impl<'a> SemanticModel<'a> {
     ///
     /// For example, given `["Class", "method"`], resolve the `BindingKind::ClassDefinition`
     /// associated with `Class`, then the `BindingKind::FunctionDefinition` associated with
-    /// `Class#method`.
+    /// `Class.method`.
     pub fn lookup_attribute(&'a self, value: &'a Expr) -> Option<BindingId> {
         let call_path = collect_call_path(value)?;
 

--- a/crates/ruff_source_file/src/locator.rs
+++ b/crates/ruff_source_file/src/locator.rs
@@ -391,7 +391,7 @@ impl<'a> Locator<'a> {
     /// Finds the closest [`TextSize`] not exceeding the offset for which `is_char_boundary` is
     /// `true`.
     ///
-    /// Can be replaced with `str#floor_char_boundary` once it's stable.
+    /// Can be replaced with `str::floor_char_boundary` once it's stable.
     ///
     /// ## Examples
     ///

--- a/crates/ruff_source_file/src/newlines.rs
+++ b/crates/ruff_source_file/src/newlines.rs
@@ -15,8 +15,8 @@ impl UniversalNewlines for str {
     }
 }
 
-/// Like [`str#lines`], but accommodates LF, CRLF, and CR line endings,
-/// the latter of which are not supported by [`str#lines`].
+/// Like [`str::lines`], but accommodates LF, CRLF, and CR line endings,
+/// the latter of which are not supported by [`str::lines`].
 ///
 /// ## Examples
 ///


### PR DESCRIPTION
## Summary

This matches the convention used in the Python documentation.