### PR TITLE
Fix playground `Quick Fix` action

### DIFF
--- a/playground/src/Editor/SourceEditor.tsx
+++ b/playground/src/Editor/SourceEditor.tsx
@@ -69,7 +69,7 @@ export default function SourceEditor({
                     edits: check.fix.edits.map((edit) => ({
                       resource: model.uri,
                       versionId: model.getVersionId(),
-                      edit: {
+                      textEdit: {
                         range: {
                           startLineNumber: edit.location.row,
                           startColumn: edit.location.column,


### PR DESCRIPTION
## Summary

This PR fixes the playground code action to start working again. It seems that
the field name was changed from `edit` to `textEdit` in some version.

Resources:
- https://microsoft.github.io/monaco-editor/docs.html#interfaces/languages.IWorkspaceTextEdit.html
- https://stackoverflow.com/a/71742764

## Test Plan

Tested it out running locally.
