### PR TITLE
Replace num_bigint with malachite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,12 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
@@ -213,6 +219,15 @@ name = "bitflags"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -496,6 +511,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +612,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +667,16 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -719,6 +763,18 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "embed-doc-image"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af36f591236d9d822425cb6896595658fa558fcebf5ee8accac1d4b92c47166e"
+dependencies = [
+ "base64 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "ena"
@@ -870,6 +926,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1168,6 +1234,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,6 +1396,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "malachite"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fa232412d927f518cd873073911726943f432bac1bbc1288316d240635dc51"
+dependencies = [
+ "malachite-base",
+ "malachite-nz",
+]
+
+[[package]]
+name = "malachite-base"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "606a61b226dc58b8b283399b74754460433c193b193f26eaaad92f7966abd72b"
+dependencies = [
+ "getrandom",
+ "itertools 0.11.0",
+ "rand",
+ "rand_chacha",
+ "ryu",
+ "sha3",
+]
+
+[[package]]
+name = "malachite-nz"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "863d06218c83cc2269c425186cc15094d6284b1333a1184d0890aecfddb8916b"
+dependencies = [
+ "embed-doc-image",
+ "itertools 0.11.0",
+ "malachite-base",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,27 +1562,6 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
 ]
 
 [[package]]
@@ -2047,9 +2136,9 @@ dependencies = [
  "itertools 0.11.0",
  "libcst",
  "log",
+ "malachite",
  "memchr",
  "natord",
- "num-bigint",
  "num-traits",
  "once_cell",
  "path-absolutize",
@@ -2298,9 +2387,8 @@ dependencies = [
  "insta",
  "is-macro",
  "itertools 0.11.0",
+ "malachite",
  "memchr",
- "num-bigint",
- "num-traits",
  "once_cell",
  "ruff_python_parser",
  "ruff_python_trivia",
@@ -2389,8 +2477,7 @@ dependencies = [
  "itertools 0.11.0",
  "lalrpop",
  "lalrpop-util",
- "num-bigint",
- "num-traits",
+ "malachite",
  "ruff_python_ast",
  "ruff_text_size",
  "rustc-hash",
@@ -2416,7 +2503,6 @@ version = "0.0.0"
 dependencies = [
  "bitflags 2.4.0",
  "is-macro",
- "num-traits",
  "ruff_index",
  "ruff_python_ast",
  "ruff_python_parser",
@@ -2762,6 +2848,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -3177,6 +3273,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3271,7 +3373,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
 dependencies = [
- "base64",
+ "base64 0.21.3",
  "flate2",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ insta = { version = "1.31.0", feature = ["filters", "glob"] }
 is-macro = { version = "0.3.0" }
 itertools = { version = "0.11.0" }
 log = { version = "0.4.17" }
+malachite = { version = "0.4.0", default-features = false, features = ["naturals_and_integers"] }
 memchr = "2.6.3"
-num-bigint = { version = "0.4.3" }
 num-traits = { version = "0.2.15" }
 once_cell = { version = "1.17.1" }
 path-absolutize = { version = "3.1.1" }

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -45,9 +45,9 @@ is-macro = { workspace = true }
 itertools = { workspace = true }
 libcst = { workspace = true }
 log = { workspace = true }
+malachite = { workspace = true }
 memchr = { workspace = true }
 natord = { version = "1.0.9" }
-num-bigint = { workspace = true }
 num-traits = { workspace = true }
 once_cell = { workspace = true }
 path-absolutize = { workspace = true, features = [

--- a/crates/ruff/src/rules/flake8_2020/rules/compare.rs
+++ b/crates/ruff/src/rules/flake8_2020/rules/compare.rs
@@ -1,8 +1,6 @@
-use num_bigint::BigInt;
-use ruff_python_ast::{self as ast, CmpOp, Constant, Expr};
-
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::{self as ast, CmpOp, Constant, Expr};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -237,7 +235,7 @@ pub(crate) fn compare(checker: &mut Checker, left: &Expr, ops: &[CmpOp], compara
                 ..
             }) = slice.as_ref()
             {
-                if *i == BigInt::from(0) {
+                if *i == 0 {
                     if let (
                         [CmpOp::Eq | CmpOp::NotEq],
                         [Expr::Constant(ast::ExprConstant {
@@ -246,13 +244,13 @@ pub(crate) fn compare(checker: &mut Checker, left: &Expr, ops: &[CmpOp], compara
                         })],
                     ) = (ops, comparators)
                     {
-                        if *n == BigInt::from(3) && checker.enabled(Rule::SysVersionInfo0Eq3) {
+                        if *n == 3 && checker.enabled(Rule::SysVersionInfo0Eq3) {
                             checker
                                 .diagnostics
                                 .push(Diagnostic::new(SysVersionInfo0Eq3, left.range()));
                         }
                     }
-                } else if *i == BigInt::from(1) {
+                } else if *i == 1 {
                     if let (
                         [CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE],
                         [Expr::Constant(ast::ExprConstant {

--- a/crates/ruff/src/rules/flake8_2020/rules/subscript.rs
+++ b/crates/ruff/src/rules/flake8_2020/rules/subscript.rs
@@ -1,4 +1,3 @@
-use num_bigint::BigInt;
 use ruff_python_ast::{self as ast, Constant, Expr};
 
 use ruff_diagnostics::{Diagnostic, Violation};
@@ -184,11 +183,11 @@ pub(crate) fn subscript(checker: &mut Checker, value: &Expr, slice: &Expr) {
                     ..
                 }) = upper.as_ref()
                 {
-                    if *i == BigInt::from(1) && checker.enabled(Rule::SysVersionSlice1) {
+                    if *i == 1 && checker.enabled(Rule::SysVersionSlice1) {
                         checker
                             .diagnostics
                             .push(Diagnostic::new(SysVersionSlice1, value.range()));
-                    } else if *i == BigInt::from(3) && checker.enabled(Rule::SysVersionSlice3) {
+                    } else if *i == 3 && checker.enabled(Rule::SysVersionSlice3) {
                         checker
                             .diagnostics
                             .push(Diagnostic::new(SysVersionSlice3, value.range()));
@@ -200,11 +199,11 @@ pub(crate) fn subscript(checker: &mut Checker, value: &Expr, slice: &Expr) {
                 value: Constant::Int(i),
                 ..
             }) => {
-                if *i == BigInt::from(2) && checker.enabled(Rule::SysVersion2) {
+                if *i == 2 && checker.enabled(Rule::SysVersion2) {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(SysVersion2, value.range()));
-                } else if *i == BigInt::from(0) && checker.enabled(Rule::SysVersion0) {
+                } else if *i == 0 && checker.enabled(Rule::SysVersion0) {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(SysVersion0, value.range()));

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
@@ -1,5 +1,3 @@
-use num_traits::{One, Zero};
-
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::{self as ast, Constant, Expr};
@@ -57,7 +55,7 @@ pub(crate) fn snmp_insecure_version(checker: &mut Checker, call: &ast::ExprCall)
                 ..
             }) = &keyword.value
             {
-                if value.is_zero() || value.is_one() {
+                if *value == 0 || *value == 1 {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(SnmpInsecureVersion, keyword.range()));

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
@@ -1,5 +1,3 @@
-use num_bigint::BigInt;
-
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::{self as ast, Constant, Expr, UnaryOp};
@@ -93,7 +91,7 @@ pub(crate) fn unnecessary_subscript_reversal(
     else {
         return;
     };
-    if *val != BigInt::from(1) {
+    if *val != 1 {
         return;
     };
     checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/flake8_pie/rules/unnecessary_range_start.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules/unnecessary_range_start.rs
@@ -1,5 +1,3 @@
-use num_bigint::BigInt;
-
 use ruff_diagnostics::Diagnostic;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -75,7 +73,7 @@ pub(crate) fn unnecessary_range_start(checker: &mut Checker, call: &ast::ExprCal
     else {
         return;
     };
-    if *value != BigInt::from(0) {
+    if *value != 0 {
         return;
     };
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
@@ -1,5 +1,3 @@
-use num_bigint::BigInt;
-use num_traits::{One, Zero};
 use ruff_python_ast::{self as ast, CmpOp, Constant, Expr};
 
 use ruff_diagnostics::{Diagnostic, Violation};
@@ -249,10 +247,10 @@ impl ExpectedComparator {
                     ..
                 }) = upper.as_ref()
                 {
-                    if *upper == BigInt::one() {
+                    if *upper == 1 {
                         return Some(ExpectedComparator::MajorTuple);
                     }
-                    if *upper == BigInt::from(2) {
+                    if *upper == 2 {
                         return Some(ExpectedComparator::MajorMinorTuple);
                     }
                 }
@@ -260,7 +258,7 @@ impl ExpectedComparator {
             Expr::Constant(ast::ExprConstant {
                 value: Constant::Int(n),
                 ..
-            }) if n.is_zero() => {
+            }) if *n == 0 => {
                 return Some(ExpectedComparator::MajorDigit);
             }
             _ => (),

--- a/crates/ruff/src/rules/pandas_vet/rules/nunique_constant_series_check.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/nunique_constant_series_check.rs
@@ -1,4 +1,3 @@
-use num_traits::One;
 use ruff_python_ast::{self as ast, CmpOp, Constant, Expr};
 
 use ruff_diagnostics::Diagnostic;
@@ -115,7 +114,7 @@ pub(crate) fn nunique_constant_series_check(
 fn is_constant_one(expr: &Expr) -> bool {
     match expr {
         Expr::Constant(constant) => match &constant.value {
-            Constant::Int(int) => int.is_one(),
+            Constant::Int(int) => *int == 1,
             _ => false,
         },
         _ => false,

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -1,7 +1,6 @@
+use malachite::Integer;
 use std::fmt;
 use std::str::FromStr;
-
-use num_bigint::BigInt;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -47,7 +46,7 @@ impl From<LiteralType> for Constant {
                 value: Vec::new(),
                 implicit_concatenated: false,
             }),
-            LiteralType::Int => Constant::Int(BigInt::from(0)),
+            LiteralType::Int => Constant::Int(Integer::from(0)),
             LiteralType::Float => Constant::Float(0.0),
             LiteralType::Bool => Constant::Bool(false),
         }

--- a/crates/ruff/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
+++ b/crates/ruff/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-use num_traits::Zero;
-
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::{self as ast, Arguments, Comprehension, Constant, Expr};
@@ -115,7 +113,7 @@ fn is_head_slice(expr: &Expr) -> bool {
         ..
     }) = expr
     {
-        value.is_zero()
+        *value == 0
     } else {
         false
     }

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -20,9 +20,8 @@ ruff_text_size = { path = "../ruff_text_size" }
 bitflags = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
+malachite = { workspace = true }
 memchr = { workspace = true }
-num-bigint = { workspace = true }
-num-traits = { workspace = true }
 once_cell = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -15,9 +15,8 @@
 //! an implicit concatenation of string literals, as these expressions are considered to
 //! have the same shape in that they evaluate to the same value.
 
-use num_bigint::BigInt;
-
 use crate as ast;
+use malachite::Integer;
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub enum ComparableBoolOp {
@@ -334,7 +333,7 @@ pub enum ComparableConstant<'a> {
     Bool(&'a bool),
     Str { value: &'a str, unicode: bool },
     Bytes(&'a [u8]),
-    Int(&'a BigInt),
+    Int(&'a Integer),
     Tuple(Vec<ComparableConstant<'a>>),
     Float(u64),
     Complex { real: u64, imag: u64 },

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::path::Path;
 
-use num_traits::Zero;
 use smallvec::SmallVec;
 
 use ruff_text_size::{Ranged, TextRange};
@@ -1073,7 +1072,7 @@ impl Truthiness {
                 Constant::None => Some(false),
                 Constant::Str(ast::StringConstant { value, .. }) => Some(!value.is_empty()),
                 Constant::Bytes(bytes) => Some(!bytes.is_empty()),
-                Constant::Int(int) => Some(!int.is_zero()),
+                Constant::Int(int) => Some(*int != 0),
                 Constant::Float(float) => Some(*float != 0.0),
                 Constant::Complex { real, imag } => Some(*real != 0.0 || *imag != 0.0),
                 Constant::Ellipsis => Some(true),

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1,11 +1,10 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 use itertools::Itertools;
+use malachite::Integer;
 use std::fmt;
 use std::fmt::Debug;
 use std::ops::Deref;
-
-use num_bigint::BigInt;
 
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
@@ -2604,7 +2603,7 @@ pub enum Constant {
     Bool(bool),
     Str(StringConstant),
     Bytes(BytesConstant),
-    Int(BigInt),
+    Int(Integer),
     Float(f64),
     Complex { real: f64, imag: f64 },
     Ellipsis,

--- a/crates/ruff_python_literal/src/float.rs
+++ b/crates/ruff_python_literal/src/float.rs
@@ -1,5 +1,5 @@
 use crate::Case;
-use num_traits::{Float, Zero};
+use num_traits::Float;
 use std::f64;
 
 pub fn parse_str(literal: &str) -> Option<f64> {
@@ -248,7 +248,7 @@ pub fn to_hex(value: f64) -> String {
     let (mantissa, exponent, sign) = value.integer_decode();
     let sign_fmt = if sign < 0 { "-" } else { "" };
     match value {
-        value if value.is_zero() => format!("{sign_fmt}0x0.0p+0"),
+        value if value == 0.0 => format!("{sign_fmt}0x0.0p+0"),
         value if value.is_infinite() => format!("{sign_fmt}inf"),
         value if value.is_nan() => "nan".to_owned(),
         _ => {

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -21,8 +21,7 @@ anyhow = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
 lalrpop-util = { version = "0.20.0", default-features = false }
-num-bigint = { workspace = true }
-num-traits = { workspace = true }
+malachite = { workspace = true }
 unicode-ident = { workspace = true }
 unicode_names2 = { version = "0.6.0", git = "https://github.com/youknowone/unicode_names2.git", rev = "4ce16aa85cbcdd9cc830410f1a72ef9a235f2fde" }
 rustc-hash = { workspace = true }

--- a/crates/ruff_python_parser/src/python.lalrpop
+++ b/crates/ruff_python_parser/src/python.lalrpop
@@ -3,7 +3,6 @@
 // See also: file:///usr/share/doc/python/html/reference/compound_stmts.html#function-definitions
 // See also: https://greentreesnakes.readthedocs.io/en/latest/nodes.html#keyword
 
-use num_bigint::BigInt;
 use ruff_text_size::{Ranged, TextSize};
 use ruff_python_ast::{self as ast, IpyEscapeKind};
 use crate::{
@@ -15,6 +14,7 @@ use crate::{
     token::{self, StringKind},
 };
 use lalrpop_util::ParseError;
+use malachite::Integer;
 
 grammar(mode: Mode);
 
@@ -1928,7 +1928,7 @@ extern {
         "True" => token::Tok::True,
         "False" => token::Tok::False,
         "None" => token::Tok::None,
-        int => token::Tok::Int { value: <BigInt> },
+        int => token::Tok::Int { value: <Integer> },
         float => token::Tok::Float { value: <f64> },
         complex => token::Tok::Complex { real: <f64>, imag: <f64> },
         string => token::Tok::String {

--- a/crates/ruff_python_parser/src/python.rs
+++ b/crates/ruff_python_parser/src/python.rs
@@ -1,6 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: e8f3229288c1a13387ea6041355e2d8fe9ab788fbc7229032d2de92beb675944
-use num_bigint::BigInt;
+// sha3: 5b982370860d3a79f183bc579ec6f5165211b83573141f4c9ceaec27436c30ad
 use ruff_text_size::{Ranged, TextSize};
 use ruff_python_ast::{self as ast, IpyEscapeKind};
 use crate::{
@@ -12,6 +11,7 @@ use crate::{
     token::{self, StringKind},
 };
 use lalrpop_util::ParseError;
+use malachite::Integer;
 #[allow(unused_extern_crates)]
 extern crate lalrpop_util as __lalrpop_util;
 #[allow(unused_imports)]
@@ -23,7 +23,6 @@ extern crate alloc;
 #[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::all)]
 mod __parse__Top {
 
-    use num_bigint::BigInt;
     use ruff_text_size::{Ranged, TextSize};
     use ruff_python_ast::{self as ast, IpyEscapeKind};
     use crate::{
@@ -35,6 +34,7 @@ mod __parse__Top {
     token::{self, StringKind},
 };
     use lalrpop_util::ParseError;
+    use malachite::Integer;
     #[allow(unused_extern_crates)]
     extern crate lalrpop_util as __lalrpop_util;
     #[allow(unused_imports)]
@@ -48,7 +48,7 @@ mod __parse__Top {
         Variant0(token::Tok),
         Variant1((f64, f64)),
         Variant2(f64),
-        Variant3(BigInt),
+        Variant3(Integer),
         Variant4((IpyEscapeKind, String)),
         Variant5(String),
         Variant6((String, StringKind, bool)),
@@ -17716,7 +17716,7 @@ mod __parse__Top {
     fn __pop_Variant3<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
-    ) -> (TextSize, BigInt, TextSize)
+    ) -> (TextSize, Integer, TextSize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant3(__v), __r)) => (__l, __v, __r),
@@ -34480,7 +34480,7 @@ fn __action232<
 fn __action233<
 >(
     mode: Mode,
-    (_, value, _): (TextSize, BigInt, TextSize),
+    (_, value, _): (TextSize, Integer, TextSize),
 ) -> ast::Constant
 {
     ast::Constant::Int(value)

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -5,7 +5,7 @@
 //!
 //! [CPython source]: https://github.com/python/cpython/blob/dfc2e065a2e71011017077e549cd2f9bf4944c54/Include/internal/pycore_token.h;
 use crate::Mode;
-use num_bigint::BigInt;
+use malachite::Integer;
 use ruff_python_ast::IpyEscapeKind;
 use ruff_text_size::TextSize;
 use std::fmt;
@@ -21,7 +21,7 @@ pub enum Tok {
     /// Token value for an integer.
     Int {
         /// The integer value.
-        value: BigInt,
+        value: Integer,
     },
     /// Token value for a floating point number.
     Float {

--- a/crates/ruff_python_semantic/Cargo.toml
+++ b/crates/ruff_python_semantic/Cargo.toml
@@ -21,7 +21,6 @@ ruff_text_size = { path = "../ruff_text_size" }
 
 bitflags = { workspace = true }
 is-macro = { workspace = true }
-num-traits = { workspace = true }
 rustc-hash = { workspace = true }
 smallvec = { workspace = true }
 

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -1,6 +1,5 @@
 //! Analysis rules for the `typing` module.
 
-use num_traits::identities::Zero;
 use ruff_python_ast::{
     self as ast, Constant, Expr, Operator, ParameterWithDefault, Parameters, Stmt,
 };
@@ -319,7 +318,7 @@ pub fn is_type_checking_block(stmt: &ast::StmtIf, semantic: &SemanticModel) -> b
         ..
     }) = test.as_ref()
     {
-        if value.is_zero() {
+        if *value == 0 {
             return true;
         }
     }


### PR DESCRIPTION
[malachite](https://www.malachite.rs/) is an arbitrary precision crate that unlike num_bigint implement as small integer optimization. This avoids allocating a `Vec` for every single number parse and instead only allocates for rare unusually large numbers.

This is also a correctness improvement since we'd previously just ignore the higher parts of unreasonably large numbers.

The disadvantage is that malachite is slow to compile.

TODO: Is the LGPL that malachite uses ok for ruff?