### PR TITLE
Add maximum length for `line-length` to JSON schema

### DIFF
--- a/crates/ruff/src/line_width.rs
+++ b/crates/ruff/src/line_width.rs
@@ -13,6 +13,7 @@ use ruff_macros::CacheKey;
 /// The allowed range of values is 1..=320
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[schemars(range(min = 1, max = 320))]
 pub struct LineLength(NonZeroU16);
 
 impl LineLength {

--- a/crates/ruff/src/line_width.rs
+++ b/crates/ruff/src/line_width.rs
@@ -13,7 +13,6 @@ use ruff_macros::CacheKey;
 /// The allowed range of values is 1..=320
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[schemars(range(min = 1, max = 320))]
 pub struct LineLength(NonZeroU16);
 
 impl LineLength {

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -320,6 +320,7 @@ pub struct Options {
     )]
     /// The line length to use when enforcing long-lines violations (like
     /// `E501`). Must be greater than `0`.
+    #[schemars(range(min = 1, max = 320))]
     pub line_length: Option<LineLength>,
     #[option(
         default = "4",

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -384,7 +384,9 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "maximum": 320.0,
+      "minimum": 1.0
     },
     "logger-objects": {
       "description": "A list of objects that should be treated equivalently to a `logging.Logger` object.\n\nThis is useful for ensuring proper diagnostics (e.g., to identify `logging` deprecations and other best-practices) for projects that re-export a `logging.Logger` object from a common module.\n\nFor example, if you have a module `logging_setup.py` with the following contents: ```python import logging\n\nlogger = logging.getLogger(__name__) ```\n\nAdding `\"logging_setup.logger\"` to `logger-objects` will ensure that `logging_setup.logger` is treated as a `logging.Logger` object when imported from other modules (e.g., `from logging_setup import logger`).",


### PR DESCRIPTION
- Add maximum length for `line-length` to schema
- Move annotation to parent object

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
