### PR TITLE
Avoid extra parentheses in `yield` expressions

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/yield.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/yield.py
@@ -104,3 +104,20 @@ yield (
 yield "#   * Make sure each ForeignKey and OneToOneField has `on_delete` set "    "to the desired behavior"
 yield "#   * Remove `managed = False` lines if you wish to allow " "Django to create, modify, and delete the table"
 yield "# Feel free to rename the models, but don't rename db_table values or "    "field names."
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/7420
+result = yield self.request(
+    f"/applications/{int(application_id)}/guilds/{int(scope)}/commands/{int(command_id)}/permissions"
+)
+
+result = yield (self.request(
+    f"/applications/{int(application_id)}/guilds/{int(scope)}/commands/{int(command_id)}/permissions"
+))
+
+result = yield
+
+result = yield (1 + f(1, 2, 3,))
+
+result = (yield (1 + f(1, 2, 3,)))
+
+print((yield x))

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__yield.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__yield.py.snap
@@ -110,6 +110,23 @@ yield (
 yield "#   * Make sure each ForeignKey and OneToOneField has `on_delete` set "    "to the desired behavior"
 yield "#   * Remove `managed = False` lines if you wish to allow " "Django to create, modify, and delete the table"
 yield "# Feel free to rename the models, but don't rename db_table values or "    "field names."
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/7420
+result = yield self.request(
+    f"/applications/{int(application_id)}/guilds/{int(scope)}/commands/{int(command_id)}/permissions"
+)
+
+result = yield (self.request(
+    f"/applications/{int(application_id)}/guilds/{int(scope)}/commands/{int(command_id)}/permissions"
+))
+
+result = yield
+
+result = yield (1 + f(1, 2, 3,))
+
+result = (yield (1 + f(1, 2, 3,)))
+
+print((yield x))
 ```
 
 ## Output
@@ -230,6 +247,39 @@ yield (
     "# Feel free to rename the models, but don't rename db_table values or "
     "field names."
 )
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/7420
+result = yield self.request(
+    f"/applications/{int(application_id)}/guilds/{int(scope)}/commands/{int(command_id)}/permissions"
+)
+
+result = yield (
+    self.request(
+        f"/applications/{int(application_id)}/guilds/{int(scope)}/commands/{int(command_id)}/permissions"
+    )
+)
+
+result = yield
+
+result = yield (
+    1
+    + f(
+        1,
+        2,
+        3,
+    )
+)
+
+result = yield (
+    1
+    + f(
+        1,
+        2,
+        3,
+    )
+)
+
+print((yield x))
 ```
 
 


### PR DESCRIPTION
## Summary

This is equivalent to https://github.com/astral-sh/ruff/pull/7424, but for `yield` and `yield from` expressions. Specifically, we want to avoid adding unnecessary extra parentheses for `yield expr` when `expr` itself does not require parentheses.

## Test Plan

`cargo test`

No change in any of the similarity metrics.

Before:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99982 |              2760 |                37 |
| transformers |           0.99957 |              2587 |               399 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| warehouse    |           0.99929 |               648 |                16 |
| zulip        |           0.99962 |              1437 |                22 |

After:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99982 |              2760 |                37 |
| transformers |           0.99957 |              2587 |               399 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| warehouse    |           0.99929 |               648 |                16 |
| zulip        |           0.99962 |              1437 |                22 |
