### PR TITLE
Fix `''' ""'''` formatting

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/string.py
@@ -130,3 +130,6 @@ test_particular = [
 x = ("""aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa""" """bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb""")
 x = (f"""aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa""" f"""bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb""")
 x = (b"""aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa""" b"""bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb""")
+
+# https://github.com/astral-sh/ruff/issues/7460
+trailing_preferred_quote_texts = [''' "''', ''' ""''', ''' """''', ''' """"''']

--- a/crates/ruff_python_formatter/src/expression/string.rs
+++ b/crates/ruff_python_formatter/src/expression/string.rs
@@ -543,10 +543,17 @@ fn preferred_quotes(
                             // `""` or `''`
                             chars.next();
 
-                            if chars.peek().copied() == Some(configured_quote_char) {
-                                // `"""` or `'''`
-                                chars.next();
-                                uses_triple_quotes = true;
+                            match chars.peek().copied() {
+                                Some(c) if c == configured_quote_char => {
+                                    // `"""` or `'''`
+                                    chars.next();
+                                    uses_triple_quotes = true;
+                                }
+                                Some(_) => {}
+                                None => {
+                                    // Handle `''' ""'''`
+                                    uses_triple_quotes = true;
+                                }
                             }
                         }
                         Some(_) => {

--- a/crates/ruff_python_formatter/src/expression/string.rs
+++ b/crates/ruff_python_formatter/src/expression/string.rs
@@ -548,11 +548,15 @@ fn preferred_quotes(
                                     // `"""` or `'''`
                                     chars.next();
                                     uses_triple_quotes = true;
+                                    break;
                                 }
                                 Some(_) => {}
                                 None => {
-                                    // Handle `''' ""'''`
+                                    // Handle `''' ""'''`. At this point we have consumed both
+                                    // double quotes, so on the next iteration the iterator is empty
+                                    // and we'd miss the string ending with a preferred quote
                                     uses_triple_quotes = true;
+                                    break;
                                 }
                             }
                         }
@@ -562,6 +566,7 @@ fn preferred_quotes(
                         None => {
                             // Trailing quote at the end of the comment
                             uses_triple_quotes = true;
+                            break;
                         }
                     }
                 }

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -136,6 +136,9 @@ test_particular = [
 x = ("""aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa""" """bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb""")
 x = (f"""aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa""" f"""bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb""")
 x = (b"""aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa""" b"""bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb""")
+
+# https://github.com/astral-sh/ruff/issues/7460
+trailing_preferred_quote_texts = [''' "''', ''' ""''', ''' """''', ''' """"''']
 ```
 
 ## Outputs
@@ -305,6 +308,9 @@ x = (
     b"""aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"""
     b"""bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"""
 )
+
+# https://github.com/astral-sh/ruff/issues/7460
+trailing_preferred_quote_texts = [''' "''', ''' ""''', ''' """''', ''' """"''']
 ```
 
 
@@ -474,6 +480,9 @@ x = (
     b'''aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'''
     b'''bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'''
 )
+
+# https://github.com/astral-sh/ruff/issues/7460
+trailing_preferred_quote_texts = [''' "''', ''' ""''', ''' """''', ''' """"''']
 ```
 
 


### PR DESCRIPTION
## Summary

`''' ""'''` is an edge case that was previously incorrectly formatted as `""" """""`.

Fixes #7460

## Test Plan

Added regression test
