### PR TITLE
Break `with` on end-of-line trailing comments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
@@ -109,6 +109,40 @@ with (
 ): ...
 
 with (
+    # comment
+    a
+):
+    pass
+
+with (
+    a  # comment
+):
+    pass
+
+with (
+    a
+    # comment
+):
+    pass
+
+with (
+    # comment
+    a as b
+):
+    pass
+
+with (
+    a as b  # comment
+):
+    pass
+
+with (
+    a as b
+    # comment
+):
+    pass
+
+with (
     [
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "bbbbbbbbbb",

--- a/crates/ruff_python_formatter/src/statement/stmt_with.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_with.rs
@@ -84,9 +84,9 @@ impl FormatNodeRule<StmtWith> for FormatStmtWith {
                             }))
                             .fmt(f)?;
                         } else if let [item] = item.items.as_slice() {
-                            // This is similar to `maybe_parenthesize_expression`, but we're not dealing with an
-                            // expression here, it's a `WithItem`.
-                            if comments.has_leading(item) || comments.has_trailing_own_line(item) {
+                            // This is similar to `maybe_parenthesize_expression`, but we're not
+                            // dealing with an expression here, it's a `WithItem`.
+                            if comments.has_leading(item) || comments.has_trailing(item) {
                                 optional_parentheses(&item.format()).fmt(f)?;
                             } else {
                                 item.format().fmt(f)?;

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
@@ -115,6 +115,40 @@ with (
 ): ...
 
 with (
+    # comment
+    a
+):
+    pass
+
+with (
+    a  # comment
+):
+    pass
+
+with (
+    a
+    # comment
+):
+    pass
+
+with (
+    # comment
+    a as b
+):
+    pass
+
+with (
+    a as b  # comment
+):
+    pass
+
+with (
+    a as b
+    # comment
+):
+    pass
+
+with (
     [
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "bbbbbbbbbb",
@@ -297,10 +331,12 @@ with (
     ...  # body
     # body trailing own
 
-with a as (  # a  # as
-    # own line
-    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-):  # b
+with (
+    a as (  # a  # as
+        # own line
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    )  # b
+):
     pass
 
 
@@ -372,12 +408,48 @@ with (
     ...
 
 with (
-    a
-    # trailing own line comment
-) as (  # trailing as same line comment
-    b
-):  # trailing b same line comment
+    (
+        a
+        # trailing own line comment
+    ) as (  # trailing as same line comment
+        b
+    )  # trailing b same line comment
+):
     ...
+
+with (
+    # comment
+    a
+):
+    pass
+
+with (
+    a  # comment
+):
+    pass
+
+with (
+    a
+    # comment
+):
+    pass
+
+with (
+    # comment
+    a as b
+):
+    pass
+
+with (
+    a as b  # comment
+):
+    pass
+
+with (
+    a as b
+    # comment
+):
+    pass
 
 with (
     [


### PR DESCRIPTION
## Summary

Ensures that:

```python
with (
    a  # comment
):
    pass
```

Retains its parentheses.

Closes https://github.com/astral-sh/ruff/issues/6750.

## Test Plan

`cargo test`

No change in similarity.
