### PR TITLE
fix(schema): restore limit on line-length

### DIFF
--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -15,7 +15,9 @@ use ruff_text_size::TextSize;
 /// The allowed range of values is 1..=320
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub struct LineLength(NonZeroU16);
+pub struct LineLength(
+    #[cfg_attr(feature = "schemars", schemars(range(min = 1, max = 320)))] NonZeroU16,
+);
 
 impl LineLength {
     /// Maximum allowed value for a valid [`LineLength`]

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1556,6 +1556,7 @@
       "description": "The length of a line of text that is considered too long.\n\nThe allowed range of values is 1..=320",
       "type": "integer",
       "format": "uint16",
+      "maximum": 320.0,
       "minimum": 1.0
     },
     "LintOptions": {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Restores functionality of #7875 but in the correct place. Closes #7877.

~~I couldn't figure out how to get cargo fmt to work, so hopefully that's run in CI.~~ Nevermind, figured it out.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Can see output of json.

<!-- How was it tested? -->
