### PR TITLE
Update UP038 docs to note that it results in slower code

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
@@ -39,8 +39,12 @@ impl CallKind {
 ///
 /// ## Why is this bad?
 /// Since Python 3.10, `isinstance` and `issubclass` can be passed a
-/// `|`-separated union of types, which is more concise and consistent
+/// `|`-separated union of types, which is consistent
 /// with the union operator introduced in [PEP 604].
+///
+/// Note that this results in slower code. Ignore this rule if the
+/// performance of an `isinstance` or `issubclass` check is a
+/// concern, e.g., in a hot loop.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
See discussion in #7871. I tried to use language similar to the existing performance warnings in the `flake8-use-pathlib` docs, e.g. https://docs.astral.sh/ruff/rules/os-path-abspath/#os-path-abspath-pth100