### PR TITLE
Decrease PEP 593 error to a debug warning

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -29,7 +29,7 @@
 use std::path::Path;
 
 use itertools::Itertools;
-use log::error;
+use log::debug;
 use ruff_python_ast::{
     self as ast, Arguments, Comprehension, Constant, ElifElseClause, ExceptHandler, Expr,
     ExprContext, Keyword, MatchCase, Parameter, ParameterWithDefault, Parameters, Pattern, Stmt,
@@ -1176,7 +1176,7 @@ where
                                     self.visit_expr_context(ctx);
                                 }
                             } else {
-                                error!("Found non-Expr::Tuple argument to PEP 593 Annotation.");
+                                debug!("Found non-Expr::Tuple argument to PEP 593 Annotation.");
                             }
                         }
                         None => {


### PR DESCRIPTION
## Summary

There's no way for users to fix this warning if they're intentionally using an "invalid" PEP 593 annotation, as is the case in CPython. This is a symptom of having warnings that aren't themselves diagnostics. If we want this to be user-facing, we should add a diagnostic for it!

## Test Plan

Ran `cargo run -p ruff_cli -- check foo.py -n` on:

```python
from typing import Annotated

Annotated[int]
```
