### PR TITLE
Extend `bad-dunder-method-name` to permit `__html__`

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/bad_dunder_method_name.py
+++ b/crates/ruff/resources/test/fixtures/pylint/bad_dunder_method_name.py
@@ -59,6 +59,10 @@ class Apples:
     def __attrs_init__(self):
         pass
 
+    # Allow __html__, used by Jinja2 and Django.
+    def __html__(self):
+        pass
+
 
 def __foo_bar__():  # this is not checked by the [bad-dunder-name] rule
     ...

--- a/crates/ruff/src/rules/pylint/rules/bad_dunder_method_name.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_dunder_method_name.rs
@@ -123,6 +123,7 @@ fn is_known_dunder_method(method: &str) -> bool {
             | "__getstate__"
             | "__gt__"
             | "__hash__"
+            | "__html__"
             | "__iadd__"
             | "__iand__"
             | "__ifloordiv__"


### PR DESCRIPTION
## Summary

Fixes #7478

## Test Plan

`cargo test` 