### PR TITLE
Avoid reordering mixed-indent-level comments after branches

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/if.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/if.py
@@ -208,6 +208,56 @@ else:
     pass
 
 
+# Regression test for: https://github.com/astral-sh/ruff/issues/7602
+if True:
+    if True:
+        if True:
+            pass
+
+        #a
+            #b
+        #c
+else:
+    pass
+
+if True:
+    if True:
+        if True:
+            pass
+            # b
+
+        # a
+        # c
+
+else:
+    pass
+
+# Same indent
+
+if True:
+    if True:
+        if True:
+            pass
+
+        #a
+        #b
+        #c
+else:
+    pass
+
+if True:
+    if True:
+        if True:
+            pass
+
+        # a
+        # b
+        # c
+
+else:
+    pass
+
+
 # Regression test for https://github.com/astral-sh/ruff/issues/5337
 if parent_body:
     if current_body:

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__if.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__if.py.snap
@@ -214,6 +214,56 @@ else:
     pass
 
 
+# Regression test for: https://github.com/astral-sh/ruff/issues/7602
+if True:
+    if True:
+        if True:
+            pass
+
+        #a
+            #b
+        #c
+else:
+    pass
+
+if True:
+    if True:
+        if True:
+            pass
+            # b
+
+        # a
+        # c
+
+else:
+    pass
+
+# Same indent
+
+if True:
+    if True:
+        if True:
+            pass
+
+        #a
+        #b
+        #c
+else:
+    pass
+
+if True:
+    if True:
+        if True:
+            pass
+
+        # a
+        # b
+        # c
+
+else:
+    pass
+
+
 # Regression test for https://github.com/astral-sh/ruff/issues/5337
 if parent_body:
     if current_body:
@@ -444,17 +494,68 @@ else:
     pass
 
 
+# Regression test for: https://github.com/astral-sh/ruff/issues/7602
+if True:
+    if True:
+        if True:
+            pass
+
+        # a
+        # b
+        # c
+
+else:
+    pass
+
+if True:
+    if True:
+        if True:
+            pass
+            # b
+
+        # a
+        # c
+else:
+    pass
+
+# Same indent
+
+if True:
+    if True:
+        if True:
+            pass
+
+        # a
+        # b
+        # c
+
+else:
+    pass
+
+if True:
+    if True:
+        if True:
+            pass
+
+        # a
+        # b
+        # c
+
+else:
+    pass
+
+
 # Regression test for https://github.com/astral-sh/ruff/issues/5337
 if parent_body:
     if current_body:
         child_in_body()
         last_child_in_current_body()  # may or may not have children on its own
-        # e
-        # f
-    # c
-    # d
 # a
 # b
+# c
+# d
+# e
+# f
 ```
 
 


### PR DESCRIPTION
## Summary

Given:

```python
if True:
    if True:
        if True:
            pass

        #a
            #b
        #c
else:
    pass
```

When determining the placement of the various comments, we compute the indentation depth of each comment, and then compare it to the depth of the previous statement. It turns out this can lead to reordering comments, e.g., above, `#b` is assigned as a trailing comment of `pass`, and so gets reordered above `#a`.

This PR modifies the logic such that when we compute the indentation depth of `#b`, we limit it to at most the indentation depth of `#a`. In other words, when analyzing comments at the end of branches, we don't let successive comments go any _deeper_ than their preceding comments.

Closes https://github.com/astral-sh/ruff/issues/7602.

## Test Plan

`cargo test`

No change in similarity.

Before:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1631 |
| django       |           0.99983 |              2760 |                36 |
| transformers |           0.99963 |              2587 |               319 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99979 |              3496 |                22 |
| warehouse    |           0.99967 |               648 |                15 |
| zulip        |           0.99972 |              1437 |                21 |

After:

| project      | similarity index  | total files       | changed files     |
|--------------|------------------:|------------------:|------------------:|
| cpython      |           0.76083 |              1789 |              1631 |
| django       |           0.99983 |              2760 |                36 |
| transformers |           0.99963 |              2587 |               319 |
| twine        |           1.00000 |                33 |                 0 |
| typeshed     |           0.99979 |              3496 |                22 |
| warehouse    |           0.99967 |               648 |                15 |
| zulip        |           0.99972 |              1437 |                21 |
