### PR TITLE
Expand `DeprecatedLogWarn` to check for `Expr::Atrribute` calls 

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pygrep_hooks/PGH002_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pygrep_hooks/PGH002_0.py
@@ -5,3 +5,6 @@ from warnings import warn
 warnings.warn("this is ok")
 warn("by itself is also ok")
 logging.warning("this is fine")
+
+logger = logging.getLogger(__name__)
+logger.warning("this is fine")

--- a/crates/ruff_linter/resources/test/fixtures/pygrep_hooks/PGH002_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/pygrep_hooks/PGH002_1.py
@@ -3,3 +3,6 @@ from logging import warn
 
 logging.warn("this is not ok")
 warn("not ok")
+
+logger = logging.getLogger(__name__)
+logger.warn("this is not ok")

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -746,7 +746,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 pygrep_hooks::rules::no_eval(checker, func);
             }
             if checker.enabled(Rule::DeprecatedLogWarn) {
-                pygrep_hooks::rules::deprecated_log_warn(checker, func);
+                pygrep_hooks::rules::deprecated_log_warn(checker, call);
             }
             if checker.enabled(Rule::UnnecessaryDirectLambdaCall) {
                 pylint::rules::unnecessary_direct_lambda_call(checker, expr, func);

--- a/crates/ruff_linter/src/rules/pygrep_hooks/snapshots/ruff_linter__rules__pygrep_hooks__tests__PGH002_PGH002_1.py.snap
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/snapshots/ruff_linter__rules__pygrep_hooks__tests__PGH002_PGH002_1.py.snap
@@ -15,6 +15,15 @@ PGH002_1.py:5:1: PGH002 `warn` is deprecated in favor of `warning`
 4 | logging.warn("this is not ok")
 5 | warn("not ok")
   | ^^^^ PGH002
+6 | 
+7 | logger = logging.getLogger(__name__)
+  |
+
+PGH002_1.py:8:1: PGH002 `warn` is deprecated in favor of `warning`
+  |
+7 | logger = logging.getLogger(__name__)
+8 | logger.warn("this is not ok")
+  | ^^^^^^^^^^^ PGH002
   |
 
 


### PR DESCRIPTION
## Summary

`PGH002`, which checks for use of deprecated `logging.warn` calls, did not check for calls made on the attribute `warn` yet. Since https://github.com/astral-sh/ruff/pull/7521 we check both cases for similar rules wherever possible. To be consistent this PR expands PGH002 to do the same.

## Test Plan

Expanded existing fixtures with `logger.warn()` calls

## Issue links

Fixes final inconsistency mentioned in https://github.com/astral-sh/ruff/issues/7502 
