### PR TITLE
Consider nursery rules to be in-preview for `ruff rule`

### DIFF
--- a/crates/ruff_cli/src/commands/rule.rs
+++ b/crates/ruff_cli/src/commands/rule.rs
@@ -35,7 +35,7 @@ impl<'a> Explanation<'a> {
             message_formats: rule.message_formats(),
             fix,
             explanation: rule.explanation(),
-            preview: rule.is_preview(),
+            preview: rule.is_preview() || rule.is_nursery(),
         }
     }
 }
@@ -61,7 +61,7 @@ fn format_rule_text(rule: Rule) -> String {
         output.push('\n');
     }
 
-    if rule.is_preview() {
+    if rule.is_preview() || rule.is_nursery() {
         output.push_str(
             r#"This rule is in preview and is not stable. The `--preview` flag is required for use."#,
         );


### PR DESCRIPTION
## Summary

We treat these rules as `preview` elsewhere, so adding `preview: false` to the JSON and such seems like an error.

Closes https://github.com/astral-sh/ruff/issues/7804.
