### PR TITLE
Fix diff (old and new were reversed)

### DIFF
--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -1111,8 +1111,8 @@ fn diff_shows_safe_fixes_by_default() {
     ----- stdout -----
     @@ -1,2 +1,2 @@
      x = {'a': 1, 'a': 1}
-    -print('foo')
-    +print(('foo'))
+    -print(('foo'))
+    +print('foo')
 
 
     ----- stderr -----
@@ -1142,10 +1142,10 @@ fn diff_shows_unsafe_fixes_with_opt_in() {
     exit_code: 1
     ----- stdout -----
     @@ -1,2 +1,2 @@
-    -x = {'a': 1}
-    -print('foo')
-    +x = {'a': 1, 'a': 1}
-    +print(('foo'))
+    -x = {'a': 1, 'a': 1}
+    -print(('foo'))
+    +x = {'a': 1}
+    +print('foo')
 
 
     ----- stderr -----

--- a/crates/ruff_linter/src/source_kind.rs
+++ b/crates/ruff_linter/src/source_kind.rs
@@ -91,7 +91,7 @@ impl SourceKind {
     pub fn diff(&self, other: &Self, path: Option<&Path>, writer: &mut dyn Write) -> Result<()> {
         match (self, other) {
             (SourceKind::Python(src), SourceKind::Python(dst)) => {
-                let text_diff = TextDiff::from_lines(dst, src);
+                let text_diff = TextDiff::from_lines(src, dst);
                 let mut unified_diff = text_diff.unified_diff();
 
                 if let Some(path) = path {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Fixes #7853.

The old and new source files were reversed in the call to `TextDiff::from_lines`, so the diff output of the CLI was also reversed.

## Test Plan

<!-- How was it tested? -->

Two snapshots were updated in the process, so any reversal should be caught :)