### PR TITLE
Use strict sorted and union for NoQA mapping insertion

### DIFF
--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -461,6 +461,18 @@ y = \
                 TextRange::new(TextSize::from(77), TextSize::from(83)),
             ])
         );
+
+        // https://github.com/astral-sh/ruff/issues/7530
+        let contents = r"
+assert foo, \
+    '''triple-quoted
+    string'''
+"
+        .trim();
+        assert_eq!(
+            noqa_mappings(contents),
+            NoqaMapping::from_iter([TextRange::new(TextSize::from(0), TextSize::from(48))])
+        );
     }
 
     #[test]

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -764,15 +764,17 @@ impl NoqaMapping {
     pub(crate) fn push_mapping(&mut self, range: TextRange) {
         if let Some(last_range) = self.ranges.last_mut() {
             // Strictly sorted insertion
-            if last_range.end() <= range.start() {
+            if last_range.end() < range.start() {
                 // OK
-            }
-            // Try merging with the last inserted range
-            else if let Some(intersected) = last_range.intersect(range) {
-                *last_range = intersected;
-                return;
-            } else {
+            } else if range.end() < last_range.start() {
+                // Incoming range is strictly before the last range which violates
+                // the function's contract.
                 panic!("Ranges must be inserted in sorted order")
+            } else {
+                // Here, it's guaranteed that `last_range` and `range` overlap
+                // in some way. We want to merge them into a single range.
+                *last_range = last_range.cover(range);
+                return;
             }
         }
 


### PR DESCRIPTION
## Summary

This PR fixes the way NoQA range is inserted to the `NoqaMapping`.

Previously, the way the mapping insertion logic worked was as follows:
1. If the range which is to be inserted _touched_ the previous range, meaning
   that the end of the previous range was the same as the start of the new
   range, then the new range was added in addition to the previous range.
2. Else, if the new range intersected the previous range, then the previous
   range was replaced with the new _intersection_ of the two ranges.

The problem with this logic is that it does not work for the following case:
```python
assert foo, \
    """multi-line
    string"""
```

Now, the comments cannot be added to the same line which ends with a continuation
character. So, the `NoQA` directive has to be added to the next line. But, the
next line is also a triple-quoted string, so the `NoQA` directive for that line
needs to be added to the next line. This creates a **union** pattern instead of an
**intersection** pattern.

But, only union doesn't suffice because (1) means that for the edge case where
the range touch only at the end, the union won't take place.

### Solution

1. Replace '<=' with '<' to have a _strict_ insertion case
2. Use union instead of intersection

## Test Plan

Add a new test case. Run the test suite to ensure that nothing is broken.

### Integration

1. Make a `test.py` file with the following contents:

    ```python
    assert foo, \
        """multi-line
        string"""
    ```

2. Run the following command:

    ```console
    $ cargo run --bin ruff -- check --isolated --no-cache --select=F821 test.py
    /Users/dhruv/playground/ruff/fstring.py:1:8: F821 Undefined name `foo`
    Found 1 error.
    ```

3. Use `--add-noqa`:

    ```console
    $ cargo run --bin ruff -- check --isolated --no-cache --select=F821 --add-noqa test.py
    Added 1 noqa directive.
    ```

4. Check that the NoQA directive was added in the correct position:

    ```python
    assert foo, \
        """multi-line
        string"""  # noqa: F821
    ```

5. Run the `check` command to ensure that the NoQA directive is respected:

    ```console
    $ cargo run --bin ruff -- check --isolated --no-cache --select=F821 test.py
    ```

fixes: #7530 