### PR TITLE
Improve `B005` documentation to reflect duplicate-character behavior

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B005_B005.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B005_B005.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
 ---
-B005.py:4:1: B005 Using `.strip()` with multi-character strings is misleading the reader
+B005.py:4:1: B005 Using `.strip()` with multi-character strings is misleading
   |
 2 | s.strip(s)  # no warning
 3 | s.strip("we")  # no warning
@@ -11,7 +11,7 @@ B005.py:4:1: B005 Using `.strip()` with multi-character strings is misleading th
 6 | s.strip("\n\t ")  # no warning
   |
 
-B005.py:7:1: B005 Using `.strip()` with multi-character strings is misleading the reader
+B005.py:7:1: B005 Using `.strip()` with multi-character strings is misleading
   |
 5 | s.strip("e")  # no warning
 6 | s.strip("\n\t ")  # no warning
@@ -21,7 +21,7 @@ B005.py:7:1: B005 Using `.strip()` with multi-character strings is misleading th
 9 | s.lstrip("we")  # no warning
   |
 
-B005.py:10:1: B005 Using `.strip()` with multi-character strings is misleading the reader
+B005.py:10:1: B005 Using `.strip()` with multi-character strings is misleading
    |
  8 | s.lstrip(s)  # no warning
  9 | s.lstrip("we")  # no warning
@@ -31,7 +31,7 @@ B005.py:10:1: B005 Using `.strip()` with multi-character strings is misleading t
 12 | s.lstrip("\n\t ")  # no warning
    |
 
-B005.py:13:1: B005 Using `.strip()` with multi-character strings is misleading the reader
+B005.py:13:1: B005 Using `.strip()` with multi-character strings is misleading
    |
 11 | s.lstrip("e")  # no warning
 12 | s.lstrip("\n\t ")  # no warning
@@ -41,7 +41,7 @@ B005.py:13:1: B005 Using `.strip()` with multi-character strings is misleading t
 15 | s.rstrip("we")  # warning
    |
 
-B005.py:16:1: B005 Using `.strip()` with multi-character strings is misleading the reader
+B005.py:16:1: B005 Using `.strip()` with multi-character strings is misleading
    |
 14 | s.rstrip(s)  # no warning
 15 | s.rstrip("we")  # warning
@@ -51,7 +51,7 @@ B005.py:16:1: B005 Using `.strip()` with multi-character strings is misleading t
 18 | s.rstrip("\n\t ")  # no warning
    |
 
-B005.py:19:1: B005 Using `.strip()` with multi-character strings is misleading the reader
+B005.py:19:1: B005 Using `.strip()` with multi-character strings is misleading
    |
 17 | s.rstrip("e")  # no warning
 18 | s.rstrip("\n\t ")  # no warning
@@ -61,7 +61,7 @@ B005.py:19:1: B005 Using `.strip()` with multi-character strings is misleading t
 21 | s.strip("あ")  # no warning
    |
 
-B005.py:22:1: B005 Using `.strip()` with multi-character strings is misleading the reader
+B005.py:22:1: B005 Using `.strip()` with multi-character strings is misleading
    |
 20 | s.strip("a")  # no warning
 21 | s.strip("あ")  # no warning
@@ -71,7 +71,7 @@ B005.py:22:1: B005 Using `.strip()` with multi-character strings is misleading t
 24 | s.strip("\u0074\u0065\u0073\u0074")  # warning
    |
 
-B005.py:24:1: B005 Using `.strip()` with multi-character strings is misleading the reader
+B005.py:24:1: B005 Using `.strip()` with multi-character strings is misleading
    |
 22 | s.strip("ああ")  # warning
 23 | s.strip("\ufeff")  # no warning


### PR DESCRIPTION
## Summary

B005 only flags `.strip()` calls for which the argument includes duplicate characters. This is consistent with bugbear, but isn't explained in the documentation.
