### PR TITLE
Respect `msgspec.Struct` default-copy semantics

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF012.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF012.py
@@ -37,3 +37,14 @@ class D(BaseModel):
     without_annotation = []
     class_variable: ClassVar[list[int]] = []
     final_variable: Final[list[int]] = []
+
+
+from msgspec import Struct
+
+
+class E(Struct):
+    mutable_default: list[int] = []
+    immutable_annotation: Sequence[int] = []
+    without_annotation = []
+    class_variable: ClassVar[list[int]] = []
+    final_variable: Final[list[int]] = []

--- a/crates/ruff_linter/src/rules/ruff/rules/mutable_class_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/mutable_class_default.rs
@@ -7,7 +7,7 @@ use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
 use crate::rules::ruff::rules::helpers::{
-    is_class_var_annotation, is_dataclass, is_final_annotation, is_pydantic_model,
+    has_default_copy_semantics, is_class_var_annotation, is_dataclass, is_final_annotation,
     is_special_attribute,
 };
 
@@ -64,8 +64,8 @@ pub(crate) fn mutable_class_default(checker: &mut Checker, class_def: &ast::Stmt
                     && !is_immutable_annotation(annotation, checker.semantic(), &[])
                     && !is_dataclass(class_def, checker.semantic())
                 {
-                    // Avoid Pydantic models, which end up copying defaults on instance creation.
-                    if is_pydantic_model(class_def, checker.semantic()) {
+                    // Avoid, e.g., Pydantic and msgspec models, which end up copying defaults on instance creation.
+                    if has_default_copy_semantics(class_def, checker.semantic()) {
                         return;
                     }
 
@@ -78,8 +78,8 @@ pub(crate) fn mutable_class_default(checker: &mut Checker, class_def: &ast::Stmt
                 if !targets.iter().all(is_special_attribute)
                     && is_mutable_expr(value, checker.semantic())
                 {
-                    // Avoid Pydantic models, which end up copying defaults on instance creation.
-                    if is_pydantic_model(class_def, checker.semantic()) {
+                    // Avoid, e.g., Pydantic and msgspec models, which end up copying defaults on instance creation.
+                    if has_default_copy_semantics(class_def, checker.semantic()) {
                         return;
                     }
 


### PR DESCRIPTION
## Summary

The carve-out we have in `RUF012` for Pydantic classes also applies to `msgspec.Struct`.

Closes https://github.com/astral-sh/ruff/issues/7785.
