### PR TITLE
Document `reimplemented-starmap` performance effects

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
@@ -17,7 +17,14 @@ use crate::registry::AsRule;
 /// When unpacking values from iterators to pass them directly to
 /// a function, prefer `itertools.starmap`.
 ///
-/// Using `itertools.starmap` is more concise and readable.
+/// Using `itertools.starmap` is more concise and readable. Furthermore, it is
+/// more efficient than generator expressions, and in some versions of Python,
+/// it is more efficient than comprehensions.
+///
+/// ## Known problems
+/// Since Python 3.12, `itertools.starmap` is less efficient than
+/// comprehensions ([#7771]). This is due to [PEP 709], which made
+/// comprehensions faster.
 ///
 /// ## Example
 /// ```python
@@ -53,6 +60,9 @@ use crate::registry::AsRule;
 ///
 /// ## References
 /// - [Python documentation: `itertools.starmap`](https://docs.python.org/3/library/itertools.html#itertools.starmap)
+///
+/// [PEP 709]: https://peps.python.org/pep-0709/
+/// [#7771]: https://github.com/astral-sh/ruff/issues/7771
 #[violation]
 pub struct ReimplementedStarmap;
 


### PR DESCRIPTION
## Summary

Document the performance effects of `itertools.starmap`, including that it is actually slower than comprehensions in Python 3.12.

Closes #7771.

## Test Plan

`python scripts/check_docs_formatted.py`
