### PR TITLE
Drop formatting specific rules from the default set

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ If left unspecified, the default configuration is equivalent to:
 
 ```toml
 [tool.ruff]
-# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F"]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+select = ["E4", "E7", "E9", "F"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Rust as a first-party feature.
 
 By default, Ruff enables Flake8's `E` and `F` rules. Ruff supports all rules from the `F` category,
 and a [subset](https://docs.astral.sh/ruff/rules/#error-e) of the `E` category, omitting those
-stylistic rules made obsolete by the use of an autoformatter, like
+stylistic rules made obsolete by the use of a formatter, like
 [Black](https://github.com/psf/black).
 
 If you're just getting started with Ruff, **the default rule set is a great place to start**: it

--- a/crates/flake8_to_ruff/src/converter.rs
+++ b/crates/flake8_to_ruff/src/converter.rs
@@ -13,6 +13,7 @@ use ruff_linter::rules::flake8_quotes::settings::Quote;
 use ruff_linter::rules::flake8_tidy_imports::settings::Strictness;
 use ruff_linter::rules::pydocstyle::settings::Convention;
 use ruff_linter::settings::types::PythonVersion;
+use ruff_linter::settings::DEFAULT_SELECTORS;
 use ruff_linter::warn_user;
 use ruff_workspace::options::{
     Flake8AnnotationsOptions, Flake8BugbearOptions, Flake8BuiltinsOptions, Flake8ErrMsgOptions,
@@ -24,11 +25,6 @@ use ruff_workspace::pyproject::Pyproject;
 use super::external_config::ExternalConfig;
 use super::plugin::Plugin;
 use super::{parser, plugin};
-
-const DEFAULT_SELECTORS: &[RuleSelector] = &[
-    RuleSelector::Linter(Linter::Pyflakes),
-    RuleSelector::Linter(Linter::Pycodestyle),
-];
 
 pub(crate) fn convert(
     config: &HashMap<String, HashMap<String, Option<String>>>,

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -88,12 +88,21 @@ pub struct LinterSettings {
     pub pyupgrade: pyupgrade::settings::Settings,
 }
 
-pub const PREFIXES: &[RuleSelector] = &[
+pub const DEFAULT_SELECTORS: &[RuleSelector] = &[
+    RuleSelector::Linter(Linter::Pyflakes),
+    // Only include pycodestyle rules that do not overlap with the formatter
     RuleSelector::Prefix {
-        prefix: RuleCodePrefix::Pycodestyle(codes::Pycodestyle::E),
+        prefix: RuleCodePrefix::Pycodestyle(codes::Pycodestyle::E4),
         redirected_from: None,
     },
-    RuleSelector::Linter(Linter::Pyflakes),
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Pycodestyle(codes::Pycodestyle::E7),
+        redirected_from: None,
+    },
+    RuleSelector::Prefix {
+        prefix: RuleCodePrefix::Pycodestyle(codes::Pycodestyle::E9),
+        redirected_from: None,
+    },
 ];
 
 pub const TASK_TAGS: &[&str] = &["TODO", "FIXME", "XXX"];
@@ -122,7 +131,7 @@ impl LinterSettings {
         Self {
             target_version: PythonVersion::default(),
             project_root: project_root.to_path_buf(),
-            rules: PREFIXES
+            rules: DEFAULT_SELECTORS
                 .iter()
                 .flat_map(|selector| selector.rules(&PreviewOptions::default()))
                 .collect(),

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -10,7 +10,7 @@ use ruff_linter::line_width::{LineLength, TabSize};
 use ruff_linter::linter::{check_path, LinterResult};
 use ruff_linter::registry::AsRule;
 use ruff_linter::settings::types::PythonVersion;
-use ruff_linter::settings::{flags, DUMMY_VARIABLE_RGX, PREFIXES};
+use ruff_linter::settings::{flags, DEFAULT_SELECTORS, DUMMY_VARIABLE_RGX};
 use ruff_linter::source_kind::SourceKind;
 use ruff_python_ast::{Mod, PySourceType};
 use ruff_python_codegen::Stylist;
@@ -133,7 +133,7 @@ impl Workspace {
                 allowed_confusables: Some(Vec::default()),
                 dummy_variable_rgx: Some(DUMMY_VARIABLE_RGX.as_str().to_string()),
                 ignore: Some(Vec::default()),
-                select: Some(PREFIXES.to_vec()),
+                select: Some(DEFAULT_SELECTORS.to_vec()),
                 extend_fixable: Some(Vec::default()),
                 extend_select: Some(Vec::default()),
                 external: Some(Vec::default()),

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -27,7 +27,7 @@ use ruff_linter::settings::types::{
     UnsafeFixes, Version,
 };
 use ruff_linter::settings::{
-    resolve_per_file_ignores, LinterSettings, DUMMY_VARIABLE_RGX, PREFIXES, TASK_TAGS,
+    resolve_per_file_ignores, LinterSettings, DEFAULT_SELECTORS, DUMMY_VARIABLE_RGX, TASK_TAGS,
 };
 use ruff_linter::{
     fs, warn_user, warn_user_once, warn_user_once_by_id, RuleSelector, RUFF_PKG_VERSION,
@@ -617,7 +617,7 @@ impl LintConfiguration {
         };
 
         // The select_set keeps track of which rules have been selected.
-        let mut select_set: RuleSet = PREFIXES
+        let mut select_set: RuleSet = DEFAULT_SELECTORS
             .iter()
             .flat_map(|selector| selector.rules(&preview))
             .collect();

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -569,11 +569,11 @@ pub struct LintOptions {
     /// `ignore`, respectively), more specific prefixes override less
     /// specific prefixes.
     #[option(
-        default = r#"["E", "F"]"#,
+        default = r#"["E4", "E7", "E9", "F"]"#,
         value_type = "list[RuleSelector]",
         example = r#"
-            # On top of the defaults (`E`, `F`), enable flake8-bugbear (`B`) and flake8-quotes (`Q`).
-            select = ["E", "F", "B", "Q"]
+            # On top of the defaults (`E4`, E7`, `E9`, and `F`), enable flake8-bugbear (`B`) and flake8-quotes (`Q`).
+            select = ["E4", "E7", "E9", "F", "B", "Q"]
         "#
     )]
     pub select: Option<Vec<RuleSelector>>,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,10 +11,10 @@ If left unspecified, Ruff's default configuration is equivalent to:
 
 ```toml
 [tool.ruff]
-# Enable the pycodestyle (`E`) and Pyflakes (`F`) rules by default.
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E", "F"]
+select = ["E4", "E7", "E9", "F"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ Yes. Ruff is compatible with [Black](https://github.com/psf/black) out-of-the-bo
 the `line-length` setting is consistent between the two.
 
 As a project, Ruff is designed to be used alongside Black and, as such, will defer implementing
-stylistic lint rules that are obviated by autoformatting.
+stylistic lint rules that are obviated by automated formatting.
 
 Note that Ruff and Black treat line-length enforcement a little differently. Black makes a
 best-effort attempt to adhere to the `line-length`, but avoids automatic line-wrapping in some cases


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/7572

Drops formatting specific rules from the default rule set as they conflict with formatters in general (and in particular, conflict with our formatter). Most of these rules are in preview, but the removal of `line-too-long` and `mixed-spaces-and-tabs` is a change to the stable rule set.

## Example

The following no longer raises `E501`
```
echo "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = 1" | ruff check -
```