### PR TITLE
Add `lint` section to Ruff configuration

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -610,7 +610,7 @@ impl ConfigurationTransformer for CliOverrides {
             config.cache_dir = Some(cache_dir.clone());
         }
         if let Some(dummy_variable_rgx) = &self.dummy_variable_rgx {
-            config.dummy_variable_rgx = Some(dummy_variable_rgx.clone());
+            config.lint.dummy_variable_rgx = Some(dummy_variable_rgx.clone());
         }
         if let Some(exclude) = &self.exclude {
             config.exclude = Some(exclude.clone());
@@ -624,7 +624,7 @@ impl ConfigurationTransformer for CliOverrides {
         if let Some(fix_only) = &self.fix_only {
             config.fix_only = Some(*fix_only);
         }
-        config.rule_selections.push(RuleSelection {
+        config.lint.rule_selections.push(RuleSelection {
             select: self.select.clone(),
             ignore: self
                 .ignore
@@ -657,7 +657,7 @@ impl ConfigurationTransformer for CliOverrides {
             config.preview = Some(*preview);
         }
         if let Some(per_file_ignores) = &self.per_file_ignores {
-            config.per_file_ignores = Some(collect_per_file_ignores(per_file_ignores.clone()));
+            config.lint.per_file_ignores = Some(collect_per_file_ignores(per_file_ignores.clone()));
         }
         if let Some(respect_gitignore) = &self.respect_gitignore {
             config.respect_gitignore = Some(*respect_gitignore);

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -12,8 +12,7 @@ use std::process::Command;
 use std::str;
 
 #[cfg(unix)]
-use anyhow::Context;
-use anyhow::Result;
+use anyhow::{Context, Result};
 #[cfg(unix)]
 use clap::Parser;
 use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};

--- a/crates/ruff_cli/tests/lint.rs
+++ b/crates/ruff_cli/tests/lint.rs
@@ -1,0 +1,157 @@
+//! Tests the interaction of the `lint` configuration section
+
+#![cfg(not(target_family = "wasm"))]
+
+use std::fs;
+use std::process::Command;
+use std::str;
+
+use anyhow::Result;
+use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
+use tempfile::TempDir;
+
+const BIN_NAME: &str = "ruff";
+const STDIN_BASE_OPTIONS: &[&str] = &["--no-cache", "--output-format", "text"];
+
+#[test]
+fn top_level_options() -> Result<()> {
+    let tempdir = TempDir::new()?;
+    let ruff_toml = tempdir.path().join("ruff.toml");
+    fs::write(
+        &ruff_toml,
+        r#"
+extend-select = ["B", "Q"]
+
+[flake8-quotes]
+inline-quotes = "single"
+"#,
+    )?;
+
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .args(STDIN_BASE_OPTIONS)
+        .arg("--config")
+        .arg(&ruff_toml)
+        .arg("-")
+        .pass_stdin(r#"a = "abcba".strip("aba")"#), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:5: Q000 [*] Double quotes found but single quotes preferred
+    -:1:5: B005 Using `.strip()` with multi-character strings is misleading
+    -:1:19: Q000 [*] Double quotes found but single quotes preferred
+    Found 3 errors.
+    [*] 2 potentially fixable with the --fix option.
+
+    ----- stderr -----
+    "###);
+    Ok(())
+}
+
+#[test]
+fn lint_options() -> Result<()> {
+    let tempdir = TempDir::new()?;
+    let ruff_toml = tempdir.path().join("ruff.toml");
+    fs::write(
+        &ruff_toml,
+        r#"
+[lint]
+extend-select = ["B", "Q"]
+
+[lint.flake8-quotes]
+inline-quotes = "single"
+"#,
+    )?;
+
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .args(STDIN_BASE_OPTIONS)
+        .arg("--config")
+        .arg(&ruff_toml)
+        .arg("-")
+        .pass_stdin(r#"a = "abcba".strip("aba")"#), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:5: Q000 [*] Double quotes found but single quotes preferred
+    -:1:5: B005 Using `.strip()` with multi-character strings is misleading
+    -:1:19: Q000 [*] Double quotes found but single quotes preferred
+    Found 3 errors.
+    [*] 2 potentially fixable with the --fix option.
+
+    ----- stderr -----
+    "###);
+    Ok(())
+}
+
+/// Tests that configurations from the top-level and `lint` section are merged together.
+#[test]
+fn mixed_levels() -> Result<()> {
+    let tempdir = TempDir::new()?;
+    let ruff_toml = tempdir.path().join("ruff.toml");
+    fs::write(
+        &ruff_toml,
+        r#"
+extend-select = ["B", "Q"]
+
+[lint.flake8-quotes]
+inline-quotes = "single"
+"#,
+    )?;
+
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .args(STDIN_BASE_OPTIONS)
+        .arg("--config")
+        .arg(&ruff_toml)
+        .arg("-")
+        .pass_stdin(r#"a = "abcba".strip("aba")"#), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:5: Q000 [*] Double quotes found but single quotes preferred
+    -:1:5: B005 Using `.strip()` with multi-character strings is misleading
+    -:1:19: Q000 [*] Double quotes found but single quotes preferred
+    Found 3 errors.
+    [*] 2 potentially fixable with the --fix option.
+
+    ----- stderr -----
+    "###);
+    Ok(())
+}
+
+/// Tests that options in the `lint` section have higher precedence than top-level options (because they are more specific).
+#[test]
+fn precedence() -> Result<()> {
+    let tempdir = TempDir::new()?;
+    let ruff_toml = tempdir.path().join("ruff.toml");
+    fs::write(
+        &ruff_toml,
+        r#"
+[lint]
+extend-select = ["B", "Q"]
+
+[flake8-quotes]
+inline-quotes = "double"
+
+[lint.flake8-quotes]
+inline-quotes = "single"
+"#,
+    )?;
+
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .args(STDIN_BASE_OPTIONS)
+        .arg("--config")
+        .arg(&ruff_toml)
+        .arg("-")
+        .pass_stdin(r#"a = "abcba".strip("aba")"#), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:5: Q000 [*] Double quotes found but single quotes preferred
+    -:1:5: B005 Using `.strip()` with multi-character strings is misleading
+    -:1:19: Q000 [*] Double quotes found but single quotes preferred
+    Found 3 errors.
+    [*] 2 potentially fixable with the --fix option.
+
+    ----- stderr -----
+    "###);
+    Ok(())
+}

--- a/crates/ruff_dev/src/generate_options.rs
+++ b/crates/ruff_dev/src/generate_options.rs
@@ -14,7 +14,11 @@ pub(crate) fn generate() -> String {
 }
 
 fn generate_set(output: &mut String, set: &Set) {
-    writeln!(output, "### {title}\n", title = set.title()).unwrap();
+    if set.level() < 2 {
+        writeln!(output, "### {title}\n", title = set.title()).unwrap();
+    } else {
+        writeln!(output, "#### {title}\n", title = set.title()).unwrap();
+    }
 
     if let Some(documentation) = set.metadata().documentation() {
         output.push_str(documentation);
@@ -32,56 +36,69 @@ fn generate_set(output: &mut String, set: &Set) {
 
     // Generate the fields.
     for (name, field) in &fields {
-        emit_field(output, name, field, set.name());
+        emit_field(output, name, field, set);
         output.push_str("---\n\n");
     }
 
     // Generate all the sub-sets.
     for (set_name, sub_set) in &sets {
-        generate_set(output, &Set::Named(set_name, *sub_set));
+        generate_set(output, &Set::Named(set_name, *sub_set, set.level() + 1));
     }
 }
 
 enum Set<'a> {
     Toplevel(OptionSet),
-    Named(&'a str, OptionSet),
+    Named(&'a str, OptionSet, u32),
 }
 
 impl<'a> Set<'a> {
     fn name(&self) -> Option<&'a str> {
         match self {
             Set::Toplevel(_) => None,
-            Set::Named(name, _) => Some(name),
+            Set::Named(name, _, _) => Some(name),
         }
     }
 
     fn title(&self) -> &'a str {
         match self {
             Set::Toplevel(_) => "Top-level",
-            Set::Named(name, _) => name,
+            Set::Named(name, _, _) => name,
         }
     }
 
     fn metadata(&self) -> &OptionSet {
         match self {
             Set::Toplevel(set) => set,
-            Set::Named(_, set) => set,
+            Set::Named(_, set, _) => set,
+        }
+    }
+
+    fn level(&self) -> u32 {
+        match self {
+            Set::Toplevel(_) => 0,
+            Set::Named(_, _, level) => *level,
         }
     }
 }
 
-fn emit_field(output: &mut String, name: &str, field: &OptionField, group_name: Option<&str>) {
-    // if there's a group name, we need to add it to the anchor
-    if let Some(group_name) = group_name {
+fn emit_field(output: &mut String, name: &str, field: &OptionField, parent_set: &Set) {
+    let header_level = if parent_set.level() < 2 {
+        "####"
+    } else {
+        "#####"
+    };
+
+    // if there's a set name, we need to add it to the anchor
+    if let Some(set_name) = parent_set.name() {
         // the anchor used to just be the name, but now it's the group name
         // for backwards compatibility, we need to keep the old anchor
         output.push_str(&format!("<span id=\"{name}\"></span>\n"));
 
         output.push_str(&format!(
-            "#### [`{name}`](#{group_name}-{name}) {{: #{group_name}-{name} }}\n"
+            "{header_level} [`{name}`](#{set_name}-{name}) {{: #{set_name}-{name} }}\n"
         ));
     } else {
-        output.push_str(&format!("#### [`{name}`](#{name})\n"));
+        output.push_str(&format!("{header_level} [`{name}`](#{name})\n"));
     }
     output.push('\n');
     output.push_str(field.doc);
@@ -92,8 +109,8 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, group_name: 
     output.push('\n');
     output.push_str(&format!(
         "**Example usage**:\n\n```toml\n[tool.ruff{}]\n{}\n```\n",
-        if group_name.is_some() {
-            format!(".{}", group_name.unwrap())
+        if let Some(set_name) = parent_set.name() {
+            format!(".{set_name}")
         } else {
             String::new()
         },

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -4,7 +4,7 @@ use js_sys::Error;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
-use ruff_formatter::{FormatResult, Formatted};
+use ruff_formatter::{FormatResult, Formatted, IndentStyle};
 use ruff_linter::directives;
 use ruff_linter::line_width::{LineLength, TabSize};
 use ruff_linter::linter::{check_path, LinterResult};
@@ -14,7 +14,7 @@ use ruff_linter::settings::{flags, DUMMY_VARIABLE_RGX, PREFIXES};
 use ruff_linter::source_kind::SourceKind;
 use ruff_python_ast::{Mod, PySourceType};
 use ruff_python_codegen::Stylist;
-use ruff_python_formatter::{format_module_ast, pretty_comments, PyFormatContext};
+use ruff_python_formatter::{format_module_ast, pretty_comments, PyFormatContext, QuoteStyle};
 use ruff_python_index::{CommentRangesBuilder, Indexer};
 use ruff_python_parser::lexer::LexResult;
 use ruff_python_parser::{parse_tokens, AsMode, Mode};
@@ -22,7 +22,7 @@ use ruff_python_trivia::CommentRanges;
 use ruff_source_file::{Locator, SourceLocation};
 use ruff_text_size::Ranged;
 use ruff_workspace::configuration::Configuration;
-use ruff_workspace::options::Options;
+use ruff_workspace::options::{FormatOptions, FormatOrOutputFormat, LintOptions, Options};
 use ruff_workspace::Settings;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -119,46 +119,32 @@ impl Workspace {
     #[wasm_bindgen(js_name = defaultSettings)]
     pub fn default_settings() -> Result<JsValue, Error> {
         serde_wasm_bindgen::to_value(&Options {
-            // Propagate defaults.
-            allowed_confusables: Some(Vec::default()),
-            builtins: Some(Vec::default()),
-            dummy_variable_rgx: Some(DUMMY_VARIABLE_RGX.as_str().to_string()),
-            extend_fixable: Some(Vec::default()),
-            extend_ignore: Some(Vec::default()),
-            extend_select: Some(Vec::default()),
-            extend_unfixable: Some(Vec::default()),
-            external: Some(Vec::default()),
-            ignore: Some(Vec::default()),
-            line_length: Some(LineLength::default()),
             preview: Some(false),
-            select: Some(PREFIXES.to_vec()),
+
+            // Propagate defaults.
+            builtins: Some(Vec::default()),
+
+            line_length: Some(LineLength::default()),
+
             tab_size: Some(TabSize::default()),
             target_version: Some(PythonVersion::default()),
-            // Ignore a bunch of options that don't make sense in a single-file editor.
-            cache_dir: None,
-            exclude: None,
-            extend: None,
-            extend_exclude: None,
-            extend_include: None,
-            extend_per_file_ignores: None,
-            fix: None,
-            fix_only: None,
-            fixable: None,
-            force_exclude: None,
-            output_format: None,
-            ignore_init_module_imports: None,
-            include: None,
-            logger_objects: None,
-            namespace_packages: None,
-            per_file_ignores: None,
-            required_version: None,
-            respect_gitignore: None,
-            show_fixes: None,
-            show_source: None,
-            src: None,
-            task_tags: None,
-            typing_modules: None,
-            unfixable: None,
+
+            lint: Some(LintOptions {
+                allowed_confusables: Some(Vec::default()),
+                dummy_variable_rgx: Some(DUMMY_VARIABLE_RGX.as_str().to_string()),
+                ignore: Some(Vec::default()),
+                select: Some(PREFIXES.to_vec()),
+                extend_fixable: Some(Vec::default()),
+                extend_select: Some(Vec::default()),
+                external: Some(Vec::default()),
+
+                ..LintOptions::default()
+            }),
+            format: Some(FormatOrOutputFormat::Format(FormatOptions {
+                indent_style: Some(IndentStyle::Space),
+                quote_style: Some(QuoteStyle::Double),
+                ..FormatOptions::default()
+            })),
             ..Options::default()
         })
         .map_err(into_error)

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -39,9 +39,9 @@ use crate::options::{
     Flake8ComprehensionsOptions, Flake8CopyrightOptions, Flake8ErrMsgOptions, Flake8GetTextOptions,
     Flake8ImplicitStrConcatOptions, Flake8ImportConventionsOptions, Flake8PytestStyleOptions,
     Flake8QuotesOptions, Flake8SelfOptions, Flake8TidyImportsOptions, Flake8TypeCheckingOptions,
-    Flake8UnusedArgumentsOptions, FormatOptions, FormatOrOutputFormat, IsortOptions, McCabeOptions,
-    Options, Pep8NamingOptions, PyUpgradeOptions, PycodestyleOptions, PydocstyleOptions,
-    PyflakesOptions, PylintOptions,
+    Flake8UnusedArgumentsOptions, FormatOptions, FormatOrOutputFormat, IsortOptions, LintOptions,
+    McCabeOptions, Options, Pep8NamingOptions, PyUpgradeOptions, PycodestyleOptions,
+    PydocstyleOptions, PyflakesOptions, PylintOptions,
 };
 use crate::settings::{
     FileResolverSettings, FormatterSettings, LineEnding, Settings, EXCLUDE, INCLUDE,
@@ -59,64 +59,36 @@ pub struct RuleSelection {
 
 #[derive(Debug, Default)]
 pub struct Configuration {
-    pub rule_selections: Vec<RuleSelection>,
-    pub per_file_ignores: Option<Vec<PerFileIgnore>>,
-
-    pub allowed_confusables: Option<Vec<char>>,
-    pub builtins: Option<Vec<String>>,
+    // Global options
     pub cache_dir: Option<PathBuf>,
-    pub dummy_variable_rgx: Option<Regex>,
-    pub exclude: Option<Vec<FilePattern>>,
     pub extend: Option<PathBuf>,
-    pub extend_exclude: Vec<FilePattern>,
-    pub extend_include: Vec<FilePattern>,
-    pub extend_per_file_ignores: Vec<PerFileIgnore>,
-    pub external: Option<Vec<String>>,
     pub fix: Option<bool>,
     pub fix_only: Option<bool>,
-    pub force_exclude: Option<bool>,
     pub output_format: Option<SerializationFormat>,
-    pub ignore_init_module_imports: Option<bool>,
-    pub include: Option<Vec<FilePattern>>,
-    pub line_length: Option<LineLength>,
-    pub logger_objects: Option<Vec<String>>,
-    pub namespace_packages: Option<Vec<PathBuf>>,
     pub preview: Option<PreviewMode>,
     pub required_version: Option<Version>,
-    pub respect_gitignore: Option<bool>,
     pub show_fixes: Option<bool>,
     pub show_source: Option<bool>,
-    pub src: Option<Vec<PathBuf>>,
-    pub tab_size: Option<TabSize>,
-    pub target_version: Option<PythonVersion>,
-    pub task_tags: Option<Vec<String>>,
-    pub typing_modules: Option<Vec<String>>,
-    // Plugins
-    pub flake8_annotations: Option<Flake8AnnotationsOptions>,
-    pub flake8_bandit: Option<Flake8BanditOptions>,
-    pub flake8_bugbear: Option<Flake8BugbearOptions>,
-    pub flake8_builtins: Option<Flake8BuiltinsOptions>,
-    pub flake8_comprehensions: Option<Flake8ComprehensionsOptions>,
-    pub flake8_copyright: Option<Flake8CopyrightOptions>,
-    pub flake8_errmsg: Option<Flake8ErrMsgOptions>,
-    pub flake8_gettext: Option<Flake8GetTextOptions>,
-    pub flake8_implicit_str_concat: Option<Flake8ImplicitStrConcatOptions>,
-    pub flake8_import_conventions: Option<Flake8ImportConventionsOptions>,
-    pub flake8_pytest_style: Option<Flake8PytestStyleOptions>,
-    pub flake8_quotes: Option<Flake8QuotesOptions>,
-    pub flake8_self: Option<Flake8SelfOptions>,
-    pub flake8_tidy_imports: Option<Flake8TidyImportsOptions>,
-    pub flake8_type_checking: Option<Flake8TypeCheckingOptions>,
-    pub flake8_unused_arguments: Option<Flake8UnusedArgumentsOptions>,
-    pub isort: Option<IsortOptions>,
-    pub mccabe: Option<McCabeOptions>,
-    pub pep8_naming: Option<Pep8NamingOptions>,
-    pub pycodestyle: Option<PycodestyleOptions>,
-    pub pydocstyle: Option<PydocstyleOptions>,
-    pub pyflakes: Option<PyflakesOptions>,
-    pub pylint: Option<PylintOptions>,
-    pub pyupgrade: Option<PyUpgradeOptions>,
 
+    // File resolver options
+    pub exclude: Option<Vec<FilePattern>>,
+    pub extend_exclude: Vec<FilePattern>,
+    pub extend_include: Vec<FilePattern>,
+    pub force_exclude: Option<bool>,
+    pub include: Option<Vec<FilePattern>>,
+    pub respect_gitignore: Option<bool>,
+
+    // Generic python options settings
+    pub builtins: Option<Vec<String>>,
+    pub namespace_packages: Option<Vec<PathBuf>>,
+    pub src: Option<Vec<PathBuf>>,
+    pub target_version: Option<PythonVersion>,
+
+    // Global formatting options
+    pub line_length: Option<LineLength>,
+    pub tab_size: Option<TabSize>,
+
+    pub lint: LintConfiguration,
     pub format: FormatConfiguration,
 }
 
@@ -133,7 +105,6 @@ impl Configuration {
         }
 
         let target_version = self.target_version.unwrap_or_default();
-        let rules = self.as_rule_table();
         let preview = self.preview.unwrap_or_default();
 
         let format = self.format;
@@ -156,6 +127,8 @@ impl Configuration {
                 .magic_trailing_comma
                 .unwrap_or(format_defaults.magic_trailing_comma),
         };
+
+        let lint = self.lint;
 
         Ok(Settings {
             cache_dir: self
@@ -183,135 +156,135 @@ impl Configuration {
             },
 
             linter: LinterSettings {
+                rules: lint.as_rule_table(preview),
                 target_version,
                 project_root: project_root.to_path_buf(),
-                rules,
-                allowed_confusables: self
+                allowed_confusables: lint
                     .allowed_confusables
                     .map(FxHashSet::from_iter)
                     .unwrap_or_default(),
                 builtins: self.builtins.unwrap_or_default(),
-                dummy_variable_rgx: self
+                dummy_variable_rgx: lint
                     .dummy_variable_rgx
                     .unwrap_or_else(|| DUMMY_VARIABLE_RGX.clone()),
-                external: FxHashSet::from_iter(self.external.unwrap_or_default()),
-                ignore_init_module_imports: self.ignore_init_module_imports.unwrap_or_default(),
+                external: FxHashSet::from_iter(lint.external.unwrap_or_default()),
+                ignore_init_module_imports: lint.ignore_init_module_imports.unwrap_or_default(),
                 line_length: self.line_length.unwrap_or_default(),
                 tab_size: self.tab_size.unwrap_or_default(),
                 namespace_packages: self.namespace_packages.unwrap_or_default(),
                 per_file_ignores: resolve_per_file_ignores(
-                    self.per_file_ignores
+                    lint.per_file_ignores
                         .unwrap_or_default()
                         .into_iter()
-                        .chain(self.extend_per_file_ignores)
+                        .chain(lint.extend_per_file_ignores)
                         .collect(),
                 )?,
                 src: self.src.unwrap_or_else(|| vec![project_root.to_path_buf()]),
 
-                task_tags: self
+                task_tags: lint
                     .task_tags
                     .unwrap_or_else(|| TASK_TAGS.iter().map(ToString::to_string).collect()),
-                logger_objects: self.logger_objects.unwrap_or_default(),
+                logger_objects: lint.logger_objects.unwrap_or_default(),
                 preview,
-                typing_modules: self.typing_modules.unwrap_or_default(),
+                typing_modules: lint.typing_modules.unwrap_or_default(),
                 // Plugins
-                flake8_annotations: self
+                flake8_annotations: lint
                     .flake8_annotations
                     .map(Flake8AnnotationsOptions::into_settings)
                     .unwrap_or_default(),
-                flake8_bandit: self
+                flake8_bandit: lint
                     .flake8_bandit
                     .map(Flake8BanditOptions::into_settings)
                     .unwrap_or_default(),
-                flake8_bugbear: self
+                flake8_bugbear: lint
                     .flake8_bugbear
                     .map(Flake8BugbearOptions::into_settings)
                     .unwrap_or_default(),
-                flake8_builtins: self
+                flake8_builtins: lint
                     .flake8_builtins
                     .map(Flake8BuiltinsOptions::into_settings)
                     .unwrap_or_default(),
-                flake8_comprehensions: self
+                flake8_comprehensions: lint
                     .flake8_comprehensions
                     .map(Flake8ComprehensionsOptions::into_settings)
                     .unwrap_or_default(),
-                flake8_copyright: self
+                flake8_copyright: lint
                     .flake8_copyright
                     .map(Flake8CopyrightOptions::try_into_settings)
                     .transpose()?
                     .unwrap_or_default(),
-                flake8_errmsg: self
+                flake8_errmsg: lint
                     .flake8_errmsg
                     .map(Flake8ErrMsgOptions::into_settings)
                     .unwrap_or_default(),
-                flake8_implicit_str_concat: self
+                flake8_implicit_str_concat: lint
                     .flake8_implicit_str_concat
                     .map(Flake8ImplicitStrConcatOptions::into_settings)
                     .unwrap_or_default(),
-                flake8_import_conventions: self
+                flake8_import_conventions: lint
                     .flake8_import_conventions
                     .map(Flake8ImportConventionsOptions::into_settings)
                     .unwrap_or_default(),
-                flake8_pytest_style: self
+                flake8_pytest_style: lint
                     .flake8_pytest_style
                     .map(Flake8PytestStyleOptions::try_into_settings)
                     .transpose()?
                     .unwrap_or_default(),
-                flake8_quotes: self
+                flake8_quotes: lint
                     .flake8_quotes
                     .map(Flake8QuotesOptions::into_settings)
                     .unwrap_or_default(),
-                flake8_self: self
+                flake8_self: lint
                     .flake8_self
                     .map(Flake8SelfOptions::into_settings)
                     .unwrap_or_default(),
-                flake8_tidy_imports: self
+                flake8_tidy_imports: lint
                     .flake8_tidy_imports
                     .map(Flake8TidyImportsOptions::into_settings)
                     .unwrap_or_default(),
-                flake8_type_checking: self
+                flake8_type_checking: lint
                     .flake8_type_checking
                     .map(Flake8TypeCheckingOptions::into_settings)
                     .unwrap_or_default(),
-                flake8_unused_arguments: self
+                flake8_unused_arguments: lint
                     .flake8_unused_arguments
                     .map(Flake8UnusedArgumentsOptions::into_settings)
                     .unwrap_or_default(),
-                flake8_gettext: self
+                flake8_gettext: lint
                     .flake8_gettext
                     .map(Flake8GetTextOptions::into_settings)
                     .unwrap_or_default(),
-                isort: self
+                isort: lint
                     .isort
                     .map(IsortOptions::try_into_settings)
                     .transpose()?
                     .unwrap_or_default(),
-                mccabe: self
+                mccabe: lint
                     .mccabe
                     .map(McCabeOptions::into_settings)
                     .unwrap_or_default(),
-                pep8_naming: self
+                pep8_naming: lint
                     .pep8_naming
                     .map(Pep8NamingOptions::try_into_settings)
                     .transpose()?
                     .unwrap_or_default(),
-                pycodestyle: self
+                pycodestyle: lint
                     .pycodestyle
                     .map(PycodestyleOptions::into_settings)
                     .unwrap_or_default(),
-                pydocstyle: self
+                pydocstyle: lint
                     .pydocstyle
                     .map(PydocstyleOptions::into_settings)
                     .unwrap_or_default(),
-                pyflakes: self
+                pyflakes: lint
                     .pyflakes
                     .map(PyflakesOptions::into_settings)
                     .unwrap_or_default(),
-                pylint: self
+                pylint: lint
                     .pylint
                     .map(PylintOptions::into_settings)
                     .unwrap_or_default(),
-                pyupgrade: self
+                pyupgrade: lint
                     .pyupgrade
                     .map(PyUpgradeOptions::into_settings)
                     .unwrap_or_default(),
@@ -322,26 +295,13 @@ impl Configuration {
     }
 
     pub fn from_options(options: Options, project_root: &Path) -> Result<Self> {
+        let lint = if let Some(lint) = options.lint {
+            lint.combine(options.lint_top_level)
+        } else {
+            options.lint_top_level
+        };
+
         Ok(Self {
-            rule_selections: vec![RuleSelection {
-                select: options.select,
-                ignore: options
-                    .ignore
-                    .into_iter()
-                    .flatten()
-                    .chain(options.extend_ignore.into_iter().flatten())
-                    .collect(),
-                extend_select: options.extend_select.unwrap_or_default(),
-                fixable: options.fixable,
-                unfixable: options
-                    .unfixable
-                    .into_iter()
-                    .flatten()
-                    .chain(options.extend_unfixable.into_iter().flatten())
-                    .collect(),
-                extend_fixable: options.extend_fixable.unwrap_or_default(),
-            }],
-            allowed_confusables: options.allowed_confusables,
             builtins: options.builtins,
             cache_dir: options
                 .cache_dir
@@ -351,11 +311,7 @@ impl Configuration {
                 })
                 .transpose()
                 .map_err(|e| anyhow!("Invalid `cache-dir` value: {e}"))?,
-            dummy_variable_rgx: options
-                .dummy_variable_rgx
-                .map(|pattern| Regex::new(&pattern))
-                .transpose()
-                .map_err(|e| anyhow!("Invalid `dummy-variable-rgx` value: {e}"))?,
+
             exclude: options.exclude.map(|paths| {
                 paths
                     .into_iter()
@@ -397,6 +353,159 @@ impl Configuration {
                         .collect()
                 })
                 .unwrap_or_default(),
+            include: options.include.map(|paths| {
+                paths
+                    .into_iter()
+                    .map(|pattern| {
+                        let absolute = fs::normalize_path_to(&pattern, project_root);
+                        FilePattern::User(pattern, absolute)
+                    })
+                    .collect()
+            }),
+            fix: options.fix,
+            fix_only: options.fix_only,
+            output_format: options.output_format.or_else(|| {
+                options
+                    .format
+                    .as_ref()
+                    .and_then(FormatOrOutputFormat::as_output_format)
+            }),
+            force_exclude: options.force_exclude,
+            line_length: options.line_length,
+            tab_size: options.tab_size,
+            namespace_packages: options
+                .namespace_packages
+                .map(|namespace_package| resolve_src(&namespace_package, project_root))
+                .transpose()?,
+            preview: options.preview.map(PreviewMode::from),
+            required_version: options.required_version,
+            respect_gitignore: options.respect_gitignore,
+            show_source: options.show_source,
+            show_fixes: options.show_fixes,
+            src: options
+                .src
+                .map(|src| resolve_src(&src, project_root))
+                .transpose()?,
+            target_version: options.target_version,
+
+            lint: LintConfiguration::from_options(lint, project_root)?,
+            format: if let Some(FormatOrOutputFormat::Format(format)) = options.format {
+                FormatConfiguration::from_options(format)?
+            } else {
+                FormatConfiguration::default()
+            },
+        })
+    }
+
+    #[must_use]
+    pub fn combine(self, config: Self) -> Self {
+        Self {
+            builtins: self.builtins.or(config.builtins),
+            cache_dir: self.cache_dir.or(config.cache_dir),
+            exclude: self.exclude.or(config.exclude),
+            extend: self.extend.or(config.extend),
+            extend_exclude: config
+                .extend_exclude
+                .into_iter()
+                .chain(self.extend_exclude)
+                .collect(),
+            extend_include: config
+                .extend_include
+                .into_iter()
+                .chain(self.extend_include)
+                .collect(),
+            include: self.include.or(config.include),
+            fix: self.fix.or(config.fix),
+            fix_only: self.fix_only.or(config.fix_only),
+            output_format: self.output_format.or(config.output_format),
+            force_exclude: self.force_exclude.or(config.force_exclude),
+            line_length: self.line_length.or(config.line_length),
+            tab_size: self.tab_size.or(config.tab_size),
+            namespace_packages: self.namespace_packages.or(config.namespace_packages),
+            required_version: self.required_version.or(config.required_version),
+            respect_gitignore: self.respect_gitignore.or(config.respect_gitignore),
+            show_source: self.show_source.or(config.show_source),
+            show_fixes: self.show_fixes.or(config.show_fixes),
+            src: self.src.or(config.src),
+            target_version: self.target_version.or(config.target_version),
+            preview: self.preview.or(config.preview),
+
+            lint: self.lint.combine(config.lint),
+            format: self.format.combine(config.format),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct LintConfiguration {
+    // Rule selection
+    pub extend_per_file_ignores: Vec<PerFileIgnore>,
+    pub per_file_ignores: Option<Vec<PerFileIgnore>>,
+    pub rule_selections: Vec<RuleSelection>,
+
+    // Global lint settings
+    pub allowed_confusables: Option<Vec<char>>,
+    pub dummy_variable_rgx: Option<Regex>,
+    pub external: Option<Vec<String>>,
+    pub ignore_init_module_imports: Option<bool>,
+    pub logger_objects: Option<Vec<String>>,
+    pub task_tags: Option<Vec<String>>,
+    pub typing_modules: Option<Vec<String>>,
+
+    // Plugins
+    pub flake8_annotations: Option<Flake8AnnotationsOptions>,
+    pub flake8_bandit: Option<Flake8BanditOptions>,
+    pub flake8_bugbear: Option<Flake8BugbearOptions>,
+    pub flake8_builtins: Option<Flake8BuiltinsOptions>,
+    pub flake8_comprehensions: Option<Flake8ComprehensionsOptions>,
+    pub flake8_copyright: Option<Flake8CopyrightOptions>,
+    pub flake8_errmsg: Option<Flake8ErrMsgOptions>,
+    pub flake8_gettext: Option<Flake8GetTextOptions>,
+    pub flake8_implicit_str_concat: Option<Flake8ImplicitStrConcatOptions>,
+    pub flake8_import_conventions: Option<Flake8ImportConventionsOptions>,
+    pub flake8_pytest_style: Option<Flake8PytestStyleOptions>,
+    pub flake8_quotes: Option<Flake8QuotesOptions>,
+    pub flake8_self: Option<Flake8SelfOptions>,
+    pub flake8_tidy_imports: Option<Flake8TidyImportsOptions>,
+    pub flake8_type_checking: Option<Flake8TypeCheckingOptions>,
+    pub flake8_unused_arguments: Option<Flake8UnusedArgumentsOptions>,
+    pub isort: Option<IsortOptions>,
+    pub mccabe: Option<McCabeOptions>,
+    pub pep8_naming: Option<Pep8NamingOptions>,
+    pub pycodestyle: Option<PycodestyleOptions>,
+    pub pydocstyle: Option<PydocstyleOptions>,
+    pub pyflakes: Option<PyflakesOptions>,
+    pub pylint: Option<PylintOptions>,
+    pub pyupgrade: Option<PyUpgradeOptions>,
+}
+
+impl LintConfiguration {
+    fn from_options(options: LintOptions, project_root: &Path) -> Result<Self> {
+        Ok(LintConfiguration {
+            rule_selections: vec![RuleSelection {
+                select: options.select,
+                ignore: options
+                    .ignore
+                    .into_iter()
+                    .flatten()
+                    .chain(options.extend_ignore.into_iter().flatten())
+                    .collect(),
+                extend_select: options.extend_select.unwrap_or_default(),
+                fixable: options.fixable,
+                unfixable: options
+                    .unfixable
+                    .into_iter()
+                    .flatten()
+                    .chain(options.extend_unfixable.into_iter().flatten())
+                    .collect(),
+                extend_fixable: options.extend_fixable.unwrap_or_default(),
+            }],
+            allowed_confusables: options.allowed_confusables,
+            dummy_variable_rgx: options
+                .dummy_variable_rgx
+                .map(|pattern| Regex::new(&pattern))
+                .transpose()
+                .map_err(|e| anyhow!("Invalid `dummy-variable-rgx` value: {e}"))?,
             extend_per_file_ignores: options
                 .extend_per_file_ignores
                 .map(|per_file_ignores| {
@@ -409,32 +518,7 @@ impl Configuration {
                 })
                 .unwrap_or_default(),
             external: options.external,
-            fix: options.fix,
-            fix_only: options.fix_only,
-            output_format: options.output_format.or_else(|| {
-                options
-                    .format
-                    .as_ref()
-                    .and_then(FormatOrOutputFormat::as_output_format)
-            }),
-            force_exclude: options.force_exclude,
             ignore_init_module_imports: options.ignore_init_module_imports,
-            include: options.include.map(|paths| {
-                paths
-                    .into_iter()
-                    .map(|pattern| {
-                        let absolute = fs::normalize_path_to(&pattern, project_root);
-                        FilePattern::User(pattern, absolute)
-                    })
-                    .collect()
-            }),
-            line_length: options.line_length,
-            tab_size: options.tab_size,
-            namespace_packages: options
-                .namespace_packages
-                .map(|namespace_package| resolve_src(&namespace_package, project_root))
-                .transpose()?,
-            preview: options.preview.map(PreviewMode::from),
             per_file_ignores: options.per_file_ignores.map(|per_file_ignores| {
                 per_file_ignores
                     .into_iter()
@@ -443,15 +527,6 @@ impl Configuration {
                     })
                     .collect()
             }),
-            required_version: options.required_version,
-            respect_gitignore: options.respect_gitignore,
-            show_source: options.show_source,
-            show_fixes: options.show_fixes,
-            src: options
-                .src
-                .map(|src| resolve_src(&src, project_root))
-                .transpose()?,
-            target_version: options.target_version,
             task_tags: options.task_tags,
             logger_objects: options.logger_objects,
             typing_modules: options.typing_modules,
@@ -480,18 +555,10 @@ impl Configuration {
             pyflakes: options.pyflakes,
             pylint: options.pylint,
             pyupgrade: options.pyupgrade,
-
-            format: if let Some(FormatOrOutputFormat::Format(format)) = options.format {
-                FormatConfiguration::from_options(format)?
-            } else {
-                FormatConfiguration::default()
-            },
         })
     }
 
-    pub fn as_rule_table(&self) -> RuleTable {
-        let preview = self.preview.unwrap_or_default();
-
+    fn as_rule_table(&self, preview: PreviewMode) -> RuleTable {
         // The select_set keeps track of which rules have been selected.
         let mut select_set: RuleSet = PREFIXES
             .iter()
@@ -731,47 +798,18 @@ impl Configuration {
                 .chain(self.rule_selections)
                 .collect(),
             allowed_confusables: self.allowed_confusables.or(config.allowed_confusables),
-            builtins: self.builtins.or(config.builtins),
-            cache_dir: self.cache_dir.or(config.cache_dir),
             dummy_variable_rgx: self.dummy_variable_rgx.or(config.dummy_variable_rgx),
-            exclude: self.exclude.or(config.exclude),
-            extend: self.extend.or(config.extend),
-            extend_exclude: config
-                .extend_exclude
-                .into_iter()
-                .chain(self.extend_exclude)
-                .collect(),
-            extend_include: config
-                .extend_include
-                .into_iter()
-                .chain(self.extend_include)
-                .collect(),
             extend_per_file_ignores: config
                 .extend_per_file_ignores
                 .into_iter()
                 .chain(self.extend_per_file_ignores)
                 .collect(),
             external: self.external.or(config.external),
-            fix: self.fix.or(config.fix),
-            fix_only: self.fix_only.or(config.fix_only),
-            output_format: self.output_format.or(config.output_format),
-            force_exclude: self.force_exclude.or(config.force_exclude),
-            include: self.include.or(config.include),
             ignore_init_module_imports: self
                 .ignore_init_module_imports
                 .or(config.ignore_init_module_imports),
-            line_length: self.line_length.or(config.line_length),
             logger_objects: self.logger_objects.or(config.logger_objects),
-            tab_size: self.tab_size.or(config.tab_size),
-            namespace_packages: self.namespace_packages.or(config.namespace_packages),
             per_file_ignores: self.per_file_ignores.or(config.per_file_ignores),
-            required_version: self.required_version.or(config.required_version),
-            respect_gitignore: self.respect_gitignore.or(config.respect_gitignore),
-            show_source: self.show_source.or(config.show_source),
-            show_fixes: self.show_fixes.or(config.show_fixes),
-            src: self.src.or(config.src),
-            target_version: self.target_version.or(config.target_version),
-            preview: self.preview.or(config.preview),
             task_tags: self.task_tags.or(config.task_tags),
             typing_modules: self.typing_modules.or(config.typing_modules),
             // Plugins
@@ -809,8 +847,6 @@ impl Configuration {
             pyflakes: self.pyflakes.combine(config.pyflakes),
             pylint: self.pylint.combine(config.pylint),
             pyupgrade: self.pyupgrade.combine(config.pyupgrade),
-
-            format: self.format.combine(config.format),
         }
     }
 }
@@ -858,7 +894,6 @@ impl FormatConfiguration {
         }
     }
 }
-
 pub(crate) trait CombinePluginOptions {
     #[must_use]
     fn combine(self, other: Self) -> Self;
@@ -902,7 +937,7 @@ mod tests {
     use ruff_linter::settings::types::PreviewMode;
     use ruff_linter::RuleSelector;
 
-    use crate::configuration::{Configuration, RuleSelection};
+    use crate::configuration::{LintConfiguration, RuleSelection};
 
     const NURSERY_RULES: &[Rule] = &[
         Rule::MissingCopyrightNotice,
@@ -966,12 +1001,11 @@ mod tests {
         selections: impl IntoIterator<Item = RuleSelection>,
         preview: Option<PreviewMode>,
     ) -> RuleSet {
-        Configuration {
+        LintConfiguration {
             rule_selections: selections.into_iter().collect(),
-            preview,
-            ..Configuration::default()
+            ..LintConfiguration::default()
         }
-        .as_rule_table()
+        .as_rule_table(preview.unwrap_or_default())
         .iter_enabled()
         // Filter out rule gated behind `#[cfg(feature = "unreachable-code")]`, which is off-by-default
         .filter(|rule| rule.noqa_code() != "RUF014")

--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -161,7 +161,7 @@ mod tests {
     use ruff_linter::line_width::LineLength;
     use ruff_linter::settings::types::PatternPrefixPair;
 
-    use crate::options::Options;
+    use crate::options::{LintOptions, Options};
     use crate::pyproject::{find_settings_toml, parse_pyproject_toml, Pyproject, Tools};
     use crate::tests::test_resource_path;
 
@@ -236,7 +236,10 @@ select = ["E501"]
             pyproject.tool,
             Some(Tools {
                 ruff: Some(Options {
-                    select: Some(vec![codes::Pycodestyle::E501.into()]),
+                    lint_top_level: LintOptions {
+                        select: Some(vec![codes::Pycodestyle::E501.into()]),
+                        ..LintOptions::default()
+                    },
                     ..Options::default()
                 })
             })
@@ -254,8 +257,11 @@ ignore = ["E501"]
             pyproject.tool,
             Some(Tools {
                 ruff: Some(Options {
-                    extend_select: Some(vec![codes::Ruff::_100.into()]),
-                    ignore: Some(vec![codes::Pycodestyle::E501.into()]),
+                    lint_top_level: LintOptions {
+                        extend_select: Some(vec![codes::Ruff::_100.into()]),
+                        ignore: Some(vec![codes::Pycodestyle::E501.into()]),
+                        ..LintOptions::default()
+                    },
                     ..Options::default()
                 })
             })
@@ -308,10 +314,14 @@ other-attribute = 1
                     "migrations".to_string(),
                     "with_excluded_file/other_excluded_file.py".to_string(),
                 ]),
-                per_file_ignores: Some(FxHashMap::from_iter([(
-                    "__init__.py".to_string(),
-                    vec![codes::Pyflakes::_401.into()]
-                )])),
+
+                lint_top_level: LintOptions {
+                    per_file_ignores: Some(FxHashMap::from_iter([(
+                        "__init__.py".to_string(),
+                        vec![codes::Pyflakes::_401.into()]
+                    )])),
+                    ..LintOptions::default()
+                },
                 ..Options::default()
             }
         );

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Options",
+  "description": "Experimental section to configure Ruff's linting. This new section will eventually replace the top-level linting options.\n\nOptions specified in the `lint` section take precedence over the top-level settings.",
   "type": "object",
   "properties": {
     "allowed-confusables": {
@@ -387,6 +388,16 @@
       ],
       "maximum": 320.0,
       "minimum": 1.0
+    },
+    "lint": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LintOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "logger-objects": {
       "description": "A list of objects that should be treated equivalently to a `logging.Logger` object.\n\nThis is useful for ensuring proper diagnostics (e.g., to identify `logging` deprecations and other best-practices) for projects that re-export a `logging.Logger` object from a common module.\n\nFor example, if you have a module `logging_setup.py` with the following contents: ```python import logging\n\nlogger = logging.getLogger(__name__) ```\n\nAdding `\"logging_setup.logger\"` to `logger-objects` will ensure that `logging_setup.logger` is treated as a `logging.Logger` object when imported from other modules (e.g., `from logging_setup import logger`).",
@@ -1534,6 +1545,429 @@
       "type": "integer",
       "format": "uint16",
       "minimum": 1.0
+    },
+    "LintOptions": {
+      "description": "Experimental section to configure Ruff's linting. This new section will eventually replace the top-level linting options.\n\nOptions specified in the `lint` section take precedence over the top-level settings.",
+      "type": "object",
+      "properties": {
+        "allowed-confusables": {
+          "description": "A list of allowed \"confusable\" Unicode characters to ignore when enforcing `RUF001`, `RUF002`, and `RUF003`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string",
+            "maxLength": 1,
+            "minLength": 1
+          }
+        },
+        "dummy-variable-rgx": {
+          "description": "A regular expression used to identify \"dummy\" variables, or those which should be ignored when enforcing (e.g.) unused-variable rules. The default expression matches `_`, `__`, and `_var`, but not `_var_`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "extend-fixable": {
+          "description": "A list of rule codes or prefixes to consider autofixable, in addition to those specified by `fixable`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/RuleSelector"
+          }
+        },
+        "extend-per-file-ignores": {
+          "description": "A list of mappings from file pattern to rule codes or prefixes to exclude, in addition to any rules excluded by `per-file-ignores`.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/RuleSelector"
+            }
+          }
+        },
+        "extend-select": {
+          "description": "A list of rule codes or prefixes to enable, in addition to those specified by `select`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/RuleSelector"
+          }
+        },
+        "external": {
+          "description": "A list of rule codes that are unsupported by Ruff, but should be preserved when (e.g.) validating `# noqa` directives. Useful for retaining `# noqa` directives that cover plugins not yet implemented by Ruff.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "fixable": {
+          "description": "A list of rule codes or prefixes to consider autofixable. By default, all rules are considered autofixable.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/RuleSelector"
+          }
+        },
+        "flake8-annotations": {
+          "description": "Options for the `flake8-annotations` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8AnnotationsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-bandit": {
+          "description": "Options for the `flake8-bandit` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8BanditOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-bugbear": {
+          "description": "Options for the `flake8-bugbear` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8BugbearOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-builtins": {
+          "description": "Options for the `flake8-builtins` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8BuiltinsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-comprehensions": {
+          "description": "Options for the `flake8-comprehensions` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8ComprehensionsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-copyright": {
+          "description": "Options for the `flake8-copyright` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8CopyrightOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-errmsg": {
+          "description": "Options for the `flake8-errmsg` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8ErrMsgOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-gettext": {
+          "description": "Options for the `flake8-gettext` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8GetTextOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-implicit-str-concat": {
+          "description": "Options for the `flake8-implicit-str-concat` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8ImplicitStrConcatOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-import-conventions": {
+          "description": "Options for the `flake8-import-conventions` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8ImportConventionsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-pytest-style": {
+          "description": "Options for the `flake8-pytest-style` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8PytestStyleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-quotes": {
+          "description": "Options for the `flake8-quotes` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8QuotesOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-self": {
+          "description": "Options for the `flake8_self` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8SelfOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-tidy-imports": {
+          "description": "Options for the `flake8-tidy-imports` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8TidyImportsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-type-checking": {
+          "description": "Options for the `flake8-type-checking` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8TypeCheckingOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-unused-arguments": {
+          "description": "Options for the `flake8-unused-arguments` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8UnusedArgumentsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore": {
+          "description": "A list of rule codes or prefixes to ignore. Prefixes can specify exact rules (like `F841`), entire categories (like `F`), or anything in between.\n\nWhen breaking ties between enabled and disabled rules (via `select` and `ignore`, respectively), more specific prefixes override less specific prefixes.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/RuleSelector"
+          }
+        },
+        "ignore-init-module-imports": {
+          "description": "Avoid automatically removing unused imports in `__init__.py` files. Such imports will still be flagged, but with a dedicated message suggesting that the import is either added to the module's `__all__` symbol, or re-exported with a redundant alias (e.g., `import os as os`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "isort": {
+          "description": "Options for the `isort` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IsortOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "logger-objects": {
+          "description": "A list of objects that should be treated equivalently to a `logging.Logger` object.\n\nThis is useful for ensuring proper diagnostics (e.g., to identify `logging` deprecations and other best-practices) for projects that re-export a `logging.Logger` object from a common module.\n\nFor example, if you have a module `logging_setup.py` with the following contents: ```python import logging\n\nlogger = logging.getLogger(__name__) ```\n\nAdding `\"logging_setup.logger\"` to `logger-objects` will ensure that `logging_setup.logger` is treated as a `logging.Logger` object when imported from other modules (e.g., `from logging_setup import logger`).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "mccabe": {
+          "description": "Options for the `mccabe` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/McCabeOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pep8-naming": {
+          "description": "Options for the `pep8-naming` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Pep8NamingOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "per-file-ignores": {
+          "description": "A list of mappings from file pattern to rule codes or prefixes to exclude, when considering any matching files.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/RuleSelector"
+            }
+          }
+        },
+        "pycodestyle": {
+          "description": "Options for the `pycodestyle` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PycodestyleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pydocstyle": {
+          "description": "Options for the `pydocstyle` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PydocstyleOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pyflakes": {
+          "description": "Options for the `pyflakes` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PyflakesOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pylint": {
+          "description": "Options for the `pylint` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PylintOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pyupgrade": {
+          "description": "Options for the `pyupgrade` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PyUpgradeOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "select": {
+          "description": "A list of rule codes or prefixes to enable. Prefixes can specify exact rules (like `F841`), entire categories (like `F`), or anything in between.\n\nWhen breaking ties between enabled and disabled rules (via `select` and `ignore`, respectively), more specific prefixes override less specific prefixes.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/RuleSelector"
+          }
+        },
+        "task-tags": {
+          "description": "A list of task tags to recognize (e.g., \"TODO\", \"FIXME\", \"XXX\").\n\nComments starting with these tags will be ignored by commented-out code detection (`ERA`), and skipped by line-length rules (`E501`) if `ignore-overlong-task-comments` is set to `true`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "typing-modules": {
+          "description": "A list of modules whose exports should be treated equivalently to members of the `typing` module.\n\nThis is useful for ensuring proper type annotation inference for projects that re-export `typing` and `typing_extensions` members from a compatibility module. If omitted, any members imported from modules apart from `typing` and `typing_extensions` will be treated as ordinary Python objects.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "unfixable": {
+          "description": "A list of rule codes or prefixes to consider non-autofix-able.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/RuleSelector"
+          }
+        }
+      },
+      "additionalProperties": false
     },
     "McCabeOptions": {
       "type": "object",


### PR DESCRIPTION
## Summary

This PR adds a new `lint` section to the configuration that groups all linter-specific settings. The existing top-level configurations continue to work without any warning because the `lint.*` settings are experimental. 

The configuration merges the top level and `lint.*` settings where the settings in `lint` have higher precedence (override the top-level settings). The reasoning behind this is that the settings in `lint.` are more specific and more specific settings should override less specific settings.

I decided against showing the new `lint.*` options on our website because it would make the page extremely long (it's technically easy to do, just attribute `lint` with `[option_group`]). We may want to explore adding an `alias` field to the `option` attribute and show the alias on the website along with its regular name. 

## Test Plan

* I added new integration tests
* I verified that the generated `options.md` is identical
* Verified the default settings in the playground

![Screenshot from 2023-09-22 13-52-23](https://github.com/astral-sh/ruff/assets/1203881/7b4d9689-aa88-402e-9199-9c43c8d8cc2d)
