### PR TITLE
Require documentation for all lint rules

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -4,11 +4,11 @@
 /// `--select`. For pylint this is e.g. C0414 and E0118 but also C and E01.
 use std::fmt::Formatter;
 
-use strum_macros::{AsRefStr, EnumIter};
-
 use crate::registry::{AsRule, Linter};
 use crate::rule_selector::is_single_rule_selector;
 use crate::rules;
+
+use strum_macros::{AsRefStr, EnumIter};
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct NoqaCode(&'static str, &'static str);

--- a/crates/ruff_linter/src/registry.rs
+++ b/crates/ruff_linter/src/registry.rs
@@ -427,7 +427,18 @@ mod tests {
     use super::{Linter, Rule, RuleNamespace};
 
     #[test]
-    fn test_rule_naming_convention() {
+    fn documentation() {
+        for rule in Rule::iter() {
+            assert!(
+                rule.explanation().is_some(),
+                "Rule {} is missing documentation",
+                rule.as_ref()
+            );
+        }
+    }
+
+    #[test]
+    fn rule_naming_convention() {
         // The disallowed rule names are defined in a separate file so that they can also be picked up by add_rule.py.
         let patterns: Vec<_> = include_str!("../resources/test/disallowed_rule_names.txt")
             .trim()
@@ -459,7 +470,7 @@ mod tests {
     }
 
     #[test]
-    fn test_linter_parse_code() {
+    fn linter_parse_code() {
         for rule in Rule::iter() {
             let code = format!("{}", rule.noqa_code());
             let (linter, rest) =

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -416,6 +416,8 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a Rule>) -> TokenStream {
     }
 
     quote! {
+        use ruff_diagnostics::Violation;
+
         #[derive(
             EnumIter,
             Debug,


### PR DESCRIPTION
## Summary

Now that all rules have documentation, we can enforce the requirement in our tests.