### PR TITLE
Slice source code instead of generating it for `EM` fixes

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_errmsg/EM.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_errmsg/EM.py
@@ -58,3 +58,33 @@ def f_fix_indentation_check(foo):
 # Report these, but don't fix them
 if foo: raise RuntimeError("This is an example exception")
 if foo: x = 1; raise RuntimeError("This is an example exception")
+
+
+def f_triple_quoted_string():
+    raise RuntimeError(f"""This is an {"example"} exception""")
+
+
+def f_multi_line_string():
+    raise RuntimeError(
+        "first"
+        "second"
+    )
+
+
+def f_multi_line_string2():
+    raise RuntimeError(
+        "This is an {example} exception".format(
+            example="example"
+        )
+    )
+
+
+def f_multi_line_string2():
+    raise RuntimeError(
+        (
+            "This is an "
+            "{example} exception"
+        ).format(
+            example="example"
+        )
+    )

--- a/crates/ruff_linter/src/rules/flake8_errmsg/snapshots/ruff_linter__rules__flake8_errmsg__tests__custom.snap
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/snapshots/ruff_linter__rules__flake8_errmsg__tests__custom.snap
@@ -177,4 +177,86 @@ EM.py:60:35: EM101 Exception must not use a string literal, assign to variable f
    |
    = help: Assign to variable; remove string literal
 
+EM.py:64:24: EM102 [*] Exception must not use an f-string literal, assign to variable first
+   |
+63 | def f_triple_quoted_string():
+64 |     raise RuntimeError(f"""This is an {"example"} exception""")
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EM102
+   |
+   = help: Assign to variable; remove f-string literal
+
+ℹ Unsafe fix
+61 61 | 
+62 62 | 
+63 63 | def f_triple_quoted_string():
+64    |-    raise RuntimeError(f"""This is an {"example"} exception""")
+   64 |+    msg = f"""This is an {"example"} exception"""
+   65 |+    raise RuntimeError(msg)
+65 66 | 
+66 67 | 
+67 68 | def f_multi_line_string():
+
+EM.py:76:9: EM103 [*] Exception must not use a `.format()` string directly, assign to variable first
+   |
+74 |   def f_multi_line_string2():
+75 |       raise RuntimeError(
+76 |           "This is an {example} exception".format(
+   |  _________^
+77 | |             example="example"
+78 | |         )
+   | |_________^ EM103
+79 |       )
+   |
+   = help: Assign to variable; remove `.format()` string
+
+ℹ Unsafe fix
+72 72 | 
+73 73 | 
+74 74 | def f_multi_line_string2():
+75    |-    raise RuntimeError(
+   75 |+    msg = (
+76 76 |         "This is an {example} exception".format(
+77 77 |             example="example"
+78 78 |         )
+79 79 |     )
+   80 |+    raise RuntimeError(
+   81 |+        msg
+   82 |+    )
+80 83 | 
+81 84 | 
+82 85 | def f_multi_line_string2():
+
+EM.py:84:9: EM103 [*] Exception must not use a `.format()` string directly, assign to variable first
+   |
+82 |   def f_multi_line_string2():
+83 |       raise RuntimeError(
+84 |           (
+   |  _________^
+85 | |             "This is an "
+86 | |             "{example} exception"
+87 | |         ).format(
+88 | |             example="example"
+89 | |         )
+   | |_________^ EM103
+90 |       )
+   |
+   = help: Assign to variable; remove `.format()` string
+
+ℹ Unsafe fix
+80 80 | 
+81 81 | 
+82 82 | def f_multi_line_string2():
+83    |-    raise RuntimeError(
+   83 |+    msg = (
+84 84 |         (
+85 85 |             "This is an "
+86 86 |             "{example} exception"
+--------------------------------------------------------------------------------
+88 88 |             example="example"
+89 89 |         )
+90 90 |     )
+   91 |+    raise RuntimeError(
+   92 |+        msg
+   93 |+    )
+
 

--- a/crates/ruff_linter/src/rules/flake8_errmsg/snapshots/ruff_linter__rules__flake8_errmsg__tests__defaults.snap
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/snapshots/ruff_linter__rules__flake8_errmsg__tests__defaults.snap
@@ -215,4 +215,114 @@ EM.py:60:35: EM101 Exception must not use a string literal, assign to variable f
    |
    = help: Assign to variable; remove string literal
 
+EM.py:64:24: EM102 [*] Exception must not use an f-string literal, assign to variable first
+   |
+63 | def f_triple_quoted_string():
+64 |     raise RuntimeError(f"""This is an {"example"} exception""")
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EM102
+   |
+   = help: Assign to variable; remove f-string literal
+
+ℹ Unsafe fix
+61 61 | 
+62 62 | 
+63 63 | def f_triple_quoted_string():
+64    |-    raise RuntimeError(f"""This is an {"example"} exception""")
+   64 |+    msg = f"""This is an {"example"} exception"""
+   65 |+    raise RuntimeError(msg)
+65 66 | 
+66 67 | 
+67 68 | def f_multi_line_string():
+
+EM.py:69:9: EM101 [*] Exception must not use a string literal, assign to variable first
+   |
+67 |   def f_multi_line_string():
+68 |       raise RuntimeError(
+69 |           "first"
+   |  _________^
+70 | |         "second"
+   | |________________^ EM101
+71 |       )
+   |
+   = help: Assign to variable; remove string literal
+
+ℹ Unsafe fix
+65 65 | 
+66 66 | 
+67 67 | def f_multi_line_string():
+68    |-    raise RuntimeError(
+   68 |+    msg = (
+69 69 |         "first"
+70 70 |         "second"
+71 71 |     )
+   72 |+    raise RuntimeError(
+   73 |+        msg
+   74 |+    )
+72 75 | 
+73 76 | 
+74 77 | def f_multi_line_string2():
+
+EM.py:76:9: EM103 [*] Exception must not use a `.format()` string directly, assign to variable first
+   |
+74 |   def f_multi_line_string2():
+75 |       raise RuntimeError(
+76 |           "This is an {example} exception".format(
+   |  _________^
+77 | |             example="example"
+78 | |         )
+   | |_________^ EM103
+79 |       )
+   |
+   = help: Assign to variable; remove `.format()` string
+
+ℹ Unsafe fix
+72 72 | 
+73 73 | 
+74 74 | def f_multi_line_string2():
+75    |-    raise RuntimeError(
+   75 |+    msg = (
+76 76 |         "This is an {example} exception".format(
+77 77 |             example="example"
+78 78 |         )
+79 79 |     )
+   80 |+    raise RuntimeError(
+   81 |+        msg
+   82 |+    )
+80 83 | 
+81 84 | 
+82 85 | def f_multi_line_string2():
+
+EM.py:84:9: EM103 [*] Exception must not use a `.format()` string directly, assign to variable first
+   |
+82 |   def f_multi_line_string2():
+83 |       raise RuntimeError(
+84 |           (
+   |  _________^
+85 | |             "This is an "
+86 | |             "{example} exception"
+87 | |         ).format(
+88 | |             example="example"
+89 | |         )
+   | |_________^ EM103
+90 |       )
+   |
+   = help: Assign to variable; remove `.format()` string
+
+ℹ Unsafe fix
+80 80 | 
+81 81 | 
+82 82 | def f_multi_line_string2():
+83    |-    raise RuntimeError(
+   83 |+    msg = (
+84 84 |         (
+85 85 |             "This is an "
+86 86 |             "{example} exception"
+--------------------------------------------------------------------------------
+88 88 |             example="example"
+89 89 |         )
+90 90 |     )
+   91 |+    raise RuntimeError(
+   92 |+        msg
+   93 |+    )
+
 


### PR DESCRIPTION
## Summary

This PR fixes the bug where the generated fix for `EM*` rules would replace a
triple-quoted (f-)string with a single-quoted (f-)string. This changes the
semantic of the string in case it contains a single-quoted string literal. This
is especially evident with f-strings where the expression could contain another
string within it. For example,

```python
f"""normal {"another"} normal"""
```

## Test Plan

Add test case for triple-quoted string and update the snapshots.

fixes: #6988
fixes: #7736
