### PR TITLE
Change `Resolver` to store `Settings` instead of `AllSettings`

### DIFF
--- a/crates/ruff/src/settings/defaults.rs
+++ b/crates/ruff/src/settings/defaults.rs
@@ -1,11 +1,12 @@
+use std::collections::HashSet;
+
 use once_cell::sync::Lazy;
 use path_absolutize::path_dedot;
 use regex::Regex;
 use rustc_hash::FxHashSet;
-use std::collections::HashSet;
 
-use super::types::{FilePattern, PreviewMode, PythonVersion};
-use super::Settings;
+use ruff_cache::cache_dir;
+
 use crate::codes::{self, RuleCodePrefix};
 use crate::line_width::{LineLength, TabSize};
 use crate::registry::Linter;
@@ -18,6 +19,9 @@ use crate::rules::{
     pycodestyle, pydocstyle, pyflakes, pylint, pyupgrade,
 };
 use crate::settings::types::FilePatternSet;
+
+use super::types::{FilePattern, PreviewMode, PythonVersion};
+use super::Settings;
 
 pub const PREFIXES: &[RuleSelector] = &[
     RuleSelector::Prefix {
@@ -72,7 +76,10 @@ pub static INCLUDE: Lazy<Vec<FilePattern>> = Lazy::new(|| {
 
 impl Default for Settings {
     fn default() -> Self {
+        let project_root = path_dedot::CWD.clone();
         Self {
+            cache_dir: cache_dir(&project_root),
+
             rules: PREFIXES
                 .iter()
                 .flat_map(|selector| selector.rules(PreviewMode::default()))
@@ -92,7 +99,7 @@ impl Default for Settings {
             namespace_packages: vec![],
             preview: PreviewMode::default(),
             per_file_ignores: vec![],
-            project_root: path_dedot::CWD.clone(),
+            project_root,
             respect_gitignore: true,
             src: vec![path_dedot::CWD.clone()],
             tab_size: TabSize::default(),

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -41,7 +41,6 @@ pub struct AllSettings {
 #[allow(clippy::struct_excessive_bools)]
 /// Settings that are not used by this library and only here so that `ruff_cli` can use them.
 pub struct CliSettings {
-    pub cache_dir: PathBuf,
     pub fix: bool,
     pub fix_only: bool,
     pub format: SerializationFormat,
@@ -52,6 +51,9 @@ pub struct CliSettings {
 #[derive(Debug, CacheKey)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Settings {
+    #[cache_key(ignore)]
+    pub cache_dir: PathBuf,
+
     pub rules: RuleTable,
     pub per_file_ignores: Vec<(GlobMatcher, GlobMatcher, RuleSet)>,
 

--- a/crates/ruff_cli/src/commands/check.rs
+++ b/crates/ruff_cli/src/commands/check.rs
@@ -58,13 +58,13 @@ pub(crate) fn check(
 
         match pyproject_config.strategy {
             PyprojectDiscoveryStrategy::Fixed => {
-                init_cache(&pyproject_config.settings.cli.cache_dir);
+                init_cache(&pyproject_config.settings.lib.cache_dir);
             }
             PyprojectDiscoveryStrategy::Hierarchical => {
                 for settings in
-                    std::iter::once(&pyproject_config.settings).chain(resolver.settings())
+                    std::iter::once(&pyproject_config.settings.lib).chain(resolver.settings())
                 {
-                    init_cache(&settings.cli.cache_dir);
+                    init_cache(&settings.cache_dir);
                 }
             }
         }
@@ -88,12 +88,8 @@ pub(crate) fn check(
             .unique()
             .par_bridge()
             .map(|cache_root| {
-                let settings = resolver.resolve_all(cache_root, pyproject_config);
-                let cache = Cache::open(
-                    &settings.cli.cache_dir,
-                    cache_root.to_path_buf(),
-                    &settings.lib,
-                );
+                let settings = resolver.resolve(cache_root, pyproject_config);
+                let cache = Cache::open(cache_root.to_path_buf(), settings);
                 (cache_root, cache)
             })
             .collect::<HashMap<&Path, Cache>>()

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -222,7 +222,6 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
         format,
         show_fixes,
         show_source,
-        ..
     } = pyproject_config.settings.cli;
 
     // Autofix rules are as follows:

--- a/crates/ruff_macros/src/cache_key.rs
+++ b/crates/ruff_macros/src/cache_key.rs
@@ -1,7 +1,8 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
+use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::{Data, DeriveInput, Error, Fields};
+use syn::{Data, DeriveInput, Error, Field, Fields, Token};
 
 pub(crate) fn derive_cache_key(item: &DeriveInput) -> syn::Result<TokenStream> {
     let fields = match &item.data {
@@ -65,7 +66,15 @@ pub(crate) fn derive_cache_key(item: &DeriveInput) -> syn::Result<TokenStream> {
         }
 
         Data::Struct(item_struct) => {
-            let fields = item_struct.fields.iter().enumerate().map(|(i, field)| {
+            let mut fields = Vec::with_capacity(item_struct.fields.len());
+
+            for (i, field) in item_struct.fields.iter().enumerate() {
+                if let Some(cache_field_attribute) = cache_key_field_attribute(field)? {
+                    if cache_field_attribute.ignore {
+                        continue;
+                    }
+                }
+
                 let field_attr = match &field.ident {
                     Some(ident) => quote!(self.#ident),
                     None => {
@@ -74,8 +83,8 @@ pub(crate) fn derive_cache_key(item: &DeriveInput) -> syn::Result<TokenStream> {
                     }
                 };
 
-                quote!(#field_attr.cache_key(key);)
-            });
+                fields.push(quote!(#field_attr.cache_key(key);));
+            }
 
             quote! {#(#fields)*}
         }
@@ -100,4 +109,45 @@ pub(crate) fn derive_cache_key(item: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
     ))
+}
+
+fn cache_key_field_attribute(field: &Field) -> syn::Result<Option<CacheKeyFieldAttributes>> {
+    if let Some(attribute) = field
+        .attrs
+        .iter()
+        .find(|attribute| attribute.path().is_ident("cache_key"))
+    {
+        attribute.parse_args::<CacheKeyFieldAttributes>().map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Default)]
+struct CacheKeyFieldAttributes {
+    ignore: bool,
+}
+
+impl Parse for CacheKeyFieldAttributes {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut attributes = CacheKeyFieldAttributes::default();
+
+        let args = input.parse_terminated(Ident::parse, Token![,])?;
+
+        for arg in args {
+            match arg.to_string().as_str() {
+                "ignore" => {
+                    attributes.ignore = true;
+                }
+                name => {
+                    return Err(Error::new(
+                        arg.span(),
+                        format!("Unknown `cache_field` argument {name}"),
+                    ))
+                }
+            }
+        }
+
+        Ok(attributes)
+    }
 }

--- a/crates/ruff_macros/src/lib.rs
+++ b/crates/ruff_macros/src/lib.rs
@@ -33,7 +33,11 @@ pub fn derive_combine_options(input: TokenStream) -> TokenStream {
         .into()
 }
 
-#[proc_macro_derive(CacheKey)]
+/// Generates a [`CacheKey`] implementation for the attributed type.
+///
+/// Struct fields can be attributed with the [`cache_key`] field-attribute that supports:
+/// * `ignore`: Ignore the attributed field in the cache key
+#[proc_macro_derive(CacheKey, attributes(cache_key))]
 pub fn cache_key(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as DeriveInput);
 

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -109,10 +109,6 @@ impl Configuration {
     pub fn into_all_settings(self, project_root: &Path) -> Result<AllSettings> {
         Ok(AllSettings {
             cli: CliSettings {
-                cache_dir: self
-                    .cache_dir
-                    .clone()
-                    .unwrap_or_else(|| cache_dir(project_root)),
                 fix: self.fix.unwrap_or(false),
                 fix_only: self.fix_only.unwrap_or(false),
                 format: self.format.unwrap_or_default(),
@@ -135,6 +131,11 @@ impl Configuration {
         }
 
         Ok(Settings {
+            cache_dir: self
+                .cache_dir
+                .clone()
+                .unwrap_or_else(|| cache_dir(project_root)),
+
             rules: self.as_rule_table(),
             allowed_confusables: self
                 .allowed_confusables


### PR DESCRIPTION
## Summary

This PR changes `Resolver` to only store `Settings` internally instead of `AllSettings` because `AllSettings` is only intended to be used at the top-level. It moves the `cache_dir` settings from `AllSettings` to `Settings` because it is an inherited setting.

~~This comes with one semenatical change. Previously, the cache for each python package was stored at the location specified by the configuration in that python package. 
I don't think that was intentionally.~~


## Test Plan

`cargo test`

Running ruff with caching enabled is somewhat faster (proving that caching isn't broken)

```
 hyperfine --warmup 10 \
        "./target/release/ruff ./crates/ruff/resources/test/cpython -e" \
        "./target/release/ruff ./crates/ruff/resources/test/cpython --no-cache -e"
Benchmark 1: ./target/release/ruff ./crates/ruff/resources/test/cpython -e
  Time (mean ± σ):      80.1 ms ±   3.0 ms    [User: 88.5 ms, System: 97.5 ms]
  Range (min … max):    75.9 ms …  89.5 ms    35 runs
 
Benchmark 2: ./target/release/ruff ./crates/ruff/resources/test/cpython --no-cache -e
  Time (mean ± σ):     201.9 ms ±   4.7 ms    [User: 2904.2 ms, System: 125.7 ms]
  Range (min … max):   196.2 ms … 214.8 ms    14 runs
 
Summary
  ./target/release/ruff ./crates/ruff/resources/test/cpython -e ran
    2.52 ± 0.11 times faster than ./target/release/ruff ./crates/ruff/resources/test/cpython --no-cache -e
```

Verified that Ruff writes to a different cache directory when changing the `cache-dir` setting in the pyproject.toml.
