### PR TITLE
Show preview notice on rule pages for nursery rules

### DIFF
--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -44,9 +44,9 @@ pub(crate) fn main(args: &Args) -> Result<()> {
                 output.push('\n');
             }
 
-            if rule.is_preview() {
+            if rule.is_preview() || rule.is_nursery() {
                 output.push_str(
-                    r#"This rule is in preview and is not stable. The `--preview` flag is required for use."#,
+                    r#"This rule is unstable and in [preview](../preview.md). The `--preview` flag is required for use."#,
                 );
                 output.push('\n');
                 output.push('\n');


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

The note about rules being in preview was not being displayed for legacy nursery rules.

Adds a link to the new preview documentation as well.

## Test Plan

<!-- How was it tested? -->

Built locally and checked a nursery rule e.g. http://127.0.0.1:8000/ruff/rules/no-indented-block-comment/
