### PR TITLE
Correct error in tuple example in ruff formatter docs

### DIFF
--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -428,7 +428,7 @@ In particular, Ruff will always insert parentheses around tuples that expand ove
     (a, b),
     (
         c,
-        c,
+        d,
     ),
 )
 ```


### PR DESCRIPTION
## Summary

The fourth element should be "d" instead of "c" in the tuple example in the ruff formatter docs.

## Test Plan

N/A