### PR TITLE
Allow f-string modifications in line-shrinking cases

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP032_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP032_0.py
@@ -202,3 +202,8 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 "{}".format(
     1  # comment
 )
+
+
+# The fixed string will exceed the line length, but it's still smaller than the
+# existing line length, so it's fine.
+"<Customer: {}, {}, {}, {}, {}>".format(self.internal_ids, self.external_ids, self.properties, self.tags, self.others)

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -414,13 +414,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                                         pyupgrade::rules::format_literals(checker, call, &summary);
                                     }
                                     if checker.enabled(Rule::FString) {
-                                        pyupgrade::rules::f_strings(
-                                            checker,
-                                            call,
-                                            &summary,
-                                            value,
-                                            checker.settings.line_length,
-                                        );
+                                        pyupgrade::rules::f_strings(checker, call, &summary, value);
                                     }
                                 }
                             }

--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -1,12 +1,14 @@
-use ruff_cache::{CacheKey, CacheKeyHasher};
-use serde::{Deserialize, Serialize};
 use std::error::Error;
 use std::hash::Hasher;
 use std::num::{NonZeroU16, NonZeroU8, ParseIntError};
 use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
 use unicode_width::UnicodeWidthChar;
 
+use ruff_cache::{CacheKey, CacheKeyHasher};
 use ruff_macros::CacheKey;
+use ruff_text_size::TextSize;
 
 /// The length of a line of text that is considered too long.
 ///
@@ -22,6 +24,10 @@ impl LineLength {
     /// Return the numeric value for this [`LineLength`]
     pub fn value(&self) -> u16 {
         self.0.get()
+    }
+
+    pub fn text_len(&self) -> TextSize {
+        TextSize::from(u32::from(self.value()))
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
@@ -5,11 +5,10 @@ use ruff_diagnostics::{FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::{self as ast, Stmt, WithItem};
 use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
-use ruff_source_file::UniversalNewlines;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
-use crate::line_width::LineWidthBuilder;
+use crate::fix::edits::fits;
 use crate::registry::AsRule;
 
 use super::fix_with;
@@ -137,15 +136,15 @@ pub(crate) fn multiple_with_statements(
                     with_stmt,
                 ) {
                     Ok(edit) => {
-                        if edit
-                            .content()
-                            .unwrap_or_default()
-                            .universal_newlines()
-                            .all(|line| {
-                                LineWidthBuilder::new(checker.settings.tab_size).add_str(&line)
-                                    <= checker.settings.line_length
-                            })
-                        {
+                        if edit.content().map_or(true, |content| {
+                            fits(
+                                content,
+                                with_stmt.into(),
+                                checker.locator(),
+                                checker.settings.line_length,
+                                checker.settings.tab_size,
+                            )
+                        }) {
                             diagnostic.set_fix(Fix::suggested(edit));
                         }
                     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -11,12 +11,12 @@ use ruff_python_literal::format::{
     FieldName, FieldNamePart, FieldType, FormatPart, FormatString, FromTemplate,
 };
 use ruff_python_parser::{lexer, Mode, Tok};
-
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
-use crate::line_width::LineLength;
+use crate::fix::edits::fits_or_shrinks;
+
 use crate::registry::AsRule;
 use crate::rules::pyflakes::format::FormatSummary;
 use crate::rules::pyupgrade::helpers::curly_escape;
@@ -306,7 +306,6 @@ pub(crate) fn f_strings(
     call: &ast::ExprCall,
     summary: &FormatSummary,
     template: &Expr,
-    line_length: LineLength,
 ) {
     if summary.has_nested_parts {
         return;
@@ -384,22 +383,6 @@ pub(crate) fn f_strings(
     }
     contents.push_str(checker.locator().slice(TextRange::new(prev_end, end)));
 
-    // Avoid refactors that exceed the line length limit.
-    let col_offset = template.start() - checker.locator().line_start(template.start());
-    if contents.lines().enumerate().any(|(idx, line)| {
-        // If `template` is a multiline string, `col_offset` should only be applied to the first
-        // line:
-        // ```
-        // a = """{}        -> offset = col_offset (= 4)
-        // {}               -> offset = 0
-        // """.format(0, 1) -> offset = 0
-        // ```
-        let offset = if idx == 0 { col_offset.to_usize() } else { 0 };
-        offset + line.chars().count() > line_length.value() as usize
-    }) {
-        return;
-    }
-
     // If necessary, add a space between any leading keyword (`return`, `yield`, `assert`, etc.)
     // and the string. For example, `return"foo"` is valid, but `returnf"foo"` is not.
     let existing = checker.locator().slice(TextRange::up_to(call.start()));
@@ -409,6 +392,17 @@ pub(crate) fn f_strings(
         .is_some_and(|char| char.is_ascii_alphabetic())
     {
         contents.insert(0, ' ');
+    }
+
+    // Avoid refactors that exceed the line length limit.
+    if !fits_or_shrinks(
+        &contents,
+        template.into(),
+        checker.locator(),
+        checker.settings.line_length,
+        checker.settings.tab_size,
+    ) {
+        return;
     }
 
     let mut diagnostic = Diagnostic::new(FString, call.range());

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_0.py.snap
@@ -956,4 +956,20 @@ UP032_0.py:202:1: UP032 Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
+UP032_0.py:209:1: UP032 [*] Use f-string instead of `format` call
+    |
+207 | # The fixed string will exceed the line length, but it's still smaller than the
+208 | # existing line length, so it's fine.
+209 | "<Customer: {}, {}, {}, {}, {}>".format(self.internal_ids, self.external_ids, self.properties, self.tags, self.others)
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP032
+    |
+    = help: Convert to f-string
+
+ℹ Suggested fix
+206 206 | 
+207 207 | # The fixed string will exceed the line length, but it's still smaller than the
+208 208 | # existing line length, so it's fine.
+209     |-"<Customer: {}, {}, {}, {}, {}>".format(self.internal_ids, self.external_ids, self.properties, self.tags, self.others)
+    209 |+f"<Customer: {self.internal_ids}, {self.external_ids}, {self.properties}, {self.tags}, {self.others}>"
+
 


### PR DESCRIPTION
## Summary

This PR resolves an issue raised in https://github.com/astral-sh/ruff/discussions/7810, whereby we don't fix an f-string that exceeds the line length _even if_ the resultant code is _shorter_ than the current code.

As part of this change, I've also refactored and extracted some common logic we use around "ensuring a fix isn't breaking the line length rules".

## Test Plan

`cargo test`
