### PR TITLE
Change CWE reference in documentation for S607 rule

### DIFF
--- a/crates/ruff/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -148,7 +148,7 @@ impl Violation for StartProcessWithNoShell {
 ///
 /// ## References
 /// - [Python documentation: `subprocess.Popen()`](https://docs.python.org/3/library/subprocess.html#subprocess.Popen)
-/// - [Common Weakness Enumeration: CWE-78](https://cwe.mitre.org/data/definitions/78.html)
+/// - [Common Weakness Enumeration: CWE-426](https://cwe.mitre.org/data/definitions/426.html)
 #[violation]
 pub struct StartProcessWithPartialPath;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The previous reference was “CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')”, which describes another issue. The new reference is “CWE-426: Untrusted Search Path”, which describes exactly the problem that this rule should warn about.

## Test Plan

The change was not tested, as it only changes two numbers in the documentation.