### PR TITLE
Use fixed source code for parser context

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_annotations/annotation_presence.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_annotations/annotation_presence.py
@@ -158,3 +158,9 @@ class Foo:
     @decorator()
     def __init__(self: "Foo", foo: int):
        ...
+
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/7711
+class Class:
+    def __init__(self):
+        print(f"{self.attr=}")

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -468,7 +468,7 @@ pub fn lint_fix<'a>(
             &directives,
             settings,
             noqa,
-            source_kind,
+            &transformed,
             source_type,
         );
 

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__defaults.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__defaults.snap
@@ -259,5 +259,34 @@ annotation_presence.py:159:9: ANN204 [*] Missing return type annotation for spec
 159     |-    def __init__(self: "Foo", foo: int):
     159 |+    def __init__(self: "Foo", foo: int) -> None:
 160 160 |        ...
+161 161 | 
+162 162 | 
+
+annotation_presence.py:165:9: ANN204 [*] Missing return type annotation for special method `__init__`
+    |
+163 | # Regression test for: https://github.com/astral-sh/ruff/issues/7711
+164 | class Class:
+165 |     def __init__(self):
+    |         ^^^^^^^^ ANN204
+166 |         print(f"{self.attr=}")
+    |
+    = help: Add `None` return type
+
+ℹ Suggested fix
+162 162 | 
+163 163 | # Regression test for: https://github.com/astral-sh/ruff/issues/7711
+164 164 | class Class:
+165     |-    def __init__(self):
+    165 |+    def __init__(self) -> None:
+166 166 |         print(f"{self.attr=}")
+
+annotation_presence.py:165:18: ANN101 Missing type annotation for `self` in method
+    |
+163 | # Regression test for: https://github.com/astral-sh/ruff/issues/7711
+164 | class Class:
+165 |     def __init__(self):
+    |                  ^^^^ ANN101
+166 |         print(f"{self.attr=}")
+    |
 
 

--- a/crates/ruff_linter/src/test.rs
+++ b/crates/ruff_linter/src/test.rs
@@ -197,7 +197,7 @@ pub(crate) fn test_contents<'a>(
                 &directives,
                 settings,
                 flags::Noqa::Enabled,
-                source_kind,
+                &transformed,
                 source_type,
             );
 


### PR DESCRIPTION
## Summary

The parser now uses the raw source code as global context and slices into it to parse debug text. It turns out we were always passing in the _old_ source code, so when code was fixed, we were making invalid accesses. This PR modifies the call to use the _fixed_ source code, which will always be consistent with the tokens.

Closes https://github.com/astral-sh/ruff/issues/7711.

## Test Plan

`cargo test`
