### PR TITLE
Remove `Int` wrapper type from parser

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -695,7 +695,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             },
         ) => {
             let module = module.as_deref();
-            let level = level.map(|level| level.to_u32());
+            let level = *level;
             if checker.enabled(Rule::ModuleImportNotAtTopOfFile) {
                 pycodestyle::rules::module_import_not_at_top_of_file(checker, stmt);
             }

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -358,7 +358,7 @@ where
                 range: _,
             }) => {
                 let module = module.as_deref();
-                let level = level.map(|level| level.to_u32());
+                let level = *level;
                 for alias in names {
                     if let Some("__future__") = module {
                         let name = alias.asname.as_ref().unwrap_or(&alias.name);

--- a/crates/ruff_linter/src/checkers/imports.rs
+++ b/crates/ruff_linter/src/checkers/imports.rs
@@ -44,7 +44,7 @@ fn extract_import_map(path: &Path, package: Option<&Path>, blocks: &[&Block]) ->
                 level,
                 range: _,
             }) => {
-                let level = level.map_or(0, |level| level.to_usize());
+                let level = level.unwrap_or_default() as usize;
                 let module = if let Some(module) = module {
                     let module: &String = module.as_ref();
                     if level == 0 {
@@ -95,6 +95,7 @@ pub(crate) fn check_imports(
         tracker.visit_body(python_ast);
         tracker
     };
+
     let blocks: Vec<&Block> = tracker.iter().collect();
 
     // Enforce import rules.

--- a/crates/ruff_linter/src/importer/mod.rs
+++ b/crates/ruff_linter/src/importer/mod.rs
@@ -308,7 +308,7 @@ impl<'a> Importer<'a> {
                 range: _,
             }) = stmt
             {
-                if level.map_or(true, |level| level.to_u32() == 0)
+                if level.map_or(true, |level| level == 0)
                     && name.as_ref().is_some_and(|name| name == module)
                     && names.iter().all(|alias| alias.name.as_str() != "*")
                 {

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
@@ -1,4 +1,4 @@
-use ruff_python_ast::{self as ast, Identifier, Int, Stmt};
+use ruff_python_ast::{self as ast, Identifier, Stmt};
 use ruff_text_size::{Ranged, TextRange};
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
@@ -99,7 +99,7 @@ fn fix_banned_relative_import(
             TextRange::default(),
         )),
         names: names.clone(),
-        level: Some(Int::new(0)),
+        level: Some(0),
         range: TextRange::default(),
     };
     let content = generator.stmt(&node.into());

--- a/crates/ruff_linter/src/rules/isort/annotate.rs
+++ b/crates/ruff_linter/src/rules/isort/annotate.rs
@@ -118,7 +118,7 @@ pub(crate) fn annotate_imports<'a>(
                     AnnotatedImport::ImportFrom {
                         module: module.as_deref(),
                         names: aliases,
-                        level: level.map(|level| level.to_u32()),
+                        level: *level,
                         trailing_comma: if split_on_trailing_comma {
                             trailing_comma(import, locator, source_type)
                         } else {

--- a/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
@@ -75,7 +75,7 @@ fn includes_import(stmt: &Stmt, target: &AnyImport) -> bool {
                 return false;
             };
             module.as_deref() == target.module
-                && level.map(|level| level.to_u32()) == target.level
+                && *level == target.level
                 && names.iter().any(|alias| {
                     &alias.name == target.name.name
                         && alias.asname.as_deref() == target.name.as_name
@@ -166,7 +166,7 @@ pub(crate) fn add_required_imports(
                                     name: name.name.as_str(),
                                     as_name: name.asname.as_deref(),
                                 },
-                                level: level.map(|level| level.to_u32()),
+                                level: *level,
                             }),
                             python_ast,
                             locator,

--- a/crates/ruff_linter/src/rules/pylint/rules/manual_import_from.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/manual_import_from.rs
@@ -1,4 +1,4 @@
-use ruff_python_ast::{self as ast, Alias, Identifier, Int, Stmt};
+use ruff_python_ast::{self as ast, Alias, Identifier, Stmt};
 use ruff_text_size::{Ranged, TextRange};
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
@@ -80,7 +80,7 @@ pub(crate) fn manual_from_import(
                     asname: None,
                     range: TextRange::default(),
                 }],
-                level: Some(Int::new(0)),
+                level: Some(0),
                 range: TextRange::default(),
             };
             diagnostic.set_fix(Fix::automatic(Edit::range_replacement(

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
@@ -71,7 +71,7 @@ pub(crate) fn deprecated_c_element_tree(checker: &mut Checker, stmt: &Stmt) {
             level,
             range: _,
         }) => {
-            if level.is_some_and(|level| level.to_u32() > 0) {
+            if level.is_some_and(|level| level > 0) {
                 // Ex) `import .xml.etree.cElementTree as ET`
             } else if let Some(module) = module {
                 if module == "xml.etree.cElementTree" {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -323,7 +323,7 @@ pub(crate) fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
             level,
             ..
         }) => {
-            if level.is_some_and(|level| level.to_u32() > 0) {
+            if level.is_some_and(|level| level > 0) {
                 return;
             }
 

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -1161,7 +1161,7 @@ pub struct StmtImport<'a> {
 pub struct StmtImportFrom<'a> {
     module: Option<&'a str>,
     names: Vec<ComparableAlias<'a>>,
-    level: Option<ast::Int>,
+    level: Option<u32>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -466,7 +466,7 @@ pub struct StmtImportFrom {
     pub range: TextRange,
     pub module: Option<Identifier>,
     pub names: Vec<Alias>,
-    pub level: Option<Int>,
+    pub level: Option<u32>,
 }
 
 impl From<StmtImportFrom> for Stmt {
@@ -2575,35 +2575,6 @@ impl From<Identifier> for String {
 impl Ranged for Identifier {
     fn range(&self) -> TextRange {
         self.range
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Int(u32);
-
-impl Int {
-    pub fn new(i: u32) -> Self {
-        Self(i)
-    }
-    pub fn to_u32(&self) -> u32 {
-        self.0
-    }
-    pub fn to_usize(&self) -> usize {
-        self.0 as _
-    }
-}
-
-impl std::cmp::PartialEq<u32> for Int {
-    #[inline]
-    fn eq(&self, other: &u32) -> bool {
-        self.0 == *other
-    }
-}
-
-impl std::cmp::PartialEq<usize> for Int {
-    #[inline]
-    fn eq(&self, other: &usize) -> bool {
-        self.0 as usize == *other
     }
 }
 

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -577,7 +577,9 @@ impl<'a> Generator<'a> {
                 statement!({
                     self.p("from ");
                     if let Some(level) = level {
-                        self.p(&".".repeat(level.to_usize()));
+                        for _ in 0..*level {
+                            self.p(".");
+                        }
                     }
                     if let Some(module) = module {
                         self.p_id(module);

--- a/crates/ruff_python_formatter/src/statement/stmt_import_from.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_import_from.rs
@@ -21,7 +21,7 @@ impl FormatNodeRule<StmtImportFrom> for FormatStmtImportFrom {
         } = item;
 
         let level_str = level
-            .map(|level| ".".repeat(level.to_usize()))
+            .map(|level| ".".repeat(level as usize))
             .unwrap_or(String::default());
 
         write!(

--- a/crates/ruff_python_parser/src/python.lalrpop
+++ b/crates/ruff_python_parser/src/python.lalrpop
@@ -253,18 +253,18 @@ ImportStatement: ast::Stmt = {
     },
 };
 
-ImportFromLocation: (Option<ast::Int>, Option<ast::Identifier>) = {
+ImportFromLocation: (Option<u32>, Option<ast::Identifier>) = {
     <dots: ImportDots*> <name:DottedName> => {
-        (Some(ast::Int::new(dots.iter().map(ast::Int::to_u32).sum())), Some(name))
+        (Some(dots.iter().sum()), Some(name))
     },
     <dots: ImportDots+> => {
-        (Some(ast::Int::new(dots.iter().map(ast::Int::to_u32).sum())), None)
+        (Some(dots.iter().sum()), None)
     },
 };
 
-ImportDots: ast::Int = {
-    "..." => ast::Int::new(3),
-    "." => ast::Int::new(1),
+ImportDots: u32 = {
+    "..." => 3,
+    "." => 1,
 };
 
 ImportAsNames: Vec<ast::Alias> = {

--- a/crates/ruff_python_parser/src/python.rs
+++ b/crates/ruff_python_parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: e8f3229288c1a13387ea6041355e2d8fe9ab788fbc7229032d2de92beb675944
+// sha3: eb535c9ae34baad8c940ef61dbbea0a7fec7baf3cd62af40837b2616f656f927
 use num_bigint::BigInt;
 use ruff_text_size::{Ranged, TextSize};
 use ruff_python_ast::{self as ast, IpyEscapeKind};
@@ -117,9 +117,9 @@ mod __parse__Top {
         Variant69(core::option::Option<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>),
         Variant70(ast::Alias),
         Variant71(Vec<ast::Alias>),
-        Variant72(ast::Int),
-        Variant73(alloc::vec::Vec<ast::Int>),
-        Variant74((Option<ast::Int>, Option<ast::Identifier>)),
+        Variant72(u32),
+        Variant73(alloc::vec::Vec<u32>),
+        Variant74((Option<u32>, Option<ast::Identifier>)),
         Variant75(ast::MatchCase),
         Variant76(alloc::vec::Vec<ast::MatchCase>),
         Variant77(ast::PatternKeyword),
@@ -17596,7 +17596,7 @@ mod __parse__Top {
     fn __pop_Variant74<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
-    ) -> (TextSize, (Option<ast::Int>, Option<ast::Identifier>), TextSize)
+    ) -> (TextSize, (Option<u32>, Option<ast::Identifier>), TextSize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant74(__v), __r)) => (__l, __v, __r),
@@ -17973,16 +17973,6 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant73<
-    >(
-        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
-    ) -> (TextSize, alloc::vec::Vec<ast::Int>, TextSize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant73(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
     fn __pop_Variant76<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
@@ -18050,6 +18040,16 @@ mod __parse__Top {
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant21(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant73<
+    >(
+        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
+    ) -> (TextSize, alloc::vec::Vec<u32>, TextSize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant73(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -18140,16 +18140,6 @@ mod __parse__Top {
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant22(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant72<
-    >(
-        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
-    ) -> (TextSize, ast::Int, TextSize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant72(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -18520,6 +18510,16 @@ mod __parse__Top {
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant0(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant72<
+    >(
+        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
+    ) -> (TextSize, u32, TextSize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant72(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -31464,7 +31464,7 @@ fn __action61<
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
-    (_, source, _): (TextSize, (Option<ast::Int>, Option<ast::Identifier>), TextSize),
+    (_, source, _): (TextSize, (Option<u32>, Option<ast::Identifier>), TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, names, _): (TextSize, Vec<ast::Alias>, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
@@ -31488,12 +31488,12 @@ fn __action61<
 fn __action62<
 >(
     mode: Mode,
-    (_, dots, _): (TextSize, alloc::vec::Vec<ast::Int>, TextSize),
+    (_, dots, _): (TextSize, alloc::vec::Vec<u32>, TextSize),
     (_, name, _): (TextSize, ast::Identifier, TextSize),
-) -> (Option<ast::Int>, Option<ast::Identifier>)
+) -> (Option<u32>, Option<ast::Identifier>)
 {
     {
-        (Some(ast::Int::new(dots.iter().map(ast::Int::to_u32).sum())), Some(name))
+        (Some(dots.iter().sum()), Some(name))
     }
 }
 
@@ -31502,11 +31502,11 @@ fn __action62<
 fn __action63<
 >(
     mode: Mode,
-    (_, dots, _): (TextSize, alloc::vec::Vec<ast::Int>, TextSize),
-) -> (Option<ast::Int>, Option<ast::Identifier>)
+    (_, dots, _): (TextSize, alloc::vec::Vec<u32>, TextSize),
+) -> (Option<u32>, Option<ast::Identifier>)
 {
     {
-        (Some(ast::Int::new(dots.iter().map(ast::Int::to_u32).sum())), None)
+        (Some(dots.iter().sum()), None)
     }
 }
 
@@ -31516,9 +31516,9 @@ fn __action64<
 >(
     mode: Mode,
     (_, __0, _): (TextSize, token::Tok, TextSize),
-) -> ast::Int
+) -> u32
 {
-    ast::Int::new(3)
+    3
 }
 
 #[allow(unused_variables)]
@@ -31527,9 +31527,9 @@ fn __action65<
 >(
     mode: Mode,
     (_, __0, _): (TextSize, token::Tok, TextSize),
-) -> ast::Int
+) -> u32
 {
-    ast::Int::new(1)
+    1
 }
 
 #[allow(unused_variables)]
@@ -36264,8 +36264,8 @@ fn __action364<
 fn __action365<
 >(
     mode: Mode,
-    (_, __0, _): (TextSize, ast::Int, TextSize),
-) -> alloc::vec::Vec<ast::Int>
+    (_, __0, _): (TextSize, u32, TextSize),
+) -> alloc::vec::Vec<u32>
 {
     alloc::vec![__0]
 }
@@ -36275,9 +36275,9 @@ fn __action365<
 fn __action366<
 >(
     mode: Mode,
-    (_, v, _): (TextSize, alloc::vec::Vec<ast::Int>, TextSize),
-    (_, e, _): (TextSize, ast::Int, TextSize),
-) -> alloc::vec::Vec<ast::Int>
+    (_, v, _): (TextSize, alloc::vec::Vec<u32>, TextSize),
+    (_, e, _): (TextSize, u32, TextSize),
+) -> alloc::vec::Vec<u32>
 {
     { let mut v = v; v.push(e); v }
 }
@@ -36289,7 +36289,7 @@ fn __action367<
     mode: Mode,
     __lookbehind: &TextSize,
     __lookahead: &TextSize,
-) -> alloc::vec::Vec<ast::Int>
+) -> alloc::vec::Vec<u32>
 {
     alloc::vec![]
 }
@@ -36299,8 +36299,8 @@ fn __action367<
 fn __action368<
 >(
     mode: Mode,
-    (_, v, _): (TextSize, alloc::vec::Vec<ast::Int>, TextSize),
-) -> alloc::vec::Vec<ast::Int>
+    (_, v, _): (TextSize, alloc::vec::Vec<u32>, TextSize),
+) -> alloc::vec::Vec<u32>
 {
     v
 }
@@ -45772,7 +45772,7 @@ fn __action806<
 >(
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, (Option<ast::Int>, Option<ast::Identifier>), TextSize),
+    __1: (TextSize, (Option<u32>, Option<ast::Identifier>), TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, Vec<ast::Alias>, TextSize),
     __4: (TextSize, TextSize, TextSize),
@@ -59644,7 +59644,7 @@ fn __action1299<
 >(
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, (Option<ast::Int>, Option<ast::Identifier>), TextSize),
+    __1: (TextSize, (Option<u32>, Option<ast::Identifier>), TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, Vec<ast::Alias>, TextSize),
 ) -> ast::Stmt
@@ -66376,7 +66376,7 @@ fn __action1542<
 >(
     mode: Mode,
     __0: (TextSize, ast::Identifier, TextSize),
-) -> (Option<ast::Int>, Option<ast::Identifier>)
+) -> (Option<u32>, Option<ast::Identifier>)
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -66398,9 +66398,9 @@ fn __action1542<
 fn __action1543<
 >(
     mode: Mode,
-    __0: (TextSize, alloc::vec::Vec<ast::Int>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<u32>, TextSize),
     __1: (TextSize, ast::Identifier, TextSize),
-) -> (Option<ast::Int>, Option<ast::Identifier>)
+) -> (Option<u32>, Option<ast::Identifier>)
 {
     let __start0 = __0.0;
     let __end0 = __0.2;


### PR DESCRIPTION
## Summary

This is only used for the `level` field in relative imports (e.g., `from ..foo import bar`). It seems unnecessary to use a wrapper here, so this PR changes to a `u32` directly.