### PR TITLE
Avoid flagging starred expressions in UP007

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP007.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP007.py
@@ -108,3 +108,9 @@ class ServiceRefOrValue:
 # Regression test for: https://github.com/astral-sh/ruff/issues/7201
 class ServiceRefOrValue:
     service_specification: Optional[str]is not True = None
+
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/7452
+class Collection(Protocol[*_B0]):
+    def __iter__(self) -> Iterator[Union[*_B0]]:
+        ...

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP007.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP007.py.snap
@@ -410,5 +410,8 @@ UP007.py:110:28: UP007 [*] Use `X | Y` for type annotations
 109 109 | class ServiceRefOrValue:
 110     |-    service_specification: Optional[str]is not True = None
     110 |+    service_specification: str | None is not True = None
+111 111 | 
+112 112 | 
+113 113 | # Regression test for: https://github.com/astral-sh/ruff/issues/7452
 
 


### PR DESCRIPTION
## Summary

These can't be fixed, because fixing them would lead to invalid syntax. So flagging them also feels misleading.

Closes https://github.com/astral-sh/ruff/issues/7452.