### PR TITLE
Truncate to one empty line in stub files

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/newlines.pyi
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/newlines.pyi
@@ -1,0 +1,161 @@
+###
+# Blank lines around functions
+###
+
+x = 1
+
+# comment
+
+def f():
+    pass
+
+
+if True:
+    x = 1
+
+# comment
+
+def f():
+    pass
+
+
+x = 1
+
+
+
+# comment
+
+def f():
+    pass
+
+
+x = 1
+
+
+
+# comment
+def f():
+    pass
+
+
+x = 1
+
+# comment
+
+# comment
+def f():
+    pass
+
+x = 1
+
+# comment
+# comment
+
+def f():
+    pass
+
+x = 1
+
+# comment
+# comment
+def f():
+    pass
+
+
+x = 1
+
+
+# comment
+
+
+
+# comment
+
+
+
+def f():
+    pass
+# comment
+
+
+def f():
+    pass
+
+# comment
+
+def f():
+    pass
+
+
+# comment
+
+###
+# Blank lines around imports.
+###
+
+def f():
+    import x
+    # comment
+    import y
+
+
+def f():
+    import x
+
+    # comment
+    import y
+
+
+def f():
+    import x
+    # comment
+
+    import y
+
+
+def f():
+    import x
+    # comment
+
+
+    import y
+
+
+def f():
+    import x
+
+
+    # comment
+    import y
+
+
+def f():
+    import x
+
+    # comment
+
+    import y
+
+
+def f():
+    import x  # comment
+    # comment
+
+    import y
+
+
+def f(): pass  # comment
+# comment
+
+x = 1
+
+
+def f():
+    pass
+
+
+
+
+# comment
+
+x = 1

--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -308,7 +308,14 @@ impl Format<PyFormatContext<'_>> for FormatEmptyLines {
             NodeLevel::TopLevel => match self.lines {
                 0 | 1 => write!(f, [hard_line_break()]),
                 2 => write!(f, [empty_line()]),
-                _ => write!(f, [empty_line(), empty_line()]),
+                _ => match f.options().source_type() {
+                    PySourceType::Stub => {
+                        write!(f, [empty_line()])
+                    }
+                    PySourceType::Python | PySourceType::Ipynb => {
+                        write!(f, [empty_line(), empty_line()])
+                    }
+                },
             },
 
             NodeLevel::CompoundStatement => match self.lines {

--- a/crates/ruff_python_formatter/tests/snapshots/format@newlines.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@newlines.pyi.snap
@@ -1,0 +1,311 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/newlines.pyi
+---
+## Input
+```py
+###
+# Blank lines around functions
+###
+
+x = 1
+
+# comment
+
+def f():
+    pass
+
+
+if True:
+    x = 1
+
+# comment
+
+def f():
+    pass
+
+
+x = 1
+
+
+
+# comment
+
+def f():
+    pass
+
+
+x = 1
+
+
+
+# comment
+def f():
+    pass
+
+
+x = 1
+
+# comment
+
+# comment
+def f():
+    pass
+
+x = 1
+
+# comment
+# comment
+
+def f():
+    pass
+
+x = 1
+
+# comment
+# comment
+def f():
+    pass
+
+
+x = 1
+
+
+# comment
+
+
+
+# comment
+
+
+
+def f():
+    pass
+# comment
+
+
+def f():
+    pass
+
+# comment
+
+def f():
+    pass
+
+
+# comment
+
+###
+# Blank lines around imports.
+###
+
+def f():
+    import x
+    # comment
+    import y
+
+
+def f():
+    import x
+
+    # comment
+    import y
+
+
+def f():
+    import x
+    # comment
+
+    import y
+
+
+def f():
+    import x
+    # comment
+
+
+    import y
+
+
+def f():
+    import x
+
+
+    # comment
+    import y
+
+
+def f():
+    import x
+
+    # comment
+
+    import y
+
+
+def f():
+    import x  # comment
+    # comment
+
+    import y
+
+
+def f(): pass  # comment
+# comment
+
+x = 1
+
+
+def f():
+    pass
+
+
+
+
+# comment
+
+x = 1
+```
+
+## Output
+```py
+###
+# Blank lines around functions
+###
+
+x = 1
+
+# comment
+
+def f():
+    pass
+
+if True:
+    x = 1
+
+# comment
+
+def f():
+    pass
+
+x = 1
+
+# comment
+
+def f():
+    pass
+
+x = 1
+
+# comment
+def f():
+    pass
+
+x = 1
+
+# comment
+
+# comment
+def f():
+    pass
+
+x = 1
+
+# comment
+# comment
+
+def f():
+    pass
+
+x = 1
+
+# comment
+# comment
+def f():
+    pass
+
+x = 1
+
+# comment
+
+# comment
+
+def f():
+    pass
+
+# comment
+
+def f():
+    pass
+
+# comment
+
+def f():
+    pass
+
+# comment
+
+###
+# Blank lines around imports.
+###
+
+def f():
+    import x
+
+    # comment
+    import y
+
+def f():
+    import x
+
+    # comment
+    import y
+
+def f():
+    import x
+    # comment
+
+    import y
+
+def f():
+    import x
+    # comment
+
+    import y
+
+def f():
+    import x
+
+    # comment
+    import y
+
+def f():
+    import x
+
+    # comment
+
+    import y
+
+def f():
+    import x  # comment
+    # comment
+
+    import y
+
+def f():
+    pass  # comment
+
+# comment
+
+x = 1
+
+def f():
+    pass
+
+# comment
+
+x = 1
+```
+
+
+


### PR DESCRIPTION
## Summary

This PR modifies a variety of sites in which we insert up to two empty lines to instead truncate to at most one empty line in stub files. We already enforce this in _some_ places, but not all.

## Test Plan

`cargo test`

No changes in similarity (as expected, since this only impacts unformatted `.pyi` files).

Before:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1631 |
| django       |           0.99983 |              2760 |                36 |
| transformers |           0.99963 |              2587 |               323 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99979 |              3496 |                22 |
| warehouse    |           0.99967 |               648 |                15 |
| zulip        |           0.99972 |              1437 |                21 |

After:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1631 |
| django       |           0.99983 |              2760 |                36 |
| transformers |           0.99963 |              2587 |               323 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99979 |              3496 |                22 |
| warehouse    |           0.99967 |               648 |                15 |
| zulip        |           0.99972 |              1437 |                21 |
