### PR TITLE
Emit `LexError` for dedent to incorrect level

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
@@ -366,7 +366,7 @@ if (
 ):
     pass
 
- z = (
+z = (
                  a
                  +
                  # a: extracts this comment
@@ -377,7 +377,7 @@ if (
                          x and y
                      )
              )
- )
+)
 
 z = (
     (

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
@@ -372,7 +372,7 @@ if (
 ):
     pass
 
- z = (
+z = (
                  a
                  +
                  # a: extracts this comment
@@ -383,7 +383,7 @@ if (
                          x and y
                      )
              )
- )
+)
 
 z = (
     (

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__tet_too_low_dedent.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__tet_too_low_dedent.snap
@@ -1,0 +1,66 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: tokens
+---
+[
+    Ok(
+        (
+            If,
+            0..2,
+        ),
+    ),
+    Ok(
+        (
+            True,
+            3..7,
+        ),
+    ),
+    Ok(
+        (
+            Colon,
+            7..8,
+        ),
+    ),
+    Ok(
+        (
+            Newline,
+            8..9,
+        ),
+    ),
+    Ok(
+        (
+            Indent,
+            9..13,
+        ),
+    ),
+    Ok(
+        (
+            Pass,
+            13..17,
+        ),
+    ),
+    Ok(
+        (
+            Newline,
+            17..18,
+        ),
+    ),
+    Err(
+        LexicalError {
+            error: IndentationError,
+            location: 20,
+        },
+    ),
+    Ok(
+        (
+            Pass,
+            20..24,
+        ),
+    ),
+    Ok(
+        (
+            Newline,
+            24..24,
+        ),
+    ),
+]


### PR DESCRIPTION
## Summary

Fixes an issue in our lexer where it didn't emit a `LexError` for a partial dedent:

```python
if True:
    pass
  pass # <- Accepted before
```


Sourced by #7633

## Test Plan

Added test

