### PR TITLE
Update flake8-self license to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1194,7 +1194,27 @@ are:
 
 - flake8-self, licensed as follows:
   """
-    Freely Distributable
+    MIT License
+
+    Copyright (c) 2023 Korijn van Golen
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
   """
 
 - flake8-django, licensed under the GPL license.


### PR DESCRIPTION
## Summary

This PR updates the flake8-self license from Freely Distributable to the MIT License to match the upstream license, which was recently updated.

https://github.com/Korijn/flake8-self/blob/f5fc507515eaa895f56b0bdabba0041fec8af1a4/LICENSE
