### PR TITLE
Remove `Applicability::Unspecified` and associated helpers

### DIFF
--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -9,17 +9,13 @@ use crate::edit::Edit;
 /// of enum values based on their order (see Rust's [enum
 /// documentation](https://doc.rust-lang.org/reference/items/enumerations.html)). This allows us to
 /// apply [`Fix`]es based on their [`Applicability`].
-#[derive(Default, Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Applicability {
     /// The fix has a good chance of being incorrect or the code be incomplete.
     /// The fix may result in invalid code if it is applied.
     /// The fix should only be manually applied by the user.
     Manual,
-
-    /// The applicability of the fix is unknown or not relevant.
-    #[default]
-    Unspecified,
 
     /// The fix may be what the user intended, but it is uncertain.
     /// The fix should result in valid code if it is applied.
@@ -36,7 +32,7 @@ impl Applicability {
         match self {
             Self::Automatic => "*",
             Self::Suggested => "**",
-            _ => "*",
+            Self::Manual => "-",
         }
     }
 }
@@ -65,30 +61,6 @@ pub struct Fix {
 }
 
 impl Fix {
-    /// Create a new [`Fix`] with an unspecified applicability from an [`Edit`] element.
-    #[deprecated(
-        note = "Use `Fix::automatic`, `Fix::suggested`, or `Fix::manual` instead to specify an applicability."
-    )]
-    pub fn unspecified(edit: Edit) -> Self {
-        Self {
-            edits: vec![edit],
-            applicability: Applicability::Unspecified,
-            isolation_level: IsolationLevel::default(),
-        }
-    }
-
-    /// Create a new [`Fix`] with an unspecified applicability from multiple [`Edit`] elements.
-    #[deprecated(
-        note = "Use `Fix::automatic_edits`, `Fix::suggested_edits`, or `Fix::manual_edits` instead to specify an applicability."
-    )]
-    pub fn unspecified_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
-        Self {
-            edits: std::iter::once(edit).chain(rest).collect(),
-            applicability: Applicability::Unspecified,
-            isolation_level: IsolationLevel::default(),
-        }
-    }
-
     /// Create a new [`Fix`] with [automatic applicability](Applicability::Automatic) from an [`Edit`] element.
     pub fn automatic(edit: Edit) -> Self {
         Self {

--- a/crates/ruff_linter/src/fix/mod.rs
+++ b/crates/ruff_linter/src/fix/mod.rs
@@ -160,14 +160,13 @@ mod tests {
     use crate::fix::{apply_fixes, FixResult};
     use crate::rules::pycodestyle::rules::MissingNewlineAtEndOfFile;
 
-    #[allow(deprecated)]
     fn create_diagnostics(edit: impl IntoIterator<Item = Edit>) -> Vec<Diagnostic> {
         edit.into_iter()
             .map(|edit| Diagnostic {
-                // The choice of rule here is arbitrary.
+                // The choice of rule and fix applicability here is arbitarary
                 kind: MissingNewlineAtEndOfFile.into(),
                 range: edit.range(),
-                fix: Some(Fix::unspecified(edit)),
+                fix: Some(Fix::automatic(edit)),
                 parent: None,
             })
             .collect()

--- a/crates/ruff_linter/src/message/diff.rs
+++ b/crates/ruff_linter/src/message/diff.rs
@@ -55,7 +55,6 @@ impl Display for Diff<'_> {
             Applicability::Automatic => "Fix",
             Applicability::Suggested => "Suggested fix",
             Applicability::Manual => "Possible fix",
-            Applicability::Unspecified => "Suggested fix", /* For backwards compatibility, unspecified fixes are 'suggested' */
         };
         writeln!(f, "ℹ {}", message.blue())?;
 


### PR DESCRIPTION
Based on #7769

Removes the deprecated applicability level and helpers that were used to ease transitioning.