### PR TITLE
Ignore `pass-statement-stub-body` documentation formatting

### DIFF
--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -60,6 +60,7 @@ KNOWN_FORMATTING_VIOLATIONS = [
     "one-blank-line-after-class",
     "over-indentation",
     "over-indented",
+    "pass-statement-stub-body",
     "prohibited-trailing-comma",
     "shebang-leading-whitespace",
     "surrounding-whitespace",


### PR DESCRIPTION
## Summary

Fix CI (broken in #7496).

The code snippet was formatted as Black would format a stub file, but the CI script doesn't know that (it assumes all code snippets are non-stub files). Easier to ignore.

Sorry for breaking CI!

## Test Plan

`python scripts/check_docs_formatted.py`
