### PR TITLE
Support option group documentation

### DIFF
--- a/crates/ruff_dev/src/generate_options.rs
+++ b/crates/ruff_dev/src/generate_options.rs
@@ -16,6 +16,12 @@ pub(crate) fn generate() -> String {
 fn generate_set(output: &mut String, set: &Set) {
     writeln!(output, "### {title}\n", title = set.title()).unwrap();
 
+    if let Some(documentation) = set.metadata().documentation() {
+        output.push_str(documentation);
+        output.push('\n');
+        output.push('\n');
+    }
+
     let mut visitor = CollectOptionsVisitor::default();
     set.metadata().record(&mut visitor);
 

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2412,8 +2412,15 @@ impl OptionsMetadata for FormatOrOutputFormat {
     fn record(visit: &mut dyn Visit) {
         FormatOptions::record(visit);
     }
+
+    fn documentation() -> Option<&'static str> {
+        FormatOptions::documentation()
+    }
 }
 
+/// Experimental: Configures how `ruff format` formats your code.
+///
+/// Please provide feedback in [this discussion](https://github.com/astral-sh/ruff/discussions/7310).
 #[derive(
     Debug, PartialEq, Eq, Default, Serialize, Deserialize, ConfigurationOptions, CombineOptions,
 )]

--- a/crates/ruff_workspace/src/options_base.rs
+++ b/crates/ruff_workspace/src/options_base.rs
@@ -16,6 +16,10 @@ pub trait OptionsMetadata {
     /// Visits the options metadata of this object by calling `visit` for each option.
     fn record(visit: &mut dyn Visit);
 
+    fn documentation() -> Option<&'static str> {
+        None
+    }
+
     /// Returns the extracted metadata.
     fn metadata() -> OptionSet
     where
@@ -51,6 +55,7 @@ impl Display for OptionEntry {
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct OptionSet {
     record: fn(&mut dyn Visit),
+    doc: fn() -> Option<&'static str>,
 }
 
 impl OptionSet {
@@ -58,13 +63,21 @@ impl OptionSet {
     where
         T: OptionsMetadata + 'static,
     {
-        Self { record: T::record }
+        Self {
+            record: T::record,
+            doc: T::documentation,
+        }
     }
 
     /// Visits the options in this set by calling `visit` for each option.
     pub fn record(&self, visit: &mut dyn Visit) {
         let record = self.record;
         record(visit);
+    }
+
+    pub fn documentation(&self) -> Option<&'static str> {
+        let documentation = self.doc;
+        documentation()
     }
 
     /// Returns `true` if this set has an option that resolves to `name`.

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1163,6 +1163,7 @@
       "additionalProperties": false
     },
     "FormatOptions": {
+      "description": "Experimental: Configures how `ruff format` formats your code.\n\nPlease provide feedback in [this discussion](https://github.com/astral-sh/ruff/discussions/7310).",
       "type": "object",
       "properties": {
         "indent-style": {


### PR DESCRIPTION
## Summary

This PR adds support for documenting types implementing `OptionsMetadata`. 

I think we'll want to add a short explanation to the `lint` section that it is experimental.

## Test Plan

Generated the `options.md` and the documentation for `format` shows up.

![image](https://github.com/astral-sh/ruff/assets/1203881/ce1de755-e159-43c9-9a71-6cfbd12d9a74)

