### PR TITLE
Avoid N802 violations for @overload methods

### DIFF
--- a/crates/ruff/resources/test/fixtures/pep8_naming/N802.py
+++ b/crates/ruff/resources/test/fixtures/pep8_naming/N802.py
@@ -41,9 +41,13 @@ class Test(unittest.TestCase):
         assert True
 
 
-from typing import override
+from typing import override, overload
 
 
 @override
+def BAD_FUNC():
+    pass
+
+@overload
 def BAD_FUNC():
     pass

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_function_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_function_name.rs
@@ -70,9 +70,12 @@ pub(crate) fn invalid_function_name(
         return None;
     }
 
-    // Ignore any functions that are explicitly `@override`. These are defined elsewhere,
-    // so if they're first-party, we'll flag them at the definition site.
-    if visibility::is_override(decorator_list, semantic) {
+    // Ignore any functions that are explicitly `@override` or `@overload`.
+    // These are defined elsewhere, so if they're first-party,
+    // we'll flag them at the definition site.
+    if visibility::is_override(decorator_list, semantic)
+        || visibility::is_overload(decorator_list, semantic)
+    {
         return None;
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
- Close #7479

The `@override` was already implemented

## Test Plan

Tested the code in the issue. After removing all the noqa's, only one occurrence of `BadName()` raised a violation.
Added a fixture

<!-- How was it tested? -->
