### PR TITLE
Rename applicability levels to `Safe`, `Unsafe`, and `Display`

### DIFF
--- a/crates/ruff_cli/tests/format.rs
+++ b/crates/ruff_cli/tests/format.rs
@@ -175,7 +175,7 @@ import os
         },
         "filename": "-",
         "fix": {
-          "applicability": "always",
+          "applicability": "safe",
           "edits": [
             {
               "content": "",

--- a/crates/ruff_cli/tests/snapshots/integration_test__stdin_json.snap
+++ b/crates/ruff_cli/tests/snapshots/integration_test__stdin_json.snap
@@ -24,7 +24,7 @@ exit_code: 1
     },
     "filename": "/path/to/F401.py",
     "fix": {
-      "applicability": "always",
+      "applicability": "safe",
       "edits": [
         {
           "content": "",

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -10,17 +10,17 @@ use crate::edit::Edit;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum Applicability {
-    /// The fix is unsafe and should only be manually applied by the user.
+    /// The fix is unsafe and should only be displayed for manual application by the user.
     /// The fix is likely to be incorrect or the resulting code may have invalid syntax.
-    Never,
+    Display,
 
     /// The fix is unsafe and should only be applied with user opt-in.
     /// The fix may be what the user intended, but it is uncertain; the resulting code will have valid syntax.
-    Sometimes,
+    Unsafe,
 
     /// The fix is safe and can always be applied.
     /// The fix is definitely what the user intended, or it maintains the exact meaning of the code.
-    Always,
+    Safe,
 }
 
 /// Indicates the level of isolation required to apply a fix.
@@ -47,62 +47,62 @@ pub struct Fix {
 }
 
 impl Fix {
-    /// Create a new [`Fix`] that can [always](Applicability::Always) be applied from an [`Edit`] element.
-    pub fn always_applies(edit: Edit) -> Self {
+    /// Create a new [`Fix`] that is [safe](Applicability::Safe) to apply from an [`Edit`] element.
+    pub fn safe_edit(edit: Edit) -> Self {
         Self {
             edits: vec![edit],
-            applicability: Applicability::Always,
+            applicability: Applicability::Safe,
             isolation_level: IsolationLevel::default(),
         }
     }
 
-    /// Create a new [`Fix`] that can [always](Applicability::Always) be applied from multiple [`Edit`] elements.
-    pub fn always_applies_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
+    /// Create a new [`Fix`] that is [safe](Applicability::Safe) to apply from multiple [`Edit`] elements.
+    pub fn safe_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         let mut edits: Vec<Edit> = std::iter::once(edit).chain(rest).collect();
         edits.sort_by_key(|edit| (edit.start(), edit.end()));
         Self {
             edits,
-            applicability: Applicability::Always,
+            applicability: Applicability::Safe,
             isolation_level: IsolationLevel::default(),
         }
     }
 
-    /// Create a new [`Fix`] that can [sometimes](Applicability::Sometimes) be applied from an [`Edit`] element.
-    pub fn sometimes_applies(edit: Edit) -> Self {
+    /// Create a new [`Fix`] that is [unsafe](Applicability::Unsafe) to apply from an [`Edit`] element.
+    pub fn unsafe_edit(edit: Edit) -> Self {
         Self {
             edits: vec![edit],
-            applicability: Applicability::Sometimes,
+            applicability: Applicability::Unsafe,
             isolation_level: IsolationLevel::default(),
         }
     }
 
-    /// Create a new [`Fix`] that can [sometimes](Applicability::Sometimes) be applied from multiple [`Edit`] elements.
-    pub fn sometimes_applies_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
+    /// Create a new [`Fix`] that is [unsafe](Applicability::Unsafe) to apply from multiple [`Edit`] elements.
+    pub fn unsafe_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         let mut edits: Vec<Edit> = std::iter::once(edit).chain(rest).collect();
         edits.sort_by_key(|edit| (edit.start(), edit.end()));
         Self {
             edits,
-            applicability: Applicability::Sometimes,
+            applicability: Applicability::Unsafe,
             isolation_level: IsolationLevel::default(),
         }
     }
 
-    /// Create a new [`Fix`] that should [never](Applicability::Never) be applied from an [`Edit`] element .
-    pub fn never_applies(edit: Edit) -> Self {
+    /// Create a new [`Fix`] that should only [display](Applicability::Display) and not apply from an [`Edit`] element .
+    pub fn display_edit(edit: Edit) -> Self {
         Self {
             edits: vec![edit],
-            applicability: Applicability::Never,
+            applicability: Applicability::Display,
             isolation_level: IsolationLevel::default(),
         }
     }
 
-    /// Create a new [`Fix`] that should [never](Applicability::Never) be applied from multiple [`Edit`] elements.
-    pub fn never_applies_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
+    /// Create a new [`Fix`] that should only [display](Applicability::Display) and not apply from multiple [`Edit`] elements.
+    pub fn display_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         let mut edits: Vec<Edit> = std::iter::once(edit).chain(rest).collect();
         edits.sort_by_key(|edit| (edit.start(), edit.end()));
         Self {
             edits,
-            applicability: Applicability::Never,
+            applicability: Applicability::Display,
             isolation_level: IsolationLevel::default(),
         }
     }

--- a/crates/ruff_linter/src/checkers/ast/analyze/bindings.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/bindings.rs
@@ -38,7 +38,7 @@ pub(crate) fn bindings(checker: &mut Checker) {
                             binding,
                             checker.locator,
                         )
-                        .map(Fix::always_applies)
+                        .map(Fix::safe_edit)
                     });
                 }
                 checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -110,10 +110,8 @@ pub(crate) fn check_noqa(
                         let mut diagnostic =
                             Diagnostic::new(UnusedNOQA { codes: None }, directive.range());
                         if settings.rules.should_fix(diagnostic.kind.rule()) {
-                            diagnostic.set_fix(Fix::sometimes_applies(delete_noqa(
-                                directive.range(),
-                                locator,
-                            )));
+                            diagnostic
+                                .set_fix(Fix::unsafe_edit(delete_noqa(directive.range(), locator)));
                         }
                         diagnostics.push(diagnostic);
                     }
@@ -177,17 +175,15 @@ pub(crate) fn check_noqa(
                         );
                         if settings.rules.should_fix(diagnostic.kind.rule()) {
                             if valid_codes.is_empty() {
-                                diagnostic.set_fix(Fix::sometimes_applies(delete_noqa(
+                                diagnostic.set_fix(Fix::unsafe_edit(delete_noqa(
                                     directive.range(),
                                     locator,
                                 )));
                             } else {
-                                diagnostic.set_fix(Fix::sometimes_applies(
-                                    Edit::range_replacement(
-                                        format!("# noqa: {}", valid_codes.join(", ")),
-                                        directive.range(),
-                                    ),
-                                ));
+                                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                                    format!("# noqa: {}", valid_codes.join(", ")),
+                                    directive.range(),
+                                )));
                             }
                         }
                         diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/fix/mod.rs
+++ b/crates/ruff_linter/src/fix/mod.rs
@@ -163,7 +163,7 @@ mod tests {
                 // The choice of rule here is arbitrary.
                 kind: MissingNewlineAtEndOfFile.into(),
                 range: edit.range(),
-                fix: Some(Fix::always_applies(edit)),
+                fix: Some(Fix::safe_edit(edit)),
                 parent: None,
             })
             .collect()

--- a/crates/ruff_linter/src/message/diff.rs
+++ b/crates/ruff_linter/src/message/diff.rs
@@ -53,9 +53,9 @@ impl Display for Diff<'_> {
 
         let message = match self.fix.applicability() {
             // TODO(zanieb): Adjust this messaging once it's user-facing
-            Applicability::Always => "Fix",
-            Applicability::Sometimes => "Suggested fix",
-            Applicability::Never => "Possible fix",
+            Applicability::Safe => "Fix",
+            Applicability::Unsafe => "Suggested fix",
+            Applicability::Display => "Possible fix",
         };
         writeln!(f, "ℹ {}", message.blue())?;
 

--- a/crates/ruff_linter/src/message/mod.rs
+++ b/crates/ruff_linter/src/message/mod.rs
@@ -178,9 +178,10 @@ def fibonacci(n):
             },
             TextRange::new(TextSize::from(7), TextSize::from(9)),
         )
-        .with_fix(Fix::sometimes_applies(Edit::range_deletion(
-            TextRange::new(TextSize::from(0), TextSize::from(10)),
-        )));
+        .with_fix(Fix::unsafe_edit(Edit::range_deletion(TextRange::new(
+            TextSize::from(0),
+            TextSize::from(10),
+        ))));
 
         let fib_source = SourceFileBuilder::new("fib.py", fib).finish();
 
@@ -192,7 +193,7 @@ def fibonacci(n):
             },
             TextRange::new(TextSize::from(94), TextSize::from(95)),
         )
-        .with_fix(Fix::sometimes_applies(Edit::deletion(
+        .with_fix(Fix::unsafe_edit(Edit::deletion(
             TextSize::from(94),
             TextSize::from(99),
         )));

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json__tests__output.snap
@@ -11,7 +11,7 @@ expression: content
     },
     "filename": "fib.py",
     "fix": {
-      "applicability": "sometimes",
+      "applicability": "unsafe",
       "edits": [
         {
           "content": "",
@@ -43,7 +43,7 @@ expression: content
     },
     "filename": "fib.py",
     "fix": {
-      "applicability": "sometimes",
+      "applicability": "unsafe",
       "edits": [
         {
           "content": "",

--- a/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json_lines__tests__output.snap
+++ b/crates/ruff_linter/src/message/snapshots/ruff_linter__message__json_lines__tests__output.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/message/json_lines.rs
 expression: content
 ---
-{"code":"F401","end_location":{"column":10,"row":1},"filename":"fib.py","fix":{"applicability":"sometimes","edits":[{"content":"","end_location":{"column":1,"row":2},"location":{"column":1,"row":1}}],"message":"Remove unused import: `os`"},"location":{"column":8,"row":1},"message":"`os` imported but unused","noqa_row":1,"url":"https://docs.astral.sh/ruff/rules/unused-import"}
-{"code":"F841","end_location":{"column":6,"row":6},"filename":"fib.py","fix":{"applicability":"sometimes","edits":[{"content":"","end_location":{"column":10,"row":6},"location":{"column":5,"row":6}}],"message":"Remove assignment to unused variable `x`"},"location":{"column":5,"row":6},"message":"Local variable `x` is assigned to but never used","noqa_row":6,"url":"https://docs.astral.sh/ruff/rules/unused-variable"}
+{"code":"F401","end_location":{"column":10,"row":1},"filename":"fib.py","fix":{"applicability":"unsafe","edits":[{"content":"","end_location":{"column":1,"row":2},"location":{"column":1,"row":1}}],"message":"Remove unused import: `os`"},"location":{"column":8,"row":1},"message":"`os` imported but unused","noqa_row":1,"url":"https://docs.astral.sh/ruff/rules/unused-import"}
+{"code":"F841","end_location":{"column":6,"row":6},"filename":"fib.py","fix":{"applicability":"unsafe","edits":[{"content":"","end_location":{"column":10,"row":6},"location":{"column":5,"row":6}}],"message":"Remove assignment to unused variable `x`"},"location":{"column":5,"row":6},"message":"Local variable `x` is assigned to but never used","noqa_row":6,"url":"https://docs.astral.sh/ruff/rules/unused-variable"}
 {"code":"F821","end_location":{"column":5,"row":1},"filename":"undef.py","fix":null,"location":{"column":4,"row":1},"message":"Undefined name `a`","noqa_row":1,"url":"https://docs.astral.sh/ruff/rules/undefined-name"}
 

--- a/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
+++ b/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
@@ -68,7 +68,7 @@ pub(crate) fn commented_out_code(
             let mut diagnostic = Diagnostic::new(CommentedOutCode, *range);
 
             if settings.rules.should_fix(Rule::CommentedOutCode) {
-                diagnostic.set_fix(Fix::never_applies(Edit::range_deletion(
+                diagnostic.set_fix(Fix::display_edit(Edit::range_deletion(
                     locator.full_lines_range(*range),
                 )));
             }

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -703,7 +703,7 @@ pub(crate) fn definition(
                         function.identifier(),
                     );
                     if checker.patch(diagnostic.kind.rule()) {
-                        diagnostic.set_fix(Fix::sometimes_applies(Edit::insertion(
+                        diagnostic.set_fix(Fix::unsafe_edit(Edit::insertion(
                             " -> None".to_string(),
                             function.parameters.range().end(),
                         )));
@@ -721,7 +721,7 @@ pub(crate) fn definition(
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     if let Some(return_type) = simple_magic_return_type(name) {
-                        diagnostic.set_fix(Fix::sometimes_applies(Edit::insertion(
+                        diagnostic.set_fix(Fix::unsafe_edit(Edit::insertion(
                             format!(" -> {return_type}"),
                             function.parameters.range().end(),
                         )));

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -76,7 +76,7 @@ pub(crate) fn assert_false(checker: &mut Checker, stmt: &Stmt, test: &Expr, msg:
 
     let mut diagnostic = Diagnostic::new(AssertFalse, test.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             checker.generator().stmt(&assertion_error(msg)),
             stmt.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -147,7 +147,7 @@ fn duplicate_handler_exceptions<'a>(
                 expr.range(),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     // Single exceptions don't require parentheses, but since we're _removing_
                     // parentheses, insert whitespace as needed.
                     if let [elt] = unique_elts.as_slice() {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -86,7 +86,7 @@ pub(crate) fn getattr_with_constant(
 
     let mut diagnostic = Diagnostic::new(GetAttrWithConstant, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             pad(
                 if matches!(
                     obj,

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -200,8 +200,5 @@ fn move_initialization(
     }
 
     let initialization_edit = Edit::insertion(content, pos);
-    Some(Fix::never_applies_edits(
-        default_edit,
-        [initialization_edit],
-    ))
+    Some(Fix::display_edits(default_edit, [initialization_edit]))
 }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
@@ -85,7 +85,7 @@ pub(crate) fn redundant_tuple_in_exception_handler(
             // ```
             // Otherwise, the output will be invalid syntax, since we're removing a set of
             // parentheses.
-            diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 pad(
                     checker.generator().expr(elt),
                     type_.range(),

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -109,7 +109,7 @@ pub(crate) fn setattr_with_constant(
         if expr == child.as_ref() {
             let mut diagnostic = Diagnostic::new(SetAttrWithConstant, expr.range());
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                     assignment(obj, name, value, checker.generator()),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
@@ -83,7 +83,7 @@ pub(crate) fn unreliable_callable_check(
     if checker.patch(diagnostic.kind.rule()) {
         if id == "hasattr" {
             if checker.semantic().is_builtin("callable") {
-                diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     format!("callable({})", checker.locator().slice(obj)),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -168,7 +168,7 @@ pub(crate) fn unused_loop_control_variable(checker: &mut Checker, stmt_for: &ast
                         .filter(|binding| binding.start() >= expr.start())
                         .all(|binding| !binding.is_used())
                     {
-                        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                             rename,
                             expr.range(),
                         )));

--- a/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
+++ b/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
@@ -325,9 +325,7 @@ pub(crate) fn trailing_commas(
             let comma = prev.spanned.unwrap();
             let mut diagnostic = Diagnostic::new(ProhibitedTrailingComma, comma.1);
             if settings.rules.should_fix(Rule::ProhibitedTrailingComma) {
-                diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(
-                    diagnostic.range(),
-                )));
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(diagnostic.range())));
             }
             diagnostics.push(diagnostic);
         }
@@ -367,7 +365,7 @@ pub(crate) fn trailing_commas(
                 // removing any brackets in the same linter pass - doing both at the same time could
                 // lead to a syntax error.
                 let contents = locator.slice(missing_comma.1);
-                diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     format!("{contents},"),
                     missing_comma.1,
                 )));

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
@@ -1293,7 +1293,7 @@ pub(crate) fn fix_unnecessary_comprehension_any_all(
         _ => whitespace_after_arg,
     };
 
-    Ok(Fix::sometimes_applies(Edit::range_replacement(
+    Ok(Fix::unsafe_edit(Edit::range_replacement(
         tree.codegen_stylist(stylist),
         expr.range(),
     )))

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
@@ -90,9 +90,9 @@ pub(crate) fn unnecessary_call_around_sorted(
                 checker.stylist(),
             )?;
             if outer.id == "reversed" {
-                Ok(Fix::sometimes_applies(edit))
+                Ok(Fix::unsafe_edit(edit))
             } else {
-                Ok(Fix::always_applies(edit))
+                Ok(Fix::safe_edit(edit))
             }
         });
     }

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
@@ -88,7 +88,7 @@ pub(crate) fn unnecessary_collection_call(
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            fixes::fix_unnecessary_collection_call(expr, checker).map(Fix::sometimes_applies)
+            fixes::fix_unnecessary_collection_call(expr, checker).map(Fix::unsafe_edit)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -67,7 +67,7 @@ fn add_diagnostic(checker: &mut Checker, expr: &Expr) {
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
             fixes::fix_unnecessary_comprehension(expr, checker.locator(), checker.stylist())
-                .map(Fix::sometimes_applies)
+                .map(Fix::unsafe_edit)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
@@ -137,7 +137,7 @@ pub(crate) fn unnecessary_double_cast_or_process(
                     checker.locator(),
                     checker.stylist(),
                 )
-                .map(Fix::sometimes_applies)
+                .map(Fix::unsafe_edit)
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
@@ -69,7 +69,7 @@ pub(crate) fn unnecessary_generator_dict(
     let mut diagnostic = Diagnostic::new(UnnecessaryGeneratorDict, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            fixes::fix_unnecessary_generator_dict(expr, checker).map(Fix::sometimes_applies)
+            fixes::fix_unnecessary_generator_dict(expr, checker).map(Fix::unsafe_edit)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
@@ -63,7 +63,7 @@ pub(crate) fn unnecessary_generator_list(
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
                 fixes::fix_unnecessary_generator_list(expr, checker.locator(), checker.stylist())
-                    .map(Fix::sometimes_applies)
+                    .map(Fix::unsafe_edit)
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
@@ -62,7 +62,7 @@ pub(crate) fn unnecessary_generator_set(
         let mut diagnostic = Diagnostic::new(UnnecessaryGeneratorSet, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
-                fixes::fix_unnecessary_generator_set(expr, checker).map(Fix::sometimes_applies)
+                fixes::fix_unnecessary_generator_set(expr, checker).map(Fix::unsafe_edit)
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
@@ -59,7 +59,7 @@ pub(crate) fn unnecessary_list_call(
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
             fixes::fix_unnecessary_list_call(expr, checker.locator(), checker.stylist())
-                .map(Fix::sometimes_applies)
+                .map(Fix::unsafe_edit)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
@@ -67,8 +67,7 @@ pub(crate) fn unnecessary_list_comprehension_dict(
     let mut diagnostic = Diagnostic::new(UnnecessaryListComprehensionDict, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            fixes::fix_unnecessary_list_comprehension_dict(expr, checker)
-                .map(Fix::sometimes_applies)
+            fixes::fix_unnecessary_list_comprehension_dict(expr, checker).map(Fix::unsafe_edit)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
@@ -60,8 +60,7 @@ pub(crate) fn unnecessary_list_comprehension_set(
         let mut diagnostic = Diagnostic::new(UnnecessaryListComprehensionSet, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
-                fixes::fix_unnecessary_list_comprehension_set(expr, checker)
-                    .map(Fix::sometimes_applies)
+                fixes::fix_unnecessary_list_comprehension_set(expr, checker).map(Fix::unsafe_edit)
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
@@ -82,7 +82,7 @@ pub(crate) fn unnecessary_literal_dict(
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            fixes::fix_unnecessary_literal_dict(expr, checker).map(Fix::sometimes_applies)
+            fixes::fix_unnecessary_literal_dict(expr, checker).map(Fix::unsafe_edit)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
@@ -77,7 +77,7 @@ pub(crate) fn unnecessary_literal_set(
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
-            fixes::fix_unnecessary_literal_set(expr, checker).map(Fix::sometimes_applies)
+            fixes::fix_unnecessary_literal_set(expr, checker).map(Fix::unsafe_edit)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_dict_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_dict_call.rs
@@ -98,7 +98,7 @@ pub(crate) fn unnecessary_literal_within_dict_call(
                 checker.locator(),
                 checker.stylist(),
             )
-            .map(Fix::sometimes_applies)
+            .map(Fix::unsafe_edit)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
@@ -100,7 +100,7 @@ pub(crate) fn unnecessary_literal_within_list_call(
                 checker.locator(),
                 checker.stylist(),
             )
-            .map(Fix::sometimes_applies)
+            .map(Fix::unsafe_edit)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
@@ -102,7 +102,7 @@ pub(crate) fn unnecessary_literal_within_tuple_call(
                 checker.locator(),
                 checker.stylist(),
             )
-            .map(Fix::sometimes_applies)
+            .map(Fix::unsafe_edit)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -230,7 +230,7 @@ pub(crate) fn unnecessary_map(
                 checker.locator(),
                 checker.stylist(),
             )
-            .map(Fix::sometimes_applies)
+            .map(Fix::unsafe_edit)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
@@ -293,7 +293,7 @@ fn generate_fix(
         range: TextRange::default(),
     });
 
-    Fix::sometimes_applies_edits(
+    Fix::unsafe_edits(
         Edit::insertion(
             format!(
                 "{}{}{}",

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_leading_whitespace.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_leading_whitespace.rs
@@ -69,7 +69,7 @@ pub(crate) fn shebang_leading_whitespace(
     let prefix = TextRange::up_to(range.start());
     let mut diagnostic = Diagnostic::new(ShebangLeadingWhitespace, prefix);
     if settings.rules.should_fix(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(prefix)));
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(prefix)));
     }
     Some(diagnostic)
 }

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
@@ -169,7 +169,7 @@ fn concatenate_strings(a_range: TextRange, b_range: TextRange, locator: &Locator
     let concatenation = format!("{a_leading_quote}{a_body}{b_body}{a_trailing_quote}");
     let range = TextRange::new(a_range.start(), b_range.end());
 
-    Some(Fix::always_applies(Edit::range_replacement(
+    Some(Fix::safe_edit(Edit::range_replacement(
         concatenation,
         range,
     )))

--- a/crates/ruff_linter/src/rules/flake8_import_conventions/rules/unconventional_import_alias.rs
+++ b/crates/ruff_linter/src/rules/flake8_import_conventions/rules/unconventional_import_alias.rs
@@ -86,7 +86,7 @@ pub(crate) fn unconventional_import_alias(
                     let scope = &checker.semantic().scopes[binding.scope];
                     let (edit, rest) =
                         Renamer::rename(name, expected_alias, scope, checker.semantic())?;
-                    Ok(Fix::sometimes_applies_edits(edit, rest))
+                    Ok(Fix::unsafe_edits(edit, rest))
                 });
             }
         }

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/direct_logger_instantiation.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/direct_logger_instantiation.rs
@@ -69,7 +69,7 @@ pub(crate) fn direct_logger_instantiation(checker: &mut Checker, call: &ast::Exp
                     checker.semantic(),
                 )?;
                 let reference_edit = Edit::range_replacement(binding, call.func.range());
-                Ok(Fix::sometimes_applies_edits(import_edit, [reference_edit]))
+                Ok(Fix::unsafe_edits(import_edit, [reference_edit]))
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/invalid_get_logger_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/invalid_get_logger_argument.rs
@@ -82,7 +82,7 @@ pub(crate) fn invalid_get_logger_argument(checker: &mut Checker, call: &ast::Exp
     let mut diagnostic = Diagnostic::new(InvalidGetLoggerArgument, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
         if checker.semantic().is_builtin("__name__") {
-            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                 "__name__".to_string(),
                 expr.range(),
             )));

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/undocumented_warn.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/undocumented_warn.rs
@@ -63,7 +63,7 @@ pub(crate) fn undocumented_warn(checker: &mut Checker, expr: &Expr) {
                     checker.semantic(),
                 )?;
                 let reference_edit = Edit::range_replacement(binding, expr.range());
-                Ok(Fix::sometimes_applies_edits(import_edit, [reference_edit]))
+                Ok(Fix::unsafe_edits(import_edit, [reference_edit]))
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -197,7 +197,7 @@ pub(crate) fn logging_call(checker: &mut Checker, call: &ast::ExprCall) {
         ) {
             let mut diagnostic = Diagnostic::new(LoggingWarn, range);
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     "warning".to_string(),
                     range,
                 )));

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
@@ -82,7 +82,7 @@ pub(crate) fn duplicate_class_field_definition(checker: &mut Checker, body: &[St
             if checker.patch(diagnostic.kind.rule()) {
                 let edit =
                     fix::edits::delete_stmt(stmt, Some(stmt), checker.locator(), checker.indexer());
-                diagnostic.set_fix(Fix::sometimes_applies(edit).isolate(Checker::isolation(
+                diagnostic.set_fix(Fix::unsafe_edit(edit).isolate(Checker::isolation(
                     checker.semantic().current_statement_id(),
                 )));
             }

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/multiple_starts_ends_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/multiple_starts_ends_with.rs
@@ -196,7 +196,7 @@ pub(crate) fn multiple_starts_ends_with(checker: &mut Checker, expr: &Expr) {
                     range: TextRange::default(),
                 });
                 let bool_op = node;
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                     checker.generator().expr(&bool_op),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/reimplemented_list_builtin.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/reimplemented_list_builtin.rs
@@ -66,7 +66,7 @@ pub(crate) fn reimplemented_list_builtin(checker: &mut Checker, expr: &ExprLambd
                 let mut diagnostic = Diagnostic::new(ReimplementedListBuiltin, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     if checker.semantic().is_builtin("list") {
-                        diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                             "list".to_string(),
                             expr.range(),
                         )));

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_pass.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_pass.rs
@@ -70,7 +70,7 @@ pub(crate) fn no_unnecessary_pass(checker: &mut Checker, body: &[Stmt]) {
                     } else {
                         fix::edits::delete_stmt(stmt, None, checker.locator(), checker.indexer())
                     };
-                diagnostic.set_fix(Fix::always_applies(edit).isolate(Checker::isolation(
+                diagnostic.set_fix(Fix::safe_edit(edit).isolate(Checker::isolation(
                     checker.semantic().current_statement_id(),
                 )));
             }

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_range_start.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_range_start.rs
@@ -86,7 +86,7 @@ pub(crate) fn unnecessary_range_start(checker: &mut Checker, call: &ast::ExprCal
                 Parentheses::Preserve,
                 checker.locator().contents(),
             )
-            .map(Fix::always_applies)
+            .map(Fix::safe_edit)
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/any_eq_ne_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/any_eq_ne_annotation.rs
@@ -81,7 +81,7 @@ pub(crate) fn any_eq_ne_annotation(checker: &mut Checker, name: &str, parameters
         if checker.patch(diagnostic.kind.rule()) {
             // Ex) `def __eq__(self, obj: Any): ...`
             if checker.semantic().is_builtin("object") {
-                diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     "object".to_string(),
                     annotation.range(),
                 )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
@@ -72,7 +72,7 @@ pub(crate) fn duplicate_union_member<'a>(checker: &mut Checker, expr: &'a Expr) 
                 if let Some(parent @ Expr::BinOp(ast::ExprBinOp { left, right, .. })) = parent {
                     // Replace the parent with its non-duplicate child.
                     let child = if expr == left.as_ref() { right } else { left };
-                    diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                         checker.locator().slice(child.as_ref()).to_string(),
                         parent.range(),
                     )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/ellipsis_in_non_empty_class_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/ellipsis_in_non_empty_class_body.rs
@@ -66,7 +66,7 @@ pub(crate) fn ellipsis_in_non_empty_class_body(checker: &mut Checker, body: &[St
             if checker.patch(diagnostic.kind.rule()) {
                 let edit =
                     fix::edits::delete_stmt(stmt, Some(stmt), checker.locator(), checker.indexer());
-                diagnostic.set_fix(Fix::always_applies(edit).isolate(Checker::isolation(
+                diagnostic.set_fix(Fix::safe_edit(edit).isolate(Checker::isolation(
                     checker.semantic().current_statement_id(),
                 )));
             }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
@@ -177,7 +177,7 @@ fn check_short_args_list(checker: &mut Checker, parameters: &Parameters, func_ki
 
             if checker.patch(diagnostic.kind.rule()) {
                 if checker.semantic().is_builtin("object") {
-                    diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                         "object".to_string(),
                         annotation.range(),
                     )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
@@ -70,7 +70,7 @@ pub(crate) fn non_empty_stub_body(checker: &mut Checker, body: &[Stmt]) {
 
     let mut diagnostic = Diagnostic::new(NonEmptyStubBody, stmt.range());
     if checker.patch(Rule::NonEmptyStubBody) {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             format!("..."),
             stmt.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/numeric_literal_too_long.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/numeric_literal_too_long.rs
@@ -51,7 +51,7 @@ pub(crate) fn numeric_literal_too_long(checker: &mut Checker, expr: &Expr) {
 
     let mut diagnostic = Diagnostic::new(NumericLiteralTooLong, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             "...".to_string(),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_in_class_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_in_class_body.rs
@@ -63,7 +63,7 @@ pub(crate) fn pass_in_class_body(checker: &mut Checker, class_def: &ast::StmtCla
         if checker.patch(diagnostic.kind.rule()) {
             let edit =
                 fix::edits::delete_stmt(stmt, Some(stmt), checker.locator(), checker.indexer());
-            diagnostic.set_fix(Fix::always_applies(edit).isolate(Checker::isolation(
+            diagnostic.set_fix(Fix::safe_edit(edit).isolate(Checker::isolation(
                 checker.semantic().current_statement_id(),
             )));
         }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_statement_stub_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/pass_statement_stub_body.rs
@@ -48,7 +48,7 @@ pub(crate) fn pass_statement_stub_body(checker: &mut Checker, body: &[Stmt]) {
 
     let mut diagnostic = Diagnostic::new(PassStatementStubBody, pass.range());
     if checker.patch(Rule::PassStatementStubBody) {
-        diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             format!("..."),
             pass.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/quoted_annotation_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/quoted_annotation_in_stub.rs
@@ -44,7 +44,7 @@ impl AlwaysFixableViolation for QuotedAnnotationInStub {
 pub(crate) fn quoted_annotation_in_stub(checker: &mut Checker, annotation: &str, range: TextRange) {
     let mut diagnostic = Diagnostic::new(QuotedAnnotationInStub, range);
     if checker.patch(Rule::QuotedAnnotationInStub) {
-        diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             annotation.to_string(),
             range,
         )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -535,7 +535,7 @@ pub(crate) fn typed_argument_simple_defaults(checker: &mut Checker, parameters: 
                 let mut diagnostic = Diagnostic::new(TypedArgumentDefaultInStub, default.range());
 
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                         "...".to_string(),
                         default.range(),
                     )));
@@ -572,7 +572,7 @@ pub(crate) fn argument_simple_defaults(checker: &mut Checker, parameters: &Param
                 let mut diagnostic = Diagnostic::new(ArgumentDefaultInStub, default.range());
 
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                         "...".to_string(),
                         default.range(),
                     )));
@@ -607,7 +607,7 @@ pub(crate) fn assignment_default_in_stub(checker: &mut Checker, targets: &[Expr]
 
     let mut diagnostic = Diagnostic::new(AssignmentDefaultInStub, value.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             "...".to_string(),
             value.range(),
         )));
@@ -643,7 +643,7 @@ pub(crate) fn annotated_assignment_default_in_stub(
 
     let mut diagnostic = Diagnostic::new(AssignmentDefaultInStub, value.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             "...".to_string(),
             value.range(),
         )));
@@ -748,7 +748,7 @@ pub(crate) fn type_alias_without_annotation(checker: &mut Checker, value: &Expr,
                 target.start(),
                 checker.semantic(),
             )?;
-            Ok(Fix::sometimes_applies_edits(
+            Ok(Fix::unsafe_edits(
                 Edit::range_replacement(format!("{id}: {binding}"), target.range()),
                 [import_edit],
             ))

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/str_or_repr_defined_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/str_or_repr_defined_in_stub.rs
@@ -99,7 +99,7 @@ pub(crate) fn str_or_repr_defined_in_stub(checker: &mut Checker, stmt: &Stmt) {
         let stmt = checker.semantic().current_statement();
         let parent = checker.semantic().current_statement_parent();
         let edit = delete_stmt(stmt, parent, checker.locator(), checker.indexer());
-        diagnostic.set_fix(Fix::always_applies(edit).isolate(Checker::isolation(
+        diagnostic.set_fix(Fix::safe_edit(edit).isolate(Checker::isolation(
             checker.semantic().current_statement_parent_id(),
         )));
     }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
@@ -68,7 +68,7 @@ pub(crate) fn string_or_bytes_too_long(checker: &mut Checker, expr: &Expr) {
 
     let mut diagnostic = Diagnostic::new(StringOrBytesTooLong, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             "...".to_string(),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unaliased_collections_abc_set_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unaliased_collections_abc_set_import.rs
@@ -70,7 +70,7 @@ pub(crate) fn unaliased_collections_abc_set_import(
             diagnostic.try_set_fix(|| {
                 let scope = &checker.semantic().scopes[binding.scope];
                 let (edit, rest) = Renamer::rename(name, "AbstractSet", scope, checker.semantic())?;
-                Ok(Fix::sometimes_applies_edits(edit, rest))
+                Ok(Fix::unsafe_edits(edit, rest))
             });
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -292,7 +292,7 @@ pub(crate) fn unittest_assertion(
                         && !checker.indexer().comment_ranges().intersects(expr.range())
                     {
                         if let Ok(stmt) = unittest_assert.generate_assert(args, keywords) {
-                            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                                 checker.generator().stmt(&stmt),
                                 parenthesized_range(
                                     expr.into(),
@@ -401,7 +401,7 @@ pub(crate) fn unittest_raises_assertion(
                     checker.semantic(),
                 )?;
                 let edit = Edit::range_replacement(format!("{binding}({args})"), call.range());
-                Ok(Fix::sometimes_applies_edits(import_edit, [edit]))
+                Ok(Fix::unsafe_edits(import_edit, [edit]))
             });
         }
     }
@@ -756,7 +756,7 @@ pub(crate) fn composite_condition(
             {
                 diagnostic.try_set_fix(|| {
                     fix_composite_condition(stmt, checker.locator(), checker.stylist())
-                        .map(Fix::sometimes_applies)
+                        .map(Fix::unsafe_edit)
                 });
             }
         }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -700,7 +700,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &D
                     && arguments.args.is_empty()
                     && arguments.keywords.is_empty()
                 {
-                    let fix = Fix::always_applies(Edit::deletion(func.end(), decorator.end()));
+                    let fix = Fix::safe_edit(Edit::deletion(func.end(), decorator.end()));
                     pytest_fixture_parentheses(
                         checker,
                         decorator,
@@ -735,7 +735,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &D
                                     edits::Parentheses::Preserve,
                                     checker.locator().contents(),
                                 )
-                                .map(Fix::sometimes_applies)
+                                .map(Fix::unsafe_edit)
                             });
                         }
                         checker.diagnostics.push(diagnostic);
@@ -746,7 +746,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &D
         _ => {
             if checker.enabled(Rule::PytestFixtureIncorrectParenthesesStyle) {
                 if checker.settings.flake8_pytest_style.fixture_parentheses {
-                    let fix = Fix::always_applies(Edit::insertion(
+                    let fix = Fix::safe_edit(Edit::insertion(
                         Parentheses::Empty.to_string(),
                         decorator.end(),
                     ));
@@ -839,9 +839,9 @@ fn check_fixture_returns(
                 ))
             });
             if let Some(return_type_edit) = return_type_edit {
-                diagnostic.set_fix(Fix::always_applies_edits(yield_edit, [return_type_edit]));
+                diagnostic.set_fix(Fix::safe_edits(yield_edit, [return_type_edit]));
             } else {
-                diagnostic.set_fix(Fix::always_applies(yield_edit));
+                diagnostic.set_fix(Fix::safe_edit(yield_edit));
             }
         }
         checker.diagnostics.push(diagnostic);
@@ -914,7 +914,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Decorator]) {
                     Diagnostic::new(PytestUnnecessaryAsyncioMarkOnFixture, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     let range = checker.locator().full_lines_range(expr.range());
-                    diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(range)));
+                    diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(range)));
                 }
                 checker.diagnostics.push(diagnostic);
             }
@@ -926,7 +926,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Decorator]) {
                     Diagnostic::new(PytestErroneousUseFixturesOnFixture, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     let line_range = checker.locator().full_lines_range(expr.range());
-                    diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(line_range)));
+                    diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(line_range)));
                 }
                 checker.diagnostics.push(diagnostic);
             }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
@@ -152,13 +152,13 @@ fn check_mark_parentheses(checker: &mut Checker, decorator: &Decorator, call_pat
                 && args.is_empty()
                 && keywords.is_empty()
             {
-                let fix = Fix::always_applies(Edit::deletion(func.end(), decorator.end()));
+                let fix = Fix::safe_edit(Edit::deletion(func.end(), decorator.end()));
                 pytest_mark_parentheses(checker, decorator, call_path, fix, "", "()");
             }
         }
         _ => {
             if checker.settings.flake8_pytest_style.mark_parentheses {
-                let fix = Fix::always_applies(Edit::insertion("()".to_string(), decorator.end()));
+                let fix = Fix::safe_edit(Edit::insertion("()".to_string(), decorator.end()));
                 pytest_mark_parentheses(checker, decorator, call_path, fix, "()", "");
             }
         }
@@ -185,9 +185,7 @@ fn check_useless_usefixtures(checker: &mut Checker, decorator: &Decorator, call_
     if !has_parameters {
         let mut diagnostic = Diagnostic::new(PytestUseFixturesWithoutParameters, decorator.range());
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_deletion(
-                decorator.range(),
-            )));
+            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_deletion(decorator.range())));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -352,7 +352,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                                 ctx: ExprContext::Load,
                                 range: TextRange::default(),
                             });
-                            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                                 format!("({})", checker.generator().expr(&node)),
                                 name_range,
                             )));
@@ -387,7 +387,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                                 ctx: ExprContext::Load,
                                 range: TextRange::default(),
                             });
-                            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                                 checker.generator().expr(&node),
                                 name_range,
                             )));
@@ -419,7 +419,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                                 ctx: ExprContext::Load,
                                 range: TextRange::default(),
                             });
-                            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                                 checker.generator().expr(&node),
                                 expr.range(),
                             )));
@@ -435,9 +435,10 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(content) = elts_to_csv(elts, checker.generator()) {
-                                diagnostic.set_fix(Fix::sometimes_applies(
-                                    Edit::range_replacement(content, expr.range()),
-                                ));
+                                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                                    content,
+                                    expr.range(),
+                                )));
                             }
                         }
                         checker.diagnostics.push(diagnostic);
@@ -466,7 +467,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                                 ctx: ExprContext::Load,
                                 range: TextRange::default(),
                             });
-                            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                                 format!("({})", checker.generator().expr(&node)),
                                 expr.range(),
                             )));
@@ -482,9 +483,10 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(content) = elts_to_csv(elts, checker.generator()) {
-                                diagnostic.set_fix(Fix::sometimes_applies(
-                                    Edit::range_replacement(content, expr.range()),
-                                ));
+                                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                                    content,
+                                    expr.range(),
+                                )));
                             }
                         }
                         checker.diagnostics.push(diagnostic);
@@ -596,9 +598,8 @@ fn check_duplicates(checker: &mut Checker, values: &Expr) {
                             .comment_ranges()
                             .intersects(deletion_range)
                         {
-                            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_deletion(
-                                deletion_range,
-                            )));
+                            diagnostic
+                                .set_fix(Fix::unsafe_edit(Edit::range_deletion(deletion_range)));
                         }
                     }
                 }
@@ -619,7 +620,7 @@ fn handle_single_name(checker: &mut Checker, expr: &Expr, value: &Expr) {
 
     if checker.patch(diagnostic.kind.rule()) {
         let node = value.clone();
-        diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             checker.generator().expr(&node),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/avoidable_escaped_quote.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/avoidable_escaped_quote.rs
@@ -142,7 +142,7 @@ pub(crate) fn avoidable_escaped_quote(
                             quote = quotes_settings.inline_quotes.opposite().as_char(),
                             value = unescape_string(string_contents)
                         );
-                        diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                             fixed_contents,
                             tok_range,
                         )));
@@ -216,7 +216,7 @@ pub(crate) fn avoidable_escaped_quote(
                                 tok_range,
                             ),
                         ));
-                    diagnostic.set_fix(Fix::always_applies_edits(
+                    diagnostic.set_fix(Fix::safe_edits(
                         fstring_start_edit,
                         fstring_middle_and_end_edits,
                     ));

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/check_string_quotes.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/check_string_quotes.rs
@@ -240,7 +240,7 @@ fn docstring(locator: &Locator, range: TextRange, settings: &LinterSettings) -> 
         fixed_contents.push_str(&quote);
         fixed_contents.push_str(string_contents);
         fixed_contents.push_str(&quote);
-        diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             fixed_contents,
             range,
         )));
@@ -317,7 +317,7 @@ fn strings(
                 fixed_contents.push_str(quote);
                 fixed_contents.push_str(string_contents);
                 fixed_contents.push_str(quote);
-                diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     fixed_contents,
                     *range,
                 )));
@@ -342,7 +342,7 @@ fn strings(
                 fixed_contents.push(quote);
                 fixed_contents.push_str(string_contents);
                 fixed_contents.push(quote);
-                diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     fixed_contents,
                     *range,
                 )));

--- a/crates/ruff_linter/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -87,12 +87,12 @@ pub(crate) fn unnecessary_paren_on_raise_exception(checker: &mut Checker, expr: 
                 .next()
                 .is_some_and(char::is_alphanumeric)
             {
-                diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     " ".to_string(),
                     arguments.range(),
                 )));
             } else {
-                diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(arguments.range())));
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(arguments.range())));
             }
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
@@ -346,7 +346,7 @@ fn unnecessary_return_none(checker: &mut Checker, stack: &Stack) {
         }
         let mut diagnostic = Diagnostic::new(UnnecessaryReturnNone, stmt.range);
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 "return".to_string(),
                 stmt.range(),
             )));
@@ -363,7 +363,7 @@ fn implicit_return_value(checker: &mut Checker, stack: &Stack) {
         }
         let mut diagnostic = Diagnostic::new(ImplicitReturnValue, stmt.range);
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 "return None".to_string(),
                 stmt.range,
             )));
@@ -415,7 +415,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                         content.push_str(checker.stylist().line_ending().as_str());
                         content.push_str(indent);
                         content.push_str("return None");
-                        diagnostic.set_fix(Fix::sometimes_applies(Edit::insertion(
+                        diagnostic.set_fix(Fix::unsafe_edit(Edit::insertion(
                             content,
                             end_of_last_statement(stmt, checker.locator()),
                         )));
@@ -437,7 +437,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                         content.push_str(checker.stylist().line_ending().as_str());
                         content.push_str(indent);
                         content.push_str("return None");
-                        diagnostic.set_fix(Fix::sometimes_applies(Edit::insertion(
+                        diagnostic.set_fix(Fix::unsafe_edit(Edit::insertion(
                             content,
                             end_of_last_statement(stmt, checker.locator()),
                         )));
@@ -473,7 +473,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                     content.push_str(checker.stylist().line_ending().as_str());
                     content.push_str(indent);
                     content.push_str("return None");
-                    diagnostic.set_fix(Fix::sometimes_applies(Edit::insertion(
+                    diagnostic.set_fix(Fix::unsafe_edit(Edit::insertion(
                         content,
                         end_of_last_statement(stmt, checker.locator()),
                     )));
@@ -567,10 +567,7 @@ fn unnecessary_assign(checker: &mut Checker, stack: &Stack) {
                     ),
                 );
 
-                Ok(Fix::sometimes_applies_edits(
-                    replace_assign,
-                    [delete_return],
-                ))
+                Ok(Fix::unsafe_edits(replace_assign, [delete_return]))
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -461,7 +461,7 @@ pub(crate) fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
 
                     // Populate the `Fix`. Replace the _entire_ `BoolOp`. Note that if we have
                     // multiple duplicates, the fixes will conflict.
-                    diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                         checker.generator().expr(&bool_op),
                         expr.range(),
                     )));
@@ -582,7 +582,7 @@ pub(crate) fn compare_with_tuple(checker: &mut Checker, expr: &Expr) {
                 };
                 node.into()
             };
-            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                 checker.generator().expr(&in_expr),
                 expr.range(),
             )));
@@ -639,7 +639,7 @@ pub(crate) fn expr_and_not_expr(checker: &mut Checker, expr: &Expr) {
                     expr.range(),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                         "False".to_string(),
                         expr.range(),
                     )));
@@ -698,7 +698,7 @@ pub(crate) fn expr_or_not_expr(checker: &mut Checker, expr: &Expr) {
                     expr.range(),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                         "True".to_string(),
                         expr.range(),
                     )));
@@ -851,7 +851,7 @@ pub(crate) fn expr_or_true(checker: &mut Checker, expr: &Expr) {
             edit.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::sometimes_applies(edit));
+            diagnostic.set_fix(Fix::unsafe_edit(edit));
         }
         checker.diagnostics.push(diagnostic);
     }
@@ -868,7 +868,7 @@ pub(crate) fn expr_and_false(checker: &mut Checker, expr: &Expr) {
             edit.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::sometimes_applies(edit));
+            diagnostic.set_fix(Fix::unsafe_edit(edit));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -217,7 +217,7 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
             range: TextRange::default(),
         };
         let new_env_var = node.into();
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             checker.generator().expr(&new_env_var),
             slice.range(),
         )));
@@ -276,7 +276,7 @@ pub(crate) fn dict_get_with_none_default(checker: &mut Checker, expr: &Expr) {
     );
 
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             expected,
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -159,7 +159,7 @@ pub(crate) fn if_expr_with_true_false(
     );
     if checker.patch(diagnostic.kind.rule()) {
         if test.is_compare_expr() {
-            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                 checker
                     .locator()
                     .slice(
@@ -175,7 +175,7 @@ pub(crate) fn if_expr_with_true_false(
                 expr.range(),
             )));
         } else if checker.semantic().is_builtin("bool") {
-            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                 checker.generator().expr(
                     &ast::ExprCall {
                         func: Box::new(
@@ -216,7 +216,7 @@ pub(crate) fn if_expr_with_false_true(
 
     let mut diagnostic = Diagnostic::new(IfExprWithFalseTrue, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             checker.generator().expr(
                 &ast::ExprUnaryOp {
                     op: UnaryOp::Not,
@@ -279,7 +279,7 @@ pub(crate) fn twisted_arms_in_ifexpr(
             orelse: Box::new(node),
             range: TextRange::default(),
         };
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             checker.generator().expr(&node3.into()),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -182,7 +182,7 @@ pub(crate) fn negation_with_equal_op(
             comparators: comparators.clone(),
             range: TextRange::default(),
         };
-        diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             checker.generator().expr(&node.into()),
             expr.range(),
         )));
@@ -239,7 +239,7 @@ pub(crate) fn negation_with_not_equal_op(
             comparators: comparators.clone(),
             range: TextRange::default(),
         };
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             checker.generator().expr(&node.into()),
             expr.range(),
         )));
@@ -272,7 +272,7 @@ pub(crate) fn double_negation(checker: &mut Checker, expr: &Expr, op: UnaryOp, o
     );
     if checker.patch(diagnostic.kind.rule()) {
         if checker.semantic().in_boolean_test() {
-            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                 checker.locator().slice(operand.as_ref()).to_string(),
                 expr.range(),
             )));
@@ -291,7 +291,7 @@ pub(crate) fn double_negation(checker: &mut Checker, expr: &Expr, op: UnaryOp, o
                 },
                 range: TextRange::default(),
             };
-            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                 checker.generator().expr(&node1.into()),
                 expr.range(),
             )));

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
@@ -145,7 +145,7 @@ pub(crate) fn multiple_with_statements(
                                 checker.settings.tab_size,
                             )
                         }) {
-                            diagnostic.set_fix(Fix::sometimes_applies(edit));
+                            diagnostic.set_fix(Fix::unsafe_edit(edit));
                         }
                     }
                     Err(err) => error!("Failed to fix nested with: {err}"),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
@@ -123,7 +123,7 @@ pub(crate) fn nested_if_statements(
                             checker.settings.tab_size,
                         )
                     }) {
-                        diagnostic.set_fix(Fix::sometimes_applies(edit));
+                        diagnostic.set_fix(Fix::unsafe_edit(edit));
                     }
                 }
                 Err(err) => error!("Failed to fix nested if: {err}"),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
@@ -186,7 +186,7 @@ pub(crate) fn use_dict_get_with_default(checker: &mut Checker, stmt_if: &ast::St
     );
     if checker.patch(diagnostic.kind.rule()) {
         if !checker.indexer().has_comments(stmt_if, checker.locator()) {
-            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                 contents,
                 stmt_if.range(),
             )));

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_if_exp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_if_exp.rs
@@ -145,7 +145,7 @@ pub(crate) fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt) {
     );
     if checker.patch(diagnostic.kind.rule()) {
         if !checker.indexer().has_comments(stmt, checker.locator()) {
-            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                 contents,
                 stmt.range(),
             )));

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -128,12 +128,12 @@ fn key_in_dict(
                 .next()
                 .is_some_and(|char| char.is_ascii_alphabetic())
             {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                     " ".to_string(),
                     range,
                 )));
             } else {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::range_deletion(range)));
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_deletion(range)));
             }
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
@@ -112,7 +112,7 @@ pub(crate) fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
                     value: Some(Box::new(if_test.clone())),
                     range: TextRange::default(),
                 };
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                     checker.generator().stmt(&node.into()),
                     range,
                 )));
@@ -137,7 +137,7 @@ pub(crate) fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
                     value: Some(Box::new(node1.into())),
                     range: TextRange::default(),
                 };
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                     checker.generator().stmt(&node2.into()),
                     range,
                 )));

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -115,7 +115,7 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt) {
                 TextRange::new(stmt.start(), terminal.stmt.end()),
             );
             if checker.patch(diagnostic.kind.rule()) && checker.semantic().is_builtin("any") {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
                     contents,
                     stmt.start(),
                     terminal.stmt.end(),
@@ -201,7 +201,7 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt) {
                 TextRange::new(stmt.start(), terminal.stmt.end()),
             );
             if checker.patch(diagnostic.kind.rule()) && checker.semantic().is_builtin("all") {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
                     contents,
                     stmt.start(),
                     terminal.stmt.end(),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/suppressible_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/suppressible_exception.rs
@@ -148,7 +148,7 @@ pub(crate) fn suppressible_exception(
                 );
                 let remove_handler =
                     Edit::range_deletion(checker.locator().full_lines_range(*range));
-                Ok(Fix::sometimes_applies_edits(
+                Ok(Fix::unsafe_edits(
                     import_edit,
                     [replace_try, remove_handler],
                 ))

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -194,7 +194,7 @@ pub(crate) fn yoda_conditions(
             expr.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 pad(suggestion, expr.range(), checker.locator()),
                 expr.range(),
             )));

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
@@ -103,7 +103,7 @@ fn fix_banned_relative_import(
         range: TextRange::default(),
     };
     let content = generator.stmt(&node.into());
-    Some(Fix::sometimes_applies(Edit::range_replacement(
+    Some(Fix::unsafe_edit(Edit::range_replacement(
         content,
         stmt.range(),
     )))

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -319,7 +319,7 @@ fn directive_errors(
         );
 
         if settings.rules.should_fix(Rule::InvalidTodoCapitalization) {
-            diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 "TODO".to_string(),
                 directive.range,
             )));

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -61,7 +61,7 @@ pub(crate) fn empty_type_checking_block(checker: &mut Checker, stmt: &ast::StmtI
         let stmt = checker.semantic().current_statement();
         let parent = checker.semantic().current_statement_parent();
         let edit = fix::edits::delete_stmt(stmt, parent, checker.locator(), checker.indexer());
-        diagnostic.set_fix(Fix::always_applies(edit).isolate(Checker::isolation(
+        diagnostic.set_fix(Fix::safe_edit(edit).isolate(Checker::isolation(
             checker.semantic().current_statement_parent_id(),
         )));
     }

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -235,7 +235,7 @@ fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) ->
     )?;
 
     Ok(
-        Fix::sometimes_applies_edits(remove_import_edit, add_import_edit.into_edits()).isolate(
+        Fix::unsafe_edits(remove_import_edit, add_import_edit.into_edits()).isolate(
             Checker::isolation(checker.semantic().parent_statement_id(node_id)),
         ),
     )

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -486,7 +486,7 @@ fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) ->
     )?;
 
     Ok(
-        Fix::sometimes_applies_edits(remove_import_edit, add_import_edit.into_edits()).isolate(
+        Fix::unsafe_edits(remove_import_edit, add_import_edit.into_edits()).isolate(
             Checker::isolation(checker.semantic().parent_statement_id(node_id)),
         ),
     )

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
@@ -77,7 +77,7 @@ pub(crate) fn path_constructor_current_directory(checker: &mut Checker, expr: &E
     if matches!(value.as_str(), "" | ".") {
         let mut diagnostic = Diagnostic::new(PathConstructorCurrentDirectory, *range);
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(*range)));
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(*range)));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -155,7 +155,7 @@ pub(crate) fn static_join_to_fstring(checker: &mut Checker, expr: &Expr, joiner:
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             pad(contents, expr.range(), checker.locator()),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
@@ -117,7 +117,7 @@ fn add_required_import(
         TextRange::default(),
     );
     if settings.rules.should_fix(Rule::MissingRequiredImport) {
-        diagnostic.set_fix(Fix::always_applies(
+        diagnostic.set_fix(Fix::safe_edit(
             Importer::new(python_ast, locator, stylist)
                 .add_import(required_import, TextSize::default()),
         ));

--- a/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
@@ -139,7 +139,7 @@ pub(crate) fn organize_imports(
 
     let mut diagnostic = Diagnostic::new(UnsortedImports, range);
     if settings.rules.should_fix(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             indent(&expected, indentation).to_string(),
             range,
         )));

--- a/crates/ruff_linter/src/rules/numpy/rules/deprecated_function.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/deprecated_function.rs
@@ -84,10 +84,7 @@ pub(crate) fn deprecated_function(checker: &mut Checker, expr: &Expr) {
                     checker.semantic(),
                 )?;
                 let replacement_edit = Edit::range_replacement(binding, expr.range());
-                Ok(Fix::sometimes_applies_edits(
-                    import_edit,
-                    [replacement_edit],
-                ))
+                Ok(Fix::unsafe_edits(import_edit, [replacement_edit]))
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/numpy/rules/deprecated_type_alias.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/deprecated_type_alias.rs
@@ -80,7 +80,7 @@ pub(crate) fn deprecated_type_alias(checker: &mut Checker, expr: &Expr) {
                 _ => type_name,
             };
             if checker.semantic().is_builtin(type_name) {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                     type_name.to_string(),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -135,8 +135,5 @@ fn convert_inplace_argument_to_assignment(
     )
     .ok()?;
 
-    Some(Fix::sometimes_applies_edits(
-        insert_assignment,
-        [remove_argument],
-    ))
+    Some(Fix::unsafe_edits(insert_assignment, [remove_argument]))
 }

--- a/crates/ruff_linter/src/rules/perflint/rules/incorrect_dict_iterator.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/incorrect_dict_iterator.rs
@@ -110,10 +110,7 @@ pub(crate) fn incorrect_dict_iterator(checker: &mut Checker, stmt_for: &ast::Stm
                     ),
                     stmt_for.target.range(),
                 );
-                diagnostic.set_fix(Fix::sometimes_applies_edits(
-                    replace_attribute,
-                    [replace_target],
-                ));
+                diagnostic.set_fix(Fix::unsafe_edits(replace_attribute, [replace_target]));
             }
             checker.diagnostics.push(diagnostic);
         }
@@ -135,10 +132,7 @@ pub(crate) fn incorrect_dict_iterator(checker: &mut Checker, stmt_for: &ast::Stm
                     ),
                     stmt_for.target.range(),
                 );
-                diagnostic.set_fix(Fix::sometimes_applies_edits(
-                    replace_attribute,
-                    [replace_target],
-                ));
+                diagnostic.set_fix(Fix::unsafe_edits(replace_attribute, [replace_target]));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
@@ -135,7 +135,7 @@ pub(crate) fn unnecessary_list_cast(checker: &mut Checker, iter: &Expr) {
 
 /// Generate a [`Fix`] to remove a `list` cast from an expression.
 fn remove_cast(list_range: TextRange, iterable_range: TextRange) -> Fix {
-    Fix::always_applies_edits(
+    Fix::safe_edits(
         Edit::deletion(list_range.start(), iterable_range.start()),
         [Edit::deletion(iterable_range.end(), list_range.end())],
     )

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/compound_statements.rs
@@ -170,7 +170,7 @@ pub(crate) fn compound_statements(
                     let mut diagnostic =
                         Diagnostic::new(UselessSemicolon, TextRange::new(start, end));
                     if settings.rules.should_fix(Rule::UselessSemicolon) {
-                        diagnostic.set_fix(Fix::always_applies(Edit::deletion(
+                        diagnostic.set_fix(Fix::safe_edit(Edit::deletion(
                             indexer
                                 .preceded_by_continuations(start, locator)
                                 .unwrap_or(start),

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -162,7 +162,7 @@ pub(crate) fn invalid_escape_sequence(
         if contains_valid_escape_sequence {
             // Escape with backslash.
             for diagnostic in &mut invalid_escape_sequence {
-                diagnostic.set_fix(Fix::always_applies(Edit::insertion(
+                diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
                     r"\".to_string(),
                     diagnostic.start() + TextSize::from(1),
                 )));
@@ -184,7 +184,7 @@ pub(crate) fn invalid_escape_sequence(
                 // If necessary, add a space between any leading keyword (`return`, `yield`,
                 // `assert`, etc.) and the string. For example, `return"foo"` is valid, but
                 // `returnr"foo"` is not.
-                diagnostic.set_fix(Fix::always_applies(Edit::insertion(
+                diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
                     pad_start("r".to_string(), tok_start, locator),
                     tok_start,
                 )));

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -125,12 +125,12 @@ pub(crate) fn lambda_assignment(
                     .get_all(id)
                     .any(|binding_id| checker.semantic().binding(binding_id).kind.is_annotation())
             {
-                diagnostic.set_fix(Fix::never_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::display_edit(Edit::range_replacement(
                     indented,
                     stmt.range(),
                 )));
             } else {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                     indented,
                     stmt.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -287,7 +287,7 @@ pub(crate) fn literal_comparisons(checker: &mut Checker, compare: &ast::ExprComp
             checker.locator(),
         );
         for diagnostic in &mut diagnostics {
-            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                 content.to_string(),
                 compare.range(),
             )));

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/extraneous_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/extraneous_whitespace.rs
@@ -162,9 +162,8 @@ pub(crate) fn extraneous_whitespace(
                             TextRange::at(token.end(), trailing_len),
                         );
                         if fix_after_open_bracket {
-                            diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(
-                                diagnostic.range(),
-                            )));
+                            diagnostic
+                                .set_fix(Fix::safe_edit(Edit::range_deletion(diagnostic.range())));
                         }
                         context.push_diagnostic(diagnostic);
                     }
@@ -179,7 +178,7 @@ pub(crate) fn extraneous_whitespace(
                                 TextRange::at(token.start() - offset, offset),
                             );
                             if fix_before_close_bracket {
-                                diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(
+                                diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(
                                     diagnostic.range(),
                                 )));
                             }
@@ -197,7 +196,7 @@ pub(crate) fn extraneous_whitespace(
                                 TextRange::at(token.start() - offset, offset),
                             );
                             if fix_before_punctuation {
-                                diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(
+                                diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(
                                     diagnostic.range(),
                                 )));
                             }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
@@ -116,7 +116,7 @@ pub(crate) fn missing_whitespace(line: &LogicalLine, fix: bool, context: &mut Lo
                     let mut diagnostic = Diagnostic::new(kind, token.range());
 
                     if fix {
-                        diagnostic.set_fix(Fix::always_applies(Edit::insertion(
+                        diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
                             " ".to_string(),
                             token.end(),
                         )));

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
@@ -83,7 +83,7 @@ pub(crate) fn whitespace_before_parameters(
             let mut diagnostic = Diagnostic::new(kind, TextRange::new(start, end));
 
             if fix {
-                diagnostic.set_fix(Fix::always_applies(Edit::deletion(start, end)));
+                diagnostic.set_fix(Fix::safe_edit(Edit::deletion(start, end)));
             }
             context.push_diagnostic(diagnostic);
         }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/missing_newline_at_end_of_file.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/missing_newline_at_end_of_file.rs
@@ -56,7 +56,7 @@ pub(crate) fn no_newline_at_end_of_file(
 
         let mut diagnostic = Diagnostic::new(MissingNewlineAtEndOfFile, range);
         if fix {
-            diagnostic.set_fix(Fix::always_applies(Edit::insertion(
+            diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
                 stylist.line_ending().to_string(),
                 range.start(),
             )));

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/not_tests.rs
@@ -95,7 +95,7 @@ pub(crate) fn not_tests(checker: &mut Checker, unary_op: &ast::ExprUnaryOp) {
             if checker.enabled(Rule::NotInTest) {
                 let mut diagnostic = Diagnostic::new(NotInTest, unary_op.operand.range());
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                         pad(
                             generate_comparison(
                                 left,
@@ -118,7 +118,7 @@ pub(crate) fn not_tests(checker: &mut Checker, unary_op: &ast::ExprUnaryOp) {
             if checker.enabled(Rule::NotIsTest) {
                 let mut diagnostic = Diagnostic::new(NotIsTest, unary_op.operand.range());
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                         pad(
                             generate_comparison(
                                 left,

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -93,7 +93,7 @@ pub(crate) fn trailing_whitespace(
                 if settings.rules.should_fix(Rule::BlankLineWithWhitespace) {
                     // Remove any preceding continuations, to avoid introducing a potential
                     // syntax error.
-                    diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(TextRange::new(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(TextRange::new(
                         indexer
                             .preceded_by_continuations(line.start(), locator)
                             .unwrap_or(range.start()),
@@ -105,7 +105,7 @@ pub(crate) fn trailing_whitespace(
         } else if settings.rules.enabled(Rule::TrailingWhitespace) {
             let mut diagnostic = Diagnostic::new(TrailingWhitespace, range);
             if settings.rules.should_fix(Rule::TrailingWhitespace) {
-                diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(range)));
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(range)));
             }
             return Some(diagnostic);
         }

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/blank_after_summary.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/blank_after_summary.rs
@@ -114,7 +114,7 @@ pub(crate) fn blank_after_summary(checker: &mut Checker, docstring: &Docstring) 
                 }
 
                 // Insert one blank line after the summary (replacing any existing lines).
-                diagnostic.set_fix(Fix::always_applies(Edit::replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::replacement(
                     checker.stylist().line_ending().to_string(),
                     summary_end,
                     blank_end,

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -191,7 +191,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
                 let mut diagnostic = Diagnostic::new(BlankLineBeforeClass, docstring.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     // Delete the blank line before the class.
-                    diagnostic.set_fix(Fix::always_applies(Edit::deletion(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::deletion(
                         blank_lines_start,
                         docstring.start() - docstring.indentation.text_len(),
                     )));
@@ -204,7 +204,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
                 let mut diagnostic = Diagnostic::new(OneBlankLineBeforeClass, docstring.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     // Insert one blank line before the class.
-                    diagnostic.set_fix(Fix::always_applies(Edit::replacement(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::replacement(
                         checker.stylist().line_ending().to_string(),
                         blank_lines_start,
                         docstring.start() - docstring.indentation.text_len(),
@@ -252,7 +252,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
                     //     """Has priorities"""   ;   priorities=1
                     // ```
                     let next_statement = next_statement.trim_whitespace_start();
-                    diagnostic.set_fix(Fix::always_applies(Edit::replacement(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::replacement(
                         line_ending.to_string() + line_ending + indentation + next_statement,
                         replacement_start,
                         first_line.end(),
@@ -282,7 +282,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
             let mut diagnostic = Diagnostic::new(OneBlankLineAfterClass, docstring.range());
             if checker.patch(diagnostic.kind.rule()) {
                 // Insert a blank line before the class (replacing any existing lines).
-                diagnostic.set_fix(Fix::always_applies(Edit::replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::replacement(
                     checker.stylist().line_ending().to_string(),
                     replacement_start,
                     blank_lines_end,

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_function.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_function.rs
@@ -134,7 +134,7 @@ pub(crate) fn blank_before_after_function(checker: &mut Checker, docstring: &Doc
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Delete the blank line before the docstring.
-                diagnostic.set_fix(Fix::always_applies(Edit::deletion(
+                diagnostic.set_fix(Fix::safe_edit(Edit::deletion(
                     blank_lines_start,
                     docstring.start() - docstring.indentation.text_len(),
                 )));
@@ -190,7 +190,7 @@ pub(crate) fn blank_before_after_function(checker: &mut Checker, docstring: &Doc
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Delete the blank line after the docstring.
-                diagnostic.set_fix(Fix::always_applies(Edit::deletion(
+                diagnostic.set_fix(Fix::safe_edit(Edit::deletion(
                     first_line_end,
                     blank_lines_end,
                 )));

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/capitalized.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/capitalized.rs
@@ -91,7 +91,7 @@ pub(crate) fn capitalized(checker: &mut Checker, docstring: &Docstring) {
     );
 
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             capitalized_word,
             TextRange::at(body.start(), first_word.text_len()),
         )));

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_period.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_period.rs
@@ -105,7 +105,7 @@ pub(crate) fn ends_with_period(checker: &mut Checker, docstring: &Docstring) {
             let mut diagnostic = Diagnostic::new(EndsInPeriod, docstring.range());
             // Best-effort fix: avoid adding a period after other punctuation marks.
             if checker.patch(diagnostic.kind.rule()) && !trimmed.ends_with([':', ';']) {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::insertion(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::insertion(
                     ".".to_string(),
                     line.start() + trimmed.text_len(),
                 )));

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_punctuation.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_punctuation.rs
@@ -104,7 +104,7 @@ pub(crate) fn ends_with_punctuation(checker: &mut Checker, docstring: &Docstring
             let mut diagnostic = Diagnostic::new(EndsInPunctuation, docstring.range());
             // Best-effort fix: avoid adding a period after other punctuation marks.
             if checker.patch(diagnostic.kind.rule()) && !trimmed.ends_with([':', ';']) {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::insertion(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::insertion(
                     ".".to_string(),
                     line.start() + trimmed.text_len(),
                 )));

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/indent.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/indent.rs
@@ -189,7 +189,7 @@ pub(crate) fn indent(checker: &mut Checker, docstring: &Docstring) {
                 let mut diagnostic =
                     Diagnostic::new(UnderIndentation, TextRange::empty(line.start()));
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                         clean_space(docstring.indentation),
                         TextRange::at(line.start(), line_indent.text_len()),
                     )));
@@ -236,7 +236,7 @@ pub(crate) fn indent(checker: &mut Checker, docstring: &Docstring) {
                     } else {
                         Edit::range_replacement(indent, over_indented)
                     };
-                    diagnostic.set_fix(Fix::always_applies(edit));
+                    diagnostic.set_fix(Fix::safe_edit(edit));
                 }
                 checker.diagnostics.push(diagnostic);
             }
@@ -256,7 +256,7 @@ pub(crate) fn indent(checker: &mut Checker, docstring: &Docstring) {
                     } else {
                         Edit::range_replacement(indent, range)
                     };
-                    diagnostic.set_fix(Fix::always_applies(edit));
+                    diagnostic.set_fix(Fix::safe_edit(edit));
                 }
                 checker.diagnostics.push(diagnostic);
             }

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -141,7 +141,7 @@ pub(crate) fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstr
                 // Delete until first non-whitespace char.
                 for line in content_lines {
                     if let Some(end_column) = line.find(|c: char| !c.is_whitespace()) {
-                        diagnostic.set_fix(Fix::always_applies(Edit::deletion(
+                        diagnostic.set_fix(Fix::safe_edit(Edit::deletion(
                             first_line.end(),
                             line.start() + TextSize::try_from(end_column).unwrap(),
                         )));
@@ -197,7 +197,7 @@ pub(crate) fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstr
                         first_line.strip_prefix(prefix).unwrap().trim_start()
                     );
 
-                    diagnostic.set_fix(Fix::always_applies(Edit::replacement(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::replacement(
                         repl,
                         body.start(),
                         first_line.end(),

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
@@ -96,7 +96,7 @@ pub(crate) fn newline_after_last_paragraph(checker: &mut Checker, docstring: &Do
                             checker.stylist().line_ending().as_str(),
                             clean_space(docstring.indentation)
                         );
-                        diagnostic.set_fix(Fix::always_applies(Edit::replacement(
+                        diagnostic.set_fix(Fix::safe_edit(Edit::replacement(
                             content,
                             docstring.expr.end() - num_trailing_quotes - num_trailing_spaces,
                             docstring.expr.end() - num_trailing_quotes,

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
@@ -69,7 +69,7 @@ pub(crate) fn no_surrounding_whitespace(checker: &mut Checker, docstring: &Docst
         // characters, avoid applying the fix.
         if !trimmed.ends_with(quote) && !trimmed.starts_with(quote) && !ends_with_backslash(trimmed)
         {
-            diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 trimmed.to_string(),
                 TextRange::at(body.start(), line.text_len()),
             )));

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/one_liner.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/one_liner.rs
@@ -78,7 +78,7 @@ pub(crate) fn one_liner(checker: &mut Checker, docstring: &Docstring) {
                     && !trimmed.ends_with(trailing.chars().last().unwrap())
                     && !trimmed.starts_with(leading.chars().last().unwrap())
                 {
-                    diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                         format!("{leading}{trimmed}{trailing}"),
                         docstring.range(),
                     )));

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
@@ -1392,7 +1392,7 @@ fn blanks_and_section_underline(
                         let range =
                             TextRange::new(context.following_range().start(), blank_lines_end);
                         // Delete any blank lines between the header and the underline.
-                        diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(range)));
+                        diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(range)));
                     }
                     checker.diagnostics.push(diagnostic);
                 }
@@ -1420,7 +1420,7 @@ fn blanks_and_section_underline(
                             "-".repeat(context.section_name().len()),
                             checker.stylist().line_ending().as_str()
                         );
-                        diagnostic.set_fix(Fix::always_applies(Edit::replacement(
+                        diagnostic.set_fix(Fix::safe_edit(Edit::replacement(
                             content,
                             blank_lines_end,
                             non_blank_line.full_end(),
@@ -1446,7 +1446,7 @@ fn blanks_and_section_underline(
                             leading_space.text_len() + TextSize::from(1),
                         );
                         let contents = clean_space(docstring.indentation);
-                        diagnostic.set_fix(Fix::always_applies(if contents.is_empty() {
+                        diagnostic.set_fix(Fix::safe_edit(if contents.is_empty() {
                             Edit::range_deletion(range)
                         } else {
                             Edit::range_replacement(contents, range)
@@ -1486,7 +1486,7 @@ fn blanks_and_section_underline(
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             // Delete any blank lines between the header and content.
-                            diagnostic.set_fix(Fix::always_applies(Edit::deletion(
+                            diagnostic.set_fix(Fix::safe_edit(Edit::deletion(
                                 line_after_dashes.start(),
                                 blank_lines_after_dashes_end,
                             )));
@@ -1529,14 +1529,14 @@ fn blanks_and_section_underline(
                     {
                         // If an existing underline is an equal sign line of the appropriate length,
                         // replace it with a dashed line.
-                        diagnostic.set_fix(Fix::always_applies(Edit::replacement(
+                        diagnostic.set_fix(Fix::safe_edit(Edit::replacement(
                             content,
                             context.summary_range().end(),
                             non_blank_line.end(),
                         )));
                     } else {
                         // Otherwise, insert a dashed line after the section header.
-                        diagnostic.set_fix(Fix::always_applies(Edit::insertion(
+                        diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
                             content,
                             context.summary_range().end(),
                         )));
@@ -1556,7 +1556,7 @@ fn blanks_and_section_underline(
                         let range =
                             TextRange::new(context.following_range().start(), blank_lines_end);
                         // Delete any blank lines between the header and content.
-                        diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(range)));
+                        diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(range)));
                     }
                     checker.diagnostics.push(diagnostic);
                 }
@@ -1581,7 +1581,7 @@ fn blanks_and_section_underline(
                     "-".repeat(context.section_name().len()),
                 );
 
-                diagnostic.set_fix(Fix::always_applies(Edit::insertion(
+                diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
                     content,
                     context.summary_range().end(),
                 )));
@@ -1618,7 +1618,7 @@ fn common_section(
                 // Replace the section title with the capitalized variant. This requires
                 // locating the start and end of the section name.
                 let section_range = context.section_name_range();
-                diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     capitalized_section_name.to_string(),
                     section_range,
                 )));
@@ -1641,7 +1641,7 @@ fn common_section(
                 let content = clean_space(docstring.indentation);
                 let fix_range = TextRange::at(context.start(), leading_space.text_len());
 
-                diagnostic.set_fix(Fix::always_applies(if content.is_empty() {
+                diagnostic.set_fix(Fix::safe_edit(if content.is_empty() {
                     Edit::range_deletion(fix_range)
                 } else {
                     Edit::range_replacement(content, fix_range)
@@ -1664,7 +1664,7 @@ fn common_section(
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline at the beginning of the next section.
-                    diagnostic.set_fix(Fix::always_applies(Edit::insertion(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
                         line_end.to_string(),
                         next.start(),
                     )));
@@ -1681,7 +1681,7 @@ fn common_section(
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline after the section.
-                    diagnostic.set_fix(Fix::always_applies(Edit::insertion(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
                         format!("{}{}", line_end, docstring.indentation),
                         context.end(),
                     )));
@@ -1704,7 +1704,7 @@ fn common_section(
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Add a blank line before the section.
-                diagnostic.set_fix(Fix::always_applies(Edit::insertion(
+                diagnostic.set_fix(Fix::safe_edit(Edit::insertion(
                     line_end.to_string(),
                     context.start(),
                 )));
@@ -1900,7 +1900,7 @@ fn numpy_section(
             );
             if checker.patch(diagnostic.kind.rule()) {
                 let section_range = context.section_name_range();
-                diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(TextRange::at(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(TextRange::at(
                     section_range.end(),
                     suffix.text_len(),
                 ))));
@@ -1937,7 +1937,7 @@ fn google_section(
             if checker.patch(diagnostic.kind.rule()) {
                 // Replace the suffix.
                 let section_name_range = context.section_name_range();
-                diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     ":".to_string(),
                     TextRange::at(section_name_range.end(), suffix.text_len()),
                 )));

--- a/crates/ruff_linter/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -151,7 +151,7 @@ fn convert_f_string_to_regular_string(
         content.insert(0, ' ');
     }
 
-    Fix::always_applies(Edit::replacement(
+    Fix::safe_edit(Edit::replacement(
         content,
         prefix_range.start(),
         tok_range.end(),

--- a/crates/ruff_linter/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -101,7 +101,7 @@ pub(crate) fn invalid_literal_comparison(
                             None
                         }
                     } {
-                        diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                             content,
                             located_op.range + expr.start(),
                         )));

--- a/crates/ruff_linter/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -78,7 +78,7 @@ pub(crate) fn raise_not_implemented(checker: &mut Checker, expr: &Expr) {
     let mut diagnostic = Diagnostic::new(RaiseNotImplemented, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
         if checker.semantic().is_builtin("NotImplementedError") {
-            diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 "NotImplementedError".to_string(),
                 expr.range(),
             )));

--- a/crates/ruff_linter/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/repeated_keys.rs
@@ -159,7 +159,7 @@ pub(crate) fn repeated_keys(checker: &mut Checker, dict: &ast::ExprDict) {
                     );
                     if checker.patch(diagnostic.kind.rule()) {
                         if !seen_values.insert(comparable_value) {
-                            diagnostic.set_fix(Fix::sometimes_applies(Edit::deletion(
+                            diagnostic.set_fix(Fix::unsafe_edit(Edit::deletion(
                                 parenthesized_range(
                                     (&dict.values[i - 1]).into(),
                                     dict.into(),
@@ -193,7 +193,7 @@ pub(crate) fn repeated_keys(checker: &mut Checker, dict: &ast::ExprDict) {
                     if checker.patch(diagnostic.kind.rule()) {
                         let comparable_value: ComparableExpr = (&dict.values[i]).into();
                         if !seen_values.insert(comparable_value) {
-                            diagnostic.set_fix(Fix::sometimes_applies(Edit::deletion(
+                            diagnostic.set_fix(Fix::unsafe_edit(Edit::deletion(
                                 parenthesized_range(
                                     (&dict.values[i - 1]).into(),
                                     dict.into(),

--- a/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
@@ -618,7 +618,7 @@ pub(crate) fn percent_format_extra_named_arguments(
                 checker.locator(),
                 checker.stylist(),
             )?;
-            Ok(Fix::always_applies(edit))
+            Ok(Fix::safe_edit(edit))
         });
     }
     checker.diagnostics.push(diagnostic);
@@ -785,7 +785,7 @@ pub(crate) fn string_dot_format_extra_named_arguments(
                 checker.locator(),
                 checker.stylist(),
             )?;
-            Ok(Fix::always_applies(edit))
+            Ok(Fix::safe_edit(edit))
         });
     }
     checker.diagnostics.push(diagnostic);
@@ -854,7 +854,7 @@ pub(crate) fn string_dot_format_extra_positional_arguments(
                     checker.locator(),
                     checker.stylist(),
                 )?;
-                Ok(Fix::always_applies(edit))
+                Ok(Fix::safe_edit(edit))
             });
         }
     }

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -251,7 +251,7 @@ fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) ->
         checker.stylist(),
         checker.indexer(),
     )?;
-    Ok(Fix::always_applies(edit).isolate(Checker::isolation(
+    Ok(Fix::safe_edit(edit).isolate(Checker::isolation(
         checker.semantic().parent_statement_id(node_id),
     )))
 }

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_variable.rs
@@ -237,11 +237,11 @@ fn remove_unused_variable(binding: &Binding, checker: &Checker) -> Option<Fix> {
                     )?
                     .start();
                     let edit = Edit::deletion(start, end);
-                    Some(Fix::sometimes_applies(edit))
+                    Some(Fix::unsafe_edit(edit))
                 } else {
                     // If (e.g.) assigning to a constant (`x = 1`), delete the entire statement.
                     let edit = delete_stmt(statement, parent, checker.locator(), checker.indexer());
-                    Some(Fix::sometimes_applies(edit).isolate(isolation))
+                    Some(Fix::unsafe_edit(edit).isolate(isolation))
                 };
             }
         }
@@ -265,11 +265,11 @@ fn remove_unused_variable(binding: &Binding, checker: &Checker) -> Option<Fix> {
                     })?
                     .start();
                 let edit = Edit::deletion(start, end);
-                Some(Fix::sometimes_applies(edit))
+                Some(Fix::unsafe_edit(edit))
             } else {
                 // If (e.g.) assigning to a constant (`x = 1`), delete the entire statement.
                 let edit = delete_stmt(statement, parent, checker.locator(), checker.indexer());
-                Some(Fix::sometimes_applies(edit).isolate(isolation))
+                Some(Fix::unsafe_edit(edit).isolate(isolation))
             };
         }
     }
@@ -300,7 +300,7 @@ fn remove_unused_variable(binding: &Binding, checker: &Checker) -> Option<Fix> {
                     .start();
 
                     let edit = Edit::deletion(start, end);
-                    return Some(Fix::sometimes_applies(edit));
+                    return Some(Fix::unsafe_edit(edit));
                 }
             }
         }

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_string_characters.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_string_characters.rs
@@ -201,7 +201,7 @@ pub(crate) fn invalid_string_characters(
         let location = range.start() + TextSize::try_from(column).unwrap();
         let range = TextRange::at(location, c.text_len());
 
-        diagnostics.push(Diagnostic::new(rule, range).with_fix(Fix::always_applies(
+        diagnostics.push(Diagnostic::new(rule, range).with_fix(Fix::safe_edit(
             Edit::range_replacement(replacement.to_string(), range),
         )));
     }

--- a/crates/ruff_linter/src/rules/pylint/rules/manual_import_from.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/manual_import_from.rs
@@ -83,7 +83,7 @@ pub(crate) fn manual_from_import(
                 level: Some(0),
                 range: TextRange::default(),
             };
-            diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 checker.generator().stmt(&node.into()),
                 stmt.range(),
             )));

--- a/crates/ruff_linter/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nested_min_max.rs
@@ -171,7 +171,7 @@ pub(crate) fn nested_min_max(
                     },
                     range: TextRange::default(),
                 });
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                     checker.generator().expr(&flattened_expr),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_isinstance_calls.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_isinstance_calls.rs
@@ -134,7 +134,7 @@ pub(crate) fn repeated_isinstance_calls(
                 expr.range(),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     pad(call, expr.range(), checker.locator()),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/sys_exit_alias.rs
@@ -85,7 +85,7 @@ pub(crate) fn sys_exit_alias(checker: &mut Checker, func: &Expr) {
                 checker.semantic(),
             )?;
             let reference_edit = Edit::range_replacement(binding, func.range());
-            Ok(Fix::sometimes_applies_edits(import_edit, [reference_edit]))
+            Ok(Fix::unsafe_edits(import_edit, [reference_edit]))
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
@@ -50,7 +50,7 @@ pub(crate) fn useless_import_alias(checker: &mut Checker, alias: &Alias) {
 
     let mut diagnostic = Diagnostic::new(UselessImportAlias, alias.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             asname.to_string(),
             alias.range(),
         )));

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_return.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_return.rs
@@ -106,7 +106,7 @@ pub(crate) fn useless_return(
     if checker.patch(diagnostic.kind.rule()) {
         let edit =
             fix::edits::delete_stmt(last_stmt, Some(stmt), checker.locator(), checker.indexer());
-        diagnostic.set_fix(Fix::always_applies(edit).isolate(Checker::isolation(
+        diagnostic.set_fix(Fix::safe_edit(edit).isolate(Checker::isolation(
             checker.semantic().current_statement_id(),
         )));
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -241,7 +241,7 @@ fn convert_to_class(
     base_class: &Expr,
     generator: Generator,
 ) -> Fix {
-    Fix::sometimes_applies(Edit::range_replacement(
+    Fix::unsafe_edit(Edit::range_replacement(
         generator.stmt(&create_class_def_stmt(typename, body, base_class)),
         stmt.range(),
     ))

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -275,7 +275,7 @@ fn convert_to_class(
     base_class: &Expr,
     generator: Generator,
 ) -> Fix {
-    Fix::sometimes_applies(Edit::range_replacement(
+    Fix::unsafe_edit(Edit::range_replacement(
         generator.stmt(&create_class_def_stmt(
             class_name,
             body,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -66,7 +66,7 @@ pub(crate) fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
                     checker.semantic(),
                 )?;
                 let reference_edit = Edit::range_replacement(binding, expr.range());
-                Ok(Fix::sometimes_applies_edits(import_edit, [reference_edit]))
+                Ok(Fix::unsafe_edits(import_edit, [reference_edit]))
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
@@ -46,7 +46,7 @@ where
     let mut diagnostic = Diagnostic::new(DeprecatedCElementTree, node.range());
     if checker.patch(diagnostic.kind.rule()) {
         let contents = checker.locator().slice(node);
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             contents.replacen("cElementTree", "ElementTree", 1),
             node.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -632,7 +632,7 @@ pub(crate) fn deprecated_import(
         );
         if checker.patch(Rule::DeprecatedImport) {
             if let Some(content) = fix {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                     content,
                     stmt.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -262,7 +262,7 @@ pub(crate) fn deprecated_mock_attribute(checker: &mut Checker, expr: &Expr) {
                 value.range(),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                     "mock".to_string(),
                     value.range(),
                 )));
@@ -308,7 +308,7 @@ pub(crate) fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
                             name.range(),
                         );
                         if let Some(content) = content.as_ref() {
-                            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                                 content.clone(),
                                 stmt.range(),
                             )));
@@ -339,7 +339,7 @@ pub(crate) fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
                         diagnostic.try_set_fix(|| {
                             format_import_from(stmt, indent, checker.locator(), checker.stylist())
                                 .map(|content| Edit::range_replacement(content, stmt.range()))
-                                .map(Fix::sometimes_applies)
+                                .map(Fix::unsafe_edit)
                         });
                     }
                 }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -100,7 +100,7 @@ pub(crate) fn deprecated_unittest_alias(checker: &mut Checker, expr: &Expr) {
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             format!("self.{target}"),
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -157,7 +157,7 @@ pub(crate) fn extraneous_parentheses(
                 if settings.rules.should_fix(Rule::ExtraneousParentheses) {
                     let contents =
                         locator.slice(TextRange::new(start_range.start(), end_range.end()));
-                    diagnostic.set_fix(Fix::always_applies(Edit::replacement(
+                    diagnostic.set_fix(Fix::safe_edit(Edit::replacement(
                         contents[1..contents.len() - 1].to_string(),
                         start_range.start(),
                         end_range.end(),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -419,7 +419,7 @@ pub(crate) fn f_strings(
             .comment_ranges()
             .intersects(call.arguments.range())
     {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             contents,
             call.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/format_literals.rs
@@ -116,7 +116,7 @@ pub(crate) fn format_literals(
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.try_set_fix(|| {
             generate_call(call, arguments, checker.locator(), checker.stylist()).map(|suggestion| {
-                Fix::sometimes_applies(Edit::range_replacement(suggestion, call.range()))
+                Fix::unsafe_edit(Edit::range_replacement(suggestion, call.range()))
             })
         });
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -100,7 +100,7 @@ pub(crate) fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list:
                         )?;
                         let reference_edit =
                             Edit::range_replacement(binding, decorator.expression.range());
-                        Ok(Fix::always_applies_edits(import_edit, [reference_edit]))
+                        Ok(Fix::safe_edits(import_edit, [reference_edit]))
                     });
                 }
                 checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -78,7 +78,7 @@ pub(crate) fn lru_cache_without_parameters(checker: &mut Checker, decorator_list
                 TextRange::new(func.end(), decorator.end()),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(arguments.range())));
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(arguments.range())));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
@@ -185,7 +185,7 @@ pub(crate) fn native_literals(
             if checker.patch(diagnostic.kind.rule()) {
                 let constant = Constant::from(literal_type);
                 let content = checker.generator().constant(&constant);
-                diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     content,
                     call.range(),
                 )));
@@ -223,7 +223,7 @@ pub(crate) fn native_literals(
 
             let mut diagnostic = Diagnostic::new(NativeLiterals { literal_type }, call.range());
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     content,
                     call.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/open_alias.rs
@@ -56,7 +56,7 @@ pub(crate) fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
         let mut diagnostic = Diagnostic::new(OpenAlias, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             if checker.semantic().is_builtin("open") {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                     "open".to_string(),
                     func.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -83,7 +83,7 @@ fn atom_diagnostic(checker: &mut Checker, target: &Expr) {
     );
     if checker.patch(diagnostic.kind.rule()) {
         if checker.semantic().is_builtin("OSError") {
-            diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 "OSError".to_string(),
                 target.range(),
             )));
@@ -135,7 +135,7 @@ fn tuple_diagnostic(checker: &mut Checker, tuple: &ast::ExprTuple, aliases: &[&E
                 format!("({})", checker.generator().expr(&node.into()))
             };
 
-            diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 pad(content, tuple.range(), checker.locator()),
                 tuple.range(),
             )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -289,7 +289,7 @@ fn fix_always_false_branch(
                 let stmt = checker.semantic().current_statement();
                 let parent = checker.semantic().current_statement_parent();
                 let edit = delete_stmt(stmt, parent, checker.locator(), checker.indexer());
-                Some(Fix::sometimes_applies(edit))
+                Some(Fix::unsafe_edit(edit))
             }
             // If we have an `if` and an `elif`, turn the `elif` into an `if`
             Some(ElifElseClause {
@@ -304,7 +304,7 @@ fn fix_always_false_branch(
                         == "elif"
                 );
                 let end_location = range.start() + ("elif".text_len() - "if".text_len());
-                Some(Fix::sometimes_applies(Edit::deletion(
+                Some(Fix::unsafe_edit(Edit::deletion(
                     stmt_if.start(),
                     end_location,
                 )))
@@ -317,7 +317,7 @@ fn fix_always_false_branch(
                 let end = body.last()?;
                 if indentation(checker.locator(), start).is_none() {
                     // Inline `else` block (e.g., `else: x = 1`).
-                    Some(Fix::sometimes_applies(Edit::range_replacement(
+                    Some(Fix::unsafe_edit(Edit::range_replacement(
                         checker
                             .locator()
                             .slice(TextRange::new(start.start(), end.end()))
@@ -339,7 +339,7 @@ fn fix_always_false_branch(
                             .ok()
                         })
                         .map(|contents| {
-                            Fix::sometimes_applies(Edit::replacement(
+                            Fix::unsafe_edit(Edit::replacement(
                                 contents,
                                 checker.locator().line_start(stmt_if.start()),
                                 stmt_if.end(),
@@ -366,7 +366,7 @@ fn fix_always_false_branch(
                 .iter()
                 .map(Ranged::start)
                 .find(|start| *start > branch.start());
-            Some(Fix::sometimes_applies(Edit::deletion(
+            Some(Fix::unsafe_edit(Edit::deletion(
                 branch.start(),
                 next_start.unwrap_or(branch.end()),
             )))
@@ -394,7 +394,7 @@ fn fix_always_true_branch(
             let end = branch.body.last()?;
             if indentation(checker.locator(), start).is_none() {
                 // Inline `if` block (e.g., `if ...: x = 1`).
-                Some(Fix::sometimes_applies(Edit::range_replacement(
+                Some(Fix::unsafe_edit(Edit::range_replacement(
                     checker
                         .locator()
                         .slice(TextRange::new(start.start(), end.end()))
@@ -413,7 +413,7 @@ fn fix_always_true_branch(
                         .ok()
                     })
                     .map(|contents| {
-                        Fix::sometimes_applies(Edit::replacement(
+                        Fix::unsafe_edit(Edit::replacement(
                             contents,
                             checker.locator().line_start(stmt_if.start()),
                             stmt_if.end(),
@@ -428,7 +428,7 @@ fn fix_always_true_branch(
             let text = checker
                 .locator()
                 .slice(TextRange::new(branch.test.end(), end.end()));
-            Some(Fix::sometimes_applies(Edit::range_replacement(
+            Some(Fix::unsafe_edit(Edit::range_replacement(
                 format!("else{text}"),
                 TextRange::new(branch.start(), stmt_if.end()),
             )))

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -498,7 +498,7 @@ pub(crate) fn printf_string_formatting(checker: &mut Checker, expr: &Expr, right
     if checker.patch(diagnostic.kind.rule())
         && !checker.indexer().comment_ranges().intersects(right.range())
     {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             contents,
             expr.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/quoted_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/quoted_annotation.rs
@@ -54,7 +54,7 @@ impl AlwaysFixableViolation for QuotedAnnotation {
 pub(crate) fn quoted_annotation(checker: &mut Checker, annotation: &str, range: TextRange) {
     let mut diagnostic = Diagnostic::new(QuotedAnnotation, range);
     if checker.patch(Rule::QuotedAnnotation) {
-        diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             annotation.to_string(),
             range,
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -185,14 +185,13 @@ fn create_check<T: Ranged>(
     );
     if patch {
         if let Some(content) = replacement_value {
-            diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 content.to_string(),
                 mode_param.range(),
             )));
         } else {
             diagnostic.try_set_fix(|| {
-                create_remove_param_fix(locator, expr, mode_param, source_type)
-                    .map(Fix::always_applies)
+                create_remove_param_fix(locator, expr, mode_param, source_type).map(Fix::safe_edit)
             });
         }
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -105,7 +105,7 @@ fn generate_fix(
         (stderr, stdout)
     };
     // Replace one argument with `capture_output=True`, and remove the other.
-    Ok(Fix::sometimes_applies_edits(
+    Ok(Fix::unsafe_edits(
         Edit::range_replacement("capture_output=True".to_string(), first.range()),
         [remove_argument(
             second,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -74,10 +74,10 @@ pub(crate) fn replace_universal_newlines(checker: &mut Checker, call: &ast::Expr
                         Parentheses::Preserve,
                         checker.locator().contents(),
                     )
-                    .map(Fix::sometimes_applies)
+                    .map(Fix::unsafe_edit)
                 });
             } else {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                     "text".to_string(),
                     arg.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -129,7 +129,7 @@ pub(crate) fn super_call_with_parameters(checker: &mut Checker, call: &ast::Expr
 
     let mut diagnostic = Diagnostic::new(SuperCallWithParameters, call.arguments.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::deletion(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::deletion(
             call.arguments.start() + TextSize::new(1),
             call.arguments.end() - TextSize::new(1),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/type_of_primitive.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/type_of_primitive.rs
@@ -76,7 +76,7 @@ pub(crate) fn type_of_primitive(checker: &mut Checker, expr: &Expr, func: &Expr,
     if checker.patch(diagnostic.kind.rule()) {
         let builtin = primitive.builtin();
         if checker.semantic().is_builtin(&builtin) {
-            diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 pad(primitive.builtin(), expr.range(), checker.locator()),
                 expr.range(),
             )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -55,7 +55,7 @@ pub(crate) fn typing_text_str_alias(checker: &mut Checker, expr: &Expr) {
         let mut diagnostic = Diagnostic::new(TypingTextStrAlias, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             if checker.semantic().is_builtin("str") {
-                diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                     "str".to_string(),
                     expr.range(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
@@ -44,7 +44,7 @@ pub(crate) fn unicode_kind_prefix(checker: &mut Checker, expr: &Expr, is_unicode
     if is_unicode {
         let mut diagnostic = Diagnostic::new(UnicodeKindPrefix, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Fix::always_applies(Edit::range_deletion(TextRange::at(
+            diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(TextRange::at(
                 expr.start(),
                 TextSize::from(1),
             ))));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -136,7 +136,7 @@ pub(crate) fn unnecessary_builtin_import(
                 checker.stylist(),
                 checker.indexer(),
             )?;
-            Ok(Fix::sometimes_applies(edit).isolate(Checker::isolation(
+            Ok(Fix::unsafe_edit(edit).isolate(Checker::isolation(
                 checker.semantic().current_statement_parent_id(),
             )))
         });

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_class_parentheses.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_class_parentheses.rs
@@ -51,7 +51,7 @@ pub(crate) fn unnecessary_class_parentheses(checker: &mut Checker, class_def: &a
 
     let mut diagnostic = Diagnostic::new(UnnecessaryClassParentheses, arguments.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::always_applies(Edit::deletion(
+        diagnostic.set_fix(Fix::safe_edit(Edit::deletion(
             arguments.start(),
             arguments.end(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
@@ -92,7 +92,7 @@ pub(crate) fn unnecessary_coding_comment(
 
             let mut diagnostic = Diagnostic::new(UTF8EncodingDeclaration, *comment_range);
             if settings.rules.should_fix(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::always_applies(Edit::deletion(
+                diagnostic.set_fix(Fix::safe_edit(Edit::deletion(
                     line_range.start(),
                     line_range.end(),
                 )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -151,7 +151,7 @@ fn replace_with_bytes_literal(
         prev = range.end();
     }
 
-    Fix::always_applies(Edit::range_replacement(
+    Fix::safe_edit(Edit::range_replacement(
         pad(replacement, call.range(), locator),
         call.range(),
     ))
@@ -202,7 +202,7 @@ pub(crate) fn unnecessary_encode_utf8(checker: &mut Checker, call: &ast::ExprCal
                                 Parentheses::Preserve,
                                 checker.locator().contents(),
                             )
-                            .map(Fix::always_applies)
+                            .map(Fix::safe_edit)
                         });
                     }
                     checker.diagnostics.push(diagnostic);
@@ -222,7 +222,7 @@ pub(crate) fn unnecessary_encode_utf8(checker: &mut Checker, call: &ast::ExprCal
                                 Parentheses::Preserve,
                                 checker.locator().contents(),
                             )
-                            .map(Fix::always_applies)
+                            .map(Fix::safe_edit)
                         });
                     }
                     checker.diagnostics.push(diagnostic);
@@ -249,7 +249,7 @@ pub(crate) fn unnecessary_encode_utf8(checker: &mut Checker, call: &ast::ExprCal
                                 Parentheses::Preserve,
                                 checker.locator().contents(),
                             )
-                            .map(Fix::always_applies)
+                            .map(Fix::safe_edit)
                         });
                     }
                     checker.diagnostics.push(diagnostic);
@@ -269,7 +269,7 @@ pub(crate) fn unnecessary_encode_utf8(checker: &mut Checker, call: &ast::ExprCal
                                 Parentheses::Preserve,
                                 checker.locator().contents(),
                             )
-                            .map(Fix::always_applies)
+                            .map(Fix::safe_edit)
                         });
                     }
                     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -125,7 +125,7 @@ pub(crate) fn unnecessary_future_import(checker: &mut Checker, stmt: &Stmt, name
                 checker.stylist(),
                 checker.indexer(),
             )?;
-            Ok(Fix::sometimes_applies(edit).isolate(Checker::isolation(
+            Ok(Fix::unsafe_edit(edit).isolate(Checker::isolation(
                 checker.semantic().current_statement_parent_id(),
             )))
         });

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
@@ -74,7 +74,7 @@ pub(crate) fn unpacked_list_comprehension(checker: &mut Checker, targets: &[Expr
         content.push('(');
         content.push_str(&existing[1..existing.len() - 1]);
         content.push(')');
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             content,
             value.range(),
         )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -92,7 +92,7 @@ pub(crate) fn use_pep585_annotation(
                 ModuleMember::BuiltIn(name) => {
                     // Built-in type, like `list`.
                     if checker.semantic().is_builtin(name) {
-                        diagnostic.set_fix(Fix::always_applies(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                             (*name).to_string(),
                             expr.range(),
                         )));
@@ -107,7 +107,7 @@ pub(crate) fn use_pep585_annotation(
                             checker.semantic(),
                         )?;
                         let reference_edit = Edit::range_replacement(binding, expr.range());
-                        Ok(Fix::sometimes_applies_edits(import_edit, [reference_edit]))
+                        Ok(Fix::unsafe_edits(import_edit, [reference_edit]))
                     });
                 }
             }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -79,7 +79,7 @@ pub(crate) fn use_pep604_annotation(
                         // Invalid type annotation.
                     }
                     _ => {
-                        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                             pad(
                                 checker.generator().expr(&optional(slice)),
                                 expr.range(),
@@ -100,7 +100,7 @@ pub(crate) fn use_pep604_annotation(
                         // Invalid type annotation.
                     }
                     Expr::Tuple(ast::ExprTuple { elts, .. }) => {
-                        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                             pad(
                                 checker.generator().expr(&union(elts)),
                                 expr.range(),
@@ -111,7 +111,7 @@ pub(crate) fn use_pep604_annotation(
                     }
                     _ => {
                         // Single argument.
-                        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                             pad(
                                 checker.locator().slice(slice).to_string(),
                                 expr.range(),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
@@ -117,7 +117,7 @@ pub(crate) fn use_pep604_isinstance(
 
                 let mut diagnostic = Diagnostic::new(NonPEP604Isinstance { kind }, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                         checker.generator().expr(&union(elts)),
                         types.range(),
                     )));

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
@@ -145,9 +145,9 @@ pub(crate) fn non_pep695_type_alias(checker: &mut Checker, stmt: &StmtAnnAssign)
         // The fix is only safe in a type stub because new-style aliases have different runtime  behavior
         // See https://github.com/astral-sh/ruff/issues/6434
         let fix = if checker.source_type.is_stub() {
-            Fix::always_applies(edit)
+            Fix::safe_edit(edit)
         } else {
-            Fix::sometimes_applies(edit)
+            Fix::unsafe_edit(edit)
         };
 
         diagnostic.set_fix(fix);

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -67,7 +67,7 @@ pub(crate) fn useless_metaclass_type(
         let stmt = checker.semantic().current_statement();
         let parent = checker.semantic().current_statement_parent();
         let edit = fix::edits::delete_stmt(stmt, parent, checker.locator(), checker.indexer());
-        diagnostic.set_fix(Fix::always_applies(edit).isolate(Checker::isolation(
+        diagnostic.set_fix(Fix::safe_edit(edit).isolate(Checker::isolation(
             checker.semantic().current_statement_parent_id(),
         )));
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -76,7 +76,7 @@ pub(crate) fn useless_object_inheritance(checker: &mut Checker, class_def: &ast:
                     Parentheses::Remove,
                     checker.locator().contents(),
                 )
-                .map(Fix::always_applies)
+                .map(Fix::safe_edit)
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/yield_in_for_loop.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/yield_in_for_loop.rs
@@ -114,7 +114,7 @@ pub(crate) fn yield_in_for_loop(checker: &mut Checker, stmt_for: &ast::StmtFor) 
             .unwrap_or(iter.range()),
         );
         let contents = format!("yield from {contents}");
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             contents,
             stmt_for.range(),
         )));

--- a/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
@@ -113,7 +113,7 @@ pub(crate) fn check_and_remove_from_set(checker: &mut Checker, if_stmt: &ast::St
         if_stmt.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
             make_suggestion(check_set, check_element, checker.generator()),
             if_stmt.start(),
             if_stmt.end(),

--- a/crates/ruff_linter/src/rules/refurb/rules/delete_full_slice.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/delete_full_slice.rs
@@ -71,7 +71,7 @@ pub(crate) fn delete_full_slice(checker: &mut Checker, delete: &ast::StmtDelete)
         // Fix is only supported for single-target deletions.
         if checker.patch(diagnostic.kind.rule()) && delete.targets.len() == 1 {
             let replacement = generate_method_call(name, "clear", checker.generator());
-            diagnostic.set_fix(Fix::sometimes_applies(Edit::replacement(
+            diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
                 replacement,
                 delete.start(),
                 delete.end(),

--- a/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
@@ -95,7 +95,7 @@ pub(crate) fn no_implicit_cwd(checker: &mut Checker, call: &ExprCall) {
                 call.start(),
                 checker.semantic(),
             )?;
-            Ok(Fix::sometimes_applies_edits(
+            Ok(Fix::unsafe_edits(
                 Edit::range_replacement(format!("{binding}.cwd()"), call.range()),
                 [import_edit],
             ))

--- a/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
@@ -91,7 +91,7 @@ pub(crate) fn print_empty_string(checker: &mut Checker, call: &ast::ExprCall) {
             let mut diagnostic = Diagnostic::new(PrintEmptyString { reason }, call.range());
 
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
                     generate_suggestion(call, Separator::Remove, checker.generator()),
                     call.start(),
                     call.end(),
@@ -113,7 +113,7 @@ pub(crate) fn print_empty_string(checker: &mut Checker, call: &ast::ExprCall) {
                 );
 
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Fix::sometimes_applies(Edit::replacement(
+                    diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
                         generate_suggestion(call, Separator::Remove, checker.generator()),
                         call.start(),
                         call.end(),
@@ -178,7 +178,7 @@ pub(crate) fn print_empty_string(checker: &mut Checker, call: &ast::ExprCall) {
             );
 
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
                     generate_suggestion(call, separator, checker.generator()),
                     call.start(),
                     call.end(),

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
@@ -147,7 +147,7 @@ pub(crate) fn reimplemented_starmap(checker: &mut Checker, target: &StarmapCandi
                 target.try_make_suggestion(starmap_name, &comprehension.iter, func, checker)?,
                 target.range(),
             );
-            Ok(Fix::sometimes_applies_edits(import_edit, [main_edit]))
+            Ok(Fix::unsafe_edits(import_edit, [main_edit]))
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/refurb/rules/repeated_append.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/repeated_append.rs
@@ -108,7 +108,7 @@ pub(crate) fn repeated_append(checker: &mut Checker, stmt: &Stmt) {
             // We only suggest a fix when all appends in a group are clumped together. If they're
             // non-consecutive, fixing them is much more difficult.
             if checker.patch(diagnostic.kind.rule()) && group.is_consecutive {
-                diagnostic.set_fix(Fix::sometimes_applies(Edit::replacement(
+                diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
                     replacement,
                     group.start(),
                     group.end(),

--- a/crates/ruff_linter/src/rules/refurb/rules/slice_copy.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/slice_copy.rs
@@ -63,7 +63,7 @@ pub(crate) fn slice_copy(checker: &mut Checker, subscript: &ast::ExprSubscript) 
     let mut diagnostic = Diagnostic::new(SliceCopy, subscript.range());
     if checker.patch(diagnostic.kind.rule()) {
         let replacement = generate_method_call(name, "copy", checker.generator());
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
             replacement,
             subscript.start(),
             subscript.end(),

--- a/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
@@ -149,7 +149,7 @@ pub(crate) fn unnecessary_enumerate(checker: &mut Checker, stmt_for: &ast::StmtF
                     ),
                     stmt_for.target.range(),
                 );
-                diagnostic.set_fix(Fix::sometimes_applies_edits(replace_iter, [replace_target]));
+                diagnostic.set_fix(Fix::unsafe_edits(replace_iter, [replace_target]));
             }
 
             checker.diagnostics.push(diagnostic);
@@ -212,8 +212,7 @@ pub(crate) fn unnecessary_enumerate(checker: &mut Checker, stmt_for: &ast::StmtF
                         stmt_for.target.range(),
                     );
 
-                    diagnostic
-                        .set_fix(Fix::sometimes_applies_edits(replace_iter, [replace_target]));
+                    diagnostic.set_fix(Fix::unsafe_edits(replace_iter, [replace_target]));
                 }
             }
             checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -202,7 +202,7 @@ pub(crate) fn collection_literal_concatenation(checker: &mut Checker, expr: &Exp
         if !checker.indexer().has_comments(expr, checker.locator()) {
             // This suggestion could be unsafe if the non-literal expression in the
             // expression has overridden the `__add__` (or `__radd__`) magic methods.
-            diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                 contents,
                 expr.range(),
             )));

--- a/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -160,7 +160,7 @@ fn convert_call_to_conversion_flag(
         formatted_string_expression.expression = call.args[0].value.clone();
         Ok(expression)
     })
-    .map(|output| Fix::always_applies(Edit::range_replacement(output, expr.range())))
+    .map(|output| Fix::safe_edit(Edit::range_replacement(output, expr.range())))
 }
 
 /// Return the [`FormattedStringContent`] at the given index in an f-string or implicit

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -134,7 +134,7 @@ fn generate_fix(checker: &Checker, conversion_type: ConversionType, expr: &Expr)
                 range: TextRange::default(),
             });
             let content = checker.generator().expr(&new_expr);
-            Ok(Fix::sometimes_applies(Edit::range_replacement(
+            Ok(Fix::unsafe_edit(Edit::range_replacement(
                 content,
                 expr.range(),
             )))
@@ -156,7 +156,7 @@ fn generate_fix(checker: &Checker, conversion_type: ConversionType, expr: &Expr)
                 ctx: ast::ExprContext::Load,
             });
             let content = checker.generator().expr(&new_expr);
-            Ok(Fix::sometimes_applies_edits(
+            Ok(Fix::unsafe_edits(
                 Edit::range_replacement(content, expr.range()),
                 [import_edit],
             ))

--- a/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
@@ -112,7 +112,7 @@ fn convert_to_reduce(iterable: &Expr, call: &ast::ExprCall, checker: &Checker) -
         .unwrap_or(iterable.range()),
     );
 
-    Ok(Fix::sometimes_applies_edits(
+    Ok(Fix::unsafe_edits(
         Edit::range_replacement(
             format!("{reduce_binding}({iadd_binding}, {iterable}, [])"),
             call.range(),

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
@@ -97,7 +97,7 @@ pub(crate) fn unnecessary_iterable_allocation_for_first_element(
     );
 
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Fix::sometimes_applies(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             format!("next({iterable})"),
             *range,
         )));

--- a/crates/ruff_linter/src/rules/tryceratops/rules/verbose_raise.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/verbose_raise.rs
@@ -97,9 +97,10 @@ pub(crate) fn verbose_raise(checker: &mut Checker, handlers: &[ExceptHandler]) {
                         if id == exception_name.as_str() {
                             let mut diagnostic = Diagnostic::new(VerboseRaise, exc.range());
                             if checker.patch(diagnostic.kind.rule()) {
-                                diagnostic.set_fix(Fix::sometimes_applies(
-                                    Edit::range_replacement("raise".to_string(), raise.range()),
-                                ));
+                                diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
+                                    "raise".to_string(),
+                                    raise.range(),
+                                )));
                             }
                             checker.diagnostics.push(diagnostic);
                         }

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -137,8 +137,8 @@ impl From<bool> for UnsafeFixes {
 impl UnsafeFixes {
     pub fn required_applicability(&self) -> Applicability {
         match self {
-            Self::Enabled => Applicability::Sometimes,
-            Self::Disabled => Applicability::Always,
+            Self::Enabled => Applicability::Unsafe,
+            Self::Disabled => Applicability::Safe,
         }
     }
 }


### PR DESCRIPTION
After working with the previous change in https://github.com/astral-sh/ruff/pull/7821 I found the names a bit unclear and their relationship with the user-facing API muddied. Since the applicability is exposed to the user directly in our JSON output, I think it's important that these names align with our configuration options. I've replaced `Manual` or `Never` with `Display` which captures our intent for these fixes (only for display). Here, we create room for future levels, such as `HasPlaceholders`, which wouldn't fit into the `Always`/`Sometimes`/`Never` levels.

Unlike https://github.com/astral-sh/ruff/pull/7819, this retains the flat enum structure which is easier to work with.