### PR TITLE
Fix handling of `Applicability::Display` fixes when generating summary messages

### DIFF
--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -128,11 +128,13 @@ impl Printer {
                     let fix_prefix = format!("[{}]", "*".cyan());
 
                     if self.unsafe_fixes.is_enabled() {
-                        writeln!(
-                            writer,
-                            "{fix_prefix} {} fixable with the --fix option.",
-                            fixables.applicable
-                        )?;
+                        if fixables.applicable > 0 {
+                            writeln!(
+                                writer,
+                                "{fix_prefix} {} fixable with the --fix option.",
+                                fixables.applicable
+                            )?;
+                        }
                     } else {
                         if fixables.applicable > 0 && fixables.unapplicable > 0 {
                             let es = if fixables.unapplicable == 1 { "" } else { "es" };

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -136,11 +136,15 @@ impl Printer {
                             )?;
                         }
                     } else {
-                        if fixables.applicable > 0 && fixables.unapplicable > 0 {
-                            let es = if fixables.unapplicable == 1 { "" } else { "es" };
+                        if fixables.applicable > 0 && fixables.unapplicable_unsafe > 0 {
+                            let es = if fixables.unapplicable_unsafe == 1 {
+                                ""
+                            } else {
+                                "es"
+                            };
                             writeln!(writer,
                                 "{fix_prefix} {} fixable with the `--fix` option ({} hidden fix{es} can be enabled with the `--unsafe-fixes` option).",
-                                fixables.applicable, fixables.unapplicable
+                                fixables.applicable, fixables.unapplicable_unsafe
                             )?;
                         } else if fixables.applicable > 0 {
                             // Only applicable fixes
@@ -151,10 +155,14 @@ impl Printer {
                             )?;
                         } else {
                             // Only unapplicable fixes
-                            let es = if fixables.unapplicable == 1 { "" } else { "es" };
+                            let es = if fixables.unapplicable_unsafe == 1 {
+                                ""
+                            } else {
+                                "es"
+                            };
                             writeln!(writer,
                                 "{} hidden fix{es} can be enabled with the `--unsafe-fixes` option.",
-                                fixables.unapplicable
+                                fixables.unapplicable_unsafe
                             )?;
                         }
                     }
@@ -163,7 +171,7 @@ impl Printer {
                 // Check if there are unapplied fixes
                 let unapplied = {
                     if let Some(fixables) = fixables {
-                        fixables.unapplicable
+                        fixables.unapplicable_unsafe
                     } else {
                         0
                     }
@@ -499,30 +507,33 @@ fn print_fix_summary(writer: &mut dyn Write, fixed: &FxHashMap<String, FixTable>
 #[derive(Debug)]
 struct FixableStatistics {
     applicable: u32,
-    unapplicable: u32,
+    unapplicable_unsafe: u32,
 }
 
 impl FixableStatistics {
     fn try_from(diagnostics: &Diagnostics, unsafe_fixes: UnsafeFixes) -> Option<Self> {
         let mut applicable = 0;
-        let mut unapplicable = 0;
+        let mut unapplicable_unsafe = 0;
 
         for message in &diagnostics.messages {
             if let Some(fix) = &message.fix {
                 if fix.applies(unsafe_fixes.required_applicability()) {
                     applicable += 1;
                 } else {
-                    unapplicable += 1;
+                    // Do not include unapplicable fixes at other levels that do not provide an opt-in
+                    if fix.applicability().is_unsafe() {
+                        unapplicable_unsafe += 1;
+                    }
                 }
             }
         }
 
-        if applicable == 0 && unapplicable == 0 {
+        if applicable == 0 && unapplicable_unsafe == 0 {
             None
         } else {
             Some(Self {
                 applicable,
-                unapplicable,
+                unapplicable_unsafe,
             })
         }
     }

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -986,7 +986,7 @@ fn fix_applies_safe_fixes_by_default() {
                 "--output-format",
                 "text",
                 "--isolated",
-                "--no-cache", 
+                "--no-cache",
                 "--select",
                 "F601,UP034",
                 "--fix",
@@ -1015,7 +1015,7 @@ fn fix_applies_unsafe_fixes_with_opt_in() {
                 "--output-format",
                 "text",
                 "--isolated",
-                "--no-cache", 
+                "--no-cache",
                 "--select",
                 "F601,UP034",
                 "--fix",
@@ -1035,6 +1035,59 @@ fn fix_applies_unsafe_fixes_with_opt_in() {
 }
 
 #[test]
+fn fix_does_not_apply_display_only_fixes() {
+    assert_cmd_snapshot!(
+        Command::new(get_cargo_bin(BIN_NAME))
+            .args([
+                "-",
+                "--output-format",
+                "text",
+                "--isolated",
+                "--no-cache",
+                "--select",
+                "B006",
+                "--fix",
+            ])
+            .pass_stdin("def add_to_list(item, some_list=[]): ..."),
+            @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    def add_to_list(item, some_list=[]): ...
+    ----- stderr -----
+    -:1:33: B006 Do not use mutable data structures for argument defaults
+    Found 1 error.
+    "###);
+}
+
+#[test]
+fn fix_does_not_apply_display_only_fixes_with_unsafe_fixes_enabled() {
+    assert_cmd_snapshot!(
+        Command::new(get_cargo_bin(BIN_NAME))
+            .args([
+                "-",
+                "--output-format",
+                "text",
+                "--isolated",
+                "--no-cache",
+                "--select",
+                "B006",
+                "--fix",
+                "--unsafe-fixes",
+            ])
+            .pass_stdin("def add_to_list(item, some_list=[]): ..."),
+            @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    def add_to_list(item, some_list=[]): ...
+    ----- stderr -----
+    -:1:33: B006 Do not use mutable data structures for argument defaults
+    Found 1 error.
+    "###);
+}
+
+#[test]
 fn fix_only_unsafe_fixes_available() {
     assert_cmd_snapshot!(
         Command::new(get_cargo_bin(BIN_NAME))
@@ -1043,7 +1096,7 @@ fn fix_only_unsafe_fixes_available() {
                 "--output-format",
                 "text",
                 "--isolated",
-                "--no-cache", 
+                "--no-cache",
                 "--select",
                 "F601",
                 "--fix",
@@ -1072,7 +1125,7 @@ fn fix_only_flag_applies_safe_fixes_by_default() {
                 "--output-format",
                 "text",
                 "--isolated",
-                "--no-cache", 
+                "--no-cache",
                 "--select",
                 "F601,UP034",
                 "--fix-only",
@@ -1099,7 +1152,7 @@ fn fix_only_flag_applies_unsafe_fixes_with_opt_in() {
                 "--output-format",
                 "text",
                 "--isolated",
-                "--no-cache", 
+                "--no-cache",
                 "--select",
                 "F601,UP034",
                 "--fix-only",
@@ -1180,6 +1233,31 @@ fn diff_shows_unsafe_fixes_with_opt_in() {
     Would fix 2 errors.
     "###
     );
+}
+
+#[test]
+fn diff_does_not_show_display_only_fixes_with_unsafe_fixes_enabled() {
+    assert_cmd_snapshot!(
+        Command::new(get_cargo_bin(BIN_NAME))
+            .args([
+                "-",
+                "--output-format",
+                "text",
+                "--isolated",
+                "--no-cache",
+                "--select",
+                "B006",
+                "--diff",
+                "--unsafe-fixes",
+            ])
+            .pass_stdin("def add_to_list(item, some_list=[]): ..."),
+            @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    "###);
 }
 
 #[test]


### PR DESCRIPTION
We were including `Display` fixes in the summary counts for unapplicable fixes resulting in incorrect prompts to the user that a fix could be enabled.

## Example

```python
def add_to_list(item, some_list=[]):
    ...
```

Before

```
❯ ruff check example.py --no-cache --select B
example.py:1:33: B006 Do not use mutable data structures for argument defaults
Found 1 error.
1 hidden fix can be enabled with the `--unsafe-fixes` option.
❯ ruff check example.py --no-cache --select B --unsafe-fixes
example.py:1:33: B006 Do not use mutable data structures for argument defaults
Found 1 error.
[*] 0 fixable with the --fix option.
❯ ruff check example.py --no-cache --select B --unsafe-fixes --diff
No errors would be fixed (1 fix available with `--unsafe-fixes`).
❯ ruff check example.py --no-cache --select B --unsafe-fixes --fix
example.py:1:33: B006 Do not use mutable data structures for argument defaults
Found 1 error.
[*] 0 fixable with the --fix option.
```

After

```
❯ ruff check example.py --no-cache --select B --unsafe-fixes
example.py:1:33: B006 Do not use mutable data structures for argument defaults
Found 1 error.
❯ ruff check example.py --no-cache --select B
example.py:1:33: B006 Do not use mutable data structures for argument defaults
Found 1 error.
❯ ruff check example.py --no-cache --select B --unsafe-fixes --diff
❯ ruff check example.py --no-cache --select B --unsafe-fixes --fix
example.py:1:33: B006 Do not use mutable data structures for argument defaults
Found 1 error.
```