### PR TITLE
Remove min and max range on `line-length` JSON schema

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2,12 +2,11 @@ use std::collections::BTreeSet;
 use std::hash::BuildHasherDefault;
 
 use regex::Regex;
-use ruff_formatter::IndentStyle;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
-use crate::options_base::{OptionsMetadata, Visit};
+use ruff_formatter::IndentStyle;
 use ruff_linter::line_width::{LineLength, TabSize};
 use ruff_linter::rules::flake8_pytest_style::settings::SettingsError;
 use ruff_linter::rules::flake8_pytest_style::types;
@@ -30,6 +29,7 @@ use ruff_linter::{warn_user_once, RuleSelector};
 use ruff_macros::{CombineOptions, OptionsMetadata};
 use ruff_python_formatter::QuoteStyle;
 
+use crate::options_base::{OptionsMetadata, Visit};
 use crate::settings::LineEnding;
 
 #[derive(Debug, PartialEq, Eq, Default, OptionsMetadata, Serialize, Deserialize)]
@@ -362,7 +362,6 @@ pub struct Options {
         line-length = 120
         "#
     )]
-    #[cfg_attr(feature = "schemars", schemars(range(min = 1, max = 320)))]
     pub line_length: Option<LineLength>,
 
     /// The tabulation size to calculate line length.

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -392,9 +392,7 @@
         {
           "type": "null"
         }
-      ],
-      "maximum": 320.0,
-      "minimum": 1.0
+      ]
     },
     "lint": {
       "anyOf": [


### PR DESCRIPTION
## Summary

This was introduced in https://github.com/astral-sh/ruff/pull/7412, but SchemaStore doesn't accept it. I manually edited the JSON schema last time, then tried to fix this, then gave up -- so removing for now.

(See, e.g., https://github.com/SchemaStore/schemastore/pull/3278, which failed prior to removing the min and max.)
