### PR TITLE
Avoid allocations in comments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/trailing_comments.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/trailing_comments.py
@@ -1,5 +1,6 @@
 # Pragma reserved width fixtures
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # noqa: This shouldn't break
+i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # NoQA: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # type: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # pyright: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # pylint: This shouldn't break
@@ -9,6 +10,7 @@ i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # nocover
 
 # Pragma fixtures for non-breaking space (lead by NBSP)
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # noqa: This shouldn't break
+i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # NoQA: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # type: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # pyright: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # pylint: This shouldn't break

--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use ruff_formatter::{format_args, write, FormatError, FormatOptions, SourceCode};
 use ruff_python_ast::node::{AnyNodeRef, AstNode};
 use ruff_python_ast::PySourceType;
-use ruff_python_trivia::{lines_after, lines_after_ignoring_trivia, lines_before};
+use ruff_python_trivia::{is_pragma, lines_after, lines_after_ignoring_trivia, lines_before};
 use ruff_text_size::{Ranged, TextLen, TextRange};
 
 use crate::comments::{CommentLinePosition, SourceComment};
@@ -370,17 +370,8 @@ impl Format<PyFormatContext<'_>> for FormatTrailingEndOfLineComment<'_> {
 
         let normalized_comment = normalize_comment(self.comment, source)?;
 
-        // Trim the normalized comment to detect excluded pragmas (strips NBSP).
-        let trimmed = strip_comment_prefix(&normalized_comment)?.trim_start();
-
-        let is_pragma = if let Some((maybe_pragma, _)) = trimmed.split_once(':') {
-            matches!(maybe_pragma, "noqa" | "type" | "pyright" | "pylint")
-        } else {
-            trimmed.starts_with("noqa")
-        };
-
         // Don't reserve width for excluded pragma comments.
-        let reserved_width = if is_pragma {
+        let reserved_width = if is_pragma(&normalized_comment) {
             0
         } else {
             // Start with 2 because of the two leading spaces.

--- a/crates/ruff_python_formatter/tests/snapshots/format@trailing_comments.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@trailing_comments.py.snap
@@ -6,6 +6,7 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/trailing_c
 ```py
 # Pragma reserved width fixtures
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # noqa: This shouldn't break
+i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # NoQA: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # type: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # pyright: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # pylint: This shouldn't break
@@ -15,6 +16,7 @@ i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # nocover
 
 # Pragma fixtures for non-breaking space (lead by NBSP)
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # noqa: This shouldn't break
+i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # NoQA: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # type: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # pyright: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # pylint: This shouldn't break
@@ -39,6 +41,7 @@ i = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ```py
 # Pragma reserved width fixtures
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # noqa: This shouldn't break
+i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # NoQA: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # type: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # pyright: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # pylint: This shouldn't break
@@ -50,6 +53,7 @@ i = (
 
 # Pragma fixtures for non-breaking space (lead by NBSP)
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # noqa: This shouldn't break
+i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # NoQA: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  #  type: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # pyright: This shouldn't break
 i = ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",)  # pylint: This shouldn't break

--- a/crates/ruff_python_trivia/src/lib.rs
+++ b/crates/ruff_python_trivia/src/lib.rs
@@ -1,10 +1,12 @@
 mod comment_ranges;
 mod cursor;
+mod pragmas;
 pub mod textwrap;
 mod tokenizer;
 mod whitespace;
 
 pub use comment_ranges::CommentRanges;
 pub use cursor::*;
+pub use pragmas::*;
 pub use tokenizer::*;
 pub use whitespace::*;

--- a/crates/ruff_python_trivia/src/pragmas.rs
+++ b/crates/ruff_python_trivia/src/pragmas.rs
@@ -1,0 +1,30 @@
+/// Returns `true` if a comment appears to be a pragma comment.
+///
+/// ```
+/// assert!(ruff_python_trivia::is_pragma("# type: ignore"));
+/// assert!(ruff_python_trivia::is_pragma("# noqa: F401"));
+/// assert!(ruff_python_trivia::is_pragma("# noqa"));
+/// assert!(ruff_python_trivia::is_pragma("# NoQA"));
+/// assert!(ruff_python_trivia::is_pragma("# nosec"));
+/// assert!(ruff_python_trivia::is_pragma("# nosec B602, B607"));
+/// assert!(ruff_python_trivia::is_pragma("# isort: off"));
+/// assert!(ruff_python_trivia::is_pragma("# isort: skip"));
+/// ```
+pub fn is_pragma(comment: &str) -> bool {
+    let Some(content) = comment.strip_prefix('#') else {
+        return false;
+    };
+    let trimmed = content.trim_start();
+
+    // Case-insensitive match against `noqa` (which doesn't require a trailing colon).
+    matches!(
+        trimmed.as_bytes(),
+        [b'n' | b'N', b'o' | b'O', b'q' | b'Q', b'a' | b'A', ..]
+    ) ||
+        // Case-insensitive match against pragmas that don't require a trailing colon.
+        trimmed.starts_with("nosec") ||
+        // Case-sensitive match against a variety of pragmas (which do require a trailing colon).
+        trimmed
+        .split_once(':')
+        .is_some_and(|(maybe_pragma, _)| matches!(maybe_pragma, "isort" | "type" | "pyright" | "pylint" | "flake8" | "ruff"))
+}


### PR DESCRIPTION
## Summary

This PR avoids all allocations when normalizing comments. Previously, we used `Cow` for this, as we had two cases:

1. The comment is included verbatim (use `Cow`; then, when formatting, we already know the start of the range, and we use the length of the string to find the end of it -- the string itself was never used, only its length).
2. The comment is normalized (use `Borrow`).

It turns out that in the normalized case, we're _always_ printing a `#`, followed by a space, followed by some substring that already exists in the source code. (Computing this substring is a little messy due to the non-breaking-space special cases... but, in any event, it's always a substring, with some stuff trimmed from the start or end.)

Instead of using `Cow` and allocating for the normalization case, this PR adds an enum that represents the ranges of a verbatim case (Case 1) or a comment body (Case 2). When printing the former, we use the range directly; when printing the latter, we manually print the `# `, followed by the source code slice:

```rust
#[derive(Debug)]
enum NormalizedComment {
    /// A complete comment, including the leading `#`.
    Verbatim(TextRange),

    /// A comment body, exclusive of the leading `#` and a leading space.
    Body(TextRange),
}
```

## Test Plan

`cargo test`
