### PR TITLE
Fix false negative in `outdated-version-block` when using greater than comparisons

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP036_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP036_0.py
@@ -196,3 +196,9 @@ if sys.version_info < (3,10000000):
 
 if sys.version_info <= (3,10000000):
     print("py3")
+
+if sys.version_info > (3,12):
+    print("py3")
+
+if sys.version_info >= (3,12):
+    print("py3")

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -109,7 +109,7 @@ pub(crate) fn outdated_version_block(checker: &mut Checker, stmt_if: &StmtIf) {
                         return;
                     };
                     let target = checker.settings.target_version;
-                    match compare_version(&version, target, op == &CmpOp::LtE) {
+                    match version_always_less_than(&version, target, op == &CmpOp::LtE) {
                         Ok(false) => {}
                         Ok(true) => {
                             let mut diagnostic = Diagnostic::new(
@@ -138,7 +138,7 @@ pub(crate) fn outdated_version_block(checker: &mut Checker, stmt_if: &StmtIf) {
                         return;
                     };
                     let target = checker.settings.target_version;
-                    match compare_version(
+                    match version_always_less_than(
                         &version,
                         target,
                         // When making comparisons with >= we must reverse the behavior when equal
@@ -216,15 +216,15 @@ pub(crate) fn outdated_version_block(checker: &mut Checker, stmt_if: &StmtIf) {
     }
 }
 
-/// Returns true if the `target_version` is always less than the [`PythonVersion`].
-fn compare_version(
-    target_version: &[Int],
+/// Returns true if the `check_version` is always less than the [`PythonVersion`].
+fn version_always_less_than(
+    check_version: &[Int],
     py_version: PythonVersion,
     or_equal: bool,
 ) -> Result<bool> {
-    let mut target_version_iter = target_version.iter();
+    let mut check_version_iter = check_version.iter();
 
-    let Some(if_major) = target_version_iter.next() else {
+    let Some(if_major) = check_version_iter.next() else {
         return Ok(false);
     };
     let Some(if_major) = if_major.as_u8() else {
@@ -237,7 +237,7 @@ fn compare_version(
         Ordering::Less => Ok(true),
         Ordering::Greater => Ok(false),
         Ordering::Equal => {
-            let Some(if_minor) = target_version_iter.next() else {
+            let Some(if_minor) = check_version_iter.next() else {
                 return Ok(true);
             };
             let Some(if_minor) = if_minor.as_u8() else {
@@ -467,7 +467,7 @@ mod tests {
         expected: bool,
     ) -> Result<()> {
         let target_versions: Vec<_> = target_versions.iter().map(|int| Int::from(*int)).collect();
-        let actual = compare_version(&target_versions, version, or_equal)?;
+        let actual = version_always_less_than(&target_versions, version, or_equal)?;
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -138,7 +138,12 @@ pub(crate) fn outdated_version_block(checker: &mut Checker, stmt_if: &StmtIf) {
                         return;
                     };
                     let target = checker.settings.target_version;
-                    match compare_version(&version, target, op == &CmpOp::GtE) {
+                    match compare_version(
+                        &version,
+                        target,
+                        // When making comparisons with >= we must reverse the behavior when equal
+                        op != &CmpOp::GtE,
+                    ) {
                         Ok(false) => {}
                         Ok(true) => {
                             let mut diagnostic = Diagnostic::new(

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_0.py.snap
@@ -712,4 +712,22 @@ UP036_0.py:197:24: UP036 Version specifier is invalid
 198 |     print("py3")
     |
 
+UP036_0.py:203:4: UP036 [*] Version block is outdated for minimum Python version
+    |
+201 |     print("py3")
+202 | 
+203 | if sys.version_info >= (3,12):
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^ UP036
+204 |     print("py3")
+    |
+    = help: Remove outdated version block
+
+ℹ Suggested fix
+200 200 | if sys.version_info > (3,12):
+201 201 |     print("py3")
+202 202 | 
+203     |-if sys.version_info >= (3,12):
+204     |-    print("py3")
+    203 |+print("py3")
+
 


### PR DESCRIPTION
Closes #7902 

```python
# With target version of Python 3.7
import sys

if sys.version_info >= (3, 7):  # ERROR: UP036
    print('oh no')

if sys.version_info <= (3, 7):  # OK: Can evaluate to different value sometimes e.g. version 3.7 vs 3.8
    print('oh no')

if sys.version_info < (3, 7):  # ERROR: UP036
    print('oh no')

if sys.version_info > (3, 7):  # OK: Can evaluate to different value sometimes e.g. version 3.7 vs 3.8
    print('oh no')

if sys.version_info < (3, 6):  # ERROR: UP036
    print('oh no')

if sys.version_info > (3, 6):  # ERROR: UP036
    print('oh no')

if sys.version_info < (3, 8):  # OK: Can evaluate to a different value sometimes e.g. 3.7 vs 3.8
    print('oh no')

if sys.version_info > (3, 8):  # OK: Can evaluate to a different value sometimes e.g. 3.7 vs 3.9
    print('oh no')
```