### PR TITLE
Use correct start location for class/function clause header

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_skip/decorators.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_skip/decorators.py
@@ -17,3 +17,16 @@ class Test:
 def test():
     pass
 
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7735
+@decorator1
+@decorator2
+class Foo:  # fmt: skip
+    pass
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7735
+@decorator1
+@decorator2
+def foo():  # fmt: skip
+    pass

--- a/crates/ruff_python_formatter/src/statement/clause.rs
+++ b/crates/ruff_python_formatter/src/statement/clause.rs
@@ -203,15 +203,23 @@ impl<'a> ClauseHeader<'a> {
     fn first_keyword_range(self, source: &str) -> FormatResult<TextRange> {
         match self {
             ClauseHeader::Class(header) => {
-                find_keyword(header.start(), SimpleTokenKind::Class, source)
+                let start_position = header
+                    .decorator_list
+                    .last()
+                    .map_or_else(|| header.start(), Ranged::end);
+                find_keyword(start_position, SimpleTokenKind::Class, source)
             }
             ClauseHeader::Function(header) => {
+                let start_position = header
+                    .decorator_list
+                    .last()
+                    .map_or_else(|| header.start(), Ranged::end);
                 let keyword = if header.is_async {
                     SimpleTokenKind::Async
                 } else {
                     SimpleTokenKind::Def
                 };
-                find_keyword(header.start(), keyword, source)
+                find_keyword(start_position, keyword, source)
             }
             ClauseHeader::If(header) => find_keyword(header.start(), SimpleTokenKind::If, source),
             ClauseHeader::ElifElse(ElifElseClause {

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_skip__decorators.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_skip__decorators.py.snap
@@ -23,6 +23,19 @@ class Test:
 def test():
     pass
 
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7735
+@decorator1
+@decorator2
+class Foo:  # fmt: skip
+    pass
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7735
+@decorator1
+@decorator2
+def foo():  # fmt: skip
+    pass
 ```
 
 ## Output
@@ -42,6 +55,20 @@ class Test:
     list = [1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12], x = some_other_function_call({ "test": "value", "more": "other"}))  # fmt: skip
 # leading class comment
 def test():
+    pass
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7735
+@decorator1
+@decorator2
+class Foo:  # fmt: skip
+    pass
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/7735
+@decorator1
+@decorator2
+def foo():  # fmt: skip
     pass
 ```
 


### PR DESCRIPTION
## Summary

This PR fixes the bug where the formatter would panic if a class/function with
decorators had a suppression comment.

The fix is to use to correct start location to find the `async`/`def`/`class`
keyword when decorators are present which is the end of the last decorator.

## Test Plan

Add test cases for the fix and update the snapshots.
