### PR TITLE
Use `Settings` where `AllSettings` isn't required

### DIFF
--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -349,7 +349,7 @@ mod tests {
     use std::time::SystemTime;
 
     use itertools::Itertools;
-    use ruff::settings::{flags, AllSettings};
+    use ruff::settings::{flags, AllSettings, Settings};
     use ruff_cache::CACHE_DIR_NAME;
 
     use crate::cache::RelativePathBuf;
@@ -371,10 +371,10 @@ mod tests {
         let _ = fs::remove_dir_all(&cache_dir);
         cache::init(&cache_dir).unwrap();
 
-        let settings = AllSettings::default();
+        let settings = Settings::default();
 
         let package_root = fs::canonicalize(package_root).unwrap();
-        let cache = Cache::open(&cache_dir, package_root.clone(), &settings.lib);
+        let cache = Cache::open(&cache_dir, package_root.clone(), &settings);
         assert_eq!(cache.new_files.lock().unwrap().len(), 0);
 
         let mut paths = Vec::new();
@@ -426,7 +426,7 @@ mod tests {
 
         cache.store().unwrap();
 
-        let cache = Cache::open(&cache_dir, package_root.clone(), &settings.lib);
+        let cache = Cache::open(&cache_dir, package_root.clone(), &settings);
         assert_ne!(cache.package.files.len(), 0);
 
         parse_errors.sort();
@@ -710,7 +710,7 @@ mod tests {
             lint_path(
                 &self.package_root.join(path),
                 Some(&self.package_root),
-                &self.settings,
+                &self.settings.lib,
                 Some(cache),
                 flags::Noqa::Enabled,
                 flags::FixMode::Generate,

--- a/crates/ruff_cli/src/commands/check.rs
+++ b/crates/ruff_cli/src/commands/check.rs
@@ -15,7 +15,7 @@ use rustc_hash::FxHashMap;
 
 use ruff::message::Message;
 use ruff::registry::Rule;
-use ruff::settings::{flags, AllSettings};
+use ruff::settings::{flags, Settings};
 use ruff::{fs, warn_user_once, IOError};
 use ruff_diagnostics::Diagnostic;
 use ruff_python_ast::imports::ImportMap;
@@ -111,7 +111,7 @@ pub(crate) fn check(
                         .and_then(|parent| package_roots.get(parent))
                         .and_then(|package| *package);
 
-                    let settings = resolver.resolve_all(path, pyproject_config);
+                    let settings = resolver.resolve(path, pyproject_config);
 
                     let cache_root = package.unwrap_or_else(|| path.parent().unwrap_or(path));
                     let cache = caches.as_ref().and_then(|caches| {
@@ -199,7 +199,7 @@ pub(crate) fn check(
 fn lint_path(
     path: &Path,
     package: Option<&Path>,
-    settings: &AllSettings,
+    settings: &Settings,
     cache: Option<&Cache>,
     noqa: flags::Noqa,
     autofix: flags::FixMode,


### PR DESCRIPTION

## Summary

Pass `Settings` instead of `AllSettings` in places where access to `.cli` isn't required

## Test Plan

`cargo build`
