### PR TITLE
Move documentation to docs.astral.sh/ruff

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -52,4 +52,4 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           # `github.head_ref` is only set during pull requests and for manual runs or tags we use `main` to deploy to production
-          command: pages deploy site --project-name=ruff-docs --branch ${{ github.head_ref || 'main' }} --commit-hash ${GITHUB_SHA}
+          command: pages deploy site --project-name=astral-docs --branch ${{ github.head_ref || 'main' }} --commit-hash ${GITHUB_SHA}

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -44,4 +44,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          command: pages publish playground/dist --project-name=ruff --branch ${GITHUB_HEAD_REF} --commit-hash ${GITHUB_SHA}
+          command: pages publish playground/dist --project-name=ruff-playground --branch ${GITHUB_HEAD_REF} --commit-hash ${GITHUB_SHA}

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -299,4 +299,4 @@ default.
 `pyproject.toml` files are now resolved hierarchically, such that for each Python file, we find
 the first `pyproject.toml` file in its path, and use that to determine its lint settings.
 
-See the [documentation](https://beta.ruff.rs/docs/configuration/#python-file-discovery) for more.
+See the [documentation](https://docs.astral.sh/ruff/configuration/#python-file-discovery) for more.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -719,8 +719,8 @@ Module {
 - `cargo dev generate-cli-help`, `cargo dev generate-docs` and `cargo dev generate-json-schema`:
     Update just `docs/configuration.md`, `docs/rules` and `ruff.schema.json` respectively.
 - `cargo dev generate-options`: Generate a markdown-compatible table of all `pyproject.toml`
-    options. Used for <https://beta.ruff.rs/docs/settings/>
-- `cargo dev generate-rules-table`: Generate a markdown-compatible table of all rules. Used for <https://beta.ruff.rs/docs/rules/>
+    options. Used for <https://docs.astral.sh/ruff/settings/>.
+- `cargo dev generate-rules-table`: Generate a markdown-compatible table of all rules. Used for <https://docs.astral.sh/ruff/rules/>.
 - `cargo dev round-trip <python file or jupyter notebook>`: Read a Python file or Jupyter Notebook,
     parse it, serialize the parsed representation and write it back. Used to check how good our
     representation is so that fixes don't rewrite irrelevant parts of a file.
@@ -778,7 +778,7 @@ To understand Ruff's import categorization system, we first need to define two c
 - "Package root": The top-most directory defining the Python package that includes a given Python
     file. To find the package root for a given Python file, traverse up its parent directories until
     you reach a parent directory that doesn't contain an `__init__.py` file (and isn't marked as
-    a [namespace package](https://beta.ruff.rs/docs/settings/#namespace-packages)); take the directory
+    a [namespace package](https://docs.astral.sh/ruff/settings/#namespace-packages)); take the directory
     just before that, i.e., the first directory in the package.
 
 For example, given:
@@ -867,7 +867,7 @@ There are three ways in which an import can be categorized as "first-party":
     package (e.g., `from foo import bar` or `import foo.bar`), they'll be classified as first-party
     automatically. This check is as simple as comparing the first segment of the current file's
     module path to the first segment of the import.
-1. **Source roots**: Ruff supports a `[src](https://beta.ruff.rs/docs/settings/#src)` setting, which
+1. **Source roots**: Ruff supports a `[src](https://docs.astral.sh/ruff/settings/#src)` setting, which
     sets the directories to scan when identifying first-party imports. The algorithm is
     straightforward: given an import, like `import foo`, iterate over the directories enumerated in
     the `src` setting and, for each directory, check for the existence of a subdirectory `foo` or a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 rust-version = "1.71"
-homepage = "https://beta.ruff.rs/docs"
-documentation = "https://beta.ruff.rs/docs"
+homepage = "https://docs.astral.sh/ruff"
+documentation = "https://docs.astral.sh/ruff"
 repository = "https://github.com/astral-sh/ruff"
 authors = ["Charlie Marsh <charlie.r.marsh@gmail.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![image](https://img.shields.io/pypi/pyversions/ruff.svg)](https://pypi.python.org/pypi/ruff)
 [![Actions status](https://github.com/astral-sh/ruff/workflows/CI/badge.svg)](https://github.com/astral-sh/ruff/actions)
 
-[**Discord**](https://discord.gg/c9MhzV8aU5) | [**Docs**](https://beta.ruff.rs/docs/) | [**Playground**](https://play.ruff.rs/)
+[**Discord**](https://discord.gg/c9MhzV8aU5) | [**Docs**](https://docs.astral.sh/ruff/) | [**Playground**](https://play.ruff.rs/)
 
 An extremely fast Python linter, written in Rust.
 
@@ -30,13 +30,13 @@ An extremely fast Python linter, written in Rust.
 - 🤝 Python 3.11 compatibility
 - 📦 Built-in caching, to avoid re-analyzing unchanged files
 - 🔧 Autofix support, for automatic error correction (e.g., automatically remove unused imports)
-- 📏 Over [600 built-in rules](https://beta.ruff.rs/docs/rules/)
-- ⚖️ [Near-parity](https://beta.ruff.rs/docs/faq/#how-does-ruff-compare-to-flake8) with the
+- 📏 Over [600 built-in rules](https://docs.astral.sh/ruff/rules/)
+- ⚖️ [Near-parity](https://docs.astral.sh/ruff/faq/#how-does-ruff-compare-to-flake8) with the
     built-in Flake8 rule set
 - 🔌 Native re-implementations of dozens of Flake8 plugins, like flake8-bugbear
-- ⌨️ First-party [editor integrations](https://beta.ruff.rs/docs/editor-integrations/) for
+- ⌨️ First-party [editor integrations](https://docs.astral.sh/ruff/editor-integrations/) for
     [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](https://github.com/astral-sh/ruff-lsp)
-- 🌎 Monorepo-friendly, with [hierarchical and cascading configuration](https://beta.ruff.rs/docs/configuration/#pyprojecttoml-discovery)
+- 🌎 Monorepo-friendly, with [hierarchical and cascading configuration](https://docs.astral.sh/ruff/configuration/#pyprojecttoml-discovery)
 
 Ruff aims to be orders of magnitude faster than alternative tools while integrating more
 functionality behind a single, common interface.
@@ -98,7 +98,7 @@ developer of [Zulip](https://github.com/zulip/zulip):
 
 ## Table of Contents
 
-For more, see the [documentation](https://beta.ruff.rs/docs/).
+For more, see the [documentation](https://docs.astral.sh/ruff/).
 
 1. [Getting Started](#getting-started)
 1. [Configuration](#configuration)
@@ -111,7 +111,7 @@ For more, see the [documentation](https://beta.ruff.rs/docs/).
 
 ## Getting Started
 
-For more, see the [documentation](https://beta.ruff.rs/docs/).
+For more, see the [documentation](https://docs.astral.sh/ruff/).
 
 ### Installation
 
@@ -122,7 +122,7 @@ pip install ruff
 ```
 
 You can also install Ruff via [Homebrew](https://formulae.brew.sh/formula/ruff), [Conda](https://anaconda.org/conda-forge/ruff),
-and with [a variety of other package managers](https://beta.ruff.rs/docs/installation/).
+and with [a variety of other package managers](https://docs.astral.sh/ruff/installation/).
 
 ### Usage
 
@@ -165,7 +165,7 @@ jobs:
 ### Configuration
 
 Ruff can be configured through a `pyproject.toml`, `ruff.toml`, or `.ruff.toml` file (see:
-[_Configuration_](https://beta.ruff.rs/docs/configuration/), or [_Settings_](https://beta.ruff.rs/docs/settings/)
+[_Configuration_](https://docs.astral.sh/ruff/configuration/), or [_Settings_](https://docs.astral.sh/ruff/settings/)
 for a complete list of all configuration options).
 
 If left unspecified, the default configuration is equivalent to:
@@ -238,7 +238,7 @@ isort, pyupgrade, and others. Regardless of the rule's origin, Ruff re-implement
 Rust as a first-party feature.
 
 By default, Ruff enables Flake8's `E` and `F` rules. Ruff supports all rules from the `F` category,
-and a [subset](https://beta.ruff.rs/docs/rules/#error-e) of the `E` category, omitting those
+and a [subset](https://docs.astral.sh/ruff/rules/#error-e) of the `E` category, omitting those
 stylistic rules made obsolete by the use of an autoformatter, like
 [Black](https://github.com/psf/black).
 
@@ -304,12 +304,12 @@ quality tools, including:
 - [tryceratops](https://pypi.org/project/tryceratops/)
 - [yesqa](https://pypi.org/project/yesqa/)
 
-For a complete enumeration of the supported rules, see [_Rules_](https://beta.ruff.rs/docs/rules/).
+For a complete enumeration of the supported rules, see [_Rules_](https://docs.astral.sh/ruff/rules/).
 
 ## Contributing
 
 Contributions are welcome and highly appreciated. To get started, check out the
-[**contributing guidelines**](https://beta.ruff.rs/docs/contributing/).
+[**contributing guidelines**](https://docs.astral.sh/ruff/contributing/).
 
 You can also join us on [**Discord**](https://discord.gg/c9MhzV8aU5).
 

--- a/crates/flake8_to_ruff/README.md
+++ b/crates/flake8_to_ruff/README.md
@@ -86,7 +86,7 @@ flake8-to-ruff path/to/.flake8 --plugin flake8-builtins --plugin flake8-quotes
     configuration options that don't exist in Flake8.)
 1. Ruff will omit any rule codes that are unimplemented or unsupported by Ruff, including rule
     codes from unsupported plugins. (See the
-    [documentation](https://beta.ruff.rs/docs/faq/#how-does-ruff-compare-to-flake8) for the complete
+    [documentation](https://docs.astral.sh/ruff/faq/#how-does-ruff-compare-to-flake8) for the complete
     list of supported plugins.)
 
 ## License

--- a/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
@@ -33,7 +33,7 @@ expression: content
     },
     "message": "`os` imported but unused",
     "noqa_row": 1,
-    "url": "https://beta.ruff.rs/docs/rules/unused-import"
+    "url": "https://docs.astral.sh/ruff/rules/unused-import"
   },
   {
     "code": "F841",
@@ -65,7 +65,7 @@ expression: content
     },
     "message": "Local variable `x` is assigned to but never used",
     "noqa_row": 6,
-    "url": "https://beta.ruff.rs/docs/rules/unused-variable"
+    "url": "https://docs.astral.sh/ruff/rules/unused-variable"
   },
   {
     "code": "F821",
@@ -81,6 +81,6 @@ expression: content
     },
     "message": "Undefined name `a`",
     "noqa_row": 1,
-    "url": "https://beta.ruff.rs/docs/rules/undefined-name"
+    "url": "https://docs.astral.sh/ruff/rules/undefined-name"
   }
 ]

--- a/crates/ruff/src/message/snapshots/ruff__message__json_lines__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__json_lines__tests__output.snap
@@ -2,7 +2,7 @@
 source: crates/ruff/src/message/json_lines.rs
 expression: content
 ---
-{"code":"F401","end_location":{"column":10,"row":1},"filename":"fib.py","fix":{"applicability":"Suggested","edits":[{"content":"","end_location":{"column":1,"row":2},"location":{"column":1,"row":1}}],"message":"Remove unused import: `os`"},"location":{"column":8,"row":1},"message":"`os` imported but unused","noqa_row":1,"url":"https://beta.ruff.rs/docs/rules/unused-import"}
-{"code":"F841","end_location":{"column":6,"row":6},"filename":"fib.py","fix":{"applicability":"Suggested","edits":[{"content":"","end_location":{"column":10,"row":6},"location":{"column":5,"row":6}}],"message":"Remove assignment to unused variable `x`"},"location":{"column":5,"row":6},"message":"Local variable `x` is assigned to but never used","noqa_row":6,"url":"https://beta.ruff.rs/docs/rules/unused-variable"}
-{"code":"F821","end_location":{"column":5,"row":1},"filename":"undef.py","fix":null,"location":{"column":4,"row":1},"message":"Undefined name `a`","noqa_row":1,"url":"https://beta.ruff.rs/docs/rules/undefined-name"}
+{"code":"F401","end_location":{"column":10,"row":1},"filename":"fib.py","fix":{"applicability":"Suggested","edits":[{"content":"","end_location":{"column":1,"row":2},"location":{"column":1,"row":1}}],"message":"Remove unused import: `os`"},"location":{"column":8,"row":1},"message":"`os` imported but unused","noqa_row":1,"url":"https://docs.astral.sh/ruff/rules/unused-import"}
+{"code":"F841","end_location":{"column":6,"row":6},"filename":"fib.py","fix":{"applicability":"Suggested","edits":[{"content":"","end_location":{"column":10,"row":6},"location":{"column":5,"row":6}}],"message":"Remove assignment to unused variable `x`"},"location":{"column":5,"row":6},"message":"Local variable `x` is assigned to but never used","noqa_row":6,"url":"https://docs.astral.sh/ruff/rules/unused-variable"}
+{"code":"F821","end_location":{"column":5,"row":1},"filename":"undef.py","fix":null,"location":{"column":4,"row":1},"message":"Undefined name `a`","noqa_row":1,"url":"https://docs.astral.sh/ruff/rules/undefined-name"}
 

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -39,7 +39,7 @@ use crate::registry::{AsRule, Rule};
 /// ## Options
 /// - `pydocstyle.convention`
 ///
-/// [D211]: https://beta.ruff.rs/docs/rules/blank-line-before-class
+/// [D211]: https://docs.astral.sh/ruff/rules/blank-line-before-class
 #[violation]
 pub struct OneBlankLineBeforeClass;
 
@@ -136,7 +136,7 @@ impl AlwaysAutofixableViolation for OneBlankLineAfterClass {
 /// ## Options
 /// - `pydocstyle.convention`
 ///
-/// [D203]: https://beta.ruff.rs/docs/rules/one-blank-line-before-class
+/// [D203]: https://docs.astral.sh/ruff/rules/one-blank-line-before-class
 #[violation]
 pub struct BlankLineBeforeClass;
 

--- a/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -48,7 +48,7 @@ use crate::registry::{AsRule, Rule};
 ///     """
 /// ```
 ///
-/// [D213]: https://beta.ruff.rs/docs/rules/multi-line-summary-second-line
+/// [D213]: https://docs.astral.sh/ruff/rules/multi-line-summary-second-line
 #[violation]
 pub struct MultiLineSummaryFirstLine;
 
@@ -102,7 +102,7 @@ impl AlwaysAutofixableViolation for MultiLineSummaryFirstLine {
 ///     """
 /// ```
 ///
-/// [D212]: https://beta.ruff.rs/docs/rules/multi-line-summary-first-line
+/// [D212]: https://docs.astral.sh/ruff/rules/multi-line-summary-first-line
 #[violation]
 pub struct MultiLineSummarySecondLine;
 

--- a/crates/ruff/src/rules/pygrep_hooks/rules/blanket_noqa.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/blanket_noqa.rs
@@ -28,7 +28,7 @@ use crate::noqa::Directive;
 /// ```
 ///
 /// ## References
-/// - [Ruff documentation](https://beta.ruff.rs/docs/configuration/#error-suppression)
+/// - [Ruff documentation](https://docs.astral.sh/ruff/configuration/#error-suppression)
 #[violation]
 pub struct BlanketNOQA;
 

--- a/crates/ruff/src/rules/ruff/rules/unused_noqa.rs
+++ b/crates/ruff/src/rules/ruff/rules/unused_noqa.rs
@@ -36,7 +36,7 @@ pub struct UnusedCodes {
 /// ```
 ///
 /// ## References
-/// - [Automatic `noqa` management](https://beta.ruff.rs/docs/configuration/#automatic-noqa-management)
+/// - [Automatic `noqa` management](https://docs.astral.sh/ruff/configuration/#automatic-noqa-management)
 #[violation]
 pub struct UnusedNOQA {
     pub codes: Option<UnusedCodes>,

--- a/crates/ruff_cli/tests/snapshots/integration_test__stdin_json.snap
+++ b/crates/ruff_cli/tests/snapshots/integration_test__stdin_json.snap
@@ -46,7 +46,7 @@ exit_code: 1
     },
     "message": "`os` imported but unused",
     "noqa_row": 1,
-    "url": "https://beta.ruff.rs/docs/rules/unused-import"
+    "url": "https://docs.astral.sh/ruff/rules/unused-import"
   }
 ]
 ----- stderr -----

--- a/crates/ruff_dev/src/generate_options.rs
+++ b/crates/ruff_dev/src/generate_options.rs
@@ -1,6 +1,6 @@
 //! Generate a Markdown-compatible listing of configuration options for `pyproject.toml`.
 //!
-//! Used for <https://beta.ruff.rs/docs/settings/>.
+//! Used for <https://docs.astral.sh/ruff/settings/>.
 use itertools::Itertools;
 use ruff_workspace::options::Options;
 use ruff_workspace::options_base::{OptionEntry, OptionField};

--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -1,6 +1,6 @@
 //! Generate a Markdown-compatible table of supported lint rules.
 //!
-//! Used for <https://beta.ruff.rs/docs/rules/>.
+//! Used for <https://docs.astral.sh/ruff/rules/>.
 
 use itertools::Itertools;
 use strum::IntoEnumIterator;

--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -102,7 +102,7 @@ on-save by adding `"editor.formatOnSave": true` to your `settings.json`:
 
 ### Configuration
 
-The Ruff formatter respects Ruff's [`line-length`](https://beta.ruff.rs/docs/settings/#line-length)
+The Ruff formatter respects Ruff's [`line-length`](https://docs.astral.sh/ruff/settings/#line-length)
 setting, which can be provided via a `pyproject.toml` or `ruff.toml` file, or on the CLI, as in:
 
 ```console

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1994,7 +1994,7 @@ pub struct PycodestyleOptions {
     /// documentation (`W505`), including standalone comments. By default,
     /// this is set to null which disables reporting violations.
     ///
-    /// See the [`doc-line-too-long`](https://beta.ruff.rs/docs/rules/doc-line-too-long/) rule for more information.
+    /// See the [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) rule for more information.
     pub max_doc_length: Option<LineLength>,
     #[option(
         default = "false",

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -386,7 +386,9 @@ alone.
 
 ## What is preview?
 
-Preview enables a collection of newer rules and fixes that are considered experimental or unstable. See the [preview documentation](https://beta.ruff.rs/docs/preview/) for more details; or, to see which rules are currently in preview, visit the [rules reference](https://beta.ruff.rs/docs/rules/).
+Preview enables a collection of newer rules and fixes that are considered experimental or unstable.
+See the [preview documentation](preview.md) for more details; or, to see which rules are currently
+in preview, visit the [rules reference](rules.md).
 
 ## How can I tell what settings Ruff is using to check my code?
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -45,4 +45,4 @@ preview = true
 
 Or, if you provided the `--preview` CLI flag.
 
-To see which rules are currently in preview, visit the [rules reference](https://beta.ruff.rs/docs/rules/).
+To see which rules are currently in preview, visit the [rules reference](rules.md).

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -28,8 +28,8 @@ theme:
 repo_url: https://github.com/astral-sh/ruff
 repo_name: ruff
 site_author: charliermarsh
-site_url: https://beta.ruff.rs/docs/
-site_dir: site/docs
+site_url: https://docs.astral.sh/ruff/
+site_dir: site/ruff
 markdown_extensions:
   - toc:
       permalink: "#"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 
 [project.urls]
 Repository = "https://github.com/astral-sh/ruff"
-Documentation = "https://beta.ruff.rs/docs/"
+Documentation = "https://docs.astral.sh/ruff/"
 Changelog = "https://github.com/astral-sh/ruff/releases"
 
 [tool.maturin]

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1517,7 +1517,7 @@
           ]
         },
         "max-doc-length": {
-          "description": "The maximum line length to allow for line-length violations within documentation (`W505`), including standalone comments. By default, this is set to null which disables reporting violations.\n\nSee the [`doc-line-too-long`](https://beta.ruff.rs/docs/rules/doc-line-too-long/) rule for more information.",
+          "description": "The maximum line length to allow for line-length violations within documentation (`W505`), including standalone comments. By default, this is set to null which disables reporting violations.\n\nSee the [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) rule for more information.",
           "anyOf": [
             {
               "$ref": "#/definitions/LineLength"

--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -35,20 +35,20 @@ SECTIONS: list[Section] = [
 
 
 LINK_REWRITES: dict[str, str] = {
-    "https://beta.ruff.rs/docs/": "index.md",
-    "https://beta.ruff.rs/docs/configuration/": "configuration.md",
-    "https://beta.ruff.rs/docs/configuration/#pyprojecttoml-discovery": (
+    "https://docs.astral.sh/ruff/": "index.md",
+    "https://docs.astral.sh/ruff/configuration/": "configuration.md",
+    "https://docs.astral.sh/ruff/configuration/#pyprojecttoml-discovery": (
         "configuration.md#pyprojecttoml-discovery"
     ),
-    "https://beta.ruff.rs/docs/contributing/": "contributing.md",
-    "https://beta.ruff.rs/docs/editor-integrations/": "editor-integrations.md",
-    "https://beta.ruff.rs/docs/faq/#how-does-ruff-compare-to-flake8": (
+    "https://docs.astral.sh/ruff/contributing/": "contributing.md",
+    "https://docs.astral.sh/ruff/editor-integrations/": "editor-integrations.md",
+    "https://docs.astral.sh/ruff/faq/#how-does-ruff-compare-to-flake8": (
         "faq.md#how-does-ruff-compare-to-flake8"
     ),
-    "https://beta.ruff.rs/docs/installation/": "installation.md",
-    "https://beta.ruff.rs/docs/rules/": "rules.md",
-    "https://beta.ruff.rs/docs/rules/#error-e": "rules.md#error-e",
-    "https://beta.ruff.rs/docs/settings/": "settings.md",
+    "https://docs.astral.sh/ruff/installation/": "installation.md",
+    "https://docs.astral.sh/ruff/rules/": "rules.md",
+    "https://docs.astral.sh/ruff/rules/#error-e": "rules.md#error-e",
+    "https://docs.astral.sh/ruff/settings/": "settings.md",
 }
 
 
@@ -94,7 +94,7 @@ def main() -> None:
             raise ValueError(msg)
         content = after
 
-    if m := re.search(r"\(https://beta.ruff.rs/docs/.*\)", content):
+    if m := re.search(r"\(https://docs.astral.sh/ruff/.*\)", content):
         msg = f"Unexpected absolute link to documentation: {m.group(0)}"
         raise ValueError(msg)
 


### PR DESCRIPTION
## Summary

We're planning to move the documentation from [https://beta.ruff.rs/docs](https://beta.ruff.rs/docs) to [https://docs.astral.sh/ruff](https://docs.astral.sh/ruff), for a few reasons:

1. We want to remove the `beta` from the domain, as Ruff is no longer considered beta software.
2. We want to migrate to a structure that could accommodate multiple future tools living under one domain.

The docs are actually already live at [https://docs.astral.sh/ruff](https://docs.astral.sh/ruff), but later today, I'll add a permanent redirect from the previous to the new domain. **All existing links will continue to work, now and in perpetuity.**

This PR contains the code changes necessary for the updated documentation. As part of this effort, I moved the playground and documentation from my personal Cloudflare account to our team Cloudflare account (hence the new `--project-name` references). After merging, I'll also update the secrets on this repo.
