### PR TITLE
Fix false positive in `PLR6301`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/no_self_use.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/no_self_use.py
@@ -1,5 +1,7 @@
 import abc
 
+from typing_extensions import override
+
 
 class Person:
     def developer_greeting(self, name):  # [no-self-use]
@@ -60,3 +62,24 @@ class Prop:
     @property
     def count(self):
         return 24
+
+
+class A:
+    def foo(self):
+        ...
+
+
+class B(A):
+    @override
+    def foo(self):
+        ...
+
+    def foobar(self):
+        super()
+
+    def bar(self):
+        super().foo()
+
+    def baz(self):
+        if super().foo():
+            ...

--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
@@ -306,7 +306,7 @@ pub(crate) fn deferred_scopes(checker: &mut Checker) {
 
         if scope.kind.is_function() {
             if checker.enabled(Rule::NoSelfUse) {
-                pylint::rules::no_self_use(checker, scope, &mut diagnostics);
+                pylint::rules::no_self_use(checker, scope_id, scope, &mut diagnostics);
             }
         }
     }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR6301_no_self_use.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR6301_no_self_use.py.snap
@@ -1,39 +1,30 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-no_self_use.py:5:28: PLR6301 Method `developer_greeting` could be a function or static method
+no_self_use.py:7:28: PLR6301 Method `developer_greeting` could be a function or static method
   |
-4 | class Person:
-5 |     def developer_greeting(self, name):  # [no-self-use]
+6 | class Person:
+7 |     def developer_greeting(self, name):  # [no-self-use]
   |                            ^^^^ PLR6301
-6 |         print(f"Greetings {name}!")
+8 |         print(f"Greetings {name}!")
   |
 
-no_self_use.py:8:20: PLR6301 Method `greeting_1` could be a function or static method
-  |
-6 |         print(f"Greetings {name}!")
-7 | 
-8 |     def greeting_1(self):  # [no-self-use]
-  |                    ^^^^ PLR6301
-9 |         print("Hello!")
-  |
-
-no_self_use.py:11:20: PLR6301 Method `greeting_2` could be a function or static method
+no_self_use.py:10:20: PLR6301 Method `greeting_1` could be a function or static method
    |
- 9 |         print("Hello!")
-10 | 
-11 |     def greeting_2(self):  # [no-self-use]
+ 8 |         print(f"Greetings {name}!")
+ 9 | 
+10 |     def greeting_1(self):  # [no-self-use]
    |                    ^^^^ PLR6301
-12 |         print("Hi!")
+11 |         print("Hello!")
    |
 
-no_self_use.py:55:25: PLR6301 Method `abstract_method` could be a function or static method
+no_self_use.py:13:20: PLR6301 Method `greeting_2` could be a function or static method
    |
-53 | class Sub(Base):
-54 |     @override
-55 |     def abstract_method(self):
-   |                         ^^^^ PLR6301
-56 |         print("concrete method")
+11 |         print("Hello!")
+12 | 
+13 |     def greeting_2(self):  # [no-self-use]
+   |                    ^^^^ PLR6301
+14 |         print("Hi!")
    |
 
 


### PR DESCRIPTION
## Summary

Don't report a diagnostic if the method contains a `super()` call.

Closes #6961

## Test Plan

`cargo test`
