### PR TITLE
Allow `is` and `is` not for direct type comparisons

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E721.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E721.py
@@ -4,18 +4,18 @@ if type(res) == type(42):
 #: E721
 if type(res) != type(""):
     pass
-#: E721
+#: Okay
 import types
 
 if res == types.IntType:
     pass
-#: E721
+#: Okay
 import types
 
 if type(res) is not types.ListType:
     pass
 #: E721
-assert type(res) == type(False)
+assert type(res) == type(False) or type(res) == type(None)
 #: E721
 assert type(res) == type([])
 #: E721
@@ -25,21 +25,18 @@ assert type(res) == type((0,))
 #: E721
 assert type(res) == type((0))
 #: E721
-assert type(res) != type((1,))
-#: E721
-assert type(res) is type((1,))
-#: E721
-assert type(res) is not type((1,))
+assert type(res) != type((1, ))
+#: Okay
+assert type(res) is type((1, ))
+#: Okay
+assert type(res) is not type((1, ))
 #: E211 E721
-assert type(res) == type(
-    [
-        2,
-    ]
-)
+assert type(res) == type ([2, ])
 #: E201 E201 E202 E721
-assert type(res) == type(())
+assert type(res) == type( ( ) )
 #: E201 E202 E721
-assert type(res) == type((0,))
+assert type(res) == type( (0, ) )
+#:
 
 #: Okay
 import types
@@ -50,17 +47,47 @@ if isinstance(res, str):
     pass
 if isinstance(res, types.MethodType):
     pass
-if type(a) != type(b) or type(a) == type(ccc):
+#: Okay
+def func_histype(a, b, c):
     pass
-
-assert type(res) == type(None)
-
-types = StrEnum
-if x == types.X:
+#: E722
+try:
     pass
+except:
+    pass
+#: E722
+try:
+    pass
+except Exception:
+    pass
+except:
+    pass
+#: E722 E203 E271
+try:
+    pass
+except  :
+    pass
+#: Okay
+fake_code = """"
+try:
+    do_something()
+except:
+    pass
+"""
+try:
+    pass
+except Exception:
+    pass
+#: Okay
+from . import custom_types as types
 
-#: E721
-assert type(res) is int
+red = types.ColorTypeRED
+red is types.ColorType.RED
+#: Okay
+from . import compute_type
+
+if compute_type(foo) == 5:
+    pass
 
 
 class Foo:

--- a/crates/ruff_linter/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/mod.rs
@@ -16,6 +16,7 @@ mod tests {
 
     use crate::line_width::LineLength;
     use crate::registry::Rule;
+    use crate::settings::types::PreviewMode;
     use crate::test::test_path;
     use crate::{assert_messages, settings};
 
@@ -56,6 +57,24 @@ mod tests {
         let diagnostics = test_path(
             Path::new("pycodestyle").join(path).as_path(),
             &settings::LinterSettings::for_rule(rule_code),
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Rule::TypeComparison, Path::new("E721.py"))]
+    fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!(
+            "preview__{}_{}",
+            rule_code.noqa_code(),
+            path.to_string_lossy()
+        );
+        let diagnostics = test_path(
+            Path::new("pycodestyle").join(path).as_path(),
+            &settings::LinterSettings {
+                preview: PreviewMode::Enabled,
+                ..settings::LinterSettings::for_rule(rule_code)
+            },
         )?;
         assert_messages!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__E721_E721.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__E721_E721.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E721.py:2:4: E721 Do not compare types, use `isinstance()`
+E721.py:2:4: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
   |
 1 | #: E721
 2 | if type(res) == type(42):
@@ -10,7 +10,7 @@ E721.py:2:4: E721 Do not compare types, use `isinstance()`
 4 | #: E721
   |
 
-E721.py:5:4: E721 Do not compare types, use `isinstance()`
+E721.py:5:4: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
   |
 3 |     pass
 4 | #: E721
@@ -20,17 +20,7 @@ E721.py:5:4: E721 Do not compare types, use `isinstance()`
 7 | #: Okay
   |
 
-E721.py:15:4: E721 Do not compare types, use `isinstance()`
-   |
-13 | import types
-14 | 
-15 | if type(res) is not types.ListType:
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
-16 |     pass
-17 | #: E721
-   |
-
-E721.py:18:8: E721 Do not compare types, use `isinstance()`
+E721.py:18:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
 16 |     pass
 17 | #: E721
@@ -40,7 +30,7 @@ E721.py:18:8: E721 Do not compare types, use `isinstance()`
 20 | assert type(res) == type([])
    |
 
-E721.py:20:8: E721 Do not compare types, use `isinstance()`
+E721.py:20:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
 18 | assert type(res) == type(False) or type(res) == type(None)
 19 | #: E721
@@ -50,7 +40,7 @@ E721.py:20:8: E721 Do not compare types, use `isinstance()`
 22 | assert type(res) == type(())
    |
 
-E721.py:22:8: E721 Do not compare types, use `isinstance()`
+E721.py:22:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
 20 | assert type(res) == type([])
 21 | #: E721
@@ -60,7 +50,7 @@ E721.py:22:8: E721 Do not compare types, use `isinstance()`
 24 | assert type(res) == type((0,))
    |
 
-E721.py:24:8: E721 Do not compare types, use `isinstance()`
+E721.py:24:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
 22 | assert type(res) == type(())
 23 | #: E721
@@ -70,7 +60,7 @@ E721.py:24:8: E721 Do not compare types, use `isinstance()`
 26 | assert type(res) == type((0))
    |
 
-E721.py:26:8: E721 Do not compare types, use `isinstance()`
+E721.py:26:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
 24 | assert type(res) == type((0,))
 25 | #: E721
@@ -80,7 +70,7 @@ E721.py:26:8: E721 Do not compare types, use `isinstance()`
 28 | assert type(res) != type((1, ))
    |
 
-E721.py:28:8: E721 Do not compare types, use `isinstance()`
+E721.py:28:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
 26 | assert type(res) == type((0))
 27 | #: E721
@@ -90,27 +80,7 @@ E721.py:28:8: E721 Do not compare types, use `isinstance()`
 30 | assert type(res) is type((1, ))
    |
 
-E721.py:30:8: E721 Do not compare types, use `isinstance()`
-   |
-28 | assert type(res) != type((1, ))
-29 | #: Okay
-30 | assert type(res) is type((1, ))
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^ E721
-31 | #: Okay
-32 | assert type(res) is not type((1, ))
-   |
-
-E721.py:32:8: E721 Do not compare types, use `isinstance()`
-   |
-30 | assert type(res) is type((1, ))
-31 | #: Okay
-32 | assert type(res) is not type((1, ))
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
-33 | #: E211 E721
-34 | assert type(res) == type ([2, ])
-   |
-
-E721.py:34:8: E721 Do not compare types, use `isinstance()`
+E721.py:34:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
 32 | assert type(res) is not type((1, ))
 33 | #: E211 E721
@@ -120,7 +90,7 @@ E721.py:34:8: E721 Do not compare types, use `isinstance()`
 36 | assert type(res) == type( ( ) )
    |
 
-E721.py:36:8: E721 Do not compare types, use `isinstance()`
+E721.py:36:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
 34 | assert type(res) == type ([2, ])
 35 | #: E201 E201 E202 E721
@@ -130,7 +100,7 @@ E721.py:36:8: E721 Do not compare types, use `isinstance()`
 38 | assert type(res) == type( (0, ) )
    |
 
-E721.py:38:8: E721 Do not compare types, use `isinstance()`
+E721.py:38:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
 36 | assert type(res) == type( ( ) )
 37 | #: E201 E202 E721
@@ -138,23 +108,5 @@ E721.py:38:8: E721 Do not compare types, use `isinstance()`
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
 39 | #:
    |
-
-E721.py:96:12: E721 Do not compare types, use `isinstance()`
-   |
-94 |     def asdf(self, value: str | None):
-95 |         #: E721
-96 |         if type(value) is str:
-   |            ^^^^^^^^^^^^^^^^^^ E721
-97 |             ...
-   |
-
-E721.py:106:12: E721 Do not compare types, use `isinstance()`
-    |
-104 |     def asdf(self, value: str | None):
-105 |         #: E721
-106 |         if type(value) is str:
-    |            ^^^^^^^^^^^^^^^^^^ E721
-107 |             ...
-    |
 
 


### PR DESCRIPTION
## Summary

This PR updates our E721 implementation and semantics to match the updated `pycodestyle` logic, which I think is an improvement. Specifically, we now allow `type(obj) is int` for exact type comparisons, which were previously impossible. So now, we're largely just linting against code like `type(obj) == int`.

This change is gated to preview mode.

Closes https://github.com/astral-sh/ruff/issues/7904.

## Test Plan

Updated the test fixture and ensured parity with latest Flake8.