### PR TITLE
Unify `Settings` and `AllSettings`

### DIFF
--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -59,21 +59,18 @@ pub(crate) struct Cache {
 impl Cache {
     /// Open or create a new cache.
     ///
-    /// `cache_dir` is considered the root directory of the cache, which can be
-    /// local to the project, global or otherwise set by the user.
-    ///
     /// `package_root` is the path to root of the package that is contained
     /// within this cache and must be canonicalized (to avoid considering `./`
     /// and `../project` being different).
     ///
     /// Finally `settings` is used to ensure we don't open a cache for different
-    /// settings.
-    pub(crate) fn open(cache_dir: &Path, package_root: PathBuf, settings: &Settings) -> Cache {
+    /// settings. It also defines the directory where to store the cache.
+    pub(crate) fn open(package_root: PathBuf, settings: &Settings) -> Cache {
         debug_assert!(package_root.is_absolute(), "package root not canonicalized");
 
         let mut buf = itoa::Buffer::new();
         let key = Path::new(buf.format(cache_key(&package_root, settings)));
-        let path = PathBuf::from_iter([cache_dir, Path::new("content"), key]);
+        let path = PathBuf::from_iter([&settings.cache_dir, Path::new("content"), key]);
 
         let file = match File::open(&path) {
             Ok(file) => file,
@@ -350,7 +347,7 @@ mod tests {
 
     use itertools::Itertools;
     use ruff_cache::CACHE_DIR_NAME;
-    use ruff_linter::settings::{flags, AllSettings, Settings};
+    use ruff_linter::settings::{flags, Settings};
 
     use crate::cache::RelativePathBuf;
     use crate::cache::{self, Cache, FileCache};
@@ -371,10 +368,13 @@ mod tests {
         let _ = fs::remove_dir_all(&cache_dir);
         cache::init(&cache_dir).unwrap();
 
-        let settings = Settings::default();
+        let settings = Settings {
+            cache_dir,
+            ..Settings::default()
+        };
 
         let package_root = fs::canonicalize(package_root).unwrap();
-        let cache = Cache::open(&cache_dir, package_root.clone(), &settings);
+        let cache = Cache::open(package_root.clone(), &settings);
         assert_eq!(cache.new_files.lock().unwrap().len(), 0);
 
         let mut paths = Vec::new();
@@ -426,7 +426,7 @@ mod tests {
 
         cache.store().unwrap();
 
-        let cache = Cache::open(&cache_dir, package_root.clone(), &settings);
+        let cache = Cache::open(package_root.clone(), &settings);
         assert_ne!(cache.package.files.len(), 0);
 
         parse_errors.sort();
@@ -651,9 +651,8 @@ mod tests {
     }
 
     struct TestCache {
-        cache_dir: PathBuf,
         package_root: PathBuf,
-        settings: AllSettings,
+        settings: Settings,
     }
 
     impl TestCache {
@@ -672,10 +671,12 @@ mod tests {
             cache::init(&cache_dir).unwrap();
             fs::create_dir(package_root.clone()).unwrap();
 
-            let settings = AllSettings::default();
+            let settings = Settings {
+                cache_dir,
+                ..Settings::default()
+            };
 
             Self {
-                cache_dir,
                 package_root,
                 settings,
             }
@@ -695,11 +696,7 @@ mod tests {
         }
 
         fn open(&self) -> Cache {
-            Cache::open(
-                &self.cache_dir,
-                self.package_root.clone(),
-                &self.settings.lib,
-            )
+            Cache::open(self.package_root.clone(), &self.settings)
         }
 
         fn lint_file_with_cache(
@@ -710,7 +707,7 @@ mod tests {
             lint_path(
                 &self.package_root.join(path),
                 Some(&self.package_root),
-                &self.settings.lib,
+                &self.settings,
                 Some(cache),
                 flags::Noqa::Enabled,
                 flags::FixMode::Generate,
@@ -720,7 +717,7 @@ mod tests {
 
     impl Drop for TestCache {
         fn drop(&mut self) {
-            let _ = fs::remove_dir_all(&self.cache_dir);
+            let _ = fs::remove_dir_all(&self.settings.cache_dir);
         }
     }
 }

--- a/crates/ruff_cli/src/commands/check_stdin.rs
+++ b/crates/ruff_cli/src/commands/check_stdin.rs
@@ -24,14 +24,14 @@ pub(crate) fn check_stdin(
         }
     }
     let package_root = filename.and_then(Path::parent).and_then(|path| {
-        packaging::detect_package_root(path, &pyproject_config.settings.lib.namespace_packages)
+        packaging::detect_package_root(path, &pyproject_config.settings.namespace_packages)
     });
     let stdin = read_from_stdin()?;
     let mut diagnostics = lint_stdin(
         filename,
         package_root,
         stdin,
-        &pyproject_config.settings.lib,
+        &pyproject_config.settings,
         noqa,
         autofix,
     )?;

--- a/crates/ruff_cli/src/commands/format_stdin.rs
+++ b/crates/ruff_cli/src/commands/format_stdin.rs
@@ -39,11 +39,11 @@ pub(crate) fn format_stdin(cli: &FormatArguments, overrides: &Overrides) -> Resu
     // Format the file.
     let path = cli.stdin_filename.as_deref();
 
-    let preview = match pyproject_config.settings.lib.preview {
+    let preview = match pyproject_config.settings.preview {
         PreviewMode::Enabled => ruff_python_formatter::PreviewMode::Enabled,
         PreviewMode::Disabled => ruff_python_formatter::PreviewMode::Disabled,
     };
-    let line_length = pyproject_config.settings.lib.line_length;
+    let line_length = pyproject_config.settings.line_length;
 
     let options = path
         .map(PyFormatOptions::from_extension)

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -11,7 +11,7 @@ use notify::{recommended_watcher, RecursiveMode, Watcher};
 
 use ruff_linter::logging::{set_up_logging, LogLevel};
 use ruff_linter::settings::types::SerializationFormat;
-use ruff_linter::settings::{flags, CliSettings};
+use ruff_linter::settings::{flags, Settings};
 use ruff_linter::{fs, warn_user, warn_user_once};
 
 use crate::args::{Args, CheckCommand, Command, FormatCommand};
@@ -224,14 +224,14 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
 
     // Extract options that are included in `Settings`, but only apply at the top
     // level.
-    let CliSettings {
+    let Settings {
         fix,
         fix_only,
         output_format,
         show_fixes,
         show_source,
         ..
-    } = pyproject_config.settings.cli;
+    } = pyproject_config.settings;
 
     // Autofix rules are as follows:
     // - By default, generate all fixes, but don't apply them to the filesystem.

--- a/crates/ruff_dev/src/format_dev.rs
+++ b/crates/ruff_dev/src/format_dev.rs
@@ -60,7 +60,7 @@ fn ruff_check_paths(
         cli.stdin_filename.as_deref(),
     )?;
     // We don't want to format pyproject.toml
-    pyproject_config.settings.lib.include = FilePatternSet::try_from_vec(vec![
+    pyproject_config.settings.include = FilePatternSet::try_from_vec(vec![
         FilePattern::Builtin("*.py"),
         FilePattern::Builtin("*.pyi"),
     ])

--- a/crates/ruff_linter/src/settings/defaults.rs
+++ b/crates/ruff_linter/src/settings/defaults.rs
@@ -1,6 +1,7 @@
 use once_cell::sync::Lazy;
 use path_absolutize::path_dedot;
 use regex::Regex;
+use ruff_cache::cache_dir;
 use rustc_hash::FxHashSet;
 use std::collections::HashSet;
 
@@ -17,7 +18,7 @@ use crate::rules::{
     flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments, isort, mccabe, pep8_naming,
     pycodestyle, pydocstyle, pyflakes, pylint, pyupgrade,
 };
-use crate::settings::types::FilePatternSet;
+use crate::settings::types::{FilePatternSet, SerializationFormat};
 
 pub const PREFIXES: &[RuleSelector] = &[
     RuleSelector::Prefix {
@@ -72,7 +73,15 @@ pub static INCLUDE: Lazy<Vec<FilePattern>> = Lazy::new(|| {
 
 impl Default for Settings {
     fn default() -> Self {
+        let project_root = path_dedot::CWD.clone();
         Self {
+            cache_dir: cache_dir(&project_root),
+            fix: false,
+            fix_only: false,
+            output_format: SerializationFormat::default(),
+            show_fixes: false,
+            show_source: false,
+
             rules: PREFIXES
                 .iter()
                 .flat_map(|selector| selector.rules(PreviewMode::default()))
@@ -92,7 +101,7 @@ impl Default for Settings {
             namespace_packages: vec![],
             preview: PreviewMode::default(),
             per_file_ignores: vec![],
-            project_root: path_dedot::CWD.clone(),
+            project_root,
             respect_gitignore: true,
             src: vec![path_dedot::CWD.clone()],
             tab_size: TabSize::default(),

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -31,27 +31,22 @@ pub mod flags;
 pub mod rule_table;
 pub mod types;
 
-#[derive(Debug, Default)]
-pub struct AllSettings {
-    pub cli: CliSettings,
-    pub lib: Settings,
-}
-
-#[derive(Debug, Default, Clone)]
-#[allow(clippy::struct_excessive_bools)]
-/// Settings that are not used by this library and only here so that `ruff_cli` can use them.
-pub struct CliSettings {
-    pub cache_dir: PathBuf,
-    pub fix: bool,
-    pub fix_only: bool,
-    pub output_format: SerializationFormat,
-    pub show_fixes: bool,
-    pub show_source: bool,
-}
-
 #[derive(Debug, CacheKey)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Settings {
+    #[cache_key(ignore)]
+    pub cache_dir: PathBuf,
+    #[cache_key(ignore)]
+    pub fix: bool,
+    #[cache_key(ignore)]
+    pub fix_only: bool,
+    #[cache_key(ignore)]
+    pub output_format: SerializationFormat,
+    #[cache_key(ignore)]
+    pub show_fixes: bool,
+    #[cache_key(ignore)]
+    pub show_source: bool,
+
     pub rules: RuleTable,
     pub per_file_ignores: Vec<(GlobMatcher, GlobMatcher, RuleSet)>,
 

--- a/crates/ruff_macros/src/cache_key.rs
+++ b/crates/ruff_macros/src/cache_key.rs
@@ -1,7 +1,8 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
+use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::{Data, DeriveInput, Error, Fields};
+use syn::{Data, DeriveInput, Error, Field, Fields, Token};
 
 pub(crate) fn derive_cache_key(item: &DeriveInput) -> syn::Result<TokenStream> {
     let fields = match &item.data {
@@ -65,7 +66,15 @@ pub(crate) fn derive_cache_key(item: &DeriveInput) -> syn::Result<TokenStream> {
         }
 
         Data::Struct(item_struct) => {
-            let fields = item_struct.fields.iter().enumerate().map(|(i, field)| {
+            let mut fields = Vec::with_capacity(item_struct.fields.len());
+
+            for (i, field) in item_struct.fields.iter().enumerate() {
+                if let Some(cache_field_attribute) = cache_key_field_attribute(field)? {
+                    if cache_field_attribute.ignore {
+                        continue;
+                    }
+                }
+
                 let field_attr = match &field.ident {
                     Some(ident) => quote!(self.#ident),
                     None => {
@@ -74,8 +83,8 @@ pub(crate) fn derive_cache_key(item: &DeriveInput) -> syn::Result<TokenStream> {
                     }
                 };
 
-                quote!(#field_attr.cache_key(key);)
-            });
+                fields.push(quote!(#field_attr.cache_key(key);));
+            }
 
             quote! {#(#fields)*}
         }
@@ -100,4 +109,45 @@ pub(crate) fn derive_cache_key(item: &DeriveInput) -> syn::Result<TokenStream> {
             }
         }
     ))
+}
+
+fn cache_key_field_attribute(field: &Field) -> syn::Result<Option<CacheKeyFieldAttributes>> {
+    if let Some(attribute) = field
+        .attrs
+        .iter()
+        .find(|attribute| attribute.path().is_ident("cache_key"))
+    {
+        attribute.parse_args::<CacheKeyFieldAttributes>().map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Default)]
+struct CacheKeyFieldAttributes {
+    ignore: bool,
+}
+
+impl Parse for CacheKeyFieldAttributes {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut attributes = CacheKeyFieldAttributes::default();
+
+        let args = input.parse_terminated(Ident::parse, Token![,])?;
+
+        for arg in args {
+            match arg.to_string().as_str() {
+                "ignore" => {
+                    attributes.ignore = true;
+                }
+                name => {
+                    return Err(Error::new(
+                        arg.span(),
+                        format!("Unknown `cache_field` argument {name}"),
+                    ))
+                }
+            }
+        }
+
+        Ok(attributes)
+    }
 }

--- a/crates/ruff_macros/src/lib.rs
+++ b/crates/ruff_macros/src/lib.rs
@@ -33,7 +33,11 @@ pub fn derive_combine_options(input: TokenStream) -> TokenStream {
         .into()
 }
 
-#[proc_macro_derive(CacheKey)]
+/// Generates a [`CacheKey`] implementation for the attributed type.
+///
+/// Struct fields can be attributed with the `cache_key` field-attribute that supports:
+/// * `ignore`: Ignore the attributed field in the cache key
+#[proc_macro_derive(CacheKey, attributes(cache_key))]
 pub fn cache_key(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as DeriveInput);
 

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -27,9 +27,7 @@ use ruff_linter::settings::types::{
     FilePattern, FilePatternSet, PerFileIgnore, PreviewMode, PythonVersion, SerializationFormat,
     Version,
 };
-use ruff_linter::settings::{
-    defaults, resolve_per_file_ignores, AllSettings, CliSettings, Settings,
-};
+use ruff_linter::settings::{defaults, resolve_per_file_ignores, Settings};
 use ruff_linter::{
     fs, warn_user, warn_user_once, warn_user_once_by_id, RuleSelector, RUFF_PKG_VERSION,
 };
@@ -110,23 +108,6 @@ pub struct Configuration {
 }
 
 impl Configuration {
-    pub fn into_all_settings(self, project_root: &Path) -> Result<AllSettings> {
-        Ok(AllSettings {
-            cli: CliSettings {
-                cache_dir: self
-                    .cache_dir
-                    .clone()
-                    .unwrap_or_else(|| cache_dir(project_root)),
-                fix: self.fix.unwrap_or(false),
-                fix_only: self.fix_only.unwrap_or(false),
-                output_format: self.output_format.unwrap_or_default(),
-                show_fixes: self.show_fixes.unwrap_or(false),
-                show_source: self.show_source.unwrap_or(false),
-            },
-            lib: self.into_settings(project_root)?,
-        })
-    }
-
     pub fn into_settings(self, project_root: &Path) -> Result<Settings> {
         if let Some(required_version) = &self.required_version {
             if &**required_version != RUFF_PKG_VERSION {
@@ -139,6 +120,16 @@ impl Configuration {
         }
 
         Ok(Settings {
+            cache_dir: self
+                .cache_dir
+                .clone()
+                .unwrap_or_else(|| cache_dir(project_root)),
+            fix: self.fix.unwrap_or(false),
+            fix_only: self.fix_only.unwrap_or(false),
+            output_format: self.output_format.unwrap_or_default(),
+            show_fixes: self.show_fixes.unwrap_or(false),
+            show_source: self.show_source.unwrap_or(false),
+
             rules: self.as_rule_table(),
             allowed_confusables: self
                 .allowed_confusables


### PR DESCRIPTION
## Summary

This PR merges `AllSettings` and `Settings` (by merging `CliSettings` into `Settings`). The main motivation is to avoid the confusion of why the two settings exist, which still isn't entirely clear to me. 
Here's what I understand today (I am happy to close this PR if we can get to the bottom of why the two structs exist)

#1891 split `Settings` into `AllSettings` and `Settings` 

> We want to automatically derive Hash for the library settings, which
requires us to split off all the settings unused by the library
(since these shouldn't affect the hash used by ruff_cli::cache).

I solved this by extending the `CacheKey` derive macro to support the `cache_key(ignore)` field attribute to ignore individual fields. We can keep the automatically derived `CacheKey` implementation and explicitly mark the excluded fields.

There has been some argument whether the two settings exist because the `CliSettings` are only respected for the "root" configuration. This holds true for all `CliSettings` except `cache-dir` as #7520 showed. Meaning that distinction may have been true but no longer is. 

My final guess is that the `CliSettings` used to be unique to using `ruff` from the cli. I think this is still mostly true (although most of the resolver code now lives inside `ruff_workspace`). However, I don't think it is sufficient reason to separate the two structs, especially considering that we could show diagnostics in our playground similar to [biome](https://biomejs.dev/playground/?code=aQBmACAAKABhACAAPQA9ACAAYgApAA%3D%3D) (see console tab) where we would want to respect the `output-format` configuration (and `--show-sources` etc). `fix`, `fix-only` and `cache-dir` likely remain CLI only settings but, IMO, don't justify the cognitive load of having multiple settings structs. 

The main justification for me to keep the separate settings struct is that the linter doesn't need the `CliSettings`. These are settings that only concern the diagnostic rendering, and file traversal (although the same is true for `exclude`, `respect_gitignore` and other global settings). That's why I plan to split settings in more semantic sub-settings:

* Linter settings
* Formatter settings
* common / shared settings
* Maybe; Resolver settings?

## Test Plan

`cargo test`
