### PR TITLE
Consume the escaped Windows newline (`\r\n`) for `FStringMiddle`

### DIFF
--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_mac_eol.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: fstring_single_quote_escape_eol(MAC_EOL)
+---
+[
+    (
+        FStringStart,
+        0..2,
+    ),
+    (
+        FStringMiddle {
+            value: "text \\\r more text",
+            is_raw: false,
+        },
+        2..19,
+    ),
+    (
+        FStringEnd,
+        19..20,
+    ),
+    (
+        Newline,
+        20..20,
+    ),
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_unix_eol.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: fstring_single_quote_escape_eol(UNIX_EOL)
+---
+[
+    (
+        FStringStart,
+        0..2,
+    ),
+    (
+        FStringMiddle {
+            value: "text \\\n more text",
+            is_raw: false,
+        },
+        2..19,
+    ),
+    (
+        FStringEnd,
+        19..20,
+    ),
+    (
+        Newline,
+        20..20,
+    ),
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__fstring_single_quote_escape_windows_eol.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: fstring_single_quote_escape_eol(WINDOWS_EOL)
+---
+[
+    (
+        FStringStart,
+        0..2,
+    ),
+    (
+        FStringMiddle {
+            value: "text \\\r\n more text",
+            is_raw: false,
+        },
+        2..20,
+    ),
+    (
+        FStringEnd,
+        20..21,
+    ),
+    (
+        Newline,
+        21..21,
+    ),
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__string_parser_escaped_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__string_parser_escaped_mac_eol.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff_python_parser/src/string.rs
+expression: parse_ast
+---
+[
+    Expr(
+        StmtExpr {
+            range: 0..18,
+            value: Constant(
+                ExprConstant {
+                    range: 0..18,
+                    value: Str(
+                        StringConstant {
+                            value: "text more text",
+                            unicode: false,
+                            implicit_concatenated: false,
+                        },
+                    ),
+                },
+            ),
+        },
+    ),
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__string_parser_escaped_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__string_parser_escaped_unix_eol.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff_python_parser/src/string.rs
+expression: parse_ast
+---
+[
+    Expr(
+        StmtExpr {
+            range: 0..18,
+            value: Constant(
+                ExprConstant {
+                    range: 0..18,
+                    value: Str(
+                        StringConstant {
+                            value: "text more text",
+                            unicode: false,
+                            implicit_concatenated: false,
+                        },
+                    ),
+                },
+            ),
+        },
+    ),
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__string_parser_escaped_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__string_parser_escaped_windows_eol.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff_python_parser/src/string.rs
+expression: parse_ast
+---
+[
+    Expr(
+        StmtExpr {
+            range: 0..19,
+            value: Constant(
+                ExprConstant {
+                    range: 0..19,
+                    value: Str(
+                        StringConstant {
+                            value: "text more text",
+                            unicode: false,
+                            implicit_concatenated: false,
+                        },
+                    ),
+                },
+            ),
+        },
+    ),
+]


### PR DESCRIPTION
## Summary

This PR fixes a bug where if a Windows newline (`\r\n`) character was escaped, then only the `\r` was consumed and not `\n` leading to an unterminated string error.

## Test Plan

Add new test cases to check the newline escapes.

fixes: #7632
