### PR TITLE
Refactor applicability to use safe and unsafe

### DIFF
--- a/crates/ruff_cli/tests/format.rs
+++ b/crates/ruff_cli/tests/format.rs
@@ -175,7 +175,9 @@ import os
         },
         "filename": "-",
         "fix": {
-          "applicability": "Automatic",
+          "applicability": {
+            "automatic": "safe"
+          },
           "edits": [
             {
               "content": "",

--- a/crates/ruff_cli/tests/snapshots/integration_test__stdin_json.snap
+++ b/crates/ruff_cli/tests/snapshots/integration_test__stdin_json.snap
@@ -24,7 +24,9 @@ exit_code: 1
     },
     "filename": "/path/to/F401.py",
     "fix": {
-      "applicability": "Automatic",
+      "applicability": {
+        "automatic": "safe"
+      },
       "edits": [
         {
           "content": "",

--- a/crates/ruff_diagnostics/src/lib.rs
+++ b/crates/ruff_diagnostics/src/lib.rs
@@ -1,6 +1,6 @@
 pub use diagnostic::{Diagnostic, DiagnosticKind};
 pub use edit::Edit;
-pub use fix::{Applicability, Fix, IsolationLevel};
+pub use fix::{Applicability, Fix, IsolationLevel, Safety};
 pub use source_map::{SourceMap, SourceMarker};
 pub use violation::{AlwaysFixableViolation, FixAvailability, Violation};
 

--- a/crates/ruff_linter/src/checkers/ast/analyze/bindings.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/bindings.rs
@@ -38,7 +38,7 @@ pub(crate) fn bindings(checker: &mut Checker) {
                             binding,
                             checker.locator,
                         )
-                        .map(Fix::automatic)
+                        .map(Fix::automatic_safe)
                     });
                 }
                 checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -110,8 +110,10 @@ pub(crate) fn check_noqa(
                         let mut diagnostic =
                             Diagnostic::new(UnusedNOQA { codes: None }, directive.range());
                         if settings.rules.should_fix(diagnostic.kind.rule()) {
-                            diagnostic
-                                .set_fix(Fix::suggested(delete_noqa(directive.range(), locator)));
+                            diagnostic.set_fix(Fix::automatic_unsafe(delete_noqa(
+                                directive.range(),
+                                locator,
+                            )));
                         }
                         diagnostics.push(diagnostic);
                     }
@@ -175,12 +177,12 @@ pub(crate) fn check_noqa(
                         );
                         if settings.rules.should_fix(diagnostic.kind.rule()) {
                             if valid_codes.is_empty() {
-                                diagnostic.set_fix(Fix::suggested(delete_noqa(
+                                diagnostic.set_fix(Fix::automatic_unsafe(delete_noqa(
                                     directive.range(),
                                     locator,
                                 )));
                             } else {
-                                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                                     format!("# noqa: {}", valid_codes.join(", ")),
                                     directive.range(),
                                 )));

--- a/crates/ruff_linter/src/fix/mod.rs
+++ b/crates/ruff_linter/src/fix/mod.rs
@@ -151,7 +151,7 @@ mod tests {
                 // The choice of rule here is arbitrary.
                 kind: MissingNewlineAtEndOfFile.into(),
                 range: edit.range(),
-                fix: Some(Fix::unspecified(edit)),
+                fix: Some(Fix::automatic_safe(edit)),
                 parent: None,
             })
             .collect()

--- a/crates/ruff_linter/src/message/diff.rs
+++ b/crates/ruff_linter/src/message/diff.rs
@@ -6,7 +6,7 @@ use colored::{Color, ColoredString, Colorize, Styles};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use similar::{ChangeTag, TextDiff};
 
-use ruff_diagnostics::{Applicability, Fix};
+use ruff_diagnostics::{Applicability, Fix, Safety};
 use ruff_source_file::{OneIndexed, SourceFile};
 
 use crate::message::Message;
@@ -52,10 +52,12 @@ impl Display for Diff<'_> {
         let diff = TextDiff::from_lines(self.source_code.source_text(), &output);
 
         let message = match self.fix.applicability() {
-            Applicability::Automatic => "Fix",
-            Applicability::Suggested => "Suggested fix",
-            Applicability::Manual => "Possible fix",
-            Applicability::Unspecified => "Suggested fix", /* For backwards compatibility, unspecified fixes are 'suggested' */
+            // TODO(zanieb): Adjust this messaging once it's user-facing
+            Applicability::Automatic(safety) => match safety {
+                Safety::Safe => "Fix",
+                Safety::Unsafe => "Unsafe fix",
+            },
+            Applicability::Manual => "Manual fix",
         };
         writeln!(f, "ℹ {}", message.blue())?;
 

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -178,7 +178,7 @@ def fibonacci(n):
             },
             TextRange::new(TextSize::from(7), TextSize::from(9)),
         )
-        .with_fix(Fix::suggested(Edit::range_deletion(TextRange::new(
+        .with_fix(Fix::automatic_unsafe(Edit::range_deletion(TextRange::new(
             TextSize::from(0),
             TextSize::from(10),
         ))));
@@ -193,7 +193,7 @@ def fibonacci(n):
             },
             TextRange::new(TextSize::from(94), TextSize::from(95)),
         )
-        .with_fix(Fix::suggested(Edit::deletion(
+        .with_fix(Fix::automatic_unsafe(Edit::deletion(
             TextSize::from(94),
             TextSize::from(99),
         )));

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json__tests__output.snap
@@ -11,7 +11,9 @@ expression: content
     },
     "filename": "fib.py",
     "fix": {
-      "applicability": "Suggested",
+      "applicability": {
+        "automatic": "unsafe"
+      },
       "edits": [
         {
           "content": "",
@@ -43,7 +45,9 @@ expression: content
     },
     "filename": "fib.py",
     "fix": {
-      "applicability": "Suggested",
+      "applicability": {
+        "automatic": "unsafe"
+      },
       "edits": [
         {
           "content": "",

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json_lines__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json_lines__tests__output.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/message/json_lines.rs
 expression: content
 ---
-{"code":"F401","end_location":{"column":10,"row":1},"filename":"fib.py","fix":{"applicability":"Suggested","edits":[{"content":"","end_location":{"column":1,"row":2},"location":{"column":1,"row":1}}],"message":"Remove unused import: `os`"},"location":{"column":8,"row":1},"message":"`os` imported but unused","noqa_row":1,"url":"https://docs.astral.sh/ruff/rules/unused-import"}
-{"code":"F841","end_location":{"column":6,"row":6},"filename":"fib.py","fix":{"applicability":"Suggested","edits":[{"content":"","end_location":{"column":10,"row":6},"location":{"column":5,"row":6}}],"message":"Remove assignment to unused variable `x`"},"location":{"column":5,"row":6},"message":"Local variable `x` is assigned to but never used","noqa_row":6,"url":"https://docs.astral.sh/ruff/rules/unused-variable"}
+{"code":"F401","end_location":{"column":10,"row":1},"filename":"fib.py","fix":{"applicability":{"automatic":"unsafe"},"edits":[{"content":"","end_location":{"column":1,"row":2},"location":{"column":1,"row":1}}],"message":"Remove unused import: `os`"},"location":{"column":8,"row":1},"message":"`os` imported but unused","noqa_row":1,"url":"https://docs.astral.sh/ruff/rules/unused-import"}
+{"code":"F841","end_location":{"column":6,"row":6},"filename":"fib.py","fix":{"applicability":{"automatic":"unsafe"},"edits":[{"content":"","end_location":{"column":10,"row":6},"location":{"column":5,"row":6}}],"message":"Remove assignment to unused variable `x`"},"location":{"column":5,"row":6},"message":"Local variable `x` is assigned to but never used","noqa_row":6,"url":"https://docs.astral.sh/ruff/rules/unused-variable"}
 {"code":"F821","end_location":{"column":5,"row":1},"filename":"undef.py","fix":null,"location":{"column":4,"row":1},"message":"Undefined name `a`","noqa_row":1,"url":"https://docs.astral.sh/ruff/rules/undefined-name"}
 

--- a/crates/ruff_linter/src/rules/eradicate/snapshots/ruff_linter__rules__eradicate__tests__ERA001_ERA001.py.snap
+++ b/crates/ruff_linter/src/rules/eradicate/snapshots/ruff_linter__rules__eradicate__tests__ERA001_ERA001.py.snap
@@ -10,7 +10,7 @@ ERA001.py:1:1: ERA001 [*] Found commented-out code
   |
   = help: Remove commented-out code
 
-ℹ Possible fix
+ℹ Manual fix
 1   |-#import os
 2 1 | # from foo import junk
 3 2 | #a = 3
@@ -26,7 +26,7 @@ ERA001.py:2:1: ERA001 [*] Found commented-out code
   |
   = help: Remove commented-out code
 
-ℹ Possible fix
+ℹ Manual fix
 1 1 | #import os
 2   |-# from foo import junk
 3 2 | #a = 3
@@ -44,7 +44,7 @@ ERA001.py:3:1: ERA001 [*] Found commented-out code
   |
   = help: Remove commented-out code
 
-ℹ Possible fix
+ℹ Manual fix
 1 1 | #import os
 2 2 | # from foo import junk
 3   |-#a = 3
@@ -63,7 +63,7 @@ ERA001.py:5:1: ERA001 [*] Found commented-out code
   |
   = help: Remove commented-out code
 
-ℹ Possible fix
+ℹ Manual fix
 2 2 | # from foo import junk
 3 3 | #a = 3
 4 4 | a = 4
@@ -82,7 +82,7 @@ ERA001.py:13:5: ERA001 [*] Found commented-out code
    |
    = help: Remove commented-out code
 
-ℹ Possible fix
+ℹ Manual fix
 10 10 | 
 11 11 |     # This is a real comment.
 12 12 |     # # This is a (nested) comment.
@@ -100,7 +100,7 @@ ERA001.py:21:5: ERA001 [*] Found commented-out code
    |
    = help: Remove commented-out code
 
-ℹ Possible fix
+ℹ Manual fix
 18 18 | 
 19 19 | class A():
 20 20 |     pass
@@ -120,7 +120,7 @@ ERA001.py:26:5: ERA001 [*] Found commented-out code
    |
    = help: Remove commented-out code
 
-ℹ Possible fix
+ℹ Manual fix
 23 23 | 
 24 24 | dictionary = {
 25 25 |     # "key1": 123,  # noqa: ERA001
@@ -139,7 +139,7 @@ ERA001.py:27:5: ERA001 [*] Found commented-out code
    |
    = help: Remove commented-out code
 
-ℹ Possible fix
+ℹ Manual fix
 24 24 | dictionary = {
 25 25 |     # "key1": 123,  # noqa: ERA001
 26 26 |     # "key2": 456,

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -703,7 +703,7 @@ pub(crate) fn definition(
                         function.identifier(),
                     );
                     if checker.patch(diagnostic.kind.rule()) {
-                        diagnostic.set_fix(Fix::suggested(Edit::insertion(
+                        diagnostic.set_fix(Fix::automatic_unsafe(Edit::insertion(
                             " -> None".to_string(),
                             function.parameters.range().end(),
                         )));
@@ -721,7 +721,7 @@ pub(crate) fn definition(
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     if let Some(return_type) = simple_magic_return_type(name) {
-                        diagnostic.set_fix(Fix::suggested(Edit::insertion(
+                        diagnostic.set_fix(Fix::automatic_unsafe(Edit::insertion(
                             format!(" -> {return_type}"),
                             function.parameters.range().end(),
                         )));

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__defaults.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__defaults.snap
@@ -252,7 +252,7 @@ annotation_presence.py:159:9: ANN204 [*] Missing return type annotation for spec
     |
     = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 156 156 | 
 157 157 | class Foo:
 158 158 |     @decorator()
@@ -272,7 +272,7 @@ annotation_presence.py:165:9: ANN204 [*] Missing return type annotation for spec
     |
     = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 162 162 | 
 163 163 | # Regression test for: https://github.com/astral-sh/ruff/issues/7711
 164 164 | class Class:

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__mypy_init_return.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__mypy_init_return.snap
@@ -11,7 +11,7 @@ mypy_init_return.py:5:9: ANN204 [*] Missing return type annotation for special m
   |
   = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | 
 3 3 | # Error
 4 4 | class Foo:
@@ -31,7 +31,7 @@ mypy_init_return.py:11:9: ANN204 [*] Missing return type annotation for special 
    |
    = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | 
 9  9  | # Error
 10 10 | class Foo:
@@ -59,7 +59,7 @@ mypy_init_return.py:47:9: ANN204 [*] Missing return type annotation for special 
    |
    = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 44 44 | # Error – used to be ok for a moment since the mere presence
 45 45 | # of a vararg falsely indicated that the function has a typed argument.
 46 46 | class Foo:

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__simple_magic_methods.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__simple_magic_methods.snap
@@ -10,7 +10,7 @@ simple_magic_methods.py:2:9: ANN204 [*] Missing return type annotation for speci
   |
   = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | class Foo:
 2   |-    def __str__(self):
   2 |+    def __str__(self) -> str:
@@ -28,7 +28,7 @@ simple_magic_methods.py:5:9: ANN204 [*] Missing return type annotation for speci
   |
   = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 |     def __str__(self):
 3 3 |         ...
 4 4 | 
@@ -48,7 +48,7 @@ simple_magic_methods.py:8:9: ANN204 [*] Missing return type annotation for speci
   |
   = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 |     def __repr__(self):
 6 6 |         ...
 7 7 | 
@@ -68,7 +68,7 @@ simple_magic_methods.py:11:9: ANN204 [*] Missing return type annotation for spec
    |
    = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  |     def __len__(self):
 9  9  |         ...
 10 10 | 
@@ -88,7 +88,7 @@ simple_magic_methods.py:14:9: ANN204 [*] Missing return type annotation for spec
    |
    = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 |     def __length_hint__(self):
 12 12 |         ...
 13 13 | 
@@ -108,7 +108,7 @@ simple_magic_methods.py:17:9: ANN204 [*] Missing return type annotation for spec
    |
    = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 |     def __init__(self):
 15 15 |         ...
 16 16 | 
@@ -128,7 +128,7 @@ simple_magic_methods.py:20:9: ANN204 [*] Missing return type annotation for spec
    |
    = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 |     def __del__(self):
 18 18 |         ...
 19 19 | 
@@ -148,7 +148,7 @@ simple_magic_methods.py:23:9: ANN204 [*] Missing return type annotation for spec
    |
    = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 |     def __bool__(self):
 21 21 |         ...
 22 22 | 
@@ -168,7 +168,7 @@ simple_magic_methods.py:26:9: ANN204 [*] Missing return type annotation for spec
    |
    = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 |     def __bytes__(self):
 24 24 |         ...
 25 25 | 
@@ -188,7 +188,7 @@ simple_magic_methods.py:29:9: ANN204 [*] Missing return type annotation for spec
    |
    = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 26 26 |     def __format__(self, format_spec):
 27 27 |         ...
 28 28 | 
@@ -208,7 +208,7 @@ simple_magic_methods.py:32:9: ANN204 [*] Missing return type annotation for spec
    |
    = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 29 29 |     def __contains__(self, item):
 30 30 |         ...
 31 31 | 
@@ -228,7 +228,7 @@ simple_magic_methods.py:35:9: ANN204 [*] Missing return type annotation for spec
    |
    = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 32 32 |     def __complex__(self):
 33 33 |         ...
 34 34 | 
@@ -248,7 +248,7 @@ simple_magic_methods.py:38:9: ANN204 [*] Missing return type annotation for spec
    |
    = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 35 35 |     def __int__(self):
 36 36 |         ...
 37 37 | 
@@ -268,7 +268,7 @@ simple_magic_methods.py:41:9: ANN204 [*] Missing return type annotation for spec
    |
    = help: Add `None` return type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 38 38 |     def __float__(self):
 39 39 |         ...
 40 40 | 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -76,7 +76,7 @@ pub(crate) fn assert_false(checker: &mut Checker, stmt: &Stmt, test: &Expr, msg:
 
     let mut diagnostic = Diagnostic::new(AssertFalse, test.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             checker.generator().stmt(&assertion_error(msg)),
             stmt.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -147,7 +147,7 @@ fn duplicate_handler_exceptions<'a>(
                 expr.range(),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                     // Single exceptions don't require parentheses, but since we're _removing_
                     // parentheses, insert whitespace as needed.
                     if let [elt] = unique_elts.as_slice() {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -86,7 +86,7 @@ pub(crate) fn getattr_with_constant(
 
     let mut diagnostic = Diagnostic::new(GetAttrWithConstant, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             pad(
                 if matches!(
                     obj,

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
@@ -85,7 +85,7 @@ pub(crate) fn redundant_tuple_in_exception_handler(
             // ```
             // Otherwise, the output will be invalid syntax, since we're removing a set of
             // parentheses.
-            diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                 pad(
                     checker.generator().expr(elt),
                     type_.range(),

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -109,7 +109,7 @@ pub(crate) fn setattr_with_constant(
         if expr == child.as_ref() {
             let mut diagnostic = Diagnostic::new(SetAttrWithConstant, expr.range());
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                     assignment(obj, name, value, checker.generator()),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
@@ -83,7 +83,7 @@ pub(crate) fn unreliable_callable_check(
     if checker.patch(diagnostic.kind.rule()) {
         if id == "hasattr" {
             if checker.semantic().is_builtin("callable") {
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                     format!("callable({})", checker.locator().slice(obj)),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -168,7 +168,7 @@ pub(crate) fn unused_loop_control_variable(checker: &mut Checker, stmt_for: &ast
                         .filter(|binding| binding.start() >= expr.start())
                         .all(|binding| !binding.is_used())
                     {
-                        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                             rename,
                             expr.range(),
                         )));

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_1.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_1.py.snap
@@ -12,7 +12,7 @@ B006_1.py:3:22: B006 [*] Do not use mutable data structures for argument default
   |
   = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 1 1 | # Docstring followed by a newline
 2 2 | 
 3   |-def foobar(foor, bar={}):    

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_2.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_2.py.snap
@@ -12,7 +12,7 @@ B006_2.py:4:22: B006 [*] Do not use mutable data structures for argument default
   |
   = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 1 1 | # Docstring followed by whitespace with no newline
 2 2 | # Regression test for https://github.com/astral-sh/ruff/issues/7155
 3 3 | 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_3.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_3.py.snap
@@ -10,7 +10,7 @@ B006_3.py:4:22: B006 [*] Do not use mutable data structures for argument default
   |
   = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 1 1 | # Docstring with no newline
 2 2 | 
 3 3 | 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_4.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_4.py.snap
@@ -10,7 +10,7 @@ B006_4.py:7:26: B006 [*] Do not use mutable data structures for argument default
   |
   = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 4  4  | 
 5  5  | 
 6  6  | class FormFeedIndent:

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_5.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_5.py.snap
@@ -9,7 +9,7 @@ B006_5.py:5:49: B006 [*] Do not use mutable data structures for argument default
   |
   = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 2 2 | # https://github.com/astral-sh/ruff/issues/7616
 3 3 | 
 4 4 | 
@@ -30,7 +30,7 @@ B006_5.py:9:61: B006 [*] Do not use mutable data structures for argument default
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 6  6  |     import os
 7  7  | 
 8  8  | 
@@ -53,7 +53,7 @@ B006_5.py:15:50: B006 [*] Do not use mutable data structures for argument defaul
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 12 12 |     return 2
 13 13 | 
 14 14 | 
@@ -76,7 +76,7 @@ B006_5.py:21:54: B006 [*] Do not use mutable data structures for argument defaul
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 18 18 |     import itertools
 19 19 | 
 20 20 | 
@@ -98,7 +98,7 @@ B006_5.py:25:55: B006 [*] Do not use mutable data structures for argument defaul
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 22 22 |     from os import path
 23 23 | 
 24 24 | 
@@ -121,7 +121,7 @@ B006_5.py:30:66: B006 [*] Do not use mutable data structures for argument defaul
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 27 27 |     from sys import version_info
 28 28 | 
 29 29 | 
@@ -144,7 +144,7 @@ B006_5.py:35:59: B006 [*] Do not use mutable data structures for argument defaul
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 32 32 |     from sys import version_info
 33 33 | 
 34 34 | 
@@ -167,7 +167,7 @@ B006_5.py:40:49: B006 [*] Do not use mutable data structures for argument defaul
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 37 37 |     import os
 38 38 | 
 39 39 | 
@@ -190,7 +190,7 @@ B006_5.py:45:49: B006 [*] Do not use mutable data structures for argument defaul
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 42 42 |     import os; import sys
 43 43 | 
 44 44 | 
@@ -212,7 +212,7 @@ B006_5.py:50:49: B006 [*] Do not use mutable data structures for argument defaul
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 47 47 |     import os; import sys; x = 1
 48 48 | 
 49 49 | 
@@ -234,7 +234,7 @@ B006_5.py:55:49: B006 [*] Do not use mutable data structures for argument defaul
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 52 52 |     import os; import sys
 53 53 | 
 54 54 | 
@@ -255,7 +255,7 @@ B006_5.py:59:49: B006 [*] Do not use mutable data structures for argument defaul
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 56 56 |     import os; import sys
 57 57 | 
 58 58 | 
@@ -275,7 +275,7 @@ B006_5.py:63:49: B006 [*] Do not use mutable data structures for argument defaul
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 60 60 |     import os; import sys; x = 1
 61 61 | 
 62 62 | 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_6.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_6.py.snap
@@ -11,7 +11,7 @@ B006_6.py:4:22: B006 [*] Do not use mutable data structures for argument default
   |
   = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 1 1 | # Import followed by whitespace with no newline
 2 2 | # Same as B006_2.py, but import instead of docstring
 3 3 | 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_7.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_7.py.snap
@@ -11,7 +11,7 @@ B006_7.py:4:22: B006 [*] Do not use mutable data structures for argument default
   |
   = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 1 1 | # Import with no newline
 2 2 | # Same as B006_3.py, but import instead of docstring
 3 3 | 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
@@ -9,7 +9,7 @@ B006_B008.py:63:25: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 60 60 | # Flag mutable literals/comprehensions
 61 61 | 
 62 62 | 
@@ -29,7 +29,7 @@ B006_B008.py:67:30: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 64 64 |     ...
 65 65 | 
 66 66 | 
@@ -51,7 +51,7 @@ B006_B008.py:73:52: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 70 70 | 
 71 71 | class Foo:
 72 72 |     @staticmethod
@@ -74,7 +74,7 @@ B006_B008.py:77:31: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 74 74 |         pass
 75 75 | 
 76 76 | 
@@ -105,7 +105,7 @@ B006_B008.py:85:20: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 82 82 | def single_line_func_wrong(value = {}): ...
 83 83 | 
 84 84 | 
@@ -125,7 +125,7 @@ B006_B008.py:89:20: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 86 86 |     ...
 87 87 | 
 88 88 | 
@@ -145,7 +145,7 @@ B006_B008.py:93:32: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 90 90 |     ...
 91 91 | 
 92 92 | 
@@ -165,7 +165,7 @@ B006_B008.py:97:26: B006 [*] Do not use mutable data structures for argument def
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 94  94  |     ...
 95  95  | 
 96  96  | 
@@ -186,7 +186,7 @@ B006_B008.py:102:46: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 99  99  | 
 100 100 | 
 101 101 | # N.B. we're also flagging the function call in the comprehension
@@ -206,7 +206,7 @@ B006_B008.py:106:46: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 103 103 |     pass
 104 104 | 
 105 105 | 
@@ -226,7 +226,7 @@ B006_B008.py:110:45: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 107 107 |     pass
 108 108 | 
 109 109 | 
@@ -246,7 +246,7 @@ B006_B008.py:114:33: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 111 111 |     pass
 112 112 | 
 113 113 | 
@@ -268,7 +268,7 @@ B006_B008.py:239:20: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 236 236 | 
 237 237 | # B006 and B008
 238 238 | # We should handle arbitrary nesting of these B008.
@@ -290,7 +290,7 @@ B006_B008.py:276:27: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 273 273 | 
 274 274 | 
 275 275 | def mutable_annotations(
@@ -317,7 +317,7 @@ B006_B008.py:277:35: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 274 274 | 
 275 275 | def mutable_annotations(
 276 276 |     a: list[int] | None = [],
@@ -343,7 +343,7 @@ B006_B008.py:278:62: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 275 275 | def mutable_annotations(
 276 276 |     a: list[int] | None = [],
 277 277 |     b: Optional[Dict[int, int]] = {},
@@ -368,7 +368,7 @@ B006_B008.py:279:80: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 276 276 |     a: list[int] | None = [],
 277 277 |     b: Optional[Dict[int, int]] = {},
 278 278 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
@@ -389,7 +389,7 @@ B006_B008.py:284:52: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 281 281 |     pass
 282 282 | 
 283 283 | 
@@ -411,7 +411,7 @@ B006_B008.py:288:52: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 285 285 |     """Docstring"""
 286 286 | 
 287 287 | 
@@ -432,7 +432,7 @@ B006_B008.py:293:52: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 290 290 |     ...
 291 291 | 
 292 292 | 
@@ -453,7 +453,7 @@ B006_B008.py:297:52: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 294 294 |     """Docstring"""; ...
 295 295 | 
 296 296 | 
@@ -476,7 +476,7 @@ B006_B008.py:302:52: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 299 299 |         ...
 300 300 | 
 301 301 | 
@@ -508,7 +508,7 @@ B006_B008.py:313:52: B006 [*] Do not use mutable data structures for argument de
     |
     = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 310 310 |     """Docstring"""
 311 311 | 
 312 312 | 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B007_B007.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B007_B007.py.snap
@@ -21,7 +21,7 @@ B007.py:18:13: B007 [*] Loop control variable `k` not used within loop body
    |
    = help: Rename unused `k` to `_k`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | 
 16 16 | for i in range(10):
 17 17 |     for j in range(10):
@@ -47,7 +47,7 @@ B007.py:30:13: B007 [*] Loop control variable `k` not used within loop body
    |
    = help: Rename unused `k` to `_k`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 |                     yield i, (j, (k, l))
 28 28 | 
 29 29 | 
@@ -110,7 +110,7 @@ B007.py:52:14: B007 [*] Loop control variable `bar` not used within loop body
    |
    = help: Rename unused `bar` to `_bar`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 49 49 | 
 50 50 | def f():
 51 51 |     # Fixable.
@@ -142,7 +142,7 @@ B007.py:68:14: B007 [*] Loop control variable `bar` not used within loop body
    |
    = help: Rename unused `bar` to `_bar`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 65 65 | 
 66 66 | def f():
 67 67 |     # Fixable.

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B009_B009_B010.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B009_B009_B010.py.snap
@@ -11,7 +11,7 @@ B009_B010.py:19:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | getattr(foo, "__123abc")
 17 17 | 
 18 18 | # Invalid usage
@@ -32,7 +32,7 @@ B009_B010.py:20:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | 
 18 18 | # Invalid usage
 19 19 | getattr(foo, "bar")
@@ -53,7 +53,7 @@ B009_B010.py:21:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 | # Invalid usage
 19 19 | getattr(foo, "bar")
 20 20 | getattr(foo, "_123abc")
@@ -74,7 +74,7 @@ B009_B010.py:22:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | getattr(foo, "bar")
 20 20 | getattr(foo, "_123abc")
 21 21 | getattr(foo, "__123abc__")
@@ -95,7 +95,7 @@ B009_B010.py:23:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 | getattr(foo, "_123abc")
 21 21 | getattr(foo, "__123abc__")
 22 22 | getattr(foo, "abc123")
@@ -116,7 +116,7 @@ B009_B010.py:24:15: B009 [*] Do not call `getattr` with a constant attribute val
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | getattr(foo, "__123abc__")
 22 22 | getattr(foo, "abc123")
 23 23 | getattr(foo, r"abc123")
@@ -137,7 +137,7 @@ B009_B010.py:25:4: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | getattr(foo, "abc123")
 23 23 | getattr(foo, r"abc123")
 24 24 | _ = lambda x: getattr(x, "bar")
@@ -158,7 +158,7 @@ B009_B010.py:27:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 24 24 | _ = lambda x: getattr(x, "bar")
 25 25 | if getattr(x, "bar"):
 26 26 |     pass
@@ -179,7 +179,7 @@ B009_B010.py:28:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 25 25 | if getattr(x, "bar"):
 26 26 |     pass
 27 27 | getattr(1, "real")
@@ -200,7 +200,7 @@ B009_B010.py:29:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 26 26 |     pass
 27 27 | getattr(1, "real")
 28 28 | getattr(1., "real")
@@ -221,7 +221,7 @@ B009_B010.py:30:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 | getattr(1, "real")
 28 28 | getattr(1., "real")
 29 29 | getattr(1.0, "real")
@@ -242,7 +242,7 @@ B009_B010.py:31:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 28 28 | getattr(1., "real")
 29 29 | getattr(1.0, "real")
 30 30 | getattr(1j, "real")
@@ -263,7 +263,7 @@ B009_B010.py:32:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 29 29 | getattr(1.0, "real")
 30 30 | getattr(1j, "real")
 31 31 | getattr(True, "real")
@@ -284,7 +284,7 @@ B009_B010.py:33:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 30 30 | getattr(1j, "real")
 31 31 | getattr(True, "real")
 32 32 | getattr(x := 1, "real")
@@ -304,7 +304,7 @@ B009_B010.py:34:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 31 31 | getattr(True, "real")
 32 32 | getattr(x := 1, "real")
 33 33 | getattr(x + y, "real")
@@ -326,7 +326,7 @@ B009_B010.py:58:8: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 55 55 | setattr(foo.bar, r"baz", None)
 56 56 | 
 57 57 | # Regression test for: https://github.com/astral-sh/ruff/issues/7455#issuecomment-1722458885
@@ -345,7 +345,7 @@ B009_B010.py:65:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Unsafe fix
 62 62 | setattr(*foo, "bar", None)
 63 63 | 
 64 64 | # Regression test for: https://github.com/astral-sh/ruff/issues/7455#issuecomment-1739800901

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B010_B009_B010.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B010_B009_B010.py.snap
@@ -11,7 +11,7 @@ B009_B010.py:50:1: B010 [*] Do not call `setattr` with a constant attribute valu
    |
    = help: Replace `setattr` with assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 47 47 |     pass
 48 48 | 
 49 49 | # Invalid usage
@@ -32,7 +32,7 @@ B009_B010.py:51:1: B010 [*] Do not call `setattr` with a constant attribute valu
    |
    = help: Replace `setattr` with assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 48 48 | 
 49 49 | # Invalid usage
 50 50 | setattr(foo, "bar", None)
@@ -53,7 +53,7 @@ B009_B010.py:52:1: B010 [*] Do not call `setattr` with a constant attribute valu
    |
    = help: Replace `setattr` with assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 49 49 | # Invalid usage
 50 50 | setattr(foo, "bar", None)
 51 51 | setattr(foo, "_123abc", None)
@@ -74,7 +74,7 @@ B009_B010.py:53:1: B010 [*] Do not call `setattr` with a constant attribute valu
    |
    = help: Replace `setattr` with assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 50 50 | setattr(foo, "bar", None)
 51 51 | setattr(foo, "_123abc", None)
 52 52 | setattr(foo, "__123abc__", None)
@@ -94,7 +94,7 @@ B009_B010.py:54:1: B010 [*] Do not call `setattr` with a constant attribute valu
    |
    = help: Replace `setattr` with assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 51 51 | setattr(foo, "_123abc", None)
 52 52 | setattr(foo, "__123abc__", None)
 53 53 | setattr(foo, "abc123", None)
@@ -115,7 +115,7 @@ B009_B010.py:55:1: B010 [*] Do not call `setattr` with a constant attribute valu
    |
    = help: Replace `setattr` with assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 52 52 | setattr(foo, "__123abc__", None)
 53 53 | setattr(foo, "abc123", None)
 54 54 | setattr(foo, r"abc123", None)

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B011_B011.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B011_B011.py.snap
@@ -11,7 +11,7 @@ B011.py:8:8: B011 [*] Do not `assert False` (`python -O` removes these calls), r
    |
    = help: Replace `assert False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | """
 6 6 | 
 7 7 | assert 1 != 2
@@ -29,7 +29,7 @@ B011.py:10:8: B011 [*] Do not `assert False` (`python -O` removes these calls), 
    |
    = help: Replace `assert False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | assert 1 != 2
 8  8  | assert False
 9  9  | assert 1 != 2, "message"

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__extend_immutable_calls_arg_annotation.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__extend_immutable_calls_arg_annotation.snap
@@ -9,7 +9,7 @@ B006_extended.py:17:55: B006 [*] Do not use mutable data structures for argument
    |
    = help: Replace with `None`; initialize within function
 
-ℹ Possible fix
+ℹ Manual fix
 14 14 |     ...
 15 15 | 
 16 16 | 

--- a/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
+++ b/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
@@ -325,7 +325,9 @@ pub(crate) fn trailing_commas(
             let comma = prev.spanned.unwrap();
             let mut diagnostic = Diagnostic::new(ProhibitedTrailingComma, comma.1);
             if settings.rules.should_fix(Rule::ProhibitedTrailingComma) {
-                diagnostic.set_fix(Fix::automatic(Edit::range_deletion(diagnostic.range())));
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(
+                    diagnostic.range(),
+                )));
             }
             diagnostics.push(diagnostic);
         }
@@ -365,7 +367,7 @@ pub(crate) fn trailing_commas(
                 // removing any brackets in the same linter pass - doing both at the same time could
                 // lead to a syntax error.
                 let contents = locator.slice(missing_comma.1);
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                     format!("{contents},"),
                     missing_comma.1,
                 )));

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
@@ -1293,7 +1293,7 @@ pub(crate) fn fix_unnecessary_comprehension_any_all(
         _ => whitespace_after_arg,
     };
 
-    Ok(Fix::suggested(Edit::range_replacement(
+    Ok(Fix::automatic_unsafe(Edit::range_replacement(
         tree.codegen_stylist(stylist),
         expr.range(),
     )))

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
@@ -90,9 +90,9 @@ pub(crate) fn unnecessary_call_around_sorted(
                 checker.stylist(),
             )?;
             if outer.id == "reversed" {
-                Ok(Fix::suggested(edit))
+                Ok(Fix::automatic_unsafe(edit))
             } else {
-                Ok(Fix::automatic(edit))
+                Ok(Fix::automatic_safe(edit))
             }
         });
     }

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
@@ -88,7 +88,7 @@ pub(crate) fn unnecessary_collection_call(
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            fixes::fix_unnecessary_collection_call(expr, checker).map(Fix::suggested)
+            fixes::fix_unnecessary_collection_call(expr, checker).map(Fix::automatic_unsafe)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -67,7 +67,7 @@ fn add_diagnostic(checker: &mut Checker, expr: &Expr) {
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
             fixes::fix_unnecessary_comprehension(expr, checker.locator(), checker.stylist())
-                .map(Fix::suggested)
+                .map(Fix::automatic_unsafe)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
@@ -137,7 +137,7 @@ pub(crate) fn unnecessary_double_cast_or_process(
                     checker.locator(),
                     checker.stylist(),
                 )
-                .map(Fix::suggested)
+                .map(Fix::automatic_unsafe)
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
@@ -69,7 +69,7 @@ pub(crate) fn unnecessary_generator_dict(
     let mut diagnostic = Diagnostic::new(UnnecessaryGeneratorDict, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            fixes::fix_unnecessary_generator_dict(expr, checker).map(Fix::suggested)
+            fixes::fix_unnecessary_generator_dict(expr, checker).map(Fix::automatic_unsafe)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
@@ -63,7 +63,7 @@ pub(crate) fn unnecessary_generator_list(
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
                 fixes::fix_unnecessary_generator_list(expr, checker.locator(), checker.stylist())
-                    .map(Fix::suggested)
+                    .map(Fix::automatic_unsafe)
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
@@ -62,7 +62,7 @@ pub(crate) fn unnecessary_generator_set(
         let mut diagnostic = Diagnostic::new(UnnecessaryGeneratorSet, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
-                fixes::fix_unnecessary_generator_set(expr, checker).map(Fix::suggested)
+                fixes::fix_unnecessary_generator_set(expr, checker).map(Fix::automatic_unsafe)
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
@@ -59,7 +59,7 @@ pub(crate) fn unnecessary_list_call(
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
             fixes::fix_unnecessary_list_call(expr, checker.locator(), checker.stylist())
-                .map(Fix::suggested)
+                .map(Fix::automatic_unsafe)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
@@ -67,7 +67,7 @@ pub(crate) fn unnecessary_list_comprehension_dict(
     let mut diagnostic = Diagnostic::new(UnnecessaryListComprehensionDict, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            fixes::fix_unnecessary_list_comprehension_dict(expr, checker).map(Fix::suggested)
+            fixes::fix_unnecessary_list_comprehension_dict(expr, checker).map(Fix::automatic_unsafe)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
@@ -60,7 +60,8 @@ pub(crate) fn unnecessary_list_comprehension_set(
         let mut diagnostic = Diagnostic::new(UnnecessaryListComprehensionSet, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
-                fixes::fix_unnecessary_list_comprehension_set(expr, checker).map(Fix::suggested)
+                fixes::fix_unnecessary_list_comprehension_set(expr, checker)
+                    .map(Fix::automatic_unsafe)
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
@@ -81,8 +81,9 @@ pub(crate) fn unnecessary_literal_dict(
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic
-            .try_set_fix(|| fixes::fix_unnecessary_literal_dict(expr, checker).map(Fix::suggested));
+        diagnostic.try_set_fix(|| {
+            fixes::fix_unnecessary_literal_dict(expr, checker).map(Fix::automatic_unsafe)
+        });
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
@@ -76,8 +76,9 @@ pub(crate) fn unnecessary_literal_set(
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic
-            .try_set_fix(|| fixes::fix_unnecessary_literal_set(expr, checker).map(Fix::suggested));
+        diagnostic.try_set_fix(|| {
+            fixes::fix_unnecessary_literal_set(expr, checker).map(Fix::automatic_unsafe)
+        });
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_dict_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_dict_call.rs
@@ -98,7 +98,7 @@ pub(crate) fn unnecessary_literal_within_dict_call(
                 checker.locator(),
                 checker.stylist(),
             )
-            .map(Fix::suggested)
+            .map(Fix::automatic_unsafe)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
@@ -100,7 +100,7 @@ pub(crate) fn unnecessary_literal_within_list_call(
                 checker.locator(),
                 checker.stylist(),
             )
-            .map(Fix::suggested)
+            .map(Fix::automatic_unsafe)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
@@ -102,7 +102,7 @@ pub(crate) fn unnecessary_literal_within_tuple_call(
                 checker.locator(),
                 checker.stylist(),
             )
-            .map(Fix::suggested)
+            .map(Fix::automatic_unsafe)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -230,7 +230,7 @@ pub(crate) fn unnecessary_map(
                 checker.locator(),
                 checker.stylist(),
             )
-            .map(Fix::suggested)
+            .map(Fix::automatic_unsafe)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C400_C400.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C400_C400.py.snap
@@ -10,7 +10,7 @@ C400.py:1:5: C400 [*] Unnecessary generator (rewrite as a `list` comprehension)
   |
   = help: Rewrite as a `list` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-x = list(x for x in range(3))
   1 |+x = [x for x in range(3)]
 2 2 | x = list(
@@ -28,7 +28,7 @@ C400.py:2:5: C400 [*] Unnecessary generator (rewrite as a `list` comprehension)
   |
   = help: Rewrite as a `list` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | x = list(x for x in range(3))
 2   |-x = list(
   2 |+x = [

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C401_C401.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C401_C401.py.snap
@@ -10,7 +10,7 @@ C401.py:1:5: C401 [*] Unnecessary generator (rewrite as a `set` comprehension)
   |
   = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-x = set(x for x in range(3))
   1 |+x = {x for x in range(3)}
 2 2 | x = set(x for x in range(3))
@@ -27,7 +27,7 @@ C401.py:2:5: C401 [*] Unnecessary generator (rewrite as a `set` comprehension)
   |
   = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | x = set(x for x in range(3))
 2   |-x = set(x for x in range(3))
   2 |+x = {x for x in range(3)}
@@ -46,7 +46,7 @@ C401.py:3:8: C401 [*] Unnecessary generator (rewrite as a `set` comprehension)
   |
   = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | x = set(x for x in range(3))
 2 2 | x = set(x for x in range(3))
 3   |-y = f"{set(a if a < 6 else 0  for a in range(3))}"
@@ -65,7 +65,7 @@ C401.py:4:17: C401 [*] Unnecessary generator (rewrite as a `set` comprehension)
   |
   = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | x = set(x for x in range(3))
 2 2 | x = set(x for x in range(3))
 3 3 | y = f"{set(a if a < 6 else 0  for a in range(3))}"
@@ -84,7 +84,7 @@ C401.py:5:16: C401 [*] Unnecessary generator (rewrite as a `set` comprehension)
   |
   = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | x = set(x for x in range(3))
 3 3 | y = f"{set(a if a < 6 else 0  for a in range(3))}"
 4 4 | _ = "{}".format(set(a if a < 6 else 0 for a in range(3)))
@@ -103,7 +103,7 @@ C401.py:12:16: C401 [*] Unnecessary generator (rewrite as a `set` comprehension)
    |
    = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  |     return x
 10 10 | 
 11 11 | 
@@ -123,7 +123,7 @@ C401.py:13:16: C401 [*] Unnecessary generator (rewrite as a `set` comprehension)
    |
    = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | 
 11 11 | 
 12 12 | print(f'Hello {set(a for a in "abc")} World')
@@ -144,7 +144,7 @@ C401.py:14:16: C401 [*] Unnecessary generator (rewrite as a `set` comprehension)
    |
    = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | 
 12 12 | print(f'Hello {set(a for a in "abc")} World')
 13 13 | print(f"Hello {set(a for a in 'abc')} World")
@@ -164,7 +164,7 @@ C401.py:15:10: C401 [*] Unnecessary generator (rewrite as a `set` comprehension)
    |
    = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | print(f'Hello {set(a for a in "abc")} World')
 13 13 | print(f"Hello {set(a for a in 'abc')} World")
 14 14 | print(f"Hello {set(f(a) for a in 'abc')} World")
@@ -184,7 +184,7 @@ C401.py:15:34: C401 [*] Unnecessary generator (rewrite as a `set` comprehension)
    |
    = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | print(f'Hello {set(a for a in "abc")} World')
 13 13 | print(f"Hello {set(a for a in 'abc')} World")
 14 14 | print(f"Hello {set(f(a) for a in 'abc')} World")
@@ -205,7 +205,7 @@ C401.py:16:11: C401 [*] Unnecessary generator (rewrite as a `set` comprehension)
    |
    = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | print(f"Hello {set(a for a in 'abc')} World")
 14 14 | print(f"Hello {set(f(a) for a in 'abc')} World")
 15 15 | print(f"{set(a for a in 'abc') - set(a for a in 'ab')}")
@@ -226,7 +226,7 @@ C401.py:16:35: C401 [*] Unnecessary generator (rewrite as a `set` comprehension)
    |
    = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | print(f"Hello {set(a for a in 'abc')} World")
 14 14 | print(f"Hello {set(f(a) for a in 'abc')} World")
 15 15 | print(f"{set(a for a in 'abc') - set(a for a in 'ab')}")
@@ -245,7 +245,7 @@ C401.py:20:12: C401 [*] Unnecessary generator (rewrite as a `set` comprehension)
    |
    = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | 
 18 18 | # The fix generated for this diagnostic is incorrect, as we add additional space
 19 19 | # around the set comprehension.

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C402_C402.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C402_C402.py.snap
@@ -10,7 +10,7 @@ C402.py:1:1: C402 [*] Unnecessary generator (rewrite as a `dict` comprehension)
   |
   = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-dict((x, x) for x in range(3))
   1 |+{x: x for x in range(3)}
 2 2 | dict(
@@ -29,7 +29,7 @@ C402.py:2:1: C402 [*] Unnecessary generator (rewrite as a `dict` comprehension)
   |
   = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | dict((x, x) for x in range(3))
 2   |-dict(
 3   |-    (x, x) for x in range(3)
@@ -52,7 +52,7 @@ C402.py:6:8: C402 [*] Unnecessary generator (rewrite as a `dict` comprehension)
   |
   = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 |     (x, x) for x in range(3)
 4 4 | )
 5 5 | dict(((x, x) for x in range(3)), z=3)
@@ -73,7 +73,7 @@ C402.py:7:16: C402 [*] Unnecessary generator (rewrite as a `dict` comprehension)
   |
   = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | )
 5 5 | dict(((x, x) for x in range(3)), z=3)
 6 6 | y = f'{dict((x, x) for x in range(3))}'
@@ -94,7 +94,7 @@ C402.py:8:16: C402 [*] Unnecessary generator (rewrite as a `dict` comprehension)
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | dict(((x, x) for x in range(3)), z=3)
 6 6 | y = f'{dict((x, x) for x in range(3))}'
 7 7 | print(f'Hello {dict((x, x) for x in range(3))} World')
@@ -114,7 +114,7 @@ C402.py:9:16: C402 [*] Unnecessary generator (rewrite as a `dict` comprehension)
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | y = f'{dict((x, x) for x in range(3))}'
 7  7  | print(f'Hello {dict((x, x) for x in range(3))} World')
 8  8  | print(f"Hello {dict((x, x) for x in 'abc')} World")
@@ -135,7 +135,7 @@ C402.py:10:16: C402 [*] Unnecessary generator (rewrite as a `dict` comprehension
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | print(f'Hello {dict((x, x) for x in range(3))} World')
 8  8  | print(f"Hello {dict((x, x) for x in 'abc')} World")
 9  9  | print(f'Hello {dict((x, x) for x in "abc")} World')
@@ -155,7 +155,7 @@ C402.py:12:4: C402 [*] Unnecessary generator (rewrite as a `dict` comprehension)
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | print(f'Hello {dict((x, x) for x in "abc")} World')
 10 10 | print(f'Hello {dict((x,x) for x in "abc")} World')
 11 11 | 
@@ -175,7 +175,7 @@ C402.py:12:37: C402 [*] Unnecessary generator (rewrite as a `dict` comprehension
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | print(f'Hello {dict((x, x) for x in "abc")} World')
 10 10 | print(f'Hello {dict((x,x) for x in "abc")} World')
 11 11 | 
@@ -195,7 +195,7 @@ C402.py:13:5: C402 [*] Unnecessary generator (rewrite as a `dict` comprehension)
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | print(f'Hello {dict((x,x) for x in "abc")} World')
 11 11 | 
 12 12 | f'{dict((x, x) for x in range(3)) | dict((x, x) for x in range(3))}'
@@ -215,7 +215,7 @@ C402.py:13:38: C402 [*] Unnecessary generator (rewrite as a `dict` comprehension
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | print(f'Hello {dict((x,x) for x in "abc")} World')
 11 11 | 
 12 12 | f'{dict((x, x) for x in range(3)) | dict((x, x) for x in range(3))}'
@@ -236,7 +236,7 @@ C402.py:18:16: C402 [*] Unnecessary generator (rewrite as a `dict` comprehension
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | def f(x):
 16 16 |     return x
 17 17 | 
@@ -256,7 +256,7 @@ C402.py:21:1: C402 [*] Unnecessary generator (rewrite as a `dict` comprehension)
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 | print(f'Hello {dict((x,f(x)) for x in "abc")} World')
 19 19 | 
 20 20 | # Regression test for: https://github.com/astral-sh/ruff/issues/7086

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C403_C403.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C403_C403.py.snap
@@ -10,7 +10,7 @@ C403.py:1:5: C403 [*] Unnecessary `list` comprehension (rewrite as a `set` compr
   |
   = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-s = set([x for x in range(3)])
   1 |+s = {x for x in range(3)}
 2 2 | s = set(
@@ -30,7 +30,7 @@ C403.py:2:5: C403 [*] Unnecessary `list` comprehension (rewrite as a `set` compr
   |
   = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | s = set([x for x in range(3)])
 2   |-s = set(
 3   |-    [x for x in range(3)]
@@ -52,7 +52,7 @@ C403.py:6:8: C403 [*] Unnecessary `list` comprehension (rewrite as a `set` compr
   |
   = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 |     [x for x in range(3)]
 4 4 | )
 5 5 | 
@@ -72,7 +72,7 @@ C403.py:7:8: C403 [*] Unnecessary `list` comprehension (rewrite as a `set` compr
   |
   = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | )
 5 5 | 
 6 6 | s = f"{set([x for x in 'ab'])}"
@@ -93,7 +93,7 @@ C403.py:12:8: C403 [*] Unnecessary `list` comprehension (rewrite as a `set` comp
    |
    = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | def f(x):
 10 10 |     return x
 11 11 | 
@@ -113,7 +113,7 @@ C403.py:14:9: C403 [*] Unnecessary `list` comprehension (rewrite as a `set` comp
    |
    = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | 
 12 12 | s = f"{set([f(x) for x in 'ab'])}"
 13 13 | 
@@ -131,7 +131,7 @@ C403.py:14:34: C403 [*] Unnecessary `list` comprehension (rewrite as a `set` com
    |
    = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | 
 12 12 | s = f"{set([f(x) for x in 'ab'])}"
 13 13 | 
@@ -147,7 +147,7 @@ C403.py:15:8: C403 [*] Unnecessary `list` comprehension (rewrite as a `set` comp
    |
    = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | s = f"{set([f(x) for x in 'ab'])}"
 13 13 | 
 14 14 | s = f"{ set([x for x in 'ab']) | set([x for x in 'ab']) }"
@@ -162,7 +162,7 @@ C403.py:15:33: C403 [*] Unnecessary `list` comprehension (rewrite as a `set` com
    |
    = help: Rewrite as a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | s = f"{set([f(x) for x in 'ab'])}"
 13 13 | 
 14 14 | s = f"{ set([x for x in 'ab']) | set([x for x in 'ab']) }"

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C404_C404.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C404_C404.py.snap
@@ -9,7 +9,7 @@ C404.py:1:1: C404 [*] Unnecessary `list` comprehension (rewrite as a `dict` comp
   |
   = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-dict([(i, i) for i in range(3)])
   1 |+{i: i for i in range(3)}
 2 2 | dict([(i, i) for i in range(3)], z=4)
@@ -27,7 +27,7 @@ C404.py:7:4: C404 [*] Unnecessary `list` comprehension (rewrite as a `dict` comp
   |
   = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | def f(x):
 5 5 |     return x
 6 6 | 
@@ -47,7 +47,7 @@ C404.py:8:4: C404 [*] Unnecessary `list` comprehension (rewrite as a `dict` comp
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 |     return x
 6 6 | 
 7 7 | f'{dict([(s,s) for s in "ab"])}'
@@ -67,7 +67,7 @@ C404.py:9:4: C404 [*] Unnecessary `list` comprehension (rewrite as a `dict` comp
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | 
 7  7  | f'{dict([(s,s) for s in "ab"])}'
 8  8  | f"{dict([(s,s) for s in 'ab'])}"
@@ -88,7 +88,7 @@ C404.py:10:4: C404 [*] Unnecessary `list` comprehension (rewrite as a `dict` com
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | f'{dict([(s,s) for s in "ab"])}'
 8  8  | f"{dict([(s,s) for s in 'ab'])}"
 9  9  | f"{dict([(s, s) for s in 'ab'])}"
@@ -108,7 +108,7 @@ C404.py:12:4: C404 [*] Unnecessary `list` comprehension (rewrite as a `dict` com
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | f"{dict([(s, s) for s in 'ab'])}"
 10 10 | f"{dict([(s,f(s)) for s in 'ab'])}"
 11 11 | 
@@ -128,7 +128,7 @@ C404.py:12:34: C404 [*] Unnecessary `list` comprehension (rewrite as a `dict` co
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | f"{dict([(s, s) for s in 'ab'])}"
 10 10 | f"{dict([(s,f(s)) for s in 'ab'])}"
 11 11 | 
@@ -148,7 +148,7 @@ C404.py:13:5: C404 [*] Unnecessary `list` comprehension (rewrite as a `dict` com
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | f"{dict([(s,f(s)) for s in 'ab'])}"
 11 11 | 
 12 12 | f'{dict([(s,s) for s in "ab"]) | dict([(s,s) for s in "ab"])}'
@@ -168,7 +168,7 @@ C404.py:13:35: C404 [*] Unnecessary `list` comprehension (rewrite as a `dict` co
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | f"{dict([(s,f(s)) for s in 'ab'])}"
 11 11 | 
 12 12 | f'{dict([(s,s) for s in "ab"]) | dict([(s,s) for s in "ab"])}'
@@ -186,7 +186,7 @@ C404.py:16:14: C404 [*] Unnecessary `list` comprehension (rewrite as a `dict` co
    |
    = help: Rewrite as a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | f'{ dict([(s,s) for s in "ab"]) | dict([(s,s) for s in "ab"]) }'
 14 14 | 
 15 15 | # Regression test for: https://github.com/astral-sh/ruff/issues/7087

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C405_C405.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C405_C405.py.snap
@@ -10,7 +10,7 @@ C405.py:1:1: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
   |
   = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-set([1, 2])
   1 |+{1, 2}
 2 2 | set((1, 2))
@@ -27,7 +27,7 @@ C405.py:2:1: C405 [*] Unnecessary `tuple` literal (rewrite as a `set` literal)
   |
   = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | set([1, 2])
 2   |-set((1, 2))
   2 |+{1, 2}
@@ -46,7 +46,7 @@ C405.py:3:1: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
   |
   = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | set([1, 2])
 2 2 | set((1, 2))
 3   |-set([])
@@ -66,7 +66,7 @@ C405.py:4:1: C405 [*] Unnecessary `tuple` literal (rewrite as a `set` literal)
   |
   = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | set([1, 2])
 2 2 | set((1, 2))
 3 3 | set([])
@@ -88,7 +88,7 @@ C405.py:6:1: C405 [*] Unnecessary `tuple` literal (rewrite as a `set` literal)
   |
   = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | set([])
 4 4 | set(())
 5 5 | set()
@@ -111,7 +111,7 @@ C405.py:7:1: C405 [*] Unnecessary `tuple` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4  4  | set(())
 5  5  | set()
 6  6  | set((1,))
@@ -137,7 +137,7 @@ C405.py:10:1: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | set((
 8  8  |     1,
 9  9  | ))
@@ -163,7 +163,7 @@ C405.py:13:1: C405 [*] Unnecessary `tuple` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | set([
 11 11 |     1,
 12 12 | ])
@@ -188,7 +188,7 @@ C405.py:16:1: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | set(
 14 14 |     (1,)
 15 15 | )
@@ -211,7 +211,7 @@ C405.py:19:4: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | set(
 17 17 |     [1,]
 18 18 | )
@@ -231,7 +231,7 @@ C405.py:20:4: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 |     [1,]
 18 18 | )
 19 19 | f"{set([1,2,3])}"
@@ -252,7 +252,7 @@ C405.py:21:4: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 | )
 19 19 | f"{set([1,2,3])}"
 20 20 | f"{set(['a', 'b'])}"
@@ -273,7 +273,7 @@ C405.py:23:4: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 | f"{set(['a', 'b'])}"
 21 21 | f'{set(["a", "b"])}'
 22 22 | 
@@ -294,7 +294,7 @@ C405.py:23:22: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 | f"{set(['a', 'b'])}"
 21 21 | f'{set(["a", "b"])}'
 22 22 | 
@@ -314,7 +314,7 @@ C405.py:24:5: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | f'{set(["a", "b"])}'
 22 22 | 
 23 23 | f"{set(['a', 'b']) - set(['a'])}"
@@ -333,7 +333,7 @@ C405.py:24:23: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | f'{set(["a", "b"])}'
 22 22 | 
 23 23 | f"{set(['a', 'b']) - set(['a'])}"
@@ -352,7 +352,7 @@ C405.py:25:6: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | 
 23 23 | f"{set(['a', 'b']) - set(['a'])}"
 24 24 | f"{ set(['a', 'b']) - set(['a']) }"
@@ -370,7 +370,7 @@ C405.py:25:24: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | 
 23 23 | f"{set(['a', 'b']) - set(['a'])}"
 24 24 | f"{ set(['a', 'b']) - set(['a']) }"
@@ -387,7 +387,7 @@ C405.py:26:7: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 | f"{set(['a', 'b']) - set(['a'])}"
 24 24 | f"{ set(['a', 'b']) - set(['a']) }"
 25 25 | f"a {set(['a', 'b']) - set(['a'])} b"
@@ -403,7 +403,7 @@ C405.py:26:25: C405 [*] Unnecessary `list` literal (rewrite as a `set` literal)
    |
    = help: Rewrite as a `set` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 | f"{set(['a', 'b']) - set(['a'])}"
 24 24 | f"{ set(['a', 'b']) - set(['a']) }"
 25 25 | f"a {set(['a', 'b']) - set(['a'])} b"

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C406_C406.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C406_C406.py.snap
@@ -10,7 +10,7 @@ C406.py:1:6: C406 [*] Unnecessary `list` literal (rewrite as a `dict` literal)
   |
   = help: Rewrite as a `dict` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-d1 = dict([(1, 2)])
   1 |+d1 = {1: 2}
 2 2 | d2 = dict(((1, 2),))
@@ -27,7 +27,7 @@ C406.py:2:6: C406 [*] Unnecessary `tuple` literal (rewrite as a `dict` literal)
   |
   = help: Rewrite as a `dict` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | d1 = dict([(1, 2)])
 2   |-d2 = dict(((1, 2),))
   2 |+d2 = {1: 2,}
@@ -46,7 +46,7 @@ C406.py:3:6: C406 [*] Unnecessary `list` literal (rewrite as a `dict` literal)
   |
   = help: Rewrite as a `dict` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | d1 = dict([(1, 2)])
 2 2 | d2 = dict(((1, 2),))
 3   |-d3 = dict([])
@@ -64,7 +64,7 @@ C406.py:4:6: C406 [*] Unnecessary `tuple` literal (rewrite as a `dict` literal)
   |
   = help: Rewrite as a `dict` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | d1 = dict([(1, 2)])
 2 2 | d2 = dict(((1, 2),))
 3 3 | d3 = dict([])

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C408_C408.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C408_C408.py.snap
@@ -10,7 +10,7 @@ C408.py:1:5: C408 [*] Unnecessary `tuple` call (rewrite as a literal)
   |
   = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-t = tuple()
   1 |+t = ()
 2 2 | l = list()
@@ -27,7 +27,7 @@ C408.py:2:5: C408 [*] Unnecessary `list` call (rewrite as a literal)
   |
   = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | t = tuple()
 2   |-l = list()
   2 |+l = []
@@ -46,7 +46,7 @@ C408.py:3:6: C408 [*] Unnecessary `dict` call (rewrite as a literal)
   |
   = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | t = tuple()
 2 2 | l = list()
 3   |-d1 = dict()
@@ -65,7 +65,7 @@ C408.py:4:6: C408 [*] Unnecessary `dict` call (rewrite as a literal)
   |
   = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | t = tuple()
 2 2 | l = list()
 3 3 | d1 = dict()
@@ -86,7 +86,7 @@ C408.py:14:4: C408 [*] Unnecessary `dict` call (rewrite as a literal)
    |
    = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | 
 12 12 | a = list()
 13 13 | 
@@ -106,7 +106,7 @@ C408.py:15:4: C408 [*] Unnecessary `dict` call (rewrite as a literal)
    |
    = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | a = list()
 13 13 | 
 14 14 | f"{dict(x='y')}"
@@ -126,7 +126,7 @@ C408.py:16:4: C408 [*] Unnecessary `dict` call (rewrite as a literal)
    |
    = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | 
 14 14 | f"{dict(x='y')}"
 15 15 | f'{dict(x="y")}'
@@ -147,7 +147,7 @@ C408.py:17:6: C408 [*] Unnecessary `dict` call (rewrite as a literal)
    |
    = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | f"{dict(x='y')}"
 15 15 | f'{dict(x="y")}'
 16 16 | f"{dict()}"
@@ -168,7 +168,7 @@ C408.py:19:4: C408 [*] Unnecessary `dict` call (rewrite as a literal)
    |
    = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | f"{dict()}"
 17 17 | f"a {dict()} b"
 18 18 | 
@@ -189,7 +189,7 @@ C408.py:19:18: C408 [*] Unnecessary `dict` call (rewrite as a literal)
    |
    = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | f"{dict()}"
 17 17 | f"a {dict()} b"
 18 18 | 
@@ -209,7 +209,7 @@ C408.py:20:5: C408 [*] Unnecessary `dict` call (rewrite as a literal)
    |
    = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | f"a {dict()} b"
 18 18 | 
 19 19 | f"{dict(x='y') | dict(y='z')}"
@@ -228,7 +228,7 @@ C408.py:20:19: C408 [*] Unnecessary `dict` call (rewrite as a literal)
    |
    = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | f"a {dict()} b"
 18 18 | 
 19 19 | f"{dict(x='y') | dict(y='z')}"
@@ -247,7 +247,7 @@ C408.py:21:6: C408 [*] Unnecessary `dict` call (rewrite as a literal)
    |
    = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 | 
 19 19 | f"{dict(x='y') | dict(y='z')}"
 20 20 | f"{ dict(x='y') | dict(y='z') }"
@@ -265,7 +265,7 @@ C408.py:21:20: C408 [*] Unnecessary `dict` call (rewrite as a literal)
    |
    = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 | 
 19 19 | f"{dict(x='y') | dict(y='z')}"
 20 20 | f"{ dict(x='y') | dict(y='z') }"
@@ -282,7 +282,7 @@ C408.py:22:7: C408 [*] Unnecessary `dict` call (rewrite as a literal)
    |
    = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | f"{dict(x='y') | dict(y='z')}"
 20 20 | f"{ dict(x='y') | dict(y='z') }"
 21 21 | f"a {dict(x='y') | dict(y='z')} b"
@@ -298,7 +298,7 @@ C408.py:22:21: C408 [*] Unnecessary `dict` call (rewrite as a literal)
    |
    = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | f"{dict(x='y') | dict(y='z')}"
 20 20 | f"{ dict(x='y') | dict(y='z') }"
 21 21 | f"a {dict(x='y') | dict(y='z')} b"

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C408_C408.py_allow_dict_calls_with_keyword_arguments.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C408_C408.py_allow_dict_calls_with_keyword_arguments.snap
@@ -10,7 +10,7 @@ C408.py:1:5: C408 [*] Unnecessary `tuple` call (rewrite as a literal)
   |
   = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-t = tuple()
   1 |+t = ()
 2 2 | l = list()
@@ -27,7 +27,7 @@ C408.py:2:5: C408 [*] Unnecessary `list` call (rewrite as a literal)
   |
   = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | t = tuple()
 2   |-l = list()
   2 |+l = []
@@ -46,7 +46,7 @@ C408.py:3:6: C408 [*] Unnecessary `dict` call (rewrite as a literal)
   |
   = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | t = tuple()
 2 2 | l = list()
 3   |-d1 = dict()
@@ -65,7 +65,7 @@ C408.py:16:4: C408 [*] Unnecessary `dict` call (rewrite as a literal)
    |
    = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | 
 14 14 | f"{dict(x='y')}"
 15 15 | f'{dict(x="y")}'
@@ -86,7 +86,7 @@ C408.py:17:6: C408 [*] Unnecessary `dict` call (rewrite as a literal)
    |
    = help: Rewrite as a literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | f"{dict(x='y')}"
 15 15 | f'{dict(x="y")}'
 16 16 | f"{dict()}"

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C409_C409.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C409_C409.py.snap
@@ -10,7 +10,7 @@ C409.py:1:6: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite as
   |
   = help: Rewrite as a `tuple` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-t1 = tuple([])
   1 |+t1 = ()
 2 2 | t2 = tuple([1, 2])
@@ -27,7 +27,7 @@ C409.py:2:6: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite as
   |
   = help: Rewrite as a `tuple` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | t1 = tuple([])
 2   |-t2 = tuple([1, 2])
   2 |+t2 = (1, 2)
@@ -46,7 +46,7 @@ C409.py:3:6: C409 [*] Unnecessary `tuple` literal passed to `tuple()` (remove th
   |
   = help: Remove outer `tuple` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | t1 = tuple([])
 2 2 | t2 = tuple([1, 2])
 3   |-t3 = tuple((1, 2))
@@ -70,7 +70,7 @@ C409.py:4:6: C409 [*] Unnecessary `list` literal passed to `tuple()` (rewrite as
   |
   = help: Rewrite as a `tuple` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | t1 = tuple([])
 2 2 | t2 = tuple([1, 2])
 3 3 | t3 = tuple((1, 2))
@@ -96,7 +96,7 @@ C409.py:8:6: C409 [*] Unnecessary `tuple` literal passed to `tuple()` (remove th
    |
    = help: Remove outer `tuple` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 |     1,
 6 6 |     2
 7 7 | ])

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C410_C410.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C410_C410.py.snap
@@ -10,7 +10,7 @@ C410.py:1:6: C410 [*] Unnecessary `list` literal passed to `list()` (remove the 
   |
   = help: Remove outer `list` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-l1 = list([1, 2])
   1 |+l1 = [1, 2]
 2 2 | l2 = list((1, 2))
@@ -27,7 +27,7 @@ C410.py:2:6: C410 [*] Unnecessary `tuple` literal passed to `list()` (rewrite as
   |
   = help: Rewrite as a `list` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | l1 = list([1, 2])
 2   |-l2 = list((1, 2))
   2 |+l2 = [1, 2]
@@ -44,7 +44,7 @@ C410.py:3:6: C410 [*] Unnecessary `list` literal passed to `list()` (remove the 
   |
   = help: Remove outer `list` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | l1 = list([1, 2])
 2 2 | l2 = list((1, 2))
 3   |-l3 = list([])
@@ -60,7 +60,7 @@ C410.py:4:6: C410 [*] Unnecessary `tuple` literal passed to `list()` (rewrite as
   |
   = help: Rewrite as a `list` literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | l1 = list([1, 2])
 2 2 | l2 = list((1, 2))
 3 3 | l3 = list([])

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C411_C411.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C411_C411.py.snap
@@ -9,7 +9,7 @@ C411.py:2:1: C411 [*] Unnecessary `list` call (remove the outer call to `list()`
   |
   = help: Remove outer `list` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | x = [1, 2, 3]
 2   |-list([i for i in x])
   2 |+[i for i in x]

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C413_C413.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C413_C413.py.snap
@@ -32,7 +32,7 @@ C413.py:4:1: C413 [*] Unnecessary `reversed` call around `sorted()`
   |
   = help: Remove unnecessary `reversed` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | x = [2, 3, 1]
 2 2 | list(x)
 3 3 | list(sorted(x))
@@ -53,7 +53,7 @@ C413.py:5:1: C413 [*] Unnecessary `reversed` call around `sorted()`
   |
   = help: Remove unnecessary `reversed` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | list(x)
 3 3 | list(sorted(x))
 4 4 | reversed(sorted(x))
@@ -74,7 +74,7 @@ C413.py:6:1: C413 [*] Unnecessary `reversed` call around `sorted()`
   |
   = help: Remove unnecessary `reversed` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | list(sorted(x))
 4 4 | reversed(sorted(x))
 5 5 | reversed(sorted(x, key=lambda e: e))
@@ -95,7 +95,7 @@ C413.py:7:1: C413 [*] Unnecessary `reversed` call around `sorted()`
   |
   = help: Remove unnecessary `reversed` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | reversed(sorted(x))
 5 5 | reversed(sorted(x, key=lambda e: e))
 6 6 | reversed(sorted(x, reverse=True))
@@ -116,7 +116,7 @@ C413.py:8:1: C413 [*] Unnecessary `reversed` call around `sorted()`
    |
    = help: Remove unnecessary `reversed` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | reversed(sorted(x, key=lambda e: e))
 6 6 | reversed(sorted(x, reverse=True))
 7 7 | reversed(sorted(x, key=lambda e: e, reverse=True))
@@ -137,7 +137,7 @@ C413.py:9:1: C413 [*] Unnecessary `reversed` call around `sorted()`
    |
    = help: Remove unnecessary `reversed` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | reversed(sorted(x, reverse=True))
 7  7  | reversed(sorted(x, key=lambda e: e, reverse=True))
 8  8  | reversed(sorted(x, reverse=True, key=lambda e: e))
@@ -157,7 +157,7 @@ C413.py:10:1: C413 [*] Unnecessary `reversed` call around `sorted()`
    |
    = help: Remove unnecessary `reversed` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | reversed(sorted(x, key=lambda e: e, reverse=True))
 8  8  | reversed(sorted(x, reverse=True, key=lambda e: e))
 9  9  | reversed(sorted(x, reverse=False))
@@ -178,7 +178,7 @@ C413.py:11:1: C413 [*] Unnecessary `reversed` call around `sorted()`
    |
    = help: Remove unnecessary `reversed` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | reversed(sorted(x, reverse=True, key=lambda e: e))
 9  9  | reversed(sorted(x, reverse=False))
 10 10 | reversed(sorted(x, reverse=x))
@@ -197,7 +197,7 @@ C413.py:14:1: C413 [*] Unnecessary `reversed` call around `sorted()`
    |
    = help: Remove unnecessary `reversed` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | reversed(sorted(x, reverse=not x))
 12 12 | 
 13 13 | # Regression test for: https://github.com/astral-sh/ruff/issues/7289
@@ -216,7 +216,7 @@ C413.py:15:1: C413 [*] Unnecessary `reversed` call around `sorted()`
    |
    = help: Remove unnecessary `reversed` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | 
 13 13 | # Regression test for: https://github.com/astral-sh/ruff/issues/7289
 14 14 | reversed(sorted(i for i in range(42)))

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C414_C414.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C414_C414.py.snap
@@ -11,7 +11,7 @@ C414.py:2:1: C414 [*] Unnecessary `list` call within `list()`
   |
   = help: Remove the inner `list` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | x = [1, 2, 3]
 2   |-list(list(x))
   2 |+list(x)
@@ -30,7 +30,7 @@ C414.py:3:1: C414 [*] Unnecessary `tuple` call within `list()`
   |
   = help: Remove the inner `tuple` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | x = [1, 2, 3]
 2 2 | list(list(x))
 3   |-list(tuple(x))
@@ -50,7 +50,7 @@ C414.py:4:1: C414 [*] Unnecessary `list` call within `tuple()`
   |
   = help: Remove the inner `list` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | x = [1, 2, 3]
 2 2 | list(list(x))
 3 3 | list(tuple(x))
@@ -71,7 +71,7 @@ C414.py:5:1: C414 [*] Unnecessary `tuple` call within `tuple()`
   |
   = help: Remove the inner `tuple` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | list(list(x))
 3 3 | list(tuple(x))
 4 4 | tuple(list(x))
@@ -92,7 +92,7 @@ C414.py:6:1: C414 [*] Unnecessary `set` call within `set()`
   |
   = help: Remove the inner `set` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | list(tuple(x))
 4 4 | tuple(list(x))
 5 5 | tuple(tuple(x))
@@ -113,7 +113,7 @@ C414.py:7:1: C414 [*] Unnecessary `list` call within `set()`
   |
   = help: Remove the inner `list` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | tuple(list(x))
 5 5 | tuple(tuple(x))
 6 6 | set(set(x))
@@ -134,7 +134,7 @@ C414.py:8:1: C414 [*] Unnecessary `tuple` call within `set()`
    |
    = help: Remove the inner `tuple` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | tuple(tuple(x))
 6 6 | set(set(x))
 7 7 | set(list(x))
@@ -155,7 +155,7 @@ C414.py:9:1: C414 [*] Unnecessary `sorted` call within `set()`
    |
    = help: Remove the inner `sorted` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | set(set(x))
 7  7  | set(list(x))
 8  8  | set(tuple(x))
@@ -176,7 +176,7 @@ C414.py:10:1: C414 [*] Unnecessary `sorted` call within `set()`
    |
    = help: Remove the inner `sorted` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | set(list(x))
 8  8  | set(tuple(x))
 9  9  | set(sorted(x))
@@ -197,7 +197,7 @@ C414.py:11:1: C414 [*] Unnecessary `reversed` call within `set()`
    |
    = help: Remove the inner `reversed` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | set(tuple(x))
 9  9  | set(sorted(x))
 10 10 | set(sorted(x, key=lambda y: y))
@@ -218,7 +218,7 @@ C414.py:12:1: C414 [*] Unnecessary `list` call within `sorted()`
    |
    = help: Remove the inner `list` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | set(sorted(x))
 10 10 | set(sorted(x, key=lambda y: y))
 11 11 | set(reversed(x))
@@ -239,7 +239,7 @@ C414.py:13:1: C414 [*] Unnecessary `tuple` call within `sorted()`
    |
    = help: Remove the inner `tuple` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | set(sorted(x, key=lambda y: y))
 11 11 | set(reversed(x))
 12 12 | sorted(list(x))
@@ -260,7 +260,7 @@ C414.py:14:1: C414 [*] Unnecessary `sorted` call within `sorted()`
    |
    = help: Remove the inner `sorted` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | set(reversed(x))
 12 12 | sorted(list(x))
 13 13 | sorted(tuple(x))
@@ -281,7 +281,7 @@ C414.py:15:1: C414 [*] Unnecessary `sorted` call within `sorted()`
    |
    = help: Remove the inner `sorted` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | sorted(list(x))
 13 13 | sorted(tuple(x))
 14 14 | sorted(sorted(x))
@@ -302,7 +302,7 @@ C414.py:16:1: C414 [*] Unnecessary `sorted` call within `sorted()`
    |
    = help: Remove the inner `sorted` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | sorted(tuple(x))
 14 14 | sorted(sorted(x))
 15 15 | sorted(sorted(x, key=foo, reverse=False), reverse=False, key=foo)
@@ -323,7 +323,7 @@ C414.py:17:1: C414 [*] Unnecessary `reversed` call within `sorted()`
    |
    = help: Remove the inner `reversed` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | sorted(sorted(x))
 15 15 | sorted(sorted(x, key=foo, reverse=False), reverse=False, key=foo)
 16 16 | sorted(sorted(x, reverse=True), reverse=True)
@@ -344,7 +344,7 @@ C414.py:18:1: C414 [*] Unnecessary `list` call within `sorted()`
    |
    = help: Remove the inner `list` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | sorted(sorted(x, key=foo, reverse=False), reverse=False, key=foo)
 16 16 | sorted(sorted(x, reverse=True), reverse=True)
 17 17 | sorted(reversed(x))
@@ -370,7 +370,7 @@ C414.py:19:1: C414 [*] Unnecessary `list` call within `tuple()`
    |
    = help: Remove the inner `list` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | sorted(reversed(x))
 18 18 | sorted(list(x), key=lambda y: y)
 19 19 | tuple(
@@ -394,7 +394,7 @@ C414.py:25:1: C414 [*] Unnecessary `set` call within `set()`
    |
    = help: Remove the inner `set` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 |         "o"]
 23 23 |     )
 24 24 | )
@@ -415,7 +415,7 @@ C414.py:26:1: C414 [*] Unnecessary `list` call within `set()`
    |
    = help: Remove the inner `list` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 |     )
 24 24 | )
 25 25 | set(set())
@@ -435,7 +435,7 @@ C414.py:27:1: C414 [*] Unnecessary `tuple` call within `set()`
    |
    = help: Remove the inner `tuple` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 24 24 | )
 25 25 | set(set())
 26 26 | set(list())
@@ -456,7 +456,7 @@ C414.py:28:1: C414 [*] Unnecessary `reversed` call within `sorted()`
    |
    = help: Remove the inner `reversed` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 25 25 | set(set())
 26 26 | set(list())
 27 27 | set(tuple())
@@ -482,7 +482,7 @@ C414.py:37:27: C414 [*] Unnecessary `list` call within `sorted()`
    |
    = help: Remove the inner `list` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 35 35 | 
 36 36 | # Preserve trailing comments.
 37 37 | xxxxxxxxxxx_xxxxx_xxxxx = sorted(
@@ -505,7 +505,7 @@ C414.py:44:27: C414 [*] Unnecessary `list` call within `sorted()`
    |
    = help: Remove the inner `list` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 42 42 | )
 43 43 | 
 44 44 | xxxxxxxxxxx_xxxxx_xxxxx = sorted(

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C416_C416.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C416_C416.py.snap
@@ -12,7 +12,7 @@ C416.py:6:1: C416 [*] Unnecessary `list` comprehension (rewrite using `list()`)
   |
   = help: Rewrite using `list()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | z = [(1,), (2,), (3,)]
 4 4 | d = {"a": 1, "b": 2, "c": 3}
 5 5 | 
@@ -32,7 +32,7 @@ C416.py:7:1: C416 [*] Unnecessary `set` comprehension (rewrite using `set()`)
   |
   = help: Rewrite using `set()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | d = {"a": 1, "b": 2, "c": 3}
 5 5 | 
 6 6 | [i for i in x]
@@ -53,7 +53,7 @@ C416.py:8:1: C416 [*] Unnecessary `dict` comprehension (rewrite using `dict()`)
    |
    = help: Rewrite using `dict()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | 
 6 6 | [i for i in x]
 7 7 | {i for i in x}
@@ -74,7 +74,7 @@ C416.py:9:1: C416 [*] Unnecessary `dict` comprehension (rewrite using `dict()`)
    |
    = help: Rewrite using `dict()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | [i for i in x]
 7  7  | {i for i in x}
 8  8  | {k: v for k, v in y}
@@ -94,7 +94,7 @@ C416.py:10:1: C416 [*] Unnecessary `list` comprehension (rewrite using `list()`)
    |
    = help: Rewrite using `list()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | {i for i in x}
 8  8  | {k: v for k, v in y}
 9  9  | {k: v for k, v in d.items()}
@@ -115,7 +115,7 @@ C416.py:11:1: C416 [*] Unnecessary `dict` comprehension (rewrite using `dict()`)
    |
    = help: Rewrite using `dict()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | {k: v for k, v in y}
 9  9  | {k: v for k, v in d.items()}
 10 10 | [(k, v) for k, v in d.items()]
@@ -133,7 +133,7 @@ C416.py:24:70: C416 [*] Unnecessary `list` comprehension (rewrite using `list()`
    |
    = help: Rewrite using `list()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | {k: v if v else None for k, v in y}
 22 22 | 
 23 23 | # Regression test for: https://github.com/astral-sh/ruff/issues/7196

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C417_C417.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C417_C417.py.snap
@@ -12,7 +12,7 @@ C417.py:3:1: C417 [*] Unnecessary `map` usage (rewrite using a generator express
   |
   = help: Replace `map` with a generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # Errors.
 2 2 | nums = [1, 2, 3]
 3   |-map(lambda x: x + 1, nums)
@@ -32,7 +32,7 @@ C417.py:4:1: C417 [*] Unnecessary `map` usage (rewrite using a generator express
   |
   = help: Replace `map` with a generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # Errors.
 2 2 | nums = [1, 2, 3]
 3 3 | map(lambda x: x + 1, nums)
@@ -53,7 +53,7 @@ C417.py:5:1: C417 [*] Unnecessary `map` usage (rewrite using a `list` comprehens
   |
   = help: Replace `map` with a `list` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | nums = [1, 2, 3]
 3 3 | map(lambda x: x + 1, nums)
 4 4 | map(lambda x: str(x), nums)
@@ -74,7 +74,7 @@ C417.py:6:1: C417 [*] Unnecessary `map` usage (rewrite using a `set` comprehensi
   |
   = help: Replace `map` with a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | map(lambda x: x + 1, nums)
 4 4 | map(lambda x: str(x), nums)
 5 5 | list(map(lambda x: x * 2, nums))
@@ -95,7 +95,7 @@ C417.py:7:1: C417 [*] Unnecessary `map` usage (rewrite using a `dict` comprehens
   |
   = help: Replace `map` with a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | map(lambda x: str(x), nums)
 5 5 | list(map(lambda x: x * 2, nums))
 6 6 | set(map(lambda x: x % 2 == 0, nums))
@@ -116,7 +116,7 @@ C417.py:8:1: C417 [*] Unnecessary `map` usage (rewrite using a `dict` comprehens
    |
    = help: Replace `map` with a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | list(map(lambda x: x * 2, nums))
 6 6 | set(map(lambda x: x % 2 == 0, nums))
 7 7 | dict(map(lambda v: (v, v**2), nums))
@@ -137,7 +137,7 @@ C417.py:9:1: C417 [*] Unnecessary `map` usage (rewrite using a generator express
    |
    = help: Replace `map` with a generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | set(map(lambda x: x % 2 == 0, nums))
 7  7  | dict(map(lambda v: (v, v**2), nums))
 8  8  | dict(map(lambda v: [v, v**2], nums))
@@ -158,7 +158,7 @@ C417.py:10:1: C417 [*] Unnecessary `map` usage (rewrite using a generator expres
    |
    = help: Replace `map` with a generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | dict(map(lambda v: (v, v**2), nums))
 8  8  | dict(map(lambda v: [v, v**2], nums))
 9  9  | map(lambda: "const", nums)
@@ -179,7 +179,7 @@ C417.py:11:13: C417 [*] Unnecessary `map` usage (rewrite using a generator expre
    |
    = help: Replace `map` with a generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | dict(map(lambda v: [v, v**2], nums))
 9  9  | map(lambda: "const", nums)
 10 10 | map(lambda _: 3.0, nums)
@@ -200,7 +200,7 @@ C417.py:12:5: C417 [*] Unnecessary `map` usage (rewrite using a generator expres
    |
    = help: Replace `map` with a generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | map(lambda: "const", nums)
 10 10 | map(lambda _: 3.0, nums)
 11 11 | _ = "".join(map(lambda x: x in nums and "1" or "0", range(123)))
@@ -220,7 +220,7 @@ C417.py:13:14: C417 [*] Unnecessary `map` usage (rewrite using a generator expre
    |
    = help: Replace `map` with a generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | map(lambda _: 3.0, nums)
 11 11 | _ = "".join(map(lambda x: x in nums and "1" or "0", range(123)))
 12 12 | all(map(lambda v: isinstance(v, dict), nums))
@@ -241,7 +241,7 @@ C417.py:14:1: C417 [*] Unnecessary `map` usage (rewrite using a `list` comprehen
    |
    = help: Replace `map` with a `list` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | _ = "".join(map(lambda x: x in nums and "1" or "0", range(123)))
 12 12 | all(map(lambda v: isinstance(v, dict), nums))
 13 13 | filter(func, map(lambda v: v, nums))
@@ -260,7 +260,7 @@ C417.py:17:8: C417 [*] Unnecessary `map` usage (rewrite using a `set` comprehens
    |
    = help: Replace `map` with a `set` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | list(map(lambda x, y: x * y, nums))
 15 15 | 
 16 16 | # When inside f-string, then the fix should be surrounded by whitespace
@@ -281,7 +281,7 @@ C417.py:18:8: C417 [*] Unnecessary `map` usage (rewrite using a `dict` comprehen
    |
    = help: Replace `map` with a `dict` comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | 
 16 16 | # When inside f-string, then the fix should be surrounded by whitespace
 17 17 | _ = f"{set(map(lambda x: x % 2 == 0, nums))}"
@@ -301,7 +301,7 @@ C417.py:36:1: C417 [*] Unnecessary `map` usage (rewrite using a generator expres
    |
    = help: Replace `map` with a generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 33 33 | map(lambda x: lambda: x, range(4))
 34 34 | 
 35 35 | # Error: the `x` is overridden by the inner lambda.
@@ -321,7 +321,7 @@ C417.py:47:1: C417 [*] Unnecessary `map` usage (rewrite using a generator expres
    |
    = help: Replace `map` with a generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 44 44 | dict(map(lambda k, v: (k, v), keys, values))
 45 45 | 
 46 46 | # Regression test for: https://github.com/astral-sh/ruff/issues/7121
@@ -340,7 +340,7 @@ C417.py:48:1: C417 [*] Unnecessary `map` usage (rewrite using a generator expres
    |
    = help: Replace `map` with a generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 45 45 | 
 46 46 | # Regression test for: https://github.com/astral-sh/ruff/issues/7121
 47 47 | map(lambda x: x, y if y else z)
@@ -357,7 +357,7 @@ C417.py:49:1: C417 [*] Unnecessary `map` usage (rewrite using a generator expres
    |
    = help: Replace `map` with a generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 | # Regression test for: https://github.com/astral-sh/ruff/issues/7121
 47 47 | map(lambda x: x, y if y else z)
 48 48 | map(lambda x: x, (y if y else z))

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C418_C418.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C418_C418.py.snap
@@ -10,7 +10,7 @@ C418.py:1:1: C418 [*] Unnecessary `dict` literal passed to `dict()` (remove the 
   |
   = help: Remove outer `dict` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-dict({})
   1 |+{}
 2 2 | dict({'a': 1})
@@ -27,7 +27,7 @@ C418.py:2:1: C418 [*] Unnecessary `dict` literal passed to `dict()` (remove the 
   |
   = help: Remove outer `dict` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | dict({})
 2   |-dict({'a': 1})
   2 |+{'a': 1}
@@ -46,7 +46,7 @@ C418.py:3:1: C418 [*] Unnecessary `dict` comprehension passed to `dict()` (remov
   |
   = help: Remove outer `dict` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | dict({})
 2 2 | dict({'a': 1})
 3   |-dict({'x': 1 for x in range(10)})
@@ -68,7 +68,7 @@ C418.py:4:1: C418 [*] Unnecessary `dict` comprehension passed to `dict()` (remov
   |
   = help: Remove outer `dict` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | dict({})
 2 2 | dict({'a': 1})
 3 3 | dict({'x': 1 for x in range(10)})

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C419_C419.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C419_C419.py.snap
@@ -10,7 +10,7 @@ C419.py:1:5: C419 [*] Unnecessary list comprehension.
   |
   = help: Remove unnecessary list comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-any([x.id for x in bar])
   1 |+any(x.id for x in bar)
 2 2 | all([x.id for x in bar])
@@ -27,7 +27,7 @@ C419.py:2:5: C419 [*] Unnecessary list comprehension.
   |
   = help: Remove unnecessary list comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | any([x.id for x in bar])
 2   |-all([x.id for x in bar])
   2 |+all(x.id for x in bar)
@@ -46,7 +46,7 @@ C419.py:4:5: C419 [*] Unnecessary list comprehension.
   |
   = help: Remove unnecessary list comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | any([x.id for x in bar])
 2 2 | all([x.id for x in bar])
 3 3 | any(  # first comment
@@ -67,7 +67,7 @@ C419.py:7:5: C419 [*] Unnecessary list comprehension.
   |
   = help: Remove unnecessary list comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 |     [x.id for x in bar],  # second comment
 5 5 | )  # third comment
 6 6 | all(  # first comment
@@ -88,7 +88,7 @@ C419.py:9:5: C419 [*] Unnecessary list comprehension.
    |
    = help: Remove unnecessary list comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | all(  # first comment
 7  7  |     [x.id for x in bar],  # second comment
 8  8  | )  # third comment
@@ -115,7 +115,7 @@ C419.py:24:5: C419 [*] Unnecessary list comprehension.
    |
    = help: Remove unnecessary list comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | 
 22 22 | # Special comment handling
 23 23 | any(
@@ -147,7 +147,7 @@ C419.py:35:5: C419 [*] Unnecessary list comprehension.
    |
    = help: Remove unnecessary list comprehension
 
-ℹ Suggested fix
+ℹ Unsafe fix
 32 32 | 
 33 33 | # Weird case where the function call, opening bracket, and comment are all
 34 34 | # on the same line.

--- a/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
@@ -293,7 +293,7 @@ fn generate_fix(
         range: TextRange::default(),
     });
 
-    Fix::suggested_edits(
+    Fix::automatic_unsafe_edits(
         Edit::insertion(
             format!(
                 "{}{}{}",

--- a/crates/ruff_linter/src/rules/flake8_errmsg/snapshots/ruff_linter__rules__flake8_errmsg__tests__custom.snap
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/snapshots/ruff_linter__rules__flake8_errmsg__tests__custom.snap
@@ -9,7 +9,7 @@ EM.py:5:24: EM101 [*] Exception must not use a string literal, assign to variabl
   |
   = help: Assign to variable; remove string literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | 
 3 3 | 
 4 4 | def f_a():
@@ -29,7 +29,7 @@ EM.py:18:24: EM102 [*] Exception must not use an f-string literal, assign to var
    |
    = help: Assign to variable; remove f-string literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | 
 16 16 | def f_b():
 17 17 |     example = "example"
@@ -48,7 +48,7 @@ EM.py:22:24: EM103 [*] Exception must not use a `.format()` string directly, ass
    |
    = help: Assign to variable; remove `.format()` string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | 
 20 20 | 
 21 21 | def f_c():
@@ -77,7 +77,7 @@ EM.py:39:24: EM101 [*] Exception must not use a string literal, assign to variab
    |
    = help: Assign to variable; remove string literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 36 36 |     def nested():
 37 37 |         msg = "hello"
 38 38 | 
@@ -107,7 +107,7 @@ EM.py:51:28: EM101 [*] Exception must not use a string literal, assign to variab
    |
    = help: Assign to variable; remove string literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 48 48 | 
 49 49 | def f_fix_indentation_check(foo):
 50 50 |     if foo:
@@ -128,7 +128,7 @@ EM.py:54:32: EM102 [*] Exception must not use an f-string literal, assign to var
    |
    = help: Assign to variable; remove f-string literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 51 51 |         raise RuntimeError("This is an example exception")
 52 52 |     else:
 53 53 |         if foo == "foo":
@@ -148,7 +148,7 @@ EM.py:55:24: EM103 [*] Exception must not use a `.format()` string directly, ass
    |
    = help: Assign to variable; remove `.format()` string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 52 52 |     else:
 53 53 |         if foo == "foo":
 54 54 |             raise RuntimeError(f"This is an exception: {foo}")

--- a/crates/ruff_linter/src/rules/flake8_errmsg/snapshots/ruff_linter__rules__flake8_errmsg__tests__defaults.snap
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/snapshots/ruff_linter__rules__flake8_errmsg__tests__defaults.snap
@@ -9,7 +9,7 @@ EM.py:5:24: EM101 [*] Exception must not use a string literal, assign to variabl
   |
   = help: Assign to variable; remove string literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | 
 3 3 | 
 4 4 | def f_a():
@@ -28,7 +28,7 @@ EM.py:9:24: EM101 [*] Exception must not use a string literal, assign to variabl
   |
   = help: Assign to variable; remove string literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | 
 7  7  | 
 8  8  | def f_a_short():
@@ -47,7 +47,7 @@ EM.py:13:24: EM101 [*] Exception must not use a string literal, assign to variab
    |
    = help: Assign to variable; remove string literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | 
 11 11 | 
 12 12 | def f_a_empty():
@@ -67,7 +67,7 @@ EM.py:18:24: EM102 [*] Exception must not use an f-string literal, assign to var
    |
    = help: Assign to variable; remove f-string literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | 
 16 16 | def f_b():
 17 17 |     example = "example"
@@ -86,7 +86,7 @@ EM.py:22:24: EM103 [*] Exception must not use a `.format()` string directly, ass
    |
    = help: Assign to variable; remove `.format()` string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | 
 20 20 | 
 21 21 | def f_c():
@@ -115,7 +115,7 @@ EM.py:39:24: EM101 [*] Exception must not use a string literal, assign to variab
    |
    = help: Assign to variable; remove string literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 36 36 |     def nested():
 37 37 |         msg = "hello"
 38 38 | 
@@ -145,7 +145,7 @@ EM.py:51:28: EM101 [*] Exception must not use a string literal, assign to variab
    |
    = help: Assign to variable; remove string literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 48 48 | 
 49 49 | def f_fix_indentation_check(foo):
 50 50 |     if foo:
@@ -166,7 +166,7 @@ EM.py:54:32: EM102 [*] Exception must not use an f-string literal, assign to var
    |
    = help: Assign to variable; remove f-string literal
 
-ℹ Suggested fix
+ℹ Unsafe fix
 51 51 |         raise RuntimeError("This is an example exception")
 52 52 |     else:
 53 53 |         if foo == "foo":
@@ -186,7 +186,7 @@ EM.py:55:24: EM103 [*] Exception must not use a `.format()` string directly, ass
    |
    = help: Assign to variable; remove `.format()` string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 52 52 |     else:
 53 53 |         if foo == "foo":
 54 54 |             raise RuntimeError(f"This is an exception: {foo}")

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_leading_whitespace.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_leading_whitespace.rs
@@ -69,7 +69,7 @@ pub(crate) fn shebang_leading_whitespace(
     let prefix = TextRange::up_to(range.start());
     let mut diagnostic = Diagnostic::new(ShebangLeadingWhitespace, prefix);
     if settings.rules.should_fix(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::automatic(Edit::range_deletion(prefix)));
+        diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(prefix)));
     }
     Some(diagnostic)
 }

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
@@ -169,7 +169,7 @@ fn concatenate_strings(a_range: TextRange, b_range: TextRange, locator: &Locator
     let concatenation = format!("{a_leading_quote}{a_body}{b_body}{a_trailing_quote}");
     let range = TextRange::new(a_range.start(), b_range.end());
 
-    Some(Fix::automatic(Edit::range_replacement(
+    Some(Fix::automatic_safe(Edit::range_replacement(
         concatenation,
         range,
     )))

--- a/crates/ruff_linter/src/rules/flake8_import_conventions/rules/unconventional_import_alias.rs
+++ b/crates/ruff_linter/src/rules/flake8_import_conventions/rules/unconventional_import_alias.rs
@@ -86,7 +86,7 @@ pub(crate) fn unconventional_import_alias(
                     let scope = &checker.semantic().scopes[binding.scope];
                     let (edit, rest) =
                         Renamer::rename(name, expected_alias, scope, checker.semantic())?;
-                    Ok(Fix::suggested_edits(edit, rest))
+                    Ok(Fix::automatic_unsafe_edits(edit, rest))
                 });
             }
         }

--- a/crates/ruff_linter/src/rules/flake8_import_conventions/snapshots/ruff_linter__rules__flake8_import_conventions__tests__defaults.snap
+++ b/crates/ruff_linter/src/rules/flake8_import_conventions/snapshots/ruff_linter__rules__flake8_import_conventions__tests__defaults.snap
@@ -11,7 +11,7 @@ defaults.py:6:12: ICN001 [*] `altair` should be imported as `alt`
   |
   = help: Alias `altair` to `alt`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | 
 4 4 | 
 5 5 | def unconventional():
@@ -43,7 +43,7 @@ defaults.py:8:12: ICN001 [*] `numpy` should be imported as `np`
    |
    = help: Alias `numpy` to `np`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | def unconventional():
 6 6 |     import altair
 7 7 |     import matplotlib.pyplot
@@ -64,7 +64,7 @@ defaults.py:9:12: ICN001 [*] `pandas` should be imported as `pd`
    |
    = help: Alias `pandas` to `pd`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  |     import altair
 7  7  |     import matplotlib.pyplot
 8  8  |     import numpy
@@ -85,7 +85,7 @@ defaults.py:10:12: ICN001 [*] `seaborn` should be imported as `sns`
    |
    = help: Alias `seaborn` to `sns`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  |     import matplotlib.pyplot
 8  8  |     import numpy
 9  9  |     import pandas
@@ -105,7 +105,7 @@ defaults.py:11:12: ICN001 [*] `tkinter` should be imported as `tk`
    |
    = help: Alias `tkinter` to `tk`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  |     import numpy
 9  9  |     import pandas
 10 10 |     import seaborn
@@ -124,7 +124,7 @@ defaults.py:12:12: ICN001 [*] `networkx` should be imported as `nx`
    |
    = help: Alias `networkx` to `nx`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  |     import pandas
 10 10 |     import seaborn
 11 11 |     import tkinter
@@ -144,7 +144,7 @@ defaults.py:16:22: ICN001 [*] `altair` should be imported as `alt`
    |
    = help: Alias `altair` to `alt`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | 
 14 14 | 
 15 15 | def unconventional_aliases():
@@ -165,7 +165,7 @@ defaults.py:17:33: ICN001 [*] `matplotlib.pyplot` should be imported as `plt`
    |
    = help: Alias `matplotlib.pyplot` to `plt`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | 
 15 15 | def unconventional_aliases():
 16 16 |     import altair as altr
@@ -186,7 +186,7 @@ defaults.py:18:21: ICN001 [*] `numpy` should be imported as `np`
    |
    = help: Alias `numpy` to `np`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | def unconventional_aliases():
 16 16 |     import altair as altr
 17 17 |     import matplotlib.pyplot as plot
@@ -207,7 +207,7 @@ defaults.py:19:22: ICN001 [*] `pandas` should be imported as `pd`
    |
    = help: Alias `pandas` to `pd`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 |     import altair as altr
 17 17 |     import matplotlib.pyplot as plot
 18 18 |     import numpy as nmp
@@ -228,7 +228,7 @@ defaults.py:20:23: ICN001 [*] `seaborn` should be imported as `sns`
    |
    = help: Alias `seaborn` to `sns`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 |     import matplotlib.pyplot as plot
 18 18 |     import numpy as nmp
 19 19 |     import pandas as pdas
@@ -248,7 +248,7 @@ defaults.py:21:23: ICN001 [*] `tkinter` should be imported as `tk`
    |
    = help: Alias `tkinter` to `tk`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 |     import numpy as nmp
 19 19 |     import pandas as pdas
 20 20 |     import seaborn as sbrn
@@ -269,7 +269,7 @@ defaults.py:22:24: ICN001 [*] `networkx` should be imported as `nx`
    |
    = help: Alias `networkx` to `nx`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 |     import pandas as pdas
 20 20 |     import seaborn as sbrn
 21 21 |     import tkinter as tkr

--- a/crates/ruff_linter/src/rules/flake8_import_conventions/snapshots/ruff_linter__rules__flake8_import_conventions__tests__tricky.snap
+++ b/crates/ruff_linter/src/rules/flake8_import_conventions/snapshots/ruff_linter__rules__flake8_import_conventions__tests__tricky.snap
@@ -12,7 +12,7 @@ tricky.py:7:16: ICN001 [*] `pandas` should be imported as `pd`
   |
   = help: Alias `pandas` to `pd`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | 
 4 4 | def rename_global():
 5 5 |     try:

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/direct_logger_instantiation.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/direct_logger_instantiation.rs
@@ -69,7 +69,7 @@ pub(crate) fn direct_logger_instantiation(checker: &mut Checker, call: &ast::Exp
                     checker.semantic(),
                 )?;
                 let reference_edit = Edit::range_replacement(binding, call.func.range());
-                Ok(Fix::suggested_edits(import_edit, [reference_edit]))
+                Ok(Fix::automatic_unsafe_edits(import_edit, [reference_edit]))
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/invalid_get_logger_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/invalid_get_logger_argument.rs
@@ -82,7 +82,7 @@ pub(crate) fn invalid_get_logger_argument(checker: &mut Checker, call: &ast::Exp
     let mut diagnostic = Diagnostic::new(InvalidGetLoggerArgument, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
         if checker.semantic().is_builtin("__name__") {
-            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                 "__name__".to_string(),
                 expr.range(),
             )));

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/undocumented_warn.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/undocumented_warn.rs
@@ -63,7 +63,7 @@ pub(crate) fn undocumented_warn(checker: &mut Checker, expr: &Expr) {
                     checker.semantic(),
                 )?;
                 let reference_edit = Edit::range_replacement(binding, expr.range());
-                Ok(Fix::suggested_edits(import_edit, [reference_edit]))
+                Ok(Fix::automatic_unsafe_edits(import_edit, [reference_edit]))
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_logging/snapshots/ruff_linter__rules__flake8_logging__tests__LOG001_LOG001.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_logging/snapshots/ruff_linter__rules__flake8_logging__tests__LOG001_LOG001.py.snap
@@ -12,7 +12,7 @@ LOG001.py:3:1: LOG001 [*] Use `logging.getLogger()` to instantiate loggers
   |
   = help: Replace with `logging.getLogger()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import logging
 2 2 | 
 3   |-logging.Logger(__name__)
@@ -29,7 +29,7 @@ LOG001.py:4:1: LOG001 [*] Use `logging.getLogger()` to instantiate loggers
   |
   = help: Replace with `logging.getLogger()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import logging
 2 2 | 
 3 3 | logging.Logger(__name__)

--- a/crates/ruff_linter/src/rules/flake8_logging/snapshots/ruff_linter__rules__flake8_logging__tests__LOG002_LOG002.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_logging/snapshots/ruff_linter__rules__flake8_logging__tests__LOG002_LOG002.py.snap
@@ -10,7 +10,7 @@ LOG002.py:11:11: LOG002 [*] Use `__name__` with `logging.getLogger()`
    |
    = help: Replace with `name`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | logging.getLogger(name="custom")
 9  9  | 
 10 10 | # LOG002
@@ -31,7 +31,7 @@ LOG002.py:12:24: LOG002 [*] Use `__name__` with `logging.getLogger()`
    |
    = help: Replace with `name`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | 
 10 10 | # LOG002
 11 11 | getLogger(__file__)
@@ -51,7 +51,7 @@ LOG002.py:14:19: LOG002 [*] Use `__name__` with `logging.getLogger()`
    |
    = help: Replace with `name`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | getLogger(__file__)
 12 12 | logging.getLogger(name=__file__)
 13 13 | 
@@ -69,7 +69,7 @@ LOG002.py:15:16: LOG002 [*] Use `__name__` with `logging.getLogger()`
    |
    = help: Replace with `name`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | logging.getLogger(name=__file__)
 13 13 | 
 14 14 | logging.getLogger(__cached__)

--- a/crates/ruff_linter/src/rules/flake8_logging/snapshots/ruff_linter__rules__flake8_logging__tests__LOG009_LOG009.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_logging/snapshots/ruff_linter__rules__flake8_logging__tests__LOG009_LOG009.py.snap
@@ -11,7 +11,7 @@ LOG009.py:3:1: LOG009 [*] Use of undocumented `logging.WARN` constant
   |
   = help: Replace `logging.WARN` with `logging.WARNING`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import logging
 2 2 | 
 3   |-logging.WARN  # LOG009
@@ -30,7 +30,7 @@ LOG009.py:8:1: LOG009 [*] Use of undocumented `logging.WARN` constant
   |
   = help: Replace `logging.WARN` with `logging.WARNING`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | 
 6 6 | from logging import WARN, WARNING
 7 7 | 

--- a/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -197,7 +197,7 @@ pub(crate) fn logging_call(checker: &mut Checker, call: &ast::ExprCall) {
         ) {
             let mut diagnostic = Diagnostic::new(LoggingWarn, range);
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                     "warning".to_string(),
                     range,
                 )));

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
@@ -82,7 +82,7 @@ pub(crate) fn duplicate_class_field_definition(checker: &mut Checker, body: &[St
             if checker.patch(diagnostic.kind.rule()) {
                 let edit =
                     fix::edits::delete_stmt(stmt, Some(stmt), checker.locator(), checker.indexer());
-                diagnostic.set_fix(Fix::suggested(edit).isolate(Checker::isolation(
+                diagnostic.set_fix(Fix::automatic_unsafe(edit).isolate(Checker::isolation(
                     checker.semantic().current_statement_id(),
                 )));
             }

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/multiple_starts_ends_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/multiple_starts_ends_with.rs
@@ -196,7 +196,7 @@ pub(crate) fn multiple_starts_ends_with(checker: &mut Checker, expr: &Expr) {
                     range: TextRange::default(),
                 });
                 let bool_op = node;
-                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                     checker.generator().expr(&bool_op),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/reimplemented_list_builtin.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/reimplemented_list_builtin.rs
@@ -66,7 +66,7 @@ pub(crate) fn reimplemented_list_builtin(checker: &mut Checker, expr: &ExprLambd
                 let mut diagnostic = Diagnostic::new(ReimplementedListBuiltin, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     if checker.semantic().is_builtin("list") {
-                        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                             "list".to_string(),
                             expr.range(),
                         )));

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_pass.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_pass.rs
@@ -70,7 +70,7 @@ pub(crate) fn no_unnecessary_pass(checker: &mut Checker, body: &[Stmt]) {
                     } else {
                         fix::edits::delete_stmt(stmt, None, checker.locator(), checker.indexer())
                     };
-                diagnostic.set_fix(Fix::automatic(edit).isolate(Checker::isolation(
+                diagnostic.set_fix(Fix::automatic_safe(edit).isolate(Checker::isolation(
                     checker.semantic().current_statement_id(),
                 )));
             }

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_range_start.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_range_start.rs
@@ -86,7 +86,7 @@ pub(crate) fn unnecessary_range_start(checker: &mut Checker, call: &ast::ExprCal
                 Parentheses::Preserve,
                 checker.locator().contents(),
             )
-            .map(Fix::automatic)
+            .map(Fix::automatic_safe)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE794_PIE794.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE794_PIE794.py.snap
@@ -12,7 +12,7 @@ PIE794.py:4:5: PIE794 [*] Class field `name` is defined multiple times
   |
   = help: Remove duplicate field definition for `name`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | class Foo(BaseModel):
 2 2 |     name = StringField()
 3 3 |     # ....
@@ -32,7 +32,7 @@ PIE794.py:13:5: PIE794 [*] Class field `name` is defined multiple times
    |
    = help: Remove duplicate field definition for `name`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | class Foo(BaseModel):
 11 11 |     name: str = StringField()
 12 12 |     # ....
@@ -50,7 +50,7 @@ PIE794.py:23:5: PIE794 [*] Class field `bar` is defined multiple times
    |
    = help: Remove duplicate field definition for `bar`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 |     bar: str = StringField()
 21 21 |     foo: bool = BooleanField()
 22 22 |     # ...
@@ -68,7 +68,7 @@ PIE794.py:40:5: PIE794 [*] Class field `bar` is defined multiple times
    |
    = help: Remove duplicate field definition for `bar`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 37 37 |     bar: str = StringField()
 38 38 |     foo: bool = BooleanField()
 39 39 |     # ...

--- a/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE810_PIE810.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE810_PIE810.py.snap
@@ -11,7 +11,7 @@ PIE810.py:2:1: PIE810 [*] Call `startswith` once with a `tuple`
   |
   = help: Merge into a single `startswith` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # error
 2   |-obj.startswith("foo") or obj.startswith("bar")
   2 |+obj.startswith(("foo", "bar"))
@@ -30,7 +30,7 @@ PIE810.py:4:1: PIE810 [*] Call `endswith` once with a `tuple`
   |
   = help: Merge into a single `endswith` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # error
 2 2 | obj.startswith("foo") or obj.startswith("bar")
 3 3 | # error
@@ -51,7 +51,7 @@ PIE810.py:6:1: PIE810 [*] Call `startswith` once with a `tuple`
   |
   = help: Merge into a single `startswith` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | # error
 4 4 | obj.endswith("foo") or obj.endswith("bar")
 5 5 | # error
@@ -72,7 +72,7 @@ PIE810.py:8:1: PIE810 [*] Call `startswith` once with a `tuple`
    |
    = help: Merge into a single `startswith` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | # error
 6 6 | obj.startswith(foo) or obj.startswith(bar)
 7 7 | # error
@@ -93,7 +93,7 @@ PIE810.py:10:1: PIE810 [*] Call `startswith` once with a `tuple`
    |
    = help: Merge into a single `startswith` call
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | # error
 8  8  | obj.startswith(foo) or obj.startswith("foo")
 9  9  | # error

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/any_eq_ne_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/any_eq_ne_annotation.rs
@@ -81,7 +81,7 @@ pub(crate) fn any_eq_ne_annotation(checker: &mut Checker, name: &str, parameters
         if checker.patch(diagnostic.kind.rule()) {
             // Ex) `def __eq__(self, obj: Any): ...`
             if checker.semantic().is_builtin("object") {
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                     "object".to_string(),
                     annotation.range(),
                 )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
@@ -72,7 +72,7 @@ pub(crate) fn duplicate_union_member<'a>(checker: &mut Checker, expr: &'a Expr) 
                 if let Some(parent @ Expr::BinOp(ast::ExprBinOp { left, right, .. })) = parent {
                     // Replace the parent with its non-duplicate child.
                     let child = if expr == left.as_ref() { right } else { left };
-                    diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                         checker.locator().slice(child.as_ref()).to_string(),
                         parent.range(),
                     )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/ellipsis_in_non_empty_class_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/ellipsis_in_non_empty_class_body.rs
@@ -66,7 +66,7 @@ pub(crate) fn ellipsis_in_non_empty_class_body(checker: &mut Checker, body: &[St
             if checker.patch(diagnostic.kind.rule()) {
                 let edit =
                     fix::edits::delete_stmt(stmt, Some(stmt), checker.locator(), checker.indexer());
-                diagnostic.set_fix(Fix::automatic(edit).isolate(Checker::isolation(
+                diagnostic.set_fix(Fix::automatic_safe(edit).isolate(Checker::isolation(
                     checker.semantic().current_statement_id(),
                 )));
             }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
@@ -177,7 +177,7 @@ fn check_short_args_list(checker: &mut Checker, parameters: &Parameters, func_ki
 
             if checker.patch(diagnostic.kind.rule()) {
                 if checker.semantic().is_builtin("object") {
-                    diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                         "object".to_string(),
                         annotation.range(),
                     )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
@@ -70,7 +70,7 @@ pub(crate) fn non_empty_stub_body(checker: &mut Checker, body: &[Stmt]) {
 
     let mut diagnostic = Diagnostic::new(NonEmptyStubBody, stmt.range());
     if checker.patch(Rule::NonEmptyStubBody) {
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             format!("..."),
             stmt.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/numeric_literal_too_long.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/numeric_literal_too_long.rs
@@ -51,7 +51,7 @@ pub(crate) fn numeric_literal_too_long(checker: &mut Checker, expr: &Expr) {
 
     let mut diagnostic = Diagnostic::new(NumericLiteralTooLong, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             "...".to_string(),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_in_class_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_in_class_body.rs
@@ -63,7 +63,7 @@ pub(crate) fn pass_in_class_body(checker: &mut Checker, class_def: &ast::StmtCla
         if checker.patch(diagnostic.kind.rule()) {
             let edit =
                 fix::edits::delete_stmt(stmt, Some(stmt), checker.locator(), checker.indexer());
-            diagnostic.set_fix(Fix::automatic(edit).isolate(Checker::isolation(
+            diagnostic.set_fix(Fix::automatic_safe(edit).isolate(Checker::isolation(
                 checker.semantic().current_statement_id(),
             )));
         }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_statement_stub_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_statement_stub_body.rs
@@ -48,7 +48,7 @@ pub(crate) fn pass_statement_stub_body(checker: &mut Checker, body: &[Stmt]) {
 
     let mut diagnostic = Diagnostic::new(PassStatementStubBody, pass.range());
     if checker.patch(Rule::PassStatementStubBody) {
-        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
             format!("..."),
             pass.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/quoted_annotation_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/quoted_annotation_in_stub.rs
@@ -44,7 +44,7 @@ impl AlwaysFixableViolation for QuotedAnnotationInStub {
 pub(crate) fn quoted_annotation_in_stub(checker: &mut Checker, annotation: &str, range: TextRange) {
     let mut diagnostic = Diagnostic::new(QuotedAnnotationInStub, range);
     if checker.patch(Rule::QuotedAnnotationInStub) {
-        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
             annotation.to_string(),
             range,
         )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -535,7 +535,7 @@ pub(crate) fn typed_argument_simple_defaults(checker: &mut Checker, parameters: 
                 let mut diagnostic = Diagnostic::new(TypedArgumentDefaultInStub, default.range());
 
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                         "...".to_string(),
                         default.range(),
                     )));
@@ -572,7 +572,7 @@ pub(crate) fn argument_simple_defaults(checker: &mut Checker, parameters: &Param
                 let mut diagnostic = Diagnostic::new(ArgumentDefaultInStub, default.range());
 
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                         "...".to_string(),
                         default.range(),
                     )));
@@ -607,7 +607,7 @@ pub(crate) fn assignment_default_in_stub(checker: &mut Checker, targets: &[Expr]
 
     let mut diagnostic = Diagnostic::new(AssignmentDefaultInStub, value.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             "...".to_string(),
             value.range(),
         )));
@@ -643,7 +643,7 @@ pub(crate) fn annotated_assignment_default_in_stub(
 
     let mut diagnostic = Diagnostic::new(AssignmentDefaultInStub, value.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             "...".to_string(),
             value.range(),
         )));
@@ -748,7 +748,7 @@ pub(crate) fn type_alias_without_annotation(checker: &mut Checker, value: &Expr,
                 target.start(),
                 checker.semantic(),
             )?;
-            Ok(Fix::suggested_edits(
+            Ok(Fix::automatic_unsafe_edits(
                 Edit::range_replacement(format!("{id}: {binding}"), target.range()),
                 [import_edit],
             ))

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/str_or_repr_defined_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/str_or_repr_defined_in_stub.rs
@@ -99,7 +99,7 @@ pub(crate) fn str_or_repr_defined_in_stub(checker: &mut Checker, stmt: &Stmt) {
         let stmt = checker.semantic().current_statement();
         let parent = checker.semantic().current_statement_parent();
         let edit = delete_stmt(stmt, parent, checker.locator(), checker.indexer());
-        diagnostic.set_fix(Fix::automatic(edit).isolate(Checker::isolation(
+        diagnostic.set_fix(Fix::automatic_safe(edit).isolate(Checker::isolation(
             checker.semantic().current_statement_parent_id(),
         )));
     }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
@@ -68,7 +68,7 @@ pub(crate) fn string_or_bytes_too_long(checker: &mut Checker, expr: &Expr) {
 
     let mut diagnostic = Diagnostic::new(StringOrBytesTooLong, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             "...".to_string(),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unaliased_collections_abc_set_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unaliased_collections_abc_set_import.rs
@@ -70,7 +70,7 @@ pub(crate) fn unaliased_collections_abc_set_import(
             diagnostic.try_set_fix(|| {
                 let scope = &checker.semantic().scopes[binding.scope];
                 let (edit, rest) = Renamer::rename(name, "AbstractSet", scope, checker.semantic())?;
-                Ok(Fix::suggested_edits(edit, rest))
+                Ok(Fix::automatic_unsafe_edits(edit, rest))
             });
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI010_PYI010.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI010_PYI010.pyi.snap
@@ -11,7 +11,7 @@ PYI010.pyi:6:5: PYI010 [*] Function body must contain only `...`
   |
   = help: Replace function body with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 |     """foo"""  # OK, docstrings are handled by another rule
 4 4 | 
 5 5 | def buzz():
@@ -31,7 +31,7 @@ PYI010.pyi:9:5: PYI010 [*] Function body must contain only `...`
    |
    = help: Replace function body with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  |     print("buzz")  # ERROR PYI010
 7  7  | 
 8  8  | def foo2():
@@ -51,7 +51,7 @@ PYI010.pyi:12:5: PYI010 [*] Function body must contain only `...`
    |
    = help: Replace function body with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  |     123  # ERROR PYI010
 10 10 | 
 11 11 | def bizz():

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI011_PYI011.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI011_PYI011.pyi.snap
@@ -12,7 +12,7 @@ PYI011.pyi:10:14: PYI011 [*] Only simple default values allowed for typed argume
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | 
 8  8  | def f12(
 9  9  |     x,
@@ -37,7 +37,7 @@ PYI011.pyi:38:9: PYI011 [*] Only simple default values allowed for typed argumen
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 35 35 | def f152(
 36 36 |     x: dict[
 37 37 |         int, int
@@ -74,7 +74,7 @@ PYI011.pyi:46:9: PYI011 [*] Only simple default values allowed for typed argumen
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 43 43 | def f153(
 44 44 |     x: list[
 45 45 |         int
@@ -111,7 +111,7 @@ PYI011.pyi:63:9: PYI011 [*] Only simple default values allowed for typed argumen
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 60 60 | def f154(
 61 61 |     x: tuple[
 62 62 |         str, tuple[str, ...]
@@ -138,7 +138,7 @@ PYI011.pyi:71:9: PYI011 [*] Only simple default values allowed for typed argumen
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 68 68 | def f141(
 69 69 |     x: list[
 70 70 |         int
@@ -164,7 +164,7 @@ PYI011.pyi:78:9: PYI011 [*] Only simple default values allowed for typed argumen
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 75 75 | def f142(
 76 76 |     x: list[
 77 77 |         int
@@ -190,7 +190,7 @@ PYI011.pyi:85:9: PYI011 [*] Only simple default values allowed for typed argumen
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 82 82 | def f16(
 83 83 |     x: frozenset[
 84 84 |         bytes
@@ -215,7 +215,7 @@ PYI011.pyi:90:14: PYI011 [*] Only simple default values allowed for typed argume
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 87 87 |     )
 88 88 | ) -> None: ...
 89 89 | def f17(
@@ -239,7 +239,7 @@ PYI011.pyi:94:14: PYI011 [*] Only simple default values allowed for typed argume
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 91 91 |     + "bar",
 92 92 | ) -> None: ...
 93 93 | def f18(
@@ -263,7 +263,7 @@ PYI011.pyi:98:17: PYI011 [*] Only simple default values allowed for typed argume
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 95  95  |     + b"bar",
 96  96  | ) -> None: ...
 97  97  | def f19(
@@ -287,7 +287,7 @@ PYI011.pyi:102:14: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 99  99  |     + 4,
 100 100 | ) -> None: ...
 101 101 | def f20(
@@ -311,7 +311,7 @@ PYI011.pyi:106:18: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 103 103 |     + 5,  # Error PYI011 Only simple default values allowed for typed arguments
 104 104 | ) -> None: ...
 105 105 | def f21(
@@ -335,7 +335,7 @@ PYI011.pyi:110:18: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 107 107 |     - 3j,  # Error PYI011 Only simple default values allowed for typed arguments
 108 108 | ) -> None: ...
 109 109 | def f22(
@@ -357,7 +357,7 @@ PYI011.pyi:138:16: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 135 135 |     x: float = -math.inf,  # OK
 136 136 | ) -> None: ...
 137 137 | def f31(
@@ -378,7 +378,7 @@ PYI011.pyi:141:16: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 138 138 |     x: float = inf,  # Error PYI011 Only simple default values allowed for typed arguments
 139 139 | ) -> None: ...
 140 140 | def f32(
@@ -399,7 +399,7 @@ PYI011.pyi:147:16: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 144 144 |     x: float = math.nan,  # OK
 145 145 | ) -> None: ...
 146 146 | def f34(
@@ -422,7 +422,7 @@ PYI011.pyi:150:18: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 147 147 |     x: float = -math.nan,  # Error PYI011 Only simple default values allowed for typed arguments
 148 148 | ) -> None: ...
 149 149 | def f35(
@@ -445,7 +445,7 @@ PYI011.pyi:159:14: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 156 156 | ) -> None: ...
 157 157 | def f37(
 158 158 |     *,

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI014_PYI014.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI014_PYI014.pyi.snap
@@ -12,7 +12,7 @@ PYI014.pyi:3:7: PYI014 [*] Only simple default values allowed for arguments
   |
   = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | def f12(
 2 2 |     x,
 3   |-    y=os.pathsep,  # Error PYI014
@@ -36,7 +36,7 @@ PYI014.pyi:29:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 26 26 | ) -> None: ...
 27 27 | def f151(x={1: 2}) -> None: ...
 28 28 | def f152(
@@ -73,7 +73,7 @@ PYI014.pyi:35:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 32 32 |     }
 33 33 | ) -> None: ...
 34 34 | def f153(
@@ -110,7 +110,7 @@ PYI014.pyi:50:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 47 47 |     ]
 48 48 | ) -> None: ...
 49 49 | def f154(
@@ -134,7 +134,7 @@ PYI014.pyi:56:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 53 53 |     )
 54 54 | ) -> None: ...
 55 55 | def f141(
@@ -155,7 +155,7 @@ PYI014.pyi:59:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 56 56 |     x=[*range(10)],  # Error PYI014
 57 57 | ) -> None: ...
 58 58 | def f142(
@@ -176,7 +176,7 @@ PYI014.pyi:61:11: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 58 58 | def f142(
 59 59 |     x=list(range(10)),  # Error PYI014
 60 60 | ) -> None: ...
@@ -197,7 +197,7 @@ PYI014.pyi:63:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 60 60 | ) -> None: ...
 61 61 | def f16(x=frozenset({b"foo", b"bar", b"baz"})) -> None: ...  # Error PYI014
 62 62 | def f17(
@@ -218,7 +218,7 @@ PYI014.pyi:66:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 63 63 |     x="foo" + "bar",  # Error PYI014
 64 64 | ) -> None: ...
 65 65 | def f18(
@@ -239,7 +239,7 @@ PYI014.pyi:69:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 66 66 |     x=b"foo" + b"bar",  # Error PYI014
 67 67 | ) -> None: ...
 68 68 | def f19(
@@ -260,7 +260,7 @@ PYI014.pyi:72:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 69 69 |     x="foo" + 4,  # Error PYI014
 70 70 | ) -> None: ...
 71 71 | def f20(
@@ -281,7 +281,7 @@ PYI014.pyi:75:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 72 72 |     x=5 + 5,  # Error PYI014
 73 73 | ) -> None: ...
 74 74 | def f21(
@@ -302,7 +302,7 @@ PYI014.pyi:78:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 75 75 |     x=3j - 3j,  # Error PYI014
 76 76 | ) -> None: ...
 77 77 | def f22(

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI015_PYI015.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI015_PYI015.pyi.snap
@@ -11,7 +11,7 @@ PYI015.pyi:44:23: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 | field22: Final = {"foo": 5}
 42 42 | 
 43 43 | # We *should* emit Y015 for more complex default values
@@ -32,7 +32,7 @@ PYI015.pyi:45:23: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 42 42 | 
 43 43 | # We *should* emit Y015 for more complex default values
 44 44 | field221: list[int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]  # Y015 Only simple default values are allowed for assignments
@@ -53,7 +53,7 @@ PYI015.pyi:46:23: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 43 43 | # We *should* emit Y015 for more complex default values
 44 44 | field221: list[int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]  # Y015 Only simple default values are allowed for assignments
 45 45 | field223: list[int] = [*range(10)]  # Y015 Only simple default values are allowed for assignments
@@ -74,7 +74,7 @@ PYI015.pyi:47:26: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 44 44 | field221: list[int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]  # Y015 Only simple default values are allowed for assignments
 45 45 | field223: list[int] = [*range(10)]  # Y015 Only simple default values are allowed for assignments
 46 46 | field224: list[int] = list(range(10))  # Y015 Only simple default values are allowed for assignments
@@ -95,7 +95,7 @@ PYI015.pyi:48:47: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 45 45 | field223: list[int] = [*range(10)]  # Y015 Only simple default values are allowed for assignments
 46 46 | field224: list[int] = list(range(10))  # Y015 Only simple default values are allowed for assignments
 47 47 | field225: list[object] = [{}, 1, 2]  # Y015 Only simple default values are allowed for assignments
@@ -116,7 +116,7 @@ PYI015.pyi:49:31: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 | field224: list[int] = list(range(10))  # Y015 Only simple default values are allowed for assignments
 47 47 | field225: list[object] = [{}, 1, 2]  # Y015 Only simple default values are allowed for assignments
 48 48 | field226: tuple[str | tuple[str, ...], ...] = ("foo", ("foo", "bar"))  # Y015 Only simple default values are allowed for assignments
@@ -137,7 +137,7 @@ PYI015.pyi:50:37: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 47 47 | field225: list[object] = [{}, 1, 2]  # Y015 Only simple default values are allowed for assignments
 48 48 | field226: tuple[str | tuple[str, ...], ...] = ("foo", ("foo", "bar"))  # Y015 Only simple default values are allowed for assignments
 49 49 | field227: dict[str, object] = {"foo": {"foo": "bar"}}  # Y015 Only simple default values are allowed for assignments
@@ -158,7 +158,7 @@ PYI015.pyi:52:28: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 49 49 | field227: dict[str, object] = {"foo": {"foo": "bar"}}  # Y015 Only simple default values are allowed for assignments
 50 50 | field228: dict[str, list[object]] = {"foo": []}  # Y015 Only simple default values are allowed for assignments
 51 51 | # When parsed, this case results in `None` being placed in the `.keys` list for the `ast.Dict` node
@@ -179,7 +179,7 @@ PYI015.pyi:53:11: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 50 50 | field228: dict[str, list[object]] = {"foo": []}  # Y015 Only simple default values are allowed for assignments
 51 51 | # When parsed, this case results in `None` being placed in the `.keys` list for the `ast.Dict` node
 52 52 | field229: dict[int, int] = {1: 2, **{3: 4}}  # Y015 Only simple default values are allowed for assignments
@@ -199,7 +199,7 @@ PYI015.pyi:54:11: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 51 51 | # When parsed, this case results in `None` being placed in the `.keys` list for the `ast.Dict` node
 52 52 | field229: dict[int, int] = {1: 2, **{3: 4}}  # Y015 Only simple default values are allowed for assignments
 53 53 | field23 = "foo" + "bar"  # Y015 Only simple default values are allowed for assignments
@@ -220,7 +220,7 @@ PYI015.pyi:55:11: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 52 52 | field229: dict[int, int] = {1: 2, **{3: 4}}  # Y015 Only simple default values are allowed for assignments
 53 53 | field23 = "foo" + "bar"  # Y015 Only simple default values are allowed for assignments
 54 54 | field24 = b"foo" + b"bar"  # Y015 Only simple default values are allowed for assignments

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI025_PYI025.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI025_PYI025.py.snap
@@ -9,7 +9,7 @@ PYI025.py:10:33: PYI025 [*] Use `from collections.abc import Set as AbstractSet`
    |
    = help: Alias `Set` to `AbstractSet`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | 
 8  8  | 
 9  9  | def f():
@@ -29,7 +29,7 @@ PYI025.py:14:51: PYI025 [*] Use `from collections.abc import Set as AbstractSet`
    |
    = help: Alias `Set` to `AbstractSet`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | 
 12 12 | 
 13 13 | def f():

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI025_PYI025.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI025_PYI025.pyi.snap
@@ -11,7 +11,7 @@ PYI025.pyi:8:33: PYI025 [*] Use `from collections.abc import Set as AbstractSet`
    |
    = help: Alias `Set` to `AbstractSet`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 |     from collections.abc import Container, Sized, Set as AbstractSet, ValuesView  # Ok
 6 6 | 
 7 7 | def f():
@@ -31,7 +31,7 @@ PYI025.pyi:11:51: PYI025 [*] Use `from collections.abc import Set as AbstractSet
    |
    = help: Alias `Set` to `AbstractSet`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  |     from collections.abc import Set  # PYI025
 9  9  | 
 10 10 | def f():
@@ -52,7 +52,7 @@ PYI025.pyi:16:37: PYI025 [*] Use `from collections.abc import Set as AbstractSet
    |
    = help: Alias `Set` to `AbstractSet`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | def f():
 14 14 |     """Test: local symbol renaming."""
 15 15 |     if True:
@@ -87,7 +87,7 @@ PYI025.pyi:33:29: PYI025 [*] Use `from collections.abc import Set as AbstractSet
    |
    = help: Alias `Set` to `AbstractSet`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 |     else:
 18 18 |         Set = 1
 19 19 | 
@@ -130,7 +130,7 @@ PYI025.pyi:44:33: PYI025 [*] Use `from collections.abc import Set as AbstractSet
    |
    = help: Alias `Set` to `AbstractSet`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 | 
 42 42 | def f():
 43 43 |     """Test: nonlocal symbol renaming."""

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI026_PYI026.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI026_PYI026.pyi.snap
@@ -12,7 +12,7 @@ PYI026.pyi:3:1: PYI026 [*] Use `typing.TypeAlias` for type alias, e.g., `NewAny:
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-from typing import Literal, Any
   1 |+from typing import Literal, Any, TypeAlias
 2 2 | 
@@ -32,7 +32,7 @@ PYI026.pyi:4:1: PYI026 [*] Use `typing.TypeAlias` for type alias, e.g., `Optiona
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-from typing import Literal, Any
   1 |+from typing import Literal, Any, TypeAlias
 2 2 | 
@@ -54,7 +54,7 @@ PYI026.pyi:5:1: PYI026 [*] Use `typing.TypeAlias` for type alias, e.g., `Foo: Ty
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-from typing import Literal, Any
   1 |+from typing import Literal, Any, TypeAlias
 2 2 | 
@@ -76,7 +76,7 @@ PYI026.pyi:6:1: PYI026 [*] Use `typing.TypeAlias` for type alias, e.g., `IntOrSt
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-from typing import Literal, Any
   1 |+from typing import Literal, Any, TypeAlias
 2 2 | 
@@ -100,7 +100,7 @@ PYI026.pyi:7:1: PYI026 [*] Use `typing.TypeAlias` for type alias, e.g., `AliasNo
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-from typing import Literal, Any
   1 |+from typing import Literal, Any, TypeAlias
 2 2 | 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI053_PYI053.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI053_PYI053.pyi.snap
@@ -12,7 +12,7 @@ PYI053.pyi:3:14: PYI053 [*] String and bytes literals longer than 50 characters 
   |
   = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | def f1(x: str = "50 character stringggggggggggggggggggggggggggggggg") -> None: ...  # OK
 2 2 | def f2(
 3   |-    x: str = "51 character stringgggggggggggggggggggggggggggggggg",  # Error: PYI053
@@ -32,7 +32,7 @@ PYI053.pyi:9:14: PYI053 [*] String and bytes literals longer than 50 characters 
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  |     x: str = "50 character stringgggggggggggggggggggggggggggggg\U0001f600",  # OK
 7  7  | ) -> None: ...
 8  8  | def f4(
@@ -52,7 +52,7 @@ PYI053.pyi:21:16: PYI053 [*] String and bytes literals longer than 50 characters
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 |     x: bytes = b"50 character byte stringggggggggggggggggggggggggg\xff",  # OK
 19 19 | ) -> None: ...
 20 20 | def f8(
@@ -73,7 +73,7 @@ PYI053.pyi:26:12: PYI053 [*] String and bytes literals longer than 50 characters
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 | 
 24 24 | foo: str = "50 character stringggggggggggggggggggggggggggggggg"  # OK
 25 25 | 
@@ -94,7 +94,7 @@ PYI053.pyi:30:14: PYI053 [*] String and bytes literals longer than 50 characters
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 | 
 28 28 | baz: bytes = b"50 character byte stringgggggggggggggggggggggggggg"  # OK
 29 29 | 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI054_PYI054.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI054_PYI054.pyi.snap
@@ -11,7 +11,7 @@ PYI054.pyi:2:16: PYI054 [*] Numeric literals with a string representation longer
   |
   = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | field01: int = 0xFFFFFFFF
 2   |-field02: int = 0xFFFFFFFFF  # Error: PYI054
   2 |+field02: int = ...  # Error: PYI054
@@ -30,7 +30,7 @@ PYI054.pyi:4:17: PYI054 [*] Numeric literals with a string representation longer
   |
   = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | field01: int = 0xFFFFFFFF
 2 2 | field02: int = 0xFFFFFFFFF  # Error: PYI054
 3 3 | field03: int = -0xFFFFFFFF
@@ -51,7 +51,7 @@ PYI054.pyi:8:16: PYI054 [*] Numeric literals with a string representation longer
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | 
 6 6 | field05: int = 1234567890
 7 7 | field06: int = 12_456_890
@@ -72,7 +72,7 @@ PYI054.pyi:10:17: PYI054 [*] Numeric literals with a string representation longe
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | field06: int = 12_456_890
 8  8  | field07: int = 12345678901  # Error: PYI054
 9  9  | field08: int = -1234567801
@@ -92,7 +92,7 @@ PYI054.pyi:13:18: PYI054 [*] Numeric literals with a string representation longe
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | field09: int = -234_567_890  # Error: PYI054
 11 11 | 
 12 12 | field10: float = 123.456789
@@ -113,7 +113,7 @@ PYI054.pyi:15:19: PYI054 [*] Numeric literals with a string representation longe
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | field10: float = 123.456789
 13 13 | field11: float = 123.4567890  # Error: PYI054
 14 14 | field12: float = -123.456789
@@ -133,7 +133,7 @@ PYI054.pyi:18:20: PYI054 [*] Numeric literals with a string representation longe
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | field13: float = -123.567_890  # Error: PYI054
 16 16 | 
 17 17 | field14: complex = 1e1234567j
@@ -151,7 +151,7 @@ PYI054.pyi:20:20: PYI054 [*] Numeric literals with a string representation longe
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | field14: complex = 1e1234567j
 18 18 | field15: complex = 1e12345678j  # Error: PYI054
 19 19 | field16: complex = -1e1234567j

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__py38_PYI026_PYI026.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__py38_PYI026_PYI026.pyi.snap
@@ -12,7 +12,7 @@ PYI026.pyi:3:1: PYI026 [*] Use `typing_extensions.TypeAlias` for type alias, e.g
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from typing import Literal, Any
   2 |+import typing_extensions
 2 3 | 
@@ -32,7 +32,7 @@ PYI026.pyi:4:1: PYI026 [*] Use `typing_extensions.TypeAlias` for type alias, e.g
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from typing import Literal, Any
   2 |+import typing_extensions
 2 3 | 
@@ -54,7 +54,7 @@ PYI026.pyi:5:1: PYI026 [*] Use `typing_extensions.TypeAlias` for type alias, e.g
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from typing import Literal, Any
   2 |+import typing_extensions
 2 3 | 
@@ -76,7 +76,7 @@ PYI026.pyi:6:1: PYI026 [*] Use `typing_extensions.TypeAlias` for type alias, e.g
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from typing import Literal, Any
   2 |+import typing_extensions
 2 3 | 
@@ -100,7 +100,7 @@ PYI026.pyi:7:1: PYI026 [*] Use `typing_extensions.TypeAlias` for type alias, e.g
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from typing import Literal, Any
   2 |+import typing_extensions
 2 3 | 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -292,7 +292,7 @@ pub(crate) fn unittest_assertion(
                         && !checker.indexer().comment_ranges().intersects(expr.range())
                     {
                         if let Ok(stmt) = unittest_assert.generate_assert(args, keywords) {
-                            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                                 checker.generator().stmt(&stmt),
                                 parenthesized_range(
                                     expr.into(),
@@ -401,7 +401,7 @@ pub(crate) fn unittest_raises_assertion(
                     checker.semantic(),
                 )?;
                 let edit = Edit::range_replacement(format!("{binding}({args})"), call.range());
-                Ok(Fix::suggested_edits(import_edit, [edit]))
+                Ok(Fix::automatic_unsafe_edits(import_edit, [edit]))
             });
         }
     }
@@ -756,7 +756,7 @@ pub(crate) fn composite_condition(
             {
                 diagnostic.try_set_fix(|| {
                     fix_composite_condition(stmt, checker.locator(), checker.stylist())
-                        .map(Fix::suggested)
+                        .map(Fix::automatic_unsafe)
                 });
             }
         }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -700,7 +700,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &D
                     && arguments.args.is_empty()
                     && arguments.keywords.is_empty()
                 {
-                    let fix = Fix::automatic(Edit::deletion(func.end(), decorator.end()));
+                    let fix = Fix::automatic_safe(Edit::deletion(func.end(), decorator.end()));
                     pytest_fixture_parentheses(
                         checker,
                         decorator,
@@ -735,7 +735,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &D
                                     edits::Parentheses::Preserve,
                                     checker.locator().contents(),
                                 )
-                                .map(Fix::suggested)
+                                .map(Fix::automatic_unsafe)
                             });
                         }
                         checker.diagnostics.push(diagnostic);
@@ -746,7 +746,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &D
         _ => {
             if checker.enabled(Rule::PytestFixtureIncorrectParenthesesStyle) {
                 if checker.settings.flake8_pytest_style.fixture_parentheses {
-                    let fix = Fix::automatic(Edit::insertion(
+                    let fix = Fix::automatic_safe(Edit::insertion(
                         Parentheses::Empty.to_string(),
                         decorator.end(),
                     ));
@@ -839,9 +839,9 @@ fn check_fixture_returns(
                 ))
             });
             if let Some(return_type_edit) = return_type_edit {
-                diagnostic.set_fix(Fix::automatic_edits(yield_edit, [return_type_edit]));
+                diagnostic.set_fix(Fix::automatic_safe_edits(yield_edit, [return_type_edit]));
             } else {
-                diagnostic.set_fix(Fix::automatic(yield_edit));
+                diagnostic.set_fix(Fix::automatic_safe(yield_edit));
             }
         }
         checker.diagnostics.push(diagnostic);
@@ -914,7 +914,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Decorator]) {
                     Diagnostic::new(PytestUnnecessaryAsyncioMarkOnFixture, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     let range = checker.locator().full_lines_range(expr.range());
-                    diagnostic.set_fix(Fix::automatic(Edit::range_deletion(range)));
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(range)));
                 }
                 checker.diagnostics.push(diagnostic);
             }
@@ -926,7 +926,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Decorator]) {
                     Diagnostic::new(PytestErroneousUseFixturesOnFixture, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     let line_range = checker.locator().full_lines_range(expr.range());
-                    diagnostic.set_fix(Fix::automatic(Edit::range_deletion(line_range)));
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(line_range)));
                 }
                 checker.diagnostics.push(diagnostic);
             }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
@@ -152,13 +152,13 @@ fn check_mark_parentheses(checker: &mut Checker, decorator: &Decorator, call_pat
                 && args.is_empty()
                 && keywords.is_empty()
             {
-                let fix = Fix::automatic(Edit::deletion(func.end(), decorator.end()));
+                let fix = Fix::automatic_safe(Edit::deletion(func.end(), decorator.end()));
                 pytest_mark_parentheses(checker, decorator, call_path, fix, "", "()");
             }
         }
         _ => {
             if checker.settings.flake8_pytest_style.mark_parentheses {
-                let fix = Fix::automatic(Edit::insertion("()".to_string(), decorator.end()));
+                let fix = Fix::automatic_safe(Edit::insertion("()".to_string(), decorator.end()));
                 pytest_mark_parentheses(checker, decorator, call_path, fix, "()", "");
             }
         }
@@ -185,7 +185,9 @@ fn check_useless_usefixtures(checker: &mut Checker, decorator: &Decorator, call_
     if !has_parameters {
         let mut diagnostic = Diagnostic::new(PytestUseFixturesWithoutParameters, decorator.range());
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::suggested(Edit::range_deletion(decorator.range())));
+            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_deletion(
+                decorator.range(),
+            )));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -352,7 +352,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                                 ctx: ExprContext::Load,
                                 range: TextRange::default(),
                             });
-                            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                                 format!("({})", checker.generator().expr(&node)),
                                 name_range,
                             )));
@@ -387,7 +387,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                                 ctx: ExprContext::Load,
                                 range: TextRange::default(),
                             });
-                            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                                 checker.generator().expr(&node),
                                 name_range,
                             )));
@@ -419,7 +419,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                                 ctx: ExprContext::Load,
                                 range: TextRange::default(),
                             });
-                            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                                 checker.generator().expr(&node),
                                 expr.range(),
                             )));
@@ -435,7 +435,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(content) = elts_to_csv(elts, checker.generator()) {
-                                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                                     content,
                                     expr.range(),
                                 )));
@@ -467,7 +467,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                                 ctx: ExprContext::Load,
                                 range: TextRange::default(),
                             });
-                            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                                 format!("({})", checker.generator().expr(&node)),
                                 expr.range(),
                             )));
@@ -483,7 +483,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(content) = elts_to_csv(elts, checker.generator()) {
-                                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                                     content,
                                     expr.range(),
                                 )));
@@ -598,8 +598,9 @@ fn check_duplicates(checker: &mut Checker, values: &Expr) {
                             .comment_ranges()
                             .intersects(deletion_range)
                         {
-                            diagnostic
-                                .set_fix(Fix::suggested(Edit::range_deletion(deletion_range)));
+                            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_deletion(
+                                deletion_range,
+                            )));
                         }
                     }
                 }
@@ -620,7 +621,7 @@ fn handle_single_name(checker: &mut Checker, expr: &Expr, value: &Expr) {
 
     if checker.patch(diagnostic.kind.rule()) {
         let node = value.clone();
-        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
             checker.generator().expr(&node),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT003.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT003.snap
@@ -10,7 +10,7 @@ PT003.py:14:17: PT003 [*] `scope='function'` is implied in `@pytest.fixture()`
    |
    = help: Remove implied `scope` argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 |     ...
 12 12 | 
 13 13 | 
@@ -29,7 +29,7 @@ PT003.py:19:17: PT003 [*] `scope='function'` is implied in `@pytest.fixture()`
    |
    = help: Remove implied `scope` argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 |     ...
 17 17 | 
 18 18 | 
@@ -48,7 +48,7 @@ PT003.py:24:36: PT003 [*] `scope='function'` is implied in `@pytest.fixture()`
    |
    = help: Remove implied `scope` argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 |     ...
 22 22 | 
 23 23 | 
@@ -67,7 +67,7 @@ PT003.py:29:36: PT003 [*] `scope='function'` is implied in `@pytest.fixture()`
    |
    = help: Remove implied `scope` argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 26 26 |     ...
 27 27 | 
 28 28 | 
@@ -88,7 +88,7 @@ PT003.py:37:31: PT003 [*] `scope='function'` is implied in `@pytest.fixture()`
    |
    = help: Remove implied `scope` argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 34 34 | # pytest.fixture does not take positional arguments, however this 
 35 35 | # tests the general case as we use a helper function that should
 36 36 | # work for all cases.
@@ -108,7 +108,7 @@ PT003.py:43:5: PT003 [*] `scope='function'` is implied in `@pytest.fixture()`
    |
    = help: Remove implied `scope` argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 40 40 | 
 41 41 | 
 42 42 | @pytest.fixture(
@@ -128,7 +128,7 @@ PT003.py:52:5: PT003 [*] `scope='function'` is implied in `@pytest.fixture()`
    |
    = help: Remove implied `scope` argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 49 49 | 
 50 50 | @pytest.fixture(
 51 51 |     name="my_fixture",
@@ -149,7 +149,7 @@ PT003.py:66:5: PT003 [*] `scope='function'` is implied in `@pytest.fixture()`
    |
    = help: Remove implied `scope` argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 63 63 | 
 64 64 |     # another comment ,)
 65 65 |     

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_csv.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_csv.snap
@@ -10,7 +10,7 @@ PT006.py:24:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `csv` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 |     ...
 22 22 | 
 23 23 | 
@@ -48,7 +48,7 @@ PT006.py:34:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `csv` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 31 31 |     ...
 32 32 | 
 33 33 | 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_default.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_default.snap
@@ -10,7 +10,7 @@ PT006.py:9:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expec
    |
    = help: Use a `tuple` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  |     ...
 7  7  | 
 8  8  | 
@@ -29,7 +29,7 @@ PT006.py:14:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `tuple` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 |     ...
 12 12 | 
 13 13 | 
@@ -48,7 +48,7 @@ PT006.py:19:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `tuple` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 |     ...
 17 17 | 
 18 18 | 
@@ -86,7 +86,7 @@ PT006.py:34:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `tuple` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 31 31 |     ...
 32 32 | 
 33 33 | 
@@ -124,7 +124,7 @@ PT006.py:44:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `tuple` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 |     ...
 42 42 | 
 43 43 | 
@@ -143,7 +143,7 @@ PT006.py:49:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `tuple` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 |     ...
 47 47 | 
 48 48 | 
@@ -162,7 +162,7 @@ PT006.py:54:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `tuple` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 51 51 |     ...
 52 52 | 
 53 53 | 
@@ -181,7 +181,7 @@ PT006.py:59:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `tuple` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 56 56 |     ...
 57 57 | 
 58 58 | 
@@ -200,7 +200,7 @@ PT006.py:64:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `tuple` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 61 61 |     ...
 62 62 | 
 63 63 | 
@@ -219,7 +219,7 @@ PT006.py:69:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `tuple` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 66 66 |     ...
 67 67 | 
 68 68 | 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_list.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT006_list.snap
@@ -10,7 +10,7 @@ PT006.py:9:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expec
    |
    = help: Use a `list` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  |     ...
 7  7  | 
 8  8  | 
@@ -29,7 +29,7 @@ PT006.py:14:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `list` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 |     ...
 12 12 | 
 13 13 | 
@@ -48,7 +48,7 @@ PT006.py:19:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `list` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 |     ...
 17 17 | 
 18 18 | 
@@ -67,7 +67,7 @@ PT006.py:24:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `list` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 |     ...
 22 22 | 
 23 23 | 
@@ -124,7 +124,7 @@ PT006.py:54:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `list` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 51 51 |     ...
 52 52 | 
 53 53 | 
@@ -143,7 +143,7 @@ PT006.py:59:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `list` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 56 56 |     ...
 57 57 | 
 58 58 | 
@@ -162,7 +162,7 @@ PT006.py:64:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `list` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 61 61 |     ...
 62 62 | 
 63 63 | 
@@ -181,7 +181,7 @@ PT006.py:69:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `list` for parameter names
 
-ℹ Suggested fix
+ℹ Unsafe fix
 66 66 |     ...
 67 67 | 
 68 68 | 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT009.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT009.snap
@@ -12,7 +12,7 @@ PT009.py:11:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertTrue(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  |     def test_assert_true(self):
 9  9  |         expr = 1
 10 10 |         msg = "Must be True"
@@ -33,7 +33,7 @@ PT009.py:12:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertTrue(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  |         expr = 1
 10 10 |         msg = "Must be True"
 11 11 |         self.assertTrue(expr)  # Error
@@ -54,7 +54,7 @@ PT009.py:13:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertTrue(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 |         msg = "Must be True"
 11 11 |         self.assertTrue(expr)  # Error
 12 12 |         self.assertTrue(expr=expr)  # Error
@@ -75,7 +75,7 @@ PT009.py:14:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertTrue(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 |         self.assertTrue(expr)  # Error
 12 12 |         self.assertTrue(expr=expr)  # Error
 13 13 |         self.assertTrue(expr, msg)  # Error
@@ -96,7 +96,7 @@ PT009.py:15:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertTrue(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 |         self.assertTrue(expr=expr)  # Error
 13 13 |         self.assertTrue(expr, msg)  # Error
 14 14 |         self.assertTrue(expr=expr, msg=msg)  # Error
@@ -193,7 +193,7 @@ PT009.py:28:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertFalse(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 25 25 |         return self.assertEqual(True,  False)  # Error, unfixable
 26 26 | 
 27 27 |     def test_assert_false(self):
@@ -213,7 +213,7 @@ PT009.py:31:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertEqual(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 28 28 |         self.assertFalse(True)  # Error
 29 29 | 
 30 30 |     def test_assert_equal(self):
@@ -233,7 +233,7 @@ PT009.py:34:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertNotEqual(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 31 31 |         self.assertEqual(1, 2)  # Error
 32 32 | 
 33 33 |     def test_assert_not_equal(self):
@@ -253,7 +253,7 @@ PT009.py:37:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertGreater(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 34 34 |         self.assertNotEqual(1, 1)  # Error
 35 35 | 
 36 36 |     def test_assert_greater(self):
@@ -273,7 +273,7 @@ PT009.py:40:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertGreaterEqual(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 37 37 |         self.assertGreater(1, 2)  # Error
 38 38 | 
 39 39 |     def test_assert_greater_equal(self):
@@ -293,7 +293,7 @@ PT009.py:43:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertLess(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 40 40 |         self.assertGreaterEqual(1, 2)  # Error
 41 41 | 
 42 42 |     def test_assert_less(self):
@@ -313,7 +313,7 @@ PT009.py:46:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertLessEqual(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 43 43 |         self.assertLess(2, 1)  # Error
 44 44 | 
 45 45 |     def test_assert_less_equal(self):
@@ -333,7 +333,7 @@ PT009.py:49:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertIn(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 |         self.assertLessEqual(1, 2)  # Error
 47 47 | 
 48 48 |     def test_assert_in(self):
@@ -353,7 +353,7 @@ PT009.py:52:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertNotIn(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 49 49 |         self.assertIn(1, [2, 3])  # Error
 50 50 | 
 51 51 |     def test_assert_not_in(self):
@@ -373,7 +373,7 @@ PT009.py:55:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertIsNone(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 52 52 |         self.assertNotIn(2, [2, 3])  # Error
 53 53 | 
 54 54 |     def test_assert_is_none(self):
@@ -393,7 +393,7 @@ PT009.py:58:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertIsNotNone(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 55 55 |         self.assertIsNone(0)  # Error
 56 56 | 
 57 57 |     def test_assert_is_not_none(self):
@@ -413,7 +413,7 @@ PT009.py:61:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertIs(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 58 58 |         self.assertIsNotNone(0)  # Error
 59 59 | 
 60 60 |     def test_assert_is(self):
@@ -433,7 +433,7 @@ PT009.py:64:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertIsNot(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 61 61 |         self.assertIs([], [])  # Error
 62 62 | 
 63 63 |     def test_assert_is_not(self):
@@ -453,7 +453,7 @@ PT009.py:67:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertIsInstance(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 64 64 |         self.assertIsNot(1, 1)  # Error
 65 65 | 
 66 66 |     def test_assert_is_instance(self):
@@ -473,7 +473,7 @@ PT009.py:70:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertNotIsInstance(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 67 67 |         self.assertIsInstance(1, str)  # Error
 68 68 | 
 69 69 |     def test_assert_is_not_instance(self):
@@ -493,7 +493,7 @@ PT009.py:73:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertRegex(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 70 70 |         self.assertNotIsInstance(1, int)  # Error
 71 71 | 
 72 72 |     def test_assert_regex(self):
@@ -513,7 +513,7 @@ PT009.py:76:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertNotRegex(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 73 73 |         self.assertRegex("abc", r"def")  # Error
 74 74 | 
 75 75 |     def test_assert_not_regex(self):
@@ -533,7 +533,7 @@ PT009.py:79:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertRegexpMatches(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 76 76 |         self.assertNotRegex("abc", r"abc")  # Error
 77 77 | 
 78 78 |     def test_assert_regexp_matches(self):
@@ -553,7 +553,7 @@ PT009.py:82:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertNotRegex(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 79 79 |         self.assertRegexpMatches("abc", r"def")  # Error
 80 80 | 
 81 81 |     def test_assert_not_regexp_matches(self):
@@ -573,7 +573,7 @@ PT009.py:85:9: PT009 [*] Use a regular `assert` instead of unittest-style `failI
    |
    = help: Replace `failIf(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 82 82 |         self.assertNotRegex("abc", r"abc")  # Error
 83 83 | 
 84 84 |     def test_fail_if(self):
@@ -593,7 +593,7 @@ PT009.py:88:9: PT009 [*] Use a regular `assert` instead of unittest-style `failU
    |
    = help: Replace `failUnless(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 85 85 |         self.failIf("abc")  # Error
 86 86 | 
 87 87 |     def test_fail_unless(self):
@@ -613,7 +613,7 @@ PT009.py:91:9: PT009 [*] Use a regular `assert` instead of unittest-style `failU
    |
    = help: Replace `failUnlessEqual(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 88 88 |         self.failUnless("abc")  # Error
 89 89 | 
 90 90 |     def test_fail_unless_equal(self):
@@ -631,7 +631,7 @@ PT009.py:94:9: PT009 [*] Use a regular `assert` instead of unittest-style `failI
    |
    = help: Replace `failIfEqual(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 91 91 |         self.failUnlessEqual(1, 2)  # Error
 92 92 | 
 93 93 |     def test_fail_if_equal(self):
@@ -651,7 +651,7 @@ PT009.py:98:2: PT009 [*] Use a regular `assert` instead of unittest-style `asser
     |
     = help: Replace `assertTrue(...)` with `assert ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 95 95 | 
 96 96 | 
 97 97 | # Regression test for: https://github.com/astral-sh/ruff/issues/7455#issuecomment-1722459517

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT014.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT014.snap
@@ -10,7 +10,7 @@ PT014.py:4:35: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.para
   |
   = help: Remove duplicate test case
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import pytest
 2 2 | 
 3 3 | 
@@ -29,7 +29,7 @@ PT014.py:14:35: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.par
    |
    = help: Remove duplicate test case
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | c = 3
 12 12 | 
 13 13 | 
@@ -48,7 +48,7 @@ PT014.py:14:41: PT014 [*] Duplicate of test case at index 2 in `@pytest_mark.par
    |
    = help: Remove duplicate test case
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | c = 3
 12 12 | 
 13 13 | 
@@ -67,7 +67,7 @@ PT014.py:14:44: PT014 [*] Duplicate of test case at index 2 in `@pytest_mark.par
    |
    = help: Remove duplicate test case
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | c = 3
 12 12 | 
 13 13 | 
@@ -97,7 +97,7 @@ PT014.py:32:39: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.par
    |
    = help: Remove duplicate test case
 
-ℹ Suggested fix
+ℹ Unsafe fix
 29 29 |     ...
 30 30 | 
 31 31 | 
@@ -116,7 +116,7 @@ PT014.py:32:48: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.par
    |
    = help: Remove duplicate test case
 
-ℹ Suggested fix
+ℹ Unsafe fix
 29 29 |     ...
 30 30 | 
 31 31 | 
@@ -137,7 +137,7 @@ PT014.py:42:10: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.par
    |
    = help: Remove duplicate test case
 
-ℹ Suggested fix
+ℹ Unsafe fix
 39 39 |     [
 40 40 |         a,
 41 41 |         b,
@@ -157,7 +157,7 @@ PT014.py:44:11: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.par
    |
    = help: Remove duplicate test case
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 |         b,
 42 42 |         (a),
 43 43 |         c,

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT018.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT018.snap
@@ -11,7 +11,7 @@ PT018.py:14:5: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | 
 12 12 | 
 13 13 | def test_error():
@@ -33,7 +33,7 @@ PT018.py:15:5: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | 
 13 13 | def test_error():
 14 14 |     assert something and something_else
@@ -55,7 +55,7 @@ PT018.py:16:5: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | def test_error():
 14 14 |     assert something and something_else
 15 15 |     assert something and something_else and something_third
@@ -77,7 +77,7 @@ PT018.py:17:5: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 |     assert something and something_else
 15 15 |     assert something and something_else and something_third
 16 16 |     assert something and not something_else
@@ -99,7 +99,7 @@ PT018.py:18:5: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 |     assert something and something_else and something_third
 16 16 |     assert something and not something_else
 17 17 |     assert something and (something_else or something_third)
@@ -121,7 +121,7 @@ PT018.py:19:5: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 |     assert something and not something_else
 17 17 |     assert something and (something_else or something_third)
 18 18 |     assert not something and something_else
@@ -143,7 +143,7 @@ PT018.py:20:5: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 |     assert something and (something_else or something_third)
 18 18 |     assert not something and something_else
 19 19 |     assert not (something or something_else)
@@ -168,7 +168,7 @@ PT018.py:21:5: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 |     assert not something and something_else
 19 19 |     assert not (something or something_else)
 20 20 |     assert not (something or something_else or something_third)
@@ -197,7 +197,7 @@ PT018.py:24:5: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 |     assert something and something_else == """error
 22 22 |     message
 23 23 |     """
@@ -219,7 +219,7 @@ PT018.py:33:5: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 30 30 |     )
 31 31 | 
 32 32 |     # recursive case
@@ -241,7 +241,7 @@ PT018.py:34:5: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 31 31 | 
 32 32 |     # recursive case
 33 33 |     assert not (a or not (b or c))
@@ -291,7 +291,7 @@ PT018.py:44:1: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 | 
 42 42 | 
 43 43 | assert something  # OK
@@ -311,7 +311,7 @@ PT018.py:45:1: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 42 42 | 
 43 43 | assert something  # OK
 44 44 | assert something and something_else  # Error
@@ -367,7 +367,7 @@ PT018.py:59:5: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 59 59 |     assert not (
 60 60 |         self.find_graph_output(node.output[0])
 61 61 |         or self.find_graph_input(node.input[0])
@@ -396,7 +396,7 @@ PT018.py:65:5: PT018 [*] Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
-ℹ Suggested fix
+ℹ Unsafe fix
 62 62 |         or self.find_graph_output(node.input[0])
 63 63 |     )
 64 64 | 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT026.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT026.snap
@@ -10,7 +10,7 @@ PT026.py:19:1: PT026 [*] Useless `pytest.mark.usefixtures` without parameters
    |
    = help: Remove `usefixtures` decorator or pass parameters
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 |     pass
 17 17 | 
 18 18 | 
@@ -29,7 +29,7 @@ PT026.py:24:1: PT026 [*] Useless `pytest.mark.usefixtures` without parameters
    |
    = help: Remove `usefixtures` decorator or pass parameters
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 |     pass
 22 22 | 
 23 23 | 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT027_0.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT027_0.snap
@@ -12,7 +12,7 @@ PT027_0.py:6:14: PT027 [*] Use `pytest.raises` instead of unittest-style `assert
   |
   = help: Replace `assertRaises` with `pytest.raises`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import unittest
   2 |+import pytest
 2 3 | 
@@ -35,7 +35,7 @@ PT027_0.py:8:14: PT027 [*] Use `pytest.raises` instead of unittest-style `assert
   |
   = help: Replace `assertRaises` with `pytest.raises`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | import unittest
    2  |+import pytest
 2  3  | 
@@ -60,7 +60,7 @@ PT027_0.py:11:14: PT027 [*] Use `pytest.raises` instead of unittest-style `failU
    |
    = help: Replace `failUnlessRaises` with `pytest.raises`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | import unittest
    2  |+import pytest
 2  3  | 
@@ -86,7 +86,7 @@ PT027_0.py:14:14: PT027 [*] Use `pytest.raises` instead of unittest-style `asser
    |
    = help: Replace `assertRaisesRegex` with `pytest.raises`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | import unittest
    2  |+import pytest
 2  3  | 
@@ -112,7 +112,7 @@ PT027_0.py:17:14: PT027 [*] Use `pytest.raises` instead of unittest-style `asser
    |
    = help: Replace `assertRaisesRegex` with `pytest.raises`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | import unittest
    2  |+import pytest
 2  3  | 
@@ -139,7 +139,7 @@ PT027_0.py:20:14: PT027 [*] Use `pytest.raises` instead of unittest-style `asser
    |
    = help: Replace `assertRaisesRegex` with `pytest.raises`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | import unittest
    2  |+import pytest
 2  3  | 
@@ -168,7 +168,7 @@ PT027_0.py:25:14: PT027 [*] Use `pytest.raises` instead of unittest-style `asser
    |
    = help: Replace `assertRaisesRegex` with `pytest.raises`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | import unittest
    2  |+import pytest
 2  3  | 
@@ -196,7 +196,7 @@ PT027_0.py:30:14: PT027 [*] Use `pytest.raises` instead of unittest-style `asser
    |
    = help: Replace `assertRaisesRegexp` with `pytest.raises`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | import unittest
    2  |+import pytest
 2  3  | 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT027_1.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT027_1.snap
@@ -10,7 +10,7 @@ PT027_1.py:11:14: PT027 [*] Use `pytest.raises` instead of unittest-style `asser
    |
    = help: Replace `assertRaises` with `pytest.raises`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  |             raise ValueError
 9  9  | 
 10 10 |     def test_errors(self):

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/avoidable_escaped_quote.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/avoidable_escaped_quote.rs
@@ -142,7 +142,7 @@ pub(crate) fn avoidable_escaped_quote(
                             quote = quotes_settings.inline_quotes.opposite().as_char(),
                             value = unescape_string(string_contents)
                         );
-                        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                             fixed_contents,
                             tok_range,
                         )));
@@ -216,7 +216,7 @@ pub(crate) fn avoidable_escaped_quote(
                                 tok_range,
                             ),
                         ));
-                    diagnostic.set_fix(Fix::automatic_edits(
+                    diagnostic.set_fix(Fix::automatic_safe_edits(
                         fstring_start_edit,
                         fstring_middle_and_end_edits,
                     ));

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/check_string_quotes.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/check_string_quotes.rs
@@ -240,7 +240,7 @@ fn docstring(locator: &Locator, range: TextRange, settings: &LinterSettings) -> 
         fixed_contents.push_str(&quote);
         fixed_contents.push_str(string_contents);
         fixed_contents.push_str(&quote);
-        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
             fixed_contents,
             range,
         )));
@@ -317,7 +317,7 @@ fn strings(
                 fixed_contents.push_str(quote);
                 fixed_contents.push_str(string_contents);
                 fixed_contents.push_str(quote);
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                     fixed_contents,
                     *range,
                 )));
@@ -342,7 +342,7 @@ fn strings(
                 fixed_contents.push(quote);
                 fixed_contents.push_str(string_contents);
                 fixed_contents.push(quote);
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                     fixed_contents,
                     *range,
                 )));

--- a/crates/ruff_linter/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -87,12 +87,12 @@ pub(crate) fn unnecessary_paren_on_raise_exception(checker: &mut Checker, expr: 
                 .next()
                 .is_some_and(char::is_alphanumeric)
             {
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                     " ".to_string(),
                     arguments.range(),
                 )));
             } else {
-                diagnostic.set_fix(Fix::automatic(Edit::range_deletion(arguments.range())));
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(arguments.range())));
             }
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
@@ -346,7 +346,7 @@ fn unnecessary_return_none(checker: &mut Checker, stack: &Stack) {
         }
         let mut diagnostic = Diagnostic::new(UnnecessaryReturnNone, stmt.range);
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                 "return".to_string(),
                 stmt.range(),
             )));
@@ -363,7 +363,7 @@ fn implicit_return_value(checker: &mut Checker, stack: &Stack) {
         }
         let mut diagnostic = Diagnostic::new(ImplicitReturnValue, stmt.range);
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                 "return None".to_string(),
                 stmt.range,
             )));
@@ -415,7 +415,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                         content.push_str(checker.stylist().line_ending().as_str());
                         content.push_str(indent);
                         content.push_str("return None");
-                        diagnostic.set_fix(Fix::suggested(Edit::insertion(
+                        diagnostic.set_fix(Fix::automatic_unsafe(Edit::insertion(
                             content,
                             end_of_last_statement(stmt, checker.locator()),
                         )));
@@ -437,7 +437,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                         content.push_str(checker.stylist().line_ending().as_str());
                         content.push_str(indent);
                         content.push_str("return None");
-                        diagnostic.set_fix(Fix::suggested(Edit::insertion(
+                        diagnostic.set_fix(Fix::automatic_unsafe(Edit::insertion(
                             content,
                             end_of_last_statement(stmt, checker.locator()),
                         )));
@@ -473,7 +473,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                     content.push_str(checker.stylist().line_ending().as_str());
                     content.push_str(indent);
                     content.push_str("return None");
-                    diagnostic.set_fix(Fix::suggested(Edit::insertion(
+                    diagnostic.set_fix(Fix::automatic_unsafe(Edit::insertion(
                         content,
                         end_of_last_statement(stmt, checker.locator()),
                     )));
@@ -567,7 +567,7 @@ fn unnecessary_assign(checker: &mut Checker, stack: &Stack) {
                     ),
                 );
 
-                Ok(Fix::suggested_edits(replace_assign, [delete_return]))
+                Ok(Fix::automatic_unsafe_edits(replace_assign, [delete_return]))
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET503_RET503.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET503_RET503.py.snap
@@ -13,7 +13,7 @@ RET503.py:20:5: RET503 [*] Missing explicit `return` at the end of function able
    |
    = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | def x(y):
 20 20 |     if not y:
 21 21 |         return 1
@@ -33,7 +33,7 @@ RET503.py:27:9: RET503 [*] Missing explicit `return` at the end of function able
    |
    = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 25 25 | def x(y):
 26 26 |     if not y:
 27 27 |         print()  # error
@@ -51,7 +51,7 @@ RET503.py:36:5: RET503 [*] Missing explicit `return` at the end of function able
    |
    = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 34 34 |         return 1
 35 35 | 
 36 36 |     print()  # error
@@ -73,7 +73,7 @@ RET503.py:41:5: RET503 [*] Missing explicit `return` at the end of function able
    |
    = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 |     for i in range(10):
 42 42 |         if i > 10:
 43 43 |             return i
@@ -91,7 +91,7 @@ RET503.py:52:9: RET503 [*] Missing explicit `return` at the end of function able
    |
    = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 50 50 |             return i
 51 51 |     else:
 52 52 |         print()  # error
@@ -109,7 +109,7 @@ RET503.py:59:5: RET503 [*] Missing explicit `return` at the end of function able
    |
    = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 57 57 |     if x > 0:
 58 58 |         return False
 59 59 |     no_such_function()  # error
@@ -127,7 +127,7 @@ RET503.py:66:5: RET503 [*] Missing explicit `return` at the end of function able
    |
    = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 64 64 |     if x > 0:
 65 65 |         return False
 66 66 |     print("", end="")  # error
@@ -149,7 +149,7 @@ RET503.py:82:5: RET503 [*] Missing explicit `return` at the end of function able
    |
    = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 83 83 |         if y > 0:
 84 84 |             return 1
 85 85 |         y += 1
@@ -171,7 +171,7 @@ RET503.py:113:5: RET503 [*] Missing explicit `return` at the end of function abl
     |
     = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 114 114 |         if i > y:
 115 115 |             break
 116 116 |         return z
@@ -195,7 +195,7 @@ RET503.py:120:5: RET503 [*] Missing explicit `return` at the end of function abl
     |
     = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 124 124 |         else:
 125 125 |             return z
 126 126 |         return None
@@ -216,7 +216,7 @@ RET503.py:130:5: RET503 [*] Missing explicit `return` at the end of function abl
     |
     = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 131 131 |         if i < y:
 132 132 |             continue
 133 133 |         return z
@@ -240,7 +240,7 @@ RET503.py:137:5: RET503 [*] Missing explicit `return` at the end of function abl
     |
     = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 141 141 |         else:
 142 142 |             return z
 143 143 |         return None
@@ -260,7 +260,7 @@ RET503.py:274:5: RET503 [*] Missing explicit `return` at the end of function abl
     |
     = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 273 273 | 
 274 274 |     for value in values:
 275 275 |         print(value)
@@ -278,7 +278,7 @@ RET503.py:291:13: RET503 [*] Missing explicit `return` at the end of function ab
     |
     = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 289 289 |             return 1
 290 290 |         case 1:
 291 291 |             print()  # error
@@ -298,7 +298,7 @@ RET503.py:300:9: RET503 [*] Missing explicit `return` at the end of function abl
     |
     = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 299 299 |     def example():
 300 300 |         if True:
 301 301 |             return ""
@@ -317,7 +317,7 @@ RET503.py:305:9: RET503 [*] Missing explicit `return` at the end of function abl
     |
     = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 304 304 |     def example():
 305 305 |         if True:
 306 306 |             return ""
@@ -336,7 +336,7 @@ RET503.py:310:9: RET503 [*] Missing explicit `return` at the end of function abl
     |
     = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 309 309 |     def example():
 310 310 |         if True:
 311 311 |             return ""  # type: ignore
@@ -355,7 +355,7 @@ RET503.py:315:9: RET503 [*] Missing explicit `return` at the end of function abl
     |
     = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 314 314 |     def example():
 315 315 |         if True:
 316 316 |             return ""  ;
@@ -375,7 +375,7 @@ RET503.py:320:9: RET503 [*] Missing explicit `return` at the end of function abl
     |
     = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 320 320 |         if True:
 321 321 |             return "" \
 322 322 |                 ;  # type: ignore
@@ -393,7 +393,7 @@ RET503.py:328:5: RET503 [*] Missing explicit `return` at the end of function abl
     |
     = help: Add explicit `return` statement
 
-ℹ Suggested fix
+ℹ Unsafe fix
 326 326 |     if False:
 327 327 |         return 1
 328 328 |     x = 2 \

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET504_RET504.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET504_RET504.py.snap
@@ -10,7 +10,7 @@ RET504.py:6:12: RET504 [*] Unnecessary assignment to `a` before `return` stateme
   |
   = help: Remove unnecessary assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | # Errors
 3 3 | ###
 4 4 | def x():
@@ -30,7 +30,7 @@ RET504.py:23:12: RET504 [*] Unnecessary assignment to `formatted` before `return
    |
    = help: Remove unnecessary assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | def x():
 20 20 |     formatted = _USER_AGENT_FORMATTER.format(format_string, **values)
 21 21 |     # clean up after any blank components
@@ -50,7 +50,7 @@ RET504.py:246:12: RET504 [*] Unnecessary assignment to `queryset` before `return
     |
     = help: Remove unnecessary assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 242 242 | 
 243 243 | def get_queryset():
 244 244 |     queryset = Model.filter(a=1)
@@ -70,7 +70,7 @@ RET504.py:251:12: RET504 [*] Unnecessary assignment to `queryset` before `return
     |
     = help: Remove unnecessary assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 247 247 | 
 248 248 | 
 249 249 | def get_queryset():
@@ -90,7 +90,7 @@ RET504.py:269:12: RET504 [*] Unnecessary assignment to `val` before `return` sta
     |
     = help: Remove unnecessary assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 265 265 | def str_to_bool(val):
 266 266 |     if isinstance(val, bool):
 267 267 |         return val
@@ -110,7 +110,7 @@ RET504.py:321:12: RET504 [*] Unnecessary assignment to `x` before `return` state
     |
     = help: Remove unnecessary assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 317 317 | # `with` statements
 318 318 | def foo():
 319 319 |     with open("foo.txt", "r") as f:
@@ -130,7 +130,7 @@ RET504.py:342:12: RET504 [*] Unnecessary assignment to `b` before `return` state
     |
     = help: Remove unnecessary assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 338 338 | # Fix cases
 339 339 | def foo():
 340 340 |     a = 1
@@ -150,7 +150,7 @@ RET504.py:348:12: RET504 [*] Unnecessary assignment to `b` before `return` state
     |
     = help: Remove unnecessary assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 344 344 | 
 345 345 | def foo():
 346 346 |     a = 1
@@ -170,7 +170,7 @@ RET504.py:354:12: RET504 [*] Unnecessary assignment to `b` before `return` state
     |
     = help: Remove unnecessary assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 350 350 | 
 351 351 | def foo():
 352 352 |     a = 1
@@ -190,7 +190,7 @@ RET504.py:359:12: RET504 [*] Unnecessary assignment to `a` before `return` state
     |
     = help: Remove unnecessary assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 355 355 | 
 356 356 | 
 357 357 | def foo():
@@ -210,7 +210,7 @@ RET504.py:365:12: RET504 [*] Unnecessary assignment to `D` before `return` state
     |
     = help: Remove unnecessary assignment
 
-ℹ Suggested fix
+ℹ Unsafe fix
 361 361 | 
 362 362 | # Regression test for: https://github.com/astral-sh/ruff/issues/7098
 363 363 | def mavko_debari(P_kbar):

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -461,7 +461,7 @@ pub(crate) fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
 
                     // Populate the `Fix`. Replace the _entire_ `BoolOp`. Note that if we have
                     // multiple duplicates, the fixes will conflict.
-                    diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                         checker.generator().expr(&bool_op),
                         expr.range(),
                     )));
@@ -582,7 +582,7 @@ pub(crate) fn compare_with_tuple(checker: &mut Checker, expr: &Expr) {
                 };
                 node.into()
             };
-            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                 checker.generator().expr(&in_expr),
                 expr.range(),
             )));
@@ -639,7 +639,7 @@ pub(crate) fn expr_and_not_expr(checker: &mut Checker, expr: &Expr) {
                     expr.range(),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                         "False".to_string(),
                         expr.range(),
                     )));
@@ -698,7 +698,7 @@ pub(crate) fn expr_or_not_expr(checker: &mut Checker, expr: &Expr) {
                     expr.range(),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                         "True".to_string(),
                         expr.range(),
                     )));
@@ -851,7 +851,7 @@ pub(crate) fn expr_or_true(checker: &mut Checker, expr: &Expr) {
             edit.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::suggested(edit));
+            diagnostic.set_fix(Fix::automatic_unsafe(edit));
         }
         checker.diagnostics.push(diagnostic);
     }
@@ -868,7 +868,7 @@ pub(crate) fn expr_and_false(checker: &mut Checker, expr: &Expr) {
             edit.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::suggested(edit));
+            diagnostic.set_fix(Fix::automatic_unsafe(edit));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -217,7 +217,7 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
             range: TextRange::default(),
         };
         let new_env_var = node.into();
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             checker.generator().expr(&new_env_var),
             slice.range(),
         )));
@@ -276,7 +276,7 @@ pub(crate) fn dict_get_with_none_default(checker: &mut Checker, expr: &Expr) {
     );
 
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
             expected,
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_if.rs
@@ -452,7 +452,7 @@ pub(crate) fn nested_if_statements(
                                 <= checker.settings.line_length
                         })
                     {
-                        diagnostic.set_fix(Fix::suggested(edit));
+                        diagnostic.set_fix(Fix::automatic_unsafe(edit));
                     }
                 }
                 Err(err) => error!("Failed to fix nested if: {err}"),
@@ -558,7 +558,7 @@ pub(crate) fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
                     value: Some(Box::new(if_test.clone())),
                     range: TextRange::default(),
                 };
-                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                     checker.generator().stmt(&node.into()),
                     range,
                 )));
@@ -583,7 +583,7 @@ pub(crate) fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
                     value: Some(Box::new(node1.into())),
                     range: TextRange::default(),
                 };
-                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                     checker.generator().stmt(&node2.into()),
                     range,
                 )));
@@ -714,7 +714,7 @@ pub(crate) fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt) {
     );
     if checker.patch(diagnostic.kind.rule()) {
         if !checker.indexer().has_comments(stmt, checker.locator()) {
-            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                 contents,
                 stmt.range(),
             )));
@@ -1022,7 +1022,7 @@ pub(crate) fn use_dict_get_with_default(checker: &mut Checker, stmt_if: &ast::St
     );
     if checker.patch(diagnostic.kind.rule()) {
         if !checker.indexer().has_comments(stmt_if, checker.locator()) {
-            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                 contents,
                 stmt_if.range(),
             )));

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -159,7 +159,7 @@ pub(crate) fn if_expr_with_true_false(
     );
     if checker.patch(diagnostic.kind.rule()) {
         if test.is_compare_expr() {
-            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                 checker
                     .locator()
                     .slice(
@@ -175,7 +175,7 @@ pub(crate) fn if_expr_with_true_false(
                 expr.range(),
             )));
         } else if checker.semantic().is_builtin("bool") {
-            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                 checker.generator().expr(
                     &ast::ExprCall {
                         func: Box::new(
@@ -216,7 +216,7 @@ pub(crate) fn if_expr_with_false_true(
 
     let mut diagnostic = Diagnostic::new(IfExprWithFalseTrue, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             checker.generator().expr(
                 &ast::ExprUnaryOp {
                     op: UnaryOp::Not,
@@ -279,7 +279,7 @@ pub(crate) fn twisted_arms_in_ifexpr(
             orelse: Box::new(node),
             range: TextRange::default(),
         };
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             checker.generator().expr(&node3.into()),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -182,7 +182,7 @@ pub(crate) fn negation_with_equal_op(
             comparators: comparators.clone(),
             range: TextRange::default(),
         };
-        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
             checker.generator().expr(&node.into()),
             expr.range(),
         )));
@@ -239,7 +239,7 @@ pub(crate) fn negation_with_not_equal_op(
             comparators: comparators.clone(),
             range: TextRange::default(),
         };
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             checker.generator().expr(&node.into()),
             expr.range(),
         )));
@@ -272,7 +272,7 @@ pub(crate) fn double_negation(checker: &mut Checker, expr: &Expr, op: UnaryOp, o
     );
     if checker.patch(diagnostic.kind.rule()) {
         if checker.semantic().in_boolean_test() {
-            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                 checker.locator().slice(operand.as_ref()).to_string(),
                 expr.range(),
             )));
@@ -291,7 +291,7 @@ pub(crate) fn double_negation(checker: &mut Checker, expr: &Expr, op: UnaryOp, o
                 },
                 range: TextRange::default(),
             };
-            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                 checker.generator().expr(&node1.into()),
                 expr.range(),
             )));

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
@@ -146,7 +146,7 @@ pub(crate) fn multiple_with_statements(
                                     <= checker.settings.line_length
                             })
                         {
-                            diagnostic.set_fix(Fix::suggested(edit));
+                            diagnostic.set_fix(Fix::automatic_unsafe(edit));
                         }
                     }
                     Err(err) => error!("Failed to fix nested with: {err}"),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -128,12 +128,12 @@ fn key_in_dict(
                 .next()
                 .is_some_and(|char| char.is_ascii_alphabetic())
             {
-                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                     " ".to_string(),
                     range,
                 )));
             } else {
-                diagnostic.set_fix(Fix::suggested(Edit::range_deletion(range)));
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_deletion(range)));
             }
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -118,7 +118,7 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt) {
                 TextRange::new(stmt.start(), terminal.stmt.end()),
             );
             if checker.patch(diagnostic.kind.rule()) && checker.semantic().is_builtin("any") {
-                diagnostic.set_fix(Fix::suggested(Edit::replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::replacement(
                     contents,
                     stmt.start(),
                     terminal.stmt.end(),
@@ -204,7 +204,7 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt) {
                 TextRange::new(stmt.start(), terminal.stmt.end()),
             );
             if checker.patch(diagnostic.kind.rule()) && checker.semantic().is_builtin("all") {
-                diagnostic.set_fix(Fix::suggested(Edit::replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::replacement(
                     contents,
                     stmt.start(),
                     terminal.stmt.end(),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/suppressible_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/suppressible_exception.rs
@@ -148,7 +148,7 @@ pub(crate) fn suppressible_exception(
                 );
                 let remove_handler =
                     Edit::range_deletion(checker.locator().full_lines_range(*range));
-                Ok(Fix::suggested_edits(
+                Ok(Fix::automatic_unsafe_edits(
                     import_edit,
                     [replace_try, remove_handler],
                 ))

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -194,7 +194,7 @@ pub(crate) fn yoda_conditions(
             expr.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                 pad(suggestion, expr.range(), checker.locator()),
                 expr.range(),
             )));

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM101_SIM101.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM101_SIM101.py.snap
@@ -9,7 +9,7 @@ SIM101.py:1:4: SIM101 [*] Multiple `isinstance` calls for `a`, merge into a sing
   |
   = help: Merge `isinstance` calls for `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-if isinstance(a, int) or isinstance(a, float):  # SIM101
   1 |+if isinstance(a, (int, float)):  # SIM101
 2 2 |     pass
@@ -26,7 +26,7 @@ SIM101.py:4:4: SIM101 [*] Multiple `isinstance` calls for `a`, merge into a sing
   |
   = help: Merge `isinstance` calls for `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | if isinstance(a, int) or isinstance(a, float):  # SIM101
 2 2 |     pass
 3 3 | 
@@ -46,7 +46,7 @@ SIM101.py:7:4: SIM101 [*] Multiple `isinstance` calls for `a`, merge into a sing
   |
   = help: Merge `isinstance` calls for `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | if isinstance(a, (int, float)) or isinstance(a, bool):  # SIM101
 5 5 |     pass
 6 6 | 
@@ -66,7 +66,7 @@ SIM101.py:10:4: SIM101 [*] Multiple `isinstance` calls for `a`, merge into a sin
    |
    = help: Merge `isinstance` calls for `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | if isinstance(a, int) or isinstance(a, float) or isinstance(b, bool):  # SIM101
 8  8  |     pass
 9  9  | 
@@ -86,7 +86,7 @@ SIM101.py:16:5: SIM101 [*] Multiple `isinstance` calls for `a`, merge into a sin
    |
    = help: Merge `isinstance` calls for `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | if isinstance(a, int) or isinstance(b, bool) or isinstance(a, float):  # SIM101
 14 14 |     pass
 15 15 | 
@@ -106,7 +106,7 @@ SIM101.py:19:4: SIM101 [*] Multiple `isinstance` calls for expression, merge int
    |
    = help: Merge `isinstance` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | if (isinstance(a, int) or isinstance(a, float)) and isinstance(b, bool):  # SIM101
 17 17 |     pass
 18 18 | 
@@ -136,7 +136,7 @@ SIM101.py:38:4: SIM101 [*] Multiple `isinstance` calls for `a`, merge into a sin
    |
    = help: Merge `isinstance` calls for `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 35 35 | if isinstance(a, int) or unrelated_condition or isinstance(a, float):
 36 36 |     pass
 37 37 | 
@@ -156,7 +156,7 @@ SIM101.py:41:4: SIM101 [*] Multiple `isinstance` calls for `a`, merge into a sin
    |
    = help: Merge `isinstance` calls for `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 38 38 | if x or isinstance(a, int) or isinstance(a, float):
 39 39 |     pass
 40 40 | 

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM102_SIM102.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM102_SIM102.py.snap
@@ -11,7 +11,7 @@ SIM102.py:2:1: SIM102 [*] Use a single `if` statement instead of nested `if` sta
   |
   = help: Combine `if` statements using `and`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # SIM102
 2   |-if a:
 3   |-    if b:
@@ -33,7 +33,7 @@ SIM102.py:7:1: SIM102 [*] Use a single `if` statement instead of nested `if` sta
    |
    = help: Combine `if` statements using `and`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4  4  |         c
 5  5  | 
 6  6  | # SIM102
@@ -60,7 +60,7 @@ SIM102.py:8:5: SIM102 [*] Use a single `if` statement instead of nested `if` sta
    |
    = help: Combine `if` statements using `and`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5  5  | 
 6  6  | # SIM102
 7  7  | if a:
@@ -84,7 +84,7 @@ SIM102.py:15:1: SIM102 [*] Use a single `if` statement instead of nested `if` st
    |
    = help: Combine `if` statements using `and`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | # SIM102
 13 13 | if a:
 14 14 |     pass
@@ -119,7 +119,7 @@ SIM102.py:26:1: SIM102 [*] Use a single `if` statement instead of nested `if` st
    |
    = help: Combine `if` statements using `and`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 |         c
 24 24 | 
 25 25 | # SIM102
@@ -147,7 +147,7 @@ SIM102.py:51:5: SIM102 [*] Use a single `if` statement instead of nested `if` st
    |
    = help: Combine `if` statements using `and`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 48 48 | 
 49 49 | while x > 0:
 50 50 |     # SIM102
@@ -183,7 +183,7 @@ SIM102.py:67:1: SIM102 [*] Use a single `if` statement instead of nested `if` st
    |
    = help: Combine `if` statements using `and`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 64 64 | 
 65 65 | 
 66 66 | # SIM102
@@ -222,7 +222,7 @@ SIM102.py:83:5: SIM102 [*] Use a single `if` statement instead of nested `if` st
    |
    = help: Combine `if` statements using `and`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 80 80 | 
 81 81 | while x > 0:
 82 82 |     # SIM102
@@ -251,7 +251,7 @@ SIM102.py:90:1: SIM102 [*] Use a single `if` statement instead of nested `if` st
    |
    = help: Combine `if` statements using `and`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 87 87 |             print("Bad module!")
 88 88 | 
 89 89 | # SIM102 (auto-fixable)
@@ -293,7 +293,7 @@ SIM102.py:106:5: SIM102 [*] Use a single `if` statement instead of nested `if` s
     |
     = help: Combine `if` statements using `and`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 103 103 | # SIM102
 104 104 | # Regression test for https://github.com/apache/airflow/blob/145b16caaa43f0c42bffd97344df916c602cddde/airflow/configuration.py#L1161
 105 105 | if a:
@@ -319,7 +319,7 @@ SIM102.py:132:5: SIM102 [*] Use a single `if` statement instead of nested `if` s
     |
     = help: Combine `if` statements using `and`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 129 129 | # OK
 130 130 | if a:
 131 131 |     # SIM 102
@@ -344,7 +344,7 @@ SIM102.py:165:5: SIM102 [*] Use a single `if` statement instead of nested `if` s
     |
     = help: Combine `if` statements using `and`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 162 162 | def f():
 163 163 |     if a:
 164 164 |         pass

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM103_SIM103.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM103_SIM103.py.snap
@@ -14,7 +14,7 @@ SIM103.py:3:5: SIM103 [*] Return the condition `a` directly
   |
   = help: Replace with `return a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | def f():
 2 2 |     # SIM103
 3   |-    if a:
@@ -39,7 +39,7 @@ SIM103.py:11:5: SIM103 [*] Return the condition `a == b` directly
    |
    = help: Replace with `return a == b`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | 
 9  9  | def f():
 10 10 |     # SIM103
@@ -65,7 +65,7 @@ SIM103.py:21:5: SIM103 [*] Return the condition `b` directly
    |
    = help: Replace with `return b`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 |     # SIM103
 19 19 |     if a:
 20 20 |         return 1
@@ -91,7 +91,7 @@ SIM103.py:32:9: SIM103 [*] Return the condition `b` directly
    |
    = help: Replace with `return b`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 29 29 |     if a:
 30 30 |         return 1
 31 31 |     else:

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM105_SIM105_0.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM105_SIM105_0.py.snap
@@ -12,7 +12,7 @@ SIM105_0.py:6:1: SIM105 [*] Use `contextlib.suppress(ValueError)` instead of `tr
   |
   = help: Replace with `contextlib.suppress(ValueError)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+import contextlib
 1  2  | def foo():
 2  3  |     pass
@@ -41,7 +41,7 @@ SIM105_0.py:13:1: SIM105 [*] Use `contextlib.suppress(ValueError, OSError)` inst
    |
    = help: Replace with `contextlib.suppress(ValueError, OSError)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+import contextlib
 1  2  | def foo():
 2  3  |     pass
@@ -72,7 +72,7 @@ SIM105_0.py:19:1: SIM105 [*] Use `contextlib.suppress(ValueError, OSError)` inst
    |
    = help: Replace with `contextlib.suppress(ValueError, OSError)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+import contextlib
 1  2  | def foo():
 2  3  |     pass
@@ -103,7 +103,7 @@ SIM105_0.py:25:1: SIM105 [*] Use `contextlib.suppress(Exception)` instead of `tr
    |
    = help: Replace with `contextlib.suppress(Exception)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+import contextlib
 1  2  | def foo():
 2  3  |     pass
@@ -134,7 +134,7 @@ SIM105_0.py:31:1: SIM105 [*] Use `contextlib.suppress(a.Error, b.Error)` instead
    |
    = help: Replace with `contextlib.suppress(a.Error, b.Error)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+import contextlib
 1  2  | def foo():
 2  3  |     pass
@@ -165,7 +165,7 @@ SIM105_0.py:85:5: SIM105 [*] Use `contextlib.suppress(ValueError)` instead of `t
    |
    = help: Replace with `contextlib.suppress(ValueError)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+import contextlib
 1  2  | def foo():
 2  3  |     pass
@@ -212,7 +212,7 @@ SIM105_0.py:117:5: SIM105 [*] Use `contextlib.suppress(OSError)` instead of `try
     |
     = help: Replace with `contextlib.suppress(OSError)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
     1   |+import contextlib
 1   2   | def foo():
 2   3   |     pass
@@ -244,7 +244,7 @@ SIM105_0.py:122:5: SIM105 [*] Use `contextlib.suppress(OSError)` instead of `try
     |
     = help: Replace with `contextlib.suppress(OSError)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
     1   |+import contextlib
 1   2   | def foo():
 2   3   |     pass
@@ -275,7 +275,7 @@ SIM105_0.py:126:5: SIM105 [*] Use `contextlib.suppress(OSError)` instead of `try
     |
     = help: Replace with `contextlib.suppress(OSError)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
     1   |+import contextlib
 1   2   | def foo():
 2   3   |     pass

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM105_SIM105_1.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM105_SIM105_1.py.snap
@@ -12,7 +12,7 @@ SIM105_1.py:5:1: SIM105 [*] Use `contextlib.suppress(ValueError)` instead of `tr
   |
   = help: Replace with `contextlib.suppress(ValueError)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | """Case: There's a random import, so it should add `contextlib` after it."""
 2 2 | import math
   3 |+import contextlib

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM105_SIM105_2.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM105_SIM105_2.py.snap
@@ -12,7 +12,7 @@ SIM105_2.py:10:1: SIM105 [*] Use `contextlib.suppress(ValueError)` instead of `t
    |
    = help: Replace with `contextlib.suppress(ValueError)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | 
 8  8  | 
 9  9  | # SIM105

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM105_SIM105_4.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM105_SIM105_4.py.snap
@@ -11,7 +11,7 @@ SIM105_4.py:2:1: SIM105 [*] Use `contextlib.suppress(ImportError)` instead of `t
   |
   = help: Replace with `contextlib.suppress(ImportError)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | ﻿#!/usr/bin/env python
 2   |-try:
   2 |+import contextlib

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM108_SIM108.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM108_SIM108.py.snap
@@ -14,7 +14,7 @@ SIM108.py:2:1: SIM108 [*] Use ternary operator `b = c if a else d` instead of `i
   |
   = help: Replace `if`-`else`-block with `b = c if a else d`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # SIM108
 2   |-if a:
 3   |-    b = c
@@ -38,7 +38,7 @@ SIM108.py:30:5: SIM108 [*] Use ternary operator `b = 1 if a else 2` instead of `
    |
    = help: Replace `if`-`else`-block with `b = 1 if a else 2`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 | if True:
 28 28 |     pass
 29 29 | else:
@@ -75,7 +75,7 @@ SIM108.py:82:1: SIM108 [*] Use ternary operator `b = "cccccccccccccccccccccccccc
    |
    = help: Replace `if`-`else`-block with `b = "cccccccccccccccccccccccccccccccccß" if a else "ddddddddddddddddddddddddddddddddd💣"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 79 79 | 
 80 80 | 
 81 81 | # SIM108

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM109_SIM109.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM109_SIM109.py.snap
@@ -10,7 +10,7 @@ SIM109.py:2:4: SIM109 [*] Use `a in (b, c)` instead of multiple equality compari
   |
   = help: Replace with `a in (b, c)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # SIM109
 2   |-if a == b or a == c:
   2 |+if a in (b, c):
@@ -27,7 +27,7 @@ SIM109.py:6:5: SIM109 [*] Use `a in (b, c)` instead of multiple equality compari
   |
   = help: Replace with `a in (b, c)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 |     d
 4 4 | 
 5 5 | # SIM109
@@ -46,7 +46,7 @@ SIM109.py:10:4: SIM109 [*] Use `a in (b, c)` instead of multiple equality compar
    |
    = help: Replace with `a in (b, c)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  |     d
 8  8  | 
 9  9  | # SIM109
@@ -65,7 +65,7 @@ SIM109.py:14:4: SIM109 [*] Use `a in (b, c)` instead of multiple equality compar
    |
    = help: Replace with `a in (b, c)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 |     d
 12 12 | 
 13 13 | # SIM109

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM110_SIM110.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM110_SIM110.py.snap
@@ -14,7 +14,7 @@ SIM110.py:3:5: SIM110 [*] Use `return any(check(x) for x in iterable)` instead o
   |
   = help: Replace with `return any(check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | def f():
 2 2 |     # SIM110
 3   |-    for x in iterable:
@@ -39,7 +39,7 @@ SIM110.py:25:5: SIM110 [*] Use `return all(not check(x) for x in iterable)` inst
    |
    = help: Replace with `return all(not check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | 
 23 23 | def f():
 24 24 |     # SIM111
@@ -65,7 +65,7 @@ SIM110.py:33:5: SIM110 [*] Use `return all(x.is_empty() for x in iterable)` inst
    |
    = help: Replace with `return all(x.is_empty() for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 30 30 | 
 31 31 | def f():
 32 32 |     # SIM111
@@ -92,7 +92,7 @@ SIM110.py:55:5: SIM110 [*] Use `return any(check(x) for x in iterable)` instead 
    |
    = help: Replace with `return any(check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 52 52 | 
 53 53 | def f():
 54 54 |     # SIM110
@@ -120,7 +120,7 @@ SIM110.py:64:5: SIM110 [*] Use `return all(not check(x) for x in iterable)` inst
    |
    = help: Replace with `return all(not check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 61 61 | 
 62 62 | def f():
 63 63 |     # SIM111
@@ -149,7 +149,7 @@ SIM110.py:73:5: SIM110 [*] Use `return any(check(x) for x in iterable)` instead 
    |
    = help: Replace with `return any(check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 70 70 | 
 71 71 | def f():
 72 72 |     # SIM110
@@ -178,7 +178,7 @@ SIM110.py:83:5: SIM110 [*] Use `return all(not check(x) for x in iterable)` inst
    |
    = help: Replace with `return all(not check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 80 80 | 
 81 81 | def f():
 82 82 |     # SIM111
@@ -230,7 +230,7 @@ SIM110.py:144:5: SIM110 [*] Use `return any(check(x) for x in iterable)` instead
     |
     = help: Replace with `return any(check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 141 141 |     x = 1
 142 142 | 
 143 143 |     # SIM110
@@ -255,7 +255,7 @@ SIM110.py:154:5: SIM110 [*] Use `return all(not check(x) for x in iterable)` ins
     |
     = help: Replace with `return all(not check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 151 151 |     x = 1
 152 152 | 
 153 153 |     # SIM111
@@ -281,7 +281,7 @@ SIM110.py:162:5: SIM110 [*] Use `return any(x.isdigit() for x in "012ß9💣2ℝ
     |
     = help: Replace with `return any(x.isdigit() for x in "012ß9💣2ℝ9012ß9💣2ℝ9012ß9💣2ℝ9012ß9💣2ℝ9012ß9💣2ℝ")`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 159 159 | 
 160 160 | def f():
 161 161 |     # SIM110
@@ -309,7 +309,7 @@ SIM110.py:184:5: SIM110 [*] Use `return any(check(x) for x in iterable)` instead
     |
     = help: Replace with `return any(check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 181 181 | 
 182 182 | async def f():
 183 183 |     # SIM110
@@ -337,7 +337,7 @@ SIM110.py:191:5: SIM110 [*] Use `return any(check(x) for x in await iterable)` i
     |
     = help: Replace with `return any(check(x) for x in await iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 188 188 | 
 189 189 | async def f():
 190 190 |     # SIM110

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM110_SIM111.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM110_SIM111.py.snap
@@ -14,7 +14,7 @@ SIM111.py:3:5: SIM110 [*] Use `return any(check(x) for x in iterable)` instead o
   |
   = help: Replace with `return any(check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | def f():
 2 2 |     # SIM110
 3   |-    for x in iterable:
@@ -39,7 +39,7 @@ SIM111.py:25:5: SIM110 [*] Use `return all(not check(x) for x in iterable)` inst
    |
    = help: Replace with `return all(not check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | 
 23 23 | def f():
 24 24 |     # SIM111
@@ -65,7 +65,7 @@ SIM111.py:33:5: SIM110 [*] Use `return all(x.is_empty() for x in iterable)` inst
    |
    = help: Replace with `return all(x.is_empty() for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 30 30 | 
 31 31 | def f():
 32 32 |     # SIM111
@@ -92,7 +92,7 @@ SIM111.py:55:5: SIM110 [*] Use `return any(check(x) for x in iterable)` instead 
    |
    = help: Replace with `return any(check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 52 52 | 
 53 53 | def f():
 54 54 |     # SIM110
@@ -120,7 +120,7 @@ SIM111.py:64:5: SIM110 [*] Use `return all(not check(x) for x in iterable)` inst
    |
    = help: Replace with `return all(not check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 61 61 | 
 62 62 | def f():
 63 63 |     # SIM111
@@ -149,7 +149,7 @@ SIM111.py:73:5: SIM110 [*] Use `return any(check(x) for x in iterable)` instead 
    |
    = help: Replace with `return any(check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 70 70 | 
 71 71 | def f():
 72 72 |     # SIM110
@@ -178,7 +178,7 @@ SIM111.py:83:5: SIM110 [*] Use `return all(not check(x) for x in iterable)` inst
    |
    = help: Replace with `return all(not check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 80 80 | 
 81 81 | def f():
 82 82 |     # SIM111
@@ -230,7 +230,7 @@ SIM111.py:144:5: SIM110 [*] Use `return any(check(x) for x in iterable)` instead
     |
     = help: Replace with `return any(check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 141 141 |     x = 1
 142 142 | 
 143 143 |     # SIM110
@@ -255,7 +255,7 @@ SIM111.py:154:5: SIM110 [*] Use `return all(not check(x) for x in iterable)` ins
     |
     = help: Replace with `return all(not check(x) for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 151 151 |     x = 1
 152 152 | 
 153 153 |     # SIM111
@@ -281,7 +281,7 @@ SIM111.py:162:5: SIM110 [*] Use `return all(x in y for x in iterable)` instead o
     |
     = help: Replace with `return all(x in y for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 159 159 | 
 160 160 | def f():
 161 161 |     # SIM111
@@ -307,7 +307,7 @@ SIM111.py:170:5: SIM110 [*] Use `return all(x <= y for x in iterable)` instead o
     |
     = help: Replace with `return all(x <= y for x in iterable)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 167 167 | 
 168 168 | def f():
 169 169 |     # SIM111
@@ -333,7 +333,7 @@ SIM111.py:178:5: SIM110 [*] Use `return all(not x.isdigit() for x in "012ß9💣
     |
     = help: Replace with `return all(not x.isdigit() for x in "012ß9💣2ℝ9012ß9💣2ℝ9012ß9💣2ℝ9012ß9💣2ℝ9012ß9")`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 175 175 | 
 176 176 | def f():
 177 177 |     # SIM111

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM112_SIM112.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM112_SIM112.py.snap
@@ -11,7 +11,7 @@ SIM112.py:4:12: SIM112 [*] Use capitalized environment variable `FOO` instead of
   |
   = help: Replace `foo` with `FOO`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import os
 2 2 | 
 3 3 | # Bad
@@ -76,7 +76,7 @@ SIM112.py:14:18: SIM112 [*] Use capitalized environment variable `FOO` instead o
    |
    = help: Replace `foo` with `FOO`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | 
 12 12 | env = os.environ.get('foo')
 13 13 | 
@@ -106,7 +106,7 @@ SIM112.py:19:22: SIM112 [*] Use capitalized environment variable `FOO` instead o
    |
    = help: Replace `foo` with `FOO`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | if env := os.environ.get('foo'):
 17 17 |     pass
 18 18 | 

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM117_SIM117.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM117_SIM117.py.snap
@@ -11,7 +11,7 @@ SIM117.py:2:1: SIM117 [*] Use a single `with` statement with multiple contexts i
   |
   = help: Combine `with` statements
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # SIM117
 2   |-with A() as a:
 3   |-    with B() as b:
@@ -33,7 +33,7 @@ SIM117.py:7:1: SIM117 [*] Use a single `with` statement with multiple contexts i
    |
    = help: Combine `with` statements
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4  4  |         print("hello")
 5  5  | 
 6  6  | # SIM117
@@ -70,7 +70,7 @@ SIM117.py:19:1: SIM117 [*] Use a single `with` statement with multiple contexts 
    |
    = help: Combine `with` statements
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 |         print("hello")
 17 17 | 
 18 18 | # SIM117
@@ -95,7 +95,7 @@ SIM117.py:47:1: SIM117 [*] Use a single `with` statement with multiple contexts 
    |
    = help: Combine `with` statements
 
-ℹ Suggested fix
+ℹ Unsafe fix
 44 44 |         print("hello")
 45 45 | 
 46 46 | # SIM117
@@ -121,7 +121,7 @@ SIM117.py:53:5: SIM117 [*] Use a single `with` statement with multiple contexts 
    |
    = help: Combine `with` statements
 
-ℹ Suggested fix
+ℹ Unsafe fix
 50 50 | 
 51 51 | while True:
 52 52 |     # SIM117
@@ -159,7 +159,7 @@ SIM117.py:68:1: SIM117 [*] Use a single `with` statement with multiple contexts 
    |
    = help: Combine `with` statements
 
-ℹ Suggested fix
+ℹ Unsafe fix
 67 67 | # SIM117
 68 68 | with (
 69 69 |     A() as a,
@@ -186,7 +186,7 @@ SIM117.py:76:1: SIM117 [*] Use a single `with` statement with multiple contexts 
    |
    = help: Combine `with` statements
 
-ℹ Suggested fix
+ℹ Unsafe fix
 73 73 |         print("hello")
 74 74 | 
 75 75 | # SIM117
@@ -221,7 +221,7 @@ SIM117.py:84:1: SIM117 [*] Use a single `with` statement with multiple contexts 
    |
    = help: Combine `with` statements
 
-ℹ Suggested fix
+ℹ Unsafe fix
 83 83 | # SIM117
 84 84 | with (
 85 85 |     A() as a,
@@ -249,7 +249,7 @@ SIM117.py:95:1: SIM117 [*] Use a single `with` statement with multiple contexts 
    |
    = help: Combine `with` statements
 
-ℹ Suggested fix
+ℹ Unsafe fix
 92 92 |         print("hello")
 93 93 | 
 94 94 | # SIM117 (auto-fixable)
@@ -294,7 +294,7 @@ SIM117.py:126:1: SIM117 [*] Use a single `with` statement with multiple contexts
     |
     = help: Combine `with` statements
 
-ℹ Suggested fix
+ℹ Unsafe fix
 123 123 |             f(b2, c2, d2)
 124 124 | 
 125 125 | # SIM117

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM118_SIM118.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM118_SIM118.py.snap
@@ -10,7 +10,7 @@ SIM118.py:1:1: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
   |
   = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-key in obj.keys()  # SIM118
   1 |+key in obj  # SIM118
 2 2 | 
@@ -28,7 +28,7 @@ SIM118.py:3:1: SIM118 [*] Use `key not in dict` instead of `key not in dict.keys
   |
   = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | key in obj.keys()  # SIM118
 2 2 | 
 3   |-key not in obj.keys()  # SIM118
@@ -48,7 +48,7 @@ SIM118.py:5:1: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
   |
   = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | 
 3 3 | key not in obj.keys()  # SIM118
 4 4 | 
@@ -69,7 +69,7 @@ SIM118.py:7:1: SIM118 [*] Use `key not in dict` instead of `key not in dict.keys
   |
   = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | 
 5 5 | foo["bar"] in obj.keys()  # SIM118
 6 6 | 
@@ -90,7 +90,7 @@ SIM118.py:9:1: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | 
 7  7  | foo["bar"] not in obj.keys()  # SIM118
 8  8  | 
@@ -111,7 +111,7 @@ SIM118.py:11:1: SIM118 [*] Use `key not in dict` instead of `key not in dict.key
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | 
 9  9  | foo['bar'] in obj.keys()  # SIM118
 10 10 | 
@@ -132,7 +132,7 @@ SIM118.py:13:1: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | 
 11 11 | foo['bar'] not in obj.keys()  # SIM118
 12 12 | 
@@ -153,7 +153,7 @@ SIM118.py:15:1: SIM118 [*] Use `key not in dict` instead of `key not in dict.key
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | 
 13 13 | foo() in obj.keys()  # SIM118
 14 14 | 
@@ -173,7 +173,7 @@ SIM118.py:17:5: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | 
 15 15 | foo() not in obj.keys()  # SIM118
 16 16 | 
@@ -194,7 +194,7 @@ SIM118.py:24:8: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 |     if some_property(key):
 22 22 |         del obj[key]
 23 23 | 
@@ -215,7 +215,7 @@ SIM118.py:26:8: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 | 
 24 24 | [k for k in obj.keys()]  # SIM118
 25 25 | 
@@ -236,7 +236,7 @@ SIM118.py:28:11: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 25 25 | 
 26 26 | {k for k in obj.keys()}  # SIM118
 27 27 | 
@@ -257,7 +257,7 @@ SIM118.py:30:8: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 | 
 28 28 | {k: k for k in obj.keys()}  # SIM118
 29 29 | 
@@ -278,7 +278,7 @@ SIM118.py:32:1: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 29 29 | 
 30 30 | (k for k in obj.keys())  # SIM118
 31 31 | 
@@ -299,7 +299,7 @@ SIM118.py:34:1: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 31 31 | 
 32 32 | key in (obj or {}).keys()  # SIM118
 33 33 | 
@@ -319,7 +319,7 @@ SIM118.py:48:1: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 45 45 | 
 46 46 | 
 47 47 | # Regression test for: https://github.com/astral-sh/ruff/issues/7124
@@ -339,7 +339,7 @@ SIM118.py:49:2: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 | 
 47 47 | # Regression test for: https://github.com/astral-sh/ruff/issues/7124
 48 48 | key in obj.keys()and foo
@@ -360,7 +360,7 @@ SIM118.py:50:1: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 47 47 | # Regression test for: https://github.com/astral-sh/ruff/issues/7124
 48 48 | key in obj.keys()and foo
 49 49 | (key in obj.keys())and foo
@@ -384,7 +384,7 @@ SIM118.py:53:5: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 53 53 | for key in (
 54 54 |     self.experiment.surveys[0]
 55 55 |         .stations[0]

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM202_SIM202.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM202_SIM202.py.snap
@@ -10,7 +10,7 @@ SIM202.py:2:4: SIM202 [*] Use `a == b` instead of `not a != b`
   |
   = help: Replace with `==` operator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # SIM202
 2   |-if not a != b:
   2 |+if a == b:
@@ -27,7 +27,7 @@ SIM202.py:6:4: SIM202 [*] Use `a == b + c` instead of `not a != b + c`
   |
   = help: Replace with `==` operator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 |     pass
 4 4 | 
 5 5 | # SIM202
@@ -46,7 +46,7 @@ SIM202.py:10:4: SIM202 [*] Use `a + b == c` instead of `not a + b != c`
    |
    = help: Replace with `==` operator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  |     pass
 8  8  | 
 9  9  | # SIM202

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM208_SIM208.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM208_SIM208.py.snap
@@ -9,7 +9,7 @@ SIM208.py:1:4: SIM208 [*] Use `a` instead of `not (not a)`
   |
   = help: Replace with `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-if not (not a):  # SIM208
   1 |+if a:  # SIM208
 2 2 |     pass
@@ -26,7 +26,7 @@ SIM208.py:4:4: SIM208 [*] Use `a == b` instead of `not (not a == b)`
   |
   = help: Replace with `a == b`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | if not (not a):  # SIM208
 2 2 |     pass
 3 3 | 
@@ -47,7 +47,7 @@ SIM208.py:16:5: SIM208 [*] Use `b` instead of `not (not b)`
    |
    = help: Replace with `b`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | if not a != b:  # OK
 14 14 |     pass
 15 15 | 
@@ -68,7 +68,7 @@ SIM208.py:18:3: SIM208 [*] Use `a` instead of `not (not a)`
    |
    = help: Replace with `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | 
 16 16 | a = not not b  # SIM208
 17 17 | 
@@ -88,7 +88,7 @@ SIM208.py:20:9: SIM208 [*] Use `a` instead of `not (not a)`
    |
    = help: Replace with `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | 
 18 18 | f(not not a)  # SIM208
 19 19 | 

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM210_SIM210.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM210_SIM210.py.snap
@@ -10,7 +10,7 @@ SIM210.py:1:5: SIM210 [*] Use `bool(...)` instead of `True if ... else False`
   |
   = help: Replace with `bool(...)
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-a = True if b else False  # SIM210
   1 |+a = bool(b)  # SIM210
 2 2 | 
@@ -28,7 +28,7 @@ SIM210.py:3:5: SIM210 [*] Remove unnecessary `True if ... else False`
   |
   = help: Remove unnecessary `True if ... else False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | a = True if b else False  # SIM210
 2 2 | 
 3   |-a = True if b != c else False  # SIM210
@@ -48,7 +48,7 @@ SIM210.py:5:5: SIM210 [*] Use `bool(...)` instead of `True if ... else False`
   |
   = help: Replace with `bool(...)
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | 
 3 3 | a = True if b != c else False  # SIM210
 4 4 | 
@@ -77,7 +77,7 @@ SIM210.py:19:11: SIM210 [*] Remove unnecessary `True if ... else False`
    |
    = help: Remove unnecessary `True if ... else False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | 
 17 17 | 
 18 18 | # Regression test for: https://github.com/astral-sh/ruff/issues/7076

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM211_SIM211.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM211_SIM211.py.snap
@@ -10,7 +10,7 @@ SIM211.py:1:5: SIM211 [*] Use `not ...` instead of `False if ... else True`
   |
   = help: Replace with `not ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-a = False if b else True  # SIM211
   1 |+a = not b  # SIM211
 2 2 | 
@@ -28,7 +28,7 @@ SIM211.py:3:5: SIM211 [*] Use `not ...` instead of `False if ... else True`
   |
   = help: Replace with `not ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | a = False if b else True  # SIM211
 2 2 | 
 3   |-a = False if b != c else True  # SIM211
@@ -48,7 +48,7 @@ SIM211.py:5:5: SIM211 [*] Use `not ...` instead of `False if ... else True`
   |
   = help: Replace with `not ...`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | 
 3 3 | a = False if b != c else True  # SIM211
 4 4 | 

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM212_SIM212.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM212_SIM212.py.snap
@@ -10,7 +10,7 @@ SIM212.py:1:5: SIM212 [*] Use `a if a else b` instead of `b if not a else a`
   |
   = help: Replace with `a if a else b`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-c = b if not a else a  # SIM212
   1 |+c = a if a else b  # SIM212
 2 2 | 
@@ -28,7 +28,7 @@ SIM212.py:3:5: SIM212 [*] Use `a if a else b + c` instead of `b + c if not a els
   |
   = help: Replace with `a if a else b + c`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | c = b if not a else a  # SIM212
 2 2 | 
 3   |-c = b + c if not a else a  # SIM212

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM220_SIM220.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM220_SIM220.py.snap
@@ -9,7 +9,7 @@ SIM220.py:1:4: SIM220 [*] Use `False` instead of `a and not a`
   |
   = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-if a and not a:
   1 |+if False:
 2 2 |     pass
@@ -26,7 +26,7 @@ SIM220.py:4:5: SIM220 [*] Use `False` instead of `a and not a`
   |
   = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | if a and not a:
 2 2 |     pass
 3 3 | 
@@ -46,7 +46,7 @@ SIM220.py:7:5: SIM220 [*] Use `False` instead of `a and not a`
   |
   = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | if (a and not a) and b:
 5 5 |     pass
 6 6 | 

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM221_SIM221.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM221_SIM221.py.snap
@@ -9,7 +9,7 @@ SIM221.py:1:4: SIM221 [*] Use `True` instead of `a or not a`
   |
   = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-if a or not a:
   1 |+if True:
 2 2 |     pass
@@ -26,7 +26,7 @@ SIM221.py:4:5: SIM221 [*] Use `True` instead of `a or not a`
   |
   = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | if a or not a:
 2 2 |     pass
 3 3 | 
@@ -46,7 +46,7 @@ SIM221.py:7:5: SIM221 [*] Use `True` instead of `a or not a`
   |
   = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | if (a or not a) or b:
 5 5 |     pass
 6 6 | 

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
@@ -9,7 +9,7 @@ SIM222.py:1:4: SIM222 [*] Use `True` instead of `... or True`
   |
   = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-if a or True:  # SIM222
   1 |+if True:  # SIM222
 2 2 |     pass
@@ -26,7 +26,7 @@ SIM222.py:4:4: SIM222 [*] Use `True` instead of `... or True`
   |
   = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | if a or True:  # SIM222
 2 2 |     pass
 3 3 | 
@@ -46,7 +46,7 @@ SIM222.py:7:10: SIM222 [*] Use `True` instead of `... or True`
   |
   = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | if (a or b) or True:  # SIM222
 5 5 |     pass
 6 6 | 
@@ -66,7 +66,7 @@ SIM222.py:24:16: SIM222 [*] Use `True` instead of `True or ...`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | if a or f() or b or g() or True:  # OK
 22 22 |     pass
 23 23 | 
@@ -86,7 +86,7 @@ SIM222.py:27:4: SIM222 [*] Use `True` instead of `True or ...`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 24 24 | if a or f() or True or g() or b:  # SIM222
 25 25 |     pass
 26 26 | 
@@ -106,7 +106,7 @@ SIM222.py:30:4: SIM222 [*] Use `True` instead of `... or True or ...`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 | if True or f() or a or g() or b:  # SIM222
 28 28 |     pass
 29 29 | 
@@ -125,7 +125,7 @@ SIM222.py:47:6: SIM222 [*] Use `True` instead of `... or True`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 44 44 |     pass
 45 45 | 
 46 46 | 
@@ -146,7 +146,7 @@ SIM222.py:49:6: SIM222 [*] Use `"foo"` instead of `"foo" or ...`
    |
    = help: Replace with `"foo"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 | 
 47 47 | a or "" or True  # SIM222
 48 48 | 
@@ -167,7 +167,7 @@ SIM222.py:51:6: SIM222 [*] Use `True` instead of `... or True`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 48 48 | 
 49 49 | a or "foo" or True or "bar"  # SIM222
 50 50 | 
@@ -188,7 +188,7 @@ SIM222.py:53:6: SIM222 [*] Use `1` instead of `1 or ...`
    |
    = help: Replace with `1`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 50 50 | 
 51 51 | a or 0 or True  # SIM222
 52 52 | 
@@ -209,7 +209,7 @@ SIM222.py:55:6: SIM222 [*] Use `True` instead of `... or True`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 52 52 | 
 53 53 | a or 1 or True or 2  # SIM222
 54 54 | 
@@ -230,7 +230,7 @@ SIM222.py:57:6: SIM222 [*] Use `0.1` instead of `0.1 or ...`
    |
    = help: Replace with `0.1`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 54 54 | 
 55 55 | a or 0.0 or True  # SIM222
 56 56 | 
@@ -251,7 +251,7 @@ SIM222.py:59:6: SIM222 [*] Use `True` instead of `... or True`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 56 56 | 
 57 57 | a or 0.1 or True or 0.2  # SIM222
 58 58 | 
@@ -272,7 +272,7 @@ SIM222.py:61:6: SIM222 [*] Use `True` instead of `... or True`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 58 58 | 
 59 59 | a or [] or True  # SIM222
 60 60 | 
@@ -293,7 +293,7 @@ SIM222.py:63:6: SIM222 [*] Use `[1]` instead of `[1] or ...`
    |
    = help: Replace with `[1]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 60 60 | 
 61 61 | a or list([]) or True  # SIM222
 62 62 | 
@@ -314,7 +314,7 @@ SIM222.py:65:6: SIM222 [*] Use `list([1])` instead of `list([1]) or ...`
    |
    = help: Replace with `list([1])`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 62 62 | 
 63 63 | a or [1] or True or [2]  # SIM222
 64 64 | 
@@ -335,7 +335,7 @@ SIM222.py:67:6: SIM222 [*] Use `True` instead of `... or True`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 64 64 | 
 65 65 | a or list([1]) or True or list([2])  # SIM222
 66 66 | 
@@ -356,7 +356,7 @@ SIM222.py:69:6: SIM222 [*] Use `True` instead of `... or True`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 66 66 | 
 67 67 | a or {} or True  # SIM222
 68 68 | 
@@ -377,7 +377,7 @@ SIM222.py:71:6: SIM222 [*] Use `{1: 1}` instead of `{1: 1} or ...`
    |
    = help: Replace with `{1: 1}`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 68 68 | 
 69 69 | a or dict() or True  # SIM222
 70 70 | 
@@ -398,7 +398,7 @@ SIM222.py:73:6: SIM222 [*] Use `dict({1: 1})` instead of `dict({1: 1}) or ...`
    |
    = help: Replace with `dict({1: 1})`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 70 70 | 
 71 71 | a or {1: 1} or True or {2: 2}  # SIM222
 72 72 | 
@@ -419,7 +419,7 @@ SIM222.py:75:6: SIM222 [*] Use `True` instead of `... or True`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 72 72 | 
 73 73 | a or dict({1: 1}) or True or dict({2: 2})  # SIM222
 74 74 | 
@@ -440,7 +440,7 @@ SIM222.py:77:6: SIM222 [*] Use `True` instead of `... or True`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 74 74 | 
 75 75 | a or set() or True  # SIM222
 76 76 | 
@@ -461,7 +461,7 @@ SIM222.py:79:6: SIM222 [*] Use `{1}` instead of `{1} or ...`
    |
    = help: Replace with `{1}`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 76 76 | 
 77 77 | a or set(set()) or True  # SIM222
 78 78 | 
@@ -482,7 +482,7 @@ SIM222.py:81:6: SIM222 [*] Use `set({1})` instead of `set({1}) or ...`
    |
    = help: Replace with `set({1})`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 78 78 | 
 79 79 | a or {1} or True or {2}  # SIM222
 80 80 | 
@@ -503,7 +503,7 @@ SIM222.py:83:6: SIM222 [*] Use `True` instead of `... or True`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 80 80 | 
 81 81 | a or set({1}) or True or set({2})  # SIM222
 82 82 | 
@@ -524,7 +524,7 @@ SIM222.py:85:6: SIM222 [*] Use `True` instead of `... or True`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 82 82 | 
 83 83 | a or () or True  # SIM222
 84 84 | 
@@ -545,7 +545,7 @@ SIM222.py:87:6: SIM222 [*] Use `(1,)` instead of `(1,) or ...`
    |
    = help: Replace with `(1,)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 84 84 | 
 85 85 | a or tuple(()) or True  # SIM222
 86 86 | 
@@ -566,7 +566,7 @@ SIM222.py:89:6: SIM222 [*] Use `tuple((1,))` instead of `tuple((1,)) or ...`
    |
    = help: Replace with `tuple((1,))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 86 86 | 
 87 87 | a or (1,) or True or (2,)  # SIM222
 88 88 | 
@@ -587,7 +587,7 @@ SIM222.py:91:6: SIM222 [*] Use `True` instead of `... or True`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 88 88 | 
 89 89 | a or tuple((1,)) or True or tuple((2,))  # SIM222
 90 90 | 
@@ -608,7 +608,7 @@ SIM222.py:93:6: SIM222 [*] Use `True` instead of `... or True`
    |
    = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 90 90 | 
 91 91 | a or frozenset() or True  # SIM222
 92 92 | 
@@ -629,7 +629,7 @@ SIM222.py:95:6: SIM222 [*] Use `frozenset({1})` instead of `frozenset({1}) or ..
    |
    = help: Replace with `frozenset({1})`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 92 92 | 
 93 93 | a or frozenset(frozenset()) or True  # SIM222
 94 94 | 
@@ -648,7 +648,7 @@ SIM222.py:97:6: SIM222 [*] Use `frozenset(frozenset({1}))` instead of `frozenset
    |
    = help: Replace with `frozenset(frozenset({1}))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 94 94 | 
 95 95 | a or frozenset({1}) or True or frozenset({2})  # SIM222
 96 96 | 
@@ -669,7 +669,7 @@ SIM222.py:102:6: SIM222 [*] Use `True` instead of `... or True or ...`
     |
     = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 99  99  | 
 100 100 | # Inside test `a` is simplified.
 101 101 | 
@@ -690,7 +690,7 @@ SIM222.py:104:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
     = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 101 101 | 
 102 102 | bool(a or [1] or True or [2])  # SIM222
 103 103 | 
@@ -710,7 +710,7 @@ SIM222.py:106:5: SIM222 [*] Use `True` instead of `... or True or ...`
     |
     = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 103 103 | 
 104 104 | assert a or [1] or True or [2]  # SIM222
 105 105 | 
@@ -730,7 +730,7 @@ SIM222.py:106:35: SIM222 [*] Use `True` instead of `... or True or ...`
     |
     = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 103 103 | 
 104 104 | assert a or [1] or True or [2]  # SIM222
 105 105 | 
@@ -751,7 +751,7 @@ SIM222.py:109:6: SIM222 [*] Use `True` instead of `... or True or ...`
     |
     = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 106 106 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
 107 107 |     pass
 108 108 | 
@@ -771,7 +771,7 @@ SIM222.py:111:7: SIM222 [*] Use `True` instead of `... or True or ...`
     |
     = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 108 108 | 
 109 109 | 0 if a or [1] or True or [2] else 1  # SIM222
 110 110 | 
@@ -792,7 +792,7 @@ SIM222.py:118:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
     = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 115 115 |     0
 116 116 |     for a in range(10)
 117 117 |     for b in range(10)
@@ -812,7 +812,7 @@ SIM222.py:119:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
     = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 116 116 |     for a in range(10)
 117 117 |     for b in range(10)
 118 118 |     if a or [1] or True or [2]  # SIM222
@@ -833,7 +833,7 @@ SIM222.py:126:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
     = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 123 123 |     0
 124 124 |     for a in range(10)
 125 125 |     for b in range(10)
@@ -853,7 +853,7 @@ SIM222.py:127:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
     = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 124 124 |     for a in range(10)
 125 125 |     for b in range(10)
 126 126 |     if a or [1] or True or [2]  # SIM222
@@ -874,7 +874,7 @@ SIM222.py:134:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
     = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 131 131 |     0: 0
 132 132 |     for a in range(10)
 133 133 |     for b in range(10)
@@ -894,7 +894,7 @@ SIM222.py:135:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
     = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 132 132 |     for a in range(10)
 133 133 |     for b in range(10)
 134 134 |     if a or [1] or True or [2]  # SIM222
@@ -915,7 +915,7 @@ SIM222.py:142:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
     = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 139 139 |     0
 140 140 |     for a in range(10)
 141 141 |     for b in range(10)
@@ -935,7 +935,7 @@ SIM222.py:143:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
     = help: Replace with `True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 140 140 |     for a in range(10)
 141 141 |     for b in range(10)
 142 142 |     if a or [1] or True or [2]  # SIM222
@@ -956,7 +956,7 @@ SIM222.py:148:6: SIM222 [*] Use `[1]` instead of `[1] or ...`
     |
     = help: Replace with `[1]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 145 145 | 
 146 146 | # Outside test `a` is not simplified.
 147 147 | 
@@ -976,7 +976,7 @@ SIM222.py:150:10: SIM222 [*] Use `[1]` instead of `[1] or ...`
     |
     = help: Replace with `[1]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 147 147 | 
 148 148 | a or [1] or True or [2]  # SIM222
 149 149 | 
@@ -996,7 +996,7 @@ SIM222.py:153:11: SIM222 [*] Use `[1]` instead of `[1] or ...`
     |
     = help: Replace with `[1]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 150 150 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
 151 151 |     pass
 152 152 | 
@@ -1015,7 +1015,7 @@ SIM222.py:157:30: SIM222 [*] Use `(int, int, int)` instead of `(int, int, int) o
     |
     = help: Replace with `(int, int, int)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 154 154 |     pass
 155 155 | 
 156 156 | # Regression test for: https://github.com/astral-sh/ruff/issues/7099
@@ -1033,7 +1033,7 @@ SIM222.py:161:31: SIM222 [*] Use `(int, int, int)` instead of `(int, int, int) o
     |
     = help: Replace with `(int, int, int)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 158 158 |     m, s = divmod(s0, 60)
 159 159 | 
 160 160 | 

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
@@ -9,7 +9,7 @@ SIM223.py:1:4: SIM223 [*] Use `False` instead of `... and False`
   |
   = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-if a and False:  # SIM223
   1 |+if False:  # SIM223
 2 2 |     pass
@@ -26,7 +26,7 @@ SIM223.py:4:4: SIM223 [*] Use `False` instead of `... and False`
   |
   = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | if a and False:  # SIM223
 2 2 |     pass
 3 3 | 
@@ -46,7 +46,7 @@ SIM223.py:7:10: SIM223 [*] Use `False` instead of `... and False`
   |
   = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | if (a or b) and False:  # SIM223
 5 5 |     pass
 6 6 | 
@@ -66,7 +66,7 @@ SIM223.py:19:18: SIM223 [*] Use `False` instead of `False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | if a and f() and b and g() and False:  # OK
 17 17 |     pass
 18 18 | 
@@ -86,7 +86,7 @@ SIM223.py:22:4: SIM223 [*] Use `False` instead of `False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | if a and f() and False and g() and b:  # SIM223
 20 20 |     pass
 21 21 | 
@@ -106,7 +106,7 @@ SIM223.py:25:4: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | if False and f() and a and g() and b:  # SIM223
 23 23 |     pass
 24 24 | 
@@ -125,7 +125,7 @@ SIM223.py:42:7: SIM223 [*] Use `""` instead of `"" and ...`
    |
    = help: Replace with `""`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 39 39 |     pass
 40 40 | 
 41 41 | 
@@ -146,7 +146,7 @@ SIM223.py:44:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 | 
 42 42 | a and "" and False  # SIM223
 43 43 | 
@@ -167,7 +167,7 @@ SIM223.py:46:7: SIM223 [*] Use `0` instead of `0 and ...`
    |
    = help: Replace with `0`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 43 43 | 
 44 44 | a and "foo" and False and "bar"  # SIM223
 45 45 | 
@@ -188,7 +188,7 @@ SIM223.py:48:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 45 45 | 
 46 46 | a and 0 and False  # SIM223
 47 47 | 
@@ -209,7 +209,7 @@ SIM223.py:50:7: SIM223 [*] Use `0.0` instead of `0.0 and ...`
    |
    = help: Replace with `0.0`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 47 47 | 
 48 48 | a and 1 and False and 2  # SIM223
 49 49 | 
@@ -230,7 +230,7 @@ SIM223.py:52:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 49 49 | 
 50 50 | a and 0.0 and False  # SIM223
 51 51 | 
@@ -251,7 +251,7 @@ SIM223.py:54:7: SIM223 [*] Use `[]` instead of `[] and ...`
    |
    = help: Replace with `[]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 51 51 | 
 52 52 | a and 0.1 and False and 0.2  # SIM223
 53 53 | 
@@ -272,7 +272,7 @@ SIM223.py:56:7: SIM223 [*] Use `list([])` instead of `list([]) and ...`
    |
    = help: Replace with `list([])`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 53 53 | 
 54 54 | a and [] and False  # SIM223
 55 55 | 
@@ -293,7 +293,7 @@ SIM223.py:58:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 55 55 | 
 56 56 | a and list([]) and False  # SIM223
 57 57 | 
@@ -314,7 +314,7 @@ SIM223.py:60:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 57 57 | 
 58 58 | a and [1] and False and [2]  # SIM223
 59 59 | 
@@ -335,7 +335,7 @@ SIM223.py:62:7: SIM223 [*] Use `{}` instead of `{} and ...`
    |
    = help: Replace with `{}`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 59 59 | 
 60 60 | a and list([1]) and False and list([2])  # SIM223
 61 61 | 
@@ -356,7 +356,7 @@ SIM223.py:64:7: SIM223 [*] Use `dict()` instead of `dict() and ...`
    |
    = help: Replace with `dict()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 61 61 | 
 62 62 | a and {} and False  # SIM223
 63 63 | 
@@ -377,7 +377,7 @@ SIM223.py:66:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 63 63 | 
 64 64 | a and dict() and False  # SIM223
 65 65 | 
@@ -398,7 +398,7 @@ SIM223.py:68:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 65 65 | 
 66 66 | a and {1: 1} and False and {2: 2}  # SIM223
 67 67 | 
@@ -419,7 +419,7 @@ SIM223.py:70:7: SIM223 [*] Use `set()` instead of `set() and ...`
    |
    = help: Replace with `set()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 67 67 | 
 68 68 | a and dict({1: 1}) and False and dict({2: 2})  # SIM223
 69 69 | 
@@ -440,7 +440,7 @@ SIM223.py:72:7: SIM223 [*] Use `set(set())` instead of `set(set()) and ...`
    |
    = help: Replace with `set(set())`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 69 69 | 
 70 70 | a and set() and False  # SIM223
 71 71 | 
@@ -461,7 +461,7 @@ SIM223.py:74:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 71 71 | 
 72 72 | a and set(set()) and False  # SIM223
 73 73 | 
@@ -482,7 +482,7 @@ SIM223.py:76:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 73 73 | 
 74 74 | a and {1} and False and {2}  # SIM223
 75 75 | 
@@ -503,7 +503,7 @@ SIM223.py:78:7: SIM223 [*] Use `()` instead of `() and ...`
    |
    = help: Replace with `()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 75 75 | 
 76 76 | a and set({1}) and False and set({2})  # SIM223
 77 77 | 
@@ -524,7 +524,7 @@ SIM223.py:80:7: SIM223 [*] Use `tuple(())` instead of `tuple(()) and ...`
    |
    = help: Replace with `tuple(())`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 77 77 | 
 78 78 | a and () and False  # SIM222
 79 79 | 
@@ -545,7 +545,7 @@ SIM223.py:82:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 79 79 | 
 80 80 | a and tuple(()) and False  # SIM222
 81 81 | 
@@ -566,7 +566,7 @@ SIM223.py:84:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 81 81 | 
 82 82 | a and (1,) and False and (2,)  # SIM222
 83 83 | 
@@ -587,7 +587,7 @@ SIM223.py:86:7: SIM223 [*] Use `frozenset()` instead of `frozenset() and ...`
    |
    = help: Replace with `frozenset()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 83 83 | 
 84 84 | a and tuple((1,)) and False and tuple((2,))  # SIM222
 85 85 | 
@@ -608,7 +608,7 @@ SIM223.py:88:7: SIM223 [*] Use `frozenset(frozenset())` instead of `frozenset(fr
    |
    = help: Replace with `frozenset(frozenset())`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 85 85 | 
 86 86 | a and frozenset() and False  # SIM222
 87 87 | 
@@ -629,7 +629,7 @@ SIM223.py:90:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 87 87 | 
 88 88 | a and frozenset(frozenset()) and False  # SIM222
 89 89 | 
@@ -648,7 +648,7 @@ SIM223.py:92:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 89 89 | 
 90 90 | a and frozenset({1}) and False and frozenset({2})  # SIM222
 91 91 | 
@@ -669,7 +669,7 @@ SIM223.py:97:6: SIM223 [*] Use `False` instead of `... and False and ...`
    |
    = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 94 94 | 
 95 95 | # Inside test `a` is simplified.
 96 96 | 
@@ -690,7 +690,7 @@ SIM223.py:99:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
     = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 96  96  | 
 97  97  | bool(a and [] and False and [])  # SIM223
 98  98  | 
@@ -710,7 +710,7 @@ SIM223.py:101:5: SIM223 [*] Use `False` instead of `... and False and ...`
     |
     = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 98  98  | 
 99  99  | assert a and [] and False and []  # SIM223
 100 100 | 
@@ -730,7 +730,7 @@ SIM223.py:101:36: SIM223 [*] Use `False` instead of `... and False and ...`
     |
     = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 98  98  | 
 99  99  | assert a and [] and False and []  # SIM223
 100 100 | 
@@ -751,7 +751,7 @@ SIM223.py:104:6: SIM223 [*] Use `False` instead of `... and False and ...`
     |
     = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 101 101 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
 102 102 |     pass
 103 103 | 
@@ -771,7 +771,7 @@ SIM223.py:106:7: SIM223 [*] Use `False` instead of `... and False and ...`
     |
     = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 103 103 | 
 104 104 | 0 if a and [] and False and [] else 1  # SIM222
 105 105 | 
@@ -792,7 +792,7 @@ SIM223.py:113:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
     = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 110 110 |     0
 111 111 |     for a in range(10)
 112 112 |     for b in range(10)
@@ -812,7 +812,7 @@ SIM223.py:114:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
     = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 111 111 |     for a in range(10)
 112 112 |     for b in range(10)
 113 113 |     if a and [] and False and []  # SIM223
@@ -833,7 +833,7 @@ SIM223.py:121:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
     = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 118 118 |     0
 119 119 |     for a in range(10)
 120 120 |     for b in range(10)
@@ -853,7 +853,7 @@ SIM223.py:122:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
     = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 119 119 |     for a in range(10)
 120 120 |     for b in range(10)
 121 121 |     if a and [] and False and []  # SIM223
@@ -874,7 +874,7 @@ SIM223.py:129:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
     = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 126 126 |     0: 0
 127 127 |     for a in range(10)
 128 128 |     for b in range(10)
@@ -894,7 +894,7 @@ SIM223.py:130:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
     = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 127 127 |     for a in range(10)
 128 128 |     for b in range(10)
 129 129 |     if a and [] and False and []  # SIM223
@@ -915,7 +915,7 @@ SIM223.py:137:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
     = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 134 134 |     0
 135 135 |     for a in range(10)
 136 136 |     for b in range(10)
@@ -935,7 +935,7 @@ SIM223.py:138:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
     = help: Replace with `False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 135 135 |     for a in range(10)
 136 136 |     for b in range(10)
 137 137 |     if a and [] and False and []  # SIM223
@@ -956,7 +956,7 @@ SIM223.py:143:7: SIM223 [*] Use `[]` instead of `[] and ...`
     |
     = help: Replace with `[]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 140 140 | 
 141 141 | # Outside test `a` is not simplified.
 142 142 | 
@@ -976,7 +976,7 @@ SIM223.py:145:11: SIM223 [*] Use `[]` instead of `[] and ...`
     |
     = help: Replace with `[]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 142 142 | 
 143 143 | a and [] and False and []  # SIM223
 144 144 | 
@@ -996,7 +996,7 @@ SIM223.py:148:12: SIM223 [*] Use `[]` instead of `[] and ...`
     |
     = help: Replace with `[]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 145 145 | if (a and [] and False and []) == (a and []):  # SIM223
 146 146 |     pass
 147 147 | 

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM401_SIM401.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM401_SIM401.py.snap
@@ -14,7 +14,7 @@ SIM401.py:6:1: SIM401 [*] Use `var = a_dict.get(key, "default1")` instead of an 
    |
    = help: Replace with `var = a_dict.get(key, "default1")`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3  3  | ###
 4  4  | 
 5  5  | # SIM401 (pattern-1)
@@ -40,7 +40,7 @@ SIM401.py:12:1: SIM401 [*] Use `var = a_dict.get(key, "default2")` instead of an
    |
    = help: Replace with `var = a_dict.get(key, "default2")`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  |     var = "default1"
 10 10 | 
 11 11 | # SIM401 (pattern-2)
@@ -66,7 +66,7 @@ SIM401.py:24:1: SIM401 [*] Use `var = a_dict.get(keys[idx], "default")` instead 
    |
    = help: Replace with `var = a_dict.get(keys[idx], "default")`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 |     var = val1 + val2
 22 22 | 
 23 23 | # SIM401 (complex expression in key)
@@ -92,7 +92,7 @@ SIM401.py:30:1: SIM401 [*] Use `var = dicts[idx].get(key, "default")` instead of
    |
    = help: Replace with `var = dicts[idx].get(key, "default")`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 |     var = "default"
 28 28 | 
 29 29 | # SIM401 (complex expression in dict)
@@ -118,7 +118,7 @@ SIM401.py:36:1: SIM401 [*] Use `vars[idx] = a_dict.get(key, "defaultß9💣2ℝ6
    |
    = help: Replace with `vars[idx] = a_dict.get(key, "defaultß9💣2ℝ6789ß9💣2ℝ6789ß9💣2ℝ6789ß9💣2ℝ6789ß9💣2ℝ6789")`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 33 33 |     var = "default"
 34 34 | 
 35 35 | # SIM401 (complex expression in var)
@@ -146,7 +146,7 @@ SIM401.py:45:5: SIM401 [*] Use `vars[idx] = a_dict.get(key, "default")` instead 
    |
    = help: Replace with `vars[idx] = a_dict.get(key, "default")`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 42 42 | if foo():
 43 43 |     pass
 44 44 | else:

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
@@ -103,7 +103,7 @@ fn fix_banned_relative_import(
         range: TextRange::default(),
     };
     let content = generator.stmt(&node.into());
-    Some(Fix::suggested(Edit::range_replacement(
+    Some(Fix::automatic_unsafe(Edit::range_replacement(
         content,
         stmt.range(),
     )))

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/snapshots/ruff_linter__rules__flake8_tidy_imports__tests__ban_parent_imports_package.snap
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/snapshots/ruff_linter__rules__flake8_tidy_imports__tests__ban_parent_imports_package.snap
@@ -22,7 +22,7 @@ application.py:6:1: TID252 [*] Relative imports from parent modules are banned
   |
   = help: Replace relative imports from parent modules with absolute imports
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | import attrs
 4 4 | 
 5 5 | from ....import unknown
@@ -42,7 +42,7 @@ application.py:6:1: TID252 [*] Relative imports from parent modules are banned
   |
   = help: Replace relative imports from parent modules with absolute imports
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | import attrs
 4 4 | 
 5 5 | from ....import unknown
@@ -62,7 +62,7 @@ application.py:6:1: TID252 [*] Relative imports from parent modules are banned
   |
   = help: Replace relative imports from parent modules with absolute imports
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | import attrs
 4 4 | 
 5 5 | from ....import unknown
@@ -83,7 +83,7 @@ application.py:7:1: TID252 [*] Relative imports from parent modules are banned
   |
   = help: Replace relative imports from parent modules with absolute imports
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | 
 5 5 | from ....import unknown
 6 6 | from ..protocol import commands, definitions, responses
@@ -104,7 +104,7 @@ application.py:8:1: TID252 [*] Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | from ....import unknown
 6 6 | from ..protocol import commands, definitions, responses
 7 7 | from ..server import example
@@ -122,7 +122,7 @@ application.py:10:1: TID252 [*] Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | from ..server import example
 8  8  | from .. import server
 9  9  | from . import logger, models

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -319,7 +319,7 @@ fn directive_errors(
         );
 
         if settings.rules.should_fix(Rule::InvalidTodoCapitalization) {
-            diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                 "TODO".to_string(),
                 directive.range,
             )));

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -61,7 +61,7 @@ pub(crate) fn empty_type_checking_block(checker: &mut Checker, stmt: &ast::StmtI
         let stmt = checker.semantic().current_statement();
         let parent = checker.semantic().current_statement_parent();
         let edit = fix::edits::delete_stmt(stmt, parent, checker.locator(), checker.indexer());
-        diagnostic.set_fix(Fix::automatic(edit).isolate(Checker::isolation(
+        diagnostic.set_fix(Fix::automatic_safe(edit).isolate(Checker::isolation(
             checker.semantic().current_statement_parent_id(),
         )));
     }

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -235,7 +235,7 @@ fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) ->
     )?;
 
     Ok(
-        Fix::suggested_edits(remove_import_edit, add_import_edit.into_edits()).isolate(
+        Fix::automatic_unsafe_edits(remove_import_edit, add_import_edit.into_edits()).isolate(
             Checker::isolation(checker.semantic().parent_statement_id(node_id)),
         ),
     )

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -486,7 +486,7 @@ fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) ->
     )?;
 
     Ok(
-        Fix::suggested_edits(remove_import_edit, add_import_edit.into_edits()).isolate(
+        Fix::automatic_unsafe_edits(remove_import_edit, add_import_edit.into_edits()).isolate(
             Checker::isolation(checker.semantic().parent_statement_id(node_id)),
         ),
     )

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__exempt_modules.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__exempt_modules.snap
@@ -11,7 +11,7 @@ exempt_modules.py:14:12: TCH002 [*] Move third-party import `flask` into a type-
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+from typing import TYPE_CHECKING
    2  |+
    3  |+if TYPE_CHECKING:

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__import_from.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__import_from.snap
@@ -11,7 +11,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2  2  | from __future__ import annotations
 3  3  | 
 4  4  | from pandas import (

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__import_from_type_checking_block.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__import_from_type_checking_block.snap
@@ -11,7 +11,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4  4  | from typing import TYPE_CHECKING
 5  5  | 
 6  6  | from pandas import (

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__multiple_members.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__multiple_members.snap
@@ -11,7 +11,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3  3  | 
 4  4  | from typing import TYPE_CHECKING
 5  5  | 
@@ -39,7 +39,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3  3  | 
 4  4  | from typing import TYPE_CHECKING
 5  5  | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__multiple_modules_different_types.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__multiple_modules_different_types.snap
@@ -12,7 +12,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3  3  | 
 4  4  | from typing import TYPE_CHECKING
 5  5  | 
@@ -36,7 +36,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3  3  | 
 4  4  | from typing import TYPE_CHECKING
 5  5  | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__multiple_modules_same_type.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__multiple_modules_same_type.snap
@@ -12,7 +12,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3  3  | 
 4  4  | from typing import TYPE_CHECKING
 5  5  | 
@@ -35,7 +35,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3  3  | 
 4  4  | from typing import TYPE_CHECKING
 5  5  | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__no_typing_import.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__no_typing_import.snap
@@ -12,7 +12,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | 
 2 2 | from __future__ import annotations
 3 3 | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_1.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_1.py.snap
@@ -10,7 +10,7 @@ TCH004_1.py:4:26: TCH004 [*] Move import `datetime.datetime` out of type-checkin
   |
   = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from typing import TYPE_CHECKING
   2 |+from datetime import datetime
 2 3 | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_11.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_11.py.snap
@@ -11,7 +11,7 @@ TCH004_11.py:4:24: TCH004 [*] Move import `typing.List` out of type-checking blo
   |
   = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from typing import TYPE_CHECKING
   2 |+from typing import List
 2 3 | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_12.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_12.py.snap
@@ -11,7 +11,7 @@ TCH004_12.py:6:33: TCH004 [*] Move import `collections.abc.Callable` out of type
   |
   = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from __future__ import annotations
 2 2 | 
 3 3 | from typing import Any, TYPE_CHECKING, TypeAlias

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_2.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_2.py.snap
@@ -9,7 +9,7 @@ TCH004_2.py:4:26: TCH004 [*] Move import `datetime.date` out of type-checking bl
   |
   = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from typing import TYPE_CHECKING
   2 |+from datetime import date
 2 3 | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_4.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_4.py.snap
@@ -9,7 +9,7 @@ TCH004_4.py:4:24: TCH004 [*] Move import `typing.Any` out of type-checking block
   |
   = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from typing import TYPE_CHECKING, Type
   2 |+from typing import Any
 2 3 | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_5.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_5.py.snap
@@ -9,7 +9,7 @@ TCH004_5.py:4:24: TCH004 [*] Move import `typing.List` out of type-checking bloc
   |
   = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from typing import TYPE_CHECKING
   2 |+from typing import List, Sequence, Set
 2 3 | 
@@ -28,7 +28,7 @@ TCH004_5.py:4:30: TCH004 [*] Move import `typing.Sequence` out of type-checking 
   |
   = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from typing import TYPE_CHECKING
   2 |+from typing import List, Sequence, Set
 2 3 | 
@@ -47,7 +47,7 @@ TCH004_5.py:4:40: TCH004 [*] Move import `typing.Set` out of type-checking block
   |
   = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from typing import TYPE_CHECKING
   2 |+from typing import List, Sequence, Set
 2 3 | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_9.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_9.py.snap
@@ -11,7 +11,7 @@ TCH004_9.py:4:24: TCH004 [*] Move import `typing.Tuple` out of type-checking blo
   |
   = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from typing import TYPE_CHECKING
   2 |+from typing import Tuple, List
 2 3 | 
@@ -32,7 +32,7 @@ TCH004_9.py:4:31: TCH004 [*] Move import `typing.List` out of type-checking bloc
   |
   = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from typing import TYPE_CHECKING
   2 |+from typing import Tuple, List
 2 3 | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_runtime_evaluated_base_classes_1.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_runtime_evaluated_base_classes_1.py.snap
@@ -10,7 +10,7 @@ runtime_evaluated_base_classes_1.py:10:12: TCH004 [*] Move import `datetime` out
    |
    = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5  5  | 
 6  6  | import pydantic
 7  7  | from pydantic import BaseModel
@@ -33,7 +33,7 @@ runtime_evaluated_base_classes_1.py:11:23: TCH004 [*] Move import `array.array` 
    |
    = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5  5  | 
 6  6  | import pydantic
 7  7  | from pydantic import BaseModel
@@ -56,7 +56,7 @@ runtime_evaluated_base_classes_1.py:13:12: TCH004 [*] Move import `pandas` out o
    |
    = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5  5  | 
 6  6  | import pydantic
 7  7  | from pydantic import BaseModel

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_runtime_evaluated_decorators_1.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_runtime_evaluated_decorators_1.py.snap
@@ -10,7 +10,7 @@ runtime_evaluated_decorators_1.py:12:12: TCH004 [*] Move import `datetime` out o
    |
    = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | from attrs import frozen
 8  8  | 
 9  9  | import numpy
@@ -33,7 +33,7 @@ runtime_evaluated_decorators_1.py:13:23: TCH004 [*] Move import `array.array` ou
    |
    = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | from attrs import frozen
 8  8  | 
 9  9  | import numpy
@@ -56,7 +56,7 @@ runtime_evaluated_decorators_1.py:15:12: TCH004 [*] Move import `pandas` out of 
    |
    = help: Move out of type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | from attrs import frozen
 8  8  | 
 9  9  | import numpy

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__strict.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__strict.snap
@@ -12,7 +12,7 @@ strict.py:27:21: TCH002 [*] Move third-party import `pkg.A` into a type-checking
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | from __future__ import annotations
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -41,7 +41,7 @@ strict.py:35:21: TCH002 [*] Move third-party import `pkg.A` into a type-checking
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | from __future__ import annotations
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -71,7 +71,7 @@ strict.py:54:25: TCH002 [*] Move third-party import `pkg.bar.A` into a type-chec
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | from __future__ import annotations
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -99,7 +99,7 @@ strict.py:62:12: TCH002 [*] Move third-party import `pkg` into a type-checking b
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | from __future__ import annotations
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -127,7 +127,7 @@ strict.py:71:23: TCH002 [*] Move third-party import `pkg.foo` into a type-checki
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | from __future__ import annotations
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -155,7 +155,7 @@ strict.py:80:12: TCH002 [*] Move third-party import `pkg` into a type-checking b
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | from __future__ import annotations
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -183,7 +183,7 @@ strict.py:91:12: TCH002 [*] Move third-party import `pkg` into a type-checking b
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | from __future__ import annotations
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -212,7 +212,7 @@ strict.py:101:23: TCH002 [*] Move third-party import `pkg.foo` into a type-check
     |
     = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   1   | from __future__ import annotations
     2   |+from typing import TYPE_CHECKING
     3   |+

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__type_checking_block_after_usage.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__type_checking_block_after_usage.snap
@@ -12,7 +12,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3  3  | 
 4  4  | from typing import TYPE_CHECKING
 5  5  | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__type_checking_block_comment.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__type_checking_block_comment.snap
@@ -12,7 +12,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3  3  | 
 4  4  | from typing import TYPE_CHECKING
 5  5  | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__type_checking_block_inline.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__type_checking_block_inline.snap
@@ -12,7 +12,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | 
 4 4 | from typing import TYPE_CHECKING
 5 5 | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__type_checking_block_own_line.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__type_checking_block_own_line.snap
@@ -12,7 +12,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | 
 4 4 | from typing import TYPE_CHECKING
 5 5 | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-first-party-import_TCH001.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-first-party-import_TCH001.py.snap
@@ -11,7 +11,7 @@ TCH001.py:20:19: TCH001 [*] Move application import `.TYP001` into a type-checki
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2  2  | 
 3  3  | For typing-only import detection tests, see `TCH002.py`.
 4  4  | """

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-standard-library-import_TCH003.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-standard-library-import_TCH003.py.snap
@@ -11,7 +11,7 @@ TCH003.py:8:12: TCH003 [*] Move standard library import `os` into a type-checkin
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2  2  | 
 3  3  | For typing-only import detection tests, see `TCH002.py`.
 4  4  | """

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-standard-library-import_runtime_evaluated_base_classes_3.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-standard-library-import_runtime_evaluated_base_classes_3.py.snap
@@ -12,7 +12,7 @@ runtime_evaluated_base_classes_3.py:5:18: TCH003 [*] Move standard library impor
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2  2  | 
 3  3  | import datetime
 4  4  | import pathlib

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-standard-library-import_runtime_evaluated_decorators_3.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-standard-library-import_runtime_evaluated_decorators_3.py.snap
@@ -12,7 +12,7 @@ runtime_evaluated_decorators_3.py:6:18: TCH003 [*] Move standard library import 
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3  3  | import datetime
 4  4  | from array import array
 5  5  | from dataclasses import dataclass

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_TCH002.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_TCH002.py.snap
@@ -11,7 +11,7 @@ TCH002.py:5:22: TCH002 [*] Move third-party import `pandas` into a type-checking
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | """Tests to determine accurate detection of typing-only imports."""
   2 |+from typing import TYPE_CHECKING
   3 |+
@@ -35,7 +35,7 @@ TCH002.py:11:24: TCH002 [*] Move third-party import `pandas.DataFrame` into a ty
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | """Tests to determine accurate detection of typing-only imports."""
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -63,7 +63,7 @@ TCH002.py:17:37: TCH002 [*] Move third-party import `pandas.DataFrame` into a ty
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | """Tests to determine accurate detection of typing-only imports."""
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -91,7 +91,7 @@ TCH002.py:23:22: TCH002 [*] Move third-party import `pandas` into a type-checkin
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | """Tests to determine accurate detection of typing-only imports."""
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -119,7 +119,7 @@ TCH002.py:29:24: TCH002 [*] Move third-party import `pandas.DataFrame` into a ty
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | """Tests to determine accurate detection of typing-only imports."""
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -147,7 +147,7 @@ TCH002.py:35:37: TCH002 [*] Move third-party import `pandas.DataFrame` into a ty
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | """Tests to determine accurate detection of typing-only imports."""
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -175,7 +175,7 @@ TCH002.py:41:22: TCH002 [*] Move third-party import `pandas` into a type-checkin
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | """Tests to determine accurate detection of typing-only imports."""
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -203,7 +203,7 @@ TCH002.py:47:22: TCH002 [*] Move third-party import `pandas` into a type-checkin
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | """Tests to determine accurate detection of typing-only imports."""
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -232,7 +232,7 @@ TCH002.py:172:24: TCH002 [*] Move third-party import `module.Member` into a type
     |
     = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   1   | """Tests to determine accurate detection of typing-only imports."""
     2   |+from typing import TYPE_CHECKING
     3   |+

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_runtime_evaluated_base_classes_2.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_runtime_evaluated_base_classes_2.py.snap
@@ -12,7 +12,7 @@ runtime_evaluated_base_classes_2.py:3:21: TCH002 [*] Move third-party import `ge
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | from __future__ import annotations
 2  2  | 
 3     |-import geopandas as gpd  # TCH002
@@ -39,7 +39,7 @@ runtime_evaluated_base_classes_2.py:5:8: TCH002 [*] Move third-party import `pyp
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2  2  | 
 3  3  | import geopandas as gpd  # TCH002
 4  4  | import pydantic

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_runtime_evaluated_decorators_2.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_runtime_evaluated_decorators_2.py.snap
@@ -10,7 +10,7 @@ runtime_evaluated_decorators_2.py:10:8: TCH002 [*] Move third-party import `nump
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | import pyproj
 8  8  | from attrs import frozen
 9  9  | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_strict.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_strict.py.snap
@@ -12,7 +12,7 @@ strict.py:54:25: TCH002 [*] Move third-party import `pkg.bar.A` into a type-chec
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | from __future__ import annotations
    2  |+from typing import TYPE_CHECKING
    3  |+
@@ -40,7 +40,7 @@ strict.py:91:12: TCH002 [*] Move third-party import `pkg` into a type-checking b
    |
    = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | from __future__ import annotations
    2  |+from typing import TYPE_CHECKING
    3  |+

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing_import_after_package_import.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing_import_after_package_import.snap
@@ -12,7 +12,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | 
 2  2  | from __future__ import annotations
 3  3  | 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing_import_before_package_import.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing_import_before_package_import.snap
@@ -12,7 +12,7 @@ source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
   |
   = help: Move into type-checking block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3  3  | 
 4  4  | from typing import TYPE_CHECKING
 5  5  | 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
@@ -77,7 +77,7 @@ pub(crate) fn path_constructor_current_directory(checker: &mut Checker, expr: &E
     if matches!(value.as_str(), "" | ".") {
         let mut diagnostic = Diagnostic::new(PathConstructorCurrentDirectory, *range);
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::automatic(Edit::range_deletion(*range)));
+            diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(*range)));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -155,7 +155,7 @@ pub(crate) fn static_join_to_fstring(checker: &mut Checker, expr: &Expr, joiner:
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             pad(contents, expr.range(), checker.locator()),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/flynt/snapshots/ruff_linter__rules__flynt__tests__FLY002_FLY002.py.snap
+++ b/crates/ruff_linter/src/rules/flynt/snapshots/ruff_linter__rules__flynt__tests__FLY002_FLY002.py.snap
@@ -11,7 +11,7 @@ FLY002.py:5:7: FLY002 [*] Consider `f"{a}  World"` instead of string join
   |
   = help: Replace with `f"{a}  World"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | from random import random, choice
 3 3 | 
 4 4 | a = "Hello"
@@ -32,7 +32,7 @@ FLY002.py:6:7: FLY002 [*] Consider `f"Finally, {a} World"` instead of string joi
   |
   = help: Replace with `f"Finally, {a} World"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | 
 4 4 | a = "Hello"
 5 5 | ok1 = " ".join([a, " World"])  # OK
@@ -53,7 +53,7 @@ FLY002.py:7:7: FLY002 [*] Consider `"1x2x3"` instead of string join
   |
   = help: Replace with `"1x2x3"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | a = "Hello"
 5 5 | ok1 = " ".join([a, " World"])  # OK
 6 6 | ok2 = "".join(["Finally, ", a, " World"])  # OK
@@ -74,7 +74,7 @@ FLY002.py:8:7: FLY002 [*] Consider `f"{1}y{2}y{3}"` instead of string join
    |
    = help: Replace with `f"{1}y{2}y{3}"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | ok1 = " ".join([a, " World"])  # OK
 6 6 | ok2 = "".join(["Finally, ", a, " World"])  # OK
 7 7 | ok3 = "x".join(("1", "2", "3"))  # OK
@@ -94,7 +94,7 @@ FLY002.py:9:7: FLY002 [*] Consider `f"{random()}a{random()}"` instead of string 
    |
    = help: Replace with `f"{random()}a{random()}"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | ok2 = "".join(["Finally, ", a, " World"])  # OK
 7  7  | ok3 = "x".join(("1", "2", "3"))  # OK
 8  8  | ok4 = "y".join([1, 2, 3])  # Technically OK, though would've been an error originally
@@ -115,7 +115,7 @@ FLY002.py:10:7: FLY002 [*] Consider `f"{secrets.token_urlsafe()}a{secrets.token_
    |
    = help: Replace with `f"{secrets.token_urlsafe()}a{secrets.token_hex()}"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | ok3 = "x".join(("1", "2", "3"))  # OK
 8  8  | ok4 = "y".join([1, 2, 3])  # Technically OK, though would've been an error originally
 9  9  | ok5 = "a".join([random(), random()])  # OK (simple calls)
@@ -134,7 +134,7 @@ FLY002.py:23:11: FLY002 [*] Consider `f"{url}{filename}"` instead of string join
    |
    = help: Replace with `f"{url}{filename}"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 | 
 21 21 | # Regression test for: https://github.com/astral-sh/ruff/issues/7197
 22 22 | def create_file_public_url(url, filename):

--- a/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
@@ -117,7 +117,7 @@ fn add_required_import(
         TextRange::default(),
     );
     if settings.rules.should_fix(Rule::MissingRequiredImport) {
-        diagnostic.set_fix(Fix::automatic(
+        diagnostic.set_fix(Fix::automatic_safe(
             Importer::new(python_ast, locator, stylist)
                 .add_import(required_import, TextSize::default()),
         ));

--- a/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
@@ -139,7 +139,7 @@ pub(crate) fn organize_imports(
 
     let mut diagnostic = Diagnostic::new(UnsortedImports, range);
     if settings.rules.should_fix(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
             indent(&expected, indentation).to_string(),
             range,
         )));

--- a/crates/ruff_linter/src/rules/numpy/rules/deprecated_function.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/deprecated_function.rs
@@ -84,7 +84,7 @@ pub(crate) fn deprecated_function(checker: &mut Checker, expr: &Expr) {
                     checker.semantic(),
                 )?;
                 let replacement_edit = Edit::range_replacement(binding, expr.range());
-                Ok(Fix::suggested_edits(import_edit, [replacement_edit]))
+                Ok(Fix::automatic_unsafe_edits(import_edit, [replacement_edit]))
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/numpy/rules/deprecated_type_alias.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/deprecated_type_alias.rs
@@ -80,7 +80,7 @@ pub(crate) fn deprecated_type_alias(checker: &mut Checker, expr: &Expr) {
                 _ => type_name,
             };
             if checker.semantic().is_builtin(type_name) {
-                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                     type_name.to_string(),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy-deprecated-function_NPY003.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy-deprecated-function_NPY003.py.snap
@@ -12,7 +12,7 @@ NPY003.py:4:5: NPY003 [*] `np.round_` is deprecated; use `np.round` instead
   |
   = help: Replace with `np.round`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | def func():
 2 2 |     import numpy as np
 3 3 | 
@@ -32,7 +32,7 @@ NPY003.py:5:5: NPY003 [*] `np.product` is deprecated; use `np.prod` instead
   |
   = help: Replace with `np.prod`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 |     import numpy as np
 3 3 | 
 4 4 |     np.round_(np.random.rand(5, 5), 2)
@@ -53,7 +53,7 @@ NPY003.py:6:5: NPY003 [*] `np.cumproduct` is deprecated; use `np.cumprod` instea
   |
   = help: Replace with `np.cumprod`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | 
 4 4 |     np.round_(np.random.rand(5, 5), 2)
 5 5 |     np.product(np.random.rand(5, 5))
@@ -73,7 +73,7 @@ NPY003.py:7:5: NPY003 [*] `np.sometrue` is deprecated; use `np.any` instead
   |
   = help: Replace with `np.any`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 |     np.round_(np.random.rand(5, 5), 2)
 5 5 |     np.product(np.random.rand(5, 5))
 6 6 |     np.cumproduct(np.random.rand(5, 5))
@@ -92,7 +92,7 @@ NPY003.py:8:5: NPY003 [*] `np.alltrue` is deprecated; use `np.all` instead
   |
   = help: Replace with `np.all`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 |     np.product(np.random.rand(5, 5))
 6 6 |     np.cumproduct(np.random.rand(5, 5))
 7 7 |     np.sometrue(np.random.rand(5, 5))
@@ -113,7 +113,7 @@ NPY003.py:14:5: NPY003 [*] `np.round_` is deprecated; use `np.round` instead
    |
    = help: Replace with `np.round`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+from numpy import round
 1  2  | def func():
 2  3  |     import numpy as np
@@ -138,7 +138,7 @@ NPY003.py:15:5: NPY003 [*] `np.product` is deprecated; use `np.prod` instead
    |
    = help: Replace with `np.prod`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+from numpy import prod
 1  2  | def func():
 2  3  |     import numpy as np
@@ -164,7 +164,7 @@ NPY003.py:16:5: NPY003 [*] `np.cumproduct` is deprecated; use `np.cumprod` inste
    |
    = help: Replace with `np.cumprod`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+from numpy import cumprod
 1  2  | def func():
 2  3  |     import numpy as np
@@ -188,7 +188,7 @@ NPY003.py:17:5: NPY003 [*] `np.sometrue` is deprecated; use `np.any` instead
    |
    = help: Replace with `np.any`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+from numpy import any
 1  2  | def func():
 2  3  |     import numpy as np
@@ -210,7 +210,7 @@ NPY003.py:18:5: NPY003 [*] `np.alltrue` is deprecated; use `np.all` instead
    |
    = help: Replace with `np.all`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+from numpy import all
 1  2  | def func():
 2  3  |     import numpy as np

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy-deprecated-type-alias_NPY001.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy-deprecated-type-alias_NPY001.py.snap
@@ -10,7 +10,7 @@ NPY001.py:6:1: NPY001 [*] Type alias `np.bool` is deprecated, replace with built
   |
   = help: Replace `np.bool` with builtin type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | import numpy
 4 4 | 
 5 5 | # Error
@@ -31,7 +31,7 @@ NPY001.py:7:1: NPY001 [*] Type alias `np.int` is deprecated, replace with builti
   |
   = help: Replace `np.int` with builtin type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | 
 5 5 | # Error
 6 6 | npy.bool
@@ -51,7 +51,7 @@ NPY001.py:9:13: NPY001 [*] Type alias `np.object` is deprecated, replace with bu
    |
    = help: Replace `np.object` with builtin type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | npy.bool
 7  7  | npy.int
 8  8  | 
@@ -72,7 +72,7 @@ NPY001.py:12:72: NPY001 [*] Type alias `np.int` is deprecated, replace with buil
    |
    = help: Replace `np.int` with builtin type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | if dtype == np.object:
 10 10 |     ...
 11 11 | 
@@ -93,7 +93,7 @@ NPY001.py:12:80: NPY001 [*] Type alias `np.long` is deprecated, replace with bui
    |
    = help: Replace `np.long` with builtin type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | if dtype == np.object:
 10 10 |     ...
 11 11 | 
@@ -113,7 +113,7 @@ NPY001.py:17:11: NPY001 [*] Type alias `np.object` is deprecated, replace with b
    |
    = help: Replace `np.object` with builtin type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | pdf = pd.DataFrame(
 15 15 |     data=[[1, 2, 3]],
 16 16 |     columns=["a", "b", "c"],
@@ -134,7 +134,7 @@ NPY001.py:20:16: NPY001 [*] Type alias `np.int` is deprecated, replace with buil
    |
    = help: Replace `np.int` with builtin type
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 |     dtype=numpy.object,
 18 18 | )
 19 19 | 

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -135,5 +135,8 @@ fn convert_inplace_argument_to_assignment(
     )
     .ok()?;
 
-    Some(Fix::suggested_edits(insert_assignment, [remove_argument]))
+    Some(Fix::automatic_unsafe_edits(
+        insert_assignment,
+        [remove_argument],
+    ))
 }

--- a/crates/ruff_linter/src/rules/pandas_vet/snapshots/ruff_linter__rules__pandas_vet__tests__PD002_PD002.py.snap
+++ b/crates/ruff_linter/src/rules/pandas_vet/snapshots/ruff_linter__rules__pandas_vet__tests__PD002_PD002.py.snap
@@ -12,7 +12,7 @@ PD002.py:5:23: PD002 [*] `inplace=True` should be avoided; it has inconsistent b
   |
   = help: Assign to variable; remove `inplace` arg
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | 
 3 3 | x = pd.DataFrame()
 4 4 | 
@@ -33,7 +33,7 @@ PD002.py:7:25: PD002 [*] `inplace=True` should be avoided; it has inconsistent b
   |
   = help: Assign to variable; remove `inplace` arg
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | 
 5 5 | x.drop(["a"], axis=1, inplace=True)
 6 6 | 
@@ -54,7 +54,7 @@ PD002.py:9:28: PD002 [*] `inplace=True` should be avoided; it has inconsistent b
    |
    = help: Assign to variable; remove `inplace` arg
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | 
 7  7  | x.y.drop(["a"], axis=1, inplace=True)
 8  8  | 
@@ -74,7 +74,7 @@ PD002.py:12:5: PD002 [*] `inplace=True` should be avoided; it has inconsistent b
    |
    = help: Assign to variable; remove `inplace` arg
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | 
 9  9  | x["y"].drop(["a"], axis=1, inplace=True)
 10 10 | 
@@ -96,7 +96,7 @@ PD002.py:19:9: PD002 [*] `inplace=True` should be avoided; it has inconsistent b
    |
    = help: Assign to variable; remove `inplace` arg
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | )
 16 16 | 
 17 17 | if True:
@@ -118,7 +118,7 @@ PD002.py:24:33: PD002 [*] `inplace=True` should be avoided; it has inconsistent 
    |
    = help: Assign to variable; remove `inplace` arg
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 |         axis=1,
 22 22 |     )
 23 23 | 
@@ -167,7 +167,7 @@ PD002.py:33:24: PD002 [*] `inplace=True` should be avoided; it has inconsistent 
    |
    = help: Assign to variable; remove `inplace` arg
 
-ℹ Suggested fix
+ℹ Unsafe fix
 30 30 | 
 31 31 | torch.m.ReLU(inplace=True)  # safe because this isn't a pandas call
 32 32 | 

--- a/crates/ruff_linter/src/rules/pandas_vet/snapshots/ruff_linter__rules__pandas_vet__tests__PD002_fail.snap
+++ b/crates/ruff_linter/src/rules/pandas_vet/snapshots/ruff_linter__rules__pandas_vet__tests__PD002_fail.snap
@@ -10,7 +10,7 @@ source: crates/ruff_linter/src/rules/pandas_vet/mod.rs
   |
   = help: Assign to variable; remove `inplace` arg
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | 
 2 2 | import pandas as pd
 3 3 | x = pd.DataFrame()

--- a/crates/ruff_linter/src/rules/perflint/rules/incorrect_dict_iterator.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/incorrect_dict_iterator.rs
@@ -110,7 +110,10 @@ pub(crate) fn incorrect_dict_iterator(checker: &mut Checker, stmt_for: &ast::Stm
                     ),
                     stmt_for.target.range(),
                 );
-                diagnostic.set_fix(Fix::suggested_edits(replace_attribute, [replace_target]));
+                diagnostic.set_fix(Fix::automatic_unsafe_edits(
+                    replace_attribute,
+                    [replace_target],
+                ));
             }
             checker.diagnostics.push(diagnostic);
         }
@@ -132,7 +135,10 @@ pub(crate) fn incorrect_dict_iterator(checker: &mut Checker, stmt_for: &ast::Stm
                     ),
                     stmt_for.target.range(),
                 );
-                diagnostic.set_fix(Fix::suggested_edits(replace_attribute, [replace_target]));
+                diagnostic.set_fix(Fix::automatic_unsafe_edits(
+                    replace_attribute,
+                    [replace_target],
+                ));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
@@ -135,7 +135,7 @@ pub(crate) fn unnecessary_list_cast(checker: &mut Checker, iter: &Expr) {
 
 /// Generate a [`Fix`] to remove a `list` cast from an expression.
 fn remove_cast(list_range: TextRange, iterable_range: TextRange) -> Fix {
-    Fix::automatic_edits(
+    Fix::automatic_safe_edits(
         Edit::deletion(list_range.start(), iterable_range.start()),
         [Edit::deletion(iterable_range.end(), list_range.end())],
     )

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF102_PERF102.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF102_PERF102.py.snap
@@ -10,7 +10,7 @@ PERF102.py:5:21: PERF102 [*] When using only the values of a dict use the `value
   |
   = help: Replace `.items()` with `.values()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | 
 3 3 | 
 4 4 | def f():
@@ -29,7 +29,7 @@ PERF102.py:10:19: PERF102 [*] When using only the keys of a dict use the `keys()
    |
    = help: Replace `.items()` with `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | 
 8  8  | 
 9  9  | def f():
@@ -48,7 +48,7 @@ PERF102.py:15:30: PERF102 [*] When using only the keys of a dict use the `keys()
    |
    = help: Replace `.items()` with `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | 
 13 13 | 
 14 14 | def f():
@@ -67,7 +67,7 @@ PERF102.py:20:25: PERF102 [*] When using only the keys of a dict use the `keys()
    |
    = help: Replace `.items()` with `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | 
 18 18 | 
 19 19 | def f():
@@ -86,7 +86,7 @@ PERF102.py:30:30: PERF102 [*] When using only the keys of a dict use the `keys()
    |
    = help: Replace `.items()` with `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 | 
 28 28 | 
 29 29 | def f():
@@ -105,7 +105,7 @@ PERF102.py:35:36: PERF102 [*] When using only the values of a dict use the `valu
    |
    = help: Replace `.items()` with `.values()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 32 32 | 
 33 33 | 
 34 34 | def f():
@@ -124,7 +124,7 @@ PERF102.py:50:32: PERF102 [*] When using only the keys of a dict use the `keys()
    |
    = help: Replace `.items()` with `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 47 47 | 
 48 48 | 
 49 49 | def f():
@@ -143,7 +143,7 @@ PERF102.py:85:25: PERF102 [*] When using only the keys of a dict use the `keys()
    |
    = help: Replace `.items()` with `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 82 82 | 
 83 83 | 
 84 84 | def f():
@@ -162,7 +162,7 @@ PERF102.py:90:25: PERF102 [*] When using only the keys of a dict use the `keys()
    |
    = help: Replace `.items()` with `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 87 87 | 
 88 88 | 
 89 89 | def f():
@@ -181,7 +181,7 @@ PERF102.py:95:31: PERF102 [*] When using only the keys of a dict use the `keys()
    |
    = help: Replace `.items()` with `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 92 92 | 
 93 93 | 
 94 94 | def f():
@@ -200,7 +200,7 @@ PERF102.py:100:31: PERF102 [*] When using only the values of a dict use the `val
     |
     = help: Replace `.items()` with `.values()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 97  97  | 
 98  98  | 
 99  99  | def f():
@@ -220,7 +220,7 @@ PERF102.py:106:16: PERF102 [*] When using only the keys of a dict use the `keys(
     |
     = help: Replace `.items()` with `.keys()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 103 103 | 
 104 104 | # Regression test for: https://github.com/astral-sh/ruff/issues/7097
 105 105 | def _create_context(name_to_value):

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/compound_statements.rs
@@ -170,7 +170,7 @@ pub(crate) fn compound_statements(
                     let mut diagnostic =
                         Diagnostic::new(UselessSemicolon, TextRange::new(start, end));
                     if settings.rules.should_fix(Rule::UselessSemicolon) {
-                        diagnostic.set_fix(Fix::automatic(Edit::deletion(
+                        diagnostic.set_fix(Fix::automatic_safe(Edit::deletion(
                             indexer
                                 .preceded_by_continuations(start, locator)
                                 .unwrap_or(start),

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -162,7 +162,7 @@ pub(crate) fn invalid_escape_sequence(
         if contains_valid_escape_sequence {
             // Escape with backslash.
             for diagnostic in &mut invalid_escape_sequence {
-                diagnostic.set_fix(Fix::automatic(Edit::insertion(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::insertion(
                     r"\".to_string(),
                     diagnostic.start() + TextSize::from(1),
                 )));
@@ -184,7 +184,7 @@ pub(crate) fn invalid_escape_sequence(
                 // If necessary, add a space between any leading keyword (`return`, `yield`,
                 // `assert`, etc.) and the string. For example, `return"foo"` is valid, but
                 // `returnr"foo"` is not.
-                diagnostic.set_fix(Fix::automatic(Edit::insertion(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::insertion(
                     pad_start("r".to_string(), tok_start, locator),
                     tok_start,
                 )));

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -127,7 +127,7 @@ pub(crate) fn lambda_assignment(
             {
                 diagnostic.set_fix(Fix::manual(Edit::range_replacement(indented, stmt.range())));
             } else {
-                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                     indented,
                     stmt.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -287,7 +287,7 @@ pub(crate) fn literal_comparisons(checker: &mut Checker, compare: &ast::ExprComp
             checker.locator(),
         );
         for diagnostic in &mut diagnostics {
-            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                 content.to_string(),
                 compare.range(),
             )));

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/extraneous_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/extraneous_whitespace.rs
@@ -162,8 +162,9 @@ pub(crate) fn extraneous_whitespace(
                             TextRange::at(token.end(), trailing_len),
                         );
                         if fix_after_open_bracket {
-                            diagnostic
-                                .set_fix(Fix::automatic(Edit::range_deletion(diagnostic.range())));
+                            diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(
+                                diagnostic.range(),
+                            )));
                         }
                         context.push_diagnostic(diagnostic);
                     }
@@ -178,7 +179,7 @@ pub(crate) fn extraneous_whitespace(
                                 TextRange::at(token.start() - offset, offset),
                             );
                             if fix_before_close_bracket {
-                                diagnostic.set_fix(Fix::automatic(Edit::range_deletion(
+                                diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(
                                     diagnostic.range(),
                                 )));
                             }
@@ -196,7 +197,7 @@ pub(crate) fn extraneous_whitespace(
                                 TextRange::at(token.start() - offset, offset),
                             );
                             if fix_before_punctuation {
-                                diagnostic.set_fix(Fix::automatic(Edit::range_deletion(
+                                diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(
                                     diagnostic.range(),
                                 )));
                             }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
@@ -116,7 +116,7 @@ pub(crate) fn missing_whitespace(line: &LogicalLine, fix: bool, context: &mut Lo
                     let mut diagnostic = Diagnostic::new(kind, token.range());
 
                     if fix {
-                        diagnostic.set_fix(Fix::automatic(Edit::insertion(
+                        diagnostic.set_fix(Fix::automatic_safe(Edit::insertion(
                             " ".to_string(),
                             token.end(),
                         )));

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
@@ -83,7 +83,7 @@ pub(crate) fn whitespace_before_parameters(
             let mut diagnostic = Diagnostic::new(kind, TextRange::new(start, end));
 
             if fix {
-                diagnostic.set_fix(Fix::automatic(Edit::deletion(start, end)));
+                diagnostic.set_fix(Fix::automatic_safe(Edit::deletion(start, end)));
             }
             context.push_diagnostic(diagnostic);
         }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/missing_newline_at_end_of_file.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/missing_newline_at_end_of_file.rs
@@ -56,7 +56,7 @@ pub(crate) fn no_newline_at_end_of_file(
 
         let mut diagnostic = Diagnostic::new(MissingNewlineAtEndOfFile, range);
         if fix {
-            diagnostic.set_fix(Fix::automatic(Edit::insertion(
+            diagnostic.set_fix(Fix::automatic_safe(Edit::insertion(
                 stylist.line_ending().to_string(),
                 range.start(),
             )));

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/not_tests.rs
@@ -95,7 +95,7 @@ pub(crate) fn not_tests(checker: &mut Checker, unary_op: &ast::ExprUnaryOp) {
             if checker.enabled(Rule::NotInTest) {
                 let mut diagnostic = Diagnostic::new(NotInTest, unary_op.operand.range());
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                         pad(
                             generate_comparison(
                                 left,
@@ -118,7 +118,7 @@ pub(crate) fn not_tests(checker: &mut Checker, unary_op: &ast::ExprUnaryOp) {
             if checker.enabled(Rule::NotIsTest) {
                 let mut diagnostic = Diagnostic::new(NotIsTest, unary_op.operand.range());
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                         pad(
                             generate_comparison(
                                 left,

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -93,7 +93,7 @@ pub(crate) fn trailing_whitespace(
                 if settings.rules.should_fix(Rule::BlankLineWithWhitespace) {
                     // Remove any preceding continuations, to avoid introducing a potential
                     // syntax error.
-                    diagnostic.set_fix(Fix::automatic(Edit::range_deletion(TextRange::new(
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(TextRange::new(
                         indexer
                             .preceded_by_continuations(line.start(), locator)
                             .unwrap_or(range.start()),
@@ -105,7 +105,7 @@ pub(crate) fn trailing_whitespace(
         } else if settings.rules.enabled(Rule::TrailingWhitespace) {
             let mut diagnostic = Diagnostic::new(TrailingWhitespace, range);
             if settings.rules.should_fix(Rule::TrailingWhitespace) {
-                diagnostic.set_fix(Fix::automatic(Edit::range_deletion(range)));
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(range)));
             }
             return Some(diagnostic);
         }

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E711_E711.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E711_E711.py.snap
@@ -11,7 +11,7 @@ E711.py:2:11: E711 [*] Comparison to `None` should be `cond is None`
   |
   = help: Replace with `cond is None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | #: E711
 2   |-if res == None:
   2 |+if res is None:
@@ -30,7 +30,7 @@ E711.py:5:11: E711 [*] Comparison to `None` should be `cond is not None`
   |
   = help: Replace with `cond is not None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | if res == None:
 3 3 |     pass
 4 4 | #: E711
@@ -51,7 +51,7 @@ E711.py:8:4: E711 [*] Comparison to `None` should be `cond is None`
    |
    = help: Replace with `cond is None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | if res != None:
 6 6 |     pass
 7 7 | #: E711
@@ -72,7 +72,7 @@ E711.py:11:4: E711 [*] Comparison to `None` should be `cond is not None`
    |
    = help: Replace with `cond is not None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | if None == res:
 9  9  |     pass
 10 10 | #: E711
@@ -93,7 +93,7 @@ E711.py:14:14: E711 [*] Comparison to `None` should be `cond is None`
    |
    = help: Replace with `cond is None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | if None != res:
 12 12 |     pass
 13 13 | #: E711
@@ -114,7 +114,7 @@ E711.py:17:14: E711 [*] Comparison to `None` should be `cond is not None`
    |
    = help: Replace with `cond is not None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | if res[1] == None:
 15 15 |     pass
 16 16 | #: E711
@@ -135,7 +135,7 @@ E711.py:20:4: E711 [*] Comparison to `None` should be `cond is not None`
    |
    = help: Replace with `cond is not None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | if res[1] != None:
 18 18 |     pass
 19 19 | #: E711
@@ -155,7 +155,7 @@ E711.py:23:4: E711 [*] Comparison to `None` should be `cond is None`
    |
    = help: Replace with `cond is None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 | if None != res[1]:
 21 21 |     pass
 22 22 | #: E711
@@ -175,7 +175,7 @@ E711.py:26:9: E711 [*] Comparison to `None` should be `cond is None`
    |
    = help: Replace with `cond is None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 | if None == res[1]:
 24 24 |     pass
 25 25 | 
@@ -195,7 +195,7 @@ E711.py:26:17: E711 [*] Comparison to `None` should be `cond is not None`
    |
    = help: Replace with `cond is not None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 | if None == res[1]:
 24 24 |     pass
 25 25 | 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E712_E712.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E712_E712.py.snap
@@ -11,7 +11,7 @@ E712.py:2:11: E712 [*] Comparison to `True` should be `cond is True` or `if cond
   |
   = help: Replace with `cond is True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | #: E712
 2   |-if res == True:
   2 |+if res is True:
@@ -30,7 +30,7 @@ E712.py:5:11: E712 [*] Comparison to `False` should be `cond is not False` or `i
   |
   = help: Replace with `cond is not False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | if res == True:
 3 3 |     pass
 4 4 | #: E712
@@ -51,7 +51,7 @@ E712.py:8:4: E712 [*] Comparison to `True` should be `cond is not True` or `if n
    |
    = help: Replace with `cond is not True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | if res != False:
 6 6 |     pass
 7 7 | #: E712
@@ -72,7 +72,7 @@ E712.py:11:4: E712 [*] Comparison to `False` should be `cond is False` or `if no
    |
    = help: Replace with `cond is False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | if True != res:
 9  9  |     pass
 10 10 | #: E712
@@ -93,7 +93,7 @@ E712.py:14:14: E712 [*] Comparison to `True` should be `cond is True` or `if con
    |
    = help: Replace with `cond is True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | if False == res:
 12 12 |     pass
 13 13 | #: E712
@@ -114,7 +114,7 @@ E712.py:17:14: E712 [*] Comparison to `False` should be `cond is not False` or `
    |
    = help: Replace with `cond is not False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | if res[1] == True:
 15 15 |     pass
 16 16 | #: E712
@@ -135,7 +135,7 @@ E712.py:20:20: E712 [*] Comparison to `True` should be `cond is True` or `if con
    |
    = help: Replace with `cond is True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | if res[1] != False:
 18 18 |     pass
 19 19 | #: E712
@@ -156,7 +156,7 @@ E712.py:20:44: E712 [*] Comparison to `False` should be `cond is False` or `if n
    |
    = help: Replace with `cond is False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | if res[1] != False:
 18 18 |     pass
 19 19 | #: E712
@@ -176,7 +176,7 @@ E712.py:22:5: E712 [*] Comparison to `True` should be `cond is True` or `if cond
    |
    = help: Replace with `cond is True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | #: E712
 20 20 | var = 1 if cond == True else -1 if cond == False else cond
 21 21 | #: E712
@@ -196,7 +196,7 @@ E712.py:25:11: E712 [*] Comparison to `True` should be `cond is True` or `if con
    |
    = help: Replace with `cond is True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | if (True) == TrueElement or x == TrueElement:
 23 23 |     pass
 24 24 | 
@@ -216,7 +216,7 @@ E712.py:25:19: E712 [*] Comparison to `False` should be `cond is not False` or `
    |
    = help: Replace with `cond is not False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | if (True) == TrueElement or x == TrueElement:
 23 23 |     pass
 24 24 | 
@@ -236,7 +236,7 @@ E712.py:28:4: E712 [*] Comparison to `True` should be `cond is True` or `if cond
    |
    = help: Replace with `cond is True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 25 25 | if res == True != False:
 26 26 |     pass
 27 27 | 
@@ -256,7 +256,7 @@ E712.py:31:17: E712 [*] Comparison to `True` should be `cond is True` or `if con
    |
    = help: Replace with `cond is True`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 28 28 | if(True) == TrueElement or x == TrueElement:
 29 29 |     pass
 30 30 | 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E731_E731.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E731_E731.py.snap
@@ -10,7 +10,7 @@ E731.py:3:5: E731 [*] Do not assign a `lambda` expression, use a `def`
   |
   = help: Rewrite `f` as a `def`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | def scope():
 2 2 |     # E731
 3   |-    f = lambda x: 2 * x
@@ -29,7 +29,7 @@ E731.py:8:5: E731 [*] Do not assign a `lambda` expression, use a `def`
   |
   = help: Rewrite `f` as a `def`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5  5  | 
 6  6  | def scope():
 7  7  |     # E731
@@ -49,7 +49,7 @@ E731.py:14:9: E731 [*] Do not assign a `lambda` expression, use a `def`
    |
    = help: Rewrite `this` as a `def`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | def scope():
 12 12 |     # E731
 13 13 |     while False:
@@ -69,7 +69,7 @@ E731.py:19:5: E731 [*] Do not assign a `lambda` expression, use a `def`
    |
    = help: Rewrite `f` as a `def`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | 
 17 17 | def scope():
 18 18 |     # E731
@@ -89,7 +89,7 @@ E731.py:24:5: E731 [*] Do not assign a `lambda` expression, use a `def`
    |
    = help: Rewrite `f` as a `def`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | 
 22 22 | def scope():
 23 23 |     # E731
@@ -109,7 +109,7 @@ E731.py:57:5: E731 [*] Do not assign a `lambda` expression, use a `def`
    |
    = help: Rewrite `f` as a `def`
 
-ℹ Possible fix
+ℹ Manual fix
 54 54 | 
 55 55 | class Scope:
 56 56 |     # E731
@@ -128,7 +128,7 @@ E731.py:64:5: E731 [*] Do not assign a `lambda` expression, use a `def`
    |
    = help: Rewrite `f` as a `def`
 
-ℹ Possible fix
+ℹ Manual fix
 61 61 |     from typing import Callable
 62 62 | 
 63 63 |     # E731
@@ -150,7 +150,7 @@ E731.py:73:9: E731 [*] Do not assign a `lambda` expression, use a `def`
    |
    = help: Rewrite `x` as a `def`
 
-ℹ Possible fix
+ℹ Manual fix
 70 70 | 
 71 71 |     x: Callable[[int], int]
 72 72 |     if True:
@@ -171,7 +171,7 @@ E731.py:75:9: E731 [*] Do not assign a `lambda` expression, use a `def`
    |
    = help: Rewrite `x` as a `def`
 
-ℹ Possible fix
+ℹ Manual fix
 72 72 |     if True:
 73 73 |         x = lambda: 1
 74 74 |     else:
@@ -191,7 +191,7 @@ E731.py:86:5: E731 [*] Do not assign a `lambda` expression, use a `def`
    |
    = help: Rewrite `f` as a `def`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 83 83 | 
 84 84 |     # ParamSpec cannot be used in this context, so do not preserve the annotation.
 85 85 |     P = ParamSpec("P")
@@ -211,7 +211,7 @@ E731.py:94:5: E731 [*] Do not assign a `lambda` expression, use a `def`
    |
    = help: Rewrite `f` as a `def`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 91 91 | 
 92 92 |     from typing import Callable
 93 93 | 
@@ -231,7 +231,7 @@ E731.py:102:5: E731 [*] Do not assign a `lambda` expression, use a `def`
     |
     = help: Rewrite `f` as a `def`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 99  99  | 
 100 100 |     from typing import Callable
 101 101 | 
@@ -251,7 +251,7 @@ E731.py:110:5: E731 [*] Do not assign a `lambda` expression, use a `def`
     |
     = help: Rewrite `f` as a `def`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 107 107 | 
 108 108 |     from typing import Callable
 109 109 | 
@@ -271,7 +271,7 @@ E731.py:119:5: E731 [*] Do not assign a `lambda` expression, use a `def`
     |
     = help: Rewrite `f` as a `def`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 116 116 | 
 117 117 |     from collections.abc import Callable
 118 118 | 
@@ -291,7 +291,7 @@ E731.py:127:5: E731 [*] Do not assign a `lambda` expression, use a `def`
     |
     = help: Rewrite `f` as a `def`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 124 124 | 
 125 125 |     from collections.abc import Callable
 126 126 | 
@@ -311,7 +311,7 @@ E731.py:135:5: E731 [*] Do not assign a `lambda` expression, use a `def`
     |
     = help: Rewrite `f` as a `def`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 132 132 | 
 133 133 |     from collections.abc import Callable
 134 134 | 
@@ -331,7 +331,7 @@ E731.py:139:5: E731 [*] Do not assign a `lambda` expression, use a `def`
     |
     = help: Rewrite `CELSIUS` as a `def`
 
-ℹ Possible fix
+ℹ Manual fix
 136 136 | 
 137 137 | 
 138 138 | class TemperatureScales(Enum):
@@ -351,7 +351,7 @@ E731.py:140:5: E731 [*] Do not assign a `lambda` expression, use a `def`
     |
     = help: Rewrite `FAHRENHEIT` as a `def`
 
-ℹ Possible fix
+ℹ Manual fix
 137 137 | 
 138 138 | class TemperatureScales(Enum):
 139 139 |     CELSIUS = (lambda deg_c: deg_c)
@@ -374,7 +374,7 @@ E731.py:147:5: E731 [*] Do not assign a `lambda` expression, use a `def`
     |
     = help: Rewrite `f` as a `def`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 144 144 | def scope():
 145 145 |     # E731
 146 146 | 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__constant_literals.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__constant_literals.snap
@@ -117,7 +117,7 @@ constant_literals.py:14:4: E712 [*] Comparison to `False` should be `cond is Fal
    |
    = help: Replace with `cond is False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 |     pass
 12 12 | if False is "abc":  # F632 (fix, but leaves behind unfixable E712)
 13 13 |     pass
@@ -138,7 +138,7 @@ constant_literals.py:14:13: E711 [*] Comparison to `None` should be `cond is Non
    |
    = help: Replace with `cond is None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 |     pass
 12 12 | if False is "abc":  # F632 (fix, but leaves behind unfixable E712)
 13 13 |     pass
@@ -158,7 +158,7 @@ constant_literals.py:16:4: E711 [*] Comparison to `None` should be `cond is None
    |
    = help: Replace with `cond is None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 |     pass
 14 14 | if False == None:  # E711, E712 (fix)
 15 15 |     pass
@@ -178,7 +178,7 @@ constant_literals.py:16:12: E712 [*] Comparison to `False` should be `cond is Fa
    |
    = help: Replace with `cond is False`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 |     pass
 14 14 | if False == None:  # E711, E712 (fix)
 15 15 |     pass

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/blank_after_summary.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/blank_after_summary.rs
@@ -114,7 +114,7 @@ pub(crate) fn blank_after_summary(checker: &mut Checker, docstring: &Docstring) 
                 }
 
                 // Insert one blank line after the summary (replacing any existing lines).
-                diagnostic.set_fix(Fix::automatic(Edit::replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::replacement(
                     checker.stylist().line_ending().to_string(),
                     summary_end,
                     blank_end,

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -191,7 +191,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
                 let mut diagnostic = Diagnostic::new(BlankLineBeforeClass, docstring.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     // Delete the blank line before the class.
-                    diagnostic.set_fix(Fix::automatic(Edit::deletion(
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::deletion(
                         blank_lines_start,
                         docstring.start() - docstring.indentation.text_len(),
                     )));
@@ -204,7 +204,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
                 let mut diagnostic = Diagnostic::new(OneBlankLineBeforeClass, docstring.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     // Insert one blank line before the class.
-                    diagnostic.set_fix(Fix::automatic(Edit::replacement(
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::replacement(
                         checker.stylist().line_ending().to_string(),
                         blank_lines_start,
                         docstring.start() - docstring.indentation.text_len(),
@@ -252,7 +252,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
                     //     """Has priorities"""   ;   priorities=1
                     // ```
                     let next_statement = next_statement.trim_whitespace_start();
-                    diagnostic.set_fix(Fix::automatic(Edit::replacement(
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::replacement(
                         line_ending.to_string() + line_ending + indentation + next_statement,
                         replacement_start,
                         first_line.end(),
@@ -282,7 +282,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
             let mut diagnostic = Diagnostic::new(OneBlankLineAfterClass, docstring.range());
             if checker.patch(diagnostic.kind.rule()) {
                 // Insert a blank line before the class (replacing any existing lines).
-                diagnostic.set_fix(Fix::automatic(Edit::replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::replacement(
                     checker.stylist().line_ending().to_string(),
                     replacement_start,
                     blank_lines_end,

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_function.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_function.rs
@@ -134,7 +134,7 @@ pub(crate) fn blank_before_after_function(checker: &mut Checker, docstring: &Doc
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Delete the blank line before the docstring.
-                diagnostic.set_fix(Fix::automatic(Edit::deletion(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::deletion(
                     blank_lines_start,
                     docstring.start() - docstring.indentation.text_len(),
                 )));
@@ -190,7 +190,7 @@ pub(crate) fn blank_before_after_function(checker: &mut Checker, docstring: &Doc
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Delete the blank line after the docstring.
-                diagnostic.set_fix(Fix::automatic(Edit::deletion(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::deletion(
                     first_line_end,
                     blank_lines_end,
                 )));

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/capitalized.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/capitalized.rs
@@ -91,7 +91,7 @@ pub(crate) fn capitalized(checker: &mut Checker, docstring: &Docstring) {
     );
 
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
             capitalized_word,
             TextRange::at(body.start(), first_word.text_len()),
         )));

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_period.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_period.rs
@@ -105,7 +105,7 @@ pub(crate) fn ends_with_period(checker: &mut Checker, docstring: &Docstring) {
             let mut diagnostic = Diagnostic::new(EndsInPeriod, docstring.range());
             // Best-effort fix: avoid adding a period after other punctuation marks.
             if checker.patch(diagnostic.kind.rule()) && !trimmed.ends_with([':', ';']) {
-                diagnostic.set_fix(Fix::suggested(Edit::insertion(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::insertion(
                     ".".to_string(),
                     line.start() + trimmed.text_len(),
                 )));

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_punctuation.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_punctuation.rs
@@ -104,7 +104,7 @@ pub(crate) fn ends_with_punctuation(checker: &mut Checker, docstring: &Docstring
             let mut diagnostic = Diagnostic::new(EndsInPunctuation, docstring.range());
             // Best-effort fix: avoid adding a period after other punctuation marks.
             if checker.patch(diagnostic.kind.rule()) && !trimmed.ends_with([':', ';']) {
-                diagnostic.set_fix(Fix::suggested(Edit::insertion(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::insertion(
                     ".".to_string(),
                     line.start() + trimmed.text_len(),
                 )));

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/indent.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/indent.rs
@@ -189,7 +189,7 @@ pub(crate) fn indent(checker: &mut Checker, docstring: &Docstring) {
                 let mut diagnostic =
                     Diagnostic::new(UnderIndentation, TextRange::empty(line.start()));
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                         clean_space(docstring.indentation),
                         TextRange::at(line.start(), line_indent.text_len()),
                     )));
@@ -236,7 +236,7 @@ pub(crate) fn indent(checker: &mut Checker, docstring: &Docstring) {
                     } else {
                         Edit::range_replacement(indent, over_indented)
                     };
-                    diagnostic.set_fix(Fix::automatic(edit));
+                    diagnostic.set_fix(Fix::automatic_safe(edit));
                 }
                 checker.diagnostics.push(diagnostic);
             }
@@ -256,7 +256,7 @@ pub(crate) fn indent(checker: &mut Checker, docstring: &Docstring) {
                     } else {
                         Edit::range_replacement(indent, range)
                     };
-                    diagnostic.set_fix(Fix::automatic(edit));
+                    diagnostic.set_fix(Fix::automatic_safe(edit));
                 }
                 checker.diagnostics.push(diagnostic);
             }

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -141,7 +141,7 @@ pub(crate) fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstr
                 // Delete until first non-whitespace char.
                 for line in content_lines {
                     if let Some(end_column) = line.find(|c: char| !c.is_whitespace()) {
-                        diagnostic.set_fix(Fix::automatic(Edit::deletion(
+                        diagnostic.set_fix(Fix::automatic_safe(Edit::deletion(
                             first_line.end(),
                             line.start() + TextSize::try_from(end_column).unwrap(),
                         )));
@@ -197,7 +197,7 @@ pub(crate) fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstr
                         first_line.strip_prefix(prefix).unwrap().trim_start()
                     );
 
-                    diagnostic.set_fix(Fix::automatic(Edit::replacement(
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::replacement(
                         repl,
                         body.start(),
                         first_line.end(),

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
@@ -96,7 +96,7 @@ pub(crate) fn newline_after_last_paragraph(checker: &mut Checker, docstring: &Do
                             checker.stylist().line_ending().as_str(),
                             clean_space(docstring.indentation)
                         );
-                        diagnostic.set_fix(Fix::automatic(Edit::replacement(
+                        diagnostic.set_fix(Fix::automatic_safe(Edit::replacement(
                             content,
                             docstring.expr.end() - num_trailing_quotes - num_trailing_spaces,
                             docstring.expr.end() - num_trailing_quotes,

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
@@ -69,7 +69,7 @@ pub(crate) fn no_surrounding_whitespace(checker: &mut Checker, docstring: &Docst
         // characters, avoid applying the fix.
         if !trimmed.ends_with(quote) && !trimmed.starts_with(quote) && !ends_with_backslash(trimmed)
         {
-            diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                 trimmed.to_string(),
                 TextRange::at(body.start(), line.text_len()),
             )));

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/one_liner.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/one_liner.rs
@@ -78,7 +78,7 @@ pub(crate) fn one_liner(checker: &mut Checker, docstring: &Docstring) {
                     && !trimmed.ends_with(trailing.chars().last().unwrap())
                     && !trimmed.starts_with(leading.chars().last().unwrap())
                 {
-                    diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                         format!("{leading}{trimmed}{trailing}"),
                         docstring.range(),
                     )));

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
@@ -1392,7 +1392,7 @@ fn blanks_and_section_underline(
                         let range =
                             TextRange::new(context.following_range().start(), blank_lines_end);
                         // Delete any blank lines between the header and the underline.
-                        diagnostic.set_fix(Fix::automatic(Edit::range_deletion(range)));
+                        diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(range)));
                     }
                     checker.diagnostics.push(diagnostic);
                 }
@@ -1420,7 +1420,7 @@ fn blanks_and_section_underline(
                             "-".repeat(context.section_name().len()),
                             checker.stylist().line_ending().as_str()
                         );
-                        diagnostic.set_fix(Fix::automatic(Edit::replacement(
+                        diagnostic.set_fix(Fix::automatic_safe(Edit::replacement(
                             content,
                             blank_lines_end,
                             non_blank_line.full_end(),
@@ -1446,7 +1446,7 @@ fn blanks_and_section_underline(
                             leading_space.text_len() + TextSize::from(1),
                         );
                         let contents = clean_space(docstring.indentation);
-                        diagnostic.set_fix(Fix::automatic(if contents.is_empty() {
+                        diagnostic.set_fix(Fix::automatic_safe(if contents.is_empty() {
                             Edit::range_deletion(range)
                         } else {
                             Edit::range_replacement(contents, range)
@@ -1486,7 +1486,7 @@ fn blanks_and_section_underline(
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             // Delete any blank lines between the header and content.
-                            diagnostic.set_fix(Fix::automatic(Edit::deletion(
+                            diagnostic.set_fix(Fix::automatic_safe(Edit::deletion(
                                 line_after_dashes.start(),
                                 blank_lines_after_dashes_end,
                             )));
@@ -1529,14 +1529,14 @@ fn blanks_and_section_underline(
                     {
                         // If an existing underline is an equal sign line of the appropriate length,
                         // replace it with a dashed line.
-                        diagnostic.set_fix(Fix::automatic(Edit::replacement(
+                        diagnostic.set_fix(Fix::automatic_safe(Edit::replacement(
                             content,
                             context.summary_range().end(),
                             non_blank_line.end(),
                         )));
                     } else {
                         // Otherwise, insert a dashed line after the section header.
-                        diagnostic.set_fix(Fix::automatic(Edit::insertion(
+                        diagnostic.set_fix(Fix::automatic_safe(Edit::insertion(
                             content,
                             context.summary_range().end(),
                         )));
@@ -1556,7 +1556,7 @@ fn blanks_and_section_underline(
                         let range =
                             TextRange::new(context.following_range().start(), blank_lines_end);
                         // Delete any blank lines between the header and content.
-                        diagnostic.set_fix(Fix::automatic(Edit::range_deletion(range)));
+                        diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(range)));
                     }
                     checker.diagnostics.push(diagnostic);
                 }
@@ -1581,7 +1581,7 @@ fn blanks_and_section_underline(
                     "-".repeat(context.section_name().len()),
                 );
 
-                diagnostic.set_fix(Fix::automatic(Edit::insertion(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::insertion(
                     content,
                     context.summary_range().end(),
                 )));
@@ -1618,7 +1618,7 @@ fn common_section(
                 // Replace the section title with the capitalized variant. This requires
                 // locating the start and end of the section name.
                 let section_range = context.section_name_range();
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                     capitalized_section_name.to_string(),
                     section_range,
                 )));
@@ -1641,7 +1641,7 @@ fn common_section(
                 let content = clean_space(docstring.indentation);
                 let fix_range = TextRange::at(context.start(), leading_space.text_len());
 
-                diagnostic.set_fix(Fix::automatic(if content.is_empty() {
+                diagnostic.set_fix(Fix::automatic_safe(if content.is_empty() {
                     Edit::range_deletion(fix_range)
                 } else {
                     Edit::range_replacement(content, fix_range)
@@ -1664,7 +1664,7 @@ fn common_section(
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline at the beginning of the next section.
-                    diagnostic.set_fix(Fix::automatic(Edit::insertion(
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::insertion(
                         line_end.to_string(),
                         next.start(),
                     )));
@@ -1681,7 +1681,7 @@ fn common_section(
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline after the section.
-                    diagnostic.set_fix(Fix::automatic(Edit::insertion(
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::insertion(
                         format!("{}{}", line_end, docstring.indentation),
                         context.end(),
                     )));
@@ -1704,7 +1704,7 @@ fn common_section(
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Add a blank line before the section.
-                diagnostic.set_fix(Fix::automatic(Edit::insertion(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::insertion(
                     line_end.to_string(),
                     context.start(),
                 )));
@@ -1900,7 +1900,7 @@ fn numpy_section(
             );
             if checker.patch(diagnostic.kind.rule()) {
                 let section_range = context.section_name_range();
-                diagnostic.set_fix(Fix::automatic(Edit::range_deletion(TextRange::at(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(TextRange::at(
                     section_range.end(),
                     suffix.text_len(),
                 ))));
@@ -1937,7 +1937,7 @@ fn google_section(
             if checker.patch(diagnostic.kind.rule()) {
                 // Replace the suffix.
                 let section_name_range = context.section_name_range();
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                     ":".to_string(),
                     TextRange::at(section_name_range.end(), suffix.text_len()),
                 )));

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D200_D.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D200_D.py.snap
@@ -13,7 +13,7 @@ D.py:129:5: D200 [*] One-line docstring should fit on one line
     |
     = help: Reformat to one line
 
-ℹ Suggested fix
+ℹ Unsafe fix
 126 126 |         '(found 3)')
 127 127 | @expect('D212: Multi-line docstring summary should start at the first line')
 128 128 | def asdlkfasd():
@@ -37,7 +37,7 @@ D.py:597:5: D200 [*] One-line docstring should fit on one line
     |
     = help: Reformat to one line
 
-ℹ Suggested fix
+ℹ Unsafe fix
 594 594 |         '(found 3)')
 595 595 | @expect('D212: Multi-line docstring summary should start at the first line')
 596 596 | def one_liner():
@@ -61,7 +61,7 @@ D.py:606:5: D200 [*] One-line docstring should fit on one line
     |
     = help: Reformat to one line
 
-ℹ Suggested fix
+ℹ Unsafe fix
 603 603 |         '(found 3)')
 604 604 | @expect('D212: Multi-line docstring summary should start at the first line')
 605 605 | def one_liner():

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D200_D200.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D200_D200.py.snap
@@ -21,7 +21,7 @@ D200.py:7:5: D200 [*] One-line docstring should fit on one line
   |
   = help: Reformat to one line
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | 
 5 5 | 
 6 6 | def func():

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D400_D.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D400_D.py.snap
@@ -10,7 +10,7 @@ D.py:355:5: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 352 352 | @expect("D415: First line should end with a period, question mark, "
 353 353 |         "or exclamation point (not 'y')")
 354 354 | def lwnlkjl():
@@ -29,7 +29,7 @@ D.py:406:25: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 403 403 | @expect("D400: First line should end with a period (not 'r')")
 404 404 | @expect("D415: First line should end with a period, question mark,"
 405 405 |         " or exclamation point (not 'r')")
@@ -49,7 +49,7 @@ D.py:410:5: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 407 407 | 
 408 408 | 
 409 409 | def ignored_decorator(func):   # noqa: D400,D401,D415
@@ -69,7 +69,7 @@ D.py:416:5: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 413 413 | 
 414 414 | 
 415 415 | def decorator_for_test(func):   # noqa: D400,D401,D415
@@ -87,7 +87,7 @@ D.py:422:35: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 419 419 | 
 420 420 | 
 421 421 | @ignored_decorator
@@ -106,7 +106,7 @@ D.py:429:49: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 426 426 | @expect("D400: First line should end with a period (not 'r')")
 427 427 | @expect("D415: First line should end with a period, question mark,"
 428 428 |         " or exclamation point (not 'r')")
@@ -126,7 +126,7 @@ D.py:470:5: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 467 467 | @expect("D415: First line should end with a period, question mark, "
 468 468 |         "or exclamation point (not 'g')")
 469 469 | def docstring_bad():
@@ -145,7 +145,7 @@ D.py:475:5: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 472 472 | 
 473 473 | 
 474 474 | def docstring_bad_ignore_all():  # noqa
@@ -164,7 +164,7 @@ D.py:480:5: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 477 477 | 
 478 478 | 
 479 479 | def docstring_bad_ignore_one():  # noqa: D400,D401,D415
@@ -184,7 +184,7 @@ D.py:487:5: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 484 484 | @expect("D401: First line should be in imperative mood "
 485 485 |         "(perhaps 'Run', not 'Runs')")
 486 486 | def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
@@ -202,7 +202,7 @@ D.py:514:5: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 511 511 | 
 512 512 | 
 513 513 | def valid_google_string():  # noqa: D400
@@ -221,7 +221,7 @@ D.py:520:5: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 517 517 | @expect("D415: First line should end with a period, question mark, "
 518 518 |         "or exclamation point (not 'g')")
 519 519 | def bad_google_string():  # noqa: D400
@@ -240,7 +240,7 @@ D.py:581:5: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 578 578 | @expect("D415: First line should end with a period, question mark, "
 579 579 |         "or exclamation point (not '\"')")
 580 580 | def endswith_quote():
@@ -262,7 +262,7 @@ D.py:615:5: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 612 612 |         '(found 3)')
 613 613 | @expect('D212: Multi-line docstring summary should start at the first line')
 614 614 | def one_liner():
@@ -281,7 +281,7 @@ D.py:639:17: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 636 636 |     """ This is a docstring that starts with a space."""  # noqa: D210
 637 637 | 
 638 638 | 
@@ -300,7 +300,7 @@ D.py:641:18: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 638 638 | 
 639 639 | class SameLine: """This is a docstring on the same line"""
 640 640 | 
@@ -320,7 +320,7 @@ D.py:664:5: D400 [*] First line should end with a period
     |
     = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 662 662 | 
 663 663 | def newline_after_closing_quote(self):
 664 664 |     "We enforce a newline after the closing quote for a multi-line docstring \

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D400_D400.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D400_D400.py.snap
@@ -10,7 +10,7 @@ D400.py:2:5: D400 [*] First line should end with a period
   |
   = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | def f():
 2   |-    "Here's a line without a period"
   2 |+    "Here's a line without a period."
@@ -27,7 +27,7 @@ D400.py:7:5: D400 [*] First line should end with a period
   |
   = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | 
 5 5 | 
 6 6 | def f():
@@ -50,7 +50,7 @@ D400.py:12:5: D400 [*] First line should end with a period
    |
    = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | def f():
 12 12 |     """
 13 13 |     Here's a line without a period,
@@ -69,7 +69,7 @@ D400.py:20:5: D400 [*] First line should end with a period
    |
    = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | 
 18 18 | 
 19 19 | def f():
@@ -91,7 +91,7 @@ D400.py:25:5: D400 [*] First line should end with a period
    |
    = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 24 24 | def f():
 25 25 |     """
 26 26 |     Here's a line without a period,
@@ -113,7 +113,7 @@ D400.py:32:5: D400 [*] First line should end with a period
    |
    = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 31 31 | def f():
 32 32 |     """
 33 33 |     Here's a line without a period,
@@ -132,7 +132,7 @@ D400.py:39:5: D400 [*] First line should end with a period
    |
    = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 36 36 | 
 37 37 | 
 38 38 | def f():
@@ -151,7 +151,7 @@ D400.py:44:5: D400 [*] First line should end with a period
    |
    = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 | 
 42 42 | 
 43 43 | def f():
@@ -174,7 +174,7 @@ D400.py:49:5: D400 [*] First line should end with a period
    |
    = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 48 48 | def f():
 49 49 |     r"""
 50 50 |     Here's a line without a period,
@@ -193,7 +193,7 @@ D400.py:57:5: D400 [*] First line should end with a period
    |
    = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 54 54 | 
 55 55 | 
 56 56 | def f():
@@ -215,7 +215,7 @@ D400.py:62:5: D400 [*] First line should end with a period
    |
    = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 61 61 | def f():
 62 62 |     r"""
 63 63 |     Here's a line without a period,
@@ -237,7 +237,7 @@ D400.py:69:5: D400 [*] First line should end with a period
    |
    = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 68 68 | def f():
 69 69 |     r"""
 70 70 |     Here's a line without a period,

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D415_D.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D415_D.py.snap
@@ -10,7 +10,7 @@ D.py:355:5: D415 [*] First line should end with a period, question mark, or excl
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 352 352 | @expect("D415: First line should end with a period, question mark, "
 353 353 |         "or exclamation point (not 'y')")
 354 354 | def lwnlkjl():
@@ -29,7 +29,7 @@ D.py:406:25: D415 [*] First line should end with a period, question mark, or exc
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 403 403 | @expect("D400: First line should end with a period (not 'r')")
 404 404 | @expect("D415: First line should end with a period, question mark,"
 405 405 |         " or exclamation point (not 'r')")
@@ -49,7 +49,7 @@ D.py:410:5: D415 [*] First line should end with a period, question mark, or excl
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 407 407 | 
 408 408 | 
 409 409 | def ignored_decorator(func):   # noqa: D400,D401,D415
@@ -69,7 +69,7 @@ D.py:416:5: D415 [*] First line should end with a period, question mark, or excl
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 413 413 | 
 414 414 | 
 415 415 | def decorator_for_test(func):   # noqa: D400,D401,D415
@@ -87,7 +87,7 @@ D.py:422:35: D415 [*] First line should end with a period, question mark, or exc
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 419 419 | 
 420 420 | 
 421 421 | @ignored_decorator
@@ -106,7 +106,7 @@ D.py:429:49: D415 [*] First line should end with a period, question mark, or exc
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 426 426 | @expect("D400: First line should end with a period (not 'r')")
 427 427 | @expect("D415: First line should end with a period, question mark,"
 428 428 |         " or exclamation point (not 'r')")
@@ -126,7 +126,7 @@ D.py:470:5: D415 [*] First line should end with a period, question mark, or excl
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 467 467 | @expect("D415: First line should end with a period, question mark, "
 468 468 |         "or exclamation point (not 'g')")
 469 469 | def docstring_bad():
@@ -145,7 +145,7 @@ D.py:475:5: D415 [*] First line should end with a period, question mark, or excl
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 472 472 | 
 473 473 | 
 474 474 | def docstring_bad_ignore_all():  # noqa
@@ -164,7 +164,7 @@ D.py:480:5: D415 [*] First line should end with a period, question mark, or excl
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 477 477 | 
 478 478 | 
 479 479 | def docstring_bad_ignore_one():  # noqa: D400,D401,D415
@@ -184,7 +184,7 @@ D.py:487:5: D415 [*] First line should end with a period, question mark, or excl
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 484 484 | @expect("D401: First line should be in imperative mood "
 485 485 |         "(perhaps 'Run', not 'Runs')")
 486 486 | def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
@@ -203,7 +203,7 @@ D.py:520:5: D415 [*] First line should end with a period, question mark, or excl
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 517 517 | @expect("D415: First line should end with a period, question mark, "
 518 518 |         "or exclamation point (not 'g')")
 519 519 | def bad_google_string():  # noqa: D400
@@ -222,7 +222,7 @@ D.py:581:5: D415 [*] First line should end with a period, question mark, or excl
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 578 578 | @expect("D415: First line should end with a period, question mark, "
 579 579 |         "or exclamation point (not '\"')")
 580 580 | def endswith_quote():
@@ -244,7 +244,7 @@ D.py:615:5: D415 [*] First line should end with a period, question mark, or excl
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 612 612 |         '(found 3)')
 613 613 | @expect('D212: Multi-line docstring summary should start at the first line')
 614 614 | def one_liner():
@@ -263,7 +263,7 @@ D.py:639:17: D415 [*] First line should end with a period, question mark, or exc
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 636 636 |     """ This is a docstring that starts with a space."""  # noqa: D210
 637 637 | 
 638 638 | 
@@ -282,7 +282,7 @@ D.py:641:18: D415 [*] First line should end with a period, question mark, or exc
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 638 638 | 
 639 639 | class SameLine: """This is a docstring on the same line"""
 640 640 | 
@@ -302,7 +302,7 @@ D.py:664:5: D415 [*] First line should end with a period, question mark, or excl
     |
     = help: Add closing punctuation
 
-ℹ Suggested fix
+ℹ Unsafe fix
 662 662 | 
 663 663 | def newline_after_closing_quote(self):
 664 664 |     "We enforce a newline after the closing quote for a multi-line docstring \

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__d209_d400.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__d209_d400.snap
@@ -28,7 +28,7 @@ D209_D400.py:2:5: D400 [*] First line should end with a period
   |
   = help: Add period
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | def lorem():
 2 2 |     """lorem ipsum dolor sit amet consectetur adipiscing elit
 3   |-    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"""

--- a/crates/ruff_linter/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -151,7 +151,7 @@ fn convert_f_string_to_regular_string(
         content.insert(0, ' ');
     }
 
-    Fix::automatic(Edit::replacement(
+    Fix::automatic_safe(Edit::replacement(
         content,
         prefix_range.start(),
         tok_range.end(),

--- a/crates/ruff_linter/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -101,7 +101,7 @@ pub(crate) fn invalid_literal_comparison(
                             None
                         }
                     } {
-                        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                             content,
                             located_op.range + expr.start(),
                         )));

--- a/crates/ruff_linter/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -78,7 +78,7 @@ pub(crate) fn raise_not_implemented(checker: &mut Checker, expr: &Expr) {
     let mut diagnostic = Diagnostic::new(RaiseNotImplemented, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
         if checker.semantic().is_builtin("NotImplementedError") {
-            diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                 "NotImplementedError".to_string(),
                 expr.range(),
             )));

--- a/crates/ruff_linter/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/repeated_keys.rs
@@ -159,7 +159,7 @@ pub(crate) fn repeated_keys(checker: &mut Checker, dict: &ast::ExprDict) {
                     );
                     if checker.patch(diagnostic.kind.rule()) {
                         if !seen_values.insert(comparable_value) {
-                            diagnostic.set_fix(Fix::suggested(Edit::deletion(
+                            diagnostic.set_fix(Fix::automatic_unsafe(Edit::deletion(
                                 parenthesized_range(
                                     (&dict.values[i - 1]).into(),
                                     dict.into(),
@@ -193,7 +193,7 @@ pub(crate) fn repeated_keys(checker: &mut Checker, dict: &ast::ExprDict) {
                     if checker.patch(diagnostic.kind.rule()) {
                         let comparable_value: ComparableExpr = (&dict.values[i]).into();
                         if !seen_values.insert(comparable_value) {
-                            diagnostic.set_fix(Fix::suggested(Edit::deletion(
+                            diagnostic.set_fix(Fix::automatic_unsafe(Edit::deletion(
                                 parenthesized_range(
                                     (&dict.values[i - 1]).into(),
                                     dict.into(),

--- a/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
@@ -618,7 +618,7 @@ pub(crate) fn percent_format_extra_named_arguments(
                 checker.locator(),
                 checker.stylist(),
             )?;
-            Ok(Fix::automatic(edit))
+            Ok(Fix::automatic_safe(edit))
         });
     }
     checker.diagnostics.push(diagnostic);
@@ -785,7 +785,7 @@ pub(crate) fn string_dot_format_extra_named_arguments(
                 checker.locator(),
                 checker.stylist(),
             )?;
-            Ok(Fix::automatic(edit))
+            Ok(Fix::automatic_safe(edit))
         });
     }
     checker.diagnostics.push(diagnostic);
@@ -854,7 +854,7 @@ pub(crate) fn string_dot_format_extra_positional_arguments(
                     checker.locator(),
                     checker.stylist(),
                 )?;
-                Ok(Fix::automatic(edit))
+                Ok(Fix::automatic_safe(edit))
             });
         }
     }

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -251,7 +251,7 @@ fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) ->
         checker.stylist(),
         checker.indexer(),
     )?;
-    Ok(Fix::automatic(edit).isolate(Checker::isolation(
+    Ok(Fix::automatic_safe(edit).isolate(Checker::isolation(
         checker.semantic().parent_statement_id(node_id),
     )))
 }

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_variable.rs
@@ -237,11 +237,11 @@ fn remove_unused_variable(binding: &Binding, checker: &Checker) -> Option<Fix> {
                     )?
                     .start();
                     let edit = Edit::deletion(start, end);
-                    Some(Fix::suggested(edit))
+                    Some(Fix::automatic_unsafe(edit))
                 } else {
                     // If (e.g.) assigning to a constant (`x = 1`), delete the entire statement.
                     let edit = delete_stmt(statement, parent, checker.locator(), checker.indexer());
-                    Some(Fix::suggested(edit).isolate(isolation))
+                    Some(Fix::automatic_unsafe(edit).isolate(isolation))
                 };
             }
         }
@@ -265,11 +265,11 @@ fn remove_unused_variable(binding: &Binding, checker: &Checker) -> Option<Fix> {
                     })?
                     .start();
                 let edit = Edit::deletion(start, end);
-                Some(Fix::suggested(edit))
+                Some(Fix::automatic_unsafe(edit))
             } else {
                 // If (e.g.) assigning to a constant (`x = 1`), delete the entire statement.
                 let edit = delete_stmt(statement, parent, checker.locator(), checker.indexer());
-                Some(Fix::suggested(edit).isolate(isolation))
+                Some(Fix::automatic_unsafe(edit).isolate(isolation))
             };
         }
     }
@@ -300,7 +300,7 @@ fn remove_unused_variable(binding: &Binding, checker: &Checker) -> Option<Fix> {
                     .start();
 
                     let edit = Edit::deletion(start, end);
-                    return Some(Fix::suggested(edit));
+                    return Some(Fix::automatic_unsafe(edit));
                 }
             }
         }

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F601_F601.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F601_F601.py.snap
@@ -76,7 +76,7 @@ F601.py:18:5: F601 [*] Dictionary key literal `"a"` repeated
    |
    = help: Remove repeated key literal `"a"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 |     "a": 1,
 16 16 |     "a": 2,
 17 17 |     "a": 3,
@@ -118,7 +118,7 @@ F601.py:25:5: F601 [*] Dictionary key literal `"a"` repeated
    |
    = help: Remove repeated key literal `"a"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 |     "a": 1,
 23 23 |     "a": 2,
 24 24 |     "a": 3,
@@ -148,7 +148,7 @@ F601.py:31:5: F601 [*] Dictionary key literal `"a"` repeated
    |
    = help: Remove repeated key literal `"a"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 28 28 | 
 29 29 | x = {
 30 30 |     "a": 1,
@@ -222,7 +222,7 @@ F601.py:45:5: F601 [*] Dictionary key literal `"a"` repeated
    |
    = help: Remove repeated key literal `"a"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 42 42 |     a: 2,
 43 43 |     "a": 3,
 44 44 |     a: 3,
@@ -241,7 +241,7 @@ F601.py:49:14: F601 [*] Dictionary key literal `"a"` repeated
    |
    = help: Remove repeated key literal `"a"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 |     a: 4,
 47 47 | }
 48 48 | 
@@ -261,7 +261,7 @@ F601.py:50:22: F601 [*] Dictionary key literal `"a"` repeated
    |
    = help: Remove repeated key literal `"a"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 47 47 | }
 48 48 | 
 49 49 | x = {"a": 1, "a": 1}
@@ -291,7 +291,7 @@ F601.py:58:19: F601 [*] Dictionary key literal `"x"` repeated
    |
    = help: Remove repeated key literal `"x"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 55 55 | }
 56 56 | 
 57 57 | # Regression test for: https://github.com/astral-sh/ruff/issues/4897
@@ -309,7 +309,7 @@ F601.py:60:21: F601 [*] Dictionary key literal `"x"` repeated
    |
    = help: Remove repeated key literal `"x"`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 57 57 | # Regression test for: https://github.com/astral-sh/ruff/issues/4897
 58 58 | t={"x":"test123", "x":("test123")}
 59 59 | 

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F602_F602.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F602_F602.py.snap
@@ -44,7 +44,7 @@ F602.py:13:5: F602 [*] Dictionary key `a` repeated
    |
    = help: Remove repeated key `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 |     a: 1,
 11 11 |     a: 2,
 12 12 |     a: 3,
@@ -86,7 +86,7 @@ F602.py:20:5: F602 [*] Dictionary key `a` repeated
    |
    = help: Remove repeated key `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 |     a: 1,
 18 18 |     a: 2,
 19 19 |     a: 3,
@@ -116,7 +116,7 @@ F602.py:26:5: F602 [*] Dictionary key `a` repeated
    |
    = help: Remove repeated key `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 | 
 24 24 | x = {
 25 25 |     a: 1,
@@ -168,7 +168,7 @@ F602.py:35:5: F602 [*] Dictionary key `a` repeated
    |
    = help: Remove repeated key `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 32 32 | x = {
 33 33 |     a: 1,
 34 34 |     "a": 1,
@@ -219,7 +219,7 @@ F602.py:44:12: F602 [*] Dictionary key `a` repeated
    |
    = help: Remove repeated key `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 |     a: 4,
 42 42 | }
 43 43 | 
@@ -235,7 +235,7 @@ F602.py:45:18: F602 [*] Dictionary key `a` repeated
    |
    = help: Remove repeated key `a`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 42 42 | }
 43 43 | 
 44 44 | x = {a: 1, a: 1}

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F841_F841_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F841_F841_0.py.snap
@@ -29,7 +29,7 @@ F841_0.py:16:5: F841 [*] Local variable `z` is assigned to but never used
    |
    = help: Remove assignment to unused variable `z`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | def f():
 14 14 |     x = 1
 15 15 |     y = 2
@@ -48,7 +48,7 @@ F841_0.py:20:5: F841 [*] Local variable `foo` is assigned to but never used
    |
    = help: Remove assignment to unused variable `foo`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | 
 18 18 | 
 19 19 | def f():
@@ -88,7 +88,7 @@ F841_0.py:26:14: F841 [*] Local variable `baz` is assigned to but never used
    |
    = help: Remove assignment to unused variable `baz`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 |     bar = (1, 2)
 24 24 |     (c, d) = bar
 25 25 | 
@@ -109,7 +109,7 @@ F841_0.py:51:9: F841 [*] Local variable `b` is assigned to but never used
    |
    = help: Remove assignment to unused variable `b`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 48 48 | 
 49 49 |     def c():
 50 50 |         # F841
@@ -128,7 +128,7 @@ F841_0.py:79:26: F841 [*] Local variable `my_file` is assigned to but never used
    |
    = help: Remove assignment to unused variable `my_file`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 76 76 | 
 77 77 | 
 78 78 | def f():
@@ -149,7 +149,7 @@ F841_0.py:85:25: F841 [*] Local variable `my_file` is assigned to but never used
    |
    = help: Remove assignment to unused variable `my_file`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 82 82 | 
 83 83 | def f():
 84 84 |     with (
@@ -170,7 +170,7 @@ F841_0.py:102:5: F841 [*] Local variable `msg3` is assigned to but never used
     |
     = help: Remove assignment to unused variable `msg3`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 99  99  | def f(x: int):
 100 100 |     msg1 = "Hello, world!"
 101 101 |     msg2 = "Hello, world!"
@@ -190,7 +190,7 @@ F841_0.py:115:5: F841 [*] Local variable `Baz` is assigned to but never used
     |
     = help: Remove assignment to unused variable `Baz`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 112 112 | 
 113 113 |     Foo = enum.Enum("Foo", "A B")
 114 114 |     Bar = enum.Enum("Bar", "A B")

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F841_F841_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F841_F841_1.py.snap
@@ -25,7 +25,7 @@ F841_1.py:16:14: F841 [*] Local variable `coords` is assigned to but never used
    |
    = help: Remove assignment to unused variable `coords`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | 
 14 14 | 
 15 15 | def f():
@@ -43,7 +43,7 @@ F841_1.py:20:5: F841 [*] Local variable `coords` is assigned to but never used
    |
    = help: Remove assignment to unused variable `coords`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | 
 18 18 | 
 19 19 | def f():

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F841_F841_3.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F841_F841_3.py.snap
@@ -10,7 +10,7 @@ F841_3.py:5:5: F841 [*] Local variable `x` is assigned to but never used
   |
   = help: Remove assignment to unused variable `x`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | 
 3 3 | 
 4 4 | def f():
@@ -30,7 +30,7 @@ F841_3.py:6:5: F841 [*] Local variable `y` is assigned to but never used
   |
   = help: Remove assignment to unused variable `y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | 
 4 4 | def f():
 5 5 |     x = 1
@@ -48,7 +48,7 @@ F841_3.py:13:5: F841 [*] Local variable `x` is assigned to but never used
    |
    = help: Remove assignment to unused variable `x`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | 
 11 11 | 
 12 12 | def f():
@@ -68,7 +68,7 @@ F841_3.py:14:5: F841 [*] Local variable `y` is assigned to but never used
    |
    = help: Remove assignment to unused variable `y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | 
 12 12 | def f():
 13 13 |     x: int = 1
@@ -86,7 +86,7 @@ F841_3.py:21:19: F841 [*] Local variable `x1` is assigned to but never used
    |
    = help: Remove assignment to unused variable `x1`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 | 
 19 19 | 
 20 20 | def f():
@@ -106,7 +106,7 @@ F841_3.py:27:20: F841 [*] Local variable `x3` is assigned to but never used
    |
    = help: Remove assignment to unused variable `x3`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 24 24 |     with foo() as (x2, y2):
 25 25 |         pass
 26 26 | 
@@ -126,7 +126,7 @@ F841_3.py:27:33: F841 [*] Local variable `y3` is assigned to but never used
    |
    = help: Remove assignment to unused variable `y3`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 24 24 |     with foo() as (x2, y2):
 25 25 |         pass
 26 26 | 
@@ -146,7 +146,7 @@ F841_3.py:27:46: F841 [*] Local variable `z3` is assigned to but never used
    |
    = help: Remove assignment to unused variable `z3`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 24 24 |     with foo() as (x2, y2):
 25 25 |         pass
 26 26 | 
@@ -186,7 +186,7 @@ F841_3.py:33:16: F841 [*] Local variable `coords2` is assigned to but never used
    |
    = help: Remove assignment to unused variable `coords2`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 30 30 | 
 31 31 | def f():
 32 32 |     (x1, y1) = (1, 2)
@@ -205,7 +205,7 @@ F841_3.py:34:5: F841 [*] Local variable `coords3` is assigned to but never used
    |
    = help: Remove assignment to unused variable `coords3`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 31 31 | def f():
 32 32 |     (x1, y1) = (1, 2)
 33 33 |     (x2, y2) = coords2 = (1, 2)
@@ -265,7 +265,7 @@ F841_3.py:50:5: F841 [*] Local variable `x` is assigned to but never used
    |
    = help: Remove assignment to unused variable `x`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 47 47 | 
 48 48 | 
 49 49 | def f(a, b):
@@ -285,7 +285,7 @@ F841_3.py:56:5: F841 [*] Local variable `y` is assigned to but never used
    |
    = help: Remove assignment to unused variable `y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 53 53 |         else b
 54 54 |     )
 55 55 | 
@@ -306,7 +306,7 @@ F841_3.py:61:5: F841 [*] Local variable `x` is assigned to but never used
    |
    = help: Remove assignment to unused variable `x`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 58 58 | 
 59 59 | 
 60 60 | def f(a, b):
@@ -329,7 +329,7 @@ F841_3.py:67:5: F841 [*] Local variable `y` is assigned to but never used
    |
    = help: Remove assignment to unused variable `y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 64 64 |         else b
 65 65 |     )
 66 66 | 
@@ -348,7 +348,7 @@ F841_3.py:72:24: F841 [*] Local variable `cm` is assigned to but never used
    |
    = help: Remove assignment to unused variable `cm`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 69 69 | 
 70 70 | 
 71 71 | def f():
@@ -367,7 +367,7 @@ F841_3.py:77:25: F841 [*] Local variable `cm` is assigned to but never used
    |
    = help: Remove assignment to unused variable `cm`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 74 74 | 
 75 75 | 
 76 76 | def f():
@@ -386,7 +386,7 @@ F841_3.py:87:26: F841 [*] Local variable `cm` is assigned to but never used
    |
    = help: Remove assignment to unused variable `cm`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 84 84 | 
 85 85 | 
 86 86 | def f():
@@ -406,7 +406,7 @@ F841_3.py:92:5: F841 [*] Local variable `toplevel` is assigned to but never used
    |
    = help: Remove assignment to unused variable `toplevel`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 89 89 | 
 90 90 | 
 91 91 | def f():
@@ -424,7 +424,7 @@ F841_3.py:98:5: F841 [*] Local variable `toplevel` is assigned to but never used
    |
    = help: Remove assignment to unused variable `toplevel`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 95 95 | 
 96 96 | 
 97 97 | def f():
@@ -442,7 +442,7 @@ F841_3.py:98:16: F841 [*] Local variable `tt` is assigned to but never used
    |
    = help: Remove assignment to unused variable `tt`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 95 95 | 
 96 96 | 
 97 97 | def f():
@@ -460,7 +460,7 @@ F841_3.py:102:5: F841 [*] Local variable `toplevel` is assigned to but never use
     |
     = help: Remove assignment to unused variable `toplevel`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 99  99  | 
 100 100 | 
 101 101 | def f():
@@ -478,7 +478,7 @@ F841_3.py:106:14: F841 [*] Local variable `toplevel` is assigned to but never us
     |
     = help: Remove assignment to unused variable `toplevel`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 103 103 | 
 104 104 | 
 105 105 | def f():
@@ -496,7 +496,7 @@ F841_3.py:110:5: F841 [*] Local variable `toplevel` is assigned to but never use
     |
     = help: Remove assignment to unused variable `toplevel`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 107 107 | 
 108 108 | 
 109 109 | def f():
@@ -514,7 +514,7 @@ F841_3.py:110:16: F841 [*] Local variable `tt` is assigned to but never used
     |
     = help: Remove assignment to unused variable `tt`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 107 107 | 
 108 108 | 
 109 109 | def f():
@@ -613,7 +613,7 @@ F841_3.py:160:5: F841 [*] Local variable `x` is assigned to but never used
     |
     = help: Remove assignment to unused variable `x`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 157 157 | 
 158 158 | 
 159 159 | def f():
@@ -631,7 +631,7 @@ F841_3.py:161:5: F841 [*] Local variable `y` is assigned to but never used
     |
     = help: Remove assignment to unused variable `y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 158 158 | 
 159 159 | def f():
 160 160 |     x = 1
@@ -650,7 +650,7 @@ F841_3.py:165:5: F841 [*] Local variable `x` is assigned to but never used
     |
     = help: Remove assignment to unused variable `x`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 162 162 | 
 163 163 | 
 164 164 | def f():
@@ -668,7 +668,7 @@ F841_3.py:167:5: F841 [*] Local variable `y` is assigned to but never used
     |
     = help: Remove assignment to unused variable `y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 164 164 | def f():
 165 165 |     x = 1
 166 166 | 
@@ -686,7 +686,7 @@ F841_3.py:173:6: F841 [*] Local variable `x` is assigned to but never used
     |
     = help: Remove assignment to unused variable `x`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 170 170 | def f():
 171 171 |     (x) = foo()
 172 172 |     ((x)) = foo()

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__f841_dummy_variable_rgx.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__f841_dummy_variable_rgx.snap
@@ -29,7 +29,7 @@ F841_0.py:20:5: F841 [*] Local variable `foo` is assigned to but never used
    |
    = help: Remove assignment to unused variable `foo`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | 
 18 18 | 
 19 19 | def f():
@@ -69,7 +69,7 @@ F841_0.py:26:14: F841 [*] Local variable `baz` is assigned to but never used
    |
    = help: Remove assignment to unused variable `baz`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 |     bar = (1, 2)
 24 24 |     (c, d) = bar
 25 25 | 
@@ -89,7 +89,7 @@ F841_0.py:35:5: F841 [*] Local variable `_` is assigned to but never used
    |
    = help: Remove assignment to unused variable `_`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 32 32 | 
 33 33 | 
 34 34 | def f():
@@ -108,7 +108,7 @@ F841_0.py:36:5: F841 [*] Local variable `__` is assigned to but never used
    |
    = help: Remove assignment to unused variable ``
 
-ℹ Suggested fix
+ℹ Unsafe fix
 33 33 | 
 34 34 | def f():
 35 35 |     _ = 1
@@ -126,7 +126,7 @@ F841_0.py:37:5: F841 [*] Local variable `_discarded` is assigned to but never us
    |
    = help: Remove assignment to unused variable `_discarded`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 34 34 | def f():
 35 35 |     _ = 1
 36 36 |     __ = 1
@@ -146,7 +146,7 @@ F841_0.py:51:9: F841 [*] Local variable `b` is assigned to but never used
    |
    = help: Remove assignment to unused variable `b`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 48 48 | 
 49 49 |     def c():
 50 50 |         # F841
@@ -165,7 +165,7 @@ F841_0.py:79:26: F841 [*] Local variable `my_file` is assigned to but never used
    |
    = help: Remove assignment to unused variable `my_file`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 76 76 | 
 77 77 | 
 78 78 | def f():
@@ -186,7 +186,7 @@ F841_0.py:85:25: F841 [*] Local variable `my_file` is assigned to but never used
    |
    = help: Remove assignment to unused variable `my_file`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 82 82 | 
 83 83 | def f():
 84 84 |     with (
@@ -207,7 +207,7 @@ F841_0.py:102:5: F841 [*] Local variable `msg3` is assigned to but never used
     |
     = help: Remove assignment to unused variable `msg3`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 99  99  | def f(x: int):
 100 100 |     msg1 = "Hello, world!"
 101 101 |     msg2 = "Hello, world!"
@@ -227,7 +227,7 @@ F841_0.py:115:5: F841 [*] Local variable `Baz` is assigned to but never used
     |
     = help: Remove assignment to unused variable `Baz`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 112 112 | 
 113 113 |     Foo = enum.Enum("Foo", "A B")
 114 114 |     Bar = enum.Enum("Bar", "A B")

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_string_characters.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_string_characters.rs
@@ -201,7 +201,7 @@ pub(crate) fn invalid_string_characters(
         let location = range.start() + TextSize::try_from(column).unwrap();
         let range = TextRange::at(location, c.text_len());
 
-        diagnostics.push(Diagnostic::new(rule, range).with_fix(Fix::automatic(
+        diagnostics.push(Diagnostic::new(rule, range).with_fix(Fix::automatic_safe(
             Edit::range_replacement(replacement.to_string(), range),
         )));
     }

--- a/crates/ruff_linter/src/rules/pylint/rules/manual_import_from.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/manual_import_from.rs
@@ -83,7 +83,7 @@ pub(crate) fn manual_from_import(
                 level: Some(0),
                 range: TextRange::default(),
             };
-            diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                 checker.generator().stmt(&node.into()),
                 stmt.range(),
             )));

--- a/crates/ruff_linter/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nested_min_max.rs
@@ -171,7 +171,7 @@ pub(crate) fn nested_min_max(
                     },
                     range: TextRange::default(),
                 });
-                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                     checker.generator().expr(&flattened_expr),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_isinstance_calls.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_isinstance_calls.rs
@@ -134,7 +134,7 @@ pub(crate) fn repeated_isinstance_calls(
                 expr.range(),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                     pad(call, expr.range(), checker.locator()),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/sys_exit_alias.rs
@@ -85,7 +85,7 @@ pub(crate) fn sys_exit_alias(checker: &mut Checker, func: &Expr) {
                 checker.semantic(),
             )?;
             let reference_edit = Edit::range_replacement(binding, func.range());
-            Ok(Fix::suggested_edits(import_edit, [reference_edit]))
+            Ok(Fix::automatic_unsafe_edits(import_edit, [reference_edit]))
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
@@ -50,7 +50,7 @@ pub(crate) fn useless_import_alias(checker: &mut Checker, alias: &Alias) {
 
     let mut diagnostic = Diagnostic::new(UselessImportAlias, alias.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             asname.to_string(),
             alias.range(),
         )));

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_return.rs
@@ -106,7 +106,7 @@ pub(crate) fn useless_return(
     if checker.patch(diagnostic.kind.rule()) {
         let edit =
             fix::edits::delete_stmt(last_stmt, Some(stmt), checker.locator(), checker.indexer());
-        diagnostic.set_fix(Fix::automatic(edit).isolate(Checker::isolation(
+        diagnostic.set_fix(Fix::automatic_safe(edit).isolate(Checker::isolation(
             checker.semantic().current_statement_id(),
         )));
     }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC0414_import_aliasing.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC0414_import_aliasing.py.snap
@@ -12,7 +12,7 @@ import_aliasing.py:6:8: PLC0414 [*] Import alias does not rename original packag
   |
   = help: Remove import alias
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | # 1. useless-import-alias
 4 4 | # 2. consider-using-from-import
 5 5 | 
@@ -32,7 +32,7 @@ import_aliasing.py:7:25: PLC0414 [*] Import alias does not rename original packa
   |
   = help: Remove import alias
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | # 2. consider-using-from-import
 5 5 | 
 6 6 | import collections as collections  # [useless-import-alias]
@@ -53,7 +53,7 @@ import_aliasing.py:16:15: PLC0414 [*] Import alias does not rename original pack
    |
    = help: Remove import alias
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | import os
 14 14 | import os as OS
 15 15 | from sys import version
@@ -74,7 +74,7 @@ import_aliasing.py:19:19: PLC0414 [*] Import alias does not rename original pack
    |
    = help: Remove import alias
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | from . import bar as bar  # [useless-import-alias]
 17 17 | from . import bar as Bar
 18 18 | from . import bar
@@ -95,7 +95,7 @@ import_aliasing.py:20:23: PLC0414 [*] Import alias does not rename original pack
    |
    = help: Remove import alias
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | from . import bar as Bar
 18 18 | from . import bar
 19 19 | from ..foo import bar as bar  # [useless-import-alias]
@@ -116,7 +116,7 @@ import_aliasing.py:22:15: PLC0414 [*] Import alias does not rename original pack
    |
    = help: Remove import alias
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | from ..foo import bar as bar  # [useless-import-alias]
 20 20 | from ..foo.bar import foobar as foobar  # [useless-import-alias]
 21 21 | from ..foo.bar import foobar as anotherfoobar
@@ -137,7 +137,7 @@ import_aliasing.py:23:27: PLC0414 [*] Import alias does not rename original pack
    |
    = help: Remove import alias
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 | from ..foo.bar import foobar as foobar  # [useless-import-alias]
 21 21 | from ..foo.bar import foobar as anotherfoobar
 22 22 | from . import foo as foo, foo2 as bar2  # [useless-import-alias]
@@ -158,7 +158,7 @@ import_aliasing.py:25:21: PLC0414 [*] Import alias does not rename original pack
    |
    = help: Remove import alias
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | from . import foo as foo, foo2 as bar2  # [useless-import-alias]
 23 23 | from . import foo as bar, foo2 as foo2  # [useless-import-alias]
 24 24 | from . import foo as bar, foo2 as bar2

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_0.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_0.py.snap
@@ -9,7 +9,7 @@ sys_exit_alias_0.py:1:1: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-exit(0)
   1 |+import sys
   2 |+sys.exit(0)
@@ -25,7 +25,7 @@ sys_exit_alias_0.py:2:1: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
   1 |+import sys
 1 2 | exit(0)
 2   |-quit(0)
@@ -43,7 +43,7 @@ sys_exit_alias_0.py:6:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
   1 |+import sys
 1 2 | exit(0)
 2 3 | quit(0)
@@ -63,7 +63,7 @@ sys_exit_alias_0.py:7:5: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
   1 |+import sys
 1 2 | exit(0)
 2 3 | quit(0)

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_1.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_1.py.snap
@@ -11,7 +11,7 @@ sys_exit_alias_1.py:3:1: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import sys
 2 2 | 
 3   |-exit(0)
@@ -28,7 +28,7 @@ sys_exit_alias_1.py:4:1: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import sys
 2 2 | 
 3 3 | exit(0)
@@ -47,7 +47,7 @@ sys_exit_alias_1.py:8:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | 
 6 6 | 
 7 7 | def main():
@@ -66,7 +66,7 @@ sys_exit_alias_1.py:9:5: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | 
 7  7  | def main():
 8  8  |     exit(1)

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_11.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_11.py.snap
@@ -10,7 +10,7 @@ sys_exit_alias_11.py:3:1: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from sys import *
   2 |+import sys
 2 3 | 

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_12.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_12.py.snap
@@ -10,7 +10,7 @@ sys_exit_alias_12.py:3:1: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-import os \
   1 |+import os; import sys \
 2 2 | 

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_2.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_2.py.snap
@@ -11,7 +11,7 @@ sys_exit_alias_2.py:3:1: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import sys as sys2
 2 2 | 
 3   |-exit(0)
@@ -28,7 +28,7 @@ sys_exit_alias_2.py:4:1: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import sys as sys2
 2 2 | 
 3 3 | exit(0)
@@ -47,7 +47,7 @@ sys_exit_alias_2.py:8:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | 
 6 6 | 
 7 7 | def main():
@@ -64,7 +64,7 @@ sys_exit_alias_2.py:9:5: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6 6 | 
 7 7 | def main():
 8 8 |     exit(1)

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_3.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_3.py.snap
@@ -9,7 +9,7 @@ sys_exit_alias_3.py:4:1: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from sys import exit
 2 2 | 
 3 3 | exit(0)
@@ -28,7 +28,7 @@ sys_exit_alias_3.py:9:5: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | 
 7  7  | def main():
 8  8  |     exit(1)

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_4.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_4.py.snap
@@ -11,7 +11,7 @@ sys_exit_alias_4.py:3:1: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from sys import exit as exit2
 2 2 | 
 3   |-exit(0)
@@ -28,7 +28,7 @@ sys_exit_alias_4.py:4:1: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from sys import exit as exit2
 2 2 | 
 3 3 | exit(0)
@@ -47,7 +47,7 @@ sys_exit_alias_4.py:8:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | 
 6 6 | 
 7 7 | def main():
@@ -64,7 +64,7 @@ sys_exit_alias_4.py:9:5: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6 6 | 
 7 7 | def main():
 8 8 |     exit(1)

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_5.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_5.py.snap
@@ -11,7 +11,7 @@ sys_exit_alias_5.py:3:1: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from sys import *
   2 |+import sys
 2 3 | 
@@ -29,7 +29,7 @@ sys_exit_alias_5.py:4:1: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from sys import *
   2 |+import sys
 2 3 | 
@@ -49,7 +49,7 @@ sys_exit_alias_5.py:8:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | from sys import *
    2  |+import sys
 2  3  | 
@@ -71,7 +71,7 @@ sys_exit_alias_5.py:9:5: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | from sys import *
    2  |+import sys
 2  3  | 

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_6.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_6.py.snap
@@ -9,7 +9,7 @@ sys_exit_alias_6.py:1:1: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-exit(0)
   1 |+import sys
   2 |+sys.exit(0)
@@ -25,7 +25,7 @@ sys_exit_alias_6.py:2:1: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
   1 |+import sys
 1 2 | exit(0)
 2   |-quit(0)

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_7.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_7.py.snap
@@ -9,7 +9,7 @@ sys_exit_alias_7.py:2:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
   1 |+import sys
 1 2 | def main():
 2   |-    exit(0)

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_8.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_8.py.snap
@@ -9,7 +9,7 @@ sys_exit_alias_8.py:5:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-from sys import argv
   1 |+from sys import argv, exit
 2 2 | 

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_9.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1722_sys_exit_alias_9.py.snap
@@ -9,7 +9,7 @@ sys_exit_alias_9.py:2:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
   1 |+import sys
 1 2 | def main():
 2   |-    exit(0)

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3301_nested_min_max.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW3301_nested_min_max.py.snap
@@ -11,7 +11,7 @@ nested_min_max.py:2:1: PLW3301 [*] Nested `min` calls can be flattened
   |
   = help: Flatten nested `min` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | min(1, 2, 3)
 2   |-min(1, min(2, 3))
   2 |+min(1, 2, 3)
@@ -30,7 +30,7 @@ nested_min_max.py:3:1: PLW3301 [*] Nested `min` calls can be flattened
   |
   = help: Flatten nested `min` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | min(1, 2, 3)
 2 2 | min(1, min(2, 3))
 3   |-min(1, min(2, min(3, 4)))
@@ -50,7 +50,7 @@ nested_min_max.py:3:8: PLW3301 [*] Nested `min` calls can be flattened
   |
   = help: Flatten nested `min` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | min(1, 2, 3)
 2 2 | min(1, min(2, 3))
 3   |-min(1, min(2, min(3, 4)))
@@ -70,7 +70,7 @@ nested_min_max.py:4:1: PLW3301 [*] Nested `min` calls can be flattened
   |
   = help: Flatten nested `min` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | min(1, 2, 3)
 2 2 | min(1, min(2, 3))
 3 3 | min(1, min(2, min(3, 4)))
@@ -91,7 +91,7 @@ nested_min_max.py:7:1: PLW3301 [*] Nested `max` calls can be flattened
   |
   = help: Flatten nested `max` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | min(1, foo("a", "b"), min(3, 4))
 5 5 | min(1, max(2, 3))
 6 6 | max(1, 2, 3)
@@ -111,7 +111,7 @@ nested_min_max.py:8:1: PLW3301 [*] Nested `max` calls can be flattened
   |
   = help: Flatten nested `max` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | min(1, max(2, 3))
 6 6 | max(1, 2, 3)
 7 7 | max(1, max(2, 3))
@@ -131,7 +131,7 @@ nested_min_max.py:8:8: PLW3301 [*] Nested `max` calls can be flattened
   |
   = help: Flatten nested `max` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | min(1, max(2, 3))
 6 6 | max(1, 2, 3)
 7 7 | max(1, max(2, 3))
@@ -152,7 +152,7 @@ nested_min_max.py:9:1: PLW3301 [*] Nested `max` calls can be flattened
    |
    = help: Flatten nested `max` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | max(1, 2, 3)
 7  7  | max(1, max(2, 3))
 8  8  | max(1, max(2, max(3, 4)))
@@ -173,7 +173,7 @@ nested_min_max.py:15:1: PLW3301 [*] Nested `min` calls can be flattened
    |
    = help: Flatten nested `min` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | min(1, min(2, 3), key=test)
 13 13 | min(1, min(2, 3, key=test))
 14 14 | # This will still trigger, to merge the calls without keyword args.
@@ -206,7 +206,7 @@ nested_min_max.py:24:1: PLW3301 [*] Nested `min` calls can be flattened
    |
    = help: Flatten nested `min` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | )
 22 22 | 
 23 23 | # Handle iterable expressions.
@@ -227,7 +227,7 @@ nested_min_max.py:25:1: PLW3301 [*] Nested `min` calls can be flattened
    |
    = help: Flatten nested `min` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | 
 23 23 | # Handle iterable expressions.
 24 24 | min(1, min(a))
@@ -247,7 +247,7 @@ nested_min_max.py:26:1: PLW3301 [*] Nested `max` calls can be flattened
    |
    = help: Flatten nested `max` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 | # Handle iterable expressions.
 24 24 | min(1, min(a))
 25 25 | min(1, min(i for i in range(10)))
@@ -268,7 +268,7 @@ nested_min_max.py:27:1: PLW3301 [*] Nested `max` calls can be flattened
    |
    = help: Flatten nested `max` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 24 24 | min(1, min(a))
 25 25 | min(1, min(i for i in range(10)))
 26 26 | max(1, max(a))
@@ -286,7 +286,7 @@ nested_min_max.py:41:1: PLW3301 [*] Nested `max` calls can be flattened
    |
    = help: Flatten nested `max` calls
 
-ℹ Suggested fix
+ℹ Unsafe fix
 38 38 | max(max(tuples_list))
 39 39 | 
 40 40 | # Starred argument should be copied as it is.

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -241,7 +241,7 @@ fn convert_to_class(
     base_class: &Expr,
     generator: Generator,
 ) -> Fix {
-    Fix::suggested(Edit::range_replacement(
+    Fix::automatic_unsafe(Edit::range_replacement(
         generator.stmt(&create_class_def_stmt(typename, body, base_class)),
         stmt.range(),
     ))

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -275,7 +275,7 @@ fn convert_to_class(
     base_class: &Expr,
     generator: Generator,
 ) -> Fix {
-    Fix::suggested(Edit::range_replacement(
+    Fix::automatic_unsafe(Edit::range_replacement(
         generator.stmt(&create_class_def_stmt(
             class_name,
             body,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -66,7 +66,7 @@ pub(crate) fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
                     checker.semantic(),
                 )?;
                 let reference_edit = Edit::range_replacement(binding, expr.range());
-                Ok(Fix::suggested_edits(import_edit, [reference_edit]))
+                Ok(Fix::automatic_unsafe_edits(import_edit, [reference_edit]))
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
@@ -46,7 +46,7 @@ where
     let mut diagnostic = Diagnostic::new(DeprecatedCElementTree, node.range());
     if checker.patch(diagnostic.kind.rule()) {
         let contents = checker.locator().slice(node);
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             contents.replacen("cElementTree", "ElementTree", 1),
             node.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -632,7 +632,7 @@ pub(crate) fn deprecated_import(
         );
         if checker.patch(Rule::DeprecatedImport) {
             if let Some(content) = fix {
-                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                     content,
                     stmt.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -262,7 +262,7 @@ pub(crate) fn deprecated_mock_attribute(checker: &mut Checker, expr: &Expr) {
                 value.range(),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                     "mock".to_string(),
                     value.range(),
                 )));
@@ -308,7 +308,7 @@ pub(crate) fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
                             name.range(),
                         );
                         if let Some(content) = content.as_ref() {
-                            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                                 content.clone(),
                                 stmt.range(),
                             )));
@@ -339,7 +339,7 @@ pub(crate) fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
                         diagnostic.try_set_fix(|| {
                             format_import_from(stmt, indent, checker.locator(), checker.stylist())
                                 .map(|content| Edit::range_replacement(content, stmt.range()))
-                                .map(Fix::suggested)
+                                .map(Fix::automatic_unsafe)
                         });
                     }
                 }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -100,7 +100,7 @@ pub(crate) fn deprecated_unittest_alias(checker: &mut Checker, expr: &Expr) {
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             format!("self.{target}"),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -157,7 +157,7 @@ pub(crate) fn extraneous_parentheses(
                 if settings.rules.should_fix(Rule::ExtraneousParentheses) {
                     let contents =
                         locator.slice(TextRange::new(start_range.start(), end_range.end()));
-                    diagnostic.set_fix(Fix::automatic(Edit::replacement(
+                    diagnostic.set_fix(Fix::automatic_safe(Edit::replacement(
                         contents[1..contents.len() - 1].to_string(),
                         start_range.start(),
                         end_range.end(),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -425,7 +425,7 @@ pub(crate) fn f_strings(
             .comment_ranges()
             .intersects(call.arguments.range())
     {
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             contents,
             call.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
@@ -115,8 +115,9 @@ pub(crate) fn format_literals(
     let mut diagnostic = Diagnostic::new(FormatLiterals, call.range());
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            generate_call(call, arguments, checker.locator(), checker.stylist())
-                .map(|suggestion| Fix::suggested(Edit::range_replacement(suggestion, call.range())))
+            generate_call(call, arguments, checker.locator(), checker.stylist()).map(|suggestion| {
+                Fix::automatic_unsafe(Edit::range_replacement(suggestion, call.range()))
+            })
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -100,7 +100,7 @@ pub(crate) fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list:
                         )?;
                         let reference_edit =
                             Edit::range_replacement(binding, decorator.expression.range());
-                        Ok(Fix::automatic_edits(import_edit, [reference_edit]))
+                        Ok(Fix::automatic_safe_edits(import_edit, [reference_edit]))
                     });
                 }
                 checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -78,7 +78,7 @@ pub(crate) fn lru_cache_without_parameters(checker: &mut Checker, decorator_list
                 TextRange::new(func.end(), decorator.end()),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::automatic(Edit::range_deletion(arguments.range())));
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(arguments.range())));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
@@ -185,7 +185,7 @@ pub(crate) fn native_literals(
             if checker.patch(diagnostic.kind.rule()) {
                 let constant = Constant::from(literal_type);
                 let content = checker.generator().constant(&constant);
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                     content,
                     call.range(),
                 )));
@@ -223,7 +223,7 @@ pub(crate) fn native_literals(
 
             let mut diagnostic = Diagnostic::new(NativeLiterals { literal_type }, call.range());
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                     content,
                     call.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/open_alias.rs
@@ -56,7 +56,7 @@ pub(crate) fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
         let mut diagnostic = Diagnostic::new(OpenAlias, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             if checker.semantic().is_builtin("open") {
-                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                     "open".to_string(),
                     func.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -83,7 +83,7 @@ fn atom_diagnostic(checker: &mut Checker, target: &Expr) {
     );
     if checker.patch(diagnostic.kind.rule()) {
         if checker.semantic().is_builtin("OSError") {
-            diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                 "OSError".to_string(),
                 target.range(),
             )));
@@ -135,7 +135,7 @@ fn tuple_diagnostic(checker: &mut Checker, tuple: &ast::ExprTuple, aliases: &[&E
                 format!("({})", checker.generator().expr(&node.into()))
             };
 
-            diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                 pad(content, tuple.range(), checker.locator()),
                 tuple.range(),
             )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -289,7 +289,7 @@ fn fix_always_false_branch(
                 let stmt = checker.semantic().current_statement();
                 let parent = checker.semantic().current_statement_parent();
                 let edit = delete_stmt(stmt, parent, checker.locator(), checker.indexer());
-                Some(Fix::suggested(edit))
+                Some(Fix::automatic_unsafe(edit))
             }
             // If we have an `if` and an `elif`, turn the `elif` into an `if`
             Some(ElifElseClause {
@@ -304,7 +304,7 @@ fn fix_always_false_branch(
                         == "elif"
                 );
                 let end_location = range.start() + ("elif".text_len() - "if".text_len());
-                Some(Fix::suggested(Edit::deletion(
+                Some(Fix::automatic_unsafe(Edit::deletion(
                     stmt_if.start(),
                     end_location,
                 )))
@@ -317,7 +317,7 @@ fn fix_always_false_branch(
                 let end = body.last()?;
                 if indentation(checker.locator(), start).is_none() {
                     // Inline `else` block (e.g., `else: x = 1`).
-                    Some(Fix::suggested(Edit::range_replacement(
+                    Some(Fix::automatic_unsafe(Edit::range_replacement(
                         checker
                             .locator()
                             .slice(TextRange::new(start.start(), end.end()))
@@ -339,7 +339,7 @@ fn fix_always_false_branch(
                             .ok()
                         })
                         .map(|contents| {
-                            Fix::suggested(Edit::replacement(
+                            Fix::automatic_unsafe(Edit::replacement(
                                 contents,
                                 checker.locator().line_start(stmt_if.start()),
                                 stmt_if.end(),
@@ -366,7 +366,7 @@ fn fix_always_false_branch(
                 .iter()
                 .map(Ranged::start)
                 .find(|start| *start > branch.start());
-            Some(Fix::suggested(Edit::deletion(
+            Some(Fix::automatic_unsafe(Edit::deletion(
                 branch.start(),
                 next_start.unwrap_or(branch.end()),
             )))
@@ -394,7 +394,7 @@ fn fix_always_true_branch(
             let end = branch.body.last()?;
             if indentation(checker.locator(), start).is_none() {
                 // Inline `if` block (e.g., `if ...: x = 1`).
-                Some(Fix::suggested(Edit::range_replacement(
+                Some(Fix::automatic_unsafe(Edit::range_replacement(
                     checker
                         .locator()
                         .slice(TextRange::new(start.start(), end.end()))
@@ -413,7 +413,7 @@ fn fix_always_true_branch(
                         .ok()
                     })
                     .map(|contents| {
-                        Fix::suggested(Edit::replacement(
+                        Fix::automatic_unsafe(Edit::replacement(
                             contents,
                             checker.locator().line_start(stmt_if.start()),
                             stmt_if.end(),
@@ -428,7 +428,7 @@ fn fix_always_true_branch(
             let text = checker
                 .locator()
                 .slice(TextRange::new(branch.test.end(), end.end()));
-            Some(Fix::suggested(Edit::range_replacement(
+            Some(Fix::automatic_unsafe(Edit::range_replacement(
                 format!("else{text}"),
                 TextRange::new(branch.start(), stmt_if.end()),
             )))

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -498,7 +498,7 @@ pub(crate) fn printf_string_formatting(checker: &mut Checker, expr: &Expr, right
     if checker.patch(diagnostic.kind.rule())
         && !checker.indexer().comment_ranges().intersects(right.range())
     {
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             contents,
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/quoted_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/quoted_annotation.rs
@@ -54,7 +54,7 @@ impl AlwaysFixableViolation for QuotedAnnotation {
 pub(crate) fn quoted_annotation(checker: &mut Checker, annotation: &str, range: TextRange) {
     let mut diagnostic = Diagnostic::new(QuotedAnnotation, range);
     if checker.patch(Rule::QuotedAnnotation) {
-        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
             annotation.to_string(),
             range,
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -185,13 +185,14 @@ fn create_check<T: Ranged>(
     );
     if patch {
         if let Some(content) = replacement_value {
-            diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                 content.to_string(),
                 mode_param.range(),
             )));
         } else {
             diagnostic.try_set_fix(|| {
-                create_remove_param_fix(locator, expr, mode_param, source_type).map(Fix::automatic)
+                create_remove_param_fix(locator, expr, mode_param, source_type)
+                    .map(Fix::automatic_safe)
             });
         }
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -105,7 +105,7 @@ fn generate_fix(
         (stderr, stdout)
     };
     // Replace one argument with `capture_output=True`, and remove the other.
-    Ok(Fix::suggested_edits(
+    Ok(Fix::automatic_unsafe_edits(
         Edit::range_replacement("capture_output=True".to_string(), first.range()),
         [remove_argument(
             second,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -74,10 +74,10 @@ pub(crate) fn replace_universal_newlines(checker: &mut Checker, call: &ast::Expr
                         Parentheses::Preserve,
                         checker.locator().contents(),
                     )
-                    .map(Fix::suggested)
+                    .map(Fix::automatic_unsafe)
                 });
             } else {
-                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                     "text".to_string(),
                     arg.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -129,7 +129,7 @@ pub(crate) fn super_call_with_parameters(checker: &mut Checker, call: &ast::Expr
 
     let mut diagnostic = Diagnostic::new(SuperCallWithParameters, call.arguments.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::suggested(Edit::deletion(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::deletion(
             call.arguments.start() + TextSize::new(1),
             call.arguments.end() - TextSize::new(1),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/type_of_primitive.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/type_of_primitive.rs
@@ -76,7 +76,7 @@ pub(crate) fn type_of_primitive(checker: &mut Checker, expr: &Expr, func: &Expr,
     if checker.patch(diagnostic.kind.rule()) {
         let builtin = primitive.builtin();
         if checker.semantic().is_builtin(&builtin) {
-            diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                 pad(primitive.builtin(), expr.range(), checker.locator()),
                 expr.range(),
             )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -55,7 +55,7 @@ pub(crate) fn typing_text_str_alias(checker: &mut Checker, expr: &Expr) {
         let mut diagnostic = Diagnostic::new(TypingTextStrAlias, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             if checker.semantic().is_builtin("str") {
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                     "str".to_string(),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
@@ -44,7 +44,7 @@ pub(crate) fn unicode_kind_prefix(checker: &mut Checker, expr: &Expr, is_unicode
     if is_unicode {
         let mut diagnostic = Diagnostic::new(UnicodeKindPrefix, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::automatic(Edit::range_deletion(TextRange::at(
+            diagnostic.set_fix(Fix::automatic_safe(Edit::range_deletion(TextRange::at(
                 expr.start(),
                 TextSize::from(1),
             ))));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -136,7 +136,7 @@ pub(crate) fn unnecessary_builtin_import(
                 checker.stylist(),
                 checker.indexer(),
             )?;
-            Ok(Fix::suggested(edit).isolate(Checker::isolation(
+            Ok(Fix::automatic_unsafe(edit).isolate(Checker::isolation(
                 checker.semantic().current_statement_parent_id(),
             )))
         });

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_class_parentheses.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_class_parentheses.rs
@@ -51,7 +51,7 @@ pub(crate) fn unnecessary_class_parentheses(checker: &mut Checker, class_def: &a
 
     let mut diagnostic = Diagnostic::new(UnnecessaryClassParentheses, arguments.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::automatic(Edit::deletion(
+        diagnostic.set_fix(Fix::automatic_safe(Edit::deletion(
             arguments.start(),
             arguments.end(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
@@ -92,7 +92,7 @@ pub(crate) fn unnecessary_coding_comment(
 
             let mut diagnostic = Diagnostic::new(UTF8EncodingDeclaration, *comment_range);
             if settings.rules.should_fix(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::automatic(Edit::deletion(
+                diagnostic.set_fix(Fix::automatic_safe(Edit::deletion(
                     line_range.start(),
                     line_range.end(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -151,7 +151,7 @@ fn replace_with_bytes_literal(
         prev = range.end();
     }
 
-    Fix::automatic(Edit::range_replacement(
+    Fix::automatic_safe(Edit::range_replacement(
         pad(replacement, call.range(), locator),
         call.range(),
     ))
@@ -202,7 +202,7 @@ pub(crate) fn unnecessary_encode_utf8(checker: &mut Checker, call: &ast::ExprCal
                                 Parentheses::Preserve,
                                 checker.locator().contents(),
                             )
-                            .map(Fix::automatic)
+                            .map(Fix::automatic_safe)
                         });
                     }
                     checker.diagnostics.push(diagnostic);
@@ -222,7 +222,7 @@ pub(crate) fn unnecessary_encode_utf8(checker: &mut Checker, call: &ast::ExprCal
                                 Parentheses::Preserve,
                                 checker.locator().contents(),
                             )
-                            .map(Fix::automatic)
+                            .map(Fix::automatic_safe)
                         });
                     }
                     checker.diagnostics.push(diagnostic);
@@ -249,7 +249,7 @@ pub(crate) fn unnecessary_encode_utf8(checker: &mut Checker, call: &ast::ExprCal
                                 Parentheses::Preserve,
                                 checker.locator().contents(),
                             )
-                            .map(Fix::automatic)
+                            .map(Fix::automatic_safe)
                         });
                     }
                     checker.diagnostics.push(diagnostic);
@@ -269,7 +269,7 @@ pub(crate) fn unnecessary_encode_utf8(checker: &mut Checker, call: &ast::ExprCal
                                 Parentheses::Preserve,
                                 checker.locator().contents(),
                             )
-                            .map(Fix::automatic)
+                            .map(Fix::automatic_safe)
                         });
                     }
                     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -125,7 +125,7 @@ pub(crate) fn unnecessary_future_import(checker: &mut Checker, stmt: &Stmt, name
                 checker.stylist(),
                 checker.indexer(),
             )?;
-            Ok(Fix::suggested(edit).isolate(Checker::isolation(
+            Ok(Fix::automatic_unsafe(edit).isolate(Checker::isolation(
                 checker.semantic().current_statement_parent_id(),
             )))
         });

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
@@ -74,7 +74,7 @@ pub(crate) fn unpacked_list_comprehension(checker: &mut Checker, targets: &[Expr
         content.push('(');
         content.push_str(&existing[1..existing.len() - 1]);
         content.push(')');
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             content,
             value.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -92,7 +92,7 @@ pub(crate) fn use_pep585_annotation(
                 ModuleMember::BuiltIn(name) => {
                     // Built-in type, like `list`.
                     if checker.semantic().is_builtin(name) {
-                        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
                             (*name).to_string(),
                             expr.range(),
                         )));
@@ -107,7 +107,7 @@ pub(crate) fn use_pep585_annotation(
                             checker.semantic(),
                         )?;
                         let reference_edit = Edit::range_replacement(binding, expr.range());
-                        Ok(Fix::suggested_edits(import_edit, [reference_edit]))
+                        Ok(Fix::automatic_unsafe_edits(import_edit, [reference_edit]))
                     });
                 }
             }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -79,7 +79,7 @@ pub(crate) fn use_pep604_annotation(
                         // Invalid type annotation.
                     }
                     _ => {
-                        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                             pad(
                                 checker.generator().expr(&optional(slice)),
                                 expr.range(),
@@ -100,7 +100,7 @@ pub(crate) fn use_pep604_annotation(
                         // Invalid type annotation.
                     }
                     Expr::Tuple(ast::ExprTuple { elts, .. }) => {
-                        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                             pad(
                                 checker.generator().expr(&union(elts)),
                                 expr.range(),
@@ -111,7 +111,7 @@ pub(crate) fn use_pep604_annotation(
                     }
                     _ => {
                         // Single argument.
-                        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                             pad(
                                 checker.locator().slice(slice).to_string(),
                                 expr.range(),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
@@ -117,7 +117,7 @@ pub(crate) fn use_pep604_isinstance(
 
                 let mut diagnostic = Diagnostic::new(NonPEP604Isinstance { kind }, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                         checker.generator().expr(&union(elts)),
                         types.range(),
                     )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
@@ -132,7 +132,7 @@ pub(crate) fn non_pep695_type_alias(checker: &mut Checker, stmt: &StmtAnnAssign)
             })
         };
 
-        diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_safe(Edit::range_replacement(
             checker.generator().stmt(&Stmt::from(StmtTypeAlias {
                 range: TextRange::default(),
                 name: target.clone(),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -67,7 +67,7 @@ pub(crate) fn useless_metaclass_type(
         let stmt = checker.semantic().current_statement();
         let parent = checker.semantic().current_statement_parent();
         let edit = fix::edits::delete_stmt(stmt, parent, checker.locator(), checker.indexer());
-        diagnostic.set_fix(Fix::automatic(edit).isolate(Checker::isolation(
+        diagnostic.set_fix(Fix::automatic_safe(edit).isolate(Checker::isolation(
             checker.semantic().current_statement_parent_id(),
         )));
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -76,7 +76,7 @@ pub(crate) fn useless_object_inheritance(checker: &mut Checker, class_def: &ast:
                     Parentheses::Remove,
                     checker.locator().contents(),
                 )
-                .map(Fix::automatic)
+                .map(Fix::automatic_safe)
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/yield_in_for_loop.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/yield_in_for_loop.rs
@@ -114,7 +114,7 @@ pub(crate) fn yield_in_for_loop(checker: &mut Checker, stmt_for: &ast::StmtFor) 
             .unwrap_or(iter.range()),
         );
         let contents = format!("yield from {contents}");
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             contents,
             stmt_for.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP005.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP005.py.snap
@@ -12,7 +12,7 @@ UP005.py:6:9: UP005 [*] `assertEquals` is deprecated, use `assertEqual`
   |
   = help: Replace `assertEqual` with `assertEquals`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | 
 4 4 | class Suite(unittest.TestCase):
 5 5 |     def test(self) -> None:
@@ -33,7 +33,7 @@ UP005.py:7:9: UP005 [*] `assertEquals` is deprecated, use `assertEqual`
   |
   = help: Replace `assertEqual` with `assertEquals`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | class Suite(unittest.TestCase):
 5 5 |     def test(self) -> None:
 6 6 |         self.assertEquals (1, 2)
@@ -53,7 +53,7 @@ UP005.py:9:9: UP005 [*] `failUnlessAlmostEqual` is deprecated, use `assertAlmost
    |
    = help: Replace `assertAlmostEqual` with `failUnlessAlmostEqual`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  |         self.assertEquals (1, 2)
 7  7  |         self.assertEquals(1, 2)
 8  8  |         self.assertEqual(3, 4)
@@ -70,7 +70,7 @@ UP005.py:10:9: UP005 [*] `assertNotRegexpMatches` is deprecated, use `assertNotR
    |
    = help: Replace `assertNotRegex` with `assertNotRegexpMatches`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  |         self.assertEquals(1, 2)
 8  8  |         self.assertEqual(3, 4)
 9  9  |         self.failUnlessAlmostEqual(1, 1.1)

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP006_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP006_0.py.snap
@@ -239,7 +239,7 @@ UP006_0.py:61:10: UP006 [*] Use `collections.deque` instead of `typing.Deque` fo
    |
    = help: Replace with `collections.deque`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 | 
 21 21 | 
 22 22 | from typing import List as IList
@@ -265,7 +265,7 @@ UP006_0.py:65:10: UP006 [*] Use `collections.defaultdict` instead of `typing.Def
    |
    = help: Replace with `collections.defaultdict`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 | 
 21 21 | 
 22 22 | from typing import List as IList

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP006_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP006_1.py.snap
@@ -9,7 +9,7 @@ UP006_1.py:9:10: UP006 [*] Use `collections.defaultdict` instead of `typing.Defa
    |
    = help: Replace with `collections.defaultdict`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  |     from collections import defaultdict
 7  7  | 
 8  8  | 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP006_3.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP006_3.py.snap
@@ -9,7 +9,7 @@ UP006_3.py:7:11: UP006 [*] Use `collections.defaultdict` instead of `typing.Defa
   |
   = help: Replace with `collections.defaultdict`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 |     from collections import defaultdict
 5 5 | 
 6 6 | 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP007.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP007.py.snap
@@ -9,7 +9,7 @@ UP007.py:6:10: UP007 [*] Use `X | Y` for type annotations
   |
   = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | from typing import Union
 4 4 | 
 5 5 | 
@@ -27,7 +27,7 @@ UP007.py:10:10: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  |     ...
 8  8  | 
 9  9  | 
@@ -45,7 +45,7 @@ UP007.py:14:10: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 |     ...
 12 12 | 
 13 13 | 
@@ -63,7 +63,7 @@ UP007.py:14:26: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 |     ...
 12 12 | 
 13 13 | 
@@ -81,7 +81,7 @@ UP007.py:18:10: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 |     ...
 16 16 | 
 17 17 | 
@@ -99,7 +99,7 @@ UP007.py:22:10: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 |     ...
 20 20 | 
 21 21 | 
@@ -117,7 +117,7 @@ UP007.py:26:10: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 |     ...
 24 24 | 
 25 25 | 
@@ -135,7 +135,7 @@ UP007.py:30:10: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 |     ...
 28 28 | 
 29 29 | 
@@ -153,7 +153,7 @@ UP007.py:34:10: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 31 31 |     ...
 32 32 | 
 33 33 | 
@@ -171,7 +171,7 @@ UP007.py:38:11: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 35 35 |     ...
 36 36 | 
 37 37 | 
@@ -189,7 +189,7 @@ UP007.py:38:27: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 35 35 |     ...
 36 36 | 
 37 37 | 
@@ -207,7 +207,7 @@ UP007.py:42:11: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 39 39 |     ...
 40 40 | 
 41 41 | 
@@ -226,7 +226,7 @@ UP007.py:55:8: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 52 52 | 
 53 53 | 
 54 54 | def f() -> None:
@@ -268,7 +268,7 @@ UP007.py:60:8: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 57 57 | 
 58 58 |     x = Union[str, int]
 59 59 |     x = Union["str", "int"]
@@ -287,7 +287,7 @@ UP007.py:61:8: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 58 58 |     x = Union[str, int]
 59 59 |     x = Union["str", "int"]
 60 60 |     x: Union[str, int]
@@ -382,7 +382,7 @@ UP007.py:102:28: UP007 [*] Use `X | Y` for type annotations
     |
     = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 99  99  | 
 100 100 | # Regression test for: https://github.com/astral-sh/ruff/issues/7131
 101 101 | class ServiceRefOrValue:
@@ -404,7 +404,7 @@ UP007.py:110:28: UP007 [*] Use `X | Y` for type annotations
     |
     = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 107 107 | 
 108 108 | # Regression test for: https://github.com/astral-sh/ruff/issues/7201
 109 109 | class ServiceRefOrValue:

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP008.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP008.py.snap
@@ -11,7 +11,7 @@ UP008.py:17:23: UP008 [*] Use `super()` instead of `super(__class__, self)`
    |
    = help: Remove `super` parameters
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 |         Parent.super(1, 2)  # ok
 15 15 | 
 16 16 |     def wrong(self):
@@ -32,7 +32,7 @@ UP008.py:18:14: UP008 [*] Use `super()` instead of `super(__class__, self)`
    |
    = help: Remove `super` parameters
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | 
 16 16 |     def wrong(self):
 17 17 |         parent = super(Child, self)  # wrong
@@ -55,7 +55,7 @@ UP008.py:19:14: UP008 [*] Use `super()` instead of `super(__class__, self)`
    |
    = help: Remove `super` parameters
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 |     def wrong(self):
 17 17 |         parent = super(Child, self)  # wrong
 18 18 |         super(Child, self).method  # wrong
@@ -78,7 +78,7 @@ UP008.py:36:14: UP008 [*] Use `super()` instead of `super(__class__, self)`
    |
    = help: Remove `super` parameters
 
-ℹ Suggested fix
+ℹ Unsafe fix
 33 33 | 
 34 34 | class MyClass(BaseClass):
 35 35 |     def normal(self):
@@ -97,7 +97,7 @@ UP008.py:50:18: UP008 [*] Use `super()` instead of `super(__class__, self)`
    |
    = help: Remove `super` parameters
 
-ℹ Suggested fix
+ℹ Unsafe fix
 47 47 |             super(MyClass, self).f()  # CANNOT use super()
 48 48 | 
 49 49 |         def inner_argument(self):

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP010.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP010.py.snap
@@ -10,7 +10,7 @@ UP010.py:1:1: UP010 [*] Unnecessary `__future__` imports `generators`, `nested_s
   |
   = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-from __future__ import nested_scopes, generators
 2 1 | from __future__ import with_statement, unicode_literals
 3 2 | from __future__ import absolute_import, division
@@ -26,7 +26,7 @@ UP010.py:2:1: UP010 [*] Unnecessary `__future__` imports `unicode_literals`, `wi
   |
   = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from __future__ import nested_scopes, generators
 2   |-from __future__ import with_statement, unicode_literals
 3 2 | from __future__ import absolute_import, division
@@ -44,7 +44,7 @@ UP010.py:3:1: UP010 [*] Unnecessary `__future__` imports `absolute_import`, `div
   |
   = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from __future__ import nested_scopes, generators
 2 2 | from __future__ import with_statement, unicode_literals
 3   |-from __future__ import absolute_import, division
@@ -63,7 +63,7 @@ UP010.py:4:1: UP010 [*] Unnecessary `__future__` import `generator_stop` for tar
   |
   = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from __future__ import nested_scopes, generators
 2 2 | from __future__ import with_statement, unicode_literals
 3 3 | from __future__ import absolute_import, division
@@ -82,7 +82,7 @@ UP010.py:5:1: UP010 [*] Unnecessary `__future__` imports `generator_stop`, `prin
   |
   = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | from __future__ import with_statement, unicode_literals
 3 3 | from __future__ import absolute_import, division
 4 4 | from __future__ import generator_stop
@@ -102,7 +102,7 @@ UP010.py:6:1: UP010 [*] Unnecessary `__future__` import `generators` for target 
   |
   = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | from __future__ import absolute_import, division
 4 4 | from __future__ import generator_stop
 5 5 | from __future__ import print_function, generator_stop
@@ -121,7 +121,7 @@ UP010.py:9:5: UP010 [*] Unnecessary `__future__` import `generator_stop` for tar
    |
    = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | from __future__ import invalid_module, generators
 7  7  | 
 8  8  | if True:
@@ -141,7 +141,7 @@ UP010.py:10:5: UP010 [*] Unnecessary `__future__` import `generators` for target
    |
    = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | 
 8  8  | if True:
 9  9  |     from __future__ import generator_stop
@@ -159,7 +159,7 @@ UP010.py:13:5: UP010 [*] Unnecessary `__future__` import `generator_stop` for ta
    |
    = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 |     from __future__ import generators
 11 11 | 
 12 12 | if True:
@@ -175,7 +175,7 @@ UP010.py:14:5: UP010 [*] Unnecessary `__future__` import `generators` for target
    |
    = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | 
 12 12 | if True:
 13 13 |     from __future__ import generator_stop

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP013.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP013.py.snap
@@ -11,7 +11,7 @@ UP013.py:5:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class sy
   |
   = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | import typing
 3 3 | 
 4 4 | # dict literal
@@ -33,7 +33,7 @@ UP013.py:8:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class sy
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5  5  | MyType = TypedDict("MyType", {"a": int, "b": str})
 6  6  | 
 7  7  | # dict call
@@ -55,7 +55,7 @@ UP013.py:11:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | MyType = TypedDict("MyType", dict(a=int, b=str))
 9  9  | 
 10 10 | # kwargs
@@ -77,7 +77,7 @@ UP013.py:14:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | MyType = TypedDict("MyType", a=int, b=str)
 12 12 | 
 13 13 | # Empty TypedDict
@@ -97,7 +97,7 @@ UP013.py:17:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | MyType = TypedDict("MyType")
 15 15 | 
 16 16 | # Literal values
@@ -119,7 +119,7 @@ UP013.py:18:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | 
 16 16 | # Literal values
 17 17 | MyType = TypedDict("MyType", {"a": "hello"})
@@ -140,7 +140,7 @@ UP013.py:21:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 | MyType = TypedDict("MyType", a="hello")
 19 19 | 
 20 20 | # NotRequired
@@ -161,7 +161,7 @@ UP013.py:24:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | MyType = TypedDict("MyType", {"a": NotRequired[dict]})
 22 22 | 
 23 23 | # total
@@ -183,7 +183,7 @@ UP013.py:27:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 24 24 | MyType = TypedDict("MyType", {"x": int, "y": int}, total=False)
 25 25 | 
 26 26 | # using Literal type
@@ -204,7 +204,7 @@ UP013.py:30:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 | MyType = TypedDict("MyType", {"key": Literal["value"]})
 28 28 | 
 29 29 | # using namespace TypedDict
@@ -225,7 +225,7 @@ UP013.py:40:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 37 37 | MyType = TypedDict("MyType", {"a": int, "b": str, **c})
 38 38 | 
 39 39 | # Empty dict literal
@@ -244,7 +244,7 @@ UP013.py:43:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 40 40 | MyType = TypedDict("MyType", {})
 41 41 | 
 42 42 | # Empty dict call

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP014.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP014.py.snap
@@ -11,7 +11,7 @@ UP014.py:5:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class s
   |
   = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | import typing
 3 3 | 
 4 4 | # with complex annotations
@@ -33,7 +33,7 @@ UP014.py:8:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5  5  | MyType = NamedTuple("MyType", [("a", int), ("b", tuple[str, ...])])
 6  6  | 
 7  7  | # with namespace
@@ -55,7 +55,7 @@ UP014.py:14:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class 
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | MyType = NamedTuple("MyType", [("x-y", int), ("b", tuple[str, ...])])
 12 12 | 
 13 13 | # no fields
@@ -76,7 +76,7 @@ UP014.py:17:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class 
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | MyType = typing.NamedTuple("MyType")
 15 15 | 
 16 16 | # empty fields
@@ -97,7 +97,7 @@ UP014.py:20:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class 
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | MyType = typing.NamedTuple("MyType", [])
 18 18 | 
 19 19 | # keywords

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP020.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP020.py.snap
@@ -11,7 +11,7 @@ UP020.py:3:6: UP020 [*] Use builtin `open`
   |
   = help: Replace with builtin `open`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import io
 2 2 | 
 3   |-with io.open("f.txt", mode="r", buffering=-1, **kwargs) as f:

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP021.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP021.py.snap
@@ -11,7 +11,7 @@ UP021.py:5:25: UP021 [*] `universal_newlines` is deprecated, use `text`
   |
   = help: Replace with `text` keyword argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | from subprocess import run
 3 3 | 
 4 4 | # Errors
@@ -31,7 +31,7 @@ UP021.py:6:25: UP021 [*] `universal_newlines` is deprecated, use `text`
   |
   = help: Replace with `text` keyword argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | 
 4 4 | # Errors
 5 5 | subprocess.run(["foo"], universal_newlines=True, check=True)
@@ -52,7 +52,7 @@ UP021.py:7:14: UP021 [*] `universal_newlines` is deprecated, use `text`
   |
   = help: Replace with `text` keyword argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | # Errors
 5 5 | subprocess.run(["foo"], universal_newlines=True, check=True)
 6 6 | subprocess.run(["foo"], universal_newlines=True, text=True)

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP022.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP022.py.snap
@@ -12,7 +12,7 @@ UP022.py:4:10: UP022 [*] Sending `stdout` and `stderr` to `PIPE` is deprecated, 
   |
   = help: Replace with `capture_output` keyword argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from subprocess import run
 2 2 | import subprocess
 3 3 | 
@@ -33,7 +33,7 @@ UP022.py:6:10: UP022 [*] Sending `stdout` and `stderr` to `PIPE` is deprecated, 
   |
   = help: Replace with `capture_output` keyword argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | 
 4 4 | output = run(["foo"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 5 5 | 
@@ -54,7 +54,7 @@ UP022.py:8:10: UP022 [*] Sending `stdout` and `stderr` to `PIPE` is deprecated, 
    |
    = help: Replace with `capture_output` keyword argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | 
 6 6 | output = subprocess.run(["foo"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 7 7 | 
@@ -78,7 +78,7 @@ UP022.py:10:10: UP022 [*] Sending `stdout` and `stderr` to `PIPE` is deprecated,
    |
    = help: Replace with `capture_output` keyword argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | output = subprocess.run(stdout=subprocess.PIPE, args=["foo"],  stderr=subprocess.PIPE)
 9  9  | 
 10 10 | output = subprocess.run(
@@ -102,7 +102,7 @@ UP022.py:14:10: UP022 [*] Sending `stdout` and `stderr` to `PIPE` is deprecated,
    |
    = help: Replace with `capture_output` keyword argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | )
 13 13 | 
 14 14 | output = subprocess.run(
@@ -132,7 +132,7 @@ UP022.py:18:10: UP022 [*] Sending `stdout` and `stderr` to `PIPE` is deprecated,
    |
    = help: Replace with `capture_output` keyword argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | 
 18 18 | output = subprocess.run(
 19 19 |     ["foo"],
@@ -162,7 +162,7 @@ UP022.py:29:14: UP022 [*] Sending `stdout` and `stderr` to `PIPE` is deprecated,
    |
    = help: Replace with `capture_output` keyword argument
 
-ℹ Suggested fix
+ℹ Unsafe fix
 28 28 | if output:
 29 29 |     output = subprocess.run(
 30 30 |         ["foo"],

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP023.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP023.py.snap
@@ -10,7 +10,7 @@ UP023.py:2:1: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
   |
   = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # These two imports have something after cElementTree, so they should be fixed.
 2   |-from xml.etree.cElementTree import XML, Element, SubElement
   2 |+from xml.etree.ElementTree import XML, Element, SubElement
@@ -29,7 +29,7 @@ UP023.py:3:8: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
   |
   = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # These two imports have something after cElementTree, so they should be fixed.
 2 2 | from xml.etree.cElementTree import XML, Element, SubElement
 3   |-import xml.etree.cElementTree as ET
@@ -47,7 +47,7 @@ UP023.py:6:1: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
   |
   = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | import xml.etree.cElementTree as ET
 4 4 | 
 5 5 | # Weird spacing should not cause issues.
@@ -68,7 +68,7 @@ UP023.py:7:11: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
   |
   = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | 
 5 5 | # Weird spacing should not cause issues.
 6 6 | from   xml.etree.cElementTree    import  XML
@@ -92,7 +92,7 @@ UP023.py:10:1: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
    |
    = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | import    xml.etree.cElementTree       as      ET
 8  8  | 
 9  9  | # Multi line imports should also work fine.
@@ -112,7 +112,7 @@ UP023.py:16:12: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
    |
    = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 |     SubElement,
 14 14 | )
 15 15 | if True:
@@ -133,7 +133,7 @@ UP023.py:17:27: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
    |
    = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | )
 15 15 | if True:
 16 16 |     import xml.etree.cElementTree as ET
@@ -154,7 +154,7 @@ UP023.py:19:23: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
    |
    = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 |     import xml.etree.cElementTree as ET
 17 17 |     from xml.etree import cElementTree as CET
 18 18 | 
@@ -175,7 +175,7 @@ UP023.py:21:20: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
    |
    = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 | 
 19 19 | from xml.etree import cElementTree as ET
 20 20 | 
@@ -195,7 +195,7 @@ UP023.py:24:32: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
    |
    = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | import contextlib, xml.etree.cElementTree as ET
 22 22 | 
 23 23 | # This should fix the second, but not the first invocation.

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP026.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP026.py.snap
@@ -12,7 +12,7 @@ UP026.py:3:12: UP026 [*] `mock` is deprecated, use `unittest.mock`
   |
   = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # Error (`from unittest import mock`)
 2 2 | if True:
 3   |-    import mock
@@ -32,7 +32,7 @@ UP026.py:7:12: UP026 [*] `mock` is deprecated, use `unittest.mock`
   |
   = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | 
 5 5 | # Error (`from unittest import mock`)
 6 6 | if True:
@@ -54,7 +54,7 @@ UP026.py:11:5: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | 
 9  9  | # Error (`from unittest.mock import *`)
 10 10 | if True:
@@ -74,7 +74,7 @@ UP026.py:14:8: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 |     from mock import *
 12 12 | 
 13 13 | # Error (`from unittest import mock`)
@@ -94,7 +94,7 @@ UP026.py:17:20: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | import mock.mock
 15 15 | 
 16 16 | # Error (`from unittest import mock`)
@@ -114,7 +114,7 @@ UP026.py:20:8: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | import contextlib, mock, sys
 18 18 | 
 19 19 | # Error (`from unittest import mock`)
@@ -135,7 +135,7 @@ UP026.py:24:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | x = "This code should be preserved one line below the mock"
 22 22 | 
 23 23 | # Error (`from unittest import mock`)
@@ -160,7 +160,7 @@ UP026.py:27:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 24 24 | from mock import mock
 25 25 | 
 26 26 | # Error (keep trailing comma)
@@ -192,7 +192,7 @@ UP026.py:33:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 30 30 |     b,
 31 31 |     c,
 32 32 | )
@@ -223,7 +223,7 @@ UP026.py:41:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 38 38 | )
 39 39 | 
 40 40 | # Error (avoid trailing comma)
@@ -255,7 +255,7 @@ UP026.py:47:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 44 44 |     b,
 45 45 |     c
 46 46 | )
@@ -282,7 +282,7 @@ UP026.py:53:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 50 50 |     c,
 51 51 |     mock
 52 52 | )
@@ -304,7 +304,7 @@ UP026.py:54:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 51 51 |     mock
 52 52 | )
 53 53 | from mock import mock, a, b, c
@@ -332,7 +332,7 @@ UP026.py:58:9: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 55 55 | 
 56 56 | if True:
 57 57 |     if False:
@@ -358,7 +358,7 @@ UP026.py:69:8: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 66 66 | import os, io
 67 67 | 
 68 68 | # Error (`from unittest import mock`)
@@ -379,7 +379,7 @@ UP026.py:69:14: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 66 66 | import os, io
 67 67 | 
 68 68 | # Error (`from unittest import mock`)
@@ -400,7 +400,7 @@ UP026.py:72:8: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 69 69 | import mock, mock
 70 70 | 
 71 71 | # Error (`from unittest import mock as foo`)
@@ -420,7 +420,7 @@ UP026.py:75:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 72 72 | import mock as foo
 73 73 | 
 74 74 | # Error (`from unittest import mock as foo`)
@@ -441,7 +441,7 @@ UP026.py:79:12: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 76 76 | 
 77 77 | if True:
 78 78 |     # This should yield multiple, aliased imports.
@@ -464,7 +464,7 @@ UP026.py:79:25: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 76 76 | 
 77 77 | if True:
 78 78 |     # This should yield multiple, aliased imports.
@@ -487,7 +487,7 @@ UP026.py:79:38: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 76 76 | 
 77 77 | if True:
 78 78 |     # This should yield multiple, aliased imports.
@@ -509,7 +509,7 @@ UP026.py:82:12: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 79 79 |     import mock as foo, mock as bar, mock
 80 80 | 
 81 81 |     # This should yield multiple, aliased imports, and preserve `os`.
@@ -532,7 +532,7 @@ UP026.py:82:25: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 79 79 |     import mock as foo, mock as bar, mock
 80 80 | 
 81 81 |     # This should yield multiple, aliased imports, and preserve `os`.
@@ -555,7 +555,7 @@ UP026.py:82:38: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 79 79 |     import mock as foo, mock as bar, mock
 80 80 | 
 81 81 |     # This should yield multiple, aliased imports, and preserve `os`.
@@ -577,7 +577,7 @@ UP026.py:86:5: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Unsafe fix
 83 83 | 
 84 84 | if True:
 85 85 |     # This should yield multiple, aliased imports.
@@ -597,7 +597,7 @@ UP026.py:93:5: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Replace `mock.mock` with `mock`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 90 90 | x = mock.Mock()
 91 91 | 
 92 92 | # Error (`mock.Mock()`).

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP027.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP027.py.snap
@@ -11,7 +11,7 @@ UP027.py:2:17: UP027 [*] Replace unpacked list comprehension with a generator ex
   |
   = help: Replace with generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # Should change
 2   |-foo, bar, baz = [fn(x) for x in items]
   2 |+foo, bar, baz = (fn(x) for x in items)
@@ -30,7 +30,7 @@ UP027.py:4:16: UP027 [*] Replace unpacked list comprehension with a generator ex
   |
   = help: Replace with generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # Should change
 2 2 | foo, bar, baz = [fn(x) for x in items]
 3 3 | 
@@ -51,7 +51,7 @@ UP027.py:6:26: UP027 [*] Replace unpacked list comprehension with a generator ex
   |
   = help: Replace with generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | 
 4 4 | foo, bar, baz =[fn(x) for x in items]
 5 5 | 
@@ -72,7 +72,7 @@ UP027.py:8:17: UP027 [*] Replace unpacked list comprehension with a generator ex
    |
    = help: Replace with generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | 
 6 6 | foo, bar, baz =          [fn(x) for x in items]
 7 7 | 
@@ -97,7 +97,7 @@ UP027.py:10:17: UP027 [*] Replace unpacked list comprehension with a generator e
    |
    = help: Replace with generator expression
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | 
 8  8  | foo, bar, baz = [[i for i in fn(x)] for x in items]
 9  9  | 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP028_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP028_0.py.snap
@@ -11,7 +11,7 @@ UP028_0.py:2:5: UP028 [*] Replace `yield` over `for` loop with `yield from`
   |
   = help: Replace with `yield from`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | def f():
 2   |-    for x in y:
 3   |-        yield x
@@ -30,7 +30,7 @@ UP028_0.py:7:5: UP028 [*] Replace `yield` over `for` loop with `yield from`
   |
   = help: Replace with `yield from`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | 
 5 5 | 
 6 6 | def g():
@@ -51,7 +51,7 @@ UP028_0.py:12:5: UP028 [*] Replace `yield` over `for` loop with `yield from`
    |
    = help: Replace with `yield from`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | 
 10 10 | 
 11 11 | def h():
@@ -72,7 +72,7 @@ UP028_0.py:17:5: UP028 [*] Replace `yield` over `for` loop with `yield from`
    |
    = help: Replace with `yield from`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | 
 15 15 | 
 16 16 | def i():
@@ -93,7 +93,7 @@ UP028_0.py:22:5: UP028 [*] Replace `yield` over `for` loop with `yield from`
    |
    = help: Replace with `yield from`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | 
 20 20 | 
 21 21 | def j():
@@ -114,7 +114,7 @@ UP028_0.py:27:5: UP028 [*] Replace `yield` over `for` loop with `yield from`
    |
    = help: Replace with `yield from`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 24 24 | 
 25 25 | 
 26 26 | def k():
@@ -142,7 +142,7 @@ UP028_0.py:33:5: UP028 [*] Replace `yield` over `for` loop with `yield from`
    |
    = help: Replace with `yield from`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 30 30 | 
 31 31 | def f():  # Comment one\n'
 32 32 |     # Comment two\n'
@@ -169,7 +169,7 @@ UP028_0.py:44:5: UP028 [*] Replace `yield` over `for` loop with `yield from`
    |
    = help: Replace with `yield from`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 | 
 42 42 | 
 43 43 | def f():
@@ -192,7 +192,7 @@ UP028_0.py:49:5: UP028 [*] Replace `yield` over `for` loop with `yield from`
    |
    = help: Replace with `yield from`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 | 
 47 47 | 
 48 48 | def f():
@@ -217,7 +217,7 @@ UP028_0.py:55:9: UP028 [*] Replace `yield` over `for` loop with `yield from`
    |
    = help: Replace with `yield from`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 52 52 | def f():
 53 53 |     def func():
 54 54 |         # This comment is preserved\n'
@@ -240,7 +240,7 @@ UP028_0.py:67:5: UP028 [*] Replace `yield` over `for` loop with `yield from`
    |
    = help: Replace with `yield from`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 64 64 | def f():
 65 65 |     for x in y:
 66 66 |         yield x
@@ -262,7 +262,7 @@ UP028_0.py:72:5: UP028 [*] Replace `yield` over `for` loop with `yield from`
    |
    = help: Replace with `yield from`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 69 69 | 
 70 70 | 
 71 71 | def f():
@@ -287,7 +287,7 @@ UP028_0.py:79:5: UP028 [*] Replace `yield` over `for` loop with `yield from`
    |
    = help: Replace with `yield from`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 76 76 | 
 77 77 | # Regression test for: https://github.com/astral-sh/ruff/issues/7103
 78 78 | def _serve_method(fn):

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP029.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP029.py.snap
@@ -10,7 +10,7 @@ UP029.py:1:1: UP029 [*] Unnecessary builtin import: `*`
   |
   = help: Remove unnecessary builtin import
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-from builtins import *
 2 1 | from builtins import ascii, bytes, compile
 3 2 | from builtins import str as _str
@@ -26,7 +26,7 @@ UP029.py:2:1: UP029 [*] Unnecessary builtin imports: `ascii`, `bytes`
   |
   = help: Remove unnecessary builtin import
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from builtins import *
 2   |-from builtins import ascii, bytes, compile
   2 |+from builtins import compile
@@ -45,7 +45,7 @@ UP029.py:4:1: UP029 [*] Unnecessary builtin imports: `filter`, `zip`
   |
   = help: Remove unnecessary builtin import
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | from builtins import *
 2 2 | from builtins import ascii, bytes, compile
 3 3 | from builtins import str as _str
@@ -66,7 +66,7 @@ UP029.py:5:1: UP029 [*] Unnecessary builtin import: `open`
   |
   = help: Remove unnecessary builtin import
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | from builtins import ascii, bytes, compile
 3 3 | from builtins import str as _str
 4 4 | from six.moves import filter, zip, zip_longest

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP030_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP030_0.py.snap
@@ -12,7 +12,7 @@ UP030_0.py:3:1: UP030 [*] Use implicit references for positional format fields
   |
   = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # Invalid calls; errors expected.
 2 2 | 
 3   |-"{0}" "{1}" "{2}".format(1, 2, 3)
@@ -34,7 +34,7 @@ UP030_0.py:5:1: UP030 [*] Use implicit references for positional format fields
   |
   = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | 
 3 3 | "{0}" "{1}" "{2}".format(1, 2, 3)
 4 4 | 
@@ -57,7 +57,7 @@ UP030_0.py:9:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  |     "first", "second", "third", "fourth"
 7  7  | )
 8  8  | 
@@ -78,7 +78,7 @@ UP030_0.py:11:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | 
 9  9  | '{0}'.format(1)
 10 10 | 
@@ -99,7 +99,7 @@ UP030_0.py:13:5: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | 
 11 11 | '{0:x}'.format(30)
 12 12 | 
@@ -120,7 +120,7 @@ UP030_0.py:15:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | 
 13 13 | x = '{0}'.format(1)
 14 14 | 
@@ -143,7 +143,7 @@ UP030_0.py:17:5: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | 
 15 15 | '''{0}\n{1}\n'''.format(1, 2)
 16 16 | 
@@ -166,7 +166,7 @@ UP030_0.py:20:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | x = "foo {0}" \
 18 18 |     "bar {1}".format(1, 2)
 19 19 | 
@@ -187,7 +187,7 @@ UP030_0.py:22:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | 
 20 20 | ("{0}").format(1)
 21 21 | 
@@ -208,7 +208,7 @@ UP030_0.py:25:5: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | "\N{snowman} {0}".format(1)
 23 23 | 
 24 24 | print(
@@ -231,7 +231,7 @@ UP030_0.py:30:5: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 | )
 28 28 | 
 29 29 | print(
@@ -265,7 +265,7 @@ UP030_0.py:39:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 36 36 | args = list(range(10))
 37 37 | kwargs = {x: x for x in range(10)}
 38 38 | 
@@ -286,7 +286,7 @@ UP030_0.py:41:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 38 38 | 
 39 39 | "{0}".format(*args)
 40 40 | 
@@ -307,7 +307,7 @@ UP030_0.py:43:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 40 40 | 
 41 41 | "{0}".format(**kwargs)
 42 42 | 
@@ -328,7 +328,7 @@ UP030_0.py:45:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 42 42 | 
 43 43 | "{0}_{1}".format(*args)
 44 44 | 
@@ -349,7 +349,7 @@ UP030_0.py:47:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 44 44 | 
 45 45 | "{0}_{1}".format(1, *args)
 46 46 | 
@@ -370,7 +370,7 @@ UP030_0.py:49:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 | 
 47 47 | "{0}_{1}".format(1, 2, *args)
 48 48 | 
@@ -391,7 +391,7 @@ UP030_0.py:51:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 48 48 | 
 49 49 | "{0}_{1}".format(*args, 1, 2)
 50 50 | 
@@ -412,7 +412,7 @@ UP030_0.py:53:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 50 50 | 
 51 51 | "{0}_{1}_{2}".format(1, **kwargs)
 52 52 | 
@@ -433,7 +433,7 @@ UP030_0.py:55:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 52 52 | 
 53 53 | "{0}_{1}_{2}".format(1, 2, **kwargs)
 54 54 | 
@@ -454,7 +454,7 @@ UP030_0.py:57:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 54 54 | 
 55 55 | "{0}_{1}_{2}".format(1, 2, 3, **kwargs)
 56 56 | 
@@ -475,7 +475,7 @@ UP030_0.py:59:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 56 56 | 
 57 57 | "{0}_{1}_{2}".format(1, 2, 3, *args, **kwargs)
 58 58 | 
@@ -493,7 +493,7 @@ UP030_0.py:61:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-ℹ Suggested fix
+ℹ Unsafe fix
 58 58 | 
 59 59 | "{1}_{0}".format(1, 2, *args)
 60 60 | 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP031_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP031_0.py.snap
@@ -11,7 +11,7 @@ UP031_0.py:4:7: UP031 [*] Use format specifiers instead of percent format
   |
   = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | a, b, x, y = 1, 2, 3, 4
 2 2 | 
 3 3 | # UP031
@@ -32,7 +32,7 @@ UP031_0.py:6:7: UP031 [*] Use format specifiers instead of percent format
   |
   = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | # UP031
 4 4 | print('%s %s' % (a, b))
 5 5 | 
@@ -53,7 +53,7 @@ UP031_0.py:8:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | 
 6 6 | print('%s%s' % (a, b))
 7 7 | 
@@ -74,7 +74,7 @@ UP031_0.py:10:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | 
 8  8  | print("trivial" % ())
 9  9  | 
@@ -95,7 +95,7 @@ UP031_0.py:12:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | 
 10 10 | print("%s" % ("simple",))
 11 11 | 
@@ -116,7 +116,7 @@ UP031_0.py:12:15: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | 
 10 10 | print("%s" % ("simple",))
 11 11 | 
@@ -137,7 +137,7 @@ UP031_0.py:14:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | 
 12 12 | print("%s" % ("%s" % ("nested",),))
 13 13 | 
@@ -158,7 +158,7 @@ UP031_0.py:16:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | 
 14 14 | print("%s%% percent" % (15,))
 15 15 | 
@@ -179,7 +179,7 @@ UP031_0.py:18:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | 
 16 16 | print("%f" % (15,))
 17 17 | 
@@ -200,7 +200,7 @@ UP031_0.py:20:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | 
 18 18 | print("%.f" % (15,))
 19 19 | 
@@ -221,7 +221,7 @@ UP031_0.py:22:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | 
 20 20 | print("%.3f" % (15,))
 21 21 | 
@@ -242,7 +242,7 @@ UP031_0.py:24:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | 
 22 22 | print("%3f" % (15,))
 23 23 | 
@@ -263,7 +263,7 @@ UP031_0.py:26:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 | 
 24 24 | print("%-5f" % (5,))
 25 25 | 
@@ -284,7 +284,7 @@ UP031_0.py:28:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 25 25 | 
 26 26 | print("%9f" % (5,))
 27 27 | 
@@ -305,7 +305,7 @@ UP031_0.py:30:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 | 
 28 28 | print("%#o" % (123,))
 29 29 | 
@@ -327,7 +327,7 @@ UP031_0.py:33:3: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 30 30 | print("brace {} %s" % (1,))
 31 31 | 
 32 32 | print(
@@ -348,7 +348,7 @@ UP031_0.py:38:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 35 35 |         )
 36 36 | )
 37 37 | 
@@ -369,7 +369,7 @@ UP031_0.py:40:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 37 37 | 
 38 38 | print("foo %s " % (x,))
 39 39 | 
@@ -394,7 +394,7 @@ UP031_0.py:42:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 39 39 | 
 40 40 | print("%(k)s" % {"k": "v"})
 41 41 | 
@@ -421,7 +421,7 @@ UP031_0.py:47:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 44 44 |     "i": "j"
 45 45 | })
 46 46 | 
@@ -442,7 +442,7 @@ UP031_0.py:49:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 | 
 47 47 | print("%(to_list)s" % {"to_list": []})
 48 48 | 
@@ -463,7 +463,7 @@ UP031_0.py:51:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 48 48 | 
 49 49 | print("%(k)s" % {"k": "v", "i": 1, "j": []})
 50 50 | 
@@ -484,7 +484,7 @@ UP031_0.py:53:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 50 50 | 
 51 51 | print("%(ab)s" % {"a" "b": 1})
 52 52 | 
@@ -505,7 +505,7 @@ UP031_0.py:56:5: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 53 53 | print("%(a)s" % {"a"  :  1})
 54 54 | 
 55 55 | print((
@@ -528,7 +528,7 @@ UP031_0.py:61:5: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 58 58 | ))
 59 59 | 
 60 60 | print(
@@ -552,7 +552,7 @@ UP031_0.py:67:5: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 64 64 | 
 65 65 | bar = {"bar": y}
 66 66 | print(
@@ -575,7 +575,7 @@ UP031_0.py:71:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 68 68 |     "bar %(bar)s" % {"foo": x, **bar}
 69 69 | )
 70 70 | 
@@ -596,7 +596,7 @@ UP031_0.py:73:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 70 70 | 
 71 71 | print("%s \N{snowman}" % (a,))
 72 72 | 
@@ -617,7 +617,7 @@ UP031_0.py:75:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 72 72 | 
 73 73 | print("%(foo)s \N{snowman}" % {"foo": 1})
 74 74 | 
@@ -637,7 +637,7 @@ UP031_0.py:78:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 75 75 | print(("foo %s " "bar %s") % (x, y))
 76 76 | 
 77 77 | # Single-value expressions
@@ -658,7 +658,7 @@ UP031_0.py:79:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 76 76 | 
 77 77 | # Single-value expressions
 78 78 | print('Hello %s' % "World")
@@ -679,7 +679,7 @@ UP031_0.py:80:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 77 77 | # Single-value expressions
 78 78 | print('Hello %s' % "World")
 79 79 | print('Hello %s' % f"World")
@@ -700,7 +700,7 @@ UP031_0.py:81:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 78 78 | print('Hello %s' % "World")
 79 79 | print('Hello %s' % f"World")
 80 80 | print('Hello %s (%s)' % bar)
@@ -721,7 +721,7 @@ UP031_0.py:82:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 79 79 | print('Hello %s' % f"World")
 80 80 | print('Hello %s (%s)' % bar)
 81 81 | print('Hello %s (%s)' % bar.baz)
@@ -742,7 +742,7 @@ UP031_0.py:83:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 80 80 | print('Hello %s (%s)' % bar)
 81 81 | print('Hello %s (%s)' % bar.baz)
 82 82 | print('Hello %s (%s)' % bar['bop'])
@@ -762,7 +762,7 @@ UP031_0.py:84:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 81 81 | print('Hello %s (%s)' % bar.baz)
 82 82 | print('Hello %s (%s)' % bar['bop'])
 83 83 | print('Hello %(arg)s' % bar)
@@ -783,7 +783,7 @@ UP031_0.py:85:7: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 82 82 | print('Hello %s (%s)' % bar['bop'])
 83 83 | print('Hello %(arg)s' % bar)
 84 84 | print('Hello %(arg)s' % bar.baz)
@@ -806,7 +806,7 @@ UP031_0.py:88:1: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 86 86 | 
 87 87 | # Hanging modulos
 88 88 | (
@@ -834,7 +834,7 @@ UP031_0.py:93:1: UP031 [*] Use format specifiers instead of percent format
    |
    = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 91 91 | ) % (x, y)
 92 92 | 
 93 93 | (
@@ -859,7 +859,7 @@ UP031_0.py:99:5: UP031 [*] Use format specifiers instead of percent format
     |
     = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 96  96  | ) % {"foo": x, "bar": y}
 97  97  | 
 98  98  | (
@@ -883,7 +883,7 @@ UP031_0.py:104:5: UP031 [*] Use format specifiers instead of percent format
     |
     = help: Replace with format specifiers
 
-ℹ Suggested fix
+ℹ Unsafe fix
 102 102 | 
 103 103 | (
 104 104 |     """

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_0.py.snap
@@ -12,7 +12,7 @@ UP032_0.py:5:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | # Errors
 3 3 | ###
 4 4 | 
@@ -33,7 +33,7 @@ UP032_0.py:7:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | 
 5 5 | "{} {}".format(a, b)
 6 6 | 
@@ -54,7 +54,7 @@ UP032_0.py:9:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | 
 7  7  | "{1} {0}".format(a, b)
 8  8  | 
@@ -75,7 +75,7 @@ UP032_0.py:11:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | 
 9  9  | "{0} {1} {0}".format(a, b)
 10 10 | 
@@ -96,7 +96,7 @@ UP032_0.py:13:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | 
 11 11 | "{x.y}".format(x=z)
 12 12 | 
@@ -117,7 +117,7 @@ UP032_0.py:15:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | 
 13 13 | "{x} {y} {x}".format(x=a, y=b)
 14 14 | 
@@ -138,7 +138,7 @@ UP032_0.py:17:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | 
 15 15 | "{.x} {.y}".format(a, b)
 16 16 | 
@@ -159,7 +159,7 @@ UP032_0.py:19:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | 
 17 17 | "{} {}".format(a.b, c.d)
 18 18 | 
@@ -180,7 +180,7 @@ UP032_0.py:21:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 | 
 19 19 | "{}".format(a())
 20 20 | 
@@ -201,7 +201,7 @@ UP032_0.py:23:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 | 
 21 21 | "{}".format(a.b())
 22 22 | 
@@ -222,7 +222,7 @@ UP032_0.py:25:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | 
 23 23 | "{}".format(a.b().c())
 24 24 | 
@@ -243,7 +243,7 @@ UP032_0.py:27:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 24 24 | 
 25 25 | "hello {}!".format(name)
 26 26 | 
@@ -264,7 +264,7 @@ UP032_0.py:29:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 26 26 | 
 27 27 | "{}{b}{}".format(a, c, b=b)
 28 28 | 
@@ -285,7 +285,7 @@ UP032_0.py:31:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 28 28 | 
 29 29 | "{}".format(0x0)
 30 30 | 
@@ -306,7 +306,7 @@ UP032_0.py:33:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 30 30 | 
 31 31 | "{} {}".format(a, b)
 32 32 | 
@@ -327,7 +327,7 @@ UP032_0.py:35:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 32 32 | 
 33 33 | """{} {}""".format(a, b)
 34 34 | 
@@ -348,7 +348,7 @@ UP032_0.py:37:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 34 34 | 
 35 35 | "foo{}".format(1)
 36 36 | 
@@ -369,7 +369,7 @@ UP032_0.py:39:5: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 36 36 | 
 37 37 | r"foo{}".format(1)
 38 38 | 
@@ -390,7 +390,7 @@ UP032_0.py:41:7: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 38 38 | 
 39 39 | x = "{a}".format(a=1)
 40 40 | 
@@ -411,7 +411,7 @@ UP032_0.py:43:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 40 40 | 
 41 41 | print("foo {} ".format(x))
 42 42 | 
@@ -432,7 +432,7 @@ UP032_0.py:45:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 42 42 | 
 43 43 | "{a[b]}".format(a=a)
 44 44 | 
@@ -453,7 +453,7 @@ UP032_0.py:47:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 44 44 | 
 45 45 | "{a.a[b]}".format(a=a)
 46 46 | 
@@ -474,7 +474,7 @@ UP032_0.py:49:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 | 
 47 47 | "{}{{}}{}".format(escaped, y)
 48 48 | 
@@ -495,7 +495,7 @@ UP032_0.py:51:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 48 48 | 
 49 49 | "{}".format(a)
 50 50 | 
@@ -516,7 +516,7 @@ UP032_0.py:53:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 50 50 | 
 51 51 | '({}={{0!e}})'.format(a)
 52 52 | 
@@ -537,7 +537,7 @@ UP032_0.py:55:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 52 52 | 
 53 53 | "{[b]}".format(a)
 54 54 | 
@@ -558,7 +558,7 @@ UP032_0.py:57:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 54 54 | 
 55 55 | '{[b]}'.format(a)
 56 56 | 
@@ -579,7 +579,7 @@ UP032_0.py:59:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 56 56 | 
 57 57 | """{[b]}""".format(a)
 58 58 | 
@@ -602,7 +602,7 @@ UP032_0.py:61:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 58 58 | 
 59 59 | '''{[b]}'''.format(a)
 60 60 | 
@@ -627,7 +627,7 @@ UP032_0.py:65:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 62 62 |     1
 63 63 | )
 64 64 | 
@@ -652,7 +652,7 @@ UP032_0.py:69:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 66 66 |     1111111111111111111111111111111111111111111111111111111111111111111111111,
 67 67 | )
 68 68 | 
@@ -681,7 +681,7 @@ UP032_0.py:73:85: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 70 70 | {}
 71 71 | """.format(1)
 72 72 | 
@@ -708,7 +708,7 @@ UP032_0.py:79:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 76 76 |     111111
 77 77 | )
 78 78 | 
@@ -732,7 +732,7 @@ UP032_0.py:81:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 79 79 | "{a}" "{b}".format(a=1, b=1)
 80 80 | 
 81 81 | (
@@ -762,7 +762,7 @@ UP032_0.py:86:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 84 84 | ).format(a=1, b=1)
 85 85 | 
 86 86 | (
@@ -795,7 +795,7 @@ UP032_0.py:94:5: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 93  93  | (
 94  94  |     (
 95  95  |         # comment
@@ -824,7 +824,7 @@ UP032_0.py:104:1: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 102 102 | )
 103 103 | 
 104 104 | (
@@ -845,7 +845,7 @@ UP032_0.py:111:11: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 108 108 | 
 109 109 | 
 110 110 | def d(osname, version, release):
@@ -863,7 +863,7 @@ UP032_0.py:115:10: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 112 112 | 
 113 113 | 
 114 114 | def e():
@@ -880,7 +880,7 @@ UP032_0.py:118:7: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 115 115 |     yield"{}".format(1)
 116 116 | 
 117 117 | 
@@ -898,7 +898,7 @@ UP032_0.py:122:12: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 119 119 | 
 120 120 | 
 121 121 | async def c():
@@ -916,7 +916,7 @@ UP032_0.py:126:12: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 123 123 | 
 124 124 | 
 125 125 | async def c():
@@ -935,7 +935,7 @@ UP032_0.py:129:1: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 126 126 |     return "{}".format(1 + await 3)
 127 127 | 
 128 128 | 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_1.py.snap
@@ -8,7 +8,7 @@ UP032_1.py:1:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-"{} {}".format(a, b)  # Intentionally at start-of-file, to ensure graceful handling.
   1 |+f"{a} {b}"  # Intentionally at start-of-file, to ensure graceful handling.
 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_2.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_2.py.snap
@@ -11,7 +11,7 @@ UP032_2.py:2:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # Errors
 2   |-"{.real}".format(1)
   2 |+f"{(1).real}"
@@ -29,7 +29,7 @@ UP032_2.py:3:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # Errors
 2 2 | "{.real}".format(1)
 3   |-"{0.real}".format(1)
@@ -49,7 +49,7 @@ UP032_2.py:4:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # Errors
 2 2 | "{.real}".format(1)
 3 3 | "{0.real}".format(1)
@@ -70,7 +70,7 @@ UP032_2.py:6:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | "{0.real}".format(1)
 4 4 | "{a.real}".format(a=1)
 5 5 | 
@@ -89,7 +89,7 @@ UP032_2.py:7:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | "{a.real}".format(a=1)
 5 5 | 
 6 6 | "{.real}".format(1.0)
@@ -110,7 +110,7 @@ UP032_2.py:8:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | 
 6 6 | "{.real}".format(1.0)
 7 7 | "{0.real}".format(1.0)
@@ -131,7 +131,7 @@ UP032_2.py:10:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | "{0.real}".format(1.0)
 8  8  | "{a.real}".format(a=1.0)
 9  9  | 
@@ -150,7 +150,7 @@ UP032_2.py:11:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | "{a.real}".format(a=1.0)
 9  9  | 
 10 10 | "{.real}".format(1j)
@@ -171,7 +171,7 @@ UP032_2.py:12:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | 
 10 10 | "{.real}".format(1j)
 11 11 | "{0.real}".format(1j)
@@ -192,7 +192,7 @@ UP032_2.py:14:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | "{0.real}".format(1j)
 12 12 | "{a.real}".format(a=1j)
 13 13 | 
@@ -211,7 +211,7 @@ UP032_2.py:15:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | "{a.real}".format(a=1j)
 13 13 | 
 14 14 | "{.real}".format(0b01)
@@ -232,7 +232,7 @@ UP032_2.py:16:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | 
 14 14 | "{.real}".format(0b01)
 15 15 | "{0.real}".format(0b01)
@@ -253,7 +253,7 @@ UP032_2.py:18:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | "{0.real}".format(0b01)
 16 16 | "{a.real}".format(a=0b01)
 17 17 | 
@@ -273,7 +273,7 @@ UP032_2.py:19:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | "{a.real}".format(a=0b01)
 17 17 | 
 18 18 | "{}".format(1 + 2)
@@ -294,7 +294,7 @@ UP032_2.py:20:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | 
 18 18 | "{}".format(1 + 2)
 19 19 | "{}".format([1, 2])
@@ -314,7 +314,7 @@ UP032_2.py:21:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 | "{}".format(1 + 2)
 19 19 | "{}".format([1, 2])
 20 20 | "{}".format({1, 2})
@@ -335,7 +335,7 @@ UP032_2.py:22:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | "{}".format([1, 2])
 20 20 | "{}".format({1, 2})
 21 21 | "{}".format({1: 2, 3: 4})
@@ -356,7 +356,7 @@ UP032_2.py:24:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | "{}".format({1: 2, 3: 4})
 22 22 | "{}".format((i for i in range(2)))
 23 23 | 
@@ -376,7 +376,7 @@ UP032_2.py:25:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | "{}".format((i for i in range(2)))
 23 23 | 
 24 24 | "{.real}".format(1 + 2)
@@ -397,7 +397,7 @@ UP032_2.py:26:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 | 
 24 24 | "{.real}".format(1 + 2)
 25 25 | "{.real}".format([1, 2])
@@ -416,7 +416,7 @@ UP032_2.py:27:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 24 24 | "{.real}".format(1 + 2)
 25 25 | "{.real}".format([1, 2])
 26 26 | "{.real}".format({1, 2})
@@ -433,7 +433,7 @@ UP032_2.py:28:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 25 25 | "{.real}".format([1, 2])
 26 26 | "{.real}".format({1, 2})
 27 27 | "{.real}".format({1: 2, 3: 4})

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
@@ -11,7 +11,7 @@ UP035.py:2:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
   |
   = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # UP035
 2   |-from collections import Mapping
   2 |+from collections.abc import Mapping
@@ -30,7 +30,7 @@ UP035.py:4:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
   |
   = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # UP035
 2 2 | from collections import Mapping
 3 3 | 
@@ -51,7 +51,7 @@ UP035.py:6:1: UP035 [*] Import from `collections.abc` instead: `Mapping`, `Seque
   |
   = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | 
 4 4 | from collections import Mapping as MAP
 5 5 | 
@@ -72,7 +72,7 @@ UP035.py:8:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5  5  | 
 6  6  | from collections import Mapping, Sequence
 7  7  | 
@@ -94,7 +94,7 @@ UP035.py:10:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | 
 8  8  | from collections import Counter, Mapping
 9  9  | 
@@ -117,7 +117,7 @@ UP035.py:12:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | 
 10 10 | from collections import (Counter, Mapping)
 11 11 | 
@@ -141,7 +141,7 @@ UP035.py:15:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | from collections import (Counter,
 13 13 |                          Mapping)
 14 14 | 
@@ -164,7 +164,7 @@ UP035.py:18:1: UP035 [*] Import from `collections.abc` instead: `Mapping`, `Sequ
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | from collections import Counter, \
 16 16 |                          Mapping
 17 17 | 
@@ -186,7 +186,7 @@ UP035.py:20:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | 
 18 18 | from collections import Counter, Mapping, Sequence
 19 19 | 
@@ -207,7 +207,7 @@ UP035.py:23:5: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 | from collections import Mapping as mapping, Counter
 21 21 | 
 22 22 | if True:
@@ -229,7 +229,7 @@ UP035.py:28:5: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 25 25 | if True:
 26 26 |     if True:
 27 27 |         pass
@@ -251,7 +251,7 @@ UP035.py:30:10: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 |         pass
 28 28 |     from collections import Mapping, Counter
 29 29 | 
@@ -270,7 +270,7 @@ UP035.py:33:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 30 30 | if True: from collections import Mapping
 31 31 | 
 32 32 | import os
@@ -297,7 +297,7 @@ UP035.py:37:5: UP035 [*] Import from `collections.abc` instead: `Mapping`, `Call
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 35 35 | 
 36 36 | if True:
 37 37 |     from collections import (
@@ -322,7 +322,7 @@ UP035.py:44:1: UP035 [*] Import from `collections.abc` instead: `Callable`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 |         Good,
 42 42 |     )
 43 43 | 
@@ -344,7 +344,7 @@ UP035.py:44:1: UP035 [*] Import from `collections` instead: `OrderedDict`
    |
    = help: Import from `collections`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 |         Good,
 42 42 |     )
 43 43 | 
@@ -366,7 +366,7 @@ UP035.py:44:1: UP035 [*] Import from `re` instead: `Match`, `Pattern`
    |
    = help: Import from `re`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 |         Good,
 42 42 |     )
 43 43 | 
@@ -440,7 +440,7 @@ UP035.py:51:1: UP035 [*] Import from `collections` instead: `OrderedDict`
    |
    = help: Import from `collections`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 48 48 | 
 49 49 | # Bad imports from PYI027 that are now handled by PYI022 (UP035)
 50 50 | from typing import ContextManager
@@ -461,7 +461,7 @@ UP035.py:52:1: UP035 [*] Import from `typing` instead: `OrderedDict`
    |
    = help: Import from `typing`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 49 49 | # Bad imports from PYI027 that are now handled by PYI022 (UP035)
 50 50 | from typing import ContextManager
 51 51 | from typing import OrderedDict
@@ -482,7 +482,7 @@ UP035.py:53:1: UP035 [*] Import from `collections.abc` instead: `Callable`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 50 50 | from typing import ContextManager
 51 51 | from typing import OrderedDict
 52 52 | from typing_extensions import OrderedDict
@@ -503,7 +503,7 @@ UP035.py:54:1: UP035 [*] Import from `collections.abc` instead: `ByteString`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 51 51 | from typing import OrderedDict
 52 52 | from typing_extensions import OrderedDict
 53 53 | from typing import Callable
@@ -524,7 +524,7 @@ UP035.py:55:1: UP035 [*] Import from `collections.abc` instead: `Container`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 52 52 | from typing_extensions import OrderedDict
 53 53 | from typing import Callable
 54 54 | from typing import ByteString
@@ -545,7 +545,7 @@ UP035.py:56:1: UP035 [*] Import from `collections.abc` instead: `Hashable`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 53 53 | from typing import Callable
 54 54 | from typing import ByteString
 55 55 | from typing import Container
@@ -566,7 +566,7 @@ UP035.py:57:1: UP035 [*] Import from `collections.abc` instead: `ItemsView`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 54 54 | from typing import ByteString
 55 55 | from typing import Container
 56 56 | from typing import Hashable
@@ -587,7 +587,7 @@ UP035.py:58:1: UP035 [*] Import from `collections.abc` instead: `Iterable`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 55 55 | from typing import Container
 56 56 | from typing import Hashable
 57 57 | from typing import ItemsView
@@ -608,7 +608,7 @@ UP035.py:59:1: UP035 [*] Import from `collections.abc` instead: `Iterator`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 56 56 | from typing import Hashable
 57 57 | from typing import ItemsView
 58 58 | from typing import Iterable
@@ -629,7 +629,7 @@ UP035.py:60:1: UP035 [*] Import from `collections.abc` instead: `KeysView`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 57 57 | from typing import ItemsView
 58 58 | from typing import Iterable
 59 59 | from typing import Iterator
@@ -650,7 +650,7 @@ UP035.py:61:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 58 58 | from typing import Iterable
 59 59 | from typing import Iterator
 60 60 | from typing import KeysView
@@ -671,7 +671,7 @@ UP035.py:62:1: UP035 [*] Import from `collections.abc` instead: `MappingView`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 59 59 | from typing import Iterator
 60 60 | from typing import KeysView
 61 61 | from typing import Mapping
@@ -692,7 +692,7 @@ UP035.py:63:1: UP035 [*] Import from `collections.abc` instead: `MutableMapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 60 60 | from typing import KeysView
 61 61 | from typing import Mapping
 62 62 | from typing import MappingView
@@ -713,7 +713,7 @@ UP035.py:64:1: UP035 [*] Import from `collections.abc` instead: `MutableSequence
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 61 61 | from typing import Mapping
 62 62 | from typing import MappingView
 63 63 | from typing import MutableMapping
@@ -734,7 +734,7 @@ UP035.py:65:1: UP035 [*] Import from `collections.abc` instead: `MutableSet`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 62 62 | from typing import MappingView
 63 63 | from typing import MutableMapping
 64 64 | from typing import MutableSequence
@@ -755,7 +755,7 @@ UP035.py:66:1: UP035 [*] Import from `collections.abc` instead: `Sequence`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 63 63 | from typing import MutableMapping
 64 64 | from typing import MutableSequence
 65 65 | from typing import MutableSet
@@ -776,7 +776,7 @@ UP035.py:67:1: UP035 [*] Import from `collections.abc` instead: `Sized`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 64 64 | from typing import MutableSequence
 65 65 | from typing import MutableSet
 66 66 | from typing import Sequence
@@ -797,7 +797,7 @@ UP035.py:68:1: UP035 [*] Import from `collections.abc` instead: `ValuesView`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 65 65 | from typing import MutableSet
 66 66 | from typing import Sequence
 67 67 | from typing import Sized
@@ -818,7 +818,7 @@ UP035.py:69:1: UP035 [*] Import from `collections.abc` instead: `Awaitable`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 66 66 | from typing import Sequence
 67 67 | from typing import Sized
 68 68 | from typing import ValuesView
@@ -839,7 +839,7 @@ UP035.py:70:1: UP035 [*] Import from `collections.abc` instead: `AsyncIterator`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 67 67 | from typing import Sized
 68 68 | from typing import ValuesView
 69 69 | from typing import Awaitable
@@ -860,7 +860,7 @@ UP035.py:71:1: UP035 [*] Import from `collections.abc` instead: `AsyncIterable`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 68 68 | from typing import ValuesView
 69 69 | from typing import Awaitable
 70 70 | from typing import AsyncIterator
@@ -881,7 +881,7 @@ UP035.py:72:1: UP035 [*] Import from `collections.abc` instead: `Coroutine`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 69 69 | from typing import Awaitable
 70 70 | from typing import AsyncIterator
 71 71 | from typing import AsyncIterable
@@ -902,7 +902,7 @@ UP035.py:73:1: UP035 [*] Import from `collections.abc` instead: `Collection`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 70 70 | from typing import AsyncIterator
 71 71 | from typing import AsyncIterable
 72 72 | from typing import Coroutine
@@ -923,7 +923,7 @@ UP035.py:74:1: UP035 [*] Import from `collections.abc` instead: `AsyncGenerator`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 71 71 | from typing import AsyncIterable
 72 72 | from typing import Coroutine
 73 73 | from typing import Collection
@@ -944,7 +944,7 @@ UP035.py:75:1: UP035 [*] Import from `collections.abc` instead: `Reversible`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 72 72 | from typing import Coroutine
 73 73 | from typing import Collection
 74 74 | from typing import AsyncGenerator
@@ -965,7 +965,7 @@ UP035.py:76:1: UP035 [*] Import from `collections.abc` instead: `Generator`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 73 73 | from typing import Collection
 74 74 | from typing import AsyncGenerator
 75 75 | from typing import Reversible
@@ -985,7 +985,7 @@ UP035.py:77:1: UP035 [*] Import from `collections.abc` instead: `Callable`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 74 74 | from typing import AsyncGenerator
 75 75 | from typing import Reversible
 76 76 | from typing import Generator
@@ -1005,7 +1005,7 @@ UP035.py:87:1: UP035 [*] Import from `typing` instead: `NamedTuple`
    |
    = help: Import from `typing`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 84 84 | from typing_extensions import SupportsIndex
 85 85 | 
 86 86 | # Ok: `typing_extensions` contains backported improvements.
@@ -1023,7 +1023,7 @@ UP035.py:90:1: UP035 [*] Import from `typing` instead: `dataclass_transform`
    |
    = help: Import from `typing`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 87 87 | from typing_extensions import NamedTuple
 88 88 | 
 89 89 | # Ok: `typing_extensions` supports `frozen_default` (backported from 3.12).

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_0.py.snap
@@ -12,7 +12,7 @@ UP036_0.py:3:4: UP036 [*] Version block is outdated for minimum Python version
   |
   = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import sys
 2 2 | 
 3   |-if sys.version_info < (3,0):
@@ -35,7 +35,7 @@ UP036_0.py:8:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5  5  | else:
 6  6  |     print("py3")
 7  7  | 
@@ -61,7 +61,7 @@ UP036_0.py:16:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | else:
 14 14 |     print("py3")
 15 15 | 
@@ -82,7 +82,7 @@ UP036_0.py:20:8: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | else: print("PY3!")
 18 18 | 
 19 19 | if True:
@@ -106,7 +106,7 @@ UP036_0.py:25:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 |     else:
 23 23 |         print("PY3")
 24 24 | 
@@ -129,7 +129,7 @@ UP036_0.py:29:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 26 26 | else:
 27 27 |     print("py3")
 28 28 | 
@@ -158,7 +158,7 @@ UP036_0.py:37:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 34 34 |         print("py3")
 35 35 |         print("This the next")
 36 36 | 
@@ -182,7 +182,7 @@ UP036_0.py:45:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 42 42 | 
 43 43 | x = 1
 44 44 | 
@@ -205,7 +205,7 @@ UP036_0.py:53:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 50 50 | 
 51 51 | x = 1
 52 52 | 
@@ -227,7 +227,7 @@ UP036_0.py:56:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 53 53 | if sys.version_info > (3,0): print("py3")
 54 54 | else: print("py2")
 55 55 | 
@@ -250,7 +250,7 @@ UP036_0.py:62:8: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 59 59 |     print("py2")
 60 60 | 
 61 61 | if True:
@@ -274,7 +274,7 @@ UP036_0.py:67:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 64 64 |     else:
 65 65 |         print("py2")
 66 66 | 
@@ -297,7 +297,7 @@ UP036_0.py:73:8: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 70 70 |     print("py3")
 71 71 | 
 72 72 | def f():
@@ -324,7 +324,7 @@ UP036_0.py:86:8: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 83 83 |     def g():
 84 84 |         pass
 85 85 | 
@@ -350,7 +350,7 @@ UP036_0.py:97:8: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 94  94  |         pass
 95  95  | 
 96  96  | if True:
@@ -374,7 +374,7 @@ UP036_0.py:104:4: UP036 [*] Version block is outdated for minimum Python version
     |
     = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 101 101 | 
 102 102 |     # comment
 103 103 | 
@@ -406,7 +406,7 @@ UP036_0.py:116:8: UP036 [*] Version block is outdated for minimum Python version
     |
     = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 113 113 |         print("py3")
 114 114 | 
 115 115 | if True:
@@ -427,7 +427,7 @@ UP036_0.py:122:8: UP036 [*] Version block is outdated for minimum Python version
     |
     = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 119 119 |     print(2+3)
 120 120 | 
 121 121 | if True:
@@ -446,7 +446,7 @@ UP036_0.py:125:8: UP036 [*] Version block is outdated for minimum Python version
     |
     = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 122 122 |     if sys.version_info > (3,): print(3)
 123 123 | 
 124 124 | if True:
@@ -467,7 +467,7 @@ UP036_0.py:130:8: UP036 [*] Version block is outdated for minimum Python version
     |
     = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 127 127 | 
 128 128 | 
 129 129 | if True:
@@ -494,7 +494,7 @@ UP036_0.py:140:4: UP036 [*] Version block is outdated for minimum Python version
     |
     = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 137 137 |         ]
 138 138 | 
 139 139 | 
@@ -521,7 +521,7 @@ UP036_0.py:150:4: UP036 [*] Version block is outdated for minimum Python version
     |
     = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 147 147 |     ]
 148 148 | 
 149 149 | 
@@ -556,7 +556,7 @@ UP036_0.py:163:4: UP036 [*] Version block is outdated for minimum Python version
     |
     = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 160 160 |     ("so is"
 161 161 |      "this for some reason")
 162 162 | 
@@ -577,7 +577,7 @@ UP036_0.py:166:4: UP036 [*] Version block is outdated for minimum Python version
     |
     = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 163 163 | if sys.version_info > (3, 0): expected_error = \
 164 164 |     []
 165 165 | 
@@ -597,7 +597,7 @@ UP036_0.py:168:4: UP036 [*] Version block is outdated for minimum Python version
     |
     = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 165 165 | 
 166 166 | if sys.version_info > (3, 0): expected_error = []
 167 167 | 
@@ -617,7 +617,7 @@ UP036_0.py:172:8: UP036 [*] Version block is outdated for minimum Python version
     |
     = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 169 169 |     expected_error = []
 170 170 | 
 171 171 | if True:
@@ -637,7 +637,7 @@ UP036_0.py:176:8: UP036 [*] Version block is outdated for minimum Python version
     |
     = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 173 173 |     []
 174 174 | 
 175 175 | if True:
@@ -656,7 +656,7 @@ UP036_0.py:179:8: UP036 [*] Version block is outdated for minimum Python version
     |
     = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 176 176 |     if sys.version_info > (3, 0): expected_error = []
 177 177 | 
 178 178 | if True:
@@ -675,7 +675,7 @@ UP036_0.py:182:4: UP036 [*] Version block is outdated for minimum Python version
     |
     = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 179 179 |     if sys.version_info > (3, 0): \
 180 180 |     expected_error = []
 181 181 | 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_1.py.snap
@@ -12,7 +12,7 @@ UP036_1.py:3:4: UP036 [*] Version block is outdated for minimum Python version
   |
   = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import sys
 2 2 | 
 3   |-if sys.version_info == 2:
@@ -35,7 +35,7 @@ UP036_1.py:8:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5  5  | else:
 6  6  |     3
 7  7  | 
@@ -59,7 +59,7 @@ UP036_1.py:13:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | else:
 11 11 |     3
 12 12 | 
@@ -83,7 +83,7 @@ UP036_1.py:18:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | else:
 16 16 |     3
 17 17 | 
@@ -107,7 +107,7 @@ UP036_1.py:23:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 | else:
 21 21 |     2
 22 22 | 
@@ -131,7 +131,7 @@ UP036_1.py:28:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 25 25 | else:
 26 26 |     2
 27 27 | 
@@ -155,7 +155,7 @@ UP036_1.py:35:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 32 32 | 
 33 33 | from sys import version_info
 34 34 | 
@@ -179,7 +179,7 @@ UP036_1.py:42:6: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 39 39 | 
 40 40 | if True:
 41 41 |     print(1)
@@ -200,7 +200,7 @@ UP036_1.py:49:6: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 | 
 47 47 | if True:
 48 48 |     print(1)
@@ -223,7 +223,7 @@ UP036_1.py:56:6: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 53 53 | 
 54 54 | if True:
 55 55 |     print(1)
@@ -243,7 +243,7 @@ UP036_1.py:62:10: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 59 59 | def f():
 60 60 |     if True:
 61 61 |         print(1)
@@ -264,7 +264,7 @@ UP036_1.py:67:6: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 64 64 | 
 65 65 | if True:
 66 66 |     print(1)
@@ -284,7 +284,7 @@ UP036_1.py:75:10: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 72 72 | def f():
 73 73 |     if True:
 74 74 |         print(1)

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_2.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_2.py.snap
@@ -12,7 +12,7 @@ UP036_2.py:4:4: UP036 [*] Version block is outdated for minimum Python version
   |
   = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import sys
 2 2 | from sys import version_info
 3 3 | 
@@ -36,7 +36,7 @@ UP036_2.py:9:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | else:
 7  7  |     3-5
 8  8  | 
@@ -60,7 +60,7 @@ UP036_2.py:14:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | else:
 12 12 |     3-5
 13 13 | 
@@ -84,7 +84,7 @@ UP036_2.py:19:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | else:
 17 17 |     3-5
 18 18 | 
@@ -108,7 +108,7 @@ UP036_2.py:24:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | else:
 22 22 |     3-5
 23 23 | 
@@ -132,7 +132,7 @@ UP036_2.py:29:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 26 26 | else:
 27 27 |     3+6
 28 28 | 
@@ -156,7 +156,7 @@ UP036_2.py:34:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 31 31 | else:
 32 32 |     3+6
 33 33 | 
@@ -179,7 +179,7 @@ UP036_2.py:39:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 36 36 | else:
 37 37 |     3+6
 38 38 | 
@@ -200,7 +200,7 @@ UP036_2.py:42:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 39 39 | if sys.version_info >= (3, 5):
 40 40 |     pass
 41 41 | 
@@ -219,7 +219,7 @@ UP036_2.py:46:8: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 43 43 |     pass
 44 44 | 
 45 45 | if True:
@@ -241,7 +241,7 @@ UP036_2.py:49:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 |     if sys.version_info < (3,0):
 47 47 |         pass
 48 48 | 
@@ -264,7 +264,7 @@ UP036_2.py:54:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 51 51 | elif False:
 52 52 |     pass
 53 53 | 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_3.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_3.py.snap
@@ -12,7 +12,7 @@ UP036_3.py:3:15: UP036 [*] Version block is outdated for minimum Python version
   |
   = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | import sys
 2  2  | 
 3     |-if            sys.version_info < (3,0):
@@ -40,7 +40,7 @@ UP036_3.py:13:19: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 |         print(f"PY3-{item}")
 11 11 | 
 12 12 | if False:
@@ -67,7 +67,7 @@ UP036_3.py:23:15: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 |             print(f"PY3-{item}")
 21 21 | 
 22 22 | 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_4.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_4.py.snap
@@ -10,7 +10,7 @@ UP036_4.py:4:8: UP036 [*] Version block is outdated for minimum Python version
   |
   = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | import sys
 2 2 | 
 3 3 | if True:
@@ -31,7 +31,7 @@ UP036_4.py:11:10: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | if True:
 9  9  |     if foo:
 10 10 |         print()
@@ -53,7 +53,7 @@ UP036_4.py:17:10: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | if True:
 15 15 |     if foo:
 16 16 |         print()
@@ -73,7 +73,7 @@ UP036_4.py:24:10: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | 
 22 22 |     if foo:
 23 23 |         print()
@@ -94,7 +94,7 @@ UP036_4.py:27:8: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 24 24 |     elif sys.version_info < (3, 3):
 25 25 |         cmd = [sys.executable, "-m", "test.regrtest"]
 26 26 | 
@@ -115,7 +115,7 @@ UP036_4.py:32:10: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 29 29 | 
 30 30 |     if foo:
 31 31 |         print()
@@ -136,7 +136,7 @@ UP036_4.py:37:8: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 34 34 |     else:
 35 35 |         cmd = [sys.executable, "-m", "test", "-j0"]
 36 36 | 
@@ -160,7 +160,7 @@ UP036_4.py:42:8: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 39 39 |     else:
 40 40 |         cmd = [sys.executable, "-m", "test", "-j0"]
 41 41 | 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_5.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_5.py.snap
@@ -12,7 +12,7 @@ UP036_5.py:3:4: UP036 [*] Version block is outdated for minimum Python version
   |
   = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1  1  | import sys
 2  2  | 
 3     |-if sys.version_info < (3, 8):
@@ -41,7 +41,7 @@ UP036_5.py:18:4: UP036 [*] Version block is outdated for minimum Python version
    |
    = help: Remove outdated version block
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | 
 16 16 | import sys
 17 17 | 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP038.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP038.py.snap
@@ -9,7 +9,7 @@ UP038.py:1:1: UP038 [*] Use `X | Y` in `isinstance` call instead of `(X, Y)`
   |
   = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-isinstance(1, (int, float))  # UP038
   1 |+isinstance(1, int | float)  # UP038
 2 2 | issubclass("yes", (int, float, str))  # UP038
@@ -26,7 +26,7 @@ UP038.py:2:1: UP038 [*] Use `X | Y` in `issubclass` call instead of `(X, Y)`
   |
   = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | isinstance(1, (int, float))  # UP038
 2   |-issubclass("yes", (int, float, str))  # UP038
   2 |+issubclass("yes", int | float | str)  # UP038

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__datetime_utc_alias_py311.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__datetime_utc_alias_py311.snap
@@ -10,7 +10,7 @@ UP017.py:7:7: UP017 [*] Use `datetime.UTC` alias
   |
   = help: Convert to `datetime.UTC` alias
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | from datetime import timezone as tz
 5 5 | 
 6 6 | print(datetime.timezone(-1))
@@ -31,7 +31,7 @@ UP017.py:8:7: UP017 [*] Use `datetime.UTC` alias
    |
    = help: Convert to `datetime.UTC` alias
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | 
 6 6 | print(datetime.timezone(-1))
 7 7 | print(timezone.utc)
@@ -51,7 +51,7 @@ UP017.py:10:7: UP017 [*] Use `datetime.UTC` alias
    |
    = help: Convert to `datetime.UTC` alias
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | print(timezone.utc)
 8  8  | print(tz.utc)
 9  9  | 
@@ -67,7 +67,7 @@ UP017.py:11:7: UP017 [*] Use `datetime.UTC` alias
    |
    = help: Convert to `datetime.UTC` alias
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | print(tz.utc)
 9  9  | 
 10 10 | print(datetime.timezone.utc)

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__future_annotations_pep_604_p37.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__future_annotations_pep_604_p37.snap
@@ -10,7 +10,7 @@ future_annotations.py:40:4: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 37 37 |     return y
 38 38 | 
 39 39 | 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__future_annotations_pep_604_py310.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__future_annotations_pep_604_py310.snap
@@ -10,7 +10,7 @@ future_annotations.py:40:4: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 37 37 |     return y
 38 38 | 
 39 39 | 
@@ -28,7 +28,7 @@ future_annotations.py:42:21: UP007 [*] Use `X | Y` for type annotations
    |
    = help: Convert to `X | Y`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 39 39 | 
 40 40 | x: Optional[int] = None
 41 41 | 

--- a/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
@@ -113,7 +113,7 @@ pub(crate) fn check_and_remove_from_set(checker: &mut Checker, if_stmt: &ast::St
         if_stmt.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::suggested(Edit::replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::replacement(
             make_suggestion(check_set, check_element, checker.generator()),
             if_stmt.start(),
             if_stmt.end(),

--- a/crates/ruff_linter/src/rules/refurb/rules/delete_full_slice.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/delete_full_slice.rs
@@ -71,7 +71,7 @@ pub(crate) fn delete_full_slice(checker: &mut Checker, delete: &ast::StmtDelete)
         // Fix is only supported for single-target deletions.
         if checker.patch(diagnostic.kind.rule()) && delete.targets.len() == 1 {
             let replacement = generate_method_call(name, "clear", checker.generator());
-            diagnostic.set_fix(Fix::suggested(Edit::replacement(
+            diagnostic.set_fix(Fix::automatic_unsafe(Edit::replacement(
                 replacement,
                 delete.start(),
                 delete.end(),

--- a/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
@@ -95,7 +95,7 @@ pub(crate) fn no_implicit_cwd(checker: &mut Checker, call: &ExprCall) {
                 call.start(),
                 checker.semantic(),
             )?;
-            Ok(Fix::suggested_edits(
+            Ok(Fix::automatic_unsafe_edits(
                 Edit::range_replacement(format!("{binding}.cwd()"), call.range()),
                 [import_edit],
             ))

--- a/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
@@ -91,7 +91,7 @@ pub(crate) fn print_empty_string(checker: &mut Checker, call: &ast::ExprCall) {
             let mut diagnostic = Diagnostic::new(PrintEmptyString { reason }, call.range());
 
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::suggested(Edit::replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::replacement(
                     generate_suggestion(call, Separator::Remove, checker.generator()),
                     call.start(),
                     call.end(),
@@ -113,7 +113,7 @@ pub(crate) fn print_empty_string(checker: &mut Checker, call: &ast::ExprCall) {
                 );
 
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::suggested(Edit::replacement(
+                    diagnostic.set_fix(Fix::automatic_unsafe(Edit::replacement(
                         generate_suggestion(call, Separator::Remove, checker.generator()),
                         call.start(),
                         call.end(),
@@ -178,7 +178,7 @@ pub(crate) fn print_empty_string(checker: &mut Checker, call: &ast::ExprCall) {
             );
 
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::suggested(Edit::replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::replacement(
                     generate_suggestion(call, separator, checker.generator()),
                     call.start(),
                     call.end(),

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
@@ -147,7 +147,7 @@ pub(crate) fn reimplemented_starmap(checker: &mut Checker, target: &StarmapCandi
                 target.try_make_suggestion(starmap_name, &comprehension.iter, func, checker)?,
                 target.range(),
             );
-            Ok(Fix::suggested_edits(import_edit, [main_edit]))
+            Ok(Fix::automatic_unsafe_edits(import_edit, [main_edit]))
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/refurb/rules/repeated_append.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/repeated_append.rs
@@ -108,7 +108,7 @@ pub(crate) fn repeated_append(checker: &mut Checker, stmt: &Stmt) {
             // We only suggest a fix when all appends in a group are clumped together. If they're
             // non-consecutive, fixing them is much more difficult.
             if checker.patch(diagnostic.kind.rule()) && group.is_consecutive {
-                diagnostic.set_fix(Fix::suggested(Edit::replacement(
+                diagnostic.set_fix(Fix::automatic_unsafe(Edit::replacement(
                     replacement,
                     group.start(),
                     group.end(),

--- a/crates/ruff_linter/src/rules/refurb/rules/slice_copy.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/slice_copy.rs
@@ -63,7 +63,7 @@ pub(crate) fn slice_copy(checker: &mut Checker, subscript: &ast::ExprSubscript) 
     let mut diagnostic = Diagnostic::new(SliceCopy, subscript.range());
     if checker.patch(diagnostic.kind.rule()) {
         let replacement = generate_method_call(name, "copy", checker.generator());
-        diagnostic.set_fix(Fix::suggested(Edit::replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::replacement(
             replacement,
             subscript.start(),
             subscript.end(),

--- a/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
@@ -149,7 +149,7 @@ pub(crate) fn unnecessary_enumerate(checker: &mut Checker, stmt_for: &ast::StmtF
                     ),
                     stmt_for.target.range(),
                 );
-                diagnostic.set_fix(Fix::suggested_edits(replace_iter, [replace_target]));
+                diagnostic.set_fix(Fix::automatic_unsafe_edits(replace_iter, [replace_target]));
             }
 
             checker.diagnostics.push(diagnostic);
@@ -212,7 +212,7 @@ pub(crate) fn unnecessary_enumerate(checker: &mut Checker, stmt_for: &ast::StmtF
                         stmt_for.target.range(),
                     );
 
-                    diagnostic.set_fix(Fix::suggested_edits(replace_iter, [replace_target]));
+                    diagnostic.set_fix(Fix::automatic_unsafe_edits(replace_iter, [replace_target]));
                 }
             }
             checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB105_FURB105.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB105_FURB105.py.snap
@@ -12,7 +12,7 @@ FURB105.py:3:1: FURB105 [*] Unnecessary empty string passed to `print`
   |
   = help: Remove empty string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # Errors.
 2 2 | 
 3   |-print("")
@@ -31,7 +31,7 @@ FURB105.py:4:1: FURB105 [*] Unnecessary empty string and separator passed to `pr
   |
   = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # Errors.
 2 2 | 
 3 3 | print("")
@@ -52,7 +52,7 @@ FURB105.py:5:1: FURB105 [*] Unnecessary empty string passed to `print`
   |
   = help: Remove empty string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | 
 3 3 | print("")
 4 4 | print("", sep=",")
@@ -73,7 +73,7 @@ FURB105.py:6:1: FURB105 [*] Unnecessary empty string and separator passed to `pr
   |
   = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | print("")
 4 4 | print("", sep=",")
 5 5 | print("", end="bar")
@@ -94,7 +94,7 @@ FURB105.py:7:1: FURB105 [*] Unnecessary separator passed to `print`
   |
   = help: Remove separator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | print("", sep=",")
 5 5 | print("", end="bar")
 6 6 | print("", sep=",", end="bar")
@@ -115,7 +115,7 @@ FURB105.py:8:1: FURB105 [*] Unnecessary empty string and separator passed to `pr
    |
    = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | print("", end="bar")
 6 6 | print("", sep=",", end="bar")
 7 7 | print(sep="")
@@ -136,7 +136,7 @@ FURB105.py:9:1: FURB105 [*] Unnecessary empty string and separator passed to `pr
    |
    = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | print("", sep=",", end="bar")
 7  7  | print(sep="")
 8  8  | print("", sep="")
@@ -157,7 +157,7 @@ FURB105.py:10:1: FURB105 [*] Unnecessary empty string and separator passed to `p
    |
    = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 7  7  | print(sep="")
 8  8  | print("", sep="")
 9  9  | print("", "", sep="")
@@ -178,7 +178,7 @@ FURB105.py:11:1: FURB105 [*] Unnecessary empty string and separator passed to `p
    |
    = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | print("", sep="")
 9  9  | print("", "", sep="")
 10 10 | print("", "", sep="", end="")
@@ -199,7 +199,7 @@ FURB105.py:12:1: FURB105 [*] Unnecessary empty string and separator passed to `p
    |
    = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | print("", "", sep="")
 10 10 | print("", "", sep="", end="")
 11 11 | print("", "", sep="", end="bar")
@@ -220,7 +220,7 @@ FURB105.py:13:1: FURB105 [*] Unnecessary separator passed to `print`
    |
    = help: Remove separator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 | print("", "", sep="", end="")
 11 11 | print("", "", sep="", end="bar")
 12 12 | print("", sep="", end="bar")
@@ -241,7 +241,7 @@ FURB105.py:14:1: FURB105 [*] Unnecessary empty string and separator passed to `p
    |
    = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | print("", "", sep="", end="bar")
 12 12 | print("", sep="", end="bar")
 13 13 | print(sep="", end="bar")
@@ -262,7 +262,7 @@ FURB105.py:15:1: FURB105 [*] Unnecessary empty string and separator passed to `p
    |
    = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | print("", sep="", end="bar")
 13 13 | print(sep="", end="bar")
 14 14 | print("", "foo", sep="")
@@ -283,7 +283,7 @@ FURB105.py:16:1: FURB105 [*] Unnecessary empty string passed to `print`
    |
    = help: Remove empty string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | print(sep="", end="bar")
 14 14 | print("", "foo", sep="")
 15 15 | print("foo", "", sep="")
@@ -304,7 +304,7 @@ FURB105.py:18:1: FURB105 [*] Unnecessary empty string passed to `print`
    |
    = help: Remove empty string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | print("foo", "", sep="")
 16 16 | print("foo", "", "bar", sep="")
 17 17 | print("", *args)
@@ -324,7 +324,7 @@ FURB105.py:19:1: FURB105 [*] Unnecessary empty string passed to `print`
    |
    = help: Remove empty string
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | print("foo", "", "bar", sep="")
 17 17 | print("", *args)
 18 18 | print("", *args, sep="")
@@ -345,7 +345,7 @@ FURB105.py:20:1: FURB105 [*] Unnecessary separator passed to `print`
    |
    = help: Remove separator
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | print("", *args)
 18 18 | print("", *args, sep="")
 19 19 | print("", **kwargs)

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB113_FURB113.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB113_FURB113.py.snap
@@ -11,7 +11,7 @@ FURB113.py:23:1: FURB113 [*] Use `nums.extend((1, 2))` instead of repeatedly cal
    |
    = help: Replace with `nums.extend((1, 2))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 | 
 21 21 | 
 22 22 | # FURB113
@@ -32,7 +32,7 @@ FURB113.py:29:1: FURB113 [*] Use `nums3.extend((1, 2))` instead of repeatedly ca
    |
    = help: Replace with `nums3.extend((1, 2))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 26 26 | 
 27 27 | 
 28 28 | # FURB113
@@ -53,7 +53,7 @@ FURB113.py:35:1: FURB113 [*] Use `nums4.extend((1, 2))` instead of repeatedly ca
    |
    = help: Replace with `nums4.extend((1, 2))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 32 32 | 
 33 33 | 
 34 34 | # FURB113
@@ -118,7 +118,7 @@ FURB113.py:56:1: FURB113 [*] Use `nums4.extend((1, 2))` instead of repeatedly ca
    |
    = help: Replace with `nums4.extend((1, 2))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 53 53 | nums3.append(1)
 54 54 | nums.append(3)
 55 55 | # FURB113
@@ -139,7 +139,7 @@ FURB113.py:62:1: FURB113 [*] Use `nums.extend((1, 2, 3))` instead of repeatedly 
    |
    = help: Replace with `nums.extend((1, 2, 3))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 59 59 | pass
 60 60 | 
 61 61 | # FURB113
@@ -162,7 +162,7 @@ FURB113.py:69:5: FURB113 [*] Use `nums.extend((1, 2))` instead of repeatedly cal
    |
    = help: Replace with `nums.extend((1, 2))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 66 66 | 
 67 67 | if True:
 68 68 |     # FURB113
@@ -185,7 +185,7 @@ FURB113.py:75:5: FURB113 [*] Use `nums.extend((1, 2))` instead of repeatedly cal
    |
    = help: Replace with `nums.extend((1, 2))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 72 72 | 
 73 73 | if True:
 74 74 |     # FURB113
@@ -220,7 +220,7 @@ FURB113.py:90:5: FURB113 [*] Use `x.extend((1, 2))` instead of repeatedly callin
    |
    = help: Replace with `x.extend((1, 2))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 87 87 | 
 88 88 | def yes_one(x: list[int]):
 89 89 |     # FURB113
@@ -242,7 +242,7 @@ FURB113.py:96:5: FURB113 [*] Use `x.extend((1, 2))` instead of repeatedly callin
    |
    = help: Replace with `x.extend((1, 2))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 93 93 | 
 94 94 | def yes_two(x: List[int]):
 95 95 |     # FURB113
@@ -264,7 +264,7 @@ FURB113.py:102:5: FURB113 [*] Use `x.extend((1, 2))` instead of repeatedly calli
     |
     = help: Replace with `x.extend((1, 2))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 99  99  | 
 100 100 | def yes_three(*, x: list[int]):
 101 101 |     # FURB113
@@ -286,7 +286,7 @@ FURB113.py:108:5: FURB113 [*] Use `x.extend((1, 2))` instead of repeatedly calli
     |
     = help: Replace with `x.extend((1, 2))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 105 105 | 
 106 106 | def yes_four(x: list[int], /):
 107 107 |     # FURB113
@@ -321,7 +321,7 @@ FURB113.py:122:5: FURB113 [*] Use `x.extend((1, 2))` instead of repeatedly calli
     |
     = help: Replace with `x.extend((1, 2))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 119 119 | 
 120 120 | def yes_six(x: list):
 121 121 |     # FURB113

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB131_FURB131.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB131_FURB131.py.snap
@@ -9,7 +9,7 @@ FURB131.py:11:1: FURB131 [*] Prefer `clear` over deleting a full slice
    |
    = help: Replace with `clear()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | # these should match
 9  9  | 
 10 10 | # FURB131
@@ -27,7 +27,7 @@ FURB131.py:15:1: FURB131 [*] Prefer `clear` over deleting a full slice
    |
    = help: Replace with `clear()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | 
 13 13 | 
 14 14 | # FURB131
@@ -62,7 +62,7 @@ FURB131.py:28:5: FURB131 [*] Prefer `clear` over deleting a full slice
    |
    = help: Replace with `clear()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 25 25 | 
 26 26 | def yes_one(x: list[int]):
 27 27 |     # FURB131
@@ -81,7 +81,7 @@ FURB131.py:33:5: FURB131 [*] Prefer `clear` over deleting a full slice
    |
    = help: Replace with `clear()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 30 30 | 
 31 31 | def yes_two(x: dict[int, str]):
 32 32 |     # FURB131
@@ -100,7 +100,7 @@ FURB131.py:38:5: FURB131 [*] Prefer `clear` over deleting a full slice
    |
    = help: Replace with `clear()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 35 35 | 
 36 36 | def yes_three(x: List[int]):
 37 37 |     # FURB131
@@ -119,7 +119,7 @@ FURB131.py:43:5: FURB131 [*] Prefer `clear` over deleting a full slice
    |
    = help: Replace with `clear()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 40 40 | 
 41 41 | def yes_four(x: Dict[int, str]):
 42 42 |     # FURB131

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB132_FURB132.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB132_FURB132.py.snap
@@ -10,7 +10,7 @@ FURB132.py:12:1: FURB132 [*] Use `s.discard("x")` instead of check and `remove`
    |
    = help: Replace with `s.discard("x")`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 9  9  | # these should match
 10 10 | 
 11 11 | # FURB132
@@ -30,7 +30,7 @@ FURB132.py:22:1: FURB132 [*] Use `s3.discard("x")` instead of check and `remove`
    |
    = help: Replace with `s3.discard("x")`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | 
 20 20 | 
 21 21 | # FURB132
@@ -51,7 +51,7 @@ FURB132.py:28:1: FURB132 [*] Use `s.discard(var)` instead of check and `remove`
    |
    = help: Replace with `s.discard(var)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 25 25 | 
 26 26 | var = "y"
 27 27 | # FURB132
@@ -70,7 +70,7 @@ FURB132.py:32:1: FURB132 [*] Use `s.discard(f"{var}:{var}")` instead of check an
    |
    = help: Replace with `s.discard(f"{var}:{var}")`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 29 29 |     s.remove(var)
 30 30 | 
 31 31 | 

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB140_FURB140.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB140_FURB140.py.snap
@@ -11,7 +11,7 @@ FURB140.py:7:1: FURB140 [*] Use `itertools.starmap` instead of the generator
   |
   = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Unsafe fix
   1 |+from itertools import starmap
 1 2 | def zipped():
 2 3 |     return zip([1, 2, 3], "ABC")
@@ -35,7 +35,7 @@ FURB140.py:10:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+from itertools import starmap
 1  2  | def zipped():
 2  3  |     return zip([1, 2, 3], "ABC")
@@ -58,7 +58,7 @@ FURB140.py:13:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+from itertools import starmap
 1  2  | def zipped():
 2  3  |     return zip([1, 2, 3], "ABC")
@@ -83,7 +83,7 @@ FURB140.py:19:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | from itertools import starmap as sm
 17 17 | 
 18 18 | # FURB140
@@ -103,7 +103,7 @@ FURB140.py:22:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | [print(x, y) for x, y in zipped()]
 20 20 | 
 21 21 | # FURB140
@@ -123,7 +123,7 @@ FURB140.py:25:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | (print(x, y) for x, y in zipped())
 23 23 | 
 24 24 | # FURB140
@@ -144,7 +144,7 @@ FURB140.py:29:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 26 26 | 
 27 27 | # FURB140 (check it still flags starred arguments).
 28 28 | # See https://github.com/astral-sh/ruff/issues/7636
@@ -164,7 +164,7 @@ FURB140.py:30:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 | # FURB140 (check it still flags starred arguments).
 28 28 | # See https://github.com/astral-sh/ruff/issues/7636
 29 29 | [foo(*t) for t in [(85, 60), (100, 80)]]
@@ -185,7 +185,7 @@ FURB140.py:31:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 28 28 | # See https://github.com/astral-sh/ruff/issues/7636
 29 29 | [foo(*t) for t in [(85, 60), (100, 80)]]
 30 30 | (foo(*t) for t in [(85, 60), (100, 80)])

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB145_FURB145.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB145_FURB145.py.snap
@@ -11,7 +11,7 @@ FURB145.py:4:5: FURB145 [*] Prefer `copy` method over slicing
   |
   = help: Replace with `copy()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | l = [1, 2, 3, 4, 5]
 2 2 | 
 3 3 | # Errors.
@@ -32,7 +32,7 @@ FURB145.py:5:11: FURB145 [*] Prefer `copy` method over slicing
   |
   = help: Replace with `copy()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | 
 3 3 | # Errors.
 4 4 | a = l[:]
@@ -53,7 +53,7 @@ FURB145.py:6:8: FURB145 [*] Prefer `copy` method over slicing
   |
   = help: Replace with `copy()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | # Errors.
 4 4 | a = l[:]
 5 5 | b, c = 1, l[:]
@@ -74,7 +74,7 @@ FURB145.py:7:5: FURB145 [*] Prefer `copy` method over slicing
   |
   = help: Replace with `copy()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | a = l[:]
 5 5 | b, c = 1, l[:]
 6 6 | d, e = l[:], 1
@@ -94,7 +94,7 @@ FURB145.py:8:1: FURB145 [*] Prefer `copy` method over slicing
   |
   = help: Replace with `copy()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | b, c = 1, l[:]
 6 6 | d, e = l[:], 1
 7 7 | m = l[::]
@@ -115,7 +115,7 @@ FURB145.py:9:7: FURB145 [*] Prefer `copy` method over slicing
    |
    = help: Replace with `copy()`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  | d, e = l[:], 1
 7  7  | m = l[::]
 8  8  | l[:]

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB148_FURB148.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB148_FURB148.py.snap
@@ -10,7 +10,7 @@ FURB148.py:14:17: FURB148 [*] `enumerate` value is unused, use `for x in range(l
    |
    = help: Replace with `range(len(...))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | books_tuple = ("Dune", "Foundation", "Neuromancer")
 12 12 | 
 13 13 | # Errors
@@ -30,7 +30,7 @@ FURB148.py:17:17: FURB148 [*] `enumerate` value is unused, use `for x in range(l
    |
    = help: Replace with `range(len(...))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | for index, _ in enumerate(books):
 15 15 |     print(index)
 16 16 | 
@@ -50,7 +50,7 @@ FURB148.py:20:17: FURB148 [*] `enumerate` value is unused, use `for x in range(l
    |
    = help: Replace with `range(len(...))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | for index, _ in enumerate(books, start=0):
 18 18 |     print(index)
 19 19 | 
@@ -110,7 +110,7 @@ FURB148.py:35:16: FURB148 [*] `enumerate` index is unused, use `for x in y` inst
    |
    = help: Remove `enumerate`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 32 32 | for index, _ in enumerate(books, x):
 33 33 |     print(book)
 34 34 | 
@@ -130,7 +130,7 @@ FURB148.py:38:16: FURB148 [*] `enumerate` index is unused, use `for x in y` inst
    |
    = help: Remove `enumerate`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 35 35 | for _, book in enumerate(books):
 36 36 |     print(book)
 37 37 | 
@@ -150,7 +150,7 @@ FURB148.py:41:16: FURB148 [*] `enumerate` index is unused, use `for x in y` inst
    |
    = help: Remove `enumerate`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 38 38 | for _, book in enumerate(books, start=0):
 39 39 |     print(book)
 40 40 | 
@@ -170,7 +170,7 @@ FURB148.py:44:16: FURB148 [*] `enumerate` index is unused, use `for x in y` inst
    |
    = help: Remove `enumerate`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 | for _, book in enumerate(books, 0):
 42 42 |     print(book)
 43 43 | 
@@ -190,7 +190,7 @@ FURB148.py:47:16: FURB148 [*] `enumerate` index is unused, use `for x in y` inst
    |
    = help: Remove `enumerate`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 44 44 | for _, book in enumerate(books, start=1):
 45 45 |     print(book)
 46 46 | 
@@ -210,7 +210,7 @@ FURB148.py:50:16: FURB148 [*] `enumerate` index is unused, use `for x in y` inst
    |
    = help: Remove `enumerate`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 47 47 | for _, book in enumerate(books, 1):
 48 48 |     print(book)
 49 49 | 
@@ -230,7 +230,7 @@ FURB148.py:53:16: FURB148 [*] `enumerate` index is unused, use `for x in y` inst
    |
    = help: Remove `enumerate`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 50 50 | for _, book in enumerate(books, start=x):
 51 51 |     print(book)
 52 52 | 
@@ -250,7 +250,7 @@ FURB148.py:56:22: FURB148 [*] `enumerate` value is unused, use `for x in range(l
    |
    = help: Replace with `range(len(...))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 53 53 | for _, book in enumerate(books, x):
 54 54 |     print(book)
 55 55 | 
@@ -270,7 +270,7 @@ FURB148.py:59:21: FURB148 [*] `enumerate` index is unused, use `for x in y` inst
    |
    = help: Remove `enumerate`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 56 56 | for index, (_, _) in enumerate(books):
 57 57 |     print(index)
 58 58 | 
@@ -290,7 +290,7 @@ FURB148.py:62:17: FURB148 [*] `enumerate` value is unused, use `for x in range(l
    |
    = help: Replace with `range(len(...))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 59 59 | for (_, _), book in enumerate(books):
 60 60 |     print(book)
 61 61 | 
@@ -310,7 +310,7 @@ FURB148.py:65:18: FURB148 [*] `enumerate` value is unused, use `for x in range(l
    |
    = help: Replace with `range(len(...))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 62 62 | for(index, _)in enumerate(books):
 63 63 |     print(index)
 64 64 | 
@@ -330,7 +330,7 @@ FURB148.py:68:17: FURB148 [*] `enumerate` value is unused, use `for x in range(l
    |
    = help: Replace with `range(len(...))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 65 65 | for(index), _ in enumerate(books):
 66 66 |     print(index)
 67 67 | 
@@ -350,7 +350,7 @@ FURB148.py:71:16: FURB148 [*] `enumerate` index is unused, use `for x in y` inst
    |
    = help: Remove `enumerate`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 68 68 | for index, _ in enumerate(books_and_authors):
 69 69 |     print(index)
 70 70 | 
@@ -370,7 +370,7 @@ FURB148.py:74:17: FURB148 [*] `enumerate` value is unused, use `for x in range(l
    |
    = help: Replace with `range(len(...))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 71 71 | for _, book in enumerate(books_and_authors):
 72 72 |     print(book)
 73 73 | 
@@ -390,7 +390,7 @@ FURB148.py:77:16: FURB148 [*] `enumerate` index is unused, use `for x in y` inst
    |
    = help: Remove `enumerate`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 74 74 | for index, _ in enumerate(books_set):
 75 75 |     print(index)
 76 76 | 
@@ -410,7 +410,7 @@ FURB148.py:80:17: FURB148 [*] `enumerate` value is unused, use `for x in range(l
    |
    = help: Replace with `range(len(...))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 77 77 | for _, book in enumerate(books_set):
 78 78 |     print(book)
 79 79 | 
@@ -430,7 +430,7 @@ FURB148.py:83:16: FURB148 [*] `enumerate` index is unused, use `for x in y` inst
    |
    = help: Remove `enumerate`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 80 80 | for index, _ in enumerate(books_tuple):
 81 81 |     print(index)
 82 82 | 

--- a/crates/ruff_linter/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -202,7 +202,7 @@ pub(crate) fn collection_literal_concatenation(checker: &mut Checker, expr: &Exp
         if !checker.indexer().has_comments(expr, checker.locator()) {
             // This suggestion could be unsafe if the non-literal expression in the
             // expression has overridden the `__add__` (or `__radd__`) magic methods.
-            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                 contents,
                 expr.range(),
             )));

--- a/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -160,7 +160,7 @@ fn convert_call_to_conversion_flag(
         formatted_string_expression.expression = call.args[0].value.clone();
         Ok(expression)
     })
-    .map(|output| Fix::automatic(Edit::range_replacement(output, expr.range())))
+    .map(|output| Fix::automatic_safe(Edit::range_replacement(output, expr.range())))
 }
 
 /// Return the [`FormattedStringContent`] at the given index in an f-string or implicit

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -134,7 +134,7 @@ fn generate_fix(checker: &Checker, conversion_type: ConversionType, expr: &Expr)
                 range: TextRange::default(),
             });
             let content = checker.generator().expr(&new_expr);
-            Ok(Fix::suggested(Edit::range_replacement(
+            Ok(Fix::automatic_unsafe(Edit::range_replacement(
                 content,
                 expr.range(),
             )))
@@ -156,7 +156,7 @@ fn generate_fix(checker: &Checker, conversion_type: ConversionType, expr: &Expr)
                 ctx: ast::ExprContext::Load,
             });
             let content = checker.generator().expr(&new_expr);
-            Ok(Fix::suggested_edits(
+            Ok(Fix::automatic_unsafe_edits(
                 Edit::range_replacement(content, expr.range()),
                 [import_edit],
             ))

--- a/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
@@ -112,7 +112,7 @@ fn convert_to_reduce(iterable: &Expr, call: &ast::ExprCall, checker: &Checker) -
         .unwrap_or(iterable.range()),
     );
 
-    Ok(Fix::suggested_edits(
+    Ok(Fix::automatic_unsafe_edits(
         Edit::range_replacement(
             format!("{reduce_binding}({iadd_binding}, {iterable}, [])"),
             call.range(),

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
@@ -97,7 +97,7 @@ pub(crate) fn unnecessary_iterable_allocation_for_first_element(
     );
 
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+        diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
             format!("next({iterable})"),
             *range,
         )));

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__PY39_RUF013_RUF013_0.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__PY39_RUF013_RUF013_0.py.snap
@@ -9,7 +9,7 @@ RUF013_0.py:21:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 |     pass
 19 19 | 
 20 20 | 
@@ -27,7 +27,7 @@ RUF013_0.py:25:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 |     pass
 23 23 | 
 24 24 | 
@@ -45,7 +45,7 @@ RUF013_0.py:29:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 26 26 |     pass
 27 27 | 
 28 28 | 
@@ -63,7 +63,7 @@ RUF013_0.py:33:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 30 30 |     pass
 31 31 | 
 32 32 | 
@@ -81,7 +81,7 @@ RUF013_0.py:71:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 68 68 |     pass
 69 69 | 
 70 70 | 
@@ -99,7 +99,7 @@ RUF013_0.py:75:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 72 72 |     pass
 73 73 | 
 74 74 | 
@@ -117,7 +117,7 @@ RUF013_0.py:79:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 76 76 |     pass
 77 77 | 
 78 78 | 
@@ -135,7 +135,7 @@ RUF013_0.py:83:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 80 80 |     pass
 81 81 | 
 82 82 | 
@@ -153,7 +153,7 @@ RUF013_0.py:102:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 99  99  |     pass
 100 100 | 
 101 101 | 
@@ -171,7 +171,7 @@ RUF013_0.py:106:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 103 103 |     pass
 104 104 | 
 105 105 | 
@@ -189,7 +189,7 @@ RUF013_0.py:125:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 122 122 |     pass
 123 123 | 
 124 124 | 
@@ -207,7 +207,7 @@ RUF013_0.py:129:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 126 126 |     pass
 127 127 | 
 128 128 | 
@@ -225,7 +225,7 @@ RUF013_0.py:133:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 130 130 |     pass
 131 131 | 
 132 132 | 
@@ -243,7 +243,7 @@ RUF013_0.py:152:22: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 149 149 |     pass
 150 150 | 
 151 151 | 
@@ -261,7 +261,7 @@ RUF013_0.py:156:32: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 153 153 |     pass
 154 154 | 
 155 155 | 
@@ -281,7 +281,7 @@ RUF013_0.py:172:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 169 169 | 
 170 170 | 
 171 171 | def f(
@@ -302,7 +302,7 @@ RUF013_0.py:173:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 170 170 | 
 171 171 | def f(
 172 172 |     arg1: int = None,  # RUF013
@@ -323,7 +323,7 @@ RUF013_0.py:174:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 171 171 | def f(
 172 172 |     arg1: int = None,  # RUF013
 173 173 |     arg2: Union[int, float] = None,  # RUF013
@@ -341,7 +341,7 @@ RUF013_0.py:202:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 199 199 |     pass
 200 200 | 
 201 201 | 
@@ -359,7 +359,7 @@ RUF013_0.py:209:13: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 206 206 | # Quoted
 207 207 | 
 208 208 | 
@@ -377,7 +377,7 @@ RUF013_0.py:213:13: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 210 210 |     pass
 211 211 | 
 212 212 | 
@@ -403,7 +403,7 @@ RUF013_0.py:225:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 222 222 |     pass
 223 223 | 
 224 224 | 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__PY39_RUF013_RUF013_1.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__PY39_RUF013_RUF013_1.py.snap
@@ -9,7 +9,7 @@ RUF013_1.py:4:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
   |
   = help: Convert to `Optional[T]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # No `typing.Optional` import
   2 |+from typing import Optional
 2 3 | 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF005_RUF005.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF005_RUF005.py.snap
@@ -52,7 +52,7 @@ RUF005.py:39:7: RUF005 [*] Consider `[1, 2, 3, *foo]` instead of concatenation
    |
    = help: Replace with `[1, 2, 3, *foo]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 36 36 | yay = Fun().yay
 37 37 | 
 38 38 | foo = [4, 5, 6]
@@ -73,7 +73,7 @@ RUF005.py:41:8: RUF005 [*] Consider `(7, 8, 9, *zoob)` instead of concatenation
    |
    = help: Replace with `(7, 8, 9, *zoob)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 38 38 | foo = [4, 5, 6]
 39 39 | bar = [1, 2, 3] + foo
 40 40 | zoob = tuple(bar)
@@ -94,7 +94,7 @@ RUF005.py:42:8: RUF005 [*] Consider `(*quux, 10, 11, 12)` instead of concatenati
    |
    = help: Replace with `(*quux, 10, 11, 12)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 39 39 | bar = [1, 2, 3] + foo
 40 40 | zoob = tuple(bar)
 41 41 | quux = (7, 8, 9) + zoob
@@ -115,7 +115,7 @@ RUF005.py:44:8: RUF005 [*] Consider `[*spom, 13, 14, 15]` instead of concatenati
    |
    = help: Replace with `[*spom, 13, 14, 15]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 41 41 | quux = (7, 8, 9) + zoob
 42 42 | spam = quux + (10, 11, 12)
 43 43 | spom = list(spam)
@@ -136,7 +136,7 @@ RUF005.py:45:13: RUF005 [*] Consider `("we all say", *yay())` instead of concate
    |
    = help: Replace with `("we all say", *yay())`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 42 42 | spam = quux + (10, 11, 12)
 43 43 | spom = list(spam)
 44 44 | eggs = spom + [13, 14, 15]
@@ -156,7 +156,7 @@ RUF005.py:46:14: RUF005 [*] Consider `("we all think", *Fun().yay())` instead of
    |
    = help: Replace with `("we all think", *Fun().yay())`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 43 43 | spom = list(spam)
 44 44 | eggs = spom + [13, 14, 15]
 45 45 | elatement = ("we all say",) + yay()
@@ -177,7 +177,7 @@ RUF005.py:47:16: RUF005 [*] Consider `("we all feel", *Fun.words)` instead of co
    |
    = help: Replace with `("we all feel", *Fun.words)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 44 44 | eggs = spom + [13, 14, 15]
 45 45 | elatement = ("we all say",) + yay()
 46 46 | excitement = ("we all think",) + Fun().yay()
@@ -198,7 +198,7 @@ RUF005.py:49:9: RUF005 [*] Consider iterable unpacking instead of concatenation
    |
    = help: Replace with iterable unpacking
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 | excitement = ("we all think",) + Fun().yay()
 47 47 | astonishment = ("we all feel",) + Fun.words
 48 48 | 
@@ -219,7 +219,7 @@ RUF005.py:49:39: RUF005 [*] Consider `("yes", "no", "pants", *zoob)` instead of 
    |
    = help: Replace with `("yes", "no", "pants", *zoob)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 46 46 | excitement = ("we all think",) + Fun().yay()
 47 47 | astonishment = ("we all feel",) + Fun.words
 48 48 | 
@@ -240,7 +240,7 @@ RUF005.py:51:7: RUF005 [*] Consider `(*zoob,)` instead of concatenation
    |
    = help: Replace with `(*zoob,)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 48 48 | 
 49 49 | chain = ["a", "b", "c"] + eggs + list(("yes", "no", "pants") + zoob)
 50 50 | 
@@ -262,7 +262,7 @@ RUF005.py:53:1: RUF005 [*] Consider `[*foo]` instead of concatenation
    |
    = help: Replace with `[*foo]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 50 50 | 
 51 51 | baz = () + zoob
 52 52 | 
@@ -284,7 +284,7 @@ RUF005.py:56:15: RUF005 [*] Consider `[sys.executable, "-m", "pylint", *args, pa
    |
    = help: Replace with `[sys.executable, "-m", "pylint", *args, path]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 53 53 | [] + foo + [
 54 54 | ]
 55 55 | 
@@ -303,7 +303,7 @@ RUF005.py:57:21: RUF005 [*] Consider iterable unpacking instead of concatenation
    |
    = help: Replace with iterable unpacking
 
-ℹ Suggested fix
+ℹ Unsafe fix
 54 54 | ]
 55 55 | 
 56 56 | pylint_call = [sys.executable, "-m", "pylint"] + args + [path]
@@ -324,7 +324,7 @@ RUF005.py:58:5: RUF005 [*] Consider `[*a, 2, 3, 4]` instead of concatenation
    |
    = help: Replace with `[*a, 2, 3, 4]`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 55 55 | 
 56 56 | pylint_call = [sys.executable, "-m", "pylint"] + args + [path]
 57 57 | pylint_call_tuple = (sys.executable, "-m", "pylint") + args + (path, path2)
@@ -344,7 +344,7 @@ RUF005.py:61:4: RUF005 [*] Consider `[*a(), 'b']` instead of concatenation
    |
    = help: Replace with `[*a(), 'b']`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 58 58 | b = a + [2, 3] + [4]
 59 59 | 
 60 60 | # Uses the non-preferred quote style, which should be retained.

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF013_RUF013_0.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF013_RUF013_0.py.snap
@@ -9,7 +9,7 @@ RUF013_0.py:21:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 |     pass
 19 19 | 
 20 20 | 
@@ -27,7 +27,7 @@ RUF013_0.py:25:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 |     pass
 23 23 | 
 24 24 | 
@@ -45,7 +45,7 @@ RUF013_0.py:29:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 26 26 |     pass
 27 27 | 
 28 28 | 
@@ -63,7 +63,7 @@ RUF013_0.py:33:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 30 30 |     pass
 31 31 | 
 32 32 | 
@@ -81,7 +81,7 @@ RUF013_0.py:71:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 68 68 |     pass
 69 69 | 
 70 70 | 
@@ -99,7 +99,7 @@ RUF013_0.py:75:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 72 72 |     pass
 73 73 | 
 74 74 | 
@@ -117,7 +117,7 @@ RUF013_0.py:79:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 76 76 |     pass
 77 77 | 
 78 78 | 
@@ -135,7 +135,7 @@ RUF013_0.py:83:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
    = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 80 80 |     pass
 81 81 | 
 82 82 | 
@@ -153,7 +153,7 @@ RUF013_0.py:102:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 99  99  |     pass
 100 100 | 
 101 101 | 
@@ -171,7 +171,7 @@ RUF013_0.py:106:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 103 103 |     pass
 104 104 | 
 105 105 | 
@@ -189,7 +189,7 @@ RUF013_0.py:125:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 122 122 |     pass
 123 123 | 
 124 124 | 
@@ -207,7 +207,7 @@ RUF013_0.py:129:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 126 126 |     pass
 127 127 | 
 128 128 | 
@@ -225,7 +225,7 @@ RUF013_0.py:133:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 130 130 |     pass
 131 131 | 
 132 132 | 
@@ -243,7 +243,7 @@ RUF013_0.py:152:22: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 149 149 |     pass
 150 150 | 
 151 151 | 
@@ -261,7 +261,7 @@ RUF013_0.py:156:32: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 153 153 |     pass
 154 154 | 
 155 155 | 
@@ -281,7 +281,7 @@ RUF013_0.py:172:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 169 169 | 
 170 170 | 
 171 171 | def f(
@@ -302,7 +302,7 @@ RUF013_0.py:173:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 170 170 | 
 171 171 | def f(
 172 172 |     arg1: int = None,  # RUF013
@@ -323,7 +323,7 @@ RUF013_0.py:174:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 171 171 | def f(
 172 172 |     arg1: int = None,  # RUF013
 173 173 |     arg2: Union[int, float] = None,  # RUF013
@@ -341,7 +341,7 @@ RUF013_0.py:202:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 199 199 |     pass
 200 200 | 
 201 201 | 
@@ -359,7 +359,7 @@ RUF013_0.py:209:13: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 206 206 | # Quoted
 207 207 | 
 208 208 | 
@@ -377,7 +377,7 @@ RUF013_0.py:213:13: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 210 210 |     pass
 211 211 | 
 212 212 | 
@@ -403,7 +403,7 @@ RUF013_0.py:225:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
     = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 222 222 |     pass
 223 223 | 
 224 224 | 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF013_RUF013_1.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF013_RUF013_1.py.snap
@@ -9,7 +9,7 @@ RUF013_1.py:4:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
   |
   = help: Convert to `T | None`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # No `typing.Optional` import
 2 2 | 
 3 3 | 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF015_RUF015.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF015_RUF015.py.snap
@@ -11,7 +11,7 @@ RUF015.py:4:1: RUF015 [*] Prefer `next(iter(x))` over single element slice
   |
   = help: Replace with `next(iter(x))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | x = range(10)
 2 2 | 
 3 3 | # RUF015
@@ -32,7 +32,7 @@ RUF015.py:5:1: RUF015 [*] Prefer `next(iter(x))` over single element slice
   |
   = help: Replace with `next(iter(x))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | 
 3 3 | # RUF015
 4 4 | list(x)[0]
@@ -52,7 +52,7 @@ RUF015.py:6:1: RUF015 [*] Prefer `next(iter(x))` over single element slice
   |
   = help: Replace with `next(iter(x))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | # RUF015
 4 4 | list(x)[0]
 5 5 | tuple(x)[0]
@@ -73,7 +73,7 @@ RUF015.py:7:1: RUF015 [*] Prefer `next(iter(x))` over single element slice
   |
   = help: Replace with `next(iter(x))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | list(x)[0]
 5 5 | tuple(x)[0]
 6 6 | list(i for i in x)[0]
@@ -93,7 +93,7 @@ RUF015.py:29:1: RUF015 [*] Prefer `next(i + 1 for i in x)` over single element s
    |
    = help: Replace with `next(i + 1 for i in x)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 26 26 | [i for i in x][::]
 27 27 | 
 28 28 | # RUF015 (doesn't mirror the underlying list)
@@ -113,7 +113,7 @@ RUF015.py:30:1: RUF015 [*] Prefer `next(i for i in x if i > 5)` over single elem
    |
    = help: Replace with `next(i for i in x if i > 5)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 27 27 | 
 28 28 | # RUF015 (doesn't mirror the underlying list)
 29 29 | [i + 1 for i in x][0]
@@ -134,7 +134,7 @@ RUF015.py:31:1: RUF015 [*] Prefer `next((i, i + 1) for i in x)` over single elem
    |
    = help: Replace with `next((i, i + 1) for i in x)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 28 28 | # RUF015 (doesn't mirror the underlying list)
 29 29 | [i + 1 for i in x][0]
 30 30 | [i for i in x if i > 5][0]
@@ -155,7 +155,7 @@ RUF015.py:35:1: RUF015 [*] Prefer `next(i + j for i in x for j in y)` over singl
    |
    = help: Replace with `next(i + j for i in x for j in y)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 32 32 | 
 33 33 | # RUF015 (multiple generators)
 34 34 | y = range(10)
@@ -175,7 +175,7 @@ RUF015.py:38:1: RUF015 [*] Prefer `next(iter(range(10)))` over single element sl
    |
    = help: Replace with `next(iter(range(10)))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 35 35 | [i + j for i in x for j in y][0]
 36 36 | 
 37 37 | # RUF015
@@ -195,7 +195,7 @@ RUF015.py:39:1: RUF015 [*] Prefer `next(iter(x.y))` over single element slice
    |
    = help: Replace with `next(iter(x.y))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 36 36 | 
 37 37 | # RUF015
 38 38 | list(range(10))[0]
@@ -216,7 +216,7 @@ RUF015.py:40:1: RUF015 [*] Prefer `next(iter(x["y"]))` over single element slice
    |
    = help: Replace with `next(iter(x["y"]))`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 37 37 | # RUF015
 38 38 | list(range(10))[0]
 39 39 | list(x.y)[0]
@@ -239,7 +239,7 @@ RUF015.py:43:26: RUF015 [*] Prefer `next(...)` over single element slice
    |
    = help: Replace with `next(...)`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 40 40 | list(x["y"])[0]
 41 41 | 
 42 42 | # RUF015 (multi-line)

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF017_RUF017_0.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF017_RUF017_0.py.snap
@@ -11,7 +11,7 @@ RUF017_0.py:5:1: RUF017 [*] Avoid quadratic list summation
   |
   = help: Replace with `functools.reduce`
 
-ℹ Suggested fix
+ℹ Unsafe fix
   1 |+import functools
   2 |+import operator
 1 3 | x = [1, 2, 3]
@@ -35,7 +35,7 @@ RUF017_0.py:6:1: RUF017 [*] Avoid quadratic list summation
   |
   = help: Replace with `functools.reduce`
 
-ℹ Suggested fix
+ℹ Unsafe fix
   1 |+import functools
   2 |+import operator
 1 3 | x = [1, 2, 3]
@@ -60,7 +60,7 @@ RUF017_0.py:7:1: RUF017 [*] Avoid quadratic list summation
   |
   = help: Replace with `functools.reduce`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+import functools
    2  |+import operator
 1  3  | x = [1, 2, 3]
@@ -86,7 +86,7 @@ RUF017_0.py:8:1: RUF017 [*] Avoid quadratic list summation
    |
    = help: Replace with `functools.reduce`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+import functools
    2  |+import operator
 1  3  | x = [1, 2, 3]
@@ -114,7 +114,7 @@ RUF017_0.py:9:1: RUF017 [*] Avoid quadratic list summation
    |
    = help: Replace with `functools.reduce`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+import functools
    2  |+import operator
 1  3  | x = [1, 2, 3]
@@ -140,7 +140,7 @@ RUF017_0.py:21:5: RUF017 [*] Avoid quadratic list summation
    |
    = help: Replace with `functools.reduce`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 | def func():
 19 19 |     import functools, operator
 20 20 | 
@@ -159,7 +159,7 @@ RUF017_0.py:26:5: RUF017 [*] Avoid quadratic list summation
    |
    = help: Replace with `functools.reduce`
 
-ℹ Suggested fix
+ℹ Unsafe fix
    1  |+import functools
    2  |+import operator
 1  3  | x = [1, 2, 3]

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF017_RUF017_1.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF017_RUF017_1.py.snap
@@ -8,7 +8,7 @@ RUF017_1.py:1:1: RUF017 [*] Avoid quadratic list summation
   |
   = help: Replace with `functools.reduce`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-sum((factor.dims for factor in bases), [])
   1 |+import functools
   2 |+import operator

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__noqa.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__noqa.snap
@@ -10,7 +10,7 @@ noqa.py:23:5: F841 [*] Local variable `I` is assigned to but never used
    |
    = help: Remove assignment to unused variable `I`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 | 
 21 21 | def f():
 22 22 |     # Only `E741` should be ignored by the `noqa`.

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
@@ -10,7 +10,7 @@ RUF100_0.py:9:12: RUF100 [*] Unused blanket `noqa` directive
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 6  6  |     b = 2  # noqa: F841
 7  7  | 
 8  8  |     # Invalid
@@ -30,7 +30,7 @@ RUF100_0.py:13:12: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 10 10 |     print(c)
 11 11 | 
 12 12 |     # Invalid
@@ -50,7 +50,7 @@ RUF100_0.py:16:12: RUF100 [*] Unused `noqa` directive (unused: `F841`, `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 |     d = 1  # noqa: E501
 14 14 | 
 15 15 |     # Invalid
@@ -70,7 +70,7 @@ RUF100_0.py:19:12: RUF100 [*] Unused `noqa` directive (unused: `F841`, `W191`; n
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 |     d = 1  # noqa: F841, E501
 17 17 | 
 18 18 |     # Invalid (and unimplemented or not enabled)
@@ -90,7 +90,7 @@ RUF100_0.py:22:12: RUF100 [*] Unused `noqa` directive (unused: `F841`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 |     d = 1  # noqa: F841, W191, F821
 20 20 | 
 21 21 |     # Invalid (but external)
@@ -111,7 +111,7 @@ RUF100_0.py:26:10: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 23 23 | 
 24 24 |     # fmt: off
 25 25 |     # Invalid - no space before #
@@ -130,7 +130,7 @@ RUF100_0.py:29:5: F841 [*] Local variable `d` is assigned to but never used
    |
    = help: Remove assignment to unused variable `d`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 26 26 |     d = 1# noqa: E501
 27 27 | 
 28 28 |     # Invalid - many spaces before #
@@ -148,7 +148,7 @@ RUF100_0.py:29:33: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 26 26 |     d = 1# noqa: E501
 27 27 | 
 28 28 |     # Invalid - many spaces before #
@@ -168,7 +168,7 @@ RUF100_0.py:55:6: RUF100 [*] Unused `noqa` directive (unused: `F841`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 52 52 |     https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533
 53 53 | 
 54 54 | Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -188,7 +188,7 @@ RUF100_0.py:63:6: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 60 60 |     https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533
 61 61 | 
 62 62 | Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.
@@ -208,7 +208,7 @@ RUF100_0.py:71:6: RUF100 [*] Unused blanket `noqa` directive
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 68 68 |     https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533
 69 69 | 
 70 70 | Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.
@@ -254,7 +254,7 @@ RUF100_0.py:90:92: RUF100 [*] Unused `noqa` directive (unused: `F401`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 87 87 | 
 88 88 | print(sys.path)
 89 89 | 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_1.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_1.snap
@@ -32,7 +32,7 @@ RUF100_1.py:52:20: RUF100 [*] Unused `noqa` directive (unused: `F401`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 49 49 | def f():
 50 50 |     # This should ignore the error, but the inner noqa should be marked as unused.
 51 51 |     from typing import (  # noqa: F401
@@ -52,7 +52,7 @@ RUF100_1.py:59:20: RUF100 [*] Unused `noqa` directive (unused: `F401`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 56 56 | def f():
 57 57 |     # This should ignore the error, but the inner noqa should be marked as unused.
 58 58 |     from typing import (  # noqa
@@ -72,7 +72,7 @@ RUF100_1.py:66:16: RUF100 [*] Unused `noqa` directive (non-enabled: `F501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 63 63 | def f():
 64 64 |     # This should ignore the error, but mark F501 as unused.
 65 65 |     from typing import (  # noqa: F401
@@ -93,7 +93,7 @@ RUF100_1.py:72:27: RUF100 [*] Unused `noqa` directive (non-enabled: `F501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 69 69 | 
 70 70 | def f():
 71 71 |     # This should ignore the error, but mark F501 as unused.
@@ -144,7 +144,7 @@ RUF100_1.py:89:55: RUF100 [*] Unused `noqa` directive (non-enabled: `F501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 86 86 | 
 87 87 | def f():
 88 88 |     # This should mark F501 as unused.

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_2.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_2.snap
@@ -8,7 +8,7 @@ RUF100_2.py:1:19: RUF100 [*] Unused `noqa` directive (unused: `F401`)
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-import itertools  # noqa: F401
   1 |+import itertools
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_3.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_3.snap
@@ -10,7 +10,7 @@ RUF100_3.py:1:1: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1   |-# noqa
 2 1 | # noqa # comment
 3 2 | print()  # noqa
@@ -26,7 +26,7 @@ RUF100_3.py:2:1: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # noqa
 2   |-# noqa # comment
   2 |+# comment
@@ -45,7 +45,7 @@ RUF100_3.py:3:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # noqa
 2 2 | # noqa # comment
 3   |-print()  # noqa
@@ -65,7 +65,7 @@ RUF100_3.py:4:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | # noqa
 2 2 | # noqa # comment
 3 3 | print()  # noqa
@@ -86,7 +86,7 @@ RUF100_3.py:5:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | # noqa # comment
 3 3 | print()  # noqa
 4 4 | print()  # noqa # comment
@@ -107,7 +107,7 @@ RUF100_3.py:6:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 | print()  # noqa
 4 4 | print()  # noqa # comment
 5 5 | print()  # noqa  # comment
@@ -128,7 +128,7 @@ RUF100_3.py:7:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 4 4 | print()  # noqa # comment
 5 5 | print()  # noqa  # comment
 6 6 | print()  # noqa comment
@@ -149,7 +149,7 @@ RUF100_3.py:14:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 11 11 | print(a)  # noqa comment
 12 12 | print(a)  # noqa  comment
 13 13 | 
@@ -168,7 +168,7 @@ RUF100_3.py:15:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 12 12 | print(a)  # noqa  comment
 13 13 | 
 14 14 | # noqa: E501, F821
@@ -189,7 +189,7 @@ RUF100_3.py:16:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 13 13 | 
 14 14 | # noqa: E501, F821
 15 15 | # noqa: E501, F821 # comment
@@ -210,7 +210,7 @@ RUF100_3.py:17:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 14 14 | # noqa: E501, F821
 15 15 | # noqa: E501, F821 # comment
 16 16 | print()  # noqa: E501, F821
@@ -231,7 +231,7 @@ RUF100_3.py:18:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 15 15 | # noqa: E501, F821 # comment
 16 16 | print()  # noqa: E501, F821
 17 17 | print()  # noqa: E501, F821 # comment
@@ -252,7 +252,7 @@ RUF100_3.py:19:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 16 16 | print()  # noqa: E501, F821
 17 17 | print()  # noqa: E501, F821 # comment
 18 18 | print()  # noqa: E501, F821  # comment
@@ -273,7 +273,7 @@ RUF100_3.py:20:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 | print()  # noqa: E501, F821 # comment
 18 18 | print()  # noqa: E501, F821  # comment
 19 19 | print()  # noqa: E501, F821 comment
@@ -294,7 +294,7 @@ RUF100_3.py:21:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 18 18 | print()  # noqa: E501, F821  # comment
 19 19 | print()  # noqa: E501, F821 comment
 20 20 | print()  # noqa: E501, F821  comment
@@ -315,7 +315,7 @@ RUF100_3.py:22:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 19 19 | print()  # noqa: E501, F821 comment
 20 20 | print()  # noqa: E501, F821  comment
 21 21 | print(a)  # noqa: E501, F821
@@ -336,7 +336,7 @@ RUF100_3.py:23:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 20 20 | print()  # noqa: E501, F821  comment
 21 21 | print(a)  # noqa: E501, F821
 22 22 | print(a)  # noqa: E501, F821 # comment
@@ -355,7 +355,7 @@ RUF100_3.py:24:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 21 21 | print(a)  # noqa: E501, F821
 22 22 | print(a)  # noqa: E501, F821 # comment
 23 23 | print(a)  # noqa: E501, F821  # comment
@@ -372,7 +372,7 @@ RUF100_3.py:25:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 22 22 | print(a)  # noqa: E501, F821 # comment
 23 23 | print(a)  # noqa: E501, F821  # comment
 24 24 | print(a)  # noqa: E501, F821 comment

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_5.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_5.snap
@@ -11,7 +11,7 @@ RUF100_5.py:7:5: ERA001 [*] Found commented-out code
   |
   = help: Remove commented-out code
 
-ℹ Possible fix
+ℹ Manual fix
 4 4 | dictionary = {
 5 5 |     # "key1": 123,  # noqa: ERA001
 6 6 |     # "key2": 456,  # noqa
@@ -27,7 +27,7 @@ RUF100_5.py:11:1: ERA001 [*] Found commented-out code
    |
    = help: Remove commented-out code
 
-ℹ Possible fix
+ℹ Manual fix
 8  8  | }
 9  9  | 
 10 10 | 
@@ -40,7 +40,7 @@ RUF100_5.py:11:13: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Unsafe fix
 8  8  | }
 9  9  | 
 10 10 | 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruff_noqa_codes.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruff_noqa_codes.snap
@@ -9,7 +9,7 @@ ruff_noqa_codes.py:8:5: F841 [*] Local variable `x` is assigned to but never use
   |
   = help: Remove assignment to unused variable `x`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 5 5 | 
 6 6 | 
 7 7 | def f():

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruff_noqa_invalid.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruff_noqa_invalid.snap
@@ -22,7 +22,7 @@ ruff_noqa_invalid.py:5:5: F841 [*] Local variable `x` is assigned to but never u
   |
   = help: Remove assignment to unused variable `x`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 | 
 3 3 | 
 4 4 | def f():

--- a/crates/ruff_linter/src/rules/tryceratops/rules/verbose_raise.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/verbose_raise.rs
@@ -97,7 +97,7 @@ pub(crate) fn verbose_raise(checker: &mut Checker, handlers: &[ExceptHandler]) {
                         if id == exception_name.as_str() {
                             let mut diagnostic = Diagnostic::new(VerboseRaise, exc.range());
                             if checker.patch(diagnostic.kind.rule()) {
-                                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
+                                diagnostic.set_fix(Fix::automatic_unsafe(Edit::range_replacement(
                                     "raise".to_string(),
                                     raise.range(),
                                 )));

--- a/crates/ruff_linter/src/rules/tryceratops/snapshots/ruff_linter__rules__tryceratops__tests__verbose-raise_TRY201.py.snap
+++ b/crates/ruff_linter/src/rules/tryceratops/snapshots/ruff_linter__rules__tryceratops__tests__verbose-raise_TRY201.py.snap
@@ -10,7 +10,7 @@ TRY201.py:20:15: TRY201 [*] Use `raise` without specifying exception name
    |
    = help: Remove exception name
 
-ℹ Suggested fix
+ℹ Unsafe fix
 17 17 |         process()
 18 18 |     except MyException as e:
 19 19 |         logger.exception("process failed")
@@ -29,7 +29,7 @@ TRY201.py:63:19: TRY201 [*] Use `raise` without specifying exception name
    |
    = help: Remove exception name
 
-ℹ Suggested fix
+ℹ Unsafe fix
 60 60 |     except MyException as e:
 61 61 |         logger.exception("process failed")
 62 62 |         if True:
@@ -47,7 +47,7 @@ TRY201.py:74:23: TRY201 [*] Use `raise` without specifying exception name
    |
    = help: Remove exception name
 
-ℹ Suggested fix
+ℹ Unsafe fix
 71 71 |         if True:
 72 72 | 
 73 73 |             def foo():

--- a/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__unused_variable.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__unused_variable.snap
@@ -10,7 +10,7 @@ unused_variable.ipynb:cell 1:2:5: F841 [*] Local variable `foo1` is assigned to 
   |
   = help: Remove assignment to unused variable `foo1`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | def f():
 2   |-    foo1 = %matplotlib --list
   2 |+    %matplotlib --list
@@ -27,7 +27,7 @@ unused_variable.ipynb:cell 1:3:5: F841 [*] Local variable `foo2` is assigned to 
   |
   = help: Remove assignment to unused variable `foo2`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 1 1 | def f():
 2 2 |     foo1 = %matplotlib --list
 3   |-    foo2: list[str] = %matplotlib --list
@@ -45,7 +45,7 @@ unused_variable.ipynb:cell 2:2:5: F841 [*] Local variable `bar1` is assigned to 
   |
   = help: Remove assignment to unused variable `bar1`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 2 2 |     foo1 = %matplotlib --list
 3 3 |     foo2: list[str] = %matplotlib --list
 4 4 | def f():
@@ -62,7 +62,7 @@ unused_variable.ipynb:cell 2:3:5: F841 [*] Local variable `bar2` is assigned to 
   |
   = help: Remove assignment to unused variable `bar2`
 
-ℹ Suggested fix
+ℹ Unsafe fix
 3 3 |     foo2: list[str] = %matplotlib --list
 4 4 | def f():
 5 5 |     bar1 = !pwd


### PR DESCRIPTION
Following much discussion for #4181 at https://github.com/astral-sh/ruff/pull/5119, https://github.com/astral-sh/ruff/discussions/5476, #7769, and in [Discord](https://discord.com/channels/1039017663004942429/1082324250112823306/1159144114231709746), this pull request changes `Applicability` from using `Suggested` for uncertain fixes to `Unsafe`.

Also removes `Applicability::Unspecified` (replacing #7792).

I have some qualms about how we will explain "manual" fixes to users which are a type of unsafe fix that cannot be applied programmatically. However, since manual fixes are not presented to the user after #7769 we can worry about this in the future.