### PR TITLE
Rename `ConfigProcessor` to `ConfigurationTransformer`

### DIFF
--- a/crates/ruff_cli/src/commands/add_noqa.rs
+++ b/crates/ruff_cli/src/commands/add_noqa.rs
@@ -11,14 +11,14 @@ use ruff_linter::warn_user_once;
 use ruff_python_ast::{PySourceType, SourceType};
 use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig};
 
-use crate::args::Overrides;
+use crate::args::CliOverrides;
 use crate::diagnostics::LintSource;
 
 /// Add `noqa` directives to a collection of files.
 pub(crate) fn add_noqa(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
-    overrides: &Overrides,
+    overrides: &CliOverrides,
 ) -> Result<usize> {
     // Collect all the files to check.
     let start = Instant::now();

--- a/crates/ruff_cli/src/commands/check.rs
+++ b/crates/ruff_cli/src/commands/check.rs
@@ -23,7 +23,7 @@ use ruff_source_file::SourceFileBuilder;
 use ruff_text_size::{TextRange, TextSize};
 use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig, PyprojectDiscoveryStrategy};
 
-use crate::args::Overrides;
+use crate::args::CliOverrides;
 use crate::cache::{self, Cache};
 use crate::diagnostics::Diagnostics;
 use crate::panic::catch_unwind;
@@ -32,7 +32,7 @@ use crate::panic::catch_unwind;
 pub(crate) fn check(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
-    overrides: &Overrides,
+    overrides: &CliOverrides,
     cache: flags::Cache,
     noqa: flags::Noqa,
     autofix: flags::FixMode,
@@ -241,7 +241,7 @@ mod test {
     use ruff_linter::settings::{flags, Settings};
     use ruff_workspace::resolver::{PyprojectConfig, PyprojectDiscoveryStrategy};
 
-    use crate::args::Overrides;
+    use crate::args::CliOverrides;
 
     use super::check;
 
@@ -277,7 +277,7 @@ mod test {
             // Notebooks are not included by default
             &[tempdir.path().to_path_buf(), notebook],
             &pyproject_config,
-            &Overrides::default(),
+            &CliOverrides::default(),
             flags::Cache::Disabled,
             flags::Noqa::Disabled,
             flags::FixMode::Generate,

--- a/crates/ruff_cli/src/commands/check_stdin.rs
+++ b/crates/ruff_cli/src/commands/check_stdin.rs
@@ -6,7 +6,7 @@ use ruff_linter::packaging;
 use ruff_linter::settings::flags;
 use ruff_workspace::resolver::{python_file_at_path, PyprojectConfig};
 
-use crate::args::Overrides;
+use crate::args::CliOverrides;
 use crate::diagnostics::{lint_stdin, Diagnostics};
 use crate::stdin::read_from_stdin;
 
@@ -14,7 +14,7 @@ use crate::stdin::read_from_stdin;
 pub(crate) fn check_stdin(
     filename: Option<&Path>,
     pyproject_config: &PyprojectConfig,
-    overrides: &Overrides,
+    overrides: &CliOverrides,
     noqa: flags::Noqa,
     autofix: flags::FixMode,
 ) -> Result<Diagnostics> {

--- a/crates/ruff_cli/src/commands/format.rs
+++ b/crates/ruff_cli/src/commands/format.rs
@@ -22,7 +22,7 @@ use ruff_python_formatter::{format_module, FormatModuleError, PyFormatOptions};
 use ruff_source_file::{find_newline, LineEnding};
 use ruff_workspace::resolver::python_files_in_path;
 
-use crate::args::{FormatArguments, Overrides};
+use crate::args::{CliOverrides, FormatArguments};
 use crate::panic::{catch_unwind, PanicError};
 use crate::resolve::resolve;
 use crate::ExitStatus;
@@ -38,7 +38,7 @@ pub(crate) enum FormatMode {
 /// Format a set of files, and return the exit status.
 pub(crate) fn format(
     cli: &FormatArguments,
-    overrides: &Overrides,
+    overrides: &CliOverrides,
     log_level: LogLevel,
 ) -> Result<ExitStatus> {
     let pyproject_config = resolve(

--- a/crates/ruff_cli/src/commands/format_stdin.rs
+++ b/crates/ruff_cli/src/commands/format_stdin.rs
@@ -10,14 +10,14 @@ use ruff_linter::settings::types::PreviewMode;
 use ruff_python_formatter::{format_module, PyFormatOptions};
 use ruff_workspace::resolver::python_file_at_path;
 
-use crate::args::{FormatArguments, Overrides};
+use crate::args::{CliOverrides, FormatArguments};
 use crate::commands::format::{FormatCommandError, FormatCommandResult, FormatMode};
 use crate::resolve::resolve;
 use crate::stdin::read_from_stdin;
 use crate::ExitStatus;
 
 /// Run the formatter over a single file, read from `stdin`.
-pub(crate) fn format_stdin(cli: &FormatArguments, overrides: &Overrides) -> Result<ExitStatus> {
+pub(crate) fn format_stdin(cli: &FormatArguments, overrides: &CliOverrides) -> Result<ExitStatus> {
     let pyproject_config = resolve(
         cli.isolated,
         cli.config.as_deref(),

--- a/crates/ruff_cli/src/commands/show_files.rs
+++ b/crates/ruff_cli/src/commands/show_files.rs
@@ -7,13 +7,13 @@ use itertools::Itertools;
 use ruff_linter::warn_user_once;
 use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig};
 
-use crate::args::Overrides;
+use crate::args::CliOverrides;
 
 /// Show the list of files to be checked based on current settings.
 pub(crate) fn show_files(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
-    overrides: &Overrides,
+    overrides: &CliOverrides,
     writer: &mut impl Write,
 ) -> Result<()> {
     // Collect all files in the hierarchy.

--- a/crates/ruff_cli/src/commands/show_settings.rs
+++ b/crates/ruff_cli/src/commands/show_settings.rs
@@ -6,13 +6,13 @@ use itertools::Itertools;
 
 use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig};
 
-use crate::args::Overrides;
+use crate::args::CliOverrides;
 
 /// Print the user-facing configuration settings.
 pub(crate) fn show_settings(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
-    overrides: &Overrides,
+    overrides: &CliOverrides,
     writer: &mut impl Write,
 ) -> Result<()> {
     // Collect all files in the hierarchy.


### PR DESCRIPTION
## Summary

Renames `ConfigProcessor` to `ConfigurationTransformer` and change the method to consume the `Configuration` instead of taking a mutable reference (for easier usage)

Renames `Overrides` to `CliOverrides` to make their usage explicit (although it would be possible to use the same struct for applying other `Overrides` it is the only actual usage) 

## Test Plan

`cargo test`
