### PR TITLE
Allow up to two newlines before trailing clause body comments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/if.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/if.py
@@ -186,6 +186,28 @@ if True:
 else:
     pass
 
+if True:
+    pass
+# comment
+else:
+    pass
+
+if True:
+    pass
+
+# comment
+else:
+    pass
+
+if True:
+    pass
+
+
+# comment
+else:
+    pass
+
+
 # Regression test for https://github.com/astral-sh/ruff/issues/5337
 if parent_body:
     if current_body:

--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -86,9 +86,13 @@ impl Format<PyFormatContext<'_>> for FormatLeadingAlternateBranchComments<'_> {
         if let Some(first_leading) = self.comments.first() {
             // Leading comments only preserves the lines after the comment but not before.
             // Insert the necessary lines.
-            if lines_before(first_leading.start(), f.context().source()) > 1 {
-                write!(f, [empty_line()])?;
-            }
+            write!(
+                f,
+                [empty_lines(lines_before(
+                    first_leading.start(),
+                    f.context().source()
+                ))]
+            )?;
 
             write!(f, [leading_comments(self.comments)])?;
         } else if let Some(last_preceding) = self.last_node {

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__if.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__if.py.snap
@@ -192,6 +192,28 @@ if True:
 else:
     pass
 
+if True:
+    pass
+# comment
+else:
+    pass
+
+if True:
+    pass
+
+# comment
+else:
+    pass
+
+if True:
+    pass
+
+
+# comment
+else:
+    pass
+
+
 # Regression test for https://github.com/astral-sh/ruff/issues/5337
 if parent_body:
     if current_body:
@@ -399,6 +421,28 @@ if True:
         pass
 else:
     pass
+
+if True:
+    pass
+# comment
+else:
+    pass
+
+if True:
+    pass
+
+# comment
+else:
+    pass
+
+if True:
+    pass
+
+
+# comment
+else:
+    pass
+
 
 # Regression test for https://github.com/astral-sh/ruff/issues/5337
 if parent_body:


### PR DESCRIPTION
## Summary

This is the peer to https://github.com/astral-sh/ruff/pull/7557, but for "leading" clause comments, like:

```python
if True:
    pass


# comment
else:
    pass
```

In this case, we again want to allow up to two newlines at the top level.

## Test Plan

`cargo test`

No changes.

Before:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1631 |
| django       |           0.99983 |              2760 |                36 |
| transformers |           0.99963 |              2587 |               323 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99979 |              3496 |                22 |
| warehouse    |           0.99967 |               648 |                15 |
| zulip        |           0.99972 |              1437 |                21 |

After:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1631 |
| django       |           0.99983 |              2760 |                36 |
| transformers |           0.99963 |              2587 |               323 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99979 |              3496 |                22 |
| warehouse    |           0.99967 |               648 |                15 |
| zulip        |           0.99972 |              1437 |                21 |
