### PR TITLE
Fix typo in docs of PLR6301

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
@@ -29,7 +29,7 @@ use crate::{checkers::ast::Checker, rules::flake8_unused_arguments::helpers};
 /// class Person:
 ///     @staticmethod
 ///     def greeting():
-///         print(f"Greetings friend!")
+///         print("Greetings friend!")
 /// ```
 #[violation]
 pub struct NoSelfUse {


### PR DESCRIPTION
## Summary
The example code for [PLR6301 (no-self-use)](https://docs.astral.sh/ruff/rules/no-self-use/#example) contains f-strings without placeholder expressions, which is discouraged according to [F541 (f-string-missing-placeholders)](https://docs.astral.sh/ruff/rules/f-string-missing-placeholders/).
For such a trivial change, I didn't open a separate issue.
