### PR TITLE
crlf -> cr-lf in docs

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2557,7 +2557,7 @@ pub struct FormatOptions {
     /// * `native`: Line endings will be converted to `\n` on Unix and `\r\n` on Windows.
     #[option(
         default = r#"lf"#,
-        value_type = r#""lf" | "crlf" | "auto" | "native""#,
+        value_type = r#""lf" | "cr-lf" | "auto" | "native""#,
         example = r#"
             # Automatically detect the line ending on a file per file basis.
             line-ending = "auto"


### PR DESCRIPTION
## Summary
This change fixes an error in the documentation where cr-lf was displayed as crlf which if you tried to enter into the configuration file running ruff would break. 

## Test Plan
I ran the tests locally and I ran the documentation server locally and verified the edit 

### [Documentation Site](https://docs.astral.sh/ruff/settings/#format-line-ending)
![image](https://github.com/astral-sh/ruff/assets/50351006/8e63e49c-63ff-4027-a583-537c710e1305)

### Local
![image](https://github.com/astral-sh/ruff/assets/50351006/8845a235-8b2c-4157-99c8-908ee8f039b3)
