### PR TITLE
Re-add formatter to GitHub release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,7 +4,6 @@ changelog:
     labels:
       - internal
       - documentation
-      - formatter
   categories:
     - title: Breaking Changes
       labels:
@@ -19,6 +18,9 @@ changelog:
     - title: Bug Fixes
       labels:
         - bug
+    - title: Formatter
+      labels:
+        - formatter
     - title: Preview
       labels:
         - preview


### PR DESCRIPTION
We may choose to omit these manually, but we probably want to include _some_ of them, so it's annoying for them to be filtered out.