### PR TITLE
Treat form feed as whitespace in `SimpleTokenizer`

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/form_feed.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/form_feed.py
@@ -1,0 +1,6 @@
+# Regression test for: https://github.com/astral-sh/ruff/issues/7624
+if symbol is not None:
+    request["market"] = market["id"]
+      #             "remaining_volume": "0.0",
+else:
+    pass

--- a/crates/ruff_python_formatter/tests/snapshots/format@form_feed.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@form_feed.py.snap
@@ -1,0 +1,26 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/form_feed.py
+---
+## Input
+```py
+# Regression test for: https://github.com/astral-sh/ruff/issues/7624
+if symbol is not None:
+    request["market"] = market["id"]
+      #             "remaining_volume": "0.0",
+else:
+    pass
+```
+
+## Output
+```py
+# Regression test for: https://github.com/astral-sh/ruff/issues/7624
+if symbol is not None:
+    request["market"] = market["id"]
+#             "remaining_volume": "0.0",
+else:
+    pass
+```
+
+
+

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -543,8 +543,10 @@ impl<'a> SimpleTokenizer<'a> {
                 kind
             }
 
-            ' ' | '\t' => {
-                self.cursor.eat_while(|c| matches!(c, ' ' | '\t'));
+            // Space, tab, or form feed. We ignore the true semantics of form feed, and treat it as
+            // whitespace.
+            ' ' | '\t' | '\x0C' => {
+                self.cursor.eat_while(|c| matches!(c, ' ' | '\t' | '\x0C'));
                 SimpleTokenKind::Whitespace
             }
 
@@ -814,10 +816,13 @@ impl<'a> BackwardsTokenizer<'a> {
         }
 
         let kind = match last {
-            // This may not be 100% correct because it will lex-out trailing whitespace from a comment
-            // as whitespace rather than being part of the token. This shouldn't matter for what we use the lexer for.
-            ' ' | '\t' => {
-                self.cursor.eat_back_while(|c| matches!(c, ' ' | '\t'));
+            // Space, tab, or form feed. We ignore the true semantics of form feed, and treat it as
+            // whitespace. Note that this will lex-out trailing whitespace from a comment as
+            // whitespace rather than as part of the comment token, but this shouldn't matter for
+            // our use case.
+            ' ' | '\t' | '\x0C' => {
+                self.cursor
+                    .eat_back_while(|c| matches!(c, ' ' | '\t' | '\x0C'));
                 SimpleTokenKind::Whitespace
             }
 


### PR DESCRIPTION
## Summary

This is whitespace as per `is_python_whitespace`, and right now it tends to lead to panics in the formatter. Seems reasonable to treat it as whitespace in the `SimpleTokenizer` too.

Closes .https://github.com/astral-sh/ruff/issues/7624.
