### PR TITLE
Change `resolve_scoped_settings` return type to `Settings`

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -12,7 +12,7 @@ use ruff::settings::types::{
 };
 use ruff::{RuleSelector, RuleSelectorParser};
 use ruff_workspace::configuration::{Configuration, RuleSelection};
-use ruff_workspace::resolver::ConfigProcessor;
+use ruff_workspace::resolver::ConfigurationTransformer;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -440,7 +440,7 @@ impl From<&LogLevelArgs> for LogLevel {
 impl CheckCommand {
     /// Partition the CLI into command-line arguments and configuration
     /// overrides.
-    pub fn partition(self) -> (CheckArguments, Overrides) {
+    pub fn partition(self) -> (CheckArguments, CliConfigurationOverrides) {
         (
             CheckArguments {
                 add_noqa: self.add_noqa,
@@ -460,7 +460,7 @@ impl CheckCommand {
                 stdin_filename: self.stdin_filename,
                 watch: self.watch,
             },
-            Overrides {
+            CliConfigurationOverrides {
                 dummy_variable_rgx: self.dummy_variable_rgx,
                 exclude: self.exclude,
                 extend_exclude: self.extend_exclude,
@@ -496,7 +496,7 @@ impl CheckCommand {
 impl FormatCommand {
     /// Partition the CLI into command-line arguments and configuration
     /// overrides.
-    pub fn partition(self) -> (FormatArguments, Overrides) {
+    pub fn partition(self) -> (FormatArguments, CliConfigurationOverrides) {
         (
             FormatArguments {
                 check: self.check,
@@ -505,7 +505,7 @@ impl FormatCommand {
                 isolated: self.isolated,
                 stdin_filename: self.stdin_filename,
             },
-            Overrides {
+            CliConfigurationOverrides {
                 line_length: self.line_length,
                 respect_gitignore: resolve_bool_arg(
                     self.respect_gitignore,
@@ -514,7 +514,7 @@ impl FormatCommand {
                 preview: resolve_bool_arg(self.preview, self.no_preview).map(PreviewMode::from),
                 force_exclude: resolve_bool_arg(self.force_exclude, self.no_force_exclude),
                 // Unsupported on the formatter CLI, but required on `Overrides`.
-                ..Overrides::default()
+                ..CliConfigurationOverrides::default()
             },
         )
     }
@@ -562,10 +562,9 @@ pub struct FormatArguments {
     pub stdin_filename: Option<PathBuf>,
 }
 
-/// CLI settings that function as configuration overrides.
 #[derive(Clone, Default)]
 #[allow(clippy::struct_excessive_bools)]
-pub struct Overrides {
+pub struct CliConfigurationOverrides {
     pub dummy_variable_rgx: Option<Regex>,
     pub exclude: Option<Vec<FilePattern>>,
     pub extend_exclude: Option<Vec<FilePattern>>,
@@ -592,8 +591,8 @@ pub struct Overrides {
     pub show_fixes: Option<bool>,
 }
 
-impl ConfigProcessor for Overrides {
-    fn process_config(&self, config: &mut Configuration) {
+impl ConfigurationTransformer for CliConfigurationOverrides {
+    fn transform(&self, mut config: Configuration) -> Configuration {
         if let Some(cache_dir) = &self.cache_dir {
             config.cache_dir = Some(cache_dir.clone());
         }
@@ -659,6 +658,8 @@ impl ConfigProcessor for Overrides {
         if let Some(target_version) = &self.target_version {
             config.target_version = Some(*target_version);
         }
+
+        config
     }
 }
 
@@ -668,7 +669,7 @@ pub fn collect_per_file_ignores(pairs: Vec<PatternPrefixPair>) -> Vec<PerFileIgn
     for pair in pairs {
         per_file_ignores
             .entry(pair.pattern)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(pair.prefix);
     }
     per_file_ignores

--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -349,7 +349,7 @@ mod tests {
     use std::time::SystemTime;
 
     use itertools::Itertools;
-    use ruff::settings::{flags, AllSettings};
+    use ruff::settings::{flags, AllSettings, Settings};
     use ruff_cache::CACHE_DIR_NAME;
 
     use crate::cache::RelativePathBuf;
@@ -371,10 +371,10 @@ mod tests {
         let _ = fs::remove_dir_all(&cache_dir);
         cache::init(&cache_dir).unwrap();
 
-        let settings = AllSettings::default();
+        let settings = Settings::default();
 
         let package_root = fs::canonicalize(package_root).unwrap();
-        let cache = Cache::open(&cache_dir, package_root.clone(), &settings.lib);
+        let cache = Cache::open(&cache_dir, package_root.clone(), &settings);
         assert_eq!(cache.new_files.lock().unwrap().len(), 0);
 
         let mut paths = Vec::new();
@@ -426,7 +426,7 @@ mod tests {
 
         cache.store().unwrap();
 
-        let cache = Cache::open(&cache_dir, package_root.clone(), &settings.lib);
+        let cache = Cache::open(&cache_dir, package_root.clone(), &settings);
         assert_ne!(cache.package.files.len(), 0);
 
         parse_errors.sort();
@@ -710,7 +710,7 @@ mod tests {
             lint_path(
                 &self.package_root.join(path),
                 Some(&self.package_root),
-                &self.settings,
+                &self.settings.lib,
                 Some(cache),
                 flags::Noqa::Enabled,
                 flags::FixMode::Generate,

--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -349,7 +349,7 @@ mod tests {
     use std::time::SystemTime;
 
     use itertools::Itertools;
-    use ruff::settings::{flags, AllSettings, Settings};
+    use ruff::settings::{flags, Settings};
     use ruff_cache::CACHE_DIR_NAME;
 
     use crate::cache::RelativePathBuf;
@@ -653,7 +653,7 @@ mod tests {
     struct TestCache {
         cache_dir: PathBuf,
         package_root: PathBuf,
-        settings: AllSettings,
+        settings: Settings,
     }
 
     impl TestCache {
@@ -672,7 +672,7 @@ mod tests {
             cache::init(&cache_dir).unwrap();
             fs::create_dir(package_root.clone()).unwrap();
 
-            let settings = AllSettings::default();
+            let settings = Settings::default();
 
             Self {
                 cache_dir,
@@ -695,11 +695,7 @@ mod tests {
         }
 
         fn open(&self) -> Cache {
-            Cache::open(
-                &self.cache_dir,
-                self.package_root.clone(),
-                &self.settings.lib,
-            )
+            Cache::open(&self.cache_dir, self.package_root.clone(), &self.settings)
         }
 
         fn lint_file_with_cache(
@@ -710,7 +706,7 @@ mod tests {
             lint_path(
                 &self.package_root.join(path),
                 Some(&self.package_root),
-                &self.settings.lib,
+                &self.settings,
                 Some(cache),
                 flags::Noqa::Enabled,
                 flags::FixMode::Generate,

--- a/crates/ruff_cli/src/commands/add_noqa.rs
+++ b/crates/ruff_cli/src/commands/add_noqa.rs
@@ -11,14 +11,14 @@ use ruff::warn_user_once;
 use ruff_python_ast::{PySourceType, SourceType};
 use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig};
 
-use crate::args::Overrides;
+use crate::args::CliConfigurationOverrides;
 use crate::diagnostics::LintSource;
 
 /// Add `noqa` directives to a collection of files.
 pub(crate) fn add_noqa(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
-    overrides: &Overrides,
+    overrides: &CliConfigurationOverrides,
 ) -> Result<usize> {
     // Collect all the files to check.
     let start = Instant::now();

--- a/crates/ruff_cli/src/commands/check.rs
+++ b/crates/ruff_cli/src/commands/check.rs
@@ -23,7 +23,7 @@ use ruff_source_file::SourceFileBuilder;
 use ruff_text_size::{TextRange, TextSize};
 use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig};
 
-use crate::args::Overrides;
+use crate::args::CliConfigurationOverrides;
 use crate::cache::{self, Cache};
 use crate::diagnostics::Diagnostics;
 use crate::panic::catch_unwind;
@@ -32,7 +32,7 @@ use crate::panic::catch_unwind;
 pub(crate) fn check(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
-    overrides: &Overrides,
+    overrides: &CliConfigurationOverrides,
     cache: flags::Cache,
     noqa: flags::Noqa,
     autofix: flags::FixMode,
@@ -234,7 +234,7 @@ mod test {
     use ruff::settings::{flags, AllSettings, CliSettings, Settings};
     use ruff_workspace::resolver::{PyprojectConfig, PyprojectDiscoveryStrategy};
 
-    use crate::args::Overrides;
+    use crate::args::CliConfigurationOverrides;
 
     use super::check;
 
@@ -273,7 +273,7 @@ mod test {
             // Notebooks are not included by default
             &[tempdir.path().to_path_buf(), notebook],
             &pyproject_config,
-            &Overrides::default(),
+            &CliConfigurationOverrides::default(),
             flags::Cache::Disabled,
             flags::Noqa::Disabled,
             flags::FixMode::Generate,

--- a/crates/ruff_cli/src/commands/check.rs
+++ b/crates/ruff_cli/src/commands/check.rs
@@ -15,7 +15,7 @@ use rustc_hash::FxHashMap;
 
 use ruff::message::Message;
 use ruff::registry::Rule;
-use ruff::settings::{flags, AllSettings};
+use ruff::settings::{flags, Settings};
 use ruff::{fs, warn_user_once, IOError};
 use ruff_diagnostics::Diagnostic;
 use ruff_python_ast::imports::ImportMap;
@@ -111,7 +111,7 @@ pub(crate) fn check(
                         .and_then(|parent| package_roots.get(parent))
                         .and_then(|package| *package);
 
-                    let settings = resolver.resolve_all(path, pyproject_config);
+                    let settings = resolver.resolve(path, pyproject_config);
 
                     let cache_root = package.unwrap_or_else(|| path.parent().unwrap_or(path));
                     let cache = caches.as_ref().and_then(|caches| {
@@ -199,7 +199,7 @@ pub(crate) fn check(
 fn lint_path(
     path: &Path,
     package: Option<&Path>,
-    settings: &AllSettings,
+    settings: &Settings,
     cache: Option<&Cache>,
     noqa: flags::Noqa,
     autofix: flags::FixMode,

--- a/crates/ruff_cli/src/commands/check_stdin.rs
+++ b/crates/ruff_cli/src/commands/check_stdin.rs
@@ -6,7 +6,7 @@ use ruff::packaging;
 use ruff::settings::flags;
 use ruff_workspace::resolver::{python_file_at_path, PyprojectConfig};
 
-use crate::args::Overrides;
+use crate::args::CliConfigurationOverrides;
 use crate::diagnostics::{lint_stdin, Diagnostics};
 use crate::stdin::read_from_stdin;
 
@@ -14,7 +14,7 @@ use crate::stdin::read_from_stdin;
 pub(crate) fn check_stdin(
     filename: Option<&Path>,
     pyproject_config: &PyprojectConfig,
-    overrides: &Overrides,
+    overrides: &CliConfigurationOverrides,
     noqa: flags::Noqa,
     autofix: flags::FixMode,
 ) -> Result<Diagnostics> {

--- a/crates/ruff_cli/src/commands/format.rs
+++ b/crates/ruff_cli/src/commands/format.rs
@@ -22,7 +22,7 @@ use ruff_python_formatter::{format_module, FormatModuleError, PyFormatOptions};
 use ruff_source_file::{find_newline, LineEnding};
 use ruff_workspace::resolver::python_files_in_path;
 
-use crate::args::{FormatArguments, Overrides};
+use crate::args::{CliConfigurationOverrides, FormatArguments};
 use crate::panic::{catch_unwind, PanicError};
 use crate::resolve::resolve;
 use crate::ExitStatus;
@@ -38,14 +38,14 @@ pub(crate) enum FormatMode {
 /// Format a set of files, and return the exit status.
 pub(crate) fn format(
     cli: &FormatArguments,
-    overrides: &Overrides,
+    overrides: &CliConfigurationOverrides,
     log_level: LogLevel,
 ) -> Result<ExitStatus> {
     let pyproject_config = resolve(
         cli.isolated,
         cli.config.as_deref(),
-        overrides,
         cli.stdin_filename.as_deref(),
+        overrides,
     )?;
     let mode = if cli.check {
         FormatMode::Check

--- a/crates/ruff_cli/src/commands/format_stdin.rs
+++ b/crates/ruff_cli/src/commands/format_stdin.rs
@@ -10,19 +10,22 @@ use ruff_formatter::LineWidth;
 use ruff_python_formatter::{format_module, PyFormatOptions};
 use ruff_workspace::resolver::python_file_at_path;
 
-use crate::args::{FormatArguments, Overrides};
+use crate::args::{CliConfigurationOverrides, FormatArguments};
 use crate::commands::format::{FormatCommandError, FormatCommandResult, FormatMode};
 use crate::resolve::resolve;
 use crate::stdin::read_from_stdin;
 use crate::ExitStatus;
 
 /// Run the formatter over a single file, read from `stdin`.
-pub(crate) fn format_stdin(cli: &FormatArguments, overrides: &Overrides) -> Result<ExitStatus> {
+pub(crate) fn format_stdin(
+    cli: &FormatArguments,
+    overrides: &CliConfigurationOverrides,
+) -> Result<ExitStatus> {
     let pyproject_config = resolve(
         cli.isolated,
         cli.config.as_deref(),
-        overrides,
         cli.stdin_filename.as_deref(),
+        overrides,
     )?;
     let mode = if cli.check {
         FormatMode::Check

--- a/crates/ruff_cli/src/commands/show_files.rs
+++ b/crates/ruff_cli/src/commands/show_files.rs
@@ -7,13 +7,13 @@ use itertools::Itertools;
 use ruff::warn_user_once;
 use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig};
 
-use crate::args::Overrides;
+use crate::args::CliConfigurationOverrides;
 
 /// Show the list of files to be checked based on current settings.
 pub(crate) fn show_files(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
-    overrides: &Overrides,
+    overrides: &CliConfigurationOverrides,
     writer: &mut impl Write,
 ) -> Result<()> {
     // Collect all files in the hierarchy.

--- a/crates/ruff_cli/src/commands/show_settings.rs
+++ b/crates/ruff_cli/src/commands/show_settings.rs
@@ -6,13 +6,13 @@ use itertools::Itertools;
 
 use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig};
 
-use crate::args::Overrides;
+use crate::args::CliConfigurationOverrides;
 
 /// Print the user-facing configuration settings.
 pub(crate) fn show_settings(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
-    overrides: &Overrides,
+    overrides: &CliConfigurationOverrides,
     writer: &mut impl Write,
 ) -> Result<()> {
     // Collect all files in the hierarchy.

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -187,8 +187,8 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
     let pyproject_config = resolve::resolve(
         cli.isolated,
         cli.config.as_deref(),
-        &overrides,
         cli.stdin_filename.as_deref(),
+        &overrides,
     )?;
 
     let mut writer: Box<dyn Write> = match cli.output_file {
@@ -327,8 +327,8 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
                         pyproject_config = resolve::resolve(
                             cli.isolated,
                             cli.config.as_deref(),
-                            &overrides,
                             cli.stdin_filename.as_deref(),
+                            &overrides,
                         )?;
                     }
                     Printer::clear_screen()?;

--- a/crates/ruff_dev/src/format_dev.rs
+++ b/crates/ruff_dev/src/format_dev.rs
@@ -56,8 +56,8 @@ fn ruff_check_paths(
     let mut pyproject_config = resolve(
         cli.isolated,
         cli.config.as_deref(),
-        &overrides,
         cli.stdin_filename.as_deref(),
+        &overrides,
     )?;
     // We don't want to format pyproject.toml
     pyproject_config.settings.lib.include = FilePatternSet::try_from_vec(vec![

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -92,38 +92,30 @@ impl Relativity {
 
 #[derive(Default)]
 pub struct Resolver {
-    settings: BTreeMap<PathBuf, AllSettings>,
+    settings: BTreeMap<PathBuf, Settings>,
 }
 
 impl Resolver {
     /// Add a resolved [`Settings`] under a given [`PathBuf`] scope.
-    fn add(&mut self, path: PathBuf, settings: AllSettings) {
+    fn add(&mut self, path: PathBuf, settings: Settings) {
         self.settings.insert(path, settings);
     }
 
-    /// Return the appropriate [`AllSettings`] for a given [`Path`].
-    pub fn resolve_all<'a>(
-        &'a self,
-        path: &Path,
-        pyproject_config: &'a PyprojectConfig,
-    ) -> &'a AllSettings {
-        match pyproject_config.strategy {
-            PyprojectDiscoveryStrategy::Fixed => &pyproject_config.settings,
-            PyprojectDiscoveryStrategy::Hierarchical => self
-                .settings
-                .iter()
-                .rev()
-                .find_map(|(root, settings)| path.starts_with(root).then_some(settings))
-                .unwrap_or(&pyproject_config.settings),
-        }
-    }
-
+    /// Return the appropriate [`Settings`] for a given [`Path`].
     pub fn resolve<'a>(
         &'a self,
         path: &Path,
         pyproject_config: &'a PyprojectConfig,
     ) -> &'a Settings {
-        &self.resolve_all(path, pyproject_config).lib
+        match pyproject_config.strategy {
+            PyprojectDiscoveryStrategy::Fixed => &pyproject_config.settings.lib,
+            PyprojectDiscoveryStrategy::Hierarchical => self
+                .settings
+                .iter()
+                .rev()
+                .find_map(|(root, settings)| path.starts_with(root).then_some(settings))
+                .unwrap_or(&pyproject_config.settings.lib),
+        }
     }
 
     /// Return a mapping from Python package to its package root.
@@ -162,7 +154,7 @@ impl Resolver {
     }
 
     /// Return an iterator over the resolved [`Settings`] in this [`Resolver`].
-    pub fn settings(&self) -> impl Iterator<Item = &AllSettings> {
+    pub fn settings(&self) -> impl Iterator<Item = &Settings> {
         self.settings.values()
     }
 }
@@ -285,14 +277,13 @@ pub fn python_files_in_path(
     let mut resolver = Resolver::default();
     let mut seen = FxHashSet::default();
     if pyproject_config.strategy.is_hierarchical() {
-        for path in &paths {
-            for ancestor in path.ancestors() {
-                if seen.insert(ancestor) {
-                    if let Some(pyproject) = settings_toml(ancestor)? {
-                        let (root, settings) =
-                            resolve_scoped_settings(&pyproject, Relativity::Parent, processor)?;
-                        resolver.add(root, settings);
-                    }
+        let ancestors = paths.iter().flat_map(|path| path.ancestors()).unique();
+        for ancestor in ancestors {
+            if seen.insert(ancestor) {
+                if let Some(pyproject) = settings_toml(ancestor)? {
+                    let (root, settings) =
+                        resolve_scoped_settings(&pyproject, Relativity::Parent, processor)?;
+                    resolver.add(root, settings.lib);
                 }
             }
         }
@@ -366,7 +357,7 @@ pub fn python_files_in_path(
                                 processor,
                             ) {
                                 Ok((root, settings)) => {
-                                    resolver.write().unwrap().add(root, settings);
+                                    resolver.write().unwrap().add(root, settings.lib);
                                 }
                                 Err(err) => {
                                     *error.lock().unwrap() = Err(err);
@@ -438,7 +429,7 @@ pub fn python_file_at_path(
             if let Some(pyproject) = settings_toml(ancestor)? {
                 let (root, settings) =
                     resolve_scoped_settings(&pyproject, Relativity::Parent, processor)?;
-                resolver.add(root, settings);
+                resolver.add(root, settings.lib);
             }
         }
     }


### PR DESCRIPTION
## Summary

Changes the return type of `resolve_scoped_settings` to `Settings` from `AllSettings` and some other smaller refactors

`AllSettings` is now only used for `resolved_root_settings`, `Configuration::into_all_settings`, and in `PyprojectConfig`

## Test Plan

`cargo build`
