### PR TITLE
Make ruff format idempotent when using stdin input

### DIFF
--- a/crates/ruff_cli/src/commands/format_stdin.rs
+++ b/crates/ruff_cli/src/commands/format_stdin.rs
@@ -71,15 +71,16 @@ fn format_source(
     let formatted = format_module(&unformatted, options)
         .map_err(|err| FormatCommandError::FormatModule(path.map(Path::to_path_buf), err))?;
     let formatted = formatted.as_code();
+
+    if mode.is_write() {
+        stdout()
+            .lock()
+            .write_all(formatted.as_bytes())
+            .map_err(|err| FormatCommandError::Write(path.map(Path::to_path_buf), err))?;
+    }
     if formatted.len() == unformatted.len() && formatted == unformatted {
         Ok(FormatCommandResult::Unchanged)
     } else {
-        if mode.is_write() {
-            stdout()
-                .lock()
-                .write_all(formatted.as_bytes())
-                .map_err(|err| FormatCommandError::Write(path.map(Path::to_path_buf), err))?;
-        }
         Ok(FormatCommandResult::Formatted)
     }
 }


### PR DESCRIPTION
## Summary
Currently, this happens
```sh
$ echo "print()" | ruff format - 

#Notice that nothing went to stdout
```
Which does not match `ruff check --fix - `  behavior and deletes my code every time I format it (more or less 5 times per minute :smile:).

<!-- What's the purpose of the change? What does it do, and why? -->


<!-- How was it tested? -->
I just checked that my example works as the change was very straightforward.