### PR TITLE
Allow up to two newlines after trailing clause body comments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/if.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/if.py
@@ -138,6 +138,54 @@ if True:
 else:
     pass
 
+if True:
+    pass
+
+    # comment
+
+else:
+    pass
+
+if True:
+    pass
+
+    # comment
+
+
+else:
+    pass
+
+if True:
+    pass
+
+    # comment
+
+
+
+else:
+    pass
+
+if True:
+    if True:
+        pass
+        # comment
+
+    else:
+        pass
+else:
+    pass
+
+if True:
+    if True:
+        pass
+        # comment
+
+
+    else:
+        pass
+else:
+    pass
+
 # Regression test for https://github.com/astral-sh/ruff/issues/5337
 if parent_body:
     if current_body:

--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -101,9 +101,7 @@ impl Format<PyFormatContext<'_>> for FormatLeadingAlternateBranchComments<'_> {
             } else {
                 last_preceding.end()
             };
-            if lines_after(end, f.context().source()) > 1 {
-                write!(f, [empty_line()])?;
-            }
+            write!(f, [empty_lines(lines_after(end, f.context().source()))])?;
         }
 
         Ok(())

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__if.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__if.py.snap
@@ -144,6 +144,54 @@ if True:
 else:
     pass
 
+if True:
+    pass
+
+    # comment
+
+else:
+    pass
+
+if True:
+    pass
+
+    # comment
+
+
+else:
+    pass
+
+if True:
+    pass
+
+    # comment
+
+
+
+else:
+    pass
+
+if True:
+    if True:
+        pass
+        # comment
+
+    else:
+        pass
+else:
+    pass
+
+if True:
+    if True:
+        pass
+        # comment
+
+
+    else:
+        pass
+else:
+    pass
+
 # Regression test for https://github.com/astral-sh/ruff/issues/5337
 if parent_body:
     if current_body:
@@ -196,6 +244,7 @@ elif aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + 
     3333333333,
 ]:
     ...
+
 
 else:
     ...
@@ -302,6 +351,52 @@ else:
 
 if True:
     pass  # comment
+else:
+    pass
+
+if True:
+    pass
+
+    # comment
+
+else:
+    pass
+
+if True:
+    pass
+
+    # comment
+
+
+else:
+    pass
+
+if True:
+    pass
+
+    # comment
+
+
+else:
+    pass
+
+if True:
+    if True:
+        pass
+        # comment
+
+    else:
+        pass
+else:
+    pass
+
+if True:
+    if True:
+        pass
+        # comment
+
+    else:
+        pass
 else:
     pass
 


### PR DESCRIPTION
## Summary

The number of newlines after a trailing comment in a clause body needs to follow the usual rules -- so, up to two for top-level, up to one for nested, etc.

For example, Black preserves both newlines after `# comment` here:

```python
if True:
    pass

    # comment


else:
    pass
```

But it truncates to one newline here:

```python
if True:
    if True:
        pass
        # comment


    else:
        pass
else:
    pass
```

## Test Plan

Significant improvement on `transformers`.

Before:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1631 |
| django       |           0.99983 |              2760 |                36 |
| transformers |           0.99957 |              2587 |               402 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99979 |              3496 |                22 |
| warehouse    |           0.99967 |               648 |                15 |
| zulip        |           0.99972 |              1437 |                21 |


After:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1631 |
| django       |           0.99983 |              2760 |                36 |
| **transformers** |           **0.99963** |              **2587** |               **323** |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99979 |              3496 |                22 |
| warehouse    |           0.99967 |               648 |                15 |
| zulip        |           0.99972 |              1437 |                21 |
