### PR TITLE
Formatter quoting for f-strings with triple quotes

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -57,3 +57,7 @@ result_f = (
     ),
     2
 )
+
+# https://github.com/astral-sh/ruff/issues/6841
+x = f'''a{""}b'''
+y = f'''c{1}d"""e'''

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -61,3 +61,4 @@ result_f = (
 # https://github.com/astral-sh/ruff/issues/6841
 x = f'''a{""}b'''
 y = f'''c{1}d"""e'''
+z = f'''a{""}b''' f'''c{1}d"""e'''

--- a/crates/ruff_python_formatter/src/expression/string.rs
+++ b/crates/ruff_python_formatter/src/expression/string.rs
@@ -48,10 +48,19 @@ impl<'a> AnyString<'a> {
         match self {
             Self::Constant(_) => Quoting::CanChange,
             Self::FString(f_string) => {
+                let unprefixed = locator
+                    .slice(f_string.range)
+                    .trim_start_matches(|c| c != '"' && c != '\'');
+                let triple_quotes =
+                    unprefixed.starts_with(r#"""""#) || unprefixed.starts_with(r#"'''"#);
                 if f_string.values.iter().any(|value| match value {
                     Expr::FormattedValue(ast::ExprFormattedValue { range, .. }) => {
                         let string_content = locator.slice(*range);
-                        string_content.contains(['"', '\''])
+                        if triple_quotes {
+                            string_content.contains(r#"""""#) || string_content.contains(r#"'''"#)
+                        } else {
+                            string_content.contains(['"', '\''])
+                        }
                     }
                     _ => false,
                 }) {

--- a/crates/ruff_python_formatter/src/expression/string.rs
+++ b/crates/ruff_python_formatter/src/expression/string.rs
@@ -56,7 +56,7 @@ impl<'a> AnyString<'a> {
                 if f_string.values.iter().any(|value| match value {
                     Expr::FormattedValue(ast::ExprFormattedValue { range, .. }) => {
                         let string_content = locator.slice(*range);
-                        if triple_quotes {
+                        if triple_quoted {
                             string_content.contains(r#"""""#) || string_content.contains(r#"'''"#)
                         } else {
                             string_content.contains(['"', '\''])

--- a/crates/ruff_python_formatter/src/expression/string.rs
+++ b/crates/ruff_python_formatter/src/expression/string.rs
@@ -51,7 +51,7 @@ impl<'a> AnyString<'a> {
                 let unprefixed = locator
                     .slice(f_string.range)
                     .trim_start_matches(|c| c != '"' && c != '\'');
-                let triple_quotes =
+                let triple_quoted =
                     unprefixed.starts_with(r#"""""#) || unprefixed.starts_with(r#"'''"#);
                 if f_string.values.iter().any(|value| match value {
                     Expr::FormattedValue(ast::ExprFormattedValue { range, .. }) => {

--- a/crates/ruff_python_formatter/src/expression/string.rs
+++ b/crates/ruff_python_formatter/src/expression/string.rs
@@ -57,7 +57,7 @@ impl<'a> AnyString<'a> {
                     Expr::FormattedValue(ast::ExprFormattedValue { range, .. }) => {
                         let string_content = locator.slice(*range);
                         if triple_quoted {
-                            string_content.contains(r#"""""#) || string_content.contains(r#"'''"#)
+                            string_content.contains(r#"""""#) || string_content.contains("'''")
                         } else {
                             string_content.contains(['"', '\''])
                         }

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -63,6 +63,10 @@ result_f = (
     ),
     2
 )
+
+# https://github.com/astral-sh/ruff/issues/6841
+x = f'''a{""}b'''
+y = f'''c{1}d"""e'''
 ```
 
 ## Output
@@ -124,6 +128,10 @@ result_f = (
     ),
     2,
 )
+
+# https://github.com/astral-sh/ruff/issues/6841
+x = f"""a{""}b"""
+y = f'''c{1}d"""e'''
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -67,6 +67,7 @@ result_f = (
 # https://github.com/astral-sh/ruff/issues/6841
 x = f'''a{""}b'''
 y = f'''c{1}d"""e'''
+z = f'''a{""}b''' f'''c{1}d"""e'''
 ```
 
 ## Output
@@ -132,6 +133,7 @@ result_f = (
 # https://github.com/astral-sh/ruff/issues/6841
 x = f"""a{""}b"""
 y = f'''c{1}d"""e'''
+z = f"""a{""}b""" f'''c{1}d"""e'''
 ```
 
 


### PR DESCRIPTION
**Summary** Quoting of f-strings can change if they are triple quoted and only contain single quotes inside.

Fixes #6841

**Test Plan** New fixtures
