### PR TITLE
Fix documented examples for `unnecessary-subscript-reversal`

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -680,9 +680,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 );
             }
             if checker.enabled(Rule::UnnecessarySubscriptReversal) {
-                flake8_comprehensions::rules::unnecessary_subscript_reversal(
-                    checker, expr, func, args,
-                );
+                flake8_comprehensions::rules::unnecessary_subscript_reversal(checker, call);
             }
             if checker.enabled(Rule::UnnecessaryMap) {
                 flake8_comprehensions::rules::unnecessary_map(

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
@@ -15,16 +15,16 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Examples
 /// ```python
-/// reversed(iterable[::-1])
+/// sorted(iterable[::-1])
 /// set(iterable[::-1])
-/// sorted(iterable)[::-1]
+/// reversed(iterable[::-1])
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// reversed(iterable)
+/// sorted(iterable)
 /// set(iterable)
-/// sorted(iterable, reverse=True)
+/// iterable
 /// ```
 #[violation]
 pub struct UnnecessarySubscriptReversal {
@@ -40,16 +40,11 @@ impl Violation for UnnecessarySubscriptReversal {
 }
 
 /// C415
-pub(crate) fn unnecessary_subscript_reversal(
-    checker: &mut Checker,
-    expr: &Expr,
-    func: &Expr,
-    args: &[Expr],
-) {
-    let Some(first_arg) = args.first() else {
+pub(crate) fn unnecessary_subscript_reversal(checker: &mut Checker, call: &ast::ExprCall) {
+    let Some(first_arg) = call.arguments.args.first() else {
         return;
     };
-    let Some(func) = func.as_name_expr() else {
+    let Some(func) = call.func.as_name_expr() else {
         return;
     };
     if !matches!(func.id.as_str(), "reversed" | "set" | "sorted") {
@@ -98,6 +93,6 @@ pub(crate) fn unnecessary_subscript_reversal(
         UnnecessarySubscriptReversal {
             func: func.id.to_string(),
         },
-        expr.range(),
+        call.range(),
     ));
 }


### PR DESCRIPTION
## Summary

Two of the three listed examples were wrong: one was semantically incorrect, another was _correct_ but not actually within the scope of the rule.

Good motivation for us to start linting documentation examples :)

Closes https://github.com/astral-sh/ruff/issues/7773.
