### PR TITLE
Show changed files when running under `--check`

### DIFF
--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -41,13 +41,13 @@ impl Default for SourceType {
     }
 }
 
-impl From<&Path> for SourceType {
-    fn from(path: &Path) -> Self {
-        match path.file_name() {
+impl<P: AsRef<Path>> From<P> for SourceType {
+    fn from(path: P) -> Self {
+        match path.as_ref().file_name() {
             Some(filename) if filename == "pyproject.toml" => Self::Toml(TomlSourceType::Pyproject),
             Some(filename) if filename == "Pipfile" => Self::Toml(TomlSourceType::Pipfile),
             Some(filename) if filename == "poetry.lock" => Self::Toml(TomlSourceType::Poetry),
-            _ => match path.extension() {
+            _ => match path.as_ref().extension() {
                 Some(ext) if ext == "toml" => Self::Toml(TomlSourceType::Unrecognized),
                 _ => Self::Python(PySourceType::from(path)),
             },
@@ -79,9 +79,9 @@ pub enum PySourceType {
     Ipynb,
 }
 
-impl From<&Path> for PySourceType {
-    fn from(path: &Path) -> Self {
-        match path.extension() {
+impl<P: AsRef<Path>> From<P> for PySourceType {
+    fn from(path: P) -> Self {
+        match path.as_ref().extension() {
             Some(ext) if ext == "py" => PySourceType::Python,
             Some(ext) if ext == "pyi" => PySourceType::Stub,
             Some(ext) if ext == "ipynb" => PySourceType::Ipynb,


### PR DESCRIPTION
## Summary

We now list each changed file when running with `--check`.

Closes https://github.com/astral-sh/ruff/issues/7782.

## Test Plan

```
❯ cargo run -p ruff_cli -- format foo.py --check
   Compiling ruff_cli v0.0.292 (/Users/crmarsh/workspace/ruff/crates/ruff_cli)
rgo +    Finished dev [unoptimized + debuginfo] target(s) in 1.41s
     Running `target/debug/ruff format foo.py --check`
warning: `ruff format` is a work-in-progress, subject to change at any time, and intended only for experimentation.
Would reformat: foo.py
1 file would be reformatted
```
