### PR TITLE
Remove empty line before raw dostrings

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/class_definition.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/class_definition.py
@@ -102,6 +102,11 @@ class Test:
     x = 1
 
 
+class EmptyLineBeforeRawDocstring:
+
+    r"""Character and line based layer over a BufferedIOBase object, buffer."""
+
+
 class C(): # comment
     pass
 

--- a/crates/ruff_python_formatter/src/expression/string.rs
+++ b/crates/ruff_python_formatter/src/expression/string.rs
@@ -496,7 +496,7 @@ impl Format<PyFormatContext<'_>> for NormalizedString<'_> {
 
 bitflags! {
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-    pub(super) struct StringPrefix: u8 {
+    pub(crate) struct StringPrefix: u8 {
         const UNICODE   = 0b0000_0001;
         /// `r"test"`
         const RAW       = 0b0000_0010;
@@ -508,7 +508,7 @@ bitflags! {
 }
 
 impl StringPrefix {
-    pub(super) fn parse(input: &str) -> StringPrefix {
+    pub(crate) fn parse(input: &str) -> StringPrefix {
         let chars = input.chars();
         let mut prefix = StringPrefix::empty();
 
@@ -533,15 +533,15 @@ impl StringPrefix {
         prefix
     }
 
-    pub(super) const fn text_len(self) -> TextSize {
+    pub(crate) const fn text_len(self) -> TextSize {
         TextSize::new(self.bits().count_ones())
     }
 
-    pub(super) const fn is_raw_string(self) -> bool {
+    pub(crate) const fn is_raw_string(self) -> bool {
         self.contains(StringPrefix::RAW) || self.contains(StringPrefix::RAW_UPPER)
     }
 
-    pub(super) const fn is_fstring(self) -> bool {
+    pub(crate) const fn is_fstring(self) -> bool {
         self.contains(StringPrefix::F_STRING)
     }
 }

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__class_definition.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__class_definition.py.snap
@@ -108,6 +108,10 @@ class Test:
     x = 1
 
 
+class EmptyLineBeforeRawDocstring:
+
+    r"""Character and line based layer over a BufferedIOBase object, buffer."""
+
 class C(): # comment
     pass
 
@@ -354,6 +358,10 @@ class Test:
 
     # comment
     x = 1
+
+
+class EmptyLineBeforeRawDocstring:
+    r"""Character and line based layer over a BufferedIOBase object, buffer."""
 
 
 class C:  # comment

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__class_definition.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__class_definition.py.snap
@@ -112,6 +112,7 @@ class EmptyLineBeforeRawDocstring:
 
     r"""Character and line based layer over a BufferedIOBase object, buffer."""
 
+
 class C(): # comment
     pass
 


### PR DESCRIPTION
**Summary** This fixes a deviation with black where black would remove empty lines before raw docstrings for some reason.

