### PR TITLE
Use `OneIndexed` in `NotebookIndex`

### DIFF
--- a/crates/ruff_linter/src/logging.rs
+++ b/crates/ruff_linter/src/logging.rs
@@ -177,18 +177,15 @@ impl Display for DisplayParseError<'_> {
                     f,
                     "cell {cell}{colon}",
                     cell = jupyter_index
-                        .cell(source_location.row.get())
-                        .unwrap_or_default(),
+                        .cell(source_location.row)
+                        .unwrap_or(OneIndexed::MIN),
                     colon = ":".cyan(),
                 )?;
 
                 SourceLocation {
-                    row: OneIndexed::new(
-                        jupyter_index
-                            .cell_row(source_location.row.get())
-                            .unwrap_or(1) as usize,
-                    )
-                    .unwrap(),
+                    row: jupyter_index
+                        .cell_row(source_location.row)
+                        .unwrap_or(OneIndexed::MIN),
                     column: source_location.column,
                 }
             } else {

--- a/crates/ruff_linter/src/message/grouped.rs
+++ b/crates/ruff_linter/src/message/grouped.rs
@@ -125,18 +125,18 @@ impl Display for DisplayGroupedMessage<'_> {
                 f,
                 "cell {cell}{sep}",
                 cell = jupyter_index
-                    .cell(start_location.row.get())
-                    .unwrap_or_default(),
+                    .cell(start_location.row)
+                    .unwrap_or(OneIndexed::MIN),
                 sep = ":".cyan()
             )?;
             (
                 jupyter_index
-                    .cell_row(start_location.row.get())
-                    .unwrap_or(1) as usize,
-                start_location.column.get(),
+                    .cell_row(start_location.row)
+                    .unwrap_or(OneIndexed::MIN),
+                start_location.column,
             )
         } else {
-            (start_location.row.get(), start_location.column.get())
+            (start_location.row, start_location.column)
         };
 
         writeln!(

--- a/crates/ruff_linter/src/message/text.rs
+++ b/crates/ruff_linter/src/message/text.rs
@@ -87,18 +87,15 @@ impl Emitter for TextEmitter {
                     writer,
                     "cell {cell}{sep}",
                     cell = notebook_index
-                        .cell(start_location.row.get())
-                        .unwrap_or_default(),
+                        .cell(start_location.row)
+                        .unwrap_or(OneIndexed::MIN),
                     sep = ":".cyan(),
                 )?;
 
                 SourceLocation {
-                    row: OneIndexed::new(
-                        notebook_index
-                            .cell_row(start_location.row.get())
-                            .unwrap_or(1) as usize,
-                    )
-                    .unwrap(),
+                    row: notebook_index
+                        .cell_row(start_location.row)
+                        .unwrap_or(OneIndexed::MIN),
                     column: start_location.column,
                 }
             } else {
@@ -203,9 +200,9 @@ impl Display for MessageCodeFrame<'_> {
         // If we're working with a Jupyter Notebook, skip the lines which are
         // outside of the cell containing the diagnostic.
         if let Some(index) = self.notebook_index {
-            let content_start_cell = index.cell(content_start_index.get()).unwrap_or_default();
+            let content_start_cell = index.cell(content_start_index).unwrap_or(OneIndexed::MIN);
             while start_index < content_start_index {
-                if index.cell(start_index.get()).unwrap_or_default() == content_start_cell {
+                if index.cell(start_index).unwrap_or(OneIndexed::MIN) == content_start_cell {
                     break;
                 }
                 start_index = start_index.saturating_add(1);
@@ -228,9 +225,9 @@ impl Display for MessageCodeFrame<'_> {
         // If we're working with a Jupyter Notebook, skip the lines which are
         // outside of the cell containing the diagnostic.
         if let Some(index) = self.notebook_index {
-            let content_end_cell = index.cell(content_end_index.get()).unwrap_or_default();
+            let content_end_cell = index.cell(content_end_index).unwrap_or(OneIndexed::MIN);
             while end_index > content_end_index {
-                if index.cell(end_index.get()).unwrap_or_default() == content_end_cell {
+                if index.cell(end_index).unwrap_or(OneIndexed::MIN) == content_end_cell {
                     break;
                 }
                 end_index = end_index.saturating_sub(1);
@@ -270,8 +267,9 @@ impl Display for MessageCodeFrame<'_> {
                     || start_index.get(),
                     |notebook_index| {
                         notebook_index
-                            .cell_row(start_index.get())
-                            .unwrap_or_default() as usize
+                            .cell_row(start_index)
+                            .unwrap_or(OneIndexed::MIN)
+                            .get()
                     },
                 ),
                 annotations: vec![SourceAnnotation {

--- a/crates/ruff_notebook/Cargo.toml
+++ b/crates/ruff_notebook/Cargo.toml
@@ -14,7 +14,7 @@ license = { workspace = true }
 
 [dependencies]
 ruff_diagnostics = { path = "../ruff_diagnostics" }
-ruff_source_file = { path = "../ruff_source_file" }
+ruff_source_file = { path = "../ruff_source_file", features = ["serde"] }
 ruff_text_size = { path = "../ruff_text_size" }
 
 anyhow = { workspace = true }

--- a/crates/ruff_notebook/src/index.rs
+++ b/crates/ruff_notebook/src/index.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use ruff_source_file::OneIndexed;
+
 /// Jupyter Notebook indexing table
 ///
 /// When we lint a jupyter notebook, we have to translate the row/column based on
@@ -7,20 +9,20 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct NotebookIndex {
     /// Enter a row (1-based), get back the cell (1-based)
-    pub(super) row_to_cell: Vec<u32>,
+    pub(super) row_to_cell: Vec<OneIndexed>,
     /// Enter a row (1-based), get back the row in cell (1-based)
-    pub(super) row_to_row_in_cell: Vec<u32>,
+    pub(super) row_to_row_in_cell: Vec<OneIndexed>,
 }
 
 impl NotebookIndex {
     /// Returns the cell number (1-based) for the given row (1-based).
-    pub fn cell(&self, row: usize) -> Option<u32> {
-        self.row_to_cell.get(row).copied()
+    pub fn cell(&self, row: OneIndexed) -> Option<OneIndexed> {
+        self.row_to_cell.get(row.to_zero_indexed()).copied()
     }
 
     /// Returns the row number (1-based) in the cell (1-based) for the
     /// given row (1-based).
-    pub fn cell_row(&self, row: usize) -> Option<u32> {
-        self.row_to_row_in_cell.get(row).copied()
+    pub fn cell_row(&self, row: OneIndexed) -> Option<OneIndexed> {
+        self.row_to_row_in_cell.get(row.to_zero_indexed()).copied()
     }
 }


### PR DESCRIPTION
## Summary

This PR refactors the `NotebookIndex` struct to use `OneIndexed` to make the
intent of the code clearer.

## Test Plan

Update the existing test case and run `cargo test` to verify the change.

- [x] Verify `--diff` output
- [x] Verify the diagnostics output
- [x] Verify `--show-source` output
