### PR TITLE
Ignore blank lines between comments when counting newlines-after-imports

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/import.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/import.py
@@ -56,3 +56,12 @@ def func():
 
 
     x = 1
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/7604
+import os
+
+# Defaults for arguments are defined here
+# args.threshold = None;
+
+
+logger = logging.getLogger("FastProject")

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -190,7 +190,12 @@ impl FormatRule<Suite, PyFormatContext<'_>> for FormatSuite {
                 // a leading comment.
                 match self.kind {
                     SuiteKind::TopLevel => {
-                        match lines_after_ignoring_trivia(preceding.end(), source) {
+                        let end = if let Some(last_trailing) = preceding_comments.trailing.last() {
+                            last_trailing.end()
+                        } else {
+                            preceding.end()
+                        };
+                        match lines_after(end, source) {
                             0..=2 => empty_line().fmt(f)?,
                             _ => match source_type {
                                 PySourceType::Stub => {

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__import.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__import.py.snap
@@ -62,6 +62,15 @@ def func():
 
 
     x = 1
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/7604
+import os
+
+# Defaults for arguments are defined here
+# args.threshold = None;
+
+
+logger = logging.getLogger("FastProject")
 ```
 
 ## Output
@@ -130,6 +139,16 @@ def func():
     import sys
 
     x = 1
+
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/7604
+import os
+
+# Defaults for arguments are defined here
+# args.threshold = None;
+
+
+logger = logging.getLogger("FastProject")
 ```
 
 


### PR DESCRIPTION
## Summary

Given:

```python
# -*- coding: utf-8 -*-
import random

# Defaults for arguments are defined here
# args.threshold = None;


logger = logging.getLogger("FastProject")
```

We want to count the number of newlines after `import random`, to ensure that there's _at least one_, but up to two.

Previously, we used the end range of the statement (then skipped trivia); instead, we need to use the end of the _last comment_. This is similar to #7556.

Closes https://github.com/astral-sh/ruff/issues/7604.
