### PR TITLE
Respect parentheses for precedence in `await`

### DIFF
--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -305,3 +305,21 @@ import os
 
 import sys
 ```
+
+### Parentheses around awaited collections are not preserved
+
+Black preserves parentheses around awaited collections:
+
+```python
+await ([1, 2, 3])
+```
+
+Ruff will instead remove them:
+
+```python
+await [1, 2, 3]
+```
+
+This is more consistent to the formatting of other awaited expressions: Ruff and Black both
+remove parentheses around, e.g., `await (1)`, only retaining them when syntactically required,
+as in, e.g., `await (x := 1)`.

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/await.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/await.py
@@ -10,3 +10,34 @@ result = await (self.request(
 result = await (1 + f(1, 2, 3,))
 
 result = (await (1 + f(1, 2, 3,)))
+
+# Optional parentheses.
+await foo
+await (foo)
+await foo()
+await (foo())
+await []()
+await ([]())
+await (foo + bar)()
+await ((foo + bar)())
+await foo.bar
+await (foo.bar)
+await foo['bar']
+await (foo['bar'])
+await 1
+await (1)
+await ""
+await ("")
+await f""
+await (f"")
+await [foo]
+await ([foo])
+await {foo}
+await ({foo})
+await (lambda foo: foo)
+await (foo or bar)
+await (foo * bar)
+await (yield foo)
+await (not foo)
+await 1, 2, 3
+await (1, 2, 3)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/await.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/await.py
@@ -41,3 +41,10 @@ await (yield foo)
 await (not foo)
 await 1, 2, 3
 await (1, 2, 3)
+await ( # comment
+    [foo]
+)
+await (
+    # comment
+    [foo]
+)

--- a/crates/ruff_python_formatter/src/expression/expr_await.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_await.rs
@@ -1,6 +1,6 @@
 use ruff_formatter::write;
 use ruff_python_ast::node::AnyNodeRef;
-use ruff_python_ast::{Expr, ExprAwait};
+use ruff_python_ast::ExprAwait;
 
 use crate::expression::maybe_parenthesize_expression;
 use crate::expression::parentheses::{
@@ -15,48 +15,12 @@ impl FormatNodeRule<ExprAwait> for FormatExprAwait {
     fn fmt_fields(&self, item: &ExprAwait, f: &mut PyFormatter) -> FormatResult<()> {
         let ExprAwait { range: _, value } = item;
 
-        // Drop parentheses around low-precedence operators (constants, names, attributes, and
-        // subscripts). It would also be syntactically valid to drop parentheses around lists,
-        // sets, and dictionaries, but Black doesn't do that.
-        // See: https://docs.python.org/3/reference/expressions.html#operator-precedence
-        let parenthesize = match value.as_ref() {
-            Expr::FString(_)
-            | Expr::Constant(_)
-            | Expr::Attribute(_)
-            | Expr::Subscript(_)
-            | Expr::Call(_)
-            | Expr::Name(_) => Parenthesize::IfBreaks,
-
-            Expr::Dict(_)
-            | Expr::Set(_)
-            | Expr::ListComp(_)
-            | Expr::SetComp(_)
-            | Expr::DictComp(_)
-            | Expr::BoolOp(_)
-            | Expr::NamedExpr(_)
-            | Expr::BinOp(_)
-            | Expr::UnaryOp(_)
-            | Expr::Lambda(_)
-            | Expr::IfExp(_)
-            | Expr::GeneratorExp(_)
-            | Expr::Await(_)
-            | Expr::Yield(_)
-            | Expr::YieldFrom(_)
-            | Expr::Compare(_)
-            | Expr::FormattedValue(_)
-            | Expr::Starred(_)
-            | Expr::List(_)
-            | Expr::Tuple(_)
-            | Expr::Slice(_)
-            | Expr::IpyEscapeCommand(_) => Parenthesize::Optional,
-        };
-
         write!(
             f,
             [
                 token("await"),
                 space(),
-                maybe_parenthesize_expression(value, item, parenthesize)
+                maybe_parenthesize_expression(value, item, Parenthesize::IfBreaks)
             ]
         )
     }

--- a/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
@@ -33,7 +33,7 @@ impl NeedsParentheses for ExprBinOp {
         parent: AnyNodeRef,
         context: &PyFormatContext,
     ) -> OptionalParentheses {
-        if parent.is_expr_await() && !self.op.is_pow() {
+        if parent.is_expr_await() {
             OptionalParentheses::Always
         } else if let Expr::Constant(constant) = self.left.as_ref() {
             // Multiline strings are guaranteed to never fit, avoid adding unnecessary parentheses

--- a/crates/ruff_python_formatter/src/expression/expr_bool_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bool_op.rs
@@ -19,10 +19,14 @@ impl FormatNodeRule<ExprBoolOp> for FormatExprBoolOp {
 impl NeedsParentheses for ExprBoolOp {
     fn needs_parentheses(
         &self,
-        _parent: AnyNodeRef,
+        parent: AnyNodeRef,
         _context: &PyFormatContext,
     ) -> OptionalParentheses {
-        OptionalParentheses::Multiline
+        if parent.is_expr_await() {
+            OptionalParentheses::Always
+        } else {
+            OptionalParentheses::Multiline
+        }
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_compare.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_compare.rs
@@ -31,10 +31,12 @@ impl FormatNodeRule<ExprCompare> for FormatExprCompare {
 impl NeedsParentheses for ExprCompare {
     fn needs_parentheses(
         &self,
-        _parent: AnyNodeRef,
+        parent: AnyNodeRef,
         context: &PyFormatContext,
     ) -> OptionalParentheses {
-        if let Expr::Constant(constant) = self.left.as_ref() {
+        if parent.is_expr_await() {
+            OptionalParentheses::Always
+        } else if let Expr::Constant(constant) = self.left.as_ref() {
             // Multiline strings are guaranteed to never fit, avoid adding unnecessary parentheses
             if !constant.value.is_implicit_concatenated()
                 && is_multiline_string(constant, context.source())

--- a/crates/ruff_python_formatter/src/expression/expr_generator_exp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_generator_exp.rs
@@ -91,10 +91,14 @@ impl FormatNodeRule<ExprGeneratorExp> for FormatExprGeneratorExp {
 impl NeedsParentheses for ExprGeneratorExp {
     fn needs_parentheses(
         &self,
-        _parent: AnyNodeRef,
+        parent: AnyNodeRef,
         _context: &PyFormatContext,
     ) -> OptionalParentheses {
-        OptionalParentheses::Never
+        if parent.is_expr_await() {
+            OptionalParentheses::Always
+        } else {
+            OptionalParentheses::Never
+        }
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_if_exp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_if_exp.rs
@@ -85,10 +85,14 @@ impl FormatNodeRule<ExprIfExp> for FormatExprIfExp {
 impl NeedsParentheses for ExprIfExp {
     fn needs_parentheses(
         &self,
-        _parent: AnyNodeRef,
+        parent: AnyNodeRef,
         _context: &PyFormatContext,
     ) -> OptionalParentheses {
-        OptionalParentheses::Multiline
+        if parent.is_expr_await() {
+            OptionalParentheses::Always
+        } else {
+            OptionalParentheses::Multiline
+        }
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/expr_lambda.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_lambda.rs
@@ -64,9 +64,13 @@ impl FormatNodeRule<ExprLambda> for FormatExprLambda {
 impl NeedsParentheses for ExprLambda {
     fn needs_parentheses(
         &self,
-        _parent: AnyNodeRef,
+        parent: AnyNodeRef,
         _context: &PyFormatContext,
     ) -> OptionalParentheses {
-        OptionalParentheses::Multiline
+        if parent.is_expr_await() {
+            OptionalParentheses::Always
+        } else {
+            OptionalParentheses::Multiline
+        }
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
@@ -72,11 +72,12 @@ impl FormatNodeRule<ExprUnaryOp> for FormatExprUnaryOp {
 impl NeedsParentheses for ExprUnaryOp {
     fn needs_parentheses(
         &self,
-        _parent: AnyNodeRef,
+        parent: AnyNodeRef,
         context: &PyFormatContext,
     ) -> OptionalParentheses {
-        // We preserve the parentheses of the operand. It should not be necessary to break this expression.
-        if is_expression_parenthesized(
+        if parent.is_expr_await() {
+            OptionalParentheses::Always
+        } else if is_expression_parenthesized(
             self.operand.as_ref().into(),
             context.comments().ranges(),
             context.source(),

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__await.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__await.py.snap
@@ -16,6 +16,37 @@ result = await (self.request(
 result = await (1 + f(1, 2, 3,))
 
 result = (await (1 + f(1, 2, 3,)))
+
+# Optional parentheses.
+await foo
+await (foo)
+await foo()
+await (foo())
+await []()
+await ([]())
+await (foo + bar)()
+await ((foo + bar)())
+await foo.bar
+await (foo.bar)
+await foo['bar']
+await (foo['bar'])
+await 1
+await (1)
+await ""
+await ("")
+await f""
+await (f"")
+await [foo]
+await ([foo])
+await {foo}
+await ({foo})
+await (lambda foo: foo)
+await (foo or bar)
+await (foo * bar)
+await (yield foo)
+await (not foo)
+await 1, 2, 3
+await (1, 2, 3)
 ```
 
 ## Output
@@ -46,6 +77,37 @@ result = await (
         3,
     )
 )
+
+# Optional parentheses.
+await foo
+await foo
+await foo()
+await foo()
+await []()
+await []()
+await (foo + bar)()
+await (foo + bar)()
+await foo.bar
+await foo.bar
+await foo["bar"]
+await foo["bar"]
+await 1
+await 1
+await ""
+await ""
+await f""
+await f""
+await [foo]
+await ([foo])
+await {foo}
+await ({foo})
+await (lambda foo: foo)
+await (foo or bar)
+await (foo * bar)
+await (yield foo)
+await (not foo)
+await 1, 2, 3
+await (1, 2, 3)
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__await.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__await.py.snap
@@ -47,6 +47,13 @@ await (yield foo)
 await (not foo)
 await 1, 2, 3
 await (1, 2, 3)
+await ( # comment
+    [foo]
+)
+await (
+    # comment
+    [foo]
+)
 ```
 
 ## Output
@@ -98,9 +105,9 @@ await ""
 await f""
 await f""
 await [foo]
-await ([foo])
+await [foo]
 await {foo}
-await ({foo})
+await {foo}
 await (lambda foo: foo)
 await (foo or bar)
 await (foo * bar)
@@ -108,6 +115,13 @@ await (yield foo)
 await (not foo)
 await 1, 2, 3
 await (1, 2, 3)
+await (  # comment
+    [foo]
+)
+await (
+    # comment
+    [foo]
+)
 ```
 
 


### PR DESCRIPTION
## Summary

We were using `Parenthesize::IfBreaks` universally for `await`, but dropping parentheses can change the AST due to precedence. It turns out that Black's rules aren't _exactly_ the same as operator precedence (e.g., they leave parentheses around `await ([1, 2, 3])`, although they aren't strictly required).

Closes https://github.com/astral-sh/ruff/issues/7467.

## Test Plan

`cargo test`

No change in similarity.

Before:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99982 |              2760 |                37 |
| transformers |           0.99957 |              2587 |               398 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| warehouse    |           0.99929 |               648 |                16 |
| zulip        |           0.99962 |              1437 |                22 |

After:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99982 |              2760 |                37 |
| transformers |           0.99957 |              2587 |               398 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| warehouse    |           0.99929 |               648 |                16 |
| zulip        |           0.99962 |              1437 |                22 |
