### PR TITLE
Allow bindings to be created and referenced within annotations

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_18.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_18.py
@@ -1,0 +1,19 @@
+"""Test bindings created within annotations."""
+
+from typing import Annotated
+
+foo = [1, 2, 3, 4, 5]
+
+
+class Bar:
+    # OK: Allow list comprehensions in annotations (i.e., treat `qux` as a valid
+    # load in the scope of the annotation).
+    baz: Annotated[
+        str,
+        [qux for qux in foo],
+    ]
+
+
+# OK: Allow named expressions in annotations.
+x: (y := 1)
+print(y)

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_19.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_19.py
@@ -1,0 +1,21 @@
+"""Test bindings created within annotations under `__future__` annotations."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+foo = [1, 2, 3, 4, 5]
+
+
+class Bar:
+    # OK: Allow list comprehensions in annotations (i.e., treat `qux` as a valid
+    # load in the scope of the annotation).
+    baz: Annotated[
+        str,
+        [qux for qux in foo],
+    ]
+
+
+# Error: `y` is not defined.
+x: (y := 1)
+print(y)

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -133,6 +133,8 @@ mod tests {
     #[test_case(Rule::UndefinedName, Path::new("F821_15.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_16.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_17.py"))]
+    #[test_case(Rule::UndefinedName, Path::new("F821_18.py"))]
+    #[test_case(Rule::UndefinedName, Path::new("F821_19.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_1.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_2.py"))]

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_18.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_18.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_19.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_19.py.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+F821_19.py:21:7: F821 Undefined name `y`
+   |
+19 | # Error: `y` is not defined.
+20 | x: (y := 1)
+21 | print(y)
+   |       ^ F821
+   |
+
+


### PR DESCRIPTION
## Summary

Given:

```python
baz: Annotated[
    str,
    [qux for qux in foo],
]
```

We treat `baz` as `BindingKind::Annotation`, to ensure that references to `baz` are marked as unbound. However, we were _also_ treating `qux` as `BindingKind::Annotation`, which meant that the load in the comprehension _also_ errored.

Closes https://github.com/astral-sh/ruff/issues/7879.
