### PR TITLE
Refactor `Options` representation

### DIFF
--- a/crates/ruff_cli/src/commands/config.rs
+++ b/crates/ruff_cli/src/commands/config.rs
@@ -1,12 +1,13 @@
 use anyhow::{anyhow, Result};
 
 use ruff_workspace::options::Options;
+use ruff_workspace::options_base::OptionsMetadata;
 
 #[allow(clippy::print_stdout)]
 pub(crate) fn config(key: Option<&str>) -> Result<()> {
     match key {
         None => print!("{}", Options::metadata()),
-        Some(key) => match Options::metadata().get(key) {
+        Some(key) => match Options::metadata().find(key) {
             None => {
                 return Err(anyhow!("Unknown option: {key}"));
             }

--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -11,6 +11,7 @@ use strum::IntoEnumIterator;
 use ruff_diagnostics::AutofixKind;
 use ruff_linter::registry::{Linter, Rule, RuleNamespace};
 use ruff_workspace::options::Options;
+use ruff_workspace::options_base::OptionsMetadata;
 
 use crate::ROOT_DIR;
 
@@ -96,10 +97,7 @@ fn process_documentation(documentation: &str, out: &mut String) {
             if let Some(rest) = line.strip_prefix("- `") {
                 let option = rest.trim_end().trim_end_matches('`');
 
-                assert!(
-                    Options::metadata().get(option).is_some(),
-                    "unknown option {option}"
-                );
+                assert!(Options::metadata().has(option), "unknown option {option}");
 
                 let anchor = option.replace('.', "-");
                 out.push_str(&format!("- [`{option}`][{option}]\n"));

--- a/crates/ruff_dev/src/generate_options.rs
+++ b/crates/ruff_dev/src/generate_options.rs
@@ -1,9 +1,68 @@
 //! Generate a Markdown-compatible listing of configuration options for `pyproject.toml`.
 //!
 //! Used for <https://docs.astral.sh/ruff/settings/>.
-use itertools::Itertools;
+use std::fmt::Write;
+
 use ruff_workspace::options::Options;
-use ruff_workspace::options_base::{OptionEntry, OptionField};
+use ruff_workspace::options_base::{OptionField, OptionSet, OptionsMetadata, Visit};
+
+pub(crate) fn generate() -> String {
+    let mut output = String::new();
+    generate_set(&mut output, &Set::Toplevel(Options::metadata()));
+
+    output
+}
+
+fn generate_set(output: &mut String, set: &Set) {
+    writeln!(output, "### {title}\n", title = set.title()).unwrap();
+
+    let mut visitor = CollectOptionsVisitor::default();
+    set.metadata().record(&mut visitor);
+
+    let (mut fields, mut sets) = (visitor.fields, visitor.groups);
+
+    fields.sort_unstable_by(|(name, _), (name2, _)| name.cmp(name2));
+    sets.sort_unstable_by(|(name, _), (name2, _)| name.cmp(name2));
+
+    // Generate the fields.
+    for (name, field) in &fields {
+        emit_field(output, name, field, set.name());
+        output.push_str("---\n\n");
+    }
+
+    // Generate all the sub-sets.
+    for (set_name, sub_set) in &sets {
+        generate_set(output, &Set::Named(set_name, *sub_set));
+    }
+}
+
+enum Set<'a> {
+    Toplevel(OptionSet),
+    Named(&'a str, OptionSet),
+}
+
+impl<'a> Set<'a> {
+    fn name(&self) -> Option<&'a str> {
+        match self {
+            Set::Toplevel(_) => None,
+            Set::Named(name, _) => Some(name),
+        }
+    }
+
+    fn title(&self) -> &'a str {
+        match self {
+            Set::Toplevel(_) => "Top-level",
+            Set::Named(name, _) => name,
+        }
+    }
+
+    fn metadata(&self) -> &OptionSet {
+        match self {
+            Set::Toplevel(set) => set,
+            Set::Named(_, set) => set,
+        }
+    }
+}
 
 fn emit_field(output: &mut String, name: &str, field: &OptionField, group_name: Option<&str>) {
     // if there's a group name, we need to add it to the anchor
@@ -37,38 +96,18 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, group_name: 
     output.push('\n');
 }
 
-pub(crate) fn generate() -> String {
-    let mut output: String = "### Top-level\n\n".into();
+#[derive(Default)]
+struct CollectOptionsVisitor {
+    groups: Vec<(String, OptionSet)>,
+    fields: Vec<(String, OptionField)>,
+}
 
-    let sorted_options: Vec<_> = Options::metadata()
-        .into_iter()
-        .sorted_by_key(|(name, _)| *name)
-        .collect();
-
-    // Generate all the top-level fields.
-    for (name, entry) in &sorted_options {
-        let OptionEntry::Field(field) = entry else {
-            continue;
-        };
-        emit_field(&mut output, name, field, None);
-        output.push_str("---\n\n");
+impl Visit for CollectOptionsVisitor {
+    fn record_set(&mut self, name: &str, group: OptionSet) {
+        self.groups.push((name.to_owned(), group));
     }
 
-    // Generate all the sub-groups.
-    for (group_name, entry) in &sorted_options {
-        let OptionEntry::Group(fields) = entry else {
-            continue;
-        };
-        output.push_str(&format!("### {group_name}\n"));
-        output.push('\n');
-        for (name, entry) in fields.iter().sorted_by_key(|(name, _)| name) {
-            let OptionEntry::Field(field) = entry else {
-                continue;
-            };
-            emit_field(&mut output, name, field, Some(group_name));
-            output.push_str("---\n\n");
-        }
+    fn record_field(&mut self, name: &str, field: OptionField) {
+        self.fields.push((name.to_owned(), field));
     }
-
-    output
 }

--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -9,6 +9,7 @@ use ruff_diagnostics::AutofixKind;
 use ruff_linter::registry::{Linter, Rule, RuleNamespace};
 use ruff_linter::upstream_categories::UpstreamCategoryAndPrefix;
 use ruff_workspace::options::Options;
+use ruff_workspace::options_base::OptionsMetadata;
 
 const FIX_SYMBOL: &str = "🛠️";
 const PREVIEW_SYMBOL: &str = "🧪";
@@ -104,10 +105,7 @@ pub(crate) fn generate() -> String {
             table_out.push('\n');
         }
 
-        if Options::metadata()
-            .iter()
-            .any(|(name, _)| name == &linter.name())
-        {
+        if Options::metadata().has(linter.name()) {
             table_out.push_str(&format!(
                 "For related settings, see [{}](settings.md#{}).",
                 linter.name(),

--- a/crates/ruff_macros/src/config.rs
+++ b/crates/ruff_macros/src/config.rs
@@ -50,14 +50,11 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
                 };
             }
 
-            let options_len = output.len();
-
             Ok(quote! {
 
-                impl #ident {
-                    pub const fn metadata() -> crate::options_base::OptionGroup {
-                        const OPTIONS: [(&'static str, crate::options_base::OptionEntry); #options_len] = [#(#output),*];
-                        crate::options_base::OptionGroup::new(&OPTIONS)
+                impl crate::options_base::OptionsMetadata for #ident {
+                    fn record(visit: &mut dyn crate::options_base::Visit) {
+                        #(#output);*
                     }
                 }
             })
@@ -92,7 +89,7 @@ fn handle_option_group(field: &Field) -> syn::Result<proc_macro2::TokenStream> {
                 let kebab_name = LitStr::new(&ident.to_string().replace('_', "-"), ident.span());
 
                 Ok(quote_spanned!(
-                    ident.span() => (#kebab_name, crate::options_base::OptionEntry::Group(#path::metadata()))
+                    ident.span() => (visit.record_set(#kebab_name, crate::options_base::OptionSet::of::<#path>()))
                 ))
             }
             _ => Err(syn::Error::new(
@@ -150,12 +147,14 @@ fn handle_option(
     let kebab_name = LitStr::new(&ident.to_string().replace('_', "-"), ident.span());
 
     Ok(quote_spanned!(
-        ident.span() => (#kebab_name, crate::options_base::OptionEntry::Field(crate::options_base::OptionField {
-            doc: &#doc,
-            default: &#default,
-            value_type: &#value_type,
-            example: &#example,
-        }))
+        ident.span() => {
+            visit.record_field(#kebab_name, crate::options_base::OptionField{
+                doc: &#doc,
+                default: &#default,
+                value_type: &#value_type,
+                example: &#example,
+            })
+        }
     ))
 }
 

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -7,6 +7,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
+use crate::options_base::{OptionsMetadata, Visit};
 use ruff_linter::line_width::{LineLength, TabSize};
 use ruff_linter::rules::flake8_pytest_style::settings::SettingsError;
 use ruff_linter::rules::flake8_pytest_style::types;
@@ -2399,15 +2400,17 @@ pub enum FormatOrOutputFormat {
 }
 
 impl FormatOrOutputFormat {
-    pub const fn metadata() -> crate::options_base::OptionGroup {
-        FormatOptions::metadata()
-    }
-
     pub const fn as_output_format(&self) -> Option<SerializationFormat> {
         match self {
             FormatOrOutputFormat::Format(_) => None,
             FormatOrOutputFormat::OutputFormat(format) => Some(*format),
         }
+    }
+}
+
+impl OptionsMetadata for FormatOrOutputFormat {
+    fn record(visit: &mut dyn Visit) {
+        FormatOptions::record(visit);
     }
 }
 


### PR DESCRIPTION
## Summary

This PR refactors the `Options` representation. 

### Current Reprsentation

Our `ConfigureOptions` macro currently generates the following code (truncated):

```rust
impl Flake8BanditOptions {
    pub const fn metadata() -> crate::options_base::OptionGroup {
        const OPTIONS: [(&'static str, crate::options_base::OptionEntry); 3usize] = [
			("hardcoded-tmp-directory", crate::options_base::OptionEntry::Field(crate::options_base::OptionField { doc: &"A list of directories to consider temporary.", default: &"[\"/tmp\", \"/var/tmp\", \"/dev/shm\"]", value_type: &"list[str]", example: &"hardcoded-tmp-directory = [\"/foo/bar\"]" })), 
			("hardcoded-tmp-directory-extend", crate::options_base::OptionEntry::Field(crate::options_base::OptionField { doc: &"A list of directories to consider temporary, in addition to those\nspecified by `hardcoded-tmp-directory`.", default: &"[]", value_type: &"list[str]", example: &"extend-hardcoded-tmp-directory = [\"/foo/bar\"]" })), 
			("check-typed-exception", crate::options_base::OptionEntry::Field(crate::options_base::OptionField { doc: &"Whether to disallow `try`-`except`-`pass` (`S110`) for specific\nexception types. By default, `try`-`except`-`pass` is only\ndisallowed for `Exception` and `BaseException`.", default: &"false", value_type: &"bool", example: &"check-typed-exception = true" }))
		];
        crate::options_base::OptionGroup::new(&OPTIONS)
    }
}
```

You can see how it generates a static array and `metadata` returns an `OptionGroup(&slice)`  referring to the slice of the static array. 

Options can be nested (option-groups). The macro calls into the nested type's `metadata` function to get the `OptionGroup` and adds a `OptionEntry::Group()` to its static array

```rust
const OPTIONS: [(&'static str, crate::options_base::OptionEntry); 3usize] = [
			("hardcoded-tmp-directory", crate::options_base::OptionEntry::Field(crate::options_base::OptionField { doc: &"A list of directories to consider temporary.", default: &"[\"/tmp\", \"/var/tmp\", \"/dev/shm\"]", value_type: &"list[str]", example: &"hardcoded-tmp-directory = [\"/foo/bar\"]" })), 
			...
			("example-group", crate::options_base::OptionEntry::Group(ExampleGroup::metadata()))
		];
```

This works well enough and the API is simple. However, it requires that the macro statically determines all options to be able to set the length of the array.

### New Requirements
I'm about to introduce a new `lint` section to the configuration without removing the top-level options until the new configuration is stabilized. The simplest but very verbose approach is duplicating the `lint` options: Once at the top level and once under the `lint` section. But that's rather verbose. Ideally, I want to use serde's `flatten` feature and write:

```rust
struct Options {
	...

    // Lint options
    /// Options for the Ruff linter
    #[option_group]
    pub lint: Option<LintOptions>,

    /// Doc
    #[serde(flatten)]
    pub lint_legacy: LintOptions,
}
```

While serde and schemars support this nicely, our options macro does not, and adding it is impossible with the current representation. The problem is that macros operate on a tokens stream only. They can't resolve types (at least to my knowledge). But that's what's necessary for `Options` to statically determine the length of its `OPTIONS` array: It needs to expand the `LintOptions` options into `Options`. 

### New Representation

The new representation is inspired by serde and `tracing_subscribs`'s `Visit` trait. 

The basic idea is to implement the metadata abstraction as a visitor pass (to avoid allocations). 

```rust
/// Returns metadata for its options.
pub trait OptionsMetadata {
    /// Visits the options metadata of this object by calling `visit` for each option.
    fn record(visit: &mut dyn Visit);

    /// Returns the extracted metadata.
    fn metadata() -> OptionSet
    where
        Self: Sized + 'static,
    {
        OptionSet::of::<Self>()
    }
}

struct Root;

impl OptionsMetadata for Root {
    fn record(visit: &mut dyn Visit) {
        visit.record_field("ignore-git-ignore", OptionField {
            doc: "Whether Ruff should respect the gitignore file",
            default: "false",
            value_type: "bool",
            example: "",
        });

        visit.record_set("format", Nested::metadata());
    }
}

struct Nested;

impl OptionsMetadata for Nested {
    fn record(visit: &mut dyn Visit) {
        visit.record_field("hard-tabs", OptionField {
            doc: "Use hard tabs for indentation and spaces for alignment.",
            default: "false",
            value_type: "bool",
            example: "",
        });
    }
}
```

* Each struct that has options implements `OptionsMetadata`
* `OptionsMetadata::record` calls `record_field` or `record_set` for each option

where `Visit` is defined as

```rust
/// Visits [`OptionsMetadata`].
///
/// An instance of [`Visit`] represents the logic for inspecting an object's options metadata.
pub trait Visit {
    /// Visits an [`OptionField`] value named `name`.
    fn record_field(&mut self, name: &str, field: OptionField);

    /// Visits an [`OptionSet`] value named `name`.
    fn record_set(&mut self, name: &str, group: OptionSet);
}
```

This new representation has a few advantages:

* The `OptionsMetadata` trait can be implemented manually for cases where the derive macro isn't flexible enough
* The `OptionsMetadata` provides all relevant abstractions so that the macro is optional. It means you can now understand the system without understanding the macro.
* Implementing `flatten` becomes a simple `Nested::record(visit)` call (instead of calling `visit.record_set(name, Nested::metadata())`. Meaning we traverse into the sub-set without telling the visitor that it now enters a new set. 

The main downside of the new API is that writing visitors is awkward. This is evident by the longer implementations for `has`, `get`, and `Display`. I think that's a fair tradeoff, considering that these methods are implemented once and that a similar API is provided to consumers. 

## Test Plan

* Verified that `cargo dev generate-options` produces the exact same output
* Verfieid that the `config` command continues working
