### PR TITLE
Update fix summary message in `check --diff` to include unsafe fix hints

### DIFF
--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -177,7 +177,11 @@ impl Printer {
                             writeln!(writer, "Would fix {fixed} error{s} ({unapplied} additional fix{es} available with `--unsafe-fixes`).")?;
                         }
                     } else {
-                        writeln!(writer, "No errors fixed ({unapplied} fix{es} available with `--unsafe-fixes`).")?;
+                        if self.fix_mode.is_apply() {
+                            writeln!(writer, "No errors fixed ({unapplied} fix{es} available with `--unsafe-fixes`).")?;
+                        } else {
+                            writeln!(writer, "No errors would be fixed ({unapplied} fix{es} available with `--unsafe-fixes`).")?;
+                        }
                     }
                 } else {
                     if fixed > 0 {

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -169,17 +169,15 @@ impl Printer {
 
                 if unapplied > 0 {
                     let es = if unapplied == 1 { "" } else { "es" };
-                    let omitted =
-                        format!("({unapplied} additional fix{es} available with `--unsafe-fixes`)");
                     if fixed > 0 {
                         let s = if fixed == 1 { "" } else { "s" };
                         if self.fix_mode.is_apply() {
-                            writeln!(writer, "Fixed {fixed} error{s} {omitted}.")?;
+                            writeln!(writer, "Fixed {fixed} error{s} ({unapplied} additional fix{es} available with `--unsafe-fixes`).")?;
                         } else {
-                            writeln!(writer, "Would fix {fixed} error{s} {omitted}.")?;
+                            writeln!(writer, "Would fix {fixed} error{s} ({unapplied} additional fix{es} available with `--unsafe-fixes`).")?;
                         }
                     } else {
-                        writeln!(writer, "No errors fixed {omitted}.")?;
+                        writeln!(writer, "No errors fixed ({unapplied} fix{es} available with `--unsafe-fixes`).")?;
                     }
                 } else {
                     if fixed > 0 {

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -1022,7 +1022,7 @@ fn fix_only_flag_applies_safe_fixes_by_default() {
     print('foo')
 
     ----- stderr -----
-    Fixed 1 error.
+    Fixed 1 error (1 additional fix available with `--unsafe-fixes`).
     "###);
 }
 
@@ -1080,7 +1080,7 @@ fn diff_shows_safe_fixes_by_default() {
 
 
     ----- stderr -----
-    Would fix 1 error.
+    Would fix 1 error (1 additional fix available with `--unsafe-fixes`).
     "###
     );
 }

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -1000,6 +1000,35 @@ fn fix_applies_unsafe_fixes_with_opt_in() {
 }
 
 #[test]
+fn fix_only_unsafe_fixes_available() {
+    assert_cmd_snapshot!(
+        Command::new(get_cargo_bin(BIN_NAME))
+            .args([
+                "-",
+                "--output-format",
+                "text",
+                "--isolated",
+                "--no-cache", 
+                "--select",
+                "F601",
+                "--fix",
+            ])
+            .pass_stdin("x = {'a': 1, 'a': 1}\nprint(('foo'))\n"),
+            @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    x = {'a': 1, 'a': 1}
+    print(('foo'))
+
+    ----- stderr -----
+    -:1:14: F601 Dictionary key literal `'a'` repeated
+    Found 1 error.
+    1 hidden fix can be enabled with the `--unsafe-fixes` option.
+    "###);
+}
+
+#[test]
 fn fix_only_flag_applies_safe_fixes_by_default() {
     assert_cmd_snapshot!(
         Command::new(get_cargo_bin(BIN_NAME))
@@ -1114,6 +1143,32 @@ fn diff_shows_unsafe_fixes_with_opt_in() {
 
     ----- stderr -----
     Would fix 2 errors.
+    "###
+    );
+}
+
+#[test]
+fn diff_only_unsafe_fixes_available() {
+    assert_cmd_snapshot!(
+    Command::new(get_cargo_bin(BIN_NAME))
+        .args([
+            "-",
+            "--output-format",
+            "text",
+            "--isolated",
+            "--no-cache",
+            "--select",
+            "F601",
+            "--diff",
+        ])
+        .pass_stdin("x = {'a': 1, 'a': 1}\nprint(('foo'))\n"),
+        @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    No errors would be fixed (1 fix available with `--unsafe-fixes`).
     "###
     );
 }


### PR DESCRIPTION
Requires #7769 

Updates the CLI display for `ruff check --fix` to hint availability of unsafe fixes.

 ```
❯ ruff check example.py --select F601,T201 --diff --no-cache
No errors fixed (1 fix available with `--unsafe-fixes`).
```

```
❯ ruff check example.py --select F601,T201,W292 --diff --no-cache
--- example.py
+++ example.py
@@ -1,2 +1,2 @@
 x = {'a': 1, 'a': 1}
-print(('foo'))
+print(('foo'))
\ No newline at end of file

Would fix 1 error (1 additional fix available with `--unsafe-fixes`).
```
```
❯ ruff check example.py --select F601,T201,W292 --diff --no-cache --unsafe-fixes
--- example.py
+++ example.py
@@ -1,2 +1,2 @@
-x = {'a': 1}
-print(('foo'))
+x = {'a': 1, 'a': 1}
+print(('foo'))
\ No newline at end of file

Would fix 2 errors.
```