### PR TITLE
Resolve `cache-dir` relative to project root

### DIFF
--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -377,7 +377,7 @@ impl Configuration {
                 .cache_dir
                 .map(|dir| {
                     let dir = shellexpand::full(&dir);
-                    dir.map(|dir| PathBuf::from(dir.as_ref()))
+                    dir.map(|dir| fs::normalize_path_to(dir.as_ref(), project_root))
                 })
                 .transpose()
                 .map_err(|e| anyhow!("Invalid `cache-dir` value: {e}"))?,


### PR DESCRIPTION
## Summary

Unlike other filepath-based settings, the `cache-dir` wasn't being resolved relative to the project root, when specified as an absolute path.

Closes https://github.com/astral-sh/ruff/issues/7958.
