### PR TITLE
Update `ISC001`, `ISC002` to check in f-strings

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_implicit_str_concat/ISC.py
+++ b/crates/ruff/resources/test/fixtures/flake8_implicit_str_concat/ISC.py
@@ -59,3 +59,23 @@ _ = "abc" + "def" + foo
 _ = foo + bar + "abc"
 _ = "abc" + foo + bar
 _ = foo + "abc" + bar
+
+# Multiple strings nested inside a f-string
+_ = f"a {'b' 'c' 'd'} e"
+_ = f"""abc {"def" "ghi"} jkl"""
+_ = f"""abc {
+    "def"
+    "ghi"
+} jkl"""
+
+# Nested f-strings
+_ = "a" f"b {f"c" f"d"} e" "f"
+_ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+_ = f"b {f"abc" \
+    f"def"} g"
+
+# Explicitly concatenated nested f-strings
+_ = f"a {f"first"
+    + f"second"} d"
+_ = f"a {f"first {f"middle"}"
+    + f"second"} d"

--- a/crates/ruff/src/checkers/tokens.rs
+++ b/crates/ruff/src/checkers/tokens.rs
@@ -136,6 +136,7 @@ pub(crate) fn check_tokens(
             tokens,
             &settings.flake8_implicit_str_concat,
             locator,
+            indexer,
         );
     }
 

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__ISC001_ISC.py.snap
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__ISC001_ISC.py.snap
@@ -153,4 +153,147 @@ ISC.py:52:5: ISC001 [*] Implicitly concatenated string literals on one line
 54 54 | # Single-line explicit concatenation should be ignored.
 55 55 | _ = "abc" + "def" + "ghi"
 
+ISC.py:64:10: ISC001 [*] Implicitly concatenated string literals on one line
+   |
+63 | # Multiple strings nested inside a f-string
+64 | _ = f"a {'b' 'c' 'd'} e"
+   |          ^^^^^^^ ISC001
+65 | _ = f"""abc {"def" "ghi"} jkl"""
+66 | _ = f"""abc {
+   |
+   = help: Combine string literals
+
+ℹ Fix
+61 61 | _ = foo + "abc" + bar
+62 62 | 
+63 63 | # Multiple strings nested inside a f-string
+64    |-_ = f"a {'b' 'c' 'd'} e"
+   64 |+_ = f"a {'bc' 'd'} e"
+65 65 | _ = f"""abc {"def" "ghi"} jkl"""
+66 66 | _ = f"""abc {
+67 67 |     "def"
+
+ISC.py:64:14: ISC001 [*] Implicitly concatenated string literals on one line
+   |
+63 | # Multiple strings nested inside a f-string
+64 | _ = f"a {'b' 'c' 'd'} e"
+   |              ^^^^^^^ ISC001
+65 | _ = f"""abc {"def" "ghi"} jkl"""
+66 | _ = f"""abc {
+   |
+   = help: Combine string literals
+
+ℹ Fix
+61 61 | _ = foo + "abc" + bar
+62 62 | 
+63 63 | # Multiple strings nested inside a f-string
+64    |-_ = f"a {'b' 'c' 'd'} e"
+   64 |+_ = f"a {'b' 'cd'} e"
+65 65 | _ = f"""abc {"def" "ghi"} jkl"""
+66 66 | _ = f"""abc {
+67 67 |     "def"
+
+ISC.py:65:14: ISC001 [*] Implicitly concatenated string literals on one line
+   |
+63 | # Multiple strings nested inside a f-string
+64 | _ = f"a {'b' 'c' 'd'} e"
+65 | _ = f"""abc {"def" "ghi"} jkl"""
+   |              ^^^^^^^^^^^ ISC001
+66 | _ = f"""abc {
+67 |     "def"
+   |
+   = help: Combine string literals
+
+ℹ Fix
+62 62 | 
+63 63 | # Multiple strings nested inside a f-string
+64 64 | _ = f"a {'b' 'c' 'd'} e"
+65    |-_ = f"""abc {"def" "ghi"} jkl"""
+   65 |+_ = f"""abc {"defghi"} jkl"""
+66 66 | _ = f"""abc {
+67 67 |     "def"
+68 68 |     "ghi"
+
+ISC.py:72:5: ISC001 Implicitly concatenated string literals on one line
+   |
+71 | # Nested f-strings
+72 | _ = "a" f"b {f"c" f"d"} e" "f"
+   |     ^^^^^^^^^^^^^^^^^^^^^^ ISC001
+73 | _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+74 | _ = f"b {f"abc" \
+   |
+   = help: Combine string literals
+
+ISC.py:72:9: ISC001 Implicitly concatenated string literals on one line
+   |
+71 | # Nested f-strings
+72 | _ = "a" f"b {f"c" f"d"} e" "f"
+   |         ^^^^^^^^^^^^^^^^^^^^^^ ISC001
+73 | _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+74 | _ = f"b {f"abc" \
+   |
+   = help: Combine string literals
+
+ISC.py:72:14: ISC001 [*] Implicitly concatenated string literals on one line
+   |
+71 | # Nested f-strings
+72 | _ = "a" f"b {f"c" f"d"} e" "f"
+   |              ^^^^^^^^^ ISC001
+73 | _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+74 | _ = f"b {f"abc" \
+   |
+   = help: Combine string literals
+
+ℹ Fix
+69 69 | } jkl"""
+70 70 | 
+71 71 | # Nested f-strings
+72    |-_ = "a" f"b {f"c" f"d"} e" "f"
+   72 |+_ = "a" f"b {f"cd"} e" "f"
+73 73 | _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+74 74 | _ = f"b {f"abc" \
+75 75 |     f"def"} g"
+
+ISC.py:73:10: ISC001 [*] Implicitly concatenated string literals on one line
+   |
+71 | # Nested f-strings
+72 | _ = "a" f"b {f"c" f"d"} e" "f"
+73 | _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+   |          ^^^^^^^^^^^^^^^^^^^^^^^ ISC001
+74 | _ = f"b {f"abc" \
+75 |     f"def"} g"
+   |
+   = help: Combine string literals
+
+ℹ Fix
+70 70 | 
+71 71 | # Nested f-strings
+72 72 | _ = "a" f"b {f"c" f"d"} e" "f"
+73    |-_ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+   73 |+_ = f"b {f"cd {f"e" f"f"} g"} h"
+74 74 | _ = f"b {f"abc" \
+75 75 |     f"def"} g"
+76 76 | 
+
+ISC.py:73:20: ISC001 [*] Implicitly concatenated string literals on one line
+   |
+71 | # Nested f-strings
+72 | _ = "a" f"b {f"c" f"d"} e" "f"
+73 | _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+   |                    ^^^^^^^^^ ISC001
+74 | _ = f"b {f"abc" \
+75 |     f"def"} g"
+   |
+   = help: Combine string literals
+
+ℹ Fix
+70 70 | 
+71 71 | # Nested f-strings
+72 72 | _ = "a" f"b {f"c" f"d"} e" "f"
+73    |-_ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+   73 |+_ = f"b {f"c" f"d {f"ef"} g"} h"
+74 74 | _ = f"b {f"abc" \
+75 75 |     f"def"} g"
+76 76 | 
+
 

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__ISC002_ISC.py.snap
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__ISC002_ISC.py.snap
@@ -13,4 +13,16 @@ ISC.py:5:5: ISC002 Implicitly concatenated string literals over multiple lines
 8 |   _ = (
   |
 
+ISC.py:74:10: ISC002 Implicitly concatenated string literals over multiple lines
+   |
+72 |   _ = "a" f"b {f"c" f"d"} e" "f"
+73 |   _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+74 |   _ = f"b {f"abc" \
+   |  __________^
+75 | |     f"def"} g"
+   | |__________^ ISC002
+76 |   
+77 |   # Explicitly concatenated nested f-strings
+   |
+
 

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__ISC003_ISC.py.snap
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__ISC003_ISC.py.snap
@@ -31,4 +31,25 @@ ISC.py:19:3: ISC003 Explicitly concatenated string should be implicitly concaten
 21 |   )
    |
 
+ISC.py:78:10: ISC003 Explicitly concatenated string should be implicitly concatenated
+   |
+77 |   # Explicitly concatenated nested f-strings
+78 |   _ = f"a {f"first"
+   |  __________^
+79 | |     + f"second"} d"
+   | |_______________^ ISC003
+80 |   _ = f"a {f"first {f"middle"}"
+81 |       + f"second"} d"
+   |
+
+ISC.py:80:10: ISC003 Explicitly concatenated string should be implicitly concatenated
+   |
+78 |   _ = f"a {f"first"
+79 |       + f"second"} d"
+80 |   _ = f"a {f"first {f"middle"}"
+   |  __________^
+81 | |     + f"second"} d"
+   | |_______________^ ISC003
+   |
+
 

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__multiline_ISC001_ISC.py.snap
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__multiline_ISC001_ISC.py.snap
@@ -153,4 +153,147 @@ ISC.py:52:5: ISC001 [*] Implicitly concatenated string literals on one line
 54 54 | # Single-line explicit concatenation should be ignored.
 55 55 | _ = "abc" + "def" + "ghi"
 
+ISC.py:64:10: ISC001 [*] Implicitly concatenated string literals on one line
+   |
+63 | # Multiple strings nested inside a f-string
+64 | _ = f"a {'b' 'c' 'd'} e"
+   |          ^^^^^^^ ISC001
+65 | _ = f"""abc {"def" "ghi"} jkl"""
+66 | _ = f"""abc {
+   |
+   = help: Combine string literals
+
+ℹ Fix
+61 61 | _ = foo + "abc" + bar
+62 62 | 
+63 63 | # Multiple strings nested inside a f-string
+64    |-_ = f"a {'b' 'c' 'd'} e"
+   64 |+_ = f"a {'bc' 'd'} e"
+65 65 | _ = f"""abc {"def" "ghi"} jkl"""
+66 66 | _ = f"""abc {
+67 67 |     "def"
+
+ISC.py:64:14: ISC001 [*] Implicitly concatenated string literals on one line
+   |
+63 | # Multiple strings nested inside a f-string
+64 | _ = f"a {'b' 'c' 'd'} e"
+   |              ^^^^^^^ ISC001
+65 | _ = f"""abc {"def" "ghi"} jkl"""
+66 | _ = f"""abc {
+   |
+   = help: Combine string literals
+
+ℹ Fix
+61 61 | _ = foo + "abc" + bar
+62 62 | 
+63 63 | # Multiple strings nested inside a f-string
+64    |-_ = f"a {'b' 'c' 'd'} e"
+   64 |+_ = f"a {'b' 'cd'} e"
+65 65 | _ = f"""abc {"def" "ghi"} jkl"""
+66 66 | _ = f"""abc {
+67 67 |     "def"
+
+ISC.py:65:14: ISC001 [*] Implicitly concatenated string literals on one line
+   |
+63 | # Multiple strings nested inside a f-string
+64 | _ = f"a {'b' 'c' 'd'} e"
+65 | _ = f"""abc {"def" "ghi"} jkl"""
+   |              ^^^^^^^^^^^ ISC001
+66 | _ = f"""abc {
+67 |     "def"
+   |
+   = help: Combine string literals
+
+ℹ Fix
+62 62 | 
+63 63 | # Multiple strings nested inside a f-string
+64 64 | _ = f"a {'b' 'c' 'd'} e"
+65    |-_ = f"""abc {"def" "ghi"} jkl"""
+   65 |+_ = f"""abc {"defghi"} jkl"""
+66 66 | _ = f"""abc {
+67 67 |     "def"
+68 68 |     "ghi"
+
+ISC.py:72:5: ISC001 Implicitly concatenated string literals on one line
+   |
+71 | # Nested f-strings
+72 | _ = "a" f"b {f"c" f"d"} e" "f"
+   |     ^^^^^^^^^^^^^^^^^^^^^^ ISC001
+73 | _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+74 | _ = f"b {f"abc" \
+   |
+   = help: Combine string literals
+
+ISC.py:72:9: ISC001 Implicitly concatenated string literals on one line
+   |
+71 | # Nested f-strings
+72 | _ = "a" f"b {f"c" f"d"} e" "f"
+   |         ^^^^^^^^^^^^^^^^^^^^^^ ISC001
+73 | _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+74 | _ = f"b {f"abc" \
+   |
+   = help: Combine string literals
+
+ISC.py:72:14: ISC001 [*] Implicitly concatenated string literals on one line
+   |
+71 | # Nested f-strings
+72 | _ = "a" f"b {f"c" f"d"} e" "f"
+   |              ^^^^^^^^^ ISC001
+73 | _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+74 | _ = f"b {f"abc" \
+   |
+   = help: Combine string literals
+
+ℹ Fix
+69 69 | } jkl"""
+70 70 | 
+71 71 | # Nested f-strings
+72    |-_ = "a" f"b {f"c" f"d"} e" "f"
+   72 |+_ = "a" f"b {f"cd"} e" "f"
+73 73 | _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+74 74 | _ = f"b {f"abc" \
+75 75 |     f"def"} g"
+
+ISC.py:73:10: ISC001 [*] Implicitly concatenated string literals on one line
+   |
+71 | # Nested f-strings
+72 | _ = "a" f"b {f"c" f"d"} e" "f"
+73 | _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+   |          ^^^^^^^^^^^^^^^^^^^^^^^ ISC001
+74 | _ = f"b {f"abc" \
+75 |     f"def"} g"
+   |
+   = help: Combine string literals
+
+ℹ Fix
+70 70 | 
+71 71 | # Nested f-strings
+72 72 | _ = "a" f"b {f"c" f"d"} e" "f"
+73    |-_ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+   73 |+_ = f"b {f"cd {f"e" f"f"} g"} h"
+74 74 | _ = f"b {f"abc" \
+75 75 |     f"def"} g"
+76 76 | 
+
+ISC.py:73:20: ISC001 [*] Implicitly concatenated string literals on one line
+   |
+71 | # Nested f-strings
+72 | _ = "a" f"b {f"c" f"d"} e" "f"
+73 | _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+   |                    ^^^^^^^^^ ISC001
+74 | _ = f"b {f"abc" \
+75 |     f"def"} g"
+   |
+   = help: Combine string literals
+
+ℹ Fix
+70 70 | 
+71 71 | # Nested f-strings
+72 72 | _ = "a" f"b {f"c" f"d"} e" "f"
+73    |-_ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+   73 |+_ = f"b {f"c" f"d {f"ef"} g"} h"
+74 74 | _ = f"b {f"abc" \
+75 75 |     f"def"} g"
+76 76 | 
+
 

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__multiline_ISC002_ISC.py.snap
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__multiline_ISC002_ISC.py.snap
@@ -43,4 +43,27 @@ ISC.py:34:3: ISC002 Implicitly concatenated string literals over multiple lines
 36 |   )
    |
 
+ISC.py:67:5: ISC002 Implicitly concatenated string literals over multiple lines
+   |
+65 |   _ = f"""abc {"def" "ghi"} jkl"""
+66 |   _ = f"""abc {
+67 |       "def"
+   |  _____^
+68 | |     "ghi"
+   | |_________^ ISC002
+69 |   } jkl"""
+   |
+
+ISC.py:74:10: ISC002 Implicitly concatenated string literals over multiple lines
+   |
+72 |   _ = "a" f"b {f"c" f"d"} e" "f"
+73 |   _ = f"b {f"c" f"d {f"e" f"f"} g"} h"
+74 |   _ = f"b {f"abc" \
+   |  __________^
+75 | |     f"def"} g"
+   | |__________^ ISC002
+76 |   
+77 |   # Explicitly concatenated nested f-strings
+   |
+
 

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__multiline_ISC003_ISC.py.snap
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/snapshots/ruff__rules__flake8_implicit_str_concat__tests__multiline_ISC003_ISC.py.snap
@@ -31,4 +31,25 @@ ISC.py:19:3: ISC003 Explicitly concatenated string should be implicitly concaten
 21 |   )
    |
 
+ISC.py:78:10: ISC003 Explicitly concatenated string should be implicitly concatenated
+   |
+77 |   # Explicitly concatenated nested f-strings
+78 |   _ = f"a {f"first"
+   |  __________^
+79 | |     + f"second"} d"
+   | |_______________^ ISC003
+80 |   _ = f"a {f"first {f"middle"}"
+81 |       + f"second"} d"
+   |
+
+ISC.py:80:10: ISC003 Explicitly concatenated string should be implicitly concatenated
+   |
+78 |   _ = f"a {f"first"
+79 |       + f"second"} d"
+80 |   _ = f"a {f"first {f"middle"}"
+   |  __________^
+81 | |     + f"second"} d"
+   | |_______________^ ISC003
+   |
+
 


### PR DESCRIPTION
## Summary

This PR updates the implicit string concatenation rules, specifically `ISC001`
and `ISC002` to account for the new f-string tokens. `ISC003` checks for
explicit string concatenation and is not affected by PEP 701 because it is based
on AST.

### Implementation

The implementation is based on the boundary tokens of the f-string which are
`FStringStart` and `FStringEnd`. There are 4 cases to look for:
1. `String` followed by `FStringStart`
2. `FStringEnd` followed by `String`
3. `FStringEnd` followed by `FStringStart`
4. `String` followed by `String`

For f-string tokens, we use the `Indexer` to get the entire range of the f-string.
This is the range of the innermost f-string.

## Test Plan

Add new test cases for nested f-strings.
