### PR TITLE
Use workspace `tracing` in `ruff_formatter` crate

### DIFF
--- a/crates/ruff_formatter/Cargo.toml
+++ b/crates/ruff_formatter/Cargo.toml
@@ -20,7 +20,7 @@ rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 static_assertions = { workspace = true }
-tracing = { version = "0.1.37", default-features = false, features = ["std"] }
+tracing = { workspace = true }
 unicode-width = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
I noticed that `tracing::instrument` wasn't available with only the `"std"` feature enabled when trying to run `cargo doc -p ruff_formatter`.

I could be misunderstanding something, but I couldn't even run the tests for the crate.

```
ruff on  ruff-formatter-tracing [$] is 📦 v0.0.292 via 🦀 v1.72.0 
❯ cargo test -p ruff_formatter          
   Compiling ruff_formatter v0.0.0 (/Users/chrispryer/github/ruff/crates/ruff_formatter)
error[E0433]: failed to resolve: could not find `instrument` in `tracing`
   --> crates/ruff_formatter/src/printer/mod.rs:57:16
    |
57  |     #[tracing::instrument(name = "Printer::print", skip_all)]
    |                ^^^^^^^^^^ could not find `instrument` in `tracing`
    |
note: found an item that was configured out
   --> /Users/chrispryer/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tracing-0.1.37/src/lib.rs:959:29
    |
959 | pub use tracing_attributes::instrument;
    |                             ^^^^^^^^^^
    = note: the item is gated behind the `attributes` feature

For more information about this error, try `rustc --explain E0433`.
error: could not compile `ruff_formatter` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `ruff_formatter` (lib test) due to previous error
```

Maybe the idea is to keep this crate minimal, but I figured I'd at least point this out.