### PR TITLE
Prefer preserving `WithItem` parentheses

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
@@ -288,3 +288,22 @@ with (
 
 with (foo() as bar, baz() as bop):
     pass
+
+if True:
+    with (
+        anyio.CancelScope(shield=True)
+        if get_running_loop()
+        else contextlib.nullcontext()
+    ):
+        pass
+
+if True:
+    with (
+        anyio.CancelScope(shield=True)
+        and B and [aaaaaaaa, bbbbbbbbbbbbb, cccccccccc, dddddddddddd, eeeeeeeeeeeee]
+    ):
+        pass
+
+if True:
+    with anyio.CancelScope(shield=True) if get_running_loop() else contextlib.nullcontext():
+        pass

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
@@ -294,6 +294,25 @@ with (
 
 with (foo() as bar, baz() as bop):
     pass
+
+if True:
+    with (
+        anyio.CancelScope(shield=True)
+        if get_running_loop()
+        else contextlib.nullcontext()
+    ):
+        pass
+
+if True:
+    with (
+        anyio.CancelScope(shield=True)
+        and B and [aaaaaaaa, bbbbbbbbbbbbb, cccccccccc, dddddddddddd, eeeeeeeeeeeee]
+    ):
+        pass
+
+if True:
+    with anyio.CancelScope(shield=True) if get_running_loop() else contextlib.nullcontext():
+        pass
 ```
 
 ## Output
@@ -580,13 +599,17 @@ with f(
 ) as b, c as d:
     pass
 
-with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as b:
+with (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+) as b:
     pass
 
 with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as b:
     pass
 
-with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as b, c as d:
+with (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+) as b, c as d:
     pass
 
 with (
@@ -605,6 +628,28 @@ with (
 
 with foo() as bar, baz() as bop:
     pass
+
+if True:
+    with (
+        anyio.CancelScope(shield=True)
+        if get_running_loop()
+        else contextlib.nullcontext()
+    ):
+        pass
+
+if True:
+    with (
+        anyio.CancelScope(shield=True)
+        and B
+        and [aaaaaaaa, bbbbbbbbbbbbb, cccccccccc, dddddddddddd, eeeeeeeeeeeee]
+    ):
+        pass
+
+if True:
+    with anyio.CancelScope(
+        shield=True
+    ) if get_running_loop() else contextlib.nullcontext():
+        pass
 ```
 
 


### PR DESCRIPTION
## Summary

This PR fixes a deviation to Black when formatting `WithItem`s.

```python
if True:
    with anyio.CancelScope(shield=True) if get_running_loop() else contextlib.nullcontext() as b:
        pass
    
    with (anyio.CancelScope(shield=True) if get_running_loop() else contextlib.nullcontext()):
        pass
```

Black formats this as:

```python
if True:
    with anyio.CancelScope(
        shield=True
    ) if get_running_loop() else contextlib.nullcontext() as b:
        pass

    with (
        anyio.CancelScope(shield=True)
        if get_running_loop()
        else contextlib.nullcontext()
    ):
        pass
```

Notice that the two examples are identical except that the second example has parentheses around the with context expression. 

Ruff formats both examples as if the context expression is not parenthesized:

```python
if True:
    with anyio.CancelScope(
        shield=True
    ) if get_running_loop() else contextlib.nullcontext() as b:
        pass
```

This PR uses the `IfBreaks` layout that prefers parenthesizing the context manager when it is already parenthesized in source, aligning the behavior with black.


Closes #7441 

## Test Plan

Added tests. I reviewed the changes and they now match black's formatting. 

The similarity index remains unchanged.
