### PR TITLE
Less scary `ruff format` message

### DIFF
--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -6,6 +6,7 @@ use std::sync::mpsc::channel;
 
 use anyhow::Result;
 use clap::CommandFactory;
+use colored::Colorize;
 use log::warn;
 use notify::{recommended_watcher, RecursiveMode, Watcher};
 
@@ -104,8 +105,6 @@ pub fn run(
     }: Args,
 ) -> Result<ExitStatus> {
     {
-        use colored::Colorize;
-
         let default_panic_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {
             #[allow(clippy::print_stderr)]
@@ -166,9 +165,11 @@ pub fn run(
 }
 
 fn format(args: FormatCommand, log_level: LogLevel) -> Result<ExitStatus> {
-    warn_user_once!(
-        "`ruff format` is a work-in-progress, subject to change at any time, and intended only for \
-        experimentation."
+    eprintln!(
+        "{}{} The formatter is not stable yet. Code style, configuration and CLI are still subject \
+        to change.",
+        "note".yellow().bold(),
+        ":".bold()
     );
 
     let (cli, overrides) = args.partition();

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -165,12 +165,7 @@ pub fn run(
 }
 
 fn format(args: FormatCommand, log_level: LogLevel) -> Result<ExitStatus> {
-    eprintln!(
-        "{}{} The formatter is not stable yet. Code style, configuration and CLI are still subject \
-        to change.",
-        "note".yellow().bold(),
-        ":".bold()
-    );
+    warn_user_once!("`ruff format` is not yet stable, and subject to change in future versions.");
 
     let (cli, overrides) = args.partition();
 

--- a/crates/ruff_cli/tests/format.rs
+++ b/crates/ruff_cli/tests/format.rs
@@ -39,7 +39,7 @@ if condition:
         print('Hy "Micha"')  # Should not change quotes
 
     ----- stderr -----
-    warning: `ruff format` is a work-in-progress, subject to change at any time, and intended only for experimentation.
+    warning: `ruff format` is not yet stable, and subject to change in future versions.
     "###);
 }
 
@@ -83,7 +83,7 @@ if condition:
     	print('Should change quotes')
 
     ----- stderr -----
-    warning: `ruff format` is a work-in-progress, subject to change at any time, and intended only for experimentation.
+    warning: `ruff format` is not yet stable, and subject to change in future versions.
     "###);
     Ok(())
 }
@@ -139,7 +139,7 @@ if condition:
     	print('Should change quotes')
 
     ----- stderr -----
-    warning: `ruff format` is a work-in-progress, subject to change at any time, and intended only for experimentation.
+    warning: `ruff format` is not yet stable, and subject to change in future versions.
     "###);
     Ok(())
 }

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -486,7 +486,7 @@ fn stdin_format_jupyter() {
     }
 
     ----- stderr -----
-    warning: `ruff format` is a work-in-progress, subject to change at any time, and intended only for experimentation.
+    warning: `ruff format` is not yet stable, and subject to change in future versions.
     "###);
 }
 


### PR DESCRIPTION
The ruff formatter has stabilized a good bit since when we added the original message "intended only for experimentation" message. It's time for a less scary message to indicate it is much closer to stable usage than it used to be.

I'm not particular about the specific wording, feel free to change the text to something better.

![image](https://github.com/astral-sh/ruff/assets/6826232/225db573-bfda-446f-a403-a577ee270a0b)
