### PR TITLE
Treat parameters-with-newline as empty in function formatting

### DIFF
--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2135,6 +2135,15 @@ impl Parameters {
         }
         false
     }
+
+    /// Returns `true` if the [`Parameters`] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.posonlyargs.is_empty()
+            && self.args.is_empty()
+            && self.kwonlyargs.is_empty()
+            && self.vararg.is_none()
+            && self.kwarg.is_none()
+    }
 }
 
 /// An alternative type of AST `arg`. This is used for each function argument that might have a default value.

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/return_annotation.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/return_annotation.py
@@ -75,6 +75,12 @@ def xxxxxxxxxxxxxxxxxxxxxxxxxxxx() -> Set[
 ]:
     ...
 
+def xxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+) -> Set[
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+]:
+    ...
+
 def xxxxxxxxxxxxxxxxxxxxxxxxxxxx() -> (
     Set[
         "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"]

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__return_annotation.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__return_annotation.py.snap
@@ -81,6 +81,12 @@ def xxxxxxxxxxxxxxxxxxxxxxxxxxxx() -> Set[
 ]:
     ...
 
+def xxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+) -> Set[
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+]:
+    ...
+
 def xxxxxxxxxxxxxxxxxxxxxxxxxxxx() -> (
     Set[
         "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"]
@@ -341,6 +347,14 @@ def f[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa](
 
 # Breaking return type annotations. Black adds parentheses if the parameters are
 # empty; otherwise, it leverages the expressions own parentheses if possible.
+def xxxxxxxxxxxxxxxxxxxxxxxxxxxx() -> (
+    Set[
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    ]
+):
+    ...
+
+
 def xxxxxxxxxxxxxxxxxxxxxxxxxxxx() -> (
     Set[
         "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"


### PR DESCRIPTION
## Summary

If a function has no parameters (and no comments within the parameters' `()`), we're supposed to wrap the return annotation _whenever_ it breaks. However, our `empty_parameters` test didn't properly account for the case in which the parameters include a newline (but no other content), like:

```python
def get_dashboards_hierarchy(
) -> Dict[Type['BaseDashboard'], List[Type['BaseDashboard']]]:
    """Get hierarchy of dashboards classes.

    Returns:
        Dict of dashboards classes.
    """
    dashboards_hierarchy = {}
```

This PR fixes that detection. Instead of lexing, it now checks if the parameters itself is empty (or if it contains comments).

Closes https://github.com/astral-sh/ruff/issues/7457.
