### PR TITLE
Add documentation to `non-empty-stub-body`

### DIFF
--- a/crates/ruff/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
@@ -7,6 +7,27 @@ use ruff_text_size::Ranged;
 use crate::checkers::ast::Checker;
 use crate::registry::Rule;
 
+/// ## What it does
+/// Checks for non-empty function stub bodies.
+///
+/// ## Why is this bad?
+/// Stub files are meant to be used as a reference for the interface of a
+/// module, and should not contain any implementation details. Thus, the
+/// body of a stub function should be empty.
+///
+/// ## Example
+/// ```python
+/// def double(x: int) -> int:
+///     return x * 2
+/// ```
+///
+/// Use instead:
+/// ```python
+/// def double(x: int) -> int: ...
+/// ```
+///
+/// ## References
+/// - [PEP 484 – Type Hints: Stub Files](https://www.python.org/dev/peps/pep-0484/#stub-files)
 #[violation]
 pub struct NonEmptyStubBody;
 

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -57,6 +57,7 @@ KNOWN_FORMATTING_VIOLATIONS = [
     "no-indented-block-comment",
     "no-space-after-block-comment",
     "no-space-after-inline-comment",
+    "non-empty-stub-body",
     "one-blank-line-after-class",
     "over-indentation",
     "over-indented",


### PR DESCRIPTION
## Summary

Add documentation to `non-empty-stub-body` (`PYI010`) rule. Related to #2646.

## Test Plan

`python scripts/check_docs_formatted.py`
