### PR TITLE
Upgrade LibCST to support Python 3.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,8 +1260,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 [[package]]
 name = "libcst"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7773d520d4292e200ab1838f2daabe2feed7549f93b0a3c7582160a09e79ffde"
+source = "git+https://github.com/Instagram/LibCST.git?rev=03179b55ebe7e916f1722e18e8f0b87c01616d1f#03179b55ebe7e916f1722e18e8f0b87c01616d1f"
 dependencies = [
  "chic",
  "libcst_derive",
@@ -1275,8 +1274,7 @@ dependencies = [
 [[package]]
 name = "libcst_derive"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520197c50ba477f258cd7005ec5ed3a7393693ae6bec664990c7c8d9306a7c0d"
+source = "git+https://github.com/Instagram/LibCST.git?rev=03179b55ebe7e916f1722e18e8f0b87c01616d1f#03179b55ebe7e916f1722e18e8f0b87c01616d1f"
 dependencies = [
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,7 @@ unicode-width = "0.1.11"
 uuid = { version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics", "js"] }
 wsl = { version = "0.1.0" }
 
-# v1.0.1
-libcst = { version = "0.1.0", default-features = false }
+libcst = { git = "https://github.com/Instagram/LibCST.git", rev = "03179b55ebe7e916f1722e18e8f0b87c01616d1f", default-features = false }
 
 [profile.release]
 lto = "fat"

--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM117.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM117.py
@@ -121,3 +121,16 @@ async with b as b2:
     with c as c2:
         async with d as d2:
             f(b2, c2, d2)
+
+# SIM117
+with A() as a:
+    with B() as b:
+        type ListOrSet[T] = list[T] | set[T]
+
+        class ClassA[T: str]:
+            def method1(self) -> T:
+                ...
+
+        f" something { my_dict["key"] } something else "
+
+        f"foo {f"bar {x}"} baz"

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM117_SIM117.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM117_SIM117.py.snap
@@ -284,4 +284,37 @@ SIM117.py:106:5: SIM117 Use a single `with` statement with multiple contexts ins
     |
     = help: Combine `with` statements
 
+SIM117.py:126:1: SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
+    |
+125 |   # SIM117
+126 | / with A() as a:
+127 | |     with B() as b:
+    | |__________________^ SIM117
+128 |           type ListOrSet[T] = list[T] | set[T]
+    |
+    = help: Combine `with` statements
+
+ℹ Suggested fix
+123 123 |             f(b2, c2, d2)
+124 124 | 
+125 125 | # SIM117
+126     |-with A() as a:
+127     |-    with B() as b:
+128     |-        type ListOrSet[T] = list[T] | set[T]
+    126 |+with A() as a, B() as b:
+    127 |+    type ListOrSet[T] = list[T] | set[T]
+129 128 | 
+130     |-        class ClassA[T: str]:
+131     |-            def method1(self) -> T:
+132     |-                ...
+    129 |+    class ClassA[T: str]:
+    130 |+        def method1(self) -> T:
+    131 |+            ...
+133 132 | 
+134     |-        f" something { my_dict["key"] } something else "
+    133 |+    f" something { my_dict["key"] } something else "
+135 134 | 
+136     |-        f"foo {f"bar {x}"} baz"
+    135 |+    f"foo {f"bar {x}"} baz"
+
 


### PR DESCRIPTION
## Summary

We'll revert back to the crates.io release once it's up-to-date, but better to get this out now that Python 3.12 is released. 

## Test Plan

`cargo test`
