### PR TITLE
Make serde a default feature of ruff_python_formatter

### DIFF
--- a/crates/ruff_python_formatter/Cargo.toml
+++ b/crates/ruff_python_formatter/Cargo.toml
@@ -52,6 +52,6 @@ test = true
 required-features = ["serde"]
 
 [features]
+default = ["serde"]
 serde = ["dep:serde", "ruff_formatter/serde", "ruff_source_file/serde", "ruff_python_ast/serde"]
 schemars = ["dep:schemars", "ruff_formatter/schemars"]
-default = []


### PR DESCRIPTION
This makes `cargo test -p ruff_python_formatter` actually run the tests again
