### PR TITLE
Add optimized `best_fit_parenthesize` IR

### DIFF
--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -1451,6 +1451,150 @@ impl<Context> std::fmt::Debug for Group<'_, Context> {
     }
 }
 
+/// Content that may get parenthesized if it exceeds the configured line width but only if the parenthesized
+/// layout doesn't exceed the line width too, in which case it falls back to the flat layout.
+///
+/// This IR is identical to the following [`best_fitting`] layout but is implemented as custom IR for
+/// best performance.
+///
+/// ```rust
+/// # use ruff_formatter::prelude::*;
+/// # use ruff_formatter::format_args;
+///
+/// let format_expression = format_with(|f: &mut Formatter<SimpleFormatContext>| token("A long string").fmt(f));
+/// let _ = best_fitting![
+///     // ---------------------------------------------------------------------
+///     // Variant 1:
+///     // Try to fit the expression without any parentheses
+///     group(&format_expression),
+///     // ---------------------------------------------------------------------
+///     // Variant 2:
+///     // Try to fit the expression by adding parentheses and indenting the expression.
+///     group(&format_args![
+///         token("("),
+///         soft_block_indent(&format_expression),
+///         token(")")
+///     ])
+///     .should_expand(true),
+///     // ---------------------------------------------------------------------
+///     // Variant 3: Fallback, no parentheses
+///     // Expression doesn't fit regardless of adding the parentheses. Remove the parentheses again.
+///     group(&format_expression).should_expand(true)
+/// ]
+/// // Measure all lines, to avoid that the printer decides that this fits right after hitting
+/// // the `(`.
+/// .with_mode(BestFittingMode::AllLines)        ;
+/// ```
+///
+/// The element breaks from left-to-right because it uses the unintended version as *expanded* layout, the same as the above showed best fitting example.
+///
+/// ## Examples
+///
+/// ### Content that fits into the configured line width.
+///
+/// ```rust
+/// # use ruff_formatter::prelude::*;
+/// # use ruff_formatter::{format, PrintResult, write};
+///
+/// # fn main() -> FormatResult<()> {
+///     let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
+///         write!(f, [
+///             token("aLongerVariableName = "),
+///             best_fit_parenthesize(&token("'a string that fits into the configured line width'"))
+///         ])
+///     })])?;
+///
+///     assert_eq!(formatted.print()?.as_code(), "aLongerVariableName = 'a string that fits into the configured line width'");
+///     # Ok(())
+/// # }
+/// ```
+///
+/// ### Content that fits parenthesized
+///
+/// ```rust
+/// # use ruff_formatter::prelude::*;
+/// # use ruff_formatter::{format, PrintResult, write};
+///
+/// # fn main() -> FormatResult<()> {
+///     let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
+///         write!(f, [
+///             token("aLongerVariableName = "),
+///             best_fit_parenthesize(&token("'a string that exceeds configured line width but fits parenthesized'"))
+///         ])
+///     })])?;
+///
+///     assert_eq!(formatted.print()?.as_code(), "aLongerVariableName = (\n\t'a string that exceeds configured line width but fits parenthesized'\n)");
+///     # Ok(())
+/// # }
+/// ```
+///
+/// ### Content that exceeds the line width, parenthesized or not
+///
+/// ```rust
+/// # use ruff_formatter::prelude::*;
+/// # use ruff_formatter::{format, PrintResult, write};
+///
+/// # fn main() -> FormatResult<()> {
+///     let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
+///         write!(f, [
+///             token("aLongerVariableName = "),
+///             best_fit_parenthesize(&token("'a string that exceeds the configured line width and even parenthesizing doesn't make it fit'"))
+///         ])
+///     })])?;
+///
+///     assert_eq!(formatted.print()?.as_code(), "aLongerVariableName = 'a string that exceeds the configured line width and even parenthesizing doesn't make it fit'");
+///     # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn best_fit_parenthesize<Context>(
+    content: &impl Format<Context>,
+) -> BestFitParenthesize<Context> {
+    BestFitParenthesize {
+        content: Argument::new(content),
+        group_id: None,
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct BestFitParenthesize<'a, Context> {
+    content: Argument<'a, Context>,
+    group_id: Option<GroupId>,
+}
+
+impl<Context> BestFitParenthesize<'_, Context> {
+    /// Optional ID that can be used in conditional content that supports [`Condition`] to gate content
+    /// depending on whether the parentheses are rendered (flat: no parentheses, expanded: parentheses).
+    #[must_use]
+    pub fn with_group_id(mut self, group_id: Option<GroupId>) -> Self {
+        self.group_id = group_id;
+        self
+    }
+}
+
+impl<Context> Format<Context> for BestFitParenthesize<'_, Context> {
+    fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
+        f.write_element(FormatElement::Tag(StartBestFitParenthesize {
+            id: self.group_id,
+        }));
+
+        Arguments::from(&self.content).fmt(f)?;
+
+        f.write_element(FormatElement::Tag(EndBestFitParenthesize));
+
+        Ok(())
+    }
+}
+
+impl<Context> std::fmt::Debug for BestFitParenthesize<'_, Context> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BestFitParenthesize")
+            .field("group_id", &self.group_id)
+            .field("content", &"{{content}}")
+            .finish()
+    }
+}
+
 /// Sets the `condition` for the group. The element will behave as a regular group if `condition` is met,
 /// and as *ungrouped* content if the condition is not met.
 ///

--- a/crates/ruff_formatter/src/format_element/tag.rs
+++ b/crates/ruff_formatter/src/format_element/tag.rs
@@ -86,6 +86,13 @@ pub enum Tag {
 
     StartBestFittingEntry,
     EndBestFittingEntry,
+
+    /// Parenthesizes the content but only if adding the parentheses and indenting the content
+    /// makes the content fit in the configured line width.
+    StartBestFitParenthesize {
+        id: Option<GroupId>,
+    },
+    EndBestFitParenthesize,
 }
 
 impl Tag {
@@ -102,11 +109,12 @@ impl Tag {
                 | Tag::StartIndentIfGroupBreaks(_)
                 | Tag::StartFill
                 | Tag::StartEntry
-                | Tag::StartLineSuffix { reserved_width: _ }
+                | Tag::StartLineSuffix { .. }
                 | Tag::StartVerbatim(_)
                 | Tag::StartLabelled(_)
                 | Tag::StartFitsExpanded(_)
-                | Tag::StartBestFittingEntry,
+                | Tag::StartBestFittingEntry
+                | Tag::StartBestFitParenthesize { .. }
         )
     }
 
@@ -134,6 +142,9 @@ impl Tag {
             StartLabelled(_) | EndLabelled => TagKind::Labelled,
             StartFitsExpanded { .. } | EndFitsExpanded => TagKind::FitsExpanded,
             StartBestFittingEntry { .. } | EndBestFittingEntry => TagKind::BestFittingEntry,
+            StartBestFitParenthesize { .. } | EndBestFitParenthesize => {
+                TagKind::BestFitParenthesize
+            }
         }
     }
 }
@@ -158,6 +169,7 @@ pub enum TagKind {
     Labelled,
     FitsExpanded,
     BestFittingEntry,
+    BestFitParenthesize,
 }
 
 #[derive(Debug, Copy, Default, Clone, Eq, PartialEq)]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unsplittable.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unsplittable.py
@@ -70,3 +70,32 @@ def test():
     if True:
         VLM_m2m = VLM.m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.through
         allows_group_by_select_index = self.connection.features.allows_group_by_select_index
+
+
+# This is a deviation from Black:
+# Black keeps the comment inside of the parentheses, making it more likely to exceed the line width.
+# Ruff renders the comment after the parentheses, giving it more space to fit.
+if True:
+    if True:
+        if True:
+            # Black layout
+            model.config.use_cache = (
+                False  # FSTM still requires this hack -> FSTM should probably be refactored s
+            )
+            # Ruff layout
+            model.config.use_cache = False  # FSTM still requires this hack -> FSTM should probably be refactored s
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7463
+mp3fmt="<span style=\"color: grey\"><a href=\"{}\" id=\"audiolink\">listen</a></span></br>\n"
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7067
+def f():
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = (
+        True
+    )
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7462
+if grid is not None:
+    rgrid = (rgrid.rio.reproject_match(grid, nodata=fillvalue) # rio.reproject nodata is use to initlialize the destination array
+             .where(~grid.isnull()))

--- a/crates/ruff_python_formatter/src/expression/expr_constant.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_constant.rs
@@ -5,7 +5,7 @@ use ruff_text_size::{Ranged, TextLen, TextRange};
 
 use crate::comments::SourceComment;
 use crate::expression::number::{FormatComplex, FormatFloat, FormatInt};
-use crate::expression::parentheses::{should_use_best_fit, NeedsParentheses, OptionalParentheses};
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::expression::string::{
     AnyString, FormatString, StringLayout, StringPrefix, StringQuotes,
 };
@@ -76,16 +76,10 @@ impl NeedsParentheses for ExprConstant {
     ) -> OptionalParentheses {
         if self.value.is_implicit_concatenated() {
             OptionalParentheses::Multiline
-        } else if is_multiline_string(self, context.source())
-            || self.value.is_none()
-            || self.value.is_bool()
-            || self.value.is_ellipsis()
-        {
+        } else if is_multiline_string(self, context.source()) {
             OptionalParentheses::Never
-        } else if should_use_best_fit(self, context) {
-            OptionalParentheses::BestFit
         } else {
-            OptionalParentheses::Never
+            OptionalParentheses::BestFit
         }
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_f_string.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_f_string.rs
@@ -4,7 +4,7 @@ use ruff_formatter::FormatResult;
 use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::ExprFString;
 
-use crate::expression::parentheses::{should_use_best_fit, NeedsParentheses, OptionalParentheses};
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 
 use super::string::{AnyString, FormatString};
@@ -26,9 +26,7 @@ impl NeedsParentheses for ExprFString {
     ) -> OptionalParentheses {
         if self.implicit_concatenated {
             OptionalParentheses::Multiline
-        } else if memchr2(b'\n', b'\r', context.source()[self.range].as_bytes()).is_none()
-            && should_use_best_fit(self, context)
-        {
+        } else if memchr2(b'\n', b'\r', context.source()[self.range].as_bytes()).is_none() {
             OptionalParentheses::BestFit
         } else {
             OptionalParentheses::Never

--- a/crates/ruff_python_formatter/src/expression/expr_name.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_name.rs
@@ -3,7 +3,7 @@ use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::ExprName;
 
 use crate::comments::SourceComment;
-use crate::expression::parentheses::{should_use_best_fit, NeedsParentheses, OptionalParentheses};
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
 
 #[derive(Default)]
@@ -38,13 +38,9 @@ impl NeedsParentheses for ExprName {
     fn needs_parentheses(
         &self,
         _parent: AnyNodeRef,
-        context: &PyFormatContext,
+        _context: &PyFormatContext,
     ) -> OptionalParentheses {
-        if should_use_best_fit(self, context) {
-            OptionalParentheses::BestFit
-        } else {
-            OptionalParentheses::Never
-        }
+        OptionalParentheses::BestFit
     }
 }
 

--- a/crates/ruff_python_formatter/src/expression/parentheses.rs
+++ b/crates/ruff_python_formatter/src/expression/parentheses.rs
@@ -1,5 +1,5 @@
 use ruff_formatter::prelude::tag::Condition;
-use ruff_formatter::{format_args, write, Argument, Arguments, FormatContext, FormatOptions};
+use ruff_formatter::{format_args, write, Argument, Arguments};
 use ruff_python_ast::node::AnyNodeRef;
 use ruff_python_ast::ExpressionRef;
 use ruff_python_trivia::CommentRanges;
@@ -24,33 +24,12 @@ pub(crate) enum OptionalParentheses {
     Always,
 
     /// Add parentheses if it helps to make this expression fit. Otherwise never add parentheses.
-    /// This mode should only be used for expressions that don't have their own split points, e.g. identifiers,
-    /// or constants.
+    /// This mode should only be used for expressions that don't have their own split points to the left, e.g. identifiers,
+    /// or constants, calls starting with an identifier, etc.
     BestFit,
 
     /// Never add parentheses. Use it for expressions that have their own parentheses or if the expression body always spans multiple lines (multiline strings).
     Never,
-}
-
-pub(super) fn should_use_best_fit<T>(value: T, context: &PyFormatContext) -> bool
-where
-    T: Ranged,
-{
-    let text_len = context.source()[value.range()].len();
-
-    // Only use best fits if:
-    // * The text is longer than 5 characters:
-    //   This is to align the behavior with `True` and `False`, that don't use best fits and are 5 characters long.
-    //   It allows to avoid [`OptionalParentheses::BestFit`] for most numbers and common identifiers like `self`.
-    //   The downside is that it can result in short values not being parenthesized if they exceed the line width.
-    //   This is considered an edge case not worth the performance penalty and IMO, breaking an identifier
-    //   of 5 characters to avoid it exceeding the line width by 1 reduces the readability.
-    // * The text is know to never fit: The text can never fit even when parenthesizing if it is longer
-    //   than the configured line width (minus indent).
-    text_len > 5
-        && text_len
-            <= context.options().line_width().value() as usize
-                - context.options().indent_width().value() as usize
 }
 
 pub(crate) trait NeedsParentheses {

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__unsplittable.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__unsplittable.py.snap
@@ -76,6 +76,35 @@ def test():
     if True:
         VLM_m2m = VLM.m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.through
         allows_group_by_select_index = self.connection.features.allows_group_by_select_index
+
+
+# This is a deviation from Black:
+# Black keeps the comment inside of the parentheses, making it more likely to exceed the line width.
+# Ruff renders the comment after the parentheses, giving it more space to fit.
+if True:
+    if True:
+        if True:
+            # Black layout
+            model.config.use_cache = (
+                False  # FSTM still requires this hack -> FSTM should probably be refactored s
+            )
+            # Ruff layout
+            model.config.use_cache = False  # FSTM still requires this hack -> FSTM should probably be refactored s
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7463
+mp3fmt="<span style=\"color: grey\"><a href=\"{}\" id=\"audiolink\">listen</a></span></br>\n"
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7067
+def f():
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = (
+        True
+    )
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7462
+if grid is not None:
+    rgrid = (rgrid.rio.reproject_match(grid, nodata=fillvalue) # rio.reproject nodata is use to initlialize the destination array
+             .where(~grid.isnull()))
 ```
 
 ## Output
@@ -140,7 +169,9 @@ for converter in connection.ops.get_db_converters(
     ...
 
 
-aaa = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  # awkward comment
+aaa = (
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  # awkward comment
+)
 
 
 def test():
@@ -167,6 +198,44 @@ def test():
         allows_group_by_select_index = (
             self.connection.features.allows_group_by_select_index
         )
+
+
+# This is a deviation from Black:
+# Black keeps the comment inside of the parentheses, making it more likely to exceed the line width.
+# Ruff renders the comment after the parentheses, giving it more space to fit.
+if True:
+    if True:
+        if True:
+            # Black layout
+            model.config.use_cache = (
+                False  # FSTM still requires this hack -> FSTM should probably be refactored s
+            )
+            # Ruff layout
+            model.config.use_cache = (
+                False
+            )  # FSTM still requires this hack -> FSTM should probably be refactored s
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7463
+mp3fmt = (
+    '<span style="color: grey"><a href="{}" id="audiolink">listen</a></span></br>\n'
+)
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7067
+def f():
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = (
+        True
+    )
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7462
+if grid is not None:
+    rgrid = rgrid.rio.reproject_match(
+        grid, nodata=fillvalue
+    ).where(  # rio.reproject nodata is use to initlialize the destination array
+        ~grid.isnull()
+    )
 ```
 
 


### PR DESCRIPTION
## Summary

This PR adds a custom IR for content that should only be parenthesized if it makes it fit. The custom IR removes the need to use the costly `BestFitting` IR element, allowing us to remove the poor heuristic around when to use the `BestFit` layout (because the IR is now cheap).

The main downside of the custom IR is that it is less tested and further increases the complexity of the Printer (It is re-implementation of `BestFitting` with the three variants)

Closes https://github.com/astral-sh/ruff/issues/7463
Closes https://github.com/astral-sh/ruff/issues/7067
Closes #7462

## Test Plan

`cargo test`

**Base**

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1632 |
| django       |           0.99982 |              2760 |                37 |
| transformers |           0.99957 |              2587 |               398 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| warehouse    |           0.99929 |               648 |                16 |
| zulip        |           0.99962 |              1437 |                22 |



**This PR**
| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1631 |
| **django**       |           0.99983 |              2760 |                36 |
| **transformers** |           0.99956 |              2587 |               404 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99983 |              3496 |                18 |
| warehouse    |           0.99929 |               648 |                16 |
| **zulip**        |           0.99969 |              1437 |                21 |


New *transformers* deviations: There are a few new transformers deviations of the form:

```python
if True:
    if True:
        if True:
			model.config.use_cache = False  # FSTM still requires this hack -> FSTM should probably be refactored similar to BART afterward

# Formatted
if True:
    if True:
        if True:
			model.config.use_cache = (
				False
			)  # FSTM still requires this hack -> FSTM should probably be refactored similar to BART afterward
```

This is because the `BestFit` layout is now also applied for constants. 

The formatting is now consistent with a 6 character identifier:

```python
if True:
    if True:
        if True:
            model.config.use_cache = aaaaaa  # FSTM still requires this hack -> FSTM should probably be refactored similar to BART afterward

# Formatted
if True:
    if True:
        if True:
            model.config.use_cache = (
                aaaaaa
            )  # FSTM still requires this hack -> FSTM should probably be refactored similar to BART afterward

```
