### PR TITLE
Promote some rules to "always" fixable

### DIFF
--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -111,7 +111,7 @@ pub(crate) fn check_noqa(
                             Diagnostic::new(UnusedNOQA { codes: None }, directive.range());
                         if settings.rules.should_fix(diagnostic.kind.rule()) {
                             diagnostic
-                                .set_fix(Fix::unsafe_edit(delete_noqa(directive.range(), locator)));
+                                .set_fix(Fix::safe_edit(delete_noqa(directive.range(), locator)));
                         }
                         diagnostics.push(diagnostic);
                     }
@@ -175,12 +175,12 @@ pub(crate) fn check_noqa(
                         );
                         if settings.rules.should_fix(diagnostic.kind.rule()) {
                             if valid_codes.is_empty() {
-                                diagnostic.set_fix(Fix::unsafe_edit(delete_noqa(
+                                diagnostic.set_fix(Fix::safe_edit(delete_noqa(
                                     directive.range(),
                                     locator,
                                 )));
                             } else {
-                                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                                     format!("# noqa: {}", valid_codes.join(", ")),
                                     directive.range(),
                                 )));

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -86,7 +86,7 @@ pub(crate) fn getattr_with_constant(
 
     let mut diagnostic = Diagnostic::new(GetAttrWithConstant, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             pad(
                 if matches!(
                     obj,

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -109,7 +109,7 @@ pub(crate) fn setattr_with_constant(
         if expr == child.as_ref() {
             let mut diagnostic = Diagnostic::new(SetAttrWithConstant, expr.range());
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     assignment(obj, name, value, checker.generator()),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B009_B009_B010.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B009_B009_B010.py.snap
@@ -11,7 +11,7 @@ B009_B010.py:19:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 16 16 | getattr(foo, "__123abc")
 17 17 | 
 18 18 | # Invalid usage
@@ -32,7 +32,7 @@ B009_B010.py:20:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 17 17 | 
 18 18 | # Invalid usage
 19 19 | getattr(foo, "bar")
@@ -53,7 +53,7 @@ B009_B010.py:21:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 18 18 | # Invalid usage
 19 19 | getattr(foo, "bar")
 20 20 | getattr(foo, "_123abc")
@@ -74,7 +74,7 @@ B009_B010.py:22:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 19 19 | getattr(foo, "bar")
 20 20 | getattr(foo, "_123abc")
 21 21 | getattr(foo, "__123abc__")
@@ -95,7 +95,7 @@ B009_B010.py:23:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 20 20 | getattr(foo, "_123abc")
 21 21 | getattr(foo, "__123abc__")
 22 22 | getattr(foo, "abc123")
@@ -116,7 +116,7 @@ B009_B010.py:24:15: B009 [*] Do not call `getattr` with a constant attribute val
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 21 21 | getattr(foo, "__123abc__")
 22 22 | getattr(foo, "abc123")
 23 23 | getattr(foo, r"abc123")
@@ -137,7 +137,7 @@ B009_B010.py:25:4: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 22 22 | getattr(foo, "abc123")
 23 23 | getattr(foo, r"abc123")
 24 24 | _ = lambda x: getattr(x, "bar")
@@ -158,7 +158,7 @@ B009_B010.py:27:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 24 24 | _ = lambda x: getattr(x, "bar")
 25 25 | if getattr(x, "bar"):
 26 26 |     pass
@@ -179,7 +179,7 @@ B009_B010.py:28:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 25 25 | if getattr(x, "bar"):
 26 26 |     pass
 27 27 | getattr(1, "real")
@@ -200,7 +200,7 @@ B009_B010.py:29:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 26 26 |     pass
 27 27 | getattr(1, "real")
 28 28 | getattr(1., "real")
@@ -221,7 +221,7 @@ B009_B010.py:30:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 27 27 | getattr(1, "real")
 28 28 | getattr(1., "real")
 29 29 | getattr(1.0, "real")
@@ -242,7 +242,7 @@ B009_B010.py:31:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 28 28 | getattr(1., "real")
 29 29 | getattr(1.0, "real")
 30 30 | getattr(1j, "real")
@@ -263,7 +263,7 @@ B009_B010.py:32:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 29 29 | getattr(1.0, "real")
 30 30 | getattr(1j, "real")
 31 31 | getattr(True, "real")
@@ -284,7 +284,7 @@ B009_B010.py:33:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 30 30 | getattr(1j, "real")
 31 31 | getattr(True, "real")
 32 32 | getattr(x := 1, "real")
@@ -304,7 +304,7 @@ B009_B010.py:34:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 31 31 | getattr(True, "real")
 32 32 | getattr(x := 1, "real")
 33 33 | getattr(x + y, "real")
@@ -326,7 +326,7 @@ B009_B010.py:58:8: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 55 55 | setattr(foo.bar, r"baz", None)
 56 56 | 
 57 57 | # Regression test for: https://github.com/astral-sh/ruff/issues/7455#issuecomment-1722458885
@@ -345,7 +345,7 @@ B009_B010.py:65:1: B009 [*] Do not call `getattr` with a constant attribute valu
    |
    = help: Replace `getattr` with attribute access
 
-ℹ Suggested fix
+ℹ Fix
 62 62 | setattr(*foo, "bar", None)
 63 63 | 
 64 64 | # Regression test for: https://github.com/astral-sh/ruff/issues/7455#issuecomment-1739800901

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B010_B009_B010.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B010_B009_B010.py.snap
@@ -11,7 +11,7 @@ B009_B010.py:50:1: B010 [*] Do not call `setattr` with a constant attribute valu
    |
    = help: Replace `setattr` with assignment
 
-ℹ Suggested fix
+ℹ Fix
 47 47 |     pass
 48 48 | 
 49 49 | # Invalid usage
@@ -32,7 +32,7 @@ B009_B010.py:51:1: B010 [*] Do not call `setattr` with a constant attribute valu
    |
    = help: Replace `setattr` with assignment
 
-ℹ Suggested fix
+ℹ Fix
 48 48 | 
 49 49 | # Invalid usage
 50 50 | setattr(foo, "bar", None)
@@ -53,7 +53,7 @@ B009_B010.py:52:1: B010 [*] Do not call `setattr` with a constant attribute valu
    |
    = help: Replace `setattr` with assignment
 
-ℹ Suggested fix
+ℹ Fix
 49 49 | # Invalid usage
 50 50 | setattr(foo, "bar", None)
 51 51 | setattr(foo, "_123abc", None)
@@ -74,7 +74,7 @@ B009_B010.py:53:1: B010 [*] Do not call `setattr` with a constant attribute valu
    |
    = help: Replace `setattr` with assignment
 
-ℹ Suggested fix
+ℹ Fix
 50 50 | setattr(foo, "bar", None)
 51 51 | setattr(foo, "_123abc", None)
 52 52 | setattr(foo, "__123abc__", None)
@@ -94,7 +94,7 @@ B009_B010.py:54:1: B010 [*] Do not call `setattr` with a constant attribute valu
    |
    = help: Replace `setattr` with assignment
 
-ℹ Suggested fix
+ℹ Fix
 51 51 | setattr(foo, "_123abc", None)
 52 52 | setattr(foo, "__123abc__", None)
 53 53 | setattr(foo, "abc123", None)
@@ -115,7 +115,7 @@ B009_B010.py:55:1: B010 [*] Do not call `setattr` with a constant attribute valu
    |
    = help: Replace `setattr` with assignment
 
-ℹ Suggested fix
+ℹ Fix
 52 52 | setattr(foo, "__123abc__", None)
 53 53 | setattr(foo, "abc123", None)
 54 54 | setattr(foo, r"abc123", None)

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/undocumented_warn.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/undocumented_warn.rs
@@ -63,7 +63,7 @@ pub(crate) fn undocumented_warn(checker: &mut Checker, expr: &Expr) {
                     checker.semantic(),
                 )?;
                 let reference_edit = Edit::range_replacement(binding, expr.range());
-                Ok(Fix::unsafe_edits(import_edit, [reference_edit]))
+                Ok(Fix::safe_edits(import_edit, [reference_edit]))
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_logging/snapshots/ruff_linter__rules__flake8_logging__tests__LOG009_LOG009.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_logging/snapshots/ruff_linter__rules__flake8_logging__tests__LOG009_LOG009.py.snap
@@ -11,7 +11,7 @@ LOG009.py:3:1: LOG009 [*] Use of undocumented `logging.WARN` constant
   |
   = help: Replace `logging.WARN` with `logging.WARNING`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | import logging
 2 2 | 
 3   |-logging.WARN  # LOG009
@@ -30,7 +30,7 @@ LOG009.py:8:1: LOG009 [*] Use of undocumented `logging.WARN` constant
   |
   = help: Replace `logging.WARN` with `logging.WARNING`
 
-ℹ Suggested fix
+ℹ Fix
 5 5 | 
 6 6 | from logging import WARN, WARNING
 7 7 | 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
@@ -70,7 +70,7 @@ pub(crate) fn non_empty_stub_body(checker: &mut Checker, body: &[Stmt]) {
 
     let mut diagnostic = Diagnostic::new(NonEmptyStubBody, stmt.range());
     if checker.patch(Rule::NonEmptyStubBody) {
-        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             format!("..."),
             stmt.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/numeric_literal_too_long.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/numeric_literal_too_long.rs
@@ -51,7 +51,7 @@ pub(crate) fn numeric_literal_too_long(checker: &mut Checker, expr: &Expr) {
 
     let mut diagnostic = Diagnostic::new(NumericLiteralTooLong, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             "...".to_string(),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -535,7 +535,7 @@ pub(crate) fn typed_argument_simple_defaults(checker: &mut Checker, parameters: 
                 let mut diagnostic = Diagnostic::new(TypedArgumentDefaultInStub, default.range());
 
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                         "...".to_string(),
                         default.range(),
                     )));
@@ -572,7 +572,7 @@ pub(crate) fn argument_simple_defaults(checker: &mut Checker, parameters: &Param
                 let mut diagnostic = Diagnostic::new(ArgumentDefaultInStub, default.range());
 
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                         "...".to_string(),
                         default.range(),
                     )));
@@ -607,7 +607,7 @@ pub(crate) fn assignment_default_in_stub(checker: &mut Checker, targets: &[Expr]
 
     let mut diagnostic = Diagnostic::new(AssignmentDefaultInStub, value.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             "...".to_string(),
             value.range(),
         )));
@@ -643,7 +643,7 @@ pub(crate) fn annotated_assignment_default_in_stub(
 
     let mut diagnostic = Diagnostic::new(AssignmentDefaultInStub, value.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             "...".to_string(),
             value.range(),
         )));
@@ -748,7 +748,7 @@ pub(crate) fn type_alias_without_annotation(checker: &mut Checker, value: &Expr,
                 target.start(),
                 checker.semantic(),
             )?;
-            Ok(Fix::unsafe_edits(
+            Ok(Fix::safe_edits(
                 Edit::range_replacement(format!("{id}: {binding}"), target.range()),
                 [import_edit],
             ))

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
@@ -68,7 +68,7 @@ pub(crate) fn string_or_bytes_too_long(checker: &mut Checker, expr: &Expr) {
 
     let mut diagnostic = Diagnostic::new(StringOrBytesTooLong, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             "...".to_string(),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI010_PYI010.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI010_PYI010.pyi.snap
@@ -11,7 +11,7 @@ PYI010.pyi:6:5: PYI010 [*] Function body must contain only `...`
   |
   = help: Replace function body with `...`
 
-ℹ Suggested fix
+ℹ Fix
 3 3 |     """foo"""  # OK, docstrings are handled by another rule
 4 4 | 
 5 5 | def buzz():
@@ -31,7 +31,7 @@ PYI010.pyi:9:5: PYI010 [*] Function body must contain only `...`
    |
    = help: Replace function body with `...`
 
-ℹ Suggested fix
+ℹ Fix
 6  6  |     print("buzz")  # ERROR PYI010
 7  7  | 
 8  8  | def foo2():
@@ -51,7 +51,7 @@ PYI010.pyi:12:5: PYI010 [*] Function body must contain only `...`
    |
    = help: Replace function body with `...`
 
-ℹ Suggested fix
+ℹ Fix
 9  9  |     123  # ERROR PYI010
 10 10 | 
 11 11 | def bizz():

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI011_PYI011.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI011_PYI011.pyi.snap
@@ -12,7 +12,7 @@ PYI011.pyi:10:14: PYI011 [*] Only simple default values allowed for typed argume
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 7  7  | 
 8  8  | def f12(
 9  9  |     x,
@@ -37,7 +37,7 @@ PYI011.pyi:38:9: PYI011 [*] Only simple default values allowed for typed argumen
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 35 35 | def f152(
 36 36 |     x: dict[
 37 37 |         int, int
@@ -74,7 +74,7 @@ PYI011.pyi:46:9: PYI011 [*] Only simple default values allowed for typed argumen
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 43 43 | def f153(
 44 44 |     x: list[
 45 45 |         int
@@ -111,7 +111,7 @@ PYI011.pyi:63:9: PYI011 [*] Only simple default values allowed for typed argumen
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 60 60 | def f154(
 61 61 |     x: tuple[
 62 62 |         str, tuple[str, ...]
@@ -138,7 +138,7 @@ PYI011.pyi:71:9: PYI011 [*] Only simple default values allowed for typed argumen
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 68 68 | def f141(
 69 69 |     x: list[
 70 70 |         int
@@ -164,7 +164,7 @@ PYI011.pyi:78:9: PYI011 [*] Only simple default values allowed for typed argumen
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 75 75 | def f142(
 76 76 |     x: list[
 77 77 |         int
@@ -190,7 +190,7 @@ PYI011.pyi:85:9: PYI011 [*] Only simple default values allowed for typed argumen
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 82 82 | def f16(
 83 83 |     x: frozenset[
 84 84 |         bytes
@@ -215,7 +215,7 @@ PYI011.pyi:90:14: PYI011 [*] Only simple default values allowed for typed argume
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 87 87 |     )
 88 88 | ) -> None: ...
 89 89 | def f17(
@@ -239,7 +239,7 @@ PYI011.pyi:94:14: PYI011 [*] Only simple default values allowed for typed argume
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 91 91 |     + "bar",
 92 92 | ) -> None: ...
 93 93 | def f18(
@@ -263,7 +263,7 @@ PYI011.pyi:98:17: PYI011 [*] Only simple default values allowed for typed argume
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 95  95  |     + b"bar",
 96  96  | ) -> None: ...
 97  97  | def f19(
@@ -287,7 +287,7 @@ PYI011.pyi:102:14: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 99  99  |     + 4,
 100 100 | ) -> None: ...
 101 101 | def f20(
@@ -311,7 +311,7 @@ PYI011.pyi:106:18: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 103 103 |     + 5,  # Error PYI011 Only simple default values allowed for typed arguments
 104 104 | ) -> None: ...
 105 105 | def f21(
@@ -335,7 +335,7 @@ PYI011.pyi:110:18: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 107 107 |     - 3j,  # Error PYI011 Only simple default values allowed for typed arguments
 108 108 | ) -> None: ...
 109 109 | def f22(
@@ -357,7 +357,7 @@ PYI011.pyi:138:16: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 135 135 |     x: float = -math.inf,  # OK
 136 136 | ) -> None: ...
 137 137 | def f31(
@@ -378,7 +378,7 @@ PYI011.pyi:141:16: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 138 138 |     x: float = inf,  # Error PYI011 Only simple default values allowed for typed arguments
 139 139 | ) -> None: ...
 140 140 | def f32(
@@ -399,7 +399,7 @@ PYI011.pyi:147:16: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 144 144 |     x: float = math.nan,  # OK
 145 145 | ) -> None: ...
 146 146 | def f34(
@@ -422,7 +422,7 @@ PYI011.pyi:150:18: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 147 147 |     x: float = -math.nan,  # Error PYI011 Only simple default values allowed for typed arguments
 148 148 | ) -> None: ...
 149 149 | def f35(
@@ -445,7 +445,7 @@ PYI011.pyi:159:14: PYI011 [*] Only simple default values allowed for typed argum
     |
     = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 156 156 | ) -> None: ...
 157 157 | def f37(
 158 158 |     *,

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI014_PYI014.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI014_PYI014.pyi.snap
@@ -12,7 +12,7 @@ PYI014.pyi:3:7: PYI014 [*] Only simple default values allowed for arguments
   |
   = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | def f12(
 2 2 |     x,
 3   |-    y=os.pathsep,  # Error PYI014
@@ -36,7 +36,7 @@ PYI014.pyi:29:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 26 26 | ) -> None: ...
 27 27 | def f151(x={1: 2}) -> None: ...
 28 28 | def f152(
@@ -73,7 +73,7 @@ PYI014.pyi:35:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 32 32 |     }
 33 33 | ) -> None: ...
 34 34 | def f153(
@@ -110,7 +110,7 @@ PYI014.pyi:50:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 47 47 |     ]
 48 48 | ) -> None: ...
 49 49 | def f154(
@@ -134,7 +134,7 @@ PYI014.pyi:56:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 53 53 |     )
 54 54 | ) -> None: ...
 55 55 | def f141(
@@ -155,7 +155,7 @@ PYI014.pyi:59:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 56 56 |     x=[*range(10)],  # Error PYI014
 57 57 | ) -> None: ...
 58 58 | def f142(
@@ -176,7 +176,7 @@ PYI014.pyi:61:11: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 58 58 | def f142(
 59 59 |     x=list(range(10)),  # Error PYI014
 60 60 | ) -> None: ...
@@ -197,7 +197,7 @@ PYI014.pyi:63:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 60 60 | ) -> None: ...
 61 61 | def f16(x=frozenset({b"foo", b"bar", b"baz"})) -> None: ...  # Error PYI014
 62 62 | def f17(
@@ -218,7 +218,7 @@ PYI014.pyi:66:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 63 63 |     x="foo" + "bar",  # Error PYI014
 64 64 | ) -> None: ...
 65 65 | def f18(
@@ -239,7 +239,7 @@ PYI014.pyi:69:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 66 66 |     x=b"foo" + b"bar",  # Error PYI014
 67 67 | ) -> None: ...
 68 68 | def f19(
@@ -260,7 +260,7 @@ PYI014.pyi:72:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 69 69 |     x="foo" + 4,  # Error PYI014
 70 70 | ) -> None: ...
 71 71 | def f20(
@@ -281,7 +281,7 @@ PYI014.pyi:75:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 72 72 |     x=5 + 5,  # Error PYI014
 73 73 | ) -> None: ...
 74 74 | def f21(
@@ -302,7 +302,7 @@ PYI014.pyi:78:7: PYI014 [*] Only simple default values allowed for arguments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 75 75 |     x=3j - 3j,  # Error PYI014
 76 76 | ) -> None: ...
 77 77 | def f22(

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI015_PYI015.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI015_PYI015.pyi.snap
@@ -11,7 +11,7 @@ PYI015.pyi:44:23: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 41 41 | field22: Final = {"foo": 5}
 42 42 | 
 43 43 | # We *should* emit Y015 for more complex default values
@@ -32,7 +32,7 @@ PYI015.pyi:45:23: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 42 42 | 
 43 43 | # We *should* emit Y015 for more complex default values
 44 44 | field221: list[int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]  # Y015 Only simple default values are allowed for assignments
@@ -53,7 +53,7 @@ PYI015.pyi:46:23: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 43 43 | # We *should* emit Y015 for more complex default values
 44 44 | field221: list[int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]  # Y015 Only simple default values are allowed for assignments
 45 45 | field223: list[int] = [*range(10)]  # Y015 Only simple default values are allowed for assignments
@@ -74,7 +74,7 @@ PYI015.pyi:47:26: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 44 44 | field221: list[int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]  # Y015 Only simple default values are allowed for assignments
 45 45 | field223: list[int] = [*range(10)]  # Y015 Only simple default values are allowed for assignments
 46 46 | field224: list[int] = list(range(10))  # Y015 Only simple default values are allowed for assignments
@@ -95,7 +95,7 @@ PYI015.pyi:48:47: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 45 45 | field223: list[int] = [*range(10)]  # Y015 Only simple default values are allowed for assignments
 46 46 | field224: list[int] = list(range(10))  # Y015 Only simple default values are allowed for assignments
 47 47 | field225: list[object] = [{}, 1, 2]  # Y015 Only simple default values are allowed for assignments
@@ -116,7 +116,7 @@ PYI015.pyi:49:31: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 46 46 | field224: list[int] = list(range(10))  # Y015 Only simple default values are allowed for assignments
 47 47 | field225: list[object] = [{}, 1, 2]  # Y015 Only simple default values are allowed for assignments
 48 48 | field226: tuple[str | tuple[str, ...], ...] = ("foo", ("foo", "bar"))  # Y015 Only simple default values are allowed for assignments
@@ -137,7 +137,7 @@ PYI015.pyi:50:37: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 47 47 | field225: list[object] = [{}, 1, 2]  # Y015 Only simple default values are allowed for assignments
 48 48 | field226: tuple[str | tuple[str, ...], ...] = ("foo", ("foo", "bar"))  # Y015 Only simple default values are allowed for assignments
 49 49 | field227: dict[str, object] = {"foo": {"foo": "bar"}}  # Y015 Only simple default values are allowed for assignments
@@ -158,7 +158,7 @@ PYI015.pyi:52:28: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 49 49 | field227: dict[str, object] = {"foo": {"foo": "bar"}}  # Y015 Only simple default values are allowed for assignments
 50 50 | field228: dict[str, list[object]] = {"foo": []}  # Y015 Only simple default values are allowed for assignments
 51 51 | # When parsed, this case results in `None` being placed in the `.keys` list for the `ast.Dict` node
@@ -179,7 +179,7 @@ PYI015.pyi:53:11: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 50 50 | field228: dict[str, list[object]] = {"foo": []}  # Y015 Only simple default values are allowed for assignments
 51 51 | # When parsed, this case results in `None` being placed in the `.keys` list for the `ast.Dict` node
 52 52 | field229: dict[int, int] = {1: 2, **{3: 4}}  # Y015 Only simple default values are allowed for assignments
@@ -199,7 +199,7 @@ PYI015.pyi:54:11: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 51 51 | # When parsed, this case results in `None` being placed in the `.keys` list for the `ast.Dict` node
 52 52 | field229: dict[int, int] = {1: 2, **{3: 4}}  # Y015 Only simple default values are allowed for assignments
 53 53 | field23 = "foo" + "bar"  # Y015 Only simple default values are allowed for assignments
@@ -220,7 +220,7 @@ PYI015.pyi:55:11: PYI015 [*] Only simple default values allowed for assignments
    |
    = help: Replace default value with `...`
 
-ℹ Suggested fix
+ℹ Fix
 52 52 | field229: dict[int, int] = {1: 2, **{3: 4}}  # Y015 Only simple default values are allowed for assignments
 53 53 | field23 = "foo" + "bar"  # Y015 Only simple default values are allowed for assignments
 54 54 | field24 = b"foo" + b"bar"  # Y015 Only simple default values are allowed for assignments

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI026_PYI026.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI026_PYI026.pyi.snap
@@ -12,7 +12,7 @@ PYI026.pyi:3:1: PYI026 [*] Use `typing.TypeAlias` for type alias, e.g., `NewAny:
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Fix
 1   |-from typing import Literal, Any
   1 |+from typing import Literal, Any, TypeAlias
 2 2 | 
@@ -32,7 +32,7 @@ PYI026.pyi:4:1: PYI026 [*] Use `typing.TypeAlias` for type alias, e.g., `Optiona
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Fix
 1   |-from typing import Literal, Any
   1 |+from typing import Literal, Any, TypeAlias
 2 2 | 
@@ -54,7 +54,7 @@ PYI026.pyi:5:1: PYI026 [*] Use `typing.TypeAlias` for type alias, e.g., `Foo: Ty
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Fix
 1   |-from typing import Literal, Any
   1 |+from typing import Literal, Any, TypeAlias
 2 2 | 
@@ -76,7 +76,7 @@ PYI026.pyi:6:1: PYI026 [*] Use `typing.TypeAlias` for type alias, e.g., `IntOrSt
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Fix
 1   |-from typing import Literal, Any
   1 |+from typing import Literal, Any, TypeAlias
 2 2 | 
@@ -100,7 +100,7 @@ PYI026.pyi:7:1: PYI026 [*] Use `typing.TypeAlias` for type alias, e.g., `AliasNo
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Fix
 1   |-from typing import Literal, Any
   1 |+from typing import Literal, Any, TypeAlias
 2 2 | 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI053_PYI053.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI053_PYI053.pyi.snap
@@ -12,7 +12,7 @@ PYI053.pyi:3:14: PYI053 [*] String and bytes literals longer than 50 characters 
   |
   = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | def f1(x: str = "50 character stringggggggggggggggggggggggggggggggg") -> None: ...  # OK
 2 2 | def f2(
 3   |-    x: str = "51 character stringgggggggggggggggggggggggggggggggg",  # Error: PYI053
@@ -32,7 +32,7 @@ PYI053.pyi:9:14: PYI053 [*] String and bytes literals longer than 50 characters 
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Fix
 6  6  |     x: str = "50 character stringgggggggggggggggggggggggggggggg\U0001f600",  # OK
 7  7  | ) -> None: ...
 8  8  | def f4(
@@ -52,7 +52,7 @@ PYI053.pyi:21:16: PYI053 [*] String and bytes literals longer than 50 characters
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Fix
 18 18 |     x: bytes = b"50 character byte stringggggggggggggggggggggggggg\xff",  # OK
 19 19 | ) -> None: ...
 20 20 | def f8(
@@ -73,7 +73,7 @@ PYI053.pyi:26:12: PYI053 [*] String and bytes literals longer than 50 characters
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Fix
 23 23 | 
 24 24 | foo: str = "50 character stringggggggggggggggggggggggggggggggg"  # OK
 25 25 | 
@@ -94,7 +94,7 @@ PYI053.pyi:30:14: PYI053 [*] String and bytes literals longer than 50 characters
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Fix
 27 27 | 
 28 28 | baz: bytes = b"50 character byte stringgggggggggggggggggggggggggg"  # OK
 29 29 | 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI054_PYI054.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI054_PYI054.pyi.snap
@@ -11,7 +11,7 @@ PYI054.pyi:2:16: PYI054 [*] Numeric literals with a string representation longer
   |
   = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | field01: int = 0xFFFFFFFF
 2   |-field02: int = 0xFFFFFFFFF  # Error: PYI054
   2 |+field02: int = ...  # Error: PYI054
@@ -30,7 +30,7 @@ PYI054.pyi:4:17: PYI054 [*] Numeric literals with a string representation longer
   |
   = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | field01: int = 0xFFFFFFFF
 2 2 | field02: int = 0xFFFFFFFFF  # Error: PYI054
 3 3 | field03: int = -0xFFFFFFFF
@@ -51,7 +51,7 @@ PYI054.pyi:8:16: PYI054 [*] Numeric literals with a string representation longer
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Fix
 5 5 | 
 6 6 | field05: int = 1234567890
 7 7 | field06: int = 12_456_890
@@ -72,7 +72,7 @@ PYI054.pyi:10:17: PYI054 [*] Numeric literals with a string representation longe
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Fix
 7  7  | field06: int = 12_456_890
 8  8  | field07: int = 12345678901  # Error: PYI054
 9  9  | field08: int = -1234567801
@@ -92,7 +92,7 @@ PYI054.pyi:13:18: PYI054 [*] Numeric literals with a string representation longe
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Fix
 10 10 | field09: int = -234_567_890  # Error: PYI054
 11 11 | 
 12 12 | field10: float = 123.456789
@@ -113,7 +113,7 @@ PYI054.pyi:15:19: PYI054 [*] Numeric literals with a string representation longe
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Fix
 12 12 | field10: float = 123.456789
 13 13 | field11: float = 123.4567890  # Error: PYI054
 14 14 | field12: float = -123.456789
@@ -133,7 +133,7 @@ PYI054.pyi:18:20: PYI054 [*] Numeric literals with a string representation longe
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Fix
 15 15 | field13: float = -123.567_890  # Error: PYI054
 16 16 | 
 17 17 | field14: complex = 1e1234567j
@@ -151,7 +151,7 @@ PYI054.pyi:20:20: PYI054 [*] Numeric literals with a string representation longe
    |
    = help: Replace with `...`
 
-ℹ Suggested fix
+ℹ Fix
 17 17 | field14: complex = 1e1234567j
 18 18 | field15: complex = 1e12345678j  # Error: PYI054
 19 19 | field16: complex = -1e1234567j

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__py38_PYI026_PYI026.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__py38_PYI026_PYI026.pyi.snap
@@ -12,7 +12,7 @@ PYI026.pyi:3:1: PYI026 [*] Use `typing_extensions.TypeAlias` for type alias, e.g
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | from typing import Literal, Any
   2 |+import typing_extensions
 2 3 | 
@@ -32,7 +32,7 @@ PYI026.pyi:4:1: PYI026 [*] Use `typing_extensions.TypeAlias` for type alias, e.g
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | from typing import Literal, Any
   2 |+import typing_extensions
 2 3 | 
@@ -54,7 +54,7 @@ PYI026.pyi:5:1: PYI026 [*] Use `typing_extensions.TypeAlias` for type alias, e.g
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | from typing import Literal, Any
   2 |+import typing_extensions
 2 3 | 
@@ -76,7 +76,7 @@ PYI026.pyi:6:1: PYI026 [*] Use `typing_extensions.TypeAlias` for type alias, e.g
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | from typing import Literal, Any
   2 |+import typing_extensions
 2 3 | 
@@ -100,7 +100,7 @@ PYI026.pyi:7:1: PYI026 [*] Use `typing_extensions.TypeAlias` for type alias, e.g
   |
   = help: Add `TypeAlias` annotation
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | from typing import Literal, Any
   2 |+import typing_extensions
 2 3 | 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -239,7 +239,7 @@ pub(crate) fn negation_with_not_equal_op(
             comparators: comparators.clone(),
             range: TextRange::default(),
         };
-        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             checker.generator().expr(&node.into()),
             expr.range(),
         )));
@@ -272,7 +272,7 @@ pub(crate) fn double_negation(checker: &mut Checker, expr: &Expr, op: UnaryOp, o
     );
     if checker.patch(diagnostic.kind.rule()) {
         if checker.semantic().in_boolean_test() {
-            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 checker.locator().slice(operand.as_ref()).to_string(),
                 expr.range(),
             )));
@@ -291,7 +291,7 @@ pub(crate) fn double_negation(checker: &mut Checker, expr: &Expr, op: UnaryOp, o
                 },
                 range: TextRange::default(),
             };
-            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 checker.generator().expr(&node1.into()),
                 expr.range(),
             )));

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM202_SIM202.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM202_SIM202.py.snap
@@ -10,7 +10,7 @@ SIM202.py:2:4: SIM202 [*] Use `a == b` instead of `not a != b`
   |
   = help: Replace with `==` operator
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # SIM202
 2   |-if not a != b:
   2 |+if a == b:
@@ -27,7 +27,7 @@ SIM202.py:6:4: SIM202 [*] Use `a == b + c` instead of `not a != b + c`
   |
   = help: Replace with `==` operator
 
-ℹ Suggested fix
+ℹ Fix
 3 3 |     pass
 4 4 | 
 5 5 | # SIM202
@@ -46,7 +46,7 @@ SIM202.py:10:4: SIM202 [*] Use `a + b == c` instead of `not a + b != c`
    |
    = help: Replace with `==` operator
 
-ℹ Suggested fix
+ℹ Fix
 7  7  |     pass
 8  8  | 
 9  9  | # SIM202

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM208_SIM208.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM208_SIM208.py.snap
@@ -9,7 +9,7 @@ SIM208.py:1:4: SIM208 [*] Use `a` instead of `not (not a)`
   |
   = help: Replace with `a`
 
-ℹ Suggested fix
+ℹ Fix
 1   |-if not (not a):  # SIM208
   1 |+if a:  # SIM208
 2 2 |     pass
@@ -26,7 +26,7 @@ SIM208.py:4:4: SIM208 [*] Use `a == b` instead of `not (not a == b)`
   |
   = help: Replace with `a == b`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | if not (not a):  # SIM208
 2 2 |     pass
 3 3 | 
@@ -47,7 +47,7 @@ SIM208.py:16:5: SIM208 [*] Use `b` instead of `not (not b)`
    |
    = help: Replace with `b`
 
-ℹ Suggested fix
+ℹ Fix
 13 13 | if not a != b:  # OK
 14 14 |     pass
 15 15 | 
@@ -68,7 +68,7 @@ SIM208.py:18:3: SIM208 [*] Use `a` instead of `not (not a)`
    |
    = help: Replace with `a`
 
-ℹ Suggested fix
+ℹ Fix
 15 15 | 
 16 16 | a = not not b  # SIM208
 17 17 | 
@@ -88,7 +88,7 @@ SIM208.py:20:9: SIM208 [*] Use `a` instead of `not (not a)`
    |
    = help: Replace with `a`
 
-ℹ Suggested fix
+ℹ Fix
 17 17 | 
 18 18 | f(not not a)  # SIM208
 19 19 | 

--- a/crates/ruff_linter/src/rules/numpy/rules/deprecated_function.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/deprecated_function.rs
@@ -84,7 +84,7 @@ pub(crate) fn deprecated_function(checker: &mut Checker, expr: &Expr) {
                     checker.semantic(),
                 )?;
                 let replacement_edit = Edit::range_replacement(binding, expr.range());
-                Ok(Fix::unsafe_edits(import_edit, [replacement_edit]))
+                Ok(Fix::safe_edits(import_edit, [replacement_edit]))
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/numpy/rules/deprecated_type_alias.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/deprecated_type_alias.rs
@@ -80,7 +80,7 @@ pub(crate) fn deprecated_type_alias(checker: &mut Checker, expr: &Expr) {
                 _ => type_name,
             };
             if checker.semantic().is_builtin(type_name) {
-                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     type_name.to_string(),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy-deprecated-function_NPY003.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy-deprecated-function_NPY003.py.snap
@@ -12,7 +12,7 @@ NPY003.py:4:5: NPY003 [*] `np.round_` is deprecated; use `np.round` instead
   |
   = help: Replace with `np.round`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | def func():
 2 2 |     import numpy as np
 3 3 | 
@@ -32,7 +32,7 @@ NPY003.py:5:5: NPY003 [*] `np.product` is deprecated; use `np.prod` instead
   |
   = help: Replace with `np.prod`
 
-ℹ Suggested fix
+ℹ Fix
 2 2 |     import numpy as np
 3 3 | 
 4 4 |     np.round_(np.random.rand(5, 5), 2)
@@ -53,7 +53,7 @@ NPY003.py:6:5: NPY003 [*] `np.cumproduct` is deprecated; use `np.cumprod` instea
   |
   = help: Replace with `np.cumprod`
 
-ℹ Suggested fix
+ℹ Fix
 3 3 | 
 4 4 |     np.round_(np.random.rand(5, 5), 2)
 5 5 |     np.product(np.random.rand(5, 5))
@@ -73,7 +73,7 @@ NPY003.py:7:5: NPY003 [*] `np.sometrue` is deprecated; use `np.any` instead
   |
   = help: Replace with `np.any`
 
-ℹ Suggested fix
+ℹ Fix
 4 4 |     np.round_(np.random.rand(5, 5), 2)
 5 5 |     np.product(np.random.rand(5, 5))
 6 6 |     np.cumproduct(np.random.rand(5, 5))
@@ -92,7 +92,7 @@ NPY003.py:8:5: NPY003 [*] `np.alltrue` is deprecated; use `np.all` instead
   |
   = help: Replace with `np.all`
 
-ℹ Suggested fix
+ℹ Fix
 5 5 |     np.product(np.random.rand(5, 5))
 6 6 |     np.cumproduct(np.random.rand(5, 5))
 7 7 |     np.sometrue(np.random.rand(5, 5))
@@ -113,7 +113,7 @@ NPY003.py:14:5: NPY003 [*] `np.round_` is deprecated; use `np.round` instead
    |
    = help: Replace with `np.round`
 
-ℹ Suggested fix
+ℹ Fix
    1  |+from numpy import round
 1  2  | def func():
 2  3  |     import numpy as np
@@ -138,7 +138,7 @@ NPY003.py:15:5: NPY003 [*] `np.product` is deprecated; use `np.prod` instead
    |
    = help: Replace with `np.prod`
 
-ℹ Suggested fix
+ℹ Fix
    1  |+from numpy import prod
 1  2  | def func():
 2  3  |     import numpy as np
@@ -164,7 +164,7 @@ NPY003.py:16:5: NPY003 [*] `np.cumproduct` is deprecated; use `np.cumprod` inste
    |
    = help: Replace with `np.cumprod`
 
-ℹ Suggested fix
+ℹ Fix
    1  |+from numpy import cumprod
 1  2  | def func():
 2  3  |     import numpy as np
@@ -188,7 +188,7 @@ NPY003.py:17:5: NPY003 [*] `np.sometrue` is deprecated; use `np.any` instead
    |
    = help: Replace with `np.any`
 
-ℹ Suggested fix
+ℹ Fix
    1  |+from numpy import any
 1  2  | def func():
 2  3  |     import numpy as np
@@ -210,7 +210,7 @@ NPY003.py:18:5: NPY003 [*] `np.alltrue` is deprecated; use `np.all` instead
    |
    = help: Replace with `np.all`
 
-ℹ Suggested fix
+ℹ Fix
    1  |+from numpy import all
 1  2  | def func():
 2  3  |     import numpy as np

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy-deprecated-type-alias_NPY001.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy-deprecated-type-alias_NPY001.py.snap
@@ -10,7 +10,7 @@ NPY001.py:6:1: NPY001 [*] Type alias `np.bool` is deprecated, replace with built
   |
   = help: Replace `np.bool` with builtin type
 
-ℹ Suggested fix
+ℹ Fix
 3 3 | import numpy
 4 4 | 
 5 5 | # Error
@@ -31,7 +31,7 @@ NPY001.py:7:1: NPY001 [*] Type alias `np.int` is deprecated, replace with builti
   |
   = help: Replace `np.int` with builtin type
 
-ℹ Suggested fix
+ℹ Fix
 4 4 | 
 5 5 | # Error
 6 6 | npy.bool
@@ -51,7 +51,7 @@ NPY001.py:9:13: NPY001 [*] Type alias `np.object` is deprecated, replace with bu
    |
    = help: Replace `np.object` with builtin type
 
-ℹ Suggested fix
+ℹ Fix
 6  6  | npy.bool
 7  7  | npy.int
 8  8  | 
@@ -72,7 +72,7 @@ NPY001.py:12:72: NPY001 [*] Type alias `np.int` is deprecated, replace with buil
    |
    = help: Replace `np.int` with builtin type
 
-ℹ Suggested fix
+ℹ Fix
 9  9  | if dtype == np.object:
 10 10 |     ...
 11 11 | 
@@ -93,7 +93,7 @@ NPY001.py:12:80: NPY001 [*] Type alias `np.long` is deprecated, replace with bui
    |
    = help: Replace `np.long` with builtin type
 
-ℹ Suggested fix
+ℹ Fix
 9  9  | if dtype == np.object:
 10 10 |     ...
 11 11 | 
@@ -113,7 +113,7 @@ NPY001.py:17:11: NPY001 [*] Type alias `np.object` is deprecated, replace with b
    |
    = help: Replace `np.object` with builtin type
 
-ℹ Suggested fix
+ℹ Fix
 14 14 | pdf = pd.DataFrame(
 15 15 |     data=[[1, 2, 3]],
 16 16 |     columns=["a", "b", "c"],
@@ -134,7 +134,7 @@ NPY001.py:20:16: NPY001 [*] Type alias `np.int` is deprecated, replace with buil
    |
    = help: Replace `np.int` with builtin type
 
-ℹ Suggested fix
+ℹ Fix
 17 17 |     dtype=numpy.object,
 18 18 | )
 19 19 | 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -241,7 +241,7 @@ fn convert_to_class(
     base_class: &Expr,
     generator: Generator,
 ) -> Fix {
-    Fix::unsafe_edit(Edit::range_replacement(
+    Fix::safe_edit(Edit::range_replacement(
         generator.stmt(&create_class_def_stmt(typename, body, base_class)),
         stmt.range(),
     ))

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -275,7 +275,7 @@ fn convert_to_class(
     base_class: &Expr,
     generator: Generator,
 ) -> Fix {
-    Fix::unsafe_edit(Edit::range_replacement(
+    Fix::safe_edit(Edit::range_replacement(
         generator.stmt(&create_class_def_stmt(
             class_name,
             body,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -66,7 +66,7 @@ pub(crate) fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
                     checker.semantic(),
                 )?;
                 let reference_edit = Edit::range_replacement(binding, expr.range());
-                Ok(Fix::unsafe_edits(import_edit, [reference_edit]))
+                Ok(Fix::safe_edits(import_edit, [reference_edit]))
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
@@ -46,7 +46,7 @@ where
     let mut diagnostic = Diagnostic::new(DeprecatedCElementTree, node.range());
     if checker.patch(diagnostic.kind.rule()) {
         let contents = checker.locator().slice(node);
-        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             contents.replacen("cElementTree", "ElementTree", 1),
             node.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -632,7 +632,7 @@ pub(crate) fn deprecated_import(
         );
         if checker.patch(Rule::DeprecatedImport) {
             if let Some(content) = fix {
-                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     content,
                     stmt.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -262,7 +262,7 @@ pub(crate) fn deprecated_mock_attribute(checker: &mut Checker, expr: &Expr) {
                 value.range(),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     "mock".to_string(),
                     value.range(),
                 )));
@@ -308,7 +308,7 @@ pub(crate) fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
                             name.range(),
                         );
                         if let Some(content) = content.as_ref() {
-                            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                                 content.clone(),
                                 stmt.range(),
                             )));
@@ -339,7 +339,7 @@ pub(crate) fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
                         diagnostic.try_set_fix(|| {
                             format_import_from(stmt, indent, checker.locator(), checker.stylist())
                                 .map(|content| Edit::range_replacement(content, stmt.range()))
-                                .map(Fix::unsafe_edit)
+                                .map(Fix::safe_edit)
                         });
                     }
                 }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -100,7 +100,7 @@ pub(crate) fn deprecated_unittest_alias(checker: &mut Checker, expr: &Expr) {
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             format!("self.{target}"),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -419,7 +419,7 @@ pub(crate) fn f_strings(
             .comment_ranges()
             .intersects(call.arguments.range())
     {
-        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             contents,
             call.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/open_alias.rs
@@ -56,7 +56,7 @@ pub(crate) fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
         let mut diagnostic = Diagnostic::new(OpenAlias, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             if checker.semantic().is_builtin("open") {
-                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     "open".to_string(),
                     func.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -74,10 +74,10 @@ pub(crate) fn replace_universal_newlines(checker: &mut Checker, call: &ast::Expr
                         Parentheses::Preserve,
                         checker.locator().contents(),
                     )
-                    .map(Fix::unsafe_edit)
+                    .map(Fix::safe_edit)
                 });
             } else {
-                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     "text".to_string(),
                     arg.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -125,7 +125,7 @@ pub(crate) fn unnecessary_future_import(checker: &mut Checker, stmt: &Stmt, name
                 checker.stylist(),
                 checker.indexer(),
             )?;
-            Ok(Fix::unsafe_edit(edit).isolate(Checker::isolation(
+            Ok(Fix::safe_edit(edit).isolate(Checker::isolation(
                 checker.semantic().current_statement_parent_id(),
             )))
         });

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
@@ -74,7 +74,7 @@ pub(crate) fn unpacked_list_comprehension(checker: &mut Checker, targets: &[Expr
         content.push('(');
         content.push_str(&existing[1..existing.len() - 1]);
         content.push(')');
-        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             content,
             value.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP005.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP005.py.snap
@@ -12,7 +12,7 @@ UP005.py:6:9: UP005 [*] `assertEquals` is deprecated, use `assertEqual`
   |
   = help: Replace `assertEqual` with `assertEquals`
 
-ℹ Suggested fix
+ℹ Fix
 3 3 | 
 4 4 | class Suite(unittest.TestCase):
 5 5 |     def test(self) -> None:
@@ -33,7 +33,7 @@ UP005.py:7:9: UP005 [*] `assertEquals` is deprecated, use `assertEqual`
   |
   = help: Replace `assertEqual` with `assertEquals`
 
-ℹ Suggested fix
+ℹ Fix
 4 4 | class Suite(unittest.TestCase):
 5 5 |     def test(self) -> None:
 6 6 |         self.assertEquals (1, 2)
@@ -53,7 +53,7 @@ UP005.py:9:9: UP005 [*] `failUnlessAlmostEqual` is deprecated, use `assertAlmost
    |
    = help: Replace `assertAlmostEqual` with `failUnlessAlmostEqual`
 
-ℹ Suggested fix
+ℹ Fix
 6  6  |         self.assertEquals (1, 2)
 7  7  |         self.assertEquals(1, 2)
 8  8  |         self.assertEqual(3, 4)
@@ -70,7 +70,7 @@ UP005.py:10:9: UP005 [*] `assertNotRegexpMatches` is deprecated, use `assertNotR
    |
    = help: Replace `assertNotRegex` with `assertNotRegexpMatches`
 
-ℹ Suggested fix
+ℹ Fix
 7  7  |         self.assertEquals(1, 2)
 8  8  |         self.assertEqual(3, 4)
 9  9  |         self.failUnlessAlmostEqual(1, 1.1)

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP010.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP010.py.snap
@@ -10,7 +10,7 @@ UP010.py:1:1: UP010 [*] Unnecessary `__future__` imports `generators`, `nested_s
   |
   = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Fix
 1   |-from __future__ import nested_scopes, generators
 2 1 | from __future__ import with_statement, unicode_literals
 3 2 | from __future__ import absolute_import, division
@@ -26,7 +26,7 @@ UP010.py:2:1: UP010 [*] Unnecessary `__future__` imports `unicode_literals`, `wi
   |
   = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | from __future__ import nested_scopes, generators
 2   |-from __future__ import with_statement, unicode_literals
 3 2 | from __future__ import absolute_import, division
@@ -44,7 +44,7 @@ UP010.py:3:1: UP010 [*] Unnecessary `__future__` imports `absolute_import`, `div
   |
   = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | from __future__ import nested_scopes, generators
 2 2 | from __future__ import with_statement, unicode_literals
 3   |-from __future__ import absolute_import, division
@@ -63,7 +63,7 @@ UP010.py:4:1: UP010 [*] Unnecessary `__future__` import `generator_stop` for tar
   |
   = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | from __future__ import nested_scopes, generators
 2 2 | from __future__ import with_statement, unicode_literals
 3 3 | from __future__ import absolute_import, division
@@ -82,7 +82,7 @@ UP010.py:5:1: UP010 [*] Unnecessary `__future__` imports `generator_stop`, `prin
   |
   = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Fix
 2 2 | from __future__ import with_statement, unicode_literals
 3 3 | from __future__ import absolute_import, division
 4 4 | from __future__ import generator_stop
@@ -102,7 +102,7 @@ UP010.py:6:1: UP010 [*] Unnecessary `__future__` import `generators` for target 
   |
   = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Fix
 3 3 | from __future__ import absolute_import, division
 4 4 | from __future__ import generator_stop
 5 5 | from __future__ import print_function, generator_stop
@@ -121,7 +121,7 @@ UP010.py:9:5: UP010 [*] Unnecessary `__future__` import `generator_stop` for tar
    |
    = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Fix
 6  6  | from __future__ import invalid_module, generators
 7  7  | 
 8  8  | if True:
@@ -141,7 +141,7 @@ UP010.py:10:5: UP010 [*] Unnecessary `__future__` import `generators` for target
    |
    = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Fix
 7  7  | 
 8  8  | if True:
 9  9  |     from __future__ import generator_stop
@@ -159,7 +159,7 @@ UP010.py:13:5: UP010 [*] Unnecessary `__future__` import `generator_stop` for ta
    |
    = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Fix
 10 10 |     from __future__ import generators
 11 11 | 
 12 12 | if True:
@@ -175,7 +175,7 @@ UP010.py:14:5: UP010 [*] Unnecessary `__future__` import `generators` for target
    |
    = help: Remove unnecessary `future` import
 
-ℹ Suggested fix
+ℹ Fix
 11 11 | 
 12 12 | if True:
 13 13 |     from __future__ import generator_stop

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP013.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP013.py.snap
@@ -11,7 +11,7 @@ UP013.py:5:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class sy
   |
   = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 2 2 | import typing
 3 3 | 
 4 4 | # dict literal
@@ -33,7 +33,7 @@ UP013.py:8:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class sy
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 5  5  | MyType = TypedDict("MyType", {"a": int, "b": str})
 6  6  | 
 7  7  | # dict call
@@ -55,7 +55,7 @@ UP013.py:11:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 8  8  | MyType = TypedDict("MyType", dict(a=int, b=str))
 9  9  | 
 10 10 | # kwargs
@@ -77,7 +77,7 @@ UP013.py:14:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 11 11 | MyType = TypedDict("MyType", a=int, b=str)
 12 12 | 
 13 13 | # Empty TypedDict
@@ -97,7 +97,7 @@ UP013.py:17:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 14 14 | MyType = TypedDict("MyType")
 15 15 | 
 16 16 | # Literal values
@@ -119,7 +119,7 @@ UP013.py:18:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 15 15 | 
 16 16 | # Literal values
 17 17 | MyType = TypedDict("MyType", {"a": "hello"})
@@ -140,7 +140,7 @@ UP013.py:21:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 18 18 | MyType = TypedDict("MyType", a="hello")
 19 19 | 
 20 20 | # NotRequired
@@ -161,7 +161,7 @@ UP013.py:24:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 21 21 | MyType = TypedDict("MyType", {"a": NotRequired[dict]})
 22 22 | 
 23 23 | # total
@@ -183,7 +183,7 @@ UP013.py:27:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 24 24 | MyType = TypedDict("MyType", {"x": int, "y": int}, total=False)
 25 25 | 
 26 26 | # using Literal type
@@ -204,7 +204,7 @@ UP013.py:30:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 27 27 | MyType = TypedDict("MyType", {"key": Literal["value"]})
 28 28 | 
 29 29 | # using namespace TypedDict
@@ -225,7 +225,7 @@ UP013.py:40:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 37 37 | MyType = TypedDict("MyType", {"a": int, "b": str, **c})
 38 38 | 
 39 39 | # Empty dict literal
@@ -244,7 +244,7 @@ UP013.py:43:1: UP013 [*] Convert `MyType` from `TypedDict` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 40 40 | MyType = TypedDict("MyType", {})
 41 41 | 
 42 42 | # Empty dict call

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP014.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP014.py.snap
@@ -11,7 +11,7 @@ UP014.py:5:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class s
   |
   = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 2 2 | import typing
 3 3 | 
 4 4 | # with complex annotations
@@ -33,7 +33,7 @@ UP014.py:8:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class s
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 5  5  | MyType = NamedTuple("MyType", [("a", int), ("b", tuple[str, ...])])
 6  6  | 
 7  7  | # with namespace
@@ -55,7 +55,7 @@ UP014.py:14:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class 
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 11 11 | MyType = NamedTuple("MyType", [("x-y", int), ("b", tuple[str, ...])])
 12 12 | 
 13 13 | # no fields
@@ -76,7 +76,7 @@ UP014.py:17:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class 
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 14 14 | MyType = typing.NamedTuple("MyType")
 15 15 | 
 16 16 | # empty fields
@@ -97,7 +97,7 @@ UP014.py:20:1: UP014 [*] Convert `MyType` from `NamedTuple` functional to class 
    |
    = help: Convert `MyType` to class syntax
 
-ℹ Suggested fix
+ℹ Fix
 17 17 | MyType = typing.NamedTuple("MyType", [])
 18 18 | 
 19 19 | # keywords

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP020.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP020.py.snap
@@ -11,7 +11,7 @@ UP020.py:3:6: UP020 [*] Use builtin `open`
   |
   = help: Replace with builtin `open`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | import io
 2 2 | 
 3   |-with io.open("f.txt", mode="r", buffering=-1, **kwargs) as f:

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP021.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP021.py.snap
@@ -11,7 +11,7 @@ UP021.py:5:25: UP021 [*] `universal_newlines` is deprecated, use `text`
   |
   = help: Replace with `text` keyword argument
 
-ℹ Suggested fix
+ℹ Fix
 2 2 | from subprocess import run
 3 3 | 
 4 4 | # Errors
@@ -31,7 +31,7 @@ UP021.py:6:25: UP021 [*] `universal_newlines` is deprecated, use `text`
   |
   = help: Replace with `text` keyword argument
 
-ℹ Suggested fix
+ℹ Fix
 3 3 | 
 4 4 | # Errors
 5 5 | subprocess.run(["foo"], universal_newlines=True, check=True)
@@ -52,7 +52,7 @@ UP021.py:7:14: UP021 [*] `universal_newlines` is deprecated, use `text`
   |
   = help: Replace with `text` keyword argument
 
-ℹ Suggested fix
+ℹ Fix
 4 4 | # Errors
 5 5 | subprocess.run(["foo"], universal_newlines=True, check=True)
 6 6 | subprocess.run(["foo"], universal_newlines=True, text=True)

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP023.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP023.py.snap
@@ -10,7 +10,7 @@ UP023.py:2:1: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
   |
   = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # These two imports have something after cElementTree, so they should be fixed.
 2   |-from xml.etree.cElementTree import XML, Element, SubElement
   2 |+from xml.etree.ElementTree import XML, Element, SubElement
@@ -29,7 +29,7 @@ UP023.py:3:8: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
   |
   = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # These two imports have something after cElementTree, so they should be fixed.
 2 2 | from xml.etree.cElementTree import XML, Element, SubElement
 3   |-import xml.etree.cElementTree as ET
@@ -47,7 +47,7 @@ UP023.py:6:1: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
   |
   = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Fix
 3 3 | import xml.etree.cElementTree as ET
 4 4 | 
 5 5 | # Weird spacing should not cause issues.
@@ -68,7 +68,7 @@ UP023.py:7:11: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
   |
   = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Fix
 4 4 | 
 5 5 | # Weird spacing should not cause issues.
 6 6 | from   xml.etree.cElementTree    import  XML
@@ -92,7 +92,7 @@ UP023.py:10:1: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
    |
    = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Fix
 7  7  | import    xml.etree.cElementTree       as      ET
 8  8  | 
 9  9  | # Multi line imports should also work fine.
@@ -112,7 +112,7 @@ UP023.py:16:12: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
    |
    = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Fix
 13 13 |     SubElement,
 14 14 | )
 15 15 | if True:
@@ -133,7 +133,7 @@ UP023.py:17:27: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
    |
    = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Fix
 14 14 | )
 15 15 | if True:
 16 16 |     import xml.etree.cElementTree as ET
@@ -154,7 +154,7 @@ UP023.py:19:23: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
    |
    = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Fix
 16 16 |     import xml.etree.cElementTree as ET
 17 17 |     from xml.etree import cElementTree as CET
 18 18 | 
@@ -175,7 +175,7 @@ UP023.py:21:20: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
    |
    = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Fix
 18 18 | 
 19 19 | from xml.etree import cElementTree as ET
 20 20 | 
@@ -195,7 +195,7 @@ UP023.py:24:32: UP023 [*] `cElementTree` is deprecated, use `ElementTree`
    |
    = help: Replace with `ElementTree`
 
-ℹ Suggested fix
+ℹ Fix
 21 21 | import contextlib, xml.etree.cElementTree as ET
 22 22 | 
 23 23 | # This should fix the second, but not the first invocation.

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP026.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP026.py.snap
@@ -12,7 +12,7 @@ UP026.py:3:12: UP026 [*] `mock` is deprecated, use `unittest.mock`
   |
   = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # Error (`from unittest import mock`)
 2 2 | if True:
 3   |-    import mock
@@ -32,7 +32,7 @@ UP026.py:7:12: UP026 [*] `mock` is deprecated, use `unittest.mock`
   |
   = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 4 4 | 
 5 5 | # Error (`from unittest import mock`)
 6 6 | if True:
@@ -54,7 +54,7 @@ UP026.py:11:5: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 8  8  | 
 9  9  | # Error (`from unittest.mock import *`)
 10 10 | if True:
@@ -74,7 +74,7 @@ UP026.py:14:8: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 11 11 |     from mock import *
 12 12 | 
 13 13 | # Error (`from unittest import mock`)
@@ -94,7 +94,7 @@ UP026.py:17:20: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 14 14 | import mock.mock
 15 15 | 
 16 16 | # Error (`from unittest import mock`)
@@ -114,7 +114,7 @@ UP026.py:20:8: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 17 17 | import contextlib, mock, sys
 18 18 | 
 19 19 | # Error (`from unittest import mock`)
@@ -135,7 +135,7 @@ UP026.py:24:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 21 21 | x = "This code should be preserved one line below the mock"
 22 22 | 
 23 23 | # Error (`from unittest import mock`)
@@ -160,7 +160,7 @@ UP026.py:27:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 24 24 | from mock import mock
 25 25 | 
 26 26 | # Error (keep trailing comma)
@@ -192,7 +192,7 @@ UP026.py:33:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 30 30 |     b,
 31 31 |     c,
 32 32 | )
@@ -223,7 +223,7 @@ UP026.py:41:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 38 38 | )
 39 39 | 
 40 40 | # Error (avoid trailing comma)
@@ -255,7 +255,7 @@ UP026.py:47:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 44 44 |     b,
 45 45 |     c
 46 46 | )
@@ -282,7 +282,7 @@ UP026.py:53:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 50 50 |     c,
 51 51 |     mock
 52 52 | )
@@ -304,7 +304,7 @@ UP026.py:54:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 51 51 |     mock
 52 52 | )
 53 53 | from mock import mock, a, b, c
@@ -332,7 +332,7 @@ UP026.py:58:9: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 55 55 | 
 56 56 | if True:
 57 57 |     if False:
@@ -358,7 +358,7 @@ UP026.py:69:8: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 66 66 | import os, io
 67 67 | 
 68 68 | # Error (`from unittest import mock`)
@@ -379,7 +379,7 @@ UP026.py:69:14: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 66 66 | import os, io
 67 67 | 
 68 68 | # Error (`from unittest import mock`)
@@ -400,7 +400,7 @@ UP026.py:72:8: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 69 69 | import mock, mock
 70 70 | 
 71 71 | # Error (`from unittest import mock as foo`)
@@ -420,7 +420,7 @@ UP026.py:75:1: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 72 72 | import mock as foo
 73 73 | 
 74 74 | # Error (`from unittest import mock as foo`)
@@ -441,7 +441,7 @@ UP026.py:79:12: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 76 76 | 
 77 77 | if True:
 78 78 |     # This should yield multiple, aliased imports.
@@ -464,7 +464,7 @@ UP026.py:79:25: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 76 76 | 
 77 77 | if True:
 78 78 |     # This should yield multiple, aliased imports.
@@ -487,7 +487,7 @@ UP026.py:79:38: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 76 76 | 
 77 77 | if True:
 78 78 |     # This should yield multiple, aliased imports.
@@ -509,7 +509,7 @@ UP026.py:82:12: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 79 79 |     import mock as foo, mock as bar, mock
 80 80 | 
 81 81 |     # This should yield multiple, aliased imports, and preserve `os`.
@@ -532,7 +532,7 @@ UP026.py:82:25: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 79 79 |     import mock as foo, mock as bar, mock
 80 80 | 
 81 81 |     # This should yield multiple, aliased imports, and preserve `os`.
@@ -555,7 +555,7 @@ UP026.py:82:38: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 79 79 |     import mock as foo, mock as bar, mock
 80 80 | 
 81 81 |     # This should yield multiple, aliased imports, and preserve `os`.
@@ -577,7 +577,7 @@ UP026.py:86:5: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Import from `unittest.mock` instead
 
-ℹ Suggested fix
+ℹ Fix
 83 83 | 
 84 84 | if True:
 85 85 |     # This should yield multiple, aliased imports.
@@ -597,7 +597,7 @@ UP026.py:93:5: UP026 [*] `mock` is deprecated, use `unittest.mock`
    |
    = help: Replace `mock.mock` with `mock`
 
-ℹ Suggested fix
+ℹ Fix
 90 90 | x = mock.Mock()
 91 91 | 
 92 92 | # Error (`mock.Mock()`).

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP027.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP027.py.snap
@@ -11,7 +11,7 @@ UP027.py:2:17: UP027 [*] Replace unpacked list comprehension with a generator ex
   |
   = help: Replace with generator expression
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # Should change
 2   |-foo, bar, baz = [fn(x) for x in items]
   2 |+foo, bar, baz = (fn(x) for x in items)
@@ -30,7 +30,7 @@ UP027.py:4:16: UP027 [*] Replace unpacked list comprehension with a generator ex
   |
   = help: Replace with generator expression
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # Should change
 2 2 | foo, bar, baz = [fn(x) for x in items]
 3 3 | 
@@ -51,7 +51,7 @@ UP027.py:6:26: UP027 [*] Replace unpacked list comprehension with a generator ex
   |
   = help: Replace with generator expression
 
-ℹ Suggested fix
+ℹ Fix
 3 3 | 
 4 4 | foo, bar, baz =[fn(x) for x in items]
 5 5 | 
@@ -72,7 +72,7 @@ UP027.py:8:17: UP027 [*] Replace unpacked list comprehension with a generator ex
    |
    = help: Replace with generator expression
 
-ℹ Suggested fix
+ℹ Fix
 5 5 | 
 6 6 | foo, bar, baz =          [fn(x) for x in items]
 7 7 | 
@@ -97,7 +97,7 @@ UP027.py:10:17: UP027 [*] Replace unpacked list comprehension with a generator e
    |
    = help: Replace with generator expression
 
-ℹ Suggested fix
+ℹ Fix
 7  7  | 
 8  8  | foo, bar, baz = [[i for i in fn(x)] for x in items]
 9  9  | 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_0.py.snap
@@ -12,7 +12,7 @@ UP032_0.py:5:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 2 2 | # Errors
 3 3 | ###
 4 4 | 
@@ -33,7 +33,7 @@ UP032_0.py:7:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 4 4 | 
 5 5 | "{} {}".format(a, b)
 6 6 | 
@@ -54,7 +54,7 @@ UP032_0.py:9:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 6  6  | 
 7  7  | "{1} {0}".format(a, b)
 8  8  | 
@@ -75,7 +75,7 @@ UP032_0.py:11:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 8  8  | 
 9  9  | "{0} {1} {0}".format(a, b)
 10 10 | 
@@ -96,7 +96,7 @@ UP032_0.py:13:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 10 10 | 
 11 11 | "{x.y}".format(x=z)
 12 12 | 
@@ -117,7 +117,7 @@ UP032_0.py:15:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 12 12 | 
 13 13 | "{x} {y} {x}".format(x=a, y=b)
 14 14 | 
@@ -138,7 +138,7 @@ UP032_0.py:17:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 14 14 | 
 15 15 | "{.x} {.y}".format(a, b)
 16 16 | 
@@ -159,7 +159,7 @@ UP032_0.py:19:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 16 16 | 
 17 17 | "{} {}".format(a.b, c.d)
 18 18 | 
@@ -180,7 +180,7 @@ UP032_0.py:21:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 18 18 | 
 19 19 | "{}".format(a())
 20 20 | 
@@ -201,7 +201,7 @@ UP032_0.py:23:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 20 20 | 
 21 21 | "{}".format(a.b())
 22 22 | 
@@ -222,7 +222,7 @@ UP032_0.py:25:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 22 22 | 
 23 23 | "{}".format(a.b().c())
 24 24 | 
@@ -243,7 +243,7 @@ UP032_0.py:27:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 24 24 | 
 25 25 | "hello {}!".format(name)
 26 26 | 
@@ -264,7 +264,7 @@ UP032_0.py:29:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 26 26 | 
 27 27 | "{}{b}{}".format(a, c, b=b)
 28 28 | 
@@ -285,7 +285,7 @@ UP032_0.py:31:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 28 28 | 
 29 29 | "{}".format(0x0)
 30 30 | 
@@ -306,7 +306,7 @@ UP032_0.py:33:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 30 30 | 
 31 31 | "{} {}".format(a, b)
 32 32 | 
@@ -327,7 +327,7 @@ UP032_0.py:35:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 32 32 | 
 33 33 | """{} {}""".format(a, b)
 34 34 | 
@@ -348,7 +348,7 @@ UP032_0.py:37:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 34 34 | 
 35 35 | "foo{}".format(1)
 36 36 | 
@@ -369,7 +369,7 @@ UP032_0.py:39:5: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 36 36 | 
 37 37 | r"foo{}".format(1)
 38 38 | 
@@ -390,7 +390,7 @@ UP032_0.py:41:7: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 38 38 | 
 39 39 | x = "{a}".format(a=1)
 40 40 | 
@@ -411,7 +411,7 @@ UP032_0.py:43:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 40 40 | 
 41 41 | print("foo {} ".format(x))
 42 42 | 
@@ -432,7 +432,7 @@ UP032_0.py:45:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 42 42 | 
 43 43 | "{a[b]}".format(a=a)
 44 44 | 
@@ -453,7 +453,7 @@ UP032_0.py:47:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 44 44 | 
 45 45 | "{a.a[b]}".format(a=a)
 46 46 | 
@@ -474,7 +474,7 @@ UP032_0.py:49:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 46 46 | 
 47 47 | "{}{{}}{}".format(escaped, y)
 48 48 | 
@@ -495,7 +495,7 @@ UP032_0.py:51:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 48 48 | 
 49 49 | "{}".format(a)
 50 50 | 
@@ -516,7 +516,7 @@ UP032_0.py:53:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 50 50 | 
 51 51 | '({}={{0!e}})'.format(a)
 52 52 | 
@@ -537,7 +537,7 @@ UP032_0.py:55:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 52 52 | 
 53 53 | "{[b]}".format(a)
 54 54 | 
@@ -558,7 +558,7 @@ UP032_0.py:57:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 54 54 | 
 55 55 | '{[b]}'.format(a)
 56 56 | 
@@ -579,7 +579,7 @@ UP032_0.py:59:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 56 56 | 
 57 57 | """{[b]}""".format(a)
 58 58 | 
@@ -602,7 +602,7 @@ UP032_0.py:61:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 58 58 | 
 59 59 | '''{[b]}'''.format(a)
 60 60 | 
@@ -627,7 +627,7 @@ UP032_0.py:65:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 62 62 |     1
 63 63 | )
 64 64 | 
@@ -652,7 +652,7 @@ UP032_0.py:69:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 66 66 |     1111111111111111111111111111111111111111111111111111111111111111111111111,
 67 67 | )
 68 68 | 
@@ -681,7 +681,7 @@ UP032_0.py:73:85: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 70 70 | {}
 71 71 | """.format(1)
 72 72 | 
@@ -708,7 +708,7 @@ UP032_0.py:79:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 76 76 |     111111
 77 77 | )
 78 78 | 
@@ -732,7 +732,7 @@ UP032_0.py:81:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 79 79 | "{a}" "{b}".format(a=1, b=1)
 80 80 | 
 81 81 | (
@@ -762,7 +762,7 @@ UP032_0.py:86:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 84 84 | ).format(a=1, b=1)
 85 85 | 
 86 86 | (
@@ -795,7 +795,7 @@ UP032_0.py:94:5: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 93  93  | (
 94  94  |     (
 95  95  |         # comment
@@ -824,7 +824,7 @@ UP032_0.py:104:1: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 102 102 | )
 103 103 | 
 104 104 | (
@@ -845,7 +845,7 @@ UP032_0.py:111:11: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 108 108 | 
 109 109 | 
 110 110 | def d(osname, version, release):
@@ -863,7 +863,7 @@ UP032_0.py:115:10: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 112 112 | 
 113 113 | 
 114 114 | def e():
@@ -880,7 +880,7 @@ UP032_0.py:118:7: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 115 115 |     yield"{}".format(1)
 116 116 | 
 117 117 | 
@@ -898,7 +898,7 @@ UP032_0.py:122:12: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 119 119 | 
 120 120 | 
 121 121 | async def c():
@@ -916,7 +916,7 @@ UP032_0.py:126:12: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 123 123 | 
 124 124 | 
 125 125 | async def c():
@@ -935,7 +935,7 @@ UP032_0.py:129:1: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 126 126 |     return "{}".format(1 + await 3)
 127 127 | 
 128 128 | 
@@ -965,7 +965,7 @@ UP032_0.py:209:1: UP032 [*] Use f-string instead of `format` call
     |
     = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 206 206 | 
 207 207 | # The fixed string will exceed the line length, but it's still smaller than the
 208 208 | # existing line length, so it's fine.

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_1.py.snap
@@ -8,7 +8,7 @@ UP032_1.py:1:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 1   |-"{} {}".format(a, b)  # Intentionally at start-of-file, to ensure graceful handling.
   1 |+f"{a} {b}"  # Intentionally at start-of-file, to ensure graceful handling.
 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_2.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_2.py.snap
@@ -11,7 +11,7 @@ UP032_2.py:2:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # Errors
 2   |-"{.real}".format(1)
   2 |+f"{(1).real}"
@@ -29,7 +29,7 @@ UP032_2.py:3:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # Errors
 2 2 | "{.real}".format(1)
 3   |-"{0.real}".format(1)
@@ -49,7 +49,7 @@ UP032_2.py:4:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # Errors
 2 2 | "{.real}".format(1)
 3 3 | "{0.real}".format(1)
@@ -70,7 +70,7 @@ UP032_2.py:6:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 3 3 | "{0.real}".format(1)
 4 4 | "{a.real}".format(a=1)
 5 5 | 
@@ -89,7 +89,7 @@ UP032_2.py:7:1: UP032 [*] Use f-string instead of `format` call
   |
   = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 4 4 | "{a.real}".format(a=1)
 5 5 | 
 6 6 | "{.real}".format(1.0)
@@ -110,7 +110,7 @@ UP032_2.py:8:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 5 5 | 
 6 6 | "{.real}".format(1.0)
 7 7 | "{0.real}".format(1.0)
@@ -131,7 +131,7 @@ UP032_2.py:10:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 7  7  | "{0.real}".format(1.0)
 8  8  | "{a.real}".format(a=1.0)
 9  9  | 
@@ -150,7 +150,7 @@ UP032_2.py:11:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 8  8  | "{a.real}".format(a=1.0)
 9  9  | 
 10 10 | "{.real}".format(1j)
@@ -171,7 +171,7 @@ UP032_2.py:12:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 9  9  | 
 10 10 | "{.real}".format(1j)
 11 11 | "{0.real}".format(1j)
@@ -192,7 +192,7 @@ UP032_2.py:14:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 11 11 | "{0.real}".format(1j)
 12 12 | "{a.real}".format(a=1j)
 13 13 | 
@@ -211,7 +211,7 @@ UP032_2.py:15:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 12 12 | "{a.real}".format(a=1j)
 13 13 | 
 14 14 | "{.real}".format(0b01)
@@ -232,7 +232,7 @@ UP032_2.py:16:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 13 13 | 
 14 14 | "{.real}".format(0b01)
 15 15 | "{0.real}".format(0b01)
@@ -253,7 +253,7 @@ UP032_2.py:18:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 15 15 | "{0.real}".format(0b01)
 16 16 | "{a.real}".format(a=0b01)
 17 17 | 
@@ -273,7 +273,7 @@ UP032_2.py:19:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 16 16 | "{a.real}".format(a=0b01)
 17 17 | 
 18 18 | "{}".format(1 + 2)
@@ -294,7 +294,7 @@ UP032_2.py:20:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 17 17 | 
 18 18 | "{}".format(1 + 2)
 19 19 | "{}".format([1, 2])
@@ -314,7 +314,7 @@ UP032_2.py:21:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 18 18 | "{}".format(1 + 2)
 19 19 | "{}".format([1, 2])
 20 20 | "{}".format({1, 2})
@@ -335,7 +335,7 @@ UP032_2.py:22:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 19 19 | "{}".format([1, 2])
 20 20 | "{}".format({1, 2})
 21 21 | "{}".format({1: 2, 3: 4})
@@ -356,7 +356,7 @@ UP032_2.py:24:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 21 21 | "{}".format({1: 2, 3: 4})
 22 22 | "{}".format((i for i in range(2)))
 23 23 | 
@@ -376,7 +376,7 @@ UP032_2.py:25:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 22 22 | "{}".format((i for i in range(2)))
 23 23 | 
 24 24 | "{.real}".format(1 + 2)
@@ -397,7 +397,7 @@ UP032_2.py:26:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 23 23 | 
 24 24 | "{.real}".format(1 + 2)
 25 25 | "{.real}".format([1, 2])
@@ -416,7 +416,7 @@ UP032_2.py:27:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 24 24 | "{.real}".format(1 + 2)
 25 25 | "{.real}".format([1, 2])
 26 26 | "{.real}".format({1, 2})
@@ -433,7 +433,7 @@ UP032_2.py:28:1: UP032 [*] Use f-string instead of `format` call
    |
    = help: Convert to f-string
 
-ℹ Suggested fix
+ℹ Fix
 25 25 | "{.real}".format([1, 2])
 26 26 | "{.real}".format({1, 2})
 27 27 | "{.real}".format({1: 2, 3: 4})

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
@@ -11,7 +11,7 @@ UP035.py:2:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
   |
   = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # UP035
 2   |-from collections import Mapping
   2 |+from collections.abc import Mapping
@@ -30,7 +30,7 @@ UP035.py:4:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
   |
   = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # UP035
 2 2 | from collections import Mapping
 3 3 | 
@@ -51,7 +51,7 @@ UP035.py:6:1: UP035 [*] Import from `collections.abc` instead: `Mapping`, `Seque
   |
   = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 3 3 | 
 4 4 | from collections import Mapping as MAP
 5 5 | 
@@ -72,7 +72,7 @@ UP035.py:8:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 5  5  | 
 6  6  | from collections import Mapping, Sequence
 7  7  | 
@@ -94,7 +94,7 @@ UP035.py:10:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 7  7  | 
 8  8  | from collections import Counter, Mapping
 9  9  | 
@@ -117,7 +117,7 @@ UP035.py:12:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 9  9  | 
 10 10 | from collections import (Counter, Mapping)
 11 11 | 
@@ -141,7 +141,7 @@ UP035.py:15:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 12 12 | from collections import (Counter,
 13 13 |                          Mapping)
 14 14 | 
@@ -164,7 +164,7 @@ UP035.py:18:1: UP035 [*] Import from `collections.abc` instead: `Mapping`, `Sequ
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 15 15 | from collections import Counter, \
 16 16 |                          Mapping
 17 17 | 
@@ -186,7 +186,7 @@ UP035.py:20:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 17 17 | 
 18 18 | from collections import Counter, Mapping, Sequence
 19 19 | 
@@ -207,7 +207,7 @@ UP035.py:23:5: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 20 20 | from collections import Mapping as mapping, Counter
 21 21 | 
 22 22 | if True:
@@ -229,7 +229,7 @@ UP035.py:28:5: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 25 25 | if True:
 26 26 |     if True:
 27 27 |         pass
@@ -251,7 +251,7 @@ UP035.py:30:10: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 27 27 |         pass
 28 28 |     from collections import Mapping, Counter
 29 29 | 
@@ -270,7 +270,7 @@ UP035.py:33:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 30 30 | if True: from collections import Mapping
 31 31 | 
 32 32 | import os
@@ -297,7 +297,7 @@ UP035.py:37:5: UP035 [*] Import from `collections.abc` instead: `Mapping`, `Call
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 35 35 | 
 36 36 | if True:
 37 37 |     from collections import (
@@ -322,7 +322,7 @@ UP035.py:44:1: UP035 [*] Import from `collections.abc` instead: `Callable`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 41 41 |         Good,
 42 42 |     )
 43 43 | 
@@ -344,7 +344,7 @@ UP035.py:44:1: UP035 [*] Import from `collections` instead: `OrderedDict`
    |
    = help: Import from `collections`
 
-ℹ Suggested fix
+ℹ Fix
 41 41 |         Good,
 42 42 |     )
 43 43 | 
@@ -366,7 +366,7 @@ UP035.py:44:1: UP035 [*] Import from `re` instead: `Match`, `Pattern`
    |
    = help: Import from `re`
 
-ℹ Suggested fix
+ℹ Fix
 41 41 |         Good,
 42 42 |     )
 43 43 | 
@@ -440,7 +440,7 @@ UP035.py:51:1: UP035 [*] Import from `collections` instead: `OrderedDict`
    |
    = help: Import from `collections`
 
-ℹ Suggested fix
+ℹ Fix
 48 48 | 
 49 49 | # Bad imports from PYI027 that are now handled by PYI022 (UP035)
 50 50 | from typing import ContextManager
@@ -461,7 +461,7 @@ UP035.py:52:1: UP035 [*] Import from `typing` instead: `OrderedDict`
    |
    = help: Import from `typing`
 
-ℹ Suggested fix
+ℹ Fix
 49 49 | # Bad imports from PYI027 that are now handled by PYI022 (UP035)
 50 50 | from typing import ContextManager
 51 51 | from typing import OrderedDict
@@ -482,7 +482,7 @@ UP035.py:53:1: UP035 [*] Import from `collections.abc` instead: `Callable`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 50 50 | from typing import ContextManager
 51 51 | from typing import OrderedDict
 52 52 | from typing_extensions import OrderedDict
@@ -503,7 +503,7 @@ UP035.py:54:1: UP035 [*] Import from `collections.abc` instead: `ByteString`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 51 51 | from typing import OrderedDict
 52 52 | from typing_extensions import OrderedDict
 53 53 | from typing import Callable
@@ -524,7 +524,7 @@ UP035.py:55:1: UP035 [*] Import from `collections.abc` instead: `Container`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 52 52 | from typing_extensions import OrderedDict
 53 53 | from typing import Callable
 54 54 | from typing import ByteString
@@ -545,7 +545,7 @@ UP035.py:56:1: UP035 [*] Import from `collections.abc` instead: `Hashable`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 53 53 | from typing import Callable
 54 54 | from typing import ByteString
 55 55 | from typing import Container
@@ -566,7 +566,7 @@ UP035.py:57:1: UP035 [*] Import from `collections.abc` instead: `ItemsView`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 54 54 | from typing import ByteString
 55 55 | from typing import Container
 56 56 | from typing import Hashable
@@ -587,7 +587,7 @@ UP035.py:58:1: UP035 [*] Import from `collections.abc` instead: `Iterable`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 55 55 | from typing import Container
 56 56 | from typing import Hashable
 57 57 | from typing import ItemsView
@@ -608,7 +608,7 @@ UP035.py:59:1: UP035 [*] Import from `collections.abc` instead: `Iterator`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 56 56 | from typing import Hashable
 57 57 | from typing import ItemsView
 58 58 | from typing import Iterable
@@ -629,7 +629,7 @@ UP035.py:60:1: UP035 [*] Import from `collections.abc` instead: `KeysView`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 57 57 | from typing import ItemsView
 58 58 | from typing import Iterable
 59 59 | from typing import Iterator
@@ -650,7 +650,7 @@ UP035.py:61:1: UP035 [*] Import from `collections.abc` instead: `Mapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 58 58 | from typing import Iterable
 59 59 | from typing import Iterator
 60 60 | from typing import KeysView
@@ -671,7 +671,7 @@ UP035.py:62:1: UP035 [*] Import from `collections.abc` instead: `MappingView`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 59 59 | from typing import Iterator
 60 60 | from typing import KeysView
 61 61 | from typing import Mapping
@@ -692,7 +692,7 @@ UP035.py:63:1: UP035 [*] Import from `collections.abc` instead: `MutableMapping`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 60 60 | from typing import KeysView
 61 61 | from typing import Mapping
 62 62 | from typing import MappingView
@@ -713,7 +713,7 @@ UP035.py:64:1: UP035 [*] Import from `collections.abc` instead: `MutableSequence
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 61 61 | from typing import Mapping
 62 62 | from typing import MappingView
 63 63 | from typing import MutableMapping
@@ -734,7 +734,7 @@ UP035.py:65:1: UP035 [*] Import from `collections.abc` instead: `MutableSet`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 62 62 | from typing import MappingView
 63 63 | from typing import MutableMapping
 64 64 | from typing import MutableSequence
@@ -755,7 +755,7 @@ UP035.py:66:1: UP035 [*] Import from `collections.abc` instead: `Sequence`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 63 63 | from typing import MutableMapping
 64 64 | from typing import MutableSequence
 65 65 | from typing import MutableSet
@@ -776,7 +776,7 @@ UP035.py:67:1: UP035 [*] Import from `collections.abc` instead: `Sized`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 64 64 | from typing import MutableSequence
 65 65 | from typing import MutableSet
 66 66 | from typing import Sequence
@@ -797,7 +797,7 @@ UP035.py:68:1: UP035 [*] Import from `collections.abc` instead: `ValuesView`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 65 65 | from typing import MutableSet
 66 66 | from typing import Sequence
 67 67 | from typing import Sized
@@ -818,7 +818,7 @@ UP035.py:69:1: UP035 [*] Import from `collections.abc` instead: `Awaitable`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 66 66 | from typing import Sequence
 67 67 | from typing import Sized
 68 68 | from typing import ValuesView
@@ -839,7 +839,7 @@ UP035.py:70:1: UP035 [*] Import from `collections.abc` instead: `AsyncIterator`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 67 67 | from typing import Sized
 68 68 | from typing import ValuesView
 69 69 | from typing import Awaitable
@@ -860,7 +860,7 @@ UP035.py:71:1: UP035 [*] Import from `collections.abc` instead: `AsyncIterable`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 68 68 | from typing import ValuesView
 69 69 | from typing import Awaitable
 70 70 | from typing import AsyncIterator
@@ -881,7 +881,7 @@ UP035.py:72:1: UP035 [*] Import from `collections.abc` instead: `Coroutine`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 69 69 | from typing import Awaitable
 70 70 | from typing import AsyncIterator
 71 71 | from typing import AsyncIterable
@@ -902,7 +902,7 @@ UP035.py:73:1: UP035 [*] Import from `collections.abc` instead: `Collection`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 70 70 | from typing import AsyncIterator
 71 71 | from typing import AsyncIterable
 72 72 | from typing import Coroutine
@@ -923,7 +923,7 @@ UP035.py:74:1: UP035 [*] Import from `collections.abc` instead: `AsyncGenerator`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 71 71 | from typing import AsyncIterable
 72 72 | from typing import Coroutine
 73 73 | from typing import Collection
@@ -944,7 +944,7 @@ UP035.py:75:1: UP035 [*] Import from `collections.abc` instead: `Reversible`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 72 72 | from typing import Coroutine
 73 73 | from typing import Collection
 74 74 | from typing import AsyncGenerator
@@ -965,7 +965,7 @@ UP035.py:76:1: UP035 [*] Import from `collections.abc` instead: `Generator`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 73 73 | from typing import Collection
 74 74 | from typing import AsyncGenerator
 75 75 | from typing import Reversible
@@ -985,7 +985,7 @@ UP035.py:77:1: UP035 [*] Import from `collections.abc` instead: `Callable`
    |
    = help: Import from `collections.abc`
 
-ℹ Suggested fix
+ℹ Fix
 74 74 | from typing import AsyncGenerator
 75 75 | from typing import Reversible
 76 76 | from typing import Generator
@@ -1005,7 +1005,7 @@ UP035.py:87:1: UP035 [*] Import from `typing` instead: `NamedTuple`
    |
    = help: Import from `typing`
 
-ℹ Suggested fix
+ℹ Fix
 84 84 | from typing_extensions import SupportsIndex
 85 85 | 
 86 86 | # Ok: `typing_extensions` contains backported improvements.
@@ -1023,7 +1023,7 @@ UP035.py:90:1: UP035 [*] Import from `typing` instead: `dataclass_transform`
    |
    = help: Import from `typing`
 
-ℹ Suggested fix
+ℹ Fix
 87 87 | from typing_extensions import NamedTuple
 88 88 | 
 89 89 | # Ok: `typing_extensions` supports `frozen_default` (backported from 3.12).

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__datetime_utc_alias_py311.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__datetime_utc_alias_py311.snap
@@ -10,7 +10,7 @@ UP017.py:7:7: UP017 [*] Use `datetime.UTC` alias
   |
   = help: Convert to `datetime.UTC` alias
 
-ℹ Suggested fix
+ℹ Fix
 4 4 | from datetime import timezone as tz
 5 5 | 
 6 6 | print(datetime.timezone(-1))
@@ -31,7 +31,7 @@ UP017.py:8:7: UP017 [*] Use `datetime.UTC` alias
    |
    = help: Convert to `datetime.UTC` alias
 
-ℹ Suggested fix
+ℹ Fix
 5 5 | 
 6 6 | print(datetime.timezone(-1))
 7 7 | print(timezone.utc)
@@ -51,7 +51,7 @@ UP017.py:10:7: UP017 [*] Use `datetime.UTC` alias
    |
    = help: Convert to `datetime.UTC` alias
 
-ℹ Suggested fix
+ℹ Fix
 7  7  | print(timezone.utc)
 8  8  | print(tz.utc)
 9  9  | 
@@ -67,7 +67,7 @@ UP017.py:11:7: UP017 [*] Use `datetime.UTC` alias
    |
    = help: Convert to `datetime.UTC` alias
 
-ℹ Suggested fix
+ℹ Fix
 8  8  | print(tz.utc)
 9  9  | 
 10 10 | print(datetime.timezone.utc)

--- a/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
@@ -77,9 +77,6 @@ pub(crate) fn print_empty_string(checker: &mut Checker, call: &ast::ExprCall) {
     }
 
     match &call.arguments.args.as_slice() {
-        // Ex) `print(*args)` or `print(*args, sep="\t")`
-        [arg] if arg.is_starred_expr() => {}
-
         // Ex) `print("")` or `print("", sep="\t")`
         [arg] if is_empty_string(arg) => {
             let reason = if call.arguments.find_keyword("sep").is_some() {
@@ -91,7 +88,7 @@ pub(crate) fn print_empty_string(checker: &mut Checker, call: &ast::ExprCall) {
             let mut diagnostic = Diagnostic::new(PrintEmptyString { reason }, call.range());
 
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::replacement(
                     generate_suggestion(call, Separator::Remove, checker.generator()),
                     call.start(),
                     call.end(),
@@ -113,7 +110,7 @@ pub(crate) fn print_empty_string(checker: &mut Checker, call: &ast::ExprCall) {
                 );
 
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::replacement(
                         generate_suggestion(call, Separator::Remove, checker.generator()),
                         call.start(),
                         call.end(),
@@ -178,7 +175,7 @@ pub(crate) fn print_empty_string(checker: &mut Checker, call: &ast::ExprCall) {
             );
 
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::replacement(
                     generate_suggestion(call, separator, checker.generator()),
                     call.start(),
                     call.end(),

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
@@ -157,7 +157,7 @@ pub(crate) fn reimplemented_starmap(checker: &mut Checker, target: &StarmapCandi
                 target.try_make_suggestion(starmap_name, &comprehension.iter, func, checker)?,
                 target.range(),
             );
-            Ok(Fix::unsafe_edits(import_edit, [main_edit]))
+            Ok(Fix::safe_edits(import_edit, [main_edit]))
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/refurb/rules/slice_copy.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/slice_copy.rs
@@ -63,7 +63,7 @@ pub(crate) fn slice_copy(checker: &mut Checker, subscript: &ast::ExprSubscript) 
     let mut diagnostic = Diagnostic::new(SliceCopy, subscript.range());
     if checker.patch(diagnostic.kind.rule()) {
         let replacement = generate_method_call(name, "copy", checker.generator());
-        diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::replacement(
             replacement,
             subscript.start(),
             subscript.end(),

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB105_FURB105.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB105_FURB105.py.snap
@@ -12,7 +12,7 @@ FURB105.py:3:1: FURB105 [*] Unnecessary empty string passed to `print`
   |
   = help: Remove empty string
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # Errors.
 2 2 | 
 3   |-print("")
@@ -31,7 +31,7 @@ FURB105.py:4:1: FURB105 [*] Unnecessary empty string and separator passed to `pr
   |
   = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # Errors.
 2 2 | 
 3 3 | print("")
@@ -52,7 +52,7 @@ FURB105.py:5:1: FURB105 [*] Unnecessary empty string passed to `print`
   |
   = help: Remove empty string
 
-ℹ Suggested fix
+ℹ Fix
 2 2 | 
 3 3 | print("")
 4 4 | print("", sep=",")
@@ -73,7 +73,7 @@ FURB105.py:6:1: FURB105 [*] Unnecessary empty string and separator passed to `pr
   |
   = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Fix
 3 3 | print("")
 4 4 | print("", sep=",")
 5 5 | print("", end="bar")
@@ -94,7 +94,7 @@ FURB105.py:7:1: FURB105 [*] Unnecessary separator passed to `print`
   |
   = help: Remove separator
 
-ℹ Suggested fix
+ℹ Fix
 4 4 | print("", sep=",")
 5 5 | print("", end="bar")
 6 6 | print("", sep=",", end="bar")
@@ -115,7 +115,7 @@ FURB105.py:8:1: FURB105 [*] Unnecessary empty string and separator passed to `pr
    |
    = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Fix
 5 5 | print("", end="bar")
 6 6 | print("", sep=",", end="bar")
 7 7 | print(sep="")
@@ -136,7 +136,7 @@ FURB105.py:9:1: FURB105 [*] Unnecessary empty string and separator passed to `pr
    |
    = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Fix
 6  6  | print("", sep=",", end="bar")
 7  7  | print(sep="")
 8  8  | print("", sep="")
@@ -157,7 +157,7 @@ FURB105.py:10:1: FURB105 [*] Unnecessary empty string and separator passed to `p
    |
    = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Fix
 7  7  | print(sep="")
 8  8  | print("", sep="")
 9  9  | print("", "", sep="")
@@ -178,7 +178,7 @@ FURB105.py:11:1: FURB105 [*] Unnecessary empty string and separator passed to `p
    |
    = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Fix
 8  8  | print("", sep="")
 9  9  | print("", "", sep="")
 10 10 | print("", "", sep="", end="")
@@ -199,7 +199,7 @@ FURB105.py:12:1: FURB105 [*] Unnecessary empty string and separator passed to `p
    |
    = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Fix
 9  9  | print("", "", sep="")
 10 10 | print("", "", sep="", end="")
 11 11 | print("", "", sep="", end="bar")
@@ -220,7 +220,7 @@ FURB105.py:13:1: FURB105 [*] Unnecessary separator passed to `print`
    |
    = help: Remove separator
 
-ℹ Suggested fix
+ℹ Fix
 10 10 | print("", "", sep="", end="")
 11 11 | print("", "", sep="", end="bar")
 12 12 | print("", sep="", end="bar")
@@ -241,7 +241,7 @@ FURB105.py:14:1: FURB105 [*] Unnecessary empty string and separator passed to `p
    |
    = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Fix
 11 11 | print("", "", sep="", end="bar")
 12 12 | print("", sep="", end="bar")
 13 13 | print(sep="", end="bar")
@@ -262,7 +262,7 @@ FURB105.py:15:1: FURB105 [*] Unnecessary empty string and separator passed to `p
    |
    = help: Remove empty string and separator
 
-ℹ Suggested fix
+ℹ Fix
 12 12 | print("", sep="", end="bar")
 13 13 | print(sep="", end="bar")
 14 14 | print("", "foo", sep="")
@@ -283,7 +283,7 @@ FURB105.py:16:1: FURB105 [*] Unnecessary empty string passed to `print`
    |
    = help: Remove empty string
 
-ℹ Suggested fix
+ℹ Fix
 13 13 | print(sep="", end="bar")
 14 14 | print("", "foo", sep="")
 15 15 | print("foo", "", sep="")
@@ -304,7 +304,7 @@ FURB105.py:18:1: FURB105 [*] Unnecessary empty string passed to `print`
    |
    = help: Remove empty string
 
-ℹ Suggested fix
+ℹ Fix
 15 15 | print("foo", "", sep="")
 16 16 | print("foo", "", "bar", sep="")
 17 17 | print("", *args)
@@ -324,7 +324,7 @@ FURB105.py:19:1: FURB105 [*] Unnecessary empty string passed to `print`
    |
    = help: Remove empty string
 
-ℹ Suggested fix
+ℹ Fix
 16 16 | print("foo", "", "bar", sep="")
 17 17 | print("", *args)
 18 18 | print("", *args, sep="")
@@ -345,7 +345,7 @@ FURB105.py:20:1: FURB105 [*] Unnecessary separator passed to `print`
    |
    = help: Remove separator
 
-ℹ Suggested fix
+ℹ Fix
 17 17 | print("", *args)
 18 18 | print("", *args, sep="")
 19 19 | print("", **kwargs)

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB140_FURB140.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB140_FURB140.py.snap
@@ -11,7 +11,7 @@ FURB140.py:7:1: FURB140 [*] Use `itertools.starmap` instead of the generator
   |
   = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Fix
   1 |+from itertools import starmap
 1 2 | def zipped():
 2 3 |     return zip([1, 2, 3], "ABC")
@@ -35,7 +35,7 @@ FURB140.py:10:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Fix
    1  |+from itertools import starmap
 1  2  | def zipped():
 2  3  |     return zip([1, 2, 3], "ABC")
@@ -58,7 +58,7 @@ FURB140.py:13:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Fix
    1  |+from itertools import starmap
 1  2  | def zipped():
 2  3  |     return zip([1, 2, 3], "ABC")
@@ -83,7 +83,7 @@ FURB140.py:19:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Fix
 16 16 | from itertools import starmap as sm
 17 17 | 
 18 18 | # FURB140
@@ -103,7 +103,7 @@ FURB140.py:22:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Fix
 19 19 | [print(x, y) for x, y in zipped()]
 20 20 | 
 21 21 | # FURB140
@@ -123,7 +123,7 @@ FURB140.py:25:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Fix
 22 22 | (print(x, y) for x, y in zipped())
 23 23 | 
 24 24 | # FURB140
@@ -144,7 +144,7 @@ FURB140.py:29:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Fix
 26 26 | 
 27 27 | # FURB140 (check it still flags starred arguments).
 28 28 | # See https://github.com/astral-sh/ruff/issues/7636
@@ -164,7 +164,7 @@ FURB140.py:30:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Fix
 27 27 | # FURB140 (check it still flags starred arguments).
 28 28 | # See https://github.com/astral-sh/ruff/issues/7636
 29 29 | [foo(*t) for t in [(85, 60), (100, 80)]]
@@ -185,7 +185,7 @@ FURB140.py:31:1: FURB140 [*] Use `itertools.starmap` instead of the generator
    |
    = help: Replace with `itertools.starmap`
 
-ℹ Suggested fix
+ℹ Fix
 28 28 | # See https://github.com/astral-sh/ruff/issues/7636
 29 29 | [foo(*t) for t in [(85, 60), (100, 80)]]
 30 30 | (foo(*t) for t in [(85, 60), (100, 80)])

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB145_FURB145.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB145_FURB145.py.snap
@@ -11,7 +11,7 @@ FURB145.py:4:5: FURB145 [*] Prefer `copy` method over slicing
   |
   = help: Replace with `copy()`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | l = [1, 2, 3, 4, 5]
 2 2 | 
 3 3 | # Errors.
@@ -32,7 +32,7 @@ FURB145.py:5:11: FURB145 [*] Prefer `copy` method over slicing
   |
   = help: Replace with `copy()`
 
-ℹ Suggested fix
+ℹ Fix
 2 2 | 
 3 3 | # Errors.
 4 4 | a = l[:]
@@ -53,7 +53,7 @@ FURB145.py:6:8: FURB145 [*] Prefer `copy` method over slicing
   |
   = help: Replace with `copy()`
 
-ℹ Suggested fix
+ℹ Fix
 3 3 | # Errors.
 4 4 | a = l[:]
 5 5 | b, c = 1, l[:]
@@ -74,7 +74,7 @@ FURB145.py:7:5: FURB145 [*] Prefer `copy` method over slicing
   |
   = help: Replace with `copy()`
 
-ℹ Suggested fix
+ℹ Fix
 4 4 | a = l[:]
 5 5 | b, c = 1, l[:]
 6 6 | d, e = l[:], 1
@@ -94,7 +94,7 @@ FURB145.py:8:1: FURB145 [*] Prefer `copy` method over slicing
   |
   = help: Replace with `copy()`
 
-ℹ Suggested fix
+ℹ Fix
 5 5 | b, c = 1, l[:]
 6 6 | d, e = l[:], 1
 7 7 | m = l[::]
@@ -115,7 +115,7 @@ FURB145.py:9:7: FURB145 [*] Prefer `copy` method over slicing
    |
    = help: Replace with `copy()`
 
-ℹ Suggested fix
+ℹ Fix
 6  6  | d, e = l[:], 1
 7  7  | m = l[::]
 8  8  | l[:]

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
@@ -10,7 +10,7 @@ RUF100_0.py:9:12: RUF100 [*] Unused blanket `noqa` directive
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 6  6  |     b = 2  # noqa: F841
 7  7  | 
 8  8  |     # Invalid
@@ -30,7 +30,7 @@ RUF100_0.py:13:12: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 10 10 |     print(c)
 11 11 | 
 12 12 |     # Invalid
@@ -50,7 +50,7 @@ RUF100_0.py:16:12: RUF100 [*] Unused `noqa` directive (unused: `F841`, `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 13 13 |     d = 1  # noqa: E501
 14 14 | 
 15 15 |     # Invalid
@@ -70,7 +70,7 @@ RUF100_0.py:19:12: RUF100 [*] Unused `noqa` directive (unused: `F841`, `W191`; n
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 16 16 |     d = 1  # noqa: F841, E501
 17 17 | 
 18 18 |     # Invalid (and unimplemented or not enabled)
@@ -90,7 +90,7 @@ RUF100_0.py:22:12: RUF100 [*] Unused `noqa` directive (unused: `F841`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 19 19 |     d = 1  # noqa: F841, W191, F821
 20 20 | 
 21 21 |     # Invalid (but external)
@@ -111,7 +111,7 @@ RUF100_0.py:26:10: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 23 23 | 
 24 24 |     # fmt: off
 25 25 |     # Invalid - no space before #
@@ -148,7 +148,7 @@ RUF100_0.py:29:33: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 26 26 |     d = 1# noqa: E501
 27 27 | 
 28 28 |     # Invalid - many spaces before #
@@ -168,7 +168,7 @@ RUF100_0.py:55:6: RUF100 [*] Unused `noqa` directive (unused: `F841`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 52 52 |     https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533
 53 53 | 
 54 54 | Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -188,7 +188,7 @@ RUF100_0.py:63:6: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 60 60 |     https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533
 61 61 | 
 62 62 | Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.
@@ -208,7 +208,7 @@ RUF100_0.py:71:6: RUF100 [*] Unused blanket `noqa` directive
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 68 68 |     https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533
 69 69 | 
 70 70 | Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.
@@ -254,7 +254,7 @@ RUF100_0.py:90:92: RUF100 [*] Unused `noqa` directive (unused: `F401`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 87 87 | 
 88 88 | print(sys.path)
 89 89 | 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_1.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_1.snap
@@ -32,7 +32,7 @@ RUF100_1.py:52:20: RUF100 [*] Unused `noqa` directive (unused: `F401`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 49 49 | def f():
 50 50 |     # This should ignore the error, but the inner noqa should be marked as unused.
 51 51 |     from typing import (  # noqa: F401
@@ -52,7 +52,7 @@ RUF100_1.py:59:20: RUF100 [*] Unused `noqa` directive (unused: `F401`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 56 56 | def f():
 57 57 |     # This should ignore the error, but the inner noqa should be marked as unused.
 58 58 |     from typing import (  # noqa
@@ -72,7 +72,7 @@ RUF100_1.py:66:16: RUF100 [*] Unused `noqa` directive (non-enabled: `F501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 63 63 | def f():
 64 64 |     # This should ignore the error, but mark F501 as unused.
 65 65 |     from typing import (  # noqa: F401
@@ -93,7 +93,7 @@ RUF100_1.py:72:27: RUF100 [*] Unused `noqa` directive (non-enabled: `F501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 69 69 | 
 70 70 | def f():
 71 71 |     # This should ignore the error, but mark F501 as unused.
@@ -144,7 +144,7 @@ RUF100_1.py:89:55: RUF100 [*] Unused `noqa` directive (non-enabled: `F501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 86 86 | 
 87 87 | def f():
 88 88 |     # This should mark F501 as unused.

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_2.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_2.snap
@@ -8,7 +8,7 @@ RUF100_2.py:1:19: RUF100 [*] Unused `noqa` directive (unused: `F401`)
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 1   |-import itertools  # noqa: F401
   1 |+import itertools
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_3.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_3.snap
@@ -10,7 +10,7 @@ RUF100_3.py:1:1: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 1   |-# noqa
 2 1 | # noqa # comment
 3 2 | print()  # noqa
@@ -26,7 +26,7 @@ RUF100_3.py:2:1: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # noqa
 2   |-# noqa # comment
   2 |+# comment
@@ -45,7 +45,7 @@ RUF100_3.py:3:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # noqa
 2 2 | # noqa # comment
 3   |-print()  # noqa
@@ -65,7 +65,7 @@ RUF100_3.py:4:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | # noqa
 2 2 | # noqa # comment
 3 3 | print()  # noqa
@@ -86,7 +86,7 @@ RUF100_3.py:5:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 2 2 | # noqa # comment
 3 3 | print()  # noqa
 4 4 | print()  # noqa # comment
@@ -107,7 +107,7 @@ RUF100_3.py:6:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 3 3 | print()  # noqa
 4 4 | print()  # noqa # comment
 5 5 | print()  # noqa  # comment
@@ -128,7 +128,7 @@ RUF100_3.py:7:10: RUF100 [*] Unused blanket `noqa` directive
   |
   = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 4 4 | print()  # noqa # comment
 5 5 | print()  # noqa  # comment
 6 6 | print()  # noqa comment
@@ -149,7 +149,7 @@ RUF100_3.py:14:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 11 11 | print(a)  # noqa comment
 12 12 | print(a)  # noqa  comment
 13 13 | 
@@ -168,7 +168,7 @@ RUF100_3.py:15:1: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 12 12 | print(a)  # noqa  comment
 13 13 | 
 14 14 | # noqa: E501, F821
@@ -189,7 +189,7 @@ RUF100_3.py:16:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 13 13 | 
 14 14 | # noqa: E501, F821
 15 15 | # noqa: E501, F821 # comment
@@ -210,7 +210,7 @@ RUF100_3.py:17:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 14 14 | # noqa: E501, F821
 15 15 | # noqa: E501, F821 # comment
 16 16 | print()  # noqa: E501, F821
@@ -231,7 +231,7 @@ RUF100_3.py:18:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 15 15 | # noqa: E501, F821 # comment
 16 16 | print()  # noqa: E501, F821
 17 17 | print()  # noqa: E501, F821 # comment
@@ -252,7 +252,7 @@ RUF100_3.py:19:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 16 16 | print()  # noqa: E501, F821
 17 17 | print()  # noqa: E501, F821 # comment
 18 18 | print()  # noqa: E501, F821  # comment
@@ -273,7 +273,7 @@ RUF100_3.py:20:10: RUF100 [*] Unused `noqa` directive (unused: `E501`, `F821`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 17 17 | print()  # noqa: E501, F821 # comment
 18 18 | print()  # noqa: E501, F821  # comment
 19 19 | print()  # noqa: E501, F821 comment
@@ -294,7 +294,7 @@ RUF100_3.py:21:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 18 18 | print()  # noqa: E501, F821  # comment
 19 19 | print()  # noqa: E501, F821 comment
 20 20 | print()  # noqa: E501, F821  comment
@@ -315,7 +315,7 @@ RUF100_3.py:22:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 19 19 | print()  # noqa: E501, F821 comment
 20 20 | print()  # noqa: E501, F821  comment
 21 21 | print(a)  # noqa: E501, F821
@@ -336,7 +336,7 @@ RUF100_3.py:23:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 20 20 | print()  # noqa: E501, F821  comment
 21 21 | print(a)  # noqa: E501, F821
 22 22 | print(a)  # noqa: E501, F821 # comment
@@ -355,7 +355,7 @@ RUF100_3.py:24:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 21 21 | print(a)  # noqa: E501, F821
 22 22 | print(a)  # noqa: E501, F821 # comment
 23 23 | print(a)  # noqa: E501, F821  # comment
@@ -372,7 +372,7 @@ RUF100_3.py:25:11: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 22 22 | print(a)  # noqa: E501, F821 # comment
 23 23 | print(a)  # noqa: E501, F821  # comment
 24 24 | print(a)  # noqa: E501, F821 comment

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_5.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_5.snap
@@ -40,7 +40,7 @@ RUF100_5.py:11:13: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
    = help: Remove unused `noqa` directive
 
-ℹ Suggested fix
+ℹ Fix
 8  8  | }
 9  9  | 
 10 10 | 


### PR DESCRIPTION
## Summary

This PR upgrades some rules from "sometimes" to "always" fixes, now that we're getting ready to ship support in the CLI. The focus here was on identifying rules for which the diagnostic itself is high-confidence, and the fix itself is too (assuming that the diagnostic is correct). This is _unlike_ rules that _may_ be a false positive, like those that (e.g.) assume an object is a dictionary when you call `.values()` on it.

Specifically, I upgraded:

- A bunch of rules that only apply to `.pyi` files.
- Rules that rewrite deprecated imports or aliases.
- Some other misc. rules, like: `empty-print-string`, `unused-noqa`, `getattr-with-constant`.

Open to feedback on any of these.
