### PR TITLE
Add empty lines between options and move documents

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -29,6 +29,8 @@ use strum::IntoEnumIterator;
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Options {
+    /// A list of allowed "confusable" Unicode characters to ignore when
+    /// enforcing `RUF001`, `RUF002`, and `RUF003`.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -38,9 +40,10 @@ pub struct Options {
             allowed-confusables = ["−", "ρ", "∗"]
         "#
     )]
-    /// A list of allowed "confusable" Unicode characters to ignore when
-    /// enforcing `RUF001`, `RUF002`, and `RUF003`.
     pub allowed_confusables: Option<Vec<char>>,
+
+    /// A list of builtins to treat as defined references, in addition to the
+    /// system builtins.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -48,14 +51,8 @@ pub struct Options {
             builtins = ["_"]
         "#
     )]
-    /// A list of builtins to treat as defined references, in addition to the
-    /// system builtins.
     pub builtins: Option<Vec<String>>,
-    #[option(
-        default = ".ruff_cache",
-        value_type = "str",
-        example = r#"cache-dir = "~/.cache/ruff""#
-    )]
+
     /// A path to the cache directory.
     ///
     /// By default, Ruff stores cache results in a `.ruff_cache` directory in
@@ -66,7 +63,16 @@ pub struct Options {
     ///
     /// This setting will override even the `RUFF_CACHE_DIR` environment
     /// variable, if set.
+    #[option(
+        default = ".ruff_cache",
+        value_type = "str",
+        example = r#"cache-dir = "~/.cache/ruff""#
+    )]
     pub cache_dir: Option<String>,
+
+    /// A regular expression used to identify "dummy" variables, or those which
+    /// should be ignored when enforcing (e.g.) unused-variable rules. The
+    /// default expression matches `_`, `__`, and `_var`, but not `_var_`.
     #[option(
         default = r#""^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$""#,
         value_type = "re.Pattern",
@@ -75,17 +81,8 @@ pub struct Options {
             dummy-variable-rgx = "^_$"
         "#
     )]
-    /// A regular expression used to identify "dummy" variables, or those which
-    /// should be ignored when enforcing (e.g.) unused-variable rules. The
-    /// default expression matches `_`, `__`, and `_var`, but not `_var_`.
     pub dummy_variable_rgx: Option<String>,
-    #[option(
-        default = r#"[".bzr", ".direnv", ".eggs", ".git", ".git-rewrite", ".hg", ".mypy_cache", ".nox", ".pants.d", ".pytype", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "buck-out", "build", "dist", "node_modules", "venv"]"#,
-        value_type = "list[str]",
-        example = r#"
-            exclude = [".venv"]
-        "#
-    )]
+
     /// A list of file patterns to exclude from linting.
     ///
     /// Exclusions are based on globs, and can be either:
@@ -102,7 +99,22 @@ pub struct Options {
     ///
     /// Note that you'll typically want to use
     /// [`extend-exclude`](#extend-exclude) to modify the excluded paths.
+    #[option(
+        default = r#"[".bzr", ".direnv", ".eggs", ".git", ".git-rewrite", ".hg", ".mypy_cache", ".nox", ".pants.d", ".pytype", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "buck-out", "build", "dist", "node_modules", "venv"]"#,
+        value_type = "list[str]",
+        example = r#"
+            exclude = [".venv"]
+        "#
+    )]
     pub exclude: Option<Vec<String>>,
+
+    /// A path to a local `pyproject.toml` file to merge into this
+    /// configuration. User home directory and environment variables will be
+    /// expanded.
+    ///
+    /// To resolve the current `pyproject.toml` file, Ruff will first resolve
+    /// this base configuration file, then merge in any properties defined
+    /// in the current configuration file.
     #[option(
         default = r#"None"#,
         value_type = "str",
@@ -113,22 +125,8 @@ pub struct Options {
             line-length = 100
         "#
     )]
-    /// A path to a local `pyproject.toml` file to merge into this
-    /// configuration. User home directory and environment variables will be
-    /// expanded.
-    ///
-    /// To resolve the current `pyproject.toml` file, Ruff will first resolve
-    /// this base configuration file, then merge in any properties defined
-    /// in the current configuration file.
     pub extend: Option<String>,
-    #[option(
-        default = "[]",
-        value_type = "list[str]",
-        example = r#"
-            # In addition to the standard set of exclusions, omit all tests, plus a specific file.
-            extend-exclude = ["tests", "src/bad.py"]
-        "#
-    )]
+
     /// A list of file patterns to omit from linting, in addition to those
     /// specified by `exclude`.
     ///
@@ -143,7 +141,23 @@ pub struct Options {
     ///   (e.g., the directory containing your `pyproject.toml`).
     ///
     /// For more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).
+    #[option(
+        default = "[]",
+        value_type = "list[str]",
+        example = r#"
+            # In addition to the standard set of exclusions, omit all tests, plus a specific file.
+            extend-exclude = ["tests", "src/bad.py"]
+        "#
+    )]
     pub extend_exclude: Option<Vec<String>>,
+
+    /// A list of file patterns to include when linting, in addition to those
+    /// specified by `include`.
+    ///
+    /// Inclusion are based on globs, and should be single-path patterns, like
+    /// `*.pyw`, to include any file with the `.pyw` extension.
+    ///
+    /// For more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).
     #[option(
         default = "[]",
         value_type = "list[str]",
@@ -152,14 +166,13 @@ pub struct Options {
             extend-include = ["*.pyw"]
         "#
     )]
-    /// A list of file patterns to include when linting, in addition to those
-    /// specified by `include`.
-    ///
-    /// Inclusion are based on globs, and should be single-path patterns, like
-    /// `*.pyw`, to include any file with the `.pyw` extension.
-    ///
-    /// For more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).
     pub extend_include: Option<Vec<String>>,
+
+    /// A list of rule codes or prefixes to ignore, in addition to those
+    /// specified by `ignore`.
+    ///
+    /// This option has been **deprecated** in favor of `ignore`
+    /// since its usage is now interchangeable with `ignore`.
     #[option(
         default = "[]",
         value_type = "list[RuleSelector]",
@@ -168,13 +181,11 @@ pub struct Options {
             extend-ignore = ["F841"]
         "#
     )]
-    /// A list of rule codes or prefixes to ignore, in addition to those
-    /// specified by `ignore`.
-    ///
-    /// This option has been **deprecated** in favor of `ignore`
-    /// since its usage is now interchangeable with `ignore`.
     #[cfg_attr(feature = "schemars", schemars(skip))]
     pub extend_ignore: Option<Vec<RuleSelector>>,
+
+    /// A list of rule codes or prefixes to enable, in addition to those
+    /// specified by `select`.
     #[option(
         default = "[]",
         value_type = "list[RuleSelector]",
@@ -183,9 +194,10 @@ pub struct Options {
             extend-select = ["B", "Q"]
         "#
     )]
-    /// A list of rule codes or prefixes to enable, in addition to those
-    /// specified by `select`.
     pub extend_select: Option<Vec<RuleSelector>>,
+
+    /// A list of rule codes or prefixes to consider autofixable, in addition to those
+    /// specified by `fixable`.
     #[option(
         default = r#"[]"#,
         value_type = "list[RuleSelector]",
@@ -194,9 +206,8 @@ pub struct Options {
             extend-fixable = ["B"]
         "#
     )]
-    /// A list of rule codes or prefixes to consider autofixable, in addition to those
-    /// specified by `fixable`.
     pub extend_fixable: Option<Vec<RuleSelector>>,
+
     /// A list of rule codes or prefixes to consider non-auto-fixable, in addition to those
     /// specified by `unfixable`.
     ///
@@ -204,6 +215,11 @@ pub struct Options {
     /// interchangeable with `unfixable`.
     #[cfg_attr(feature = "schemars", schemars(skip))]
     pub extend_unfixable: Option<Vec<RuleSelector>>,
+
+    /// A list of rule codes that are unsupported by Ruff, but should be
+    /// preserved when (e.g.) validating `# noqa` directives. Useful for
+    /// retaining `# noqa` directives that cover plugins not yet implemented
+    /// by Ruff.
     #[option(
         default = "[]",
         value_type = "list[str]",
@@ -213,18 +229,19 @@ pub struct Options {
             external = ["V101"]
         "#
     )]
-    /// A list of rule codes that are unsupported by Ruff, but should be
-    /// preserved when (e.g.) validating `# noqa` directives. Useful for
-    /// retaining `# noqa` directives that cover plugins not yet implemented
-    /// by Ruff.
     pub external: Option<Vec<String>>,
-    #[option(default = "false", value_type = "bool", example = "fix = true")]
+
     /// Enable autofix behavior by-default when running `ruff` (overridden
     /// by the `--fix` and `--no-fix` command-line flags).
+    #[option(default = "false", value_type = "bool", example = "fix = true")]
     pub fix: Option<bool>,
-    #[option(default = "false", value_type = "bool", example = "fix-only = true")]
+
     /// Like `fix`, but disables reporting on leftover violation. Implies `fix`.
+    #[option(default = "false", value_type = "bool", example = "fix-only = true")]
     pub fix_only: Option<bool>,
+
+    /// A list of rule codes or prefixes to consider autofixable. By default,
+    /// all rules are considered autofixable.
     #[option(
         default = r#"["ALL"]"#,
         value_type = "list[RuleSelector]",
@@ -233,8 +250,6 @@ pub struct Options {
             fixable = ["E", "F"]
         "#
     )]
-    /// A list of rule codes or prefixes to consider autofixable. By default,
-    /// all rules are considered autofixable.
     pub fixable: Option<Vec<RuleSelector>>,
 
     /// The style in which violation messages should be formatted: `"text"`
@@ -280,7 +295,22 @@ pub struct Options {
     /// changed files to the [`ruff-pre-commit`](https://github.com/astral-sh/ruff-pre-commit)
     /// plugin, regardless of whether they're marked as excluded by Ruff's own
     /// settings.
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"
+            force-exclude = true
+        "#
+    )]
     pub force_exclude: Option<bool>,
+
+    /// A list of rule codes or prefixes to ignore. Prefixes can specify exact
+    /// rules (like `F841`), entire categories (like `F`), or anything in
+    /// between.
+    ///
+    /// When breaking ties between enabled and disabled rules (via `select` and
+    /// `ignore`, respectively), more specific prefixes override less
+    /// specific prefixes.
     #[option(
         default = "[]",
         value_type = "list[RuleSelector]",
@@ -289,14 +319,12 @@ pub struct Options {
             ignore = ["F841"]
         "#
     )]
-    /// A list of rule codes or prefixes to ignore. Prefixes can specify exact
-    /// rules (like `F841`), entire categories (like `F`), or anything in
-    /// between.
-    ///
-    /// When breaking ties between enabled and disabled rules (via `select` and
-    /// `ignore`, respectively), more specific prefixes override less
-    /// specific prefixes.
     pub ignore: Option<Vec<RuleSelector>>,
+
+    /// Avoid automatically removing unused imports in `__init__.py` files. Such
+    /// imports will still be flagged, but with a dedicated message suggesting
+    /// that the import is either added to the module's `__all__` symbol, or
+    /// re-exported with a redundant alias (e.g., `import os as os`).
     #[option(
         default = "false",
         value_type = "bool",
@@ -304,18 +332,8 @@ pub struct Options {
             ignore-init-module-imports = true
         "#
     )]
-    /// Avoid automatically removing unused imports in `__init__.py` files. Such
-    /// imports will still be flagged, but with a dedicated message suggesting
-    /// that the import is either added to the module's `__all__` symbol, or
-    /// re-exported with a redundant alias (e.g., `import os as os`).
     pub ignore_init_module_imports: Option<bool>,
-    #[option(
-        default = r#"["*.py", "*.pyi", "**/pyproject.toml"]"#,
-        value_type = "list[str]",
-        example = r#"
-            include = ["*.py"]
-        "#
-    )]
+
     /// A list of file patterns to include when linting.
     ///
     /// Inclusion are based on globs, and should be single-path patterns, like
@@ -324,7 +342,17 @@ pub struct Options {
     /// `[project]` matches the schema.
     ///
     /// For more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).
+    #[option(
+        default = r#"["*.py", "*.pyi", "**/pyproject.toml"]"#,
+        value_type = "list[str]",
+        example = r#"
+            include = ["*.py"]
+        "#
+    )]
     pub include: Option<Vec<String>>,
+
+    /// The line length to use when enforcing long-lines violations (like
+    /// `E501`). Must be greater than `0` and less than or equal to `320`.
     #[option(
         default = "88",
         value_type = "int",
@@ -333,10 +361,10 @@ pub struct Options {
         line-length = 120
         "#
     )]
-    /// The line length to use when enforcing long-lines violations (like
-    /// `E501`). Must be greater than `0` and less than or equal to `320`.
     #[cfg_attr(feature = "schemars", schemars(range(min = 1, max = 320)))]
     pub line_length: Option<LineLength>,
+
+    /// The tabulation size to calculate line length.
     #[option(
         default = "4",
         value_type = "int",
@@ -344,13 +372,8 @@ pub struct Options {
             tab-size = 8
         "#
     )]
-    /// The tabulation size to calculate line length.
     pub tab_size: Option<TabSize>,
-    #[option(
-        default = r#"[]"#,
-        value_type = "list[str]",
-        example = r#"logger-objects = ["logging_setup.logger"]"#
-    )]
+
     /// A list of objects that should be treated equivalently to a
     /// `logging.Logger` object.
     ///
@@ -369,7 +392,16 @@ pub struct Options {
     /// Adding `"logging_setup.logger"` to `logger-objects` will ensure that
     /// `logging_setup.logger` is treated as a `logging.Logger` object when
     /// imported from other modules (e.g., `from logging_setup import logger`).
+    #[option(
+        default = r#"[]"#,
+        value_type = "list[str]",
+        example = r#"logger-objects = ["logging_setup.logger"]"#
+    )]
     pub logger_objects: Option<Vec<String>>,
+
+    /// Require a specific version of Ruff to be running (useful for unifying
+    /// results across many environments, e.g., with a `pyproject.toml`
+    /// file).
     #[option(
         default = "None",
         value_type = "str",
@@ -377,10 +409,11 @@ pub struct Options {
             required-version = "0.0.193"
         "#
     )]
-    /// Require a specific version of Ruff to be running (useful for unifying
-    /// results across many environments, e.g., with a `pyproject.toml`
-    /// file).
     pub required_version: Option<Version>,
+
+    /// Whether to automatically exclude files that are ignored by `.ignore`,
+    /// `.gitignore`, `.git/info/exclude`, and global `gitignore` files.
+    /// Enabled by default.
     #[option(
         default = "true",
         value_type = "bool",
@@ -388,10 +421,15 @@ pub struct Options {
             respect-gitignore = false
         "#
     )]
-    /// Whether to automatically exclude files that are ignored by `.ignore`,
-    /// `.gitignore`, `.git/info/exclude`, and global `gitignore` files.
-    /// Enabled by default.
     pub respect_gitignore: Option<bool>,
+
+    /// A list of rule codes or prefixes to enable. Prefixes can specify exact
+    /// rules (like `F841`), entire categories (like `F`), or anything in
+    /// between.
+    ///
+    /// When breaking ties between enabled and disabled rules (via `select` and
+    /// `ignore`, respectively), more specific prefixes override less
+    /// specific prefixes.
     #[option(
         default = r#"["E", "F"]"#,
         value_type = "list[RuleSelector]",
@@ -400,14 +438,10 @@ pub struct Options {
             select = ["E", "F", "B", "Q"]
         "#
     )]
-    /// A list of rule codes or prefixes to enable. Prefixes can specify exact
-    /// rules (like `F841`), entire categories (like `F`), or anything in
-    /// between.
-    ///
-    /// When breaking ties between enabled and disabled rules (via `select` and
-    /// `ignore`, respectively), more specific prefixes override less
-    /// specific prefixes.
     pub select: Option<Vec<RuleSelector>>,
+
+    /// Whether to show source code snippets when reporting lint violations
+    /// (overridden by the `--show-source` command-line flag).
     #[option(
         default = "false",
         value_type = "bool",
@@ -416,9 +450,10 @@ pub struct Options {
             show-source = true
         "#
     )]
-    /// Whether to show source code snippets when reporting lint violations
-    /// (overridden by the `--show-source` command-line flag).
     pub show_source: Option<bool>,
+
+    /// Whether to show an enumeration of all autofixed lint violations
+    /// (overridden by the `--show-fixes` command-line flag).
     #[option(
         default = "false",
         value_type = "bool",
@@ -427,17 +462,8 @@ pub struct Options {
             show-fixes = true
         "#
     )]
-    /// Whether to show an enumeration of all autofixed lint violations
-    /// (overridden by the `--show-fixes` command-line flag).
     pub show_fixes: Option<bool>,
-    #[option(
-        default = r#"["."]"#,
-        value_type = "list[str]",
-        example = r#"
-            # Allow imports relative to the "src" and "test" directories.
-            src = ["src", "test"]
-        "#
-    )]
+
     /// The directories to consider when resolving first- vs. third-party
     /// imports.
     ///
@@ -466,7 +492,19 @@ pub struct Options {
     /// packages in a `python_modules` directory, `src = ["python_modules/*"]`
     /// would expand to incorporate all of the packages in that directory. User
     /// home directory and environment variables will also be expanded.
+    #[option(
+        default = r#"["."]"#,
+        value_type = "list[str]",
+        example = r#"
+            # Allow imports relative to the "src" and "test" directories.
+            src = ["src", "test"]
+        "#
+    )]
     pub src: Option<Vec<String>>,
+
+    /// Mark the specified directories as namespace packages. For the purpose of
+    /// module resolution, Ruff will treat those directories as if they
+    /// contained an `__init__.py` file.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -474,18 +512,8 @@ pub struct Options {
             namespace-packages = ["airflow/providers"]
         "#
     )]
-    /// Mark the specified directories as namespace packages. For the purpose of
-    /// module resolution, Ruff will treat those directories as if they
-    /// contained an `__init__.py` file.
     pub namespace_packages: Option<Vec<String>>,
-    #[option(
-        default = r#""py38""#,
-        value_type = r#""py37" | "py38" | "py39" | "py310" | "py311" | "py312""#,
-        example = r#"
-            # Always generate Python 3.7-compatible code.
-            target-version = "py37"
-        "#
-    )]
+
     /// The minimum Python version to target, e.g., when considering automatic
     /// code upgrades, like rewriting type annotations. Ruff will not propose
     /// changes using features that are not available in the given version.
@@ -497,7 +525,18 @@ pub struct Options {
     /// target version will be inferred from its `project.requires-python`
     /// field (e.g., `requires-python = ">=3.8"`). If Ruff is configured via
     /// `ruff.toml` or `.ruff.toml`, no such inference will be performed.
+    #[option(
+        default = r#""py38""#,
+        value_type = r#""py37" | "py38" | "py39" | "py310" | "py311" | "py312""#,
+        example = r#"
+            # Always generate Python 3.7-compatible code.
+            target-version = "py37"
+        "#
+    )]
     pub target_version: Option<PythonVersion>,
+
+    /// Whether to enable preview mode. When preview mode is enabled, Ruff will
+    /// use unstable rules and fixes.
     #[option(
         default = "false",
         value_type = "bool",
@@ -506,25 +545,20 @@ pub struct Options {
             preview = true
         "#
     )]
-    /// Whether to enable preview mode. When preview mode is enabled, Ruff will
-    /// use unstable rules and fixes.
     pub preview: Option<bool>,
-    #[option(
-        default = r#"["TODO", "FIXME", "XXX"]"#,
-        value_type = "list[str]",
-        example = r#"task-tags = ["HACK"]"#
-    )]
+
     /// A list of task tags to recognize (e.g., "TODO", "FIXME", "XXX").
     ///
     /// Comments starting with these tags will be ignored by commented-out code
     /// detection (`ERA`), and skipped by line-length rules (`E501`) if
     /// `ignore-overlong-task-comments` is set to `true`.
-    pub task_tags: Option<Vec<String>>,
     #[option(
-        default = r#"[]"#,
+        default = r#"["TODO", "FIXME", "XXX"]"#,
         value_type = "list[str]",
-        example = r#"typing-modules = ["airflow.typing_compat"]"#
+        example = r#"task-tags = ["HACK"]"#
     )]
+    pub task_tags: Option<Vec<String>>,
+
     /// A list of modules whose exports should be treated equivalently to
     /// members of the `typing` module.
     ///
@@ -533,7 +567,14 @@ pub struct Options {
     /// from a compatibility module. If omitted, any members imported from
     /// modules apart from `typing` and `typing_extensions` will be treated
     /// as ordinary Python objects.
+    #[option(
+        default = r#"[]"#,
+        value_type = "list[str]",
+        example = r#"typing-modules = ["airflow.typing_compat"]"#
+    )]
     pub typing_modules: Option<Vec<String>>,
+
+    /// A list of rule codes or prefixes to consider non-autofix-able.
     #[option(
         default = "[]",
         value_type = "list[RuleSelector]",
@@ -542,81 +583,107 @@ pub struct Options {
             unfixable = ["F401"]
         "#
     )]
-    /// A list of rule codes or prefixes to consider non-autofix-able.
     pub unfixable: Option<Vec<RuleSelector>>,
-    #[option_group]
+
     /// Options for the `flake8-annotations` plugin.
+    #[option_group]
     pub flake8_annotations: Option<Flake8AnnotationsOptions>,
-    #[option_group]
+
     /// Options for the `flake8-bandit` plugin.
+    #[option_group]
     pub flake8_bandit: Option<Flake8BanditOptions>,
-    #[option_group]
+
     /// Options for the `flake8-bugbear` plugin.
+    #[option_group]
     pub flake8_bugbear: Option<Flake8BugbearOptions>,
-    #[option_group]
+
     /// Options for the `flake8-builtins` plugin.
+    #[option_group]
     pub flake8_builtins: Option<Flake8BuiltinsOptions>,
-    #[option_group]
+
     /// Options for the `flake8-comprehensions` plugin.
+    #[option_group]
     pub flake8_comprehensions: Option<Flake8ComprehensionsOptions>,
-    #[option_group]
+
     /// Options for the `flake8-copyright` plugin.
+    #[option_group]
     pub flake8_copyright: Option<Flake8CopyrightOptions>,
-    #[option_group]
+
     /// Options for the `flake8-errmsg` plugin.
+    #[option_group]
     pub flake8_errmsg: Option<Flake8ErrMsgOptions>,
-    #[option_group]
+
     /// Options for the `flake8-quotes` plugin.
+    #[option_group]
     pub flake8_quotes: Option<Flake8QuotesOptions>,
-    #[option_group]
+
     /// Options for the `flake8_self` plugin.
+    #[option_group]
     pub flake8_self: Option<Flake8SelfOptions>,
-    #[option_group]
+
     /// Options for the `flake8-tidy-imports` plugin.
+    #[option_group]
     pub flake8_tidy_imports: Option<Flake8TidyImportsOptions>,
-    #[option_group]
+
     /// Options for the `flake8-type-checking` plugin.
+    #[option_group]
     pub flake8_type_checking: Option<Flake8TypeCheckingOptions>,
-    #[option_group]
+
     /// Options for the `flake8-gettext` plugin.
+    #[option_group]
     pub flake8_gettext: Option<Flake8GetTextOptions>,
-    #[option_group]
+
     /// Options for the `flake8-implicit-str-concat` plugin.
+    #[option_group]
     pub flake8_implicit_str_concat: Option<Flake8ImplicitStrConcatOptions>,
-    #[option_group]
+
     /// Options for the `flake8-import-conventions` plugin.
+    #[option_group]
     pub flake8_import_conventions: Option<Flake8ImportConventionsOptions>,
-    #[option_group]
+
     /// Options for the `flake8-pytest-style` plugin.
+    #[option_group]
     pub flake8_pytest_style: Option<Flake8PytestStyleOptions>,
-    #[option_group]
+
     /// Options for the `flake8-unused-arguments` plugin.
+    #[option_group]
     pub flake8_unused_arguments: Option<Flake8UnusedArgumentsOptions>,
-    #[option_group]
+
     /// Options for the `isort` plugin.
+    #[option_group]
     pub isort: Option<IsortOptions>,
-    #[option_group]
+
     /// Options for the `mccabe` plugin.
+    #[option_group]
     pub mccabe: Option<McCabeOptions>,
-    #[option_group]
+
     /// Options for the `pep8-naming` plugin.
+    #[option_group]
     pub pep8_naming: Option<Pep8NamingOptions>,
-    #[option_group]
+
     /// Options for the `pycodestyle` plugin.
+    #[option_group]
     pub pycodestyle: Option<PycodestyleOptions>,
-    #[option_group]
+
     /// Options for the `pydocstyle` plugin.
+    #[option_group]
     pub pydocstyle: Option<PydocstyleOptions>,
-    #[option_group]
+
     /// Options for the `pyflakes` plugin.
+    #[option_group]
     pub pyflakes: Option<PyflakesOptions>,
-    #[option_group]
+
     /// Options for the `pylint` plugin.
-    pub pylint: Option<PylintOptions>,
     #[option_group]
+    pub pylint: Option<PylintOptions>,
+
     /// Options for the `pyupgrade` plugin.
+    #[option_group]
     pub pyupgrade: Option<PyUpgradeOptions>,
+
     // Tables are required to go last.
+    /// A list of mappings from file pattern to rule codes or prefixes to
+    /// exclude, when considering any matching files.
     #[option(
         default = "{}",
         value_type = "dict[str, list[RuleSelector]]",
@@ -627,9 +694,10 @@ pub struct Options {
             "path/to/file.py" = ["E402"]
         "#
     )]
-    /// A list of mappings from file pattern to rule codes or prefixes to
-    /// exclude, when considering any matching files.
     pub per_file_ignores: Option<FxHashMap<String, Vec<RuleSelector>>>,
+
+    /// A list of mappings from file pattern to rule codes or prefixes to
+    /// exclude, in addition to any rules excluded by `per-file-ignores`.
     #[option(
         default = "{}",
         value_type = "dict[str, list[RuleSelector]]",
@@ -639,8 +707,6 @@ pub struct Options {
             "__init__.py" = ["E402"]
         "#
     )]
-    /// A list of mappings from file pattern to rule codes or prefixes to
-    /// exclude, in addition to any rules excluded by `per-file-ignores`.
     pub extend_per_file_ignores: Option<FxHashMap<String, Vec<RuleSelector>>>,
 }
 
@@ -650,50 +716,54 @@ pub struct Options {
 )]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Flake8AnnotationsOptions {
+    /// Whether to allow the omission of a return type hint for `__init__` if at
+    /// least one argument is annotated.
     #[option(
         default = "false",
         value_type = "bool",
         example = "mypy-init-return = true"
     )]
-    /// Whether to allow the omission of a return type hint for `__init__` if at
-    /// least one argument is annotated.
     pub mypy_init_return: Option<bool>,
+
+    /// Whether to suppress `ANN000`-level violations for arguments matching the
+    /// "dummy" variable regex (like `_`).
     #[option(
         default = "false",
         value_type = "bool",
         example = "suppress-dummy-args = true"
     )]
-    /// Whether to suppress `ANN000`-level violations for arguments matching the
-    /// "dummy" variable regex (like `_`).
     pub suppress_dummy_args: Option<bool>,
-    #[option(
-        default = "false",
-        value_type = "bool",
-        example = "suppress-none-returning = true"
-    )]
+
     /// Whether to suppress `ANN200`-level violations for functions that meet
     /// either of the following criteria:
     ///
     /// - Contain no `return` statement.
     /// - Explicit `return` statement(s) all return `None` (explicitly or
     ///   implicitly).
+    #[option(
+        default = "false",
+        value_type = "bool",
+        example = "suppress-none-returning = true"
+    )]
     pub suppress_none_returning: Option<bool>,
+
+    /// Whether to suppress `ANN401` for dynamically typed `*args` and
+    /// `**kwargs` arguments.
     #[option(
         default = "false",
         value_type = "bool",
         example = "allow-star-arg-any = true"
     )]
-    /// Whether to suppress `ANN401` for dynamically typed `*args` and
-    /// `**kwargs` arguments.
     pub allow_star_arg_any: Option<bool>,
+
+    /// Whether to suppress `ANN*` rules for any declaration
+    /// that hasn't been typed at all.
+    /// This makes it easier to gradually add types to a codebase.
     #[option(
         default = "false",
         value_type = "bool",
         example = "ignore-fully-untyped = true"
     )]
-    /// Whether to suppress `ANN*` rules for any declaration
-    /// that hasn't been typed at all.
-    /// This makes it easier to gradually add types to a codebase.
     pub ignore_fully_untyped: Option<bool>,
 }
 
@@ -715,29 +785,31 @@ impl Flake8AnnotationsOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8BanditOptions {
+    /// A list of directories to consider temporary.
     #[option(
         default = "[\"/tmp\", \"/var/tmp\", \"/dev/shm\"]",
         value_type = "list[str]",
         example = "hardcoded-tmp-directory = [\"/foo/bar\"]"
     )]
-    /// A list of directories to consider temporary.
     pub hardcoded_tmp_directory: Option<Vec<String>>,
+
+    /// A list of directories to consider temporary, in addition to those
+    /// specified by `hardcoded-tmp-directory`.
     #[option(
         default = "[]",
         value_type = "list[str]",
         example = "extend-hardcoded-tmp-directory = [\"/foo/bar\"]"
     )]
-    /// A list of directories to consider temporary, in addition to those
-    /// specified by `hardcoded-tmp-directory`.
     pub hardcoded_tmp_directory_extend: Option<Vec<String>>,
+
+    /// Whether to disallow `try`-`except`-`pass` (`S110`) for specific
+    /// exception types. By default, `try`-`except`-`pass` is only
+    /// disallowed for `Exception` and `BaseException`.
     #[option(
         default = "false",
         value_type = "bool",
         example = "check-typed-exception = true"
     )]
-    /// Whether to disallow `try`-`except`-`pass` (`S110`) for specific
-    /// exception types. By default, `try`-`except`-`pass` is only
-    /// disallowed for `Exception` and `BaseException`.
     pub check_typed_exception: Option<bool>,
 }
 
@@ -761,6 +833,12 @@ impl Flake8BanditOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8BugbearOptions {
+    /// Additional callable functions to consider "immutable" when evaluating, e.g., the
+    /// `function-call-in-default-argument` rule (`B008`) or `function-call-in-dataclass-defaults`
+    /// rule (`RUF009`).
+    ///
+    /// Expects to receive a list of fully-qualified names (e.g., `fastapi.Query`, rather than
+    /// `Query`).
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -769,12 +847,6 @@ pub struct Flake8BugbearOptions {
             extend-immutable-calls = ["fastapi.Depends", "fastapi.Query"]
         "#
     )]
-    /// Additional callable functions to consider "immutable" when evaluating, e.g., the
-    /// `function-call-in-default-argument` rule (`B008`) or `function-call-in-dataclass-defaults`
-    /// rule (`RUF009`).
-    ///
-    /// Expects to receive a list of fully-qualified names (e.g., `fastapi.Query`, rather than
-    /// `Query`).
     pub extend_immutable_calls: Option<Vec<String>>,
 }
 
@@ -813,12 +885,12 @@ impl Flake8BuiltinsOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8ComprehensionsOptions {
+    /// Allow `dict` calls that make use of keyword arguments (e.g., `dict(a=1, b=2)`).
     #[option(
         default = "false",
         value_type = "bool",
         example = "allow-dict-calls-with-keyword-arguments = true"
     )]
-    /// Allow `dict` calls that make use of keyword arguments (e.g., `dict(a=1, b=2)`).
     pub allow_dict_calls_with_keyword_arguments: Option<bool>,
 }
 
@@ -838,11 +910,6 @@ impl Flake8ComprehensionsOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8CopyrightOptions {
-    #[option(
-        default = r#"(?i)Copyright\s+(\(C\)\s+)?\d{4}([-,]\d{4})*"#,
-        value_type = "str",
-        example = r#"notice-rgx = "(?i)Copyright \\(C\\) \\d{4}""#
-    )]
     /// The regular expression used to match the copyright notice, compiled
     /// with the [`regex`](https://docs.rs/regex/latest/regex/) crate.
     ///
@@ -852,11 +919,20 @@ pub struct Flake8CopyrightOptions {
     /// - `Copyright (C) 2023`
     /// - `Copyright 2021-2023`
     /// - `Copyright (C) 2021-2023`
+    #[option(
+        default = r#"(?i)Copyright\s+(\(C\)\s+)?\d{4}([-,]\d{4})*"#,
+        value_type = "str",
+        example = r#"notice-rgx = "(?i)Copyright \\(C\\) \\d{4}""#
+    )]
     pub notice_rgx: Option<String>,
-    #[option(default = "None", value_type = "str", example = r#"author = "Ruff""#)]
+
     /// Author to enforce within the copyright notice. If provided, the
     /// author must be present immediately following the copyright notice.
+    #[option(default = "None", value_type = "str", example = r#"author = "Ruff""#)]
     pub author: Option<String>,
+
+    /// A minimum file size (in bytes) required for a copyright notice to
+    /// be enforced. By default, all files are validated.
     #[option(
         default = r#"0"#,
         value_type = "int",
@@ -865,8 +941,6 @@ pub struct Flake8CopyrightOptions {
             min-file-size = 1024
         "#
     )]
-    /// A minimum file size (in bytes) required for a copyright notice to
-    /// be enforced. By default, all files are validated.
     pub min_file_size: Option<usize>,
 }
 
@@ -890,8 +964,8 @@ impl Flake8CopyrightOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8ErrMsgOptions {
-    #[option(default = "0", value_type = "int", example = "max-string-length = 20")]
     /// Maximum string length for string literals in exception messages.
+    #[option(default = "0", value_type = "int", example = "max-string-length = 20")]
     pub max_string_length: Option<usize>,
 }
 
@@ -909,20 +983,21 @@ impl Flake8ErrMsgOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8GetTextOptions {
+    /// The function names to consider as internationalization calls.
     #[option(
         default = r#"["_", "gettext", "ngettext"]"#,
         value_type = "list[str]",
         example = r#"function-names = ["_", "gettext", "ngettext", "ugettetxt"]"#
     )]
-    /// The function names to consider as internationalization calls.
     pub function_names: Option<Vec<String>>,
+
+    /// Additional function names to consider as internationalization calls, in addition to those
+    /// included in `function-names`.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
         example = r#"extend-function-names = ["ugettetxt"]"#
     )]
-    /// Additional function names to consider as internationalization calls, in addition to those
-    /// included in `function-names`.
     pub extend_function_names: Option<Vec<String>>,
 }
 
@@ -945,13 +1020,6 @@ impl Flake8GetTextOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8ImplicitStrConcatOptions {
-    #[option(
-        default = r#"true"#,
-        value_type = "bool",
-        example = r#"
-            allow-multiline = false
-        "#
-    )]
     /// Whether to allow implicit string concatenations for multiline strings.
     /// By default, implicit concatenations of multiline strings are
     /// allowed (but continuation lines, delimited with a backslash, are
@@ -961,6 +1029,13 @@ pub struct Flake8ImplicitStrConcatOptions {
     /// with disabling `explicit-string-concatenation` (`ISC003`). Otherwise,
     /// both explicit and implicit multiline string concatenations will be seen
     /// as violations.
+    #[option(
+        default = r#"true"#,
+        value_type = "bool",
+        example = r#"
+            allow-multiline = false
+        "#
+    )]
     pub allow_multiline: Option<bool>,
 }
 
@@ -978,6 +1053,8 @@ impl Flake8ImplicitStrConcatOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8ImportConventionsOptions {
+    /// The conventional aliases for imports. These aliases can be extended by
+    /// the `extend_aliases` option.
     #[option(
         default = r#"{"altair": "alt", "matplotlib": "mpl", "matplotlib.pyplot": "plt", "numpy": "np", "pandas": "pd", "seaborn": "sns", "tensorflow": "tf", "tkinter":  "tk", "holoviews": "hv", "panel": "pn", "plotly.express": "px", "polars": "pl", "pyarrow": "pa"}"#,
         value_type = "dict[str, str]",
@@ -992,9 +1069,10 @@ pub struct Flake8ImportConventionsOptions {
             scipy = "sp"
         "#
     )]
-    /// The conventional aliases for imports. These aliases can be extended by
-    /// the `extend_aliases` option.
     pub aliases: Option<FxHashMap<String, String>>,
+
+    /// A mapping from module to conventional import alias. These aliases will
+    /// be added to the `aliases` mapping.
     #[option(
         default = r#"{}"#,
         value_type = "dict[str, str]",
@@ -1004,9 +1082,9 @@ pub struct Flake8ImportConventionsOptions {
             "dask.dataframe" = "dd"
         "#
     )]
-    /// A mapping from module to conventional import alias. These aliases will
-    /// be added to the `aliases` mapping.
     pub extend_aliases: Option<FxHashMap<String, String>>,
+
+    /// A mapping from module to its banned import aliases.
     #[option(
         default = r#"{}"#,
         value_type = "dict[str, list[str]]",
@@ -1016,8 +1094,13 @@ pub struct Flake8ImportConventionsOptions {
             "tensorflow.keras.backend" = ["K"]
     "#
     )]
-    /// A mapping from module to its banned import aliases.
     pub banned_aliases: Option<FxHashMap<String, Vec<String>>>,
+
+    /// A list of modules that should not be imported from using the
+    /// `from ... import ...` syntax.
+    ///
+    /// For example, given `banned-from = ["pandas"]`, `from pandas import DataFrame`
+    /// would be disallowed, while `import pandas` would be allowed.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1026,11 +1109,6 @@ pub struct Flake8ImportConventionsOptions {
             banned-from = ["typing"]
     "#
     )]
-    /// A list of modules that should not be imported from using the
-    /// `from ... import ...` syntax.
-    ///
-    /// For example, given `banned-from = ["pandas"]`, `from pandas import DataFrame`
-    /// would be disallowed, while `import pandas` would be allowed.
     pub banned_from: Option<FxHashSet<String>>,
 }
 
@@ -1057,22 +1135,18 @@ impl Flake8ImportConventionsOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8PytestStyleOptions {
-    #[option(
-        default = "true",
-        value_type = "bool",
-        example = "fixture-parentheses = true"
-    )]
     /// Boolean flag specifying whether `@pytest.fixture()` without parameters
     /// should have parentheses. If the option is set to `true` (the
     /// default), `@pytest.fixture()` is valid and `@pytest.fixture` is
     /// invalid. If set to `false`, `@pytest.fixture` is valid and
     /// `@pytest.fixture()` is invalid.
-    pub fixture_parentheses: Option<bool>,
     #[option(
-        default = "tuple",
-        value_type = r#""csv" | "tuple" | "list""#,
-        example = "parametrize-names-type = \"list\""
+        default = "true",
+        value_type = "bool",
+        example = "fixture-parentheses = true"
     )]
+    pub fixture_parentheses: Option<bool>,
+
     /// Expected type for multiple argument names in `@pytest.mark.parametrize`.
     /// The following values are supported:
     ///
@@ -1081,23 +1155,25 @@ pub struct Flake8PytestStyleOptions {
     /// - `tuple` (default) — e.g.
     ///   `@pytest.mark.parametrize(('name1', 'name2'), ...)`
     /// - `list` — e.g. `@pytest.mark.parametrize(['name1', 'name2'], ...)`
-    pub parametrize_names_type: Option<types::ParametrizeNameType>,
     #[option(
-        default = "list",
-        value_type = r#""tuple" | "list""#,
-        example = "parametrize-values-type = \"tuple\""
+        default = "tuple",
+        value_type = r#""csv" | "tuple" | "list""#,
+        example = "parametrize-names-type = \"list\""
     )]
+    pub parametrize_names_type: Option<types::ParametrizeNameType>,
+
     /// Expected type for the list of values rows in `@pytest.mark.parametrize`.
     /// The following values are supported:
     ///
     /// - `tuple` — e.g. `@pytest.mark.parametrize('name', (1, 2, 3))`
     /// - `list` (default) — e.g. `@pytest.mark.parametrize('name', [1, 2, 3])`
-    pub parametrize_values_type: Option<types::ParametrizeValuesType>,
     #[option(
-        default = "tuple",
+        default = "list",
         value_type = r#""tuple" | "list""#,
-        example = "parametrize-values-row-type = \"list\""
+        example = "parametrize-values-type = \"tuple\""
     )]
+    pub parametrize_values_type: Option<types::ParametrizeValuesType>,
+
     /// Expected type for each row of values in `@pytest.mark.parametrize` in
     /// case of multiple parameters. The following values are supported:
     ///
@@ -1105,23 +1181,25 @@ pub struct Flake8PytestStyleOptions {
     ///   `@pytest.mark.parametrize(('name1', 'name2'), [(1, 2), (3, 4)])`
     /// - `list` — e.g.
     ///   `@pytest.mark.parametrize(('name1', 'name2'), [[1, 2], [3, 4]])`
-    pub parametrize_values_row_type: Option<types::ParametrizeValuesRowType>,
     #[option(
-        default = r#"["BaseException", "Exception", "ValueError", "OSError", "IOError", "EnvironmentError", "socket.error"]"#,
-        value_type = "list[str]",
-        example = "raises-require-match-for = [\"requests.RequestException\"]"
+        default = "tuple",
+        value_type = r#""tuple" | "list""#,
+        example = "parametrize-values-row-type = \"list\""
     )]
+    pub parametrize_values_row_type: Option<types::ParametrizeValuesRowType>,
+
     /// List of exception names that require a match= parameter in a
     /// `pytest.raises()` call.
     ///
     /// Supports glob patterns. For more information on the glob syntax, refer
     /// to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).
-    pub raises_require_match_for: Option<Vec<String>>,
     #[option(
-        default = "[]",
+        default = r#"["BaseException", "Exception", "ValueError", "OSError", "IOError", "EnvironmentError", "socket.error"]"#,
         value_type = "list[str]",
-        example = "raises-extend-require-match-for = [\"requests.RequestException\"]"
+        example = "raises-require-match-for = [\"requests.RequestException\"]"
     )]
+    pub raises_require_match_for: Option<Vec<String>>,
+
     /// List of additional exception names that require a match= parameter in a
     /// `pytest.raises()` call. This extends the default list of exceptions
     /// that require a match= parameter.
@@ -1133,17 +1211,23 @@ pub struct Flake8PytestStyleOptions {
     ///
     /// Supports glob patterns. For more information on the glob syntax, refer
     /// to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).
-    pub raises_extend_require_match_for: Option<Vec<String>>,
     #[option(
-        default = "true",
-        value_type = "bool",
-        example = "mark-parentheses = true"
+        default = "[]",
+        value_type = "list[str]",
+        example = "raises-extend-require-match-for = [\"requests.RequestException\"]"
     )]
+    pub raises_extend_require_match_for: Option<Vec<String>>,
+
     /// Boolean flag specifying whether `@pytest.mark.foo()` without parameters
     /// should have parentheses. If the option is set to `true` (the
     /// default), `@pytest.mark.foo()` is valid and `@pytest.mark.foo` is
     /// invalid. If set to `false`, `@pytest.fixture` is valid and
     /// `@pytest.mark.foo()` is invalid.
+    #[option(
+        default = "true",
+        value_type = "bool",
+        example = "mark-parentheses = true"
+    )]
     pub mark_parentheses: Option<bool>,
 }
 
@@ -1187,6 +1271,8 @@ impl Flake8PytestStyleOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8QuotesOptions {
+    /// Quote style to prefer for inline strings (either "single" or
+    /// "double").
     #[option(
         default = r#""double""#,
         value_type = r#""single" | "double""#,
@@ -1194,9 +1280,10 @@ pub struct Flake8QuotesOptions {
             inline-quotes = "single"
         "#
     )]
-    /// Quote style to prefer for inline strings (either "single" or
-    /// "double").
     pub inline_quotes: Option<Quote>,
+
+    /// Quote style to prefer for multiline strings (either "single" or
+    /// "double").
     #[option(
         default = r#""double""#,
         value_type = r#""single" | "double""#,
@@ -1204,9 +1291,9 @@ pub struct Flake8QuotesOptions {
             multiline-quotes = "single"
         "#
     )]
-    /// Quote style to prefer for multiline strings (either "single" or
-    /// "double").
     pub multiline_quotes: Option<Quote>,
+
+    /// Quote style to prefer for docstrings (either "single" or "double").
     #[option(
         default = r#""double""#,
         value_type = r#""single" | "double""#,
@@ -1214,8 +1301,11 @@ pub struct Flake8QuotesOptions {
             docstring-quotes = "single"
         "#
     )]
-    /// Quote style to prefer for docstrings (either "single" or "double").
     pub docstring_quotes: Option<Quote>,
+
+    /// Whether to avoid using single quotes if a string contains single quotes,
+    /// or vice-versa with double quotes, as per [PEP 8](https://peps.python.org/pep-0008/#string-quotes).
+    /// This minimizes the need to escape quotation marks within strings.
     #[option(
         default = r#"true"#,
         value_type = "bool",
@@ -1224,9 +1314,6 @@ pub struct Flake8QuotesOptions {
             avoid-escape = false
         "#
     )]
-    /// Whether to avoid using single quotes if a string contains single quotes,
-    /// or vice-versa with double quotes, as per [PEP 8](https://peps.python.org/pep-0008/#string-quotes).
-    /// This minimizes the need to escape quotation marks within strings.
     pub avoid_escape: Option<bool>,
 }
 
@@ -1247,6 +1334,7 @@ impl Flake8QuotesOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8SelfOptions {
+    /// A list of names to ignore when considering `flake8-self` violations.
     #[option(
         default = r#"["_make", "_asdict", "_replace", "_fields", "_field_defaults", "_name_", "_value_"]"#,
         value_type = "list[str]",
@@ -1254,15 +1342,15 @@ pub struct Flake8SelfOptions {
             ignore-names = ["_new"]
         "#
     )]
-    /// A list of names to ignore when considering `flake8-self` violations.
     pub ignore_names: Option<Vec<String>>,
+
+    /// Additional names to ignore when considering `flake8-self` violations,
+    /// in addition to those included in `ignore-names`.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
         example = r#"extend-ignore-names = ["_base_manager", "_default_manager",  "_meta"]"#
     )]
-    /// Additional names to ignore when considering `flake8-self` violations,
-    /// in addition to those included in `ignore-names`.
     pub extend_ignore_names: Option<Vec<String>>,
 }
 
@@ -1286,6 +1374,8 @@ impl Flake8SelfOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8TidyImportsOptions {
+    /// Whether to ban all relative imports (`"all"`), or only those imports
+    /// that extend into the parent module or beyond (`"parents"`).
     #[option(
         default = r#""parents""#,
         value_type = r#""parents" | "all""#,
@@ -1294,9 +1384,11 @@ pub struct Flake8TidyImportsOptions {
             ban-relative-imports = "all"
         "#
     )]
-    /// Whether to ban all relative imports (`"all"`), or only those imports
-    /// that extend into the parent module or beyond (`"parents"`).
     pub ban_relative_imports: Option<Strictness>,
+
+    /// Specific modules or module members that may not be imported or accessed.
+    /// Note that this rule is only meant to flag accidental uses,
+    /// and can be circumvented via `eval` or `importlib`.
     #[option(
         default = r#"{}"#,
         value_type = r#"dict[str, { "msg": str }]"#,
@@ -1306,10 +1398,11 @@ pub struct Flake8TidyImportsOptions {
             "typing.TypedDict".msg = "Use typing_extensions.TypedDict instead."
         "#
     )]
-    /// Specific modules or module members that may not be imported or accessed.
-    /// Note that this rule is only meant to flag accidental uses,
-    /// and can be circumvented via `eval` or `importlib`.
     pub banned_api: Option<FxHashMap<String, ApiBan>>,
+
+    /// List of specific modules that may not be imported at module level, and should instead be
+    /// imported lazily (e.g., within a function definition, or an `if TYPE_CHECKING:`
+    /// block, or some other nested context).
     #[option(
         default = r#"[]"#,
         value_type = r#"list[str]"#,
@@ -1319,9 +1412,6 @@ pub struct Flake8TidyImportsOptions {
             banned-module-level-imports = ["torch", "tensorflow"]
         "#
     )]
-    /// List of specific modules that may not be imported at module level, and should instead be
-    /// imported lazily (e.g., within a function definition, or an `if TYPE_CHECKING:`
-    /// block, or some other nested context).
     pub banned_module_level_imports: Option<Vec<String>>,
 }
 
@@ -1341,6 +1431,10 @@ impl Flake8TidyImportsOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8TypeCheckingOptions {
+    /// Enforce TC001, TC002, and TC003 rules even when valid runtime imports
+    /// are present for the same module.
+    ///
+    /// See flake8-type-checking's [strict](https://github.com/snok/flake8-type-checking#strict) option.
     #[option(
         default = "false",
         value_type = "bool",
@@ -1348,11 +1442,10 @@ pub struct Flake8TypeCheckingOptions {
             strict = true
         "#
     )]
-    /// Enforce TC001, TC002, and TC003 rules even when valid runtime imports
-    /// are present for the same module.
-    ///
-    /// See flake8-type-checking's [strict](https://github.com/snok/flake8-type-checking#strict) option.
     pub strict: Option<bool>,
+
+    /// Exempt certain modules from needing to be moved into type-checking
+    /// blocks.
     #[option(
         default = "[\"typing\"]",
         value_type = "list[str]",
@@ -1360,16 +1453,8 @@ pub struct Flake8TypeCheckingOptions {
             exempt-modules = ["typing", "typing_extensions"]
         "#
     )]
-    /// Exempt certain modules from needing to be moved into type-checking
-    /// blocks.
     pub exempt_modules: Option<Vec<String>>,
-    #[option(
-        default = "[]",
-        value_type = "list[str]",
-        example = r#"
-            runtime-evaluated-base-classes = ["pydantic.BaseModel", "sqlalchemy.orm.DeclarativeBase"]
-        "#
-    )]
+
     /// Exempt classes that list any of the enumerated classes as a base class
     /// from needing to be moved into type-checking blocks.
     ///
@@ -1380,7 +1465,17 @@ pub struct Flake8TypeCheckingOptions {
     /// (e.g., `class Base(DeclarativeBase) ...` in `base.py`), you can add it to
     /// this list (`runtime-evaluated-base-classes = ["base.Base"]`) to exempt
     /// models from being moved into type-checking blocks.
+    #[option(
+        default = "[]",
+        value_type = "list[str]",
+        example = r#"
+            runtime-evaluated-base-classes = ["pydantic.BaseModel", "sqlalchemy.orm.DeclarativeBase"]
+        "#
+    )]
     pub runtime_evaluated_base_classes: Option<Vec<String>>,
+
+    /// Exempt classes decorated with any of the enumerated decorators from
+    /// needing to be moved into type-checking blocks.
     #[option(
         default = "[]",
         value_type = "list[str]",
@@ -1388,8 +1483,6 @@ pub struct Flake8TypeCheckingOptions {
             runtime-evaluated-decorators = ["attrs.define", "attrs.frozen"]
         "#
     )]
-    /// Exempt classes decorated with any of the enumerated decorators from
-    /// needing to be moved into type-checking blocks.
     pub runtime_evaluated_decorators: Option<Vec<String>>,
 }
 
@@ -1412,12 +1505,12 @@ impl Flake8TypeCheckingOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8UnusedArgumentsOptions {
+    /// Whether to allow unused variadic arguments, like `*args` and `**kwargs`.
     #[option(
         default = "false",
         value_type = "bool",
         example = "ignore-variadic-names = true"
     )]
-    /// Whether to allow unused variadic arguments, like `*args` and `**kwargs`.
     pub ignore_variadic_names: Option<bool>,
 }
 
@@ -1435,14 +1528,6 @@ impl Flake8UnusedArgumentsOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct IsortOptions {
-    #[option(
-        default = r#"false"#,
-        value_type = "bool",
-        example = r#"
-            force-wrap-aliases = true
-            combine-as-imports = true
-        "#
-    )]
     /// Force `import from` statements with multiple members and at least one
     /// alias (e.g., `import A as B`) to wrap such that every line contains
     /// exactly one member. For example, this formatting would be retained,
@@ -1459,14 +1544,25 @@ pub struct IsortOptions {
     /// `combine-as-imports = true`. When `combine-as-imports` isn't
     /// enabled, every aliased `import from` will be given its own line, in
     /// which case, wrapping is not necessary.
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"
+            force-wrap-aliases = true
+            combine-as-imports = true
+        "#
+    )]
     pub force_wrap_aliases: Option<bool>,
+
+    /// Forces all from imports to appear on their own line.
     #[option(
         default = r#"false"#,
         value_type = "bool",
         example = r#"force-single-line = true"#
     )]
-    /// Forces all from imports to appear on their own line.
     pub force_single_line: Option<bool>,
+
+    /// One or more modules to exclude from the single line rule.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1474,8 +1570,10 @@ pub struct IsortOptions {
             single-line-exclusions = ["os", "json"]
         "#
     )]
-    /// One or more modules to exclude from the single line rule.
     pub single_line_exclusions: Option<Vec<String>>,
+
+    /// Combines as imports on the same line. See isort's [`combine-as-imports`](https://pycqa.github.io/isort/docs/configuration/options.html#combine-as-imports)
+    /// option.
     #[option(
         default = r#"false"#,
         value_type = "bool",
@@ -1483,9 +1581,12 @@ pub struct IsortOptions {
             combine-as-imports = true
         "#
     )]
-    /// Combines as imports on the same line. See isort's [`combine-as-imports`](https://pycqa.github.io/isort/docs/configuration/options.html#combine-as-imports)
-    /// option.
     pub combine_as_imports: Option<bool>,
+
+    /// If a comma is placed after the last member in a multi-line import, then
+    /// the imports will never be folded into one line.
+    ///
+    /// See isort's [`split-on-trailing-comma`](https://pycqa.github.io/isort/docs/configuration/options.html#split-on-trailing-comma) option.
     #[option(
         default = r#"true"#,
         value_type = "bool",
@@ -1493,11 +1594,10 @@ pub struct IsortOptions {
             split-on-trailing-comma = false
         "#
     )]
-    /// If a comma is placed after the last member in a multi-line import, then
-    /// the imports will never be folded into one line.
-    ///
-    /// See isort's [`split-on-trailing-comma`](https://pycqa.github.io/isort/docs/configuration/options.html#split-on-trailing-comma) option.
     pub split_on_trailing_comma: Option<bool>,
+
+    /// Order imports by type, which is determined by case, in addition to
+    /// alphabetically.
     #[option(
         default = r#"true"#,
         value_type = "bool",
@@ -1505,9 +1605,11 @@ pub struct IsortOptions {
             order-by-type = true
         "#
     )]
-    /// Order imports by type, which is determined by case, in addition to
-    /// alphabetically.
     pub order_by_type: Option<bool>,
+
+    /// Don't sort straight-style imports (like `import sys`) before from-style
+    /// imports (like `from itertools import groupby`). Instead, sort the
+    /// imports by module, independent of import style.
     #[option(
         default = r#"false"#,
         value_type = "bool",
@@ -1515,10 +1617,9 @@ pub struct IsortOptions {
             force-sort-within-sections = true
         "#
     )]
-    /// Don't sort straight-style imports (like `import sys`) before from-style
-    /// imports (like `from itertools import groupby`). Instead, sort the
-    /// imports by module, independent of import style.
     pub force_sort_within_sections: Option<bool>,
+
+    /// Sort imports taking into account case sensitivity.
     #[option(
         default = r#"false"#,
         value_type = "bool",
@@ -1526,8 +1627,9 @@ pub struct IsortOptions {
             case-sensitive = true
         "#
     )]
-    /// Sort imports taking into account case sensitivity.
     pub case_sensitive: Option<bool>,
+
+    /// Force specific imports to the top of their appropriate section.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1535,8 +1637,13 @@ pub struct IsortOptions {
             force-to-top = ["src"]
         "#
     )]
-    /// Force specific imports to the top of their appropriate section.
     pub force_to_top: Option<Vec<String>>,
+
+    /// A list of modules to consider first-party, regardless of whether they
+    /// can be identified as such via introspection of the local filesystem.
+    ///
+    /// Supports glob patterns. For more information on the glob syntax, refer
+    /// to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1544,12 +1651,13 @@ pub struct IsortOptions {
             known-first-party = ["src"]
         "#
     )]
-    /// A list of modules to consider first-party, regardless of whether they
+    pub known_first_party: Option<Vec<String>>,
+
+    /// A list of modules to consider third-party, regardless of whether they
     /// can be identified as such via introspection of the local filesystem.
     ///
     /// Supports glob patterns. For more information on the glob syntax, refer
     /// to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).
-    pub known_first_party: Option<Vec<String>>,
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1557,12 +1665,13 @@ pub struct IsortOptions {
             known-third-party = ["src"]
         "#
     )]
-    /// A list of modules to consider third-party, regardless of whether they
-    /// can be identified as such via introspection of the local filesystem.
+    pub known_third_party: Option<Vec<String>>,
+
+    /// A list of modules to consider being a local folder.
+    /// Generally, this is reserved for relative imports (`from . import module`).
     ///
     /// Supports glob patterns. For more information on the glob syntax, refer
     /// to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).
-    pub known_third_party: Option<Vec<String>>,
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1570,12 +1679,13 @@ pub struct IsortOptions {
             known-local-folder = ["src"]
         "#
     )]
-    /// A list of modules to consider being a local folder.
-    /// Generally, this is reserved for relative imports (`from . import module`).
+    pub known_local_folder: Option<Vec<String>>,
+
+    /// A list of modules to consider standard-library, in addition to those
+    /// known to Ruff in advance.
     ///
     /// Supports glob patterns. For more information on the glob syntax, refer
     /// to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).
-    pub known_local_folder: Option<Vec<String>>,
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1583,19 +1693,8 @@ pub struct IsortOptions {
             extra-standard-library = ["path"]
         "#
     )]
-    /// A list of modules to consider standard-library, in addition to those
-    /// known to Ruff in advance.
-    ///
-    /// Supports glob patterns. For more information on the glob syntax, refer
-    /// to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).
     pub extra_standard_library: Option<Vec<String>>,
-    #[option(
-        default = r#"furthest-to-closest"#,
-        value_type = r#""furthest-to-closest" | "closest-to-furthest""#,
-        example = r#"
-            relative-imports-order = "closest-to-furthest"
-        "#
-    )]
+
     /// Whether to place "closer" imports (fewer `.` characters, most local)
     /// before "further" imports (more `.` characters, least local), or vice
     /// versa.
@@ -1604,7 +1703,16 @@ pub struct IsortOptions {
     /// `reverse-relative` default (`reverse-relative = false`); setting
     /// this to "closest-to-furthest" is equivalent to isort's
     /// `reverse-relative = true`.
+    #[option(
+        default = r#"furthest-to-closest"#,
+        value_type = r#""furthest-to-closest" | "closest-to-furthest""#,
+        example = r#"
+            relative-imports-order = "closest-to-furthest"
+        "#
+    )]
     pub relative_imports_order: Option<RelativeImportsOrder>,
+
+    /// Add the specified import line to all files.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1612,8 +1720,10 @@ pub struct IsortOptions {
             required-imports = ["from __future__ import annotations"]
         "#
     )]
-    /// Add the specified import line to all files.
     pub required_imports: Option<Vec<String>>,
+
+    /// An override list of tokens to always recognize as a Class for
+    /// `order-by-type` regardless of casing.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1621,9 +1731,10 @@ pub struct IsortOptions {
             classes = ["SVC"]
         "#
     )]
-    /// An override list of tokens to always recognize as a Class for
-    /// `order-by-type` regardless of casing.
     pub classes: Option<Vec<String>>,
+
+    /// An override list of tokens to always recognize as a CONSTANT
+    /// for `order-by-type` regardless of casing.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1631,9 +1742,10 @@ pub struct IsortOptions {
             constants = ["constant"]
         "#
     )]
-    /// An override list of tokens to always recognize as a CONSTANT
-    /// for `order-by-type` regardless of casing.
     pub constants: Option<Vec<String>>,
+
+    /// An override list of tokens to always recognize as a var
+    /// for `order-by-type` regardless of casing.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1641,9 +1753,10 @@ pub struct IsortOptions {
             variables = ["VAR"]
         "#
     )]
-    /// An override list of tokens to always recognize as a var
-    /// for `order-by-type` regardless of casing.
     pub variables: Option<Vec<String>>,
+
+    /// A list of sections that should _not_ be delineated from the previous
+    /// section via empty lines.
     #[option(
         default = r#"[]"#,
         value_type = r#"list["future" | "standard-library" | "third-party" | "first-party" | "local-folder" | str]"#,
@@ -1651,9 +1764,10 @@ pub struct IsortOptions {
             no-lines-before = ["future", "standard-library"]
         "#
     )]
-    /// A list of sections that should _not_ be delineated from the previous
-    /// section via empty lines.
     pub no_lines_before: Option<Vec<ImportSection>>,
+
+    /// The number of blank lines to place after imports.
+    /// Use `-1` for automatic determination.
     #[option(
         default = r#"-1"#,
         value_type = "int",
@@ -1662,9 +1776,9 @@ pub struct IsortOptions {
             lines-after-imports = 1
         "#
     )]
-    /// The number of blank lines to place after imports.
-    /// Use `-1` for automatic determination.
     pub lines_after_imports: Option<isize>,
+
+    /// The number of lines to place between "direct" and `import from` imports.
     #[option(
         default = r#"0"#,
         value_type = "int",
@@ -1673,8 +1787,10 @@ pub struct IsortOptions {
             lines-between-types = 1
         "#
     )]
-    /// The number of lines to place between "direct" and `import from` imports.
     pub lines_between_types: Option<usize>,
+
+    /// A list of modules to separate into auxiliary block(s) of imports,
+    /// in the order specified.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1682,9 +1798,9 @@ pub struct IsortOptions {
             forced-separate = ["tests"]
         "#
     )]
-    /// A list of modules to separate into auxiliary block(s) of imports,
-    /// in the order specified.
     pub forced_separate: Option<Vec<String>>,
+
+    /// Override in which order the sections should be output. Can be used to move custom sections.
     #[option(
         default = r#"["future", "standard-library", "third-party", "first-party", "local-folder"]"#,
         value_type = r#"list["future" | "standard-library" | "third-party" | "first-party" | "local-folder" | str]"#,
@@ -1692,15 +1808,8 @@ pub struct IsortOptions {
             section-order = ["future", "standard-library", "first-party", "local-folder", "third-party"]
         "#
     )]
-    /// Override in which order the sections should be output. Can be used to move custom sections.
     pub section_order: Option<Vec<ImportSection>>,
-    #[option(
-        default = r#"true"#,
-        value_type = "bool",
-        example = r#"
-            detect-same-package = false
-        "#
-    )]
+
     /// Whether to automatically mark imports from within the same package as first-party.
     /// For example, when `detect-same-package = true`, then when analyzing files within the
     /// `foo` package, any imports from within the `foo` package will be considered first-party.
@@ -1708,8 +1817,18 @@ pub struct IsortOptions {
     /// This heuristic is often unnecessary when `src` is configured to detect all first-party
     /// sources; however, if `src` is _not_ configured, this heuristic can be useful to detect
     /// first-party imports from _within_ (but not _across_) first-party packages.
+    #[option(
+        default = r#"true"#,
+        value_type = "bool",
+        example = r#"
+            detect-same-package = false
+        "#
+    )]
     pub detect_same_package: Option<bool>,
+
     // Tables are required to go last.
+    /// A list of mappings from section names to modules.
+    /// By default custom sections are output last, but this can be overridden with `section-order`.
     #[option(
         default = "{}",
         value_type = "dict[str, list[str]]",
@@ -1719,8 +1838,6 @@ pub struct IsortOptions {
             "django" = ["django"]
         "#
     )]
-    /// A list of mappings from section names to modules.
-    /// By default custom sections are output last, but this can be overridden with `section-order`.
     pub sections: Option<FxHashMap<ImportSection, Vec<String>>>,
 }
 
@@ -1894,6 +2011,7 @@ impl IsortOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct McCabeOptions {
+    /// The maximum McCabe complexity to allow before triggering `C901` errors.
     #[option(
         default = "10",
         value_type = "int",
@@ -1902,7 +2020,6 @@ pub struct McCabeOptions {
             max-complexity = 5
         "#
     )]
-    /// The maximum McCabe complexity to allow before triggering `C901` errors.
     pub max_complexity: Option<usize>,
 }
 
@@ -1922,6 +2039,7 @@ impl McCabeOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Pep8NamingOptions {
+    /// A list of names (or patterns) to ignore when considering `pep8-naming` violations.
     #[option(
         default = r#"["setUp", "tearDown", "setUpClass", "tearDownClass", "setUpModule", "tearDownModule", "asyncSetUp", "asyncTearDown", "setUpTestData", "failureException", "longMessage", "maxDiff"]"#,
         value_type = "list[str]",
@@ -1929,16 +2047,23 @@ pub struct Pep8NamingOptions {
             ignore-names = ["callMethod"]
         "#
     )]
-    /// A list of names (or patterns) to ignore when considering `pep8-naming` violations.
     pub ignore_names: Option<Vec<String>>,
+
+    /// Additional names (or patterns) to ignore when considering `pep8-naming` violations,
+    /// in addition to those included in `ignore-names`.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
         example = r#"extend-ignore-names = ["callMethod"]"#
     )]
-    /// Additional names (or patterns) to ignore when considering `pep8-naming` violations,
-    /// in addition to those included in `ignore-names`.
     pub extend_ignore_names: Option<Vec<String>>,
+
+    /// A list of decorators that, when applied to a method, indicate that the
+    /// method should be treated as a class method (in addition to the builtin
+    /// `@classmethod`).
+    ///
+    /// For example, Ruff will expect that any method decorated by a decorator
+    /// in this list takes a `cls` argument as its first argument.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1947,13 +2072,14 @@ pub struct Pep8NamingOptions {
             classmethod-decorators = ["pydantic.validator"]
         "#
     )]
+    pub classmethod_decorators: Option<Vec<String>>,
+
     /// A list of decorators that, when applied to a method, indicate that the
-    /// method should be treated as a class method (in addition to the builtin
-    /// `@classmethod`).
+    /// method should be treated as a static method (in addition to the builtin
+    /// `@staticmethod`).
     ///
     /// For example, Ruff will expect that any method decorated by a decorator
-    /// in this list takes a `cls` argument as its first argument.
-    pub classmethod_decorators: Option<Vec<String>>,
+    /// in this list has no `self` or `cls` argument.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -1962,12 +2088,6 @@ pub struct Pep8NamingOptions {
             staticmethod-decorators = ["stcmthd"]
         "#
     )]
-    /// A list of decorators that, when applied to a method, indicate that the
-    /// method should be treated as a static method (in addition to the builtin
-    /// `@staticmethod`).
-    ///
-    /// For example, Ruff will expect that any method decorated by a decorator
-    /// in this list has no `self` or `cls` argument.
     pub staticmethod_decorators: Option<Vec<String>>,
 }
 
@@ -1998,6 +2118,11 @@ impl Pep8NamingOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PycodestyleOptions {
+    /// The maximum line length to allow for line-length violations within
+    /// documentation (`W505`), including standalone comments. By default,
+    /// this is set to null which disables reporting violations.
+    ///
+    /// See the [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) rule for more information.
     #[option(
         default = "None",
         value_type = "int",
@@ -2005,12 +2130,11 @@ pub struct PycodestyleOptions {
             max-doc-length = 88
         "#
     )]
-    /// The maximum line length to allow for line-length violations within
-    /// documentation (`W505`), including standalone comments. By default,
-    /// this is set to null which disables reporting violations.
-    ///
-    /// See the [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) rule for more information.
     pub max_doc_length: Option<LineLength>,
+
+    /// Whether line-length violations (`E501`) should be triggered for
+    /// comments starting with `task-tags` (by default: \["TODO", "FIXME",
+    /// and "XXX"\]).
     #[option(
         default = "false",
         value_type = "bool",
@@ -2018,9 +2142,6 @@ pub struct PycodestyleOptions {
             ignore-overlong-task-comments = true
         "#
     )]
-    /// Whether line-length violations (`E501`) should be triggered for
-    /// comments starting with `task-tags` (by default: \["TODO", "FIXME",
-    /// and "XXX"\]).
     pub ignore_overlong_task_comments: Option<bool>,
 }
 
@@ -2039,14 +2160,6 @@ impl PycodestyleOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PydocstyleOptions {
-    #[option(
-        default = r#"None"#,
-        value_type = r#""google" | "numpy" | "pep257""#,
-        example = r#"
-            # Use Google-style docstrings.
-            convention = "google"
-        "#
-    )]
     /// Whether to use Google-style or NumPy-style conventions or the PEP257
     /// defaults when analyzing docstring sections.
     ///
@@ -2075,7 +2188,18 @@ pub struct PydocstyleOptions {
     /// As conventions force-disable all rules not included in the convention,
     /// enabling _additional_ rules on top of a convention is currently
     /// unsupported.
+    #[option(
+        default = r#"None"#,
+        value_type = r#""google" | "numpy" | "pep257""#,
+        example = r#"
+            # Use Google-style docstrings.
+            convention = "google"
+        "#
+    )]
     pub convention: Option<Convention>,
+
+    /// Ignore docstrings for functions or methods decorated with the
+    /// specified fully-qualified decorators.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -2083,9 +2207,14 @@ pub struct PydocstyleOptions {
             ignore-decorators = ["typing.overload"]
         "#
     )]
-    /// Ignore docstrings for functions or methods decorated with the
-    /// specified fully-qualified decorators.
     pub ignore_decorators: Option<Vec<String>>,
+
+    /// A list of decorators that, when applied to a method, indicate that the
+    /// method should be treated as a property (in addition to the builtin
+    /// `@property` and standard-library `@functools.cached_property`).
+    ///
+    /// For example, Ruff will expect that any method decorated by a decorator
+    /// in this list can use a non-imperative summary line.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -2093,12 +2222,6 @@ pub struct PydocstyleOptions {
             property-decorators = ["gi.repository.GObject.Property"]
         "#
     )]
-    /// A list of decorators that, when applied to a method, indicate that the
-    /// method should be treated as a property (in addition to the builtin
-    /// `@property` and standard-library `@functools.cached_property`).
-    ///
-    /// For example, Ruff will expect that any method decorated by a decorator
-    /// in this list can use a non-imperative summary line.
     pub property_decorators: Option<Vec<String>>,
 }
 
@@ -2118,17 +2241,17 @@ impl PydocstyleOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PyflakesOptions {
-    #[option(
-        default = r#"[]"#,
-        value_type = "list[str]",
-        example = "extend-generics = [\"django.db.models.ForeignKey\"]"
-    )]
     /// Additional functions or classes to consider generic, such that any
     /// subscripts should be treated as type annotation (e.g., `ForeignKey` in
     /// `django.db.models.ForeignKey["User"]`.
     ///
     /// Expects to receive a list of fully-qualified names (e.g., `django.db.models.ForeignKey`,
     /// rather than `ForeignKey`).
+    #[option(
+        default = r#"[]"#,
+        value_type = "list[str]",
+        example = "extend-generics = [\"django.db.models.ForeignKey\"]"
+    )]
     pub extend_generics: Option<Vec<String>>,
 }
 
@@ -2146,6 +2269,7 @@ impl PyflakesOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PylintOptions {
+    /// Constant types to ignore when used as "magic values" (see: `PLR2004`).
     #[option(
         default = r#"["str", "bytes"]"#,
         value_type = r#"list["str" | "bytes" | "complex" | "float" | "int" | "tuple"]"#,
@@ -2153,30 +2277,34 @@ pub struct PylintOptions {
             allow-magic-value-types = ["int"]
         "#
     )]
-    /// Constant types to ignore when used as "magic values" (see: `PLR2004`).
     pub allow_magic_value_types: Option<Vec<ConstantType>>,
-    #[option(default = r"12", value_type = "int", example = r"max-branches = 12")]
+
     /// Maximum number of branches allowed for a function or method body (see:
     /// `PLR0912`).
+    #[option(default = r"12", value_type = "int", example = r"max-branches = 12")]
     pub max_branches: Option<usize>,
-    #[option(default = r"6", value_type = "int", example = r"max-returns = 6")]
+
     /// Maximum number of return statements allowed for a function or method
     /// body (see `PLR0911`)
+    #[option(default = r"6", value_type = "int", example = r"max-returns = 6")]
     pub max_returns: Option<usize>,
-    #[option(default = r"5", value_type = "int", example = r"max-args = 5")]
+
     /// Maximum number of arguments allowed for a function or method definition
     /// (see: `PLR0913`).
+    #[option(default = r"5", value_type = "int", example = r"max-args = 5")]
     pub max_args: Option<usize>,
-    #[option(default = r"50", value_type = "int", example = r"max-statements = 50")]
+
     /// Maximum number of statements allowed for a function or method body (see:
     /// `PLR0915`).
+    #[option(default = r"50", value_type = "int", example = r"max-statements = 50")]
     pub max_statements: Option<usize>,
+
+    /// Maximum number of public methods allowed for a class (see: `PLR0904`).
     #[option(
         default = r"20",
         value_type = "int",
         example = r"max-public-methods = 20"
     )]
-    /// Maximum number of public methods allowed for a class (see: `PLR0904`).
     pub max_public_methods: Option<usize>,
 }
 
@@ -2204,14 +2332,6 @@ impl PylintOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PyUpgradeOptions {
-    #[option(
-        default = r#"false"#,
-        value_type = "bool",
-        example = r#"
-            # Preserve types, even if a file imports `from __future__ import annotations`.
-            keep-runtime-typing = true
-        "#
-    )]
     /// Whether to avoid PEP 585 (`List[int]` -> `list[int]`) and PEP 604
     /// (`Union[str, int]` -> `str | int`) rewrites even if a file imports
     /// `from __future__ import annotations`.
@@ -2242,6 +2362,14 @@ pub struct PyUpgradeOptions {
     /// ```
     ///
     ///
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"
+            # Preserve types, even if a file imports `from __future__ import annotations`.
+            keep-runtime-typing = true
+        "#
+    )]
     pub keep_runtime_typing: Option<bool>,
 }
 


### PR DESCRIPTION
## Summary

Reformat `options.rs` manually for better readability:

* Add an empty line between options
* Move the doc-comment above the attributes

## Test Plan

`cargo dev generate-all` -> Generates no changes, all good
