### PR TITLE
Fix stylist indentation with a formfeed

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_4.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_4.py
@@ -1,0 +1,9 @@
+# formfeed indent
+# https://github.com/astral-sh/ruff/issues/7455#issuecomment-1722458825
+# This is technically a stylist bug (and has a test there), but it surfaced in B006
+
+
+class FormFeedIndent:
+   def __init__(self, a=[]):
+        print(a)
+

--- a/crates/ruff/src/rules/flake8_bugbear/mod.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/mod.rs
@@ -36,6 +36,7 @@ mod tests {
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_1.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_2.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_3.py"))]
+    #[test_case(Rule::MutableArgumentDefault, Path::new("B006_4.py"))]
     #[test_case(Rule::NoExplicitStacklevel, Path::new("B028.py"))]
     #[test_case(Rule::RaiseLiteral, Path::new("B016.py"))]
     #[test_case(Rule::RaiseWithoutFromInsideExcept, Path::new("B904.py"))]

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_4.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_4.py.snap
@@ -1,0 +1,24 @@
+---
+source: crates/ruff/src/rules/flake8_bugbear/mod.rs
+---
+B006_4.py:7:26: B006 [*] Do not use mutable data structures for argument defaults
+  |
+6 | class FormFeedIndent:
+7 |    def __init__(self, a=[]):
+  |                         ^^ B006
+8 |         print(a)
+  |
+  = help: Replace with `None`; initialize within function
+
+ℹ Possible fix
+4  4  | 
+5  5  | 
+6  6  | class FormFeedIndent:
+7     |-   def __init__(self, a=[]):
+   7  |+   def __init__(self, a=None):
+   8  |+        if a is None:
+   9  |+         a = []
+8  10 |         print(a)
+9  11 | 
+
+


### PR DESCRIPTION
**Summary** In python, a formfeed is technically undefined behaviour (https://docs.python.org/3/reference/lexical_analysis.html#indentation):
> A formfeed character may be present at the start of the line; it will be ignored for
> the indentation calculations above. Formfeed characters occurring elsewhere in the
> leading whitespace have an undefined effect (for instance, they may reset the space
> count to zero).

In practice, they just reset the indentation:

https://github.com/python/cpython/blob/df8b3a46a7aa369f246a09ffd11ceedf1d34e921/Parser/tokenizer.c#L1819-L1821 https://github.com/astral-sh/ruff/blob/a41bb2733fe75a71f4cf6d4bb21e659fc4630b30/crates/ruff_python_parser/src/lexer.rs#L664-L667

The stylist didn't handle formfeeds previously and would produce invalid indents. The remedy is to cut everything before a form feed.

Checks box for https://github.com/astral-sh/ruff/issues/7455#issuecomment-1722458825

**Test Plan** Unit test for the stylist and a regression test for the rule