### PR TITLE
add autofix for `PYI055`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.py
@@ -28,5 +28,5 @@ item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
 
 def func():
     # PYI055
-    item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
-    item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
+    item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+    item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.py
@@ -28,5 +28,12 @@ item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
 
 def func():
     # PYI055
-    item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-    item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+    x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+    y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+
+
+def func():
+    from typing import Union as U
+
+    # PYI055
+    x: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.py
@@ -29,3 +29,4 @@ item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
 def func():
     # PYI055
     item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
+    item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.pyi
@@ -21,5 +21,5 @@ item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
 
 def func():
     # PYI055
-    item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
-    item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
+    item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+    item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI055.pyi
@@ -22,3 +22,4 @@ item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
 def func():
     # PYI055
     item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
+    item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
@@ -1,5 +1,5 @@
 use ast::{ExprContext, Operator};
-use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::{self as ast, Expr};
 use ruff_text_size::{Ranged, TextRange};
@@ -10,8 +10,8 @@ use crate::{checkers::ast::Checker, rules::flake8_pyi::helpers::traverse_union};
 /// Checks for the presence of multiple `type`s in a union.
 ///
 /// ## Why is this bad?
-/// The `type` built-in function accepts unions, and it is
-/// clearer to explicitly specify them as a single `type`.
+/// The `type` built-in function accepts unions, and it is clearer to
+/// explicitly specify them as a single `type`.
 ///
 /// ## Example
 /// ```python
@@ -28,7 +28,9 @@ pub struct UnnecessaryTypeUnion {
     is_pep604_union: bool,
 }
 
-impl AlwaysFixableViolation for UnnecessaryTypeUnion {
+impl Violation for UnnecessaryTypeUnion {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         let union_str = if self.is_pep604_union {
@@ -42,8 +44,8 @@ impl AlwaysFixableViolation for UnnecessaryTypeUnion {
         )
     }
 
-    fn fix_title(&self) -> String {
-        format!("Combine multiple `type` members into one union")
+    fn fix_title(&self) -> Option<String> {
+        Some(format!("Combine multiple `type` members"))
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
@@ -9,7 +9,7 @@ PYI055.py:31:8: PYI055 [*] Multiple `type` members in a union. Combine them into
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 32 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |
-   = help: Combine multiple `type` members into one union
+   = help: Combine multiple `type` members
 
 ℹ Fix
 28 28 | 
@@ -28,7 +28,7 @@ PYI055.py:32:8: PYI055 [*] Multiple `type` members in a union. Combine them into
 32 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
    |
-   = help: Combine multiple `type` members into one union
+   = help: Combine multiple `type` members
 
 ℹ Fix
 29 29 | def func():
@@ -46,7 +46,7 @@ PYI055.py:39:8: PYI055 [*] Multiple `type` members in a union. Combine them into
 39 |     x: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
    |
-   = help: Combine multiple `type` members into one union
+   = help: Combine multiple `type` members
 
 ℹ Fix
 36 36 |     from typing import Union as U

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
@@ -1,12 +1,38 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
 ---
-PYI055.py:31:11: PYI055 Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty]`.
+PYI055.py:31:11: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty]`.
    |
 29 | def func():
 30 |     # PYI055
 31 |     item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+32 |     item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
    |
+   = help: Combine multiple `type` members into one union
+
+ℹ Fix
+28 28 | 
+29 29 | def func():
+30 30 |     # PYI055
+31    |-    item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
+   31 |+    item: type[requests_mock.Mocker | httpretty] = requests_mock.Mocker
+32 32 |     item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
+
+PYI055.py:32:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty]]`.
+   |
+30 |     # PYI055
+31 |     item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
+32 |     item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+   |
+   = help: Combine multiple `type` members into one union
+
+ℹ Fix
+29 29 | def func():
+30 30 |     # PYI055
+31 31 |     item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
+32    |-    item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
+   32 |+    item2: type[Union[requests_mock.Mocker, httpretty]] = requests_mock.Mocker
 
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
 ---
-PYI055.py:31:11: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty | str]`.
+PYI055.py:31:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty | str]`.
    |
 29 | def func():
 30 |     # PYI055
-31 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-32 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+31 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+32 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |
    = help: Combine multiple `type` members into one union
 
@@ -15,24 +15,44 @@ PYI055.py:31:11: PYI055 [*] Multiple `type` members in a union. Combine them int
 28 28 | 
 29 29 | def func():
 30 30 |     # PYI055
-31    |-    item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-   31 |+    item: type[requests_mock.Mocker | httpretty | str] = requests_mock.Mocker
-32 32 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+31    |-    x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+   31 |+    x: type[requests_mock.Mocker | httpretty | str] = requests_mock.Mocker
+32 32 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+33 33 | 
+34 34 | 
 
-PYI055.py:32:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
+PYI055.py:32:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
    |
 30 |     # PYI055
-31 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-32 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+31 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+32 |     y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
    |
    = help: Combine multiple `type` members into one union
 
 ℹ Fix
 29 29 | def func():
 30 30 |     # PYI055
-31 31 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
-32    |-    item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
-   32 |+    item2: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
+31 31 |     x: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+32    |-    y: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   32 |+    y: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
+33 33 | 
+34 34 | 
+35 35 | def func():
+
+PYI055.py:39:8: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
+   |
+38 |     # PYI055
+39 |     x: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+   |
+   = help: Combine multiple `type` members into one union
+
+ℹ Fix
+36 36 |     from typing import Union as U
+37 37 | 
+38 38 |     # PYI055
+39    |-    x: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   39 |+    x: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
 
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.py.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
 ---
-PYI055.py:31:11: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty]`.
+PYI055.py:31:11: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty | str]`.
    |
 29 | def func():
 30 |     # PYI055
-31 |     item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-32 |     item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
+31 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+32 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |
    = help: Combine multiple `type` members into one union
 
@@ -15,24 +15,24 @@ PYI055.py:31:11: PYI055 [*] Multiple `type` members in a union. Combine them int
 28 28 | 
 29 29 | def func():
 30 30 |     # PYI055
-31    |-    item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
-   31 |+    item: type[requests_mock.Mocker | httpretty] = requests_mock.Mocker
-32 32 |     item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
+31    |-    item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+   31 |+    item: type[requests_mock.Mocker | httpretty | str] = requests_mock.Mocker
+32 32 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
 
-PYI055.py:32:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty]]`.
+PYI055.py:32:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
    |
 30 |     # PYI055
-31 |     item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
-32 |     item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+31 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+32 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
    |
    = help: Combine multiple `type` members into one union
 
 ℹ Fix
 29 29 | def func():
 30 30 |     # PYI055
-31 31 |     item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
-32    |-    item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
-   32 |+    item2: type[Union[requests_mock.Mocker, httpretty]] = requests_mock.Mocker
+31 31 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+32    |-    item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   32 |+    item2: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
 
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.pyi.snap
@@ -145,13 +145,13 @@ PYI055.pyi:20:7: PYI055 [*] Multiple `type` members in a union. Combine them int
 22 22 | def func():
 23 23 |     # PYI055
 
-PYI055.pyi:24:11: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty]`.
+PYI055.pyi:24:11: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty | str]`.
    |
 22 | def func():
 23 |     # PYI055
-24 |     item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
-25 |     item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
+24 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+25 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |
    = help: Combine multiple `type` members into one union
 
@@ -159,24 +159,24 @@ PYI055.pyi:24:11: PYI055 [*] Multiple `type` members in a union. Combine them in
 21 21 | 
 22 22 | def func():
 23 23 |     # PYI055
-24    |-    item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
-   24 |+    item: type[requests_mock.Mocker | httpretty] = requests_mock.Mocker
-25 25 |     item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
+24    |-    item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+   24 |+    item: type[requests_mock.Mocker | httpretty | str] = requests_mock.Mocker
+25 25 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
 
-PYI055.pyi:25:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty]]`.
+PYI055.pyi:25:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty, str]]`.
    |
 23 |     # PYI055
-24 |     item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
-25 |     item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+24 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+25 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
    |
    = help: Combine multiple `type` members into one union
 
 ℹ Fix
 22 22 | def func():
 23 23 |     # PYI055
-24 24 |     item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
-25    |-    item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
-   25 |+    item2: type[Union[requests_mock.Mocker, httpretty]] = requests_mock.Mocker
+24 24 |     item: type[requests_mock.Mocker] | type[httpretty] | type[str] = requests_mock.Mocker
+25    |-    item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
+   25 |+    item2: type[Union[requests_mock.Mocker, httpretty, str]] = requests_mock.Mocker
 
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.pyi.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
 ---
-PYI055.pyi:4:4: PYI055 Multiple `type` members in a union. Combine them into one, e.g., `type[int | str | complex]`.
+PYI055.pyi:4:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[int | str | complex]`.
   |
 2 | from typing import Union
 3 | 
@@ -10,8 +10,19 @@ PYI055.pyi:4:4: PYI055 Multiple `type` members in a union. Combine them into one
 5 | x: type[int] | type[str] | type[float]
 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
   |
+  = help: Combine multiple `type` members into one union
 
-PYI055.pyi:5:4: PYI055 Multiple `type` members in a union. Combine them into one, e.g., `type[int | str | float]`.
+ℹ Fix
+1 1 | import builtins
+2 2 | from typing import Union
+3 3 | 
+4   |-w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+  4 |+w: type[int | str | complex]
+5 5 | x: type[int] | type[str] | type[float]
+6 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
+7 7 | z: Union[type[float], type[complex]]
+
+PYI055.pyi:5:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[int | str | float]`.
   |
 4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
 5 | x: type[int] | type[str] | type[float]
@@ -19,8 +30,19 @@ PYI055.pyi:5:4: PYI055 Multiple `type` members in a union. Combine them into one
 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
 7 | z: Union[type[float], type[complex]]
   |
+  = help: Combine multiple `type` members into one union
 
-PYI055.pyi:6:4: PYI055 Multiple `type` members in a union. Combine them into one, e.g., `type[int | str | complex]`.
+ℹ Fix
+2 2 | from typing import Union
+3 3 | 
+4 4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+5   |-x: type[int] | type[str] | type[float]
+  5 |+x: type[int | str | float]
+6 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
+7 7 | z: Union[type[float], type[complex]]
+8 8 | z: Union[type[float, int], type[complex]]
+
+PYI055.pyi:6:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[int | str | complex]`.
   |
 4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
 5 | x: type[int] | type[str] | type[float]
@@ -29,8 +51,19 @@ PYI055.pyi:6:4: PYI055 Multiple `type` members in a union. Combine them into one
 7 | z: Union[type[float], type[complex]]
 8 | z: Union[type[float, int], type[complex]]
   |
+  = help: Combine multiple `type` members into one union
 
-PYI055.pyi:7:4: PYI055 Multiple `type` members in a union. Combine them into one, e.g., `type[Union[float, complex]]`.
+ℹ Fix
+3 3 | 
+4 4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+5 5 | x: type[int] | type[str] | type[float]
+6   |-y: builtins.type[int] | type[str] | builtins.type[complex]
+  6 |+y: type[int | str | complex]
+7 7 | z: Union[type[float], type[complex]]
+8 8 | z: Union[type[float, int], type[complex]]
+9 9 | 
+
+PYI055.pyi:7:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[float, complex]]`.
   |
 5 | x: type[int] | type[str] | type[float]
 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
@@ -38,8 +71,19 @@ PYI055.pyi:7:4: PYI055 Multiple `type` members in a union. Combine them into one
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 8 | z: Union[type[float, int], type[complex]]
   |
+  = help: Combine multiple `type` members into one union
 
-PYI055.pyi:8:4: PYI055 Multiple `type` members in a union. Combine them into one, e.g., `type[Union[float, int, complex]]`.
+ℹ Fix
+4 4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
+5 5 | x: type[int] | type[str] | type[float]
+6 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
+7   |-z: Union[type[float], type[complex]]
+  7 |+z: type[Union[float, complex]]
+8 8 | z: Union[type[float, int], type[complex]]
+9 9 | 
+10 10 | def func(arg: type[int] | str | type[float]) -> None: ...
+
+PYI055.pyi:8:4: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[float, int, complex]]`.
    |
  6 | y: builtins.type[int] | type[str] | builtins.type[complex]
  7 | z: Union[type[float], type[complex]]
@@ -48,8 +92,19 @@ PYI055.pyi:8:4: PYI055 Multiple `type` members in a union. Combine them into one
  9 | 
 10 | def func(arg: type[int] | str | type[float]) -> None: ...
    |
+   = help: Combine multiple `type` members into one union
 
-PYI055.pyi:10:15: PYI055 Multiple `type` members in a union. Combine them into one, e.g., `type[int | float]`.
+ℹ Fix
+5 5 | x: type[int] | type[str] | type[float]
+6 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
+7 7 | z: Union[type[float], type[complex]]
+8   |-z: Union[type[float, int], type[complex]]
+  8 |+z: type[Union[float, int, complex]]
+9 9 | 
+10 10 | def func(arg: type[int] | str | type[float]) -> None: ...
+11 11 | 
+
+PYI055.pyi:10:15: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[int | float]`.
    |
  8 | z: Union[type[float, int], type[complex]]
  9 | 
@@ -58,8 +113,19 @@ PYI055.pyi:10:15: PYI055 Multiple `type` members in a union. Combine them into o
 11 | 
 12 | # OK
    |
+   = help: Combine multiple `type` members into one union
 
-PYI055.pyi:20:7: PYI055 Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty]`.
+ℹ Fix
+7  7  | z: Union[type[float], type[complex]]
+8  8  | z: Union[type[float, int], type[complex]]
+9  9  | 
+10    |-def func(arg: type[int] | str | type[float]) -> None: ...
+   10 |+def func(arg: type[int | float]) -> None: ...
+11 11 | 
+12 12 | # OK
+13 13 | x: type[int, str, float]
+
+PYI055.pyi:20:7: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty]`.
    |
 19 | # OK
 20 | item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
@@ -67,13 +133,50 @@ PYI055.pyi:20:7: PYI055 Multiple `type` members in a union. Combine them into on
 21 | 
 22 | def func():
    |
+   = help: Combine multiple `type` members into one union
 
-PYI055.pyi:24:11: PYI055 Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty]`.
+ℹ Fix
+17 17 | def func(arg: type[int, float] | str) -> None: ...
+18 18 | 
+19 19 | # OK
+20    |-item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
+   20 |+item: type[requests_mock.Mocker | httpretty] = requests_mock.Mocker
+21 21 | 
+22 22 | def func():
+23 23 |     # PYI055
+
+PYI055.pyi:24:11: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[requests_mock.Mocker | httpretty]`.
    |
 22 | def func():
 23 |     # PYI055
 24 |     item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+25 |     item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
    |
+   = help: Combine multiple `type` members into one union
+
+ℹ Fix
+21 21 | 
+22 22 | def func():
+23 23 |     # PYI055
+24    |-    item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
+   24 |+    item: type[requests_mock.Mocker | httpretty] = requests_mock.Mocker
+25 25 |     item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
+
+PYI055.pyi:25:12: PYI055 [*] Multiple `type` members in a union. Combine them into one, e.g., `type[Union[requests_mock.Mocker, httpretty]]`.
+   |
+23 |     # PYI055
+24 |     item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
+25 |     item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
+   |
+   = help: Combine multiple `type` members into one union
+
+ℹ Fix
+22 22 | def func():
+23 23 |     # PYI055
+24 24 |     item: type[requests_mock.Mocker] | type[httpretty] = requests_mock.Mocker
+25    |-    item2: Union[type[requests_mock.Mocker], type[httpretty]] = requests_mock.Mocker
+   25 |+    item2: type[Union[requests_mock.Mocker, httpretty]] = requests_mock.Mocker
 
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI055_PYI055.pyi.snap
@@ -10,7 +10,7 @@ PYI055.pyi:4:4: PYI055 [*] Multiple `type` members in a union. Combine them into
 5 | x: type[int] | type[str] | type[float]
 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
   |
-  = help: Combine multiple `type` members into one union
+  = help: Combine multiple `type` members
 
 ℹ Fix
 1 1 | import builtins
@@ -30,7 +30,7 @@ PYI055.pyi:5:4: PYI055 [*] Multiple `type` members in a union. Combine them into
 6 | y: builtins.type[int] | type[str] | builtins.type[complex]
 7 | z: Union[type[float], type[complex]]
   |
-  = help: Combine multiple `type` members into one union
+  = help: Combine multiple `type` members
 
 ℹ Fix
 2 2 | from typing import Union
@@ -51,7 +51,7 @@ PYI055.pyi:6:4: PYI055 [*] Multiple `type` members in a union. Combine them into
 7 | z: Union[type[float], type[complex]]
 8 | z: Union[type[float, int], type[complex]]
   |
-  = help: Combine multiple `type` members into one union
+  = help: Combine multiple `type` members
 
 ℹ Fix
 3 3 | 
@@ -71,7 +71,7 @@ PYI055.pyi:7:4: PYI055 [*] Multiple `type` members in a union. Combine them into
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 8 | z: Union[type[float, int], type[complex]]
   |
-  = help: Combine multiple `type` members into one union
+  = help: Combine multiple `type` members
 
 ℹ Fix
 4 4 | w: builtins.type[int] | builtins.type[str] | builtins.type[complex]
@@ -92,7 +92,7 @@ PYI055.pyi:8:4: PYI055 [*] Multiple `type` members in a union. Combine them into
  9 | 
 10 | def func(arg: type[int] | str | type[float]) -> None: ...
    |
-   = help: Combine multiple `type` members into one union
+   = help: Combine multiple `type` members
 
 ℹ Fix
 5 5 | x: type[int] | type[str] | type[float]
@@ -113,7 +113,7 @@ PYI055.pyi:10:15: PYI055 [*] Multiple `type` members in a union. Combine them in
 11 | 
 12 | # OK
    |
-   = help: Combine multiple `type` members into one union
+   = help: Combine multiple `type` members
 
 ℹ Fix
 7  7  | z: Union[type[float], type[complex]]
@@ -133,7 +133,7 @@ PYI055.pyi:20:7: PYI055 [*] Multiple `type` members in a union. Combine them int
 21 | 
 22 | def func():
    |
-   = help: Combine multiple `type` members into one union
+   = help: Combine multiple `type` members
 
 ℹ Fix
 17 17 | def func(arg: type[int, float] | str) -> None: ...
@@ -153,7 +153,7 @@ PYI055.pyi:24:11: PYI055 [*] Multiple `type` members in a union. Combine them in
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
 25 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |
-   = help: Combine multiple `type` members into one union
+   = help: Combine multiple `type` members
 
 ℹ Fix
 21 21 | 
@@ -170,7 +170,7 @@ PYI055.pyi:25:12: PYI055 [*] Multiple `type` members in a union. Combine them in
 25 |     item2: Union[type[requests_mock.Mocker], type[httpretty], type[str]] = requests_mock.Mocker
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI055
    |
-   = help: Combine multiple `type` members into one union
+   = help: Combine multiple `type` members
 
 ℹ Fix
 22 22 | def func():


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Adds autofix for `PYI055`

Questions:
- is it intended that only the code within the `def func():` gets fixed? 🤔 I feel like some of the top-level variables would also be affected.
- should `w: builtins.type[int] | builtins.type[str] | builtins.type[complex]` turn into `w: builtins.type[int | str | complex]`?
  - or `w: type[int | str | complex]`?

## Test Plan

<!-- How was it tested? -->

`cargo test`, and manually.