### PR TITLE
Ensure that LOG007 only triggers on `.exception()` calls

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_logging/LOG007.py
+++ b/crates/ruff/resources/test/fixtures/flake8_logging/LOG007.py
@@ -8,6 +8,8 @@ logging.exception("foo", exc_info=[])  # LOG007
 logger.exception("foo")  # OK
 logger.exception("foo", exc_info=False)  # LOG007
 logger.exception("foo", exc_info=[])  # LOG007
+logger.error("foo", exc_info=False)  # OK
+logger.info("foo", exc_info=False)  # OK
 
 
 from logging import exception

--- a/crates/ruff/src/rules/flake8_logging/snapshots/ruff__rules__flake8_logging__tests__LOG007_LOG007.py.snap
+++ b/crates/ruff/src/rules/flake8_logging/snapshots/ruff__rules__flake8_logging__tests__LOG007_LOG007.py.snap
@@ -27,6 +27,7 @@ LOG007.py:9:1: LOG007 Use of `logging.exception` with falsy `exc_info`
  9 | logger.exception("foo", exc_info=False)  # LOG007
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ LOG007
 10 | logger.exception("foo", exc_info=[])  # LOG007
+11 | logger.error("foo", exc_info=False)  # OK
    |
 
 LOG007.py:10:1: LOG007 Use of `logging.exception` with falsy `exc_info`
@@ -35,6 +36,8 @@ LOG007.py:10:1: LOG007 Use of `logging.exception` with falsy `exc_info`
  9 | logger.exception("foo", exc_info=False)  # LOG007
 10 | logger.exception("foo", exc_info=[])  # LOG007
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ LOG007
+11 | logger.error("foo", exc_info=False)  # OK
+12 | logger.info("foo", exc_info=False)  # OK
    |
 
 


### PR DESCRIPTION
## Summary

Previously, this rule triggered for `logging.info("...", exc_info=False)`.

