### PR TITLE
Upgrade LibCST to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,8 +1268,9 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libcst"
-version = "0.1.0"
-source = "git+https://github.com/Instagram/LibCST.git?rev=03179b55ebe7e916f1722e18e8f0b87c01616d1f#03179b55ebe7e916f1722e18e8f0b87c01616d1f"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5c2ff400caac657bf794181d885491bb97cc37c376f8cb4fa3a0cc2176a053"
 dependencies = [
  "chic",
  "libcst_derive",
@@ -1282,8 +1283,9 @@ dependencies = [
 
 [[package]]
 name = "libcst_derive"
-version = "0.1.0"
-source = "git+https://github.com/Instagram/LibCST.git?rev=03179b55ebe7e916f1722e18e8f0b87c01616d1f#03179b55ebe7e916f1722e18e8f0b87c01616d1f"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7f252282b20bfec6fae65d351ab1df7e4552a6270dd7bb779ca9d6135aabe9"
 dependencies = [
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ignore = { version = "0.4.20" }
 insta = { version = "1.33.0", feature = ["filters", "glob"] }
 is-macro = { version = "0.3.0" }
 itertools = { version = "0.11.0" }
+libcst = { version = "1.1.0", default-features = false }
 log = { version = "0.4.17" }
 memchr = { version = "2.6.4" }
 once_cell = { version = "1.17.1" }
@@ -53,8 +54,6 @@ unicode_names2 = { version = "1.1.0" }
 unicode-width = { version = "0.1.11" }
 uuid = { version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics", "js"] }
 wsl = { version = "0.1.0" }
-
-libcst = { git = "https://github.com/Instagram/LibCST.git", rev = "03179b55ebe7e916f1722e18e8f0b87c01616d1f", default-features = false }
 
 [profile.release]
 lto = "fat"


### PR DESCRIPTION
This PR updates the `libcst` crate version to `1.1.0`. The published version contains support for 3.12: https://github.com/Instagram/LibCST/releases/tag/v1.1.0