### PR TITLE
Avoid flagging single-quoted docstrings with continuations for multi-line rules

### DIFF
--- a/crates/ruff/resources/test/fixtures/pydocstyle/D.py
+++ b/crates/ruff/resources/test/fixtures/pydocstyle/D.py
@@ -658,3 +658,8 @@ class CommentAfterDocstring:
     "After this docstring there's a comment."  # priorities=1
     def sort_services(self):
         pass
+
+
+def newline_after_closing_quote(self):
+    "We enforce a newline after the closing quote for a multi-line docstring \
+    but continuations shouldn't be considered multi-line"

--- a/crates/ruff/src/docstrings/mod.rs
+++ b/crates/ruff/src/docstrings/mod.rs
@@ -30,6 +30,11 @@ impl<'a> Docstring<'a> {
     pub(crate) fn leading_quote(&self) -> &'a str {
         &self.contents[TextRange::up_to(self.body_range.start())]
     }
+
+    pub(crate) fn triple_quoted(&self) -> bool {
+        let leading_quote = self.leading_quote();
+        leading_quote.ends_with("\"\"\"") || leading_quote.ends_with("'''")
+    }
 }
 
 impl Ranged for Docstring<'_> {

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
@@ -70,6 +70,10 @@ impl Violation for BlankLineAfterSummary {
 pub(crate) fn blank_after_summary(checker: &mut Checker, docstring: &Docstring) {
     let body = docstring.body();
 
+    if !docstring.triple_quoted() {
+        return;
+    }
+
     let mut lines_count: usize = 1;
     let mut blanks_count = 0;
     for line in body.trim().universal_newlines().skip(1) {

--- a/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
@@ -63,6 +63,10 @@ pub(crate) fn newline_after_last_paragraph(checker: &mut Checker, docstring: &Do
     let contents = docstring.contents;
     let body = docstring.body();
 
+    if !docstring.triple_quoted() {
+        return;
+    }
+
     let mut line_count = 0;
     for line in NewlineWithTrailingNewline::from(body.as_str()) {
         if !line.trim().is_empty() {

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D204_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D204_D.py.snap
@@ -97,5 +97,6 @@ D.py:658:5: D204 [*] 1 blank line required after class docstring
     659 |+
 659 660 |     def sort_services(self):
 660 661 |         pass
+661 662 | 
 
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D300_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D300_D.py.snap
@@ -77,4 +77,13 @@ D.py:658:5: D300 Use triple double quotes `"""`
 660 |         pass
     |
 
+D.py:664:5: D300 Use triple double quotes `"""`
+    |
+663 |   def newline_after_closing_quote(self):
+664 |       "We enforce a newline after the closing quote for a multi-line docstring \
+    |  _____^
+665 | |     but continuations shouldn't be considered multi-line"
+    | |_________________________________________________________^ D300
+    |
+
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D400_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D400_D.py.snap
@@ -310,4 +310,21 @@ D.py:641:18: D400 [*] First line should end with a period
 643 643 | 
 644 644 | def single_line_docstring_with_an_escaped_backslash():
 
+D.py:664:5: D400 [*] First line should end with a period
+    |
+663 |   def newline_after_closing_quote(self):
+664 |       "We enforce a newline after the closing quote for a multi-line docstring \
+    |  _____^
+665 | |     but continuations shouldn't be considered multi-line"
+    | |_________________________________________________________^ D400
+    |
+    = help: Add period
+
+ℹ Suggested fix
+662 662 | 
+663 663 | def newline_after_closing_quote(self):
+664 664 |     "We enforce a newline after the closing quote for a multi-line docstring \
+665     |-    but continuations shouldn't be considered multi-line"
+    665 |+    but continuations shouldn't be considered multi-line."
+
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D415_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D415_D.py.snap
@@ -292,4 +292,21 @@ D.py:641:18: D415 [*] First line should end with a period, question mark, or exc
 643 643 | 
 644 644 | def single_line_docstring_with_an_escaped_backslash():
 
+D.py:664:5: D415 [*] First line should end with a period, question mark, or exclamation point
+    |
+663 |   def newline_after_closing_quote(self):
+664 |       "We enforce a newline after the closing quote for a multi-line docstring \
+    |  _____^
+665 | |     but continuations shouldn't be considered multi-line"
+    | |_________________________________________________________^ D415
+    |
+    = help: Add closing punctuation
+
+ℹ Suggested fix
+662 662 | 
+663 663 | def newline_after_closing_quote(self):
+664 664 |     "We enforce a newline after the closing quote for a multi-line docstring \
+665     |-    but continuations shouldn't be considered multi-line"
+    665 |+    but continuations shouldn't be considered multi-line."
+
 


### PR DESCRIPTION
Rules like D209 and D205 are only intended to apply to multi-line docstrings. If a docstring is single-quoted, but extends via a continuation, it should be excluded (it'll be flagged by another rule anyway). Closes https://github.com/astral-sh/ruff/issues/7058.