### PR TITLE
Update return type for `PT022` autofix

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT022.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT022.py
@@ -15,3 +15,29 @@ def ok_complex_logic():
 def error():
     resource = acquire_resource()
     yield resource
+
+
+import typing
+from typing import Generator
+
+
+@pytest.fixture()
+def ok_complex_logic() -> typing.Generator[Resource, None, None]:
+    if some_condition:
+        resource = acquire_resource()
+        yield resource
+        resource.release()
+        return
+    yield None
+
+
+@pytest.fixture()
+def error() -> typing.Generator[typing.Any, None, None]:
+    resource = acquire_resource()
+    yield resource
+
+
+@pytest.fixture()
+def error() -> Generator[Resource, None, None]:
+    resource = acquire_resource()
+    yield resource

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -292,6 +292,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     stmt,
                     name,
                     parameters,
+                    returns.as_deref(),
                     decorator_list,
                     body,
                 );

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT022.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT022.snap
@@ -16,5 +16,49 @@ PT022.py:17:5: PT022 [*] No teardown in fixture `error`, use `return` instead of
 16 16 |     resource = acquire_resource()
 17    |-    yield resource
    17 |+    return resource
+18 18 | 
+19 19 | 
+20 20 | import typing
+
+PT022.py:37:5: PT022 [*] No teardown in fixture `error`, use `return` instead of `yield`
+   |
+35 | def error() -> typing.Generator[typing.Any, None, None]:
+36 |     resource = acquire_resource()
+37 |     yield resource
+   |     ^^^^^^^^^^^^^^ PT022
+   |
+   = help: Replace `yield` with `return`
+
+ℹ Fix
+32 32 | 
+33 33 | 
+34 34 | @pytest.fixture()
+35    |-def error() -> typing.Generator[typing.Any, None, None]:
+   35 |+def error() -> typing.Any:
+36 36 |     resource = acquire_resource()
+37    |-    yield resource
+   37 |+    return resource
+38 38 | 
+39 39 | 
+40 40 | @pytest.fixture()
+
+PT022.py:43:5: PT022 [*] No teardown in fixture `error`, use `return` instead of `yield`
+   |
+41 | def error() -> Generator[Resource, None, None]:
+42 |     resource = acquire_resource()
+43 |     yield resource
+   |     ^^^^^^^^^^^^^^ PT022
+   |
+   = help: Replace `yield` with `return`
+
+ℹ Fix
+38 38 | 
+39 39 | 
+40 40 | @pytest.fixture()
+41    |-def error() -> Generator[Resource, None, None]:
+   41 |+def error() -> Resource:
+42 42 |     resource = acquire_resource()
+43    |-    yield resource
+   43 |+    return resource
 
 


### PR DESCRIPTION
## Summary

This PR fixes the autofix behavior for `PT022` to create an additional edit for the return type if it's present. The edit will update the return type from `Generator[T, ...]` to `T`. As per the [official documentation](https://docs.python.org/3/library/typing.html?highlight=typing%20generator#typing.Generator), the first position is the yield type, so we can ignore other positions.

```python
typing.Generator[YieldType, SendType, ReturnType]
```

## Test Plan

Add new test cases, `cargo test` and review the snapshots.

fixes: #7610 
