### PR TITLE
[`refurb`] Implement `redundant-continue` (FURB133)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB133.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB133.py
@@ -1,0 +1,69 @@
+# Error
+
+def continue_at_end_of_while():
+    while True:
+        pass
+
+        continue
+
+def continue_at_end_of_for_loop():
+    for _ in range(10):
+        pass
+
+        continue
+
+def continue_at_end_of_else_block():
+    for x in range(10):
+        if x:
+            pass
+
+        else:
+            continue
+
+def continue_in_match():
+    for x in range(10):
+        match x:
+            case 1:
+                pass
+
+                continue
+
+            case 2:
+                pass
+
+                continue
+
+            case _:
+                continue
+
+def continue_in_with_block():
+    while True:
+        with open("file.txt") as f:
+            continue
+
+
+# OK
+
+def continue_in_match_with_trailing_stmt():
+    for x in range(10):
+        match x:
+            case 1:
+                continue
+
+            case _:
+                continue
+
+        pass
+
+def continue_match_with_single_continue():
+    for x in range(10):
+        match x:
+            case 1:
+                continue
+
+            case 2:
+                pass
+
+def while_loop_with_just_a_continue():
+    while True:
+        continue

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -914,7 +914,10 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 flake8_logging::rules::exception_without_exc_info(checker, call);
             }
             if checker.enabled(Rule::ImplicitCwd) {
-                refurb::rules::no_implicit_cwd(checker, call);
+                refurb::rules::implicit_cwd(checker, call);
+            }
+            if checker.enabled(Rule::RedundantContinue) {
+                refurb::rules::redundant_continue(checker, call);
             }
         }
         Expr::Dict(

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -922,6 +922,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Refurb, "131") => (RuleGroup::Nursery, rules::refurb::rules::DeleteFullSlice),
         #[allow(deprecated)]
         (Refurb, "132") => (RuleGroup::Nursery, rules::refurb::rules::CheckAndRemoveFromSet),
+        (Refurb, "133") => (RuleGroup::Preview, rules::refurb::rules::RedundantContinue),
         (Refurb, "140") => (RuleGroup::Preview, rules::refurb::rules::ReimplementedStarmap),
         (Refurb, "145") => (RuleGroup::Preview, rules::refurb::rules::SliceCopy),
         (Refurb, "148") => (RuleGroup::Preview, rules::refurb::rules::UnnecessaryEnumerate),

--- a/crates/ruff_linter/src/rules/refurb/mod.rs
+++ b/crates/ruff_linter/src/rules/refurb/mod.rs
@@ -22,6 +22,7 @@ mod tests {
     #[test_case(Rule::UnnecessaryEnumerate, Path::new("FURB148.py"))]
     #[test_case(Rule::PrintEmptyString, Path::new("FURB105.py"))]
     #[test_case(Rule::ImplicitCwd, Path::new("FURB177.py"))]
+    #[test_case(Rule::RedundantContinue, Path::new("FURB133.py"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
@@ -36,7 +36,7 @@ impl Violation for ImplicitCwd {
 }
 
 /// FURB177
-pub(crate) fn no_implicit_cwd(checker: &mut Checker, call: &ExprCall) {
+pub(crate) fn implicit_cwd(checker: &mut Checker, call: &ExprCall) {
     if !call.arguments.is_empty() {
         return;
     }

--- a/crates/ruff_linter/src/rules/refurb/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/mod.rs
@@ -6,6 +6,7 @@ pub(crate) use reimplemented_starmap::*;
 pub(crate) use repeated_append::*;
 pub(crate) use slice_copy::*;
 pub(crate) use unnecessary_enumerate::*;
+pub(crate) use redundant_continue::*;
 
 mod check_and_remove_from_set;
 mod delete_full_slice;
@@ -15,3 +16,4 @@ mod reimplemented_starmap;
 mod repeated_append;
 mod slice_copy;
 mod unnecessary_enumerate;
+mod redundant_continue;

--- a/crates/ruff_linter/src/rules/refurb/rules/redundant_continue.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/redundant_continue.rs
@@ -1,0 +1,46 @@
+use ruff_diagnostics::{Diagnostic, Edit, Fix, Violation};
+use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::{self as ast, Constant, Expr, ExprAttribute, ExprCall};
+use ruff_text_size::Ranged;
+
+use crate::{checkers::ast::Checker, importer::ImportRequest, registry::AsRule};
+
+/// ## What it does
+/// TODO
+///
+/// ## Why is this bad?
+/// TODO
+/// 
+///
+/// ## Example
+/// ```python
+/// def func():
+///     while True:
+///         pass
+///
+///         continue
+/// ```
+///
+/// Use instead:
+/// ```python
+/// def func():
+///     while True:
+///         pass
+/// ```
+///
+/// ## References
+/// - [Python documentation: `continue`](https://docs.python.org/3/reference/simple_stmts.html#continue)
+
+#[violation]
+pub struct ImplicitCwd;
+
+impl Violation for ImplicitCwd {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Don't explicitly continue if you are already at the end of the control flow")
+    }
+}
+
+
+/// FURB133
+pub(crate) fn no_redundant_continue(checker: &mut Checker, continue_stmt: &ast::Continue) {}


### PR DESCRIPTION
## Summary

Implement [`no-redundant-continue`](https://github.com/dosisod/refurb/blob/master/docs/checks.md#furb133-no-redundant-continue) as `redundant-continue`

Related to #1348.

## Test Plan

`cargo test`
