### PR TITLE
fix: Use BestFit layout for subscript

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/call.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/call.py
@@ -270,3 +270,6 @@ result = (
     f(111111111111111111111111111111111111111111111111111111111111111111111111111111111)
     + 1
 )()
+
+
+result = (object[complicate_caller])("argument").a["b"].test(argument)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/assign.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/assign.py
@@ -54,3 +54,16 @@ x = (
         c,
     ]
 ) = 1
+
+def main() -> None:
+    if True:
+        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
+            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
+            == "This is a very long string abcdefghijk"
+        ]
+
+        organization_application = (
+            organization_service.get_organization_applications_by_name(
+                db_request.POST["name"]
+            )
+        )[0]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/return_annotation.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/return_annotation.py
@@ -180,3 +180,9 @@ def double(a: int) -> (
     int | list[int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int]  # Hello
 ):
     pass
+
+
+def process_board_action(
+    payload: WildValue, action_type: Optional[str]
+) -> Optional[Tuple[str, str]]:
+    pass

--- a/crates/ruff_python_formatter/src/expression/expr_subscript.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_subscript.rs
@@ -5,7 +5,7 @@ use ruff_python_ast::{Expr, ExprSubscript};
 use crate::comments::SourceComment;
 use crate::expression::expr_tuple::TupleParentheses;
 use crate::expression::parentheses::{
-    is_expression_parenthesized, parenthesized, NeedsParentheses, OptionalParentheses,
+    is_expression_parenthesized, parenthesized, NeedsParentheses, OptionalParentheses, Parentheses,
 };
 use crate::expression::CallChainLayout;
 use crate::prelude::*;
@@ -42,13 +42,17 @@ impl FormatNodeRule<ExprSubscript> for FormatExprSubscript {
             "A subscript expression can only have a single dangling comment, the one after the bracket"
         );
 
-        let format_inner = format_with(|f| {
-            match value.as_ref() {
-                Expr::Attribute(expr) => expr.format().with_options(call_chain_layout).fmt(f)?,
-                Expr::Call(expr) => expr.format().with_options(call_chain_layout).fmt(f)?,
-                Expr::Subscript(expr) => expr.format().with_options(call_chain_layout).fmt(f)?,
-                _ => value.format().fmt(f)?,
-            }
+        let format_inner = format_with(|f: &mut PyFormatter| {
+            if is_expression_parenthesized(value.into(), f.context().source()) {
+                value.format().with_options(Parentheses::Always).fmt(f)
+            } else {
+                match value.as_ref() {
+                    Expr::Attribute(expr) => expr.format().with_options(call_chain_layout).fmt(f),
+                    Expr::Call(expr) => expr.format().with_options(call_chain_layout).fmt(f),
+                    Expr::Subscript(expr) => expr.format().with_options(call_chain_layout).fmt(f),
+                    _ => value.format().with_options(Parentheses::Never).fmt(f),
+                }
+            }?;
 
             let format_slice = format_with(|f: &mut PyFormatter| {
                 if let Expr::Tuple(tuple) = slice.as_ref() {
@@ -85,7 +89,7 @@ impl FormatNodeRule<ExprSubscript> for FormatExprSubscript {
 impl NeedsParentheses for ExprSubscript {
     fn needs_parentheses(
         &self,
-        _parent: AnyNodeRef,
+        parent: AnyNodeRef,
         context: &PyFormatContext,
     ) -> OptionalParentheses {
         {
@@ -97,7 +101,21 @@ impl NeedsParentheses for ExprSubscript {
                 OptionalParentheses::Never
             } else {
                 match self.value.needs_parentheses(self.into(), context) {
-                    OptionalParentheses::BestFit => OptionalParentheses::Never,
+                    OptionalParentheses::BestFit => {
+                        if parent.as_stmt_function_def().is_some_and(|function_def| {
+                            function_def
+                                .returns
+                                .as_deref()
+                                .and_then(Expr::as_subscript_expr)
+                                == Some(self)
+                        }) {
+                            // Don't use the best fitting layout for return type annotation because it results in the
+                            // return type expanding before the parameters.
+                            OptionalParentheses::Never
+                        } else {
+                            OptionalParentheses::BestFit
+                        }
+                    }
                     parentheses => parentheses,
                 }
             }

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -216,12 +216,14 @@ if True:
     #[test]
     fn quick_test() {
         let src = r#"
-(header.timecnt * 5  # Transition times and types
-  + header.typecnt * 6  # Local time type records
-  + header.charcnt  # Time zone designations
-  + header.leapcnt * 8  # Leap second records
-  + header.isstdcnt  # Standard/wall indicators
-  + header.isutcnt)  # UT/local indicators
+def main() -> None:
+    if True:
+        some_very_long_variable_name_abcdefghijk = Foo()
+        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
+            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
+            == "This is a very long string abcdefghijk"
+        ]
+
 "#;
         // Tokenize once
         let mut tokens = Vec::new();

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__call.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__call.py.snap
@@ -276,6 +276,9 @@ result = (
     f(111111111111111111111111111111111111111111111111111111111111111111111111111111111)
     + 1
 )()
+
+
+result = (object[complicate_caller])("argument").a["b"].test(argument)
 ```
 
 ## Output
@@ -548,6 +551,9 @@ result = (
     f(111111111111111111111111111111111111111111111111111111111111111111111111111111111)
     + 1
 )()
+
+
+result = (object[complicate_caller])("argument").a["b"].test(argument)
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__assign.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__assign.py.snap
@@ -60,6 +60,19 @@ x = (
         c,
     ]
 ) = 1
+
+def main() -> None:
+    if True:
+        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
+            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
+            == "This is a very long string abcdefghijk"
+        ]
+
+        organization_application = (
+            organization_service.get_organization_applications_by_name(
+                db_request.POST["name"]
+            )
+        )[0]
 ```
 
 ## Output
@@ -122,6 +135,22 @@ x = [  # comment
     b,
     c,
 ] = 1
+
+
+def main() -> None:
+    if True:
+        some_very_long_variable_name_abcdefghijk = (
+            some_very_long_variable_name_abcdefghijk[
+                some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
+                == "This is a very long string abcdefghijk"
+            ]
+        )
+
+        organization_application = (
+            organization_service.get_organization_applications_by_name(
+                db_request.POST["name"]
+            )
+        )[0]
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__return_annotation.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__return_annotation.py.snap
@@ -186,6 +186,12 @@ def double(a: int) -> (
     int | list[int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int]  # Hello
 ):
     pass
+
+
+def process_board_action(
+    payload: WildValue, action_type: Optional[str]
+) -> Optional[Tuple[str, str]]:
+    pass
 ```
 
 ## Output
@@ -514,6 +520,12 @@ def double(
         int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int
     ]  # Hello
 ):
+    pass
+
+
+def process_board_action(
+    payload: WildValue, action_type: Optional[str]
+) -> Optional[Tuple[str, str]]:
     pass
 ```
 


### PR DESCRIPTION
## Summary


Ruff never parenthesized long attribute chains followed by a subscript:

```python
def main() -> None:
    if True:
        some_very_long_variable_name_abcdefghijk = Foo()
        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
            == "This is a very long string abcdefghijk"
        ]
```

Whereas Black formats this as 

```python
def main() -> None:
    if True:
        some_very_long_variable_name_abcdefghijk = Foo()
        some_very_long_variable_name_abcdefghijk = (
            some_very_long_variable_name_abcdefghijk[
                some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
                == "This is a very long string abcdefghijk"
            ]
        )
```

This PR changes the `needs_parentheses` function of `ExprSubscript` to use the `BestFit` layout if its value proposes the `BestFit` layout (except when in return type annotations, see inline comments)

Making this change revealed an instability because the formatter incorrectly removed the parentheses from callees or objects. I changed the call chain formatting to preserve parentheses.

Closes #7407.

Closes #7422.

## Test Plan

I added new tests

**Base**

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99982 |              2760 |                37 |
| transformers |           0.99957 |              2587 |               399 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| warehouse    |           0.99923 |               648 |                18 |
| zulip        |           0.99962 |              1437 |                22 |

**This PR**

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99982 |              2760 |                37 |
| transformers |           0.99957 |              2587 |               399 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| **warehouse**    |           0.99929 |               648 |                16 | <--
| zulip        |           0.99962 |              1437 |                22 |

