### PR TITLE
Enable tab completion for `ruff rule`

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -10,7 +10,7 @@ use ruff_linter::registry::Rule;
 use ruff_linter::settings::types::{
     FilePattern, PatternPrefixPair, PerFileIgnore, PreviewMode, PythonVersion, SerializationFormat,
 };
-use ruff_linter::{RuleSelector, RuleSelectorParser};
+use ruff_linter::{RuleParser, RuleSelector, RuleSelectorParser};
 use ruff_workspace::configuration::{Configuration, RuleSelection};
 use ruff_workspace::resolver::ConfigurationTransformer;
 
@@ -39,7 +39,7 @@ pub enum Command {
     #[command(group = clap::ArgGroup::new("selector").multiple(false).required(true))]
     Rule {
         /// Rule to explain
-        #[arg(value_parser=Rule::from_code, group = "selector")]
+        #[arg(value_parser=RuleParser, group = "selector", hide_possible_values = true)]
         rule: Option<Rule>,
 
         /// Explain all rules

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -225,7 +225,7 @@ fn explain_status_codes_ruf404() {
     ----- stdout -----
 
     ----- stderr -----
-    error: invalid value 'RUF404' for '[RULE]': unknown rule code
+    error: invalid value 'RUF404' for '[RULE]'
 
     For more information, try '--help'.
     "###);

--- a/crates/ruff_linter/src/lib.rs
+++ b/crates/ruff_linter/src/lib.rs
@@ -6,6 +6,8 @@
 //! [Ruff]: https://github.com/astral-sh/ruff
 
 #[cfg(feature = "clap")]
+pub use registry::clap_completion::RuleParser;
+#[cfg(feature = "clap")]
 pub use rule_selector::clap_completion::RuleSelectorParser;
 pub use rule_selector::RuleSelector;
 pub use rules::pycodestyle::rules::{IOError, SyntaxError};


### PR DESCRIPTION
## Summary

Writing `ruff rule E1`, then tab, shows:

<img width="724" alt="Screen Shot 2023-09-20 at 9 29 09 PM" src="https://github.com/astral-sh/ruff/assets/1309177/00297f24-8828-4485-a00e-6af1ab4e7875">

Closes https://github.com/astral-sh/ruff/issues/2812.