### PR TITLE
Avoid extra parentheses in unary expressions

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unary.py
@@ -151,3 +151,13 @@ if (
   not  # comment
   a):
     ...
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/7423
+if True:
+    if True:
+        if True:
+            if not yn_question(
+                Fore.RED
+                + "WARNING: Removing listed files. Do you really want to continue. yes/n)? "
+            ):
+                pass

--- a/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
@@ -74,8 +74,10 @@ impl NeedsParentheses for ExprUnaryOp {
         // We preserve the parentheses of the operand. It should not be necessary to break this expression.
         if is_expression_parenthesized(self.operand.as_ref().into(), context.source()) {
             OptionalParentheses::Never
+        } else if context.comments().has(self.operand.as_ref()) {
+            OptionalParentheses::Always
         } else {
-            OptionalParentheses::Multiline
+            self.operand.needs_parentheses(self.into(), context)
         }
     }
 }

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__unary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__unary.py.snap
@@ -157,6 +157,16 @@ if (
   not  # comment
   a):
     ...
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/7423
+if True:
+    if True:
+        if True:
+            if not yn_question(
+                Fore.RED
+                + "WARNING: Removing listed files. Do you really want to continue. yes/n)? "
+            ):
+                pass
 ```
 
 ## Output
@@ -323,10 +333,18 @@ if (
 ):
     ...
 
-if (
-    not a  # comment
-):
+if not a:  # comment
     ...
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/7423
+if True:
+    if True:
+        if True:
+            if not yn_question(
+                Fore.RED
+                + "WARNING: Removing listed files. Do you really want to continue. yes/n)? "
+            ):
+                pass
 ```
 
 


### PR DESCRIPTION
## Summary

This PR applies a similar fix to unary expressions as in https://github.com/astral-sh/ruff/pull/7424. Specifically, we only need to parenthesize the entire operator if the operand itself doesn't have parentheses, and requires parentheses.

Closes https://github.com/astral-sh/ruff/issues/7423.

## Test Plan

`cargo test`

No change in similarity.

Before:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99982 |              2760 |                37 |
| transformers |           0.99957 |              2587 |               399 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| warehouse    |           0.99923 |               648 |                18 |
| zulip        |           0.99962 |              1437 |                22 |

After:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99982 |              2760 |                37 |
| transformers |           0.99957 |              2587 |               399 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| warehouse    |           0.99923 |               648 |                18 |
| zulip        |           0.99962 |              1437 |                22 |
