### PR TITLE
Add a test for stmt assign breaking in preview mode

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/assign_breaking.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/assign_breaking.options.json
@@ -1,0 +1,8 @@
+[
+  {
+    "preview": "disabled"
+  },
+  {
+    "preview": "enabled"
+  }
+]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/assign_breaking.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/assign_breaking.py
@@ -1,0 +1,34 @@
+# Below is black stable style
+# In preview style, black always breaks the right side first
+
+if True:
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ] = cccccccc.ccccccccccccc.cccccccc
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ] = cccccccc.ccccccccccccc().cccccccc
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ] = cccccccc.ccccccccccccc(d).cccccccc
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
+        cccccccc.ccccccccccccc(d).cccccccc + e
+    )
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
+        cccccccc.ccccccccccccc.cccccccc + e
+    )
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
+        cccccccc.ccccccccccccc.cccccccc
+        + eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+    )
+
+    self._cache: dict[
+        DependencyCacheKey, list[list[DependencyPackage]]
+    ] = collections.defaultdict(list)
+    self._cached_dependencies_by_level: dict[
+        int, list[DependencyCacheKey]
+    ] = collections.defaultdict(list)

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -263,6 +263,7 @@ impl FromStr for MagicTrailingComma {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum PreviewMode {
     #[default]
     Disabled,

--- a/crates/ruff_python_formatter/tests/fixtures.rs
+++ b/crates/ruff_python_formatter/tests/fixtures.rs
@@ -255,12 +255,14 @@ impl fmt::Display for DisplayPyOptions<'_> {
 line-width              = {line_width}
 indent-width            = {indent_width}
 quote-style             = {quote_style:?}
-magic-trailing-comma    = {magic_trailing_comma:?}"#,
+magic-trailing-comma    = {magic_trailing_comma:?}
+preview                 = {preview:?}"#,
             indent_style = self.0.indent_style(),
             indent_width = self.0.indent_width().value(),
             line_width = self.0.line_width().value(),
             quote_style = self.0.quote_style(),
-            magic_trailing_comma = self.0.magic_trailing_comma()
+            magic_trailing_comma = self.0.magic_trailing_comma(),
+            preview = self.0.preview()
         )
     }
 }

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring.py.snap
@@ -116,6 +116,7 @@ line-width              = 88
 indent-width            = 4
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py
@@ -229,6 +230,7 @@ line-width              = 88
 indent-width            = 2
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py
@@ -342,6 +344,7 @@ line-width              = 88
 indent-width            = 8
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py
@@ -455,6 +458,7 @@ line-width              = 88
 indent-width            = 4
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__bytes.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__bytes.py.snap
@@ -134,6 +134,7 @@ line-width              = 88
 indent-width            = 4
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py
@@ -282,6 +283,7 @@ line-width              = 88
 indent-width            = 4
 quote-style             = Single
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -149,6 +149,7 @@ line-width              = 88
 indent-width            = 4
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py
@@ -321,6 +322,7 @@ line-width              = 88
 indent-width            = 4
 quote-style             = Single
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__fmt_off_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__fmt_off_docstring.py.snap
@@ -33,6 +33,7 @@ line-width              = 88
 indent-width            = 4
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py
@@ -65,6 +66,7 @@ line-width              = 88
 indent-width            = 2
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__indent.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__indent.py.snap
@@ -14,6 +14,7 @@ line-width              = 88
 indent-width            = 4
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py
@@ -27,6 +28,7 @@ line-width              = 88
 indent-width            = 1
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py
@@ -40,6 +42,7 @@ line-width              = 88
 indent-width            = 4
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__mixed_space_and_tab.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__mixed_space_and_tab.py.snap
@@ -29,6 +29,7 @@ line-width              = 88
 indent-width            = 4
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py
@@ -58,6 +59,7 @@ line-width              = 88
 indent-width            = 2
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py
@@ -87,6 +89,7 @@ line-width              = 88
 indent-width            = 4
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py

--- a/crates/ruff_python_formatter/tests/snapshots/format@skip_magic_trailing_comma.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@skip_magic_trailing_comma.py.snap
@@ -47,6 +47,7 @@ line-width              = 88
 indent-width            = 4
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py
@@ -99,6 +100,7 @@ line-width              = 88
 indent-width            = 4
 quote-style             = Double
 magic-trailing-comma    = Ignore
+preview                 = Disabled
 ```
 
 ```py

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__assign_breaking.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__assign_breaking.py.snap
@@ -1,0 +1,140 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/assign_breaking.py
+---
+## Input
+```py
+# Below is black stable style
+# In preview style, black always breaks the right side first
+
+if True:
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ] = cccccccc.ccccccccccccc.cccccccc
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ] = cccccccc.ccccccccccccc().cccccccc
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ] = cccccccc.ccccccccccccc(d).cccccccc
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
+        cccccccc.ccccccccccccc(d).cccccccc + e
+    )
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
+        cccccccc.ccccccccccccc.cccccccc + e
+    )
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
+        cccccccc.ccccccccccccc.cccccccc
+        + eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+    )
+
+    self._cache: dict[
+        DependencyCacheKey, list[list[DependencyPackage]]
+    ] = collections.defaultdict(list)
+    self._cached_dependencies_by_level: dict[
+        int, list[DependencyCacheKey]
+    ] = collections.defaultdict(list)
+```
+
+## Outputs
+### Output 1
+```
+indent-style            = space
+line-width              = 88
+indent-width            = 4
+quote-style             = Double
+magic-trailing-comma    = Respect
+preview                 = Disabled
+```
+
+```py
+# Below is black stable style
+# In preview style, black always breaks the right side first
+
+if True:
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ] = cccccccc.ccccccccccccc.cccccccc
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ] = cccccccc.ccccccccccccc().cccccccc
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ] = cccccccc.ccccccccccccc(d).cccccccc
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
+        cccccccc.ccccccccccccc(d).cccccccc + e
+    )
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
+        cccccccc.ccccccccccccc.cccccccc + e
+    )
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
+        cccccccc.ccccccccccccc.cccccccc
+        + eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+    )
+
+    self._cache: dict[
+        DependencyCacheKey, list[list[DependencyPackage]]
+    ] = collections.defaultdict(list)
+    self._cached_dependencies_by_level: dict[
+        int, list[DependencyCacheKey]
+    ] = collections.defaultdict(list)
+```
+
+
+### Output 2
+```
+indent-style            = space
+line-width              = 88
+indent-width            = 4
+quote-style             = Double
+magic-trailing-comma    = Respect
+preview                 = Enabled
+```
+
+```py
+# Below is black stable style
+# In preview style, black always breaks the right side first
+
+if True:
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ] = cccccccc.ccccccccccccc.cccccccc
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ] = cccccccc.ccccccccccccc().cccccccc
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ] = cccccccc.ccccccccccccc(d).cccccccc
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
+        cccccccc.ccccccccccccc(d).cccccccc + e
+    )
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
+        cccccccc.ccccccccccccc.cccccccc + e
+    )
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
+        cccccccc.ccccccccccccc.cccccccc
+        + eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+    )
+
+    self._cache: dict[
+        DependencyCacheKey, list[list[DependencyPackage]]
+    ] = collections.defaultdict(list)
+    self._cached_dependencies_by_level: dict[
+        int, list[DependencyCacheKey]
+    ] = collections.defaultdict(list)
+```
+
+
+

--- a/crates/ruff_python_formatter/tests/snapshots/format@tab_width.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@tab_width.py.snap
@@ -22,6 +22,7 @@ line-width              = 88
 indent-width            = 2
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py
@@ -43,6 +44,7 @@ line-width              = 88
 indent-width            = 4
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py
@@ -67,6 +69,7 @@ line-width              = 88
 indent-width            = 8
 quote-style             = Double
 magic-trailing-comma    = Respect
+preview                 = Disabled
 ```
 
 ```py


### PR DESCRIPTION
In preview mode, black will consistently break the right side first. This doesn't work yet, but we'll need the test later.