### PR TITLE
chore: remove redundant `Expr::Call` checks

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -474,13 +474,13 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 }
             }
             if checker.enabled(Rule::BlockingHttpCallInAsyncFunction) {
-                flake8_async::rules::blocking_http_call(checker, expr);
+                flake8_async::rules::blocking_http_call(checker, call);
             }
             if checker.enabled(Rule::OpenSleepOrSubprocessInAsyncFunction) {
-                flake8_async::rules::open_sleep_or_subprocess_call(checker, expr);
+                flake8_async::rules::open_sleep_or_subprocess_call(checker, call);
             }
             if checker.enabled(Rule::BlockingOsCallInAsyncFunction) {
-                flake8_async::rules::blocking_os_call(checker, expr);
+                flake8_async::rules::blocking_os_call(checker, call);
             }
             if checker.any_enabled(&[Rule::Print, Rule::PPrint]) {
                 flake8_print::rules::print_call(checker, call);
@@ -508,7 +508,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 Rule::SuspiciousTelnetUsage,
                 Rule::SuspiciousFTPLibUsage,
             ]) {
-                flake8_bandit::rules::suspicious_function_call(checker, expr);
+                flake8_bandit::rules::suspicious_function_call(checker, call);
             }
             if checker.enabled(Rule::ReSubPositionalArgs) {
                 flake8_bugbear::rules::re_sub_positional_args(checker, call);

--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call.rs
@@ -1,5 +1,4 @@
-use ruff_python_ast as ast;
-use ruff_python_ast::Expr;
+use ruff_python_ast::ExprCall;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -62,20 +61,18 @@ fn is_blocking_http_call(call_path: &CallPath) -> bool {
 }
 
 /// ASYNC100
-pub(crate) fn blocking_http_call(checker: &mut Checker, expr: &Expr) {
+pub(crate) fn blocking_http_call(checker: &mut Checker, call: &ExprCall) {
     if checker.semantic().in_async_context() {
-        if let Expr::Call(ast::ExprCall { func, .. }) = expr {
-            if checker
-                .semantic()
-                .resolve_call_path(func)
-                .as_ref()
-                .is_some_and(is_blocking_http_call)
-            {
-                checker.diagnostics.push(Diagnostic::new(
-                    BlockingHttpCallInAsyncFunction,
-                    func.range(),
-                ));
-            }
+        if checker
+            .semantic()
+            .resolve_call_path(call.func.as_ref())
+            .as_ref()
+            .is_some_and(is_blocking_http_call)
+        {
+            checker.diagnostics.push(Diagnostic::new(
+                BlockingHttpCallInAsyncFunction,
+                call.func.range(),
+            ));
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_os_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_os_call.rs
@@ -1,5 +1,4 @@
-use ruff_python_ast as ast;
-use ruff_python_ast::Expr;
+use ruff_python_ast::ExprCall;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -42,19 +41,18 @@ impl Violation for BlockingOsCallInAsyncFunction {
 }
 
 /// ASYNC102
-pub(crate) fn blocking_os_call(checker: &mut Checker, expr: &Expr) {
+pub(crate) fn blocking_os_call(checker: &mut Checker, call: &ExprCall) {
     if checker.semantic().in_async_context() {
-        if let Expr::Call(ast::ExprCall { func, .. }) = expr {
-            if checker
-                .semantic()
-                .resolve_call_path(func)
-                .as_ref()
-                .is_some_and(is_unsafe_os_method)
-            {
-                checker
-                    .diagnostics
-                    .push(Diagnostic::new(BlockingOsCallInAsyncFunction, func.range()));
-            }
+        if checker
+            .semantic()
+            .resolve_call_path(call.func.as_ref())
+            .as_ref()
+            .is_some_and(is_unsafe_os_method)
+        {
+            checker.diagnostics.push(Diagnostic::new(
+                BlockingOsCallInAsyncFunction,
+                call.func.range(),
+            ));
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_async/rules/open_sleep_or_subprocess_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/open_sleep_or_subprocess_call.rs
@@ -1,5 +1,4 @@
-use ruff_python_ast as ast;
-use ruff_python_ast::Expr;
+use ruff_python_ast::ExprCall;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -42,20 +41,18 @@ impl Violation for OpenSleepOrSubprocessInAsyncFunction {
 }
 
 /// ASYNC101
-pub(crate) fn open_sleep_or_subprocess_call(checker: &mut Checker, expr: &Expr) {
+pub(crate) fn open_sleep_or_subprocess_call(checker: &mut Checker, call: &ExprCall) {
     if checker.semantic().in_async_context() {
-        if let Expr::Call(ast::ExprCall { func, .. }) = expr {
-            if checker
-                .semantic()
-                .resolve_call_path(func)
-                .as_ref()
-                .is_some_and(is_open_sleep_or_subprocess_call)
-            {
-                checker.diagnostics.push(Diagnostic::new(
-                    OpenSleepOrSubprocessInAsyncFunction,
-                    func.range(),
-                ));
-            }
+        if checker
+            .semantic()
+            .resolve_call_path(call.func.as_ref())
+            .as_ref()
+            .is_some_and(is_open_sleep_or_subprocess_call)
+        {
+            checker.diagnostics.push(Diagnostic::new(
+                OpenSleepOrSubprocessInAsyncFunction,
+                call.func.range(),
+            ));
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
@@ -1,7 +1,7 @@
 //! Check for calls to suspicious functions, or calls into suspicious modules.
 //!
 //! See: <https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html>
-use ruff_python_ast::{self as ast, Expr};
+use ruff_python_ast::ExprCall;
 
 use ruff_diagnostics::{Diagnostic, DiagnosticKind, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -825,12 +825,8 @@ impl Violation for SuspiciousFTPLibUsage {
 }
 
 /// S301, S302, S303, S304, S305, S306, S307, S308, S310, S311, S312, S313, S314, S315, S316, S317, S318, S319, S320, S321, S323
-pub(crate) fn suspicious_function_call(checker: &mut Checker, expr: &Expr) {
-    let Expr::Call(ast::ExprCall { func, .. }) = expr else {
-        return;
-    };
-
-    let Some(diagnostic_kind) = checker.semantic().resolve_call_path(func).and_then(|call_path| {
+pub(crate) fn suspicious_function_call(checker: &mut Checker, call: &ExprCall) {
+    let Some(diagnostic_kind) = checker.semantic().resolve_call_path(call.func.as_ref()).and_then(|call_path| {
         match call_path.as_slice() {
             // Pickle
             ["pickle" | "dill", "load" | "loads" | "Unpickler"] |
@@ -888,7 +884,7 @@ pub(crate) fn suspicious_function_call(checker: &mut Checker, expr: &Expr) {
         return;
     };
 
-    let diagnostic = Diagnostic::new::<DiagnosticKind>(diagnostic_kind, expr.range());
+    let diagnostic = Diagnostic::new::<DiagnosticKind>(diagnostic_kind, call.range());
     if checker.enabled(diagnostic.kind.rule()) {
         checker.diagnostics.push(diagnostic);
     }


### PR DESCRIPTION
## Summary

As we bind the `ast::ExprCall` in the big `match expr` in `expression.rs` 
```rust
Expr::Call(
    call @ ast::ExprCall {
     ...
```

There is no need for additional `let/if let` checks on `ExprCall` in downstream rules. Found a few older rules which still did this while working on something else. This PR removes the redundant check from these rules.

## Test Plan

`cargo test`
