### PR TITLE
fix: Compiler warning about unused `map_or`

### DIFF
--- a/crates/ruff/src/rules/flake8_bandit/rules/flask_debug_true.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/flask_debug_true.rs
@@ -67,26 +67,23 @@ pub(crate) fn flask_debug_true(checker: &mut Checker, call: &ExprCall) {
         return;
     };
 
-    checker
-        .semantic()
-        .resolve_name(name)
-        .map_or((), |binding_id| {
-            if let Some(Stmt::Assign(StmtAssign { value, .. })) = checker
-                .semantic()
-                .binding(binding_id)
-                .statement(checker.semantic())
-            {
-                if let Expr::Call(ExprCall { func, .. }) = value.as_ref() {
-                    if checker
-                        .semantic()
-                        .resolve_call_path(func)
-                        .is_some_and(|call_path| matches!(call_path.as_slice(), ["flask", "Flask"]))
-                    {
-                        checker
-                            .diagnostics
-                            .push(Diagnostic::new(FlaskDebugTrue, debug_argument.range()));
-                    }
+    if let Some(binding_id) = checker.semantic().resolve_name(name) {
+        if let Some(Stmt::Assign(StmtAssign { value, .. })) = checker
+            .semantic()
+            .binding(binding_id)
+            .statement(checker.semantic())
+        {
+            if let Expr::Call(ExprCall { func, .. }) = value.as_ref() {
+                if checker
+                    .semantic()
+                    .resolve_call_path(func)
+                    .is_some_and(|call_path| matches!(call_path.as_slice(), ["flask", "Flask"]))
+                {
+                    checker
+                        .diagnostics
+                        .push(Diagnostic::new(FlaskDebugTrue, debug_argument.range()));
                 }
             }
-        });
+        }
+    };
 }


### PR DESCRIPTION
## Summary

Fixes a compile error about an unused `map_or` return value by rewritting the statement to `if let Some(..) = .. {}`

## Test Plan

`cargo test`
