### PR TITLE
Remove `StringKind::FString` and `StringKind::RawFString`

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1954,6 +1954,7 @@ def f(arg=%timeit a = b):
         assert_debug_snapshot!(tokens);
     }
 
+    #[test]
     fn test_empty_fstrings() {
         let source = r#"f"" "" F"" f'' '' f"""""" f''''''"#;
         assert_debug_snapshot!(lex_source(source));


### PR DESCRIPTION
## Summary

This PR removes the now unused `StringKind::FString` and `StringKind::RawFString`
enum variants.

## Test Plan

`cargo test`
