### PR TITLE
Fix issues with SIM101 (adjacent isinstance() calls)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM101.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM101.py
@@ -31,6 +31,15 @@ if isinstance(a, bool) or isinstance(b, str):
 if isinstance(a, int) or isinstance(a.b, float):
     pass
 
+# OK
+if isinstance(a, int) or unrelated_condition or isinstance(a, float):
+    pass
+
+if x or isinstance(a, int) or isinstance(a, float):
+    pass
+
+if x or y or isinstance(a, int) or isinstance(a, float) or z:
+    pass
 
 def f():
     # OK

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -351,7 +351,7 @@ pub(crate) fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
     let mut duplicates: Vec<Vec<usize>> = Vec::new();
     let mut last_target_option: Option<ComparableExpr> = None;
     for (index, call) in values.iter().enumerate() {
-        let Some(target) = isinstance_target(&call, checker.semantic()) else {
+        let Some(target) = isinstance_target(call, checker.semantic()) else {
             last_target_option = None;
             continue;
         };

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -364,7 +364,6 @@ pub(crate) fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
         last_target_option = Some(target.into());
         duplicates.push(vec![index]);
     }
-    println!("{:?}", duplicates);
 
     // Generate a `Diagnostic` for each duplicate.
     for indices in duplicates {
@@ -444,13 +443,13 @@ pub(crate) fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
 
                     // Generate the combined `BoolOp`.
                     let before = values.iter().take(indices[0]).map(Clone::clone);
-                    let after = values.iter().skip(indices[indices.len() - 1] + 1).map(Clone::clone);
+                    let after = values
+                        .iter()
+                        .skip(indices[indices.len() - 1] + 1)
+                        .map(Clone::clone);
                     let node = ast::ExprBoolOp {
                         op: BoolOp::Or,
-                        values: before
-                            .chain(iter::once(call))
-                            .chain(after)
-                            .collect(),
+                        values: before.chain(iter::once(call)).chain(after).collect(),
                         range: TextRange::default(),
                     };
                     let bool_op = node.into();

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -443,8 +443,11 @@ pub(crate) fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
                     let call = node2.into();
 
                     // Generate the combined `BoolOp`.
-                    let before = values.iter().take(indices[0]).cloned();
-                    let after = values.iter().skip(indices[indices.len() - 1] + 1).cloned();
+                    let [first, .., last] = indices.as_slice() else {
+                        unreachable!("Indices should have at least two elements")
+                    };
+                    let before = values.iter().take(*first).cloned();
+                    let after = values.iter().skip(last + 1).cloned();
                     let node = ast::ExprBoolOp {
                         op: BoolOp::Or,
                         values: before.chain(iter::once(call)).chain(after).collect(),

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM101_SIM101.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM101_SIM101.py.snap
@@ -71,30 +71,10 @@ SIM101.py:10:4: SIM101 [*] Multiple `isinstance` calls for `a`, merge into a sin
 8  8  |     pass
 9  9  | 
 10    |-if isinstance(b, bool) or isinstance(a, int) or isinstance(a, float):  # SIM101
-   10 |+if isinstance(a, (int, float)) or isinstance(b, bool):  # SIM101
+   10 |+if isinstance(b, bool) or isinstance(a, (int, float)):  # SIM101
 11 11 |     pass
 12 12 | 
 13 13 | if isinstance(a, int) or isinstance(b, bool) or isinstance(a, float):  # SIM101
-
-SIM101.py:13:4: SIM101 [*] Multiple `isinstance` calls for `a`, merge into a single call
-   |
-11 |     pass
-12 | 
-13 | if isinstance(a, int) or isinstance(b, bool) or isinstance(a, float):  # SIM101
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM101
-14 |     pass
-   |
-   = help: Merge `isinstance` calls for `a`
-
-ℹ Suggested fix
-10 10 | if isinstance(b, bool) or isinstance(a, int) or isinstance(a, float):  # SIM101
-11 11 |     pass
-12 12 | 
-13    |-if isinstance(a, int) or isinstance(b, bool) or isinstance(a, float):  # SIM101
-   13 |+if isinstance(a, (int, float)) or isinstance(b, bool):  # SIM101
-14 14 |     pass
-15 15 | 
-16 16 | if (isinstance(a, int) or isinstance(a, float)) and isinstance(b, bool):  # SIM101
 
 SIM101.py:16:5: SIM101 [*] Multiple `isinstance` calls for `a`, merge into a single call
    |
@@ -145,5 +125,45 @@ SIM101.py:22:4: SIM101 Multiple `isinstance` calls for expression, merge into a 
 23 |     pass
    |
    = help: Merge `isinstance` calls
+
+SIM101.py:38:4: SIM101 [*] Multiple `isinstance` calls for `a`, merge into a single call
+   |
+36 |     pass
+37 | 
+38 | if x or isinstance(a, int) or isinstance(a, float):
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM101
+39 |     pass
+   |
+   = help: Merge `isinstance` calls for `a`
+
+ℹ Suggested fix
+35 35 | if isinstance(a, int) or unrelated_condition or isinstance(a, float):
+36 36 |     pass
+37 37 | 
+38    |-if x or isinstance(a, int) or isinstance(a, float):
+   38 |+if x or isinstance(a, (int, float)):
+39 39 |     pass
+40 40 | 
+41 41 | if x or y or isinstance(a, int) or isinstance(a, float) or z:
+
+SIM101.py:41:4: SIM101 [*] Multiple `isinstance` calls for `a`, merge into a single call
+   |
+39 |     pass
+40 | 
+41 | if x or y or isinstance(a, int) or isinstance(a, float) or z:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM101
+42 |     pass
+   |
+   = help: Merge `isinstance` calls for `a`
+
+ℹ Suggested fix
+38 38 | if x or isinstance(a, int) or isinstance(a, float):
+39 39 |     pass
+40 40 | 
+41    |-if x or y or isinstance(a, int) or isinstance(a, float) or z:
+   41 |+if x or y or isinstance(a, (int, float)) or z:
+42 42 |     pass
+43 43 | 
+44 44 | def f():
 
 


### PR DESCRIPTION
- Only trigger for immediately adjacent isinstance() calls with the same target
- Preserve order of or conditions

Two existing tests changed:
- One was incorrectly reordering the or conditions, and is now correct.
- Another was combining two non-adjacent isinstance() calls. It's safe enough in that example,
  but this isn't safe to do in general, and it feels low-value to come up with a heuristic for
  when it is safe, so it seems better to not combine the calls in that case.

Fixes https://github.com/astral-sh/ruff/issues/7797