### PR TITLE
Remove escaped mac/windows eol from AST string value

### DIFF
--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__string_parser_escaped_mac_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__string_parser_escaped_mac_eol.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff_python_parser/src/string.rs
+expression: parse_ast
+---
+[
+    Expr(
+        StmtExpr {
+            range: 0..18,
+            value: Constant(
+                ExprConstant {
+                    range: 0..18,
+                    value: Str(
+                        StringConstant {
+                            value: "text more text",
+                            unicode: false,
+                            implicit_concatenated: false,
+                        },
+                    ),
+                },
+            ),
+        },
+    ),
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__string_parser_escaped_unix_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__string_parser_escaped_unix_eol.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff_python_parser/src/string.rs
+expression: parse_ast
+---
+[
+    Expr(
+        StmtExpr {
+            range: 0..18,
+            value: Constant(
+                ExprConstant {
+                    range: 0..18,
+                    value: Str(
+                        StringConstant {
+                            value: "text more text",
+                            unicode: false,
+                            implicit_concatenated: false,
+                        },
+                    ),
+                },
+            ),
+        },
+    ),
+]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__string_parser_escaped_windows_eol.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__string_parser_escaped_windows_eol.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff_python_parser/src/string.rs
+expression: parse_ast
+---
+[
+    Expr(
+        StmtExpr {
+            range: 0..19,
+            value: Constant(
+                ExprConstant {
+                    range: 0..19,
+                    value: Str(
+                        StringConstant {
+                            value: "text more text",
+                            unicode: false,
+                            implicit_concatenated: false,
+                        },
+                    ),
+                },
+            ),
+        },
+    ),
+]


### PR DESCRIPTION
## Summary

This PR fixes the bug where the value of a string node type includes the escaped mac/windows newline character.

Note that the token value still includes them, it's only removed when parsing the string content.

## Test Plan

Add new test cases for the string node type to check that the escapes aren't being included in the string value.

fixes: #7723
