### PR TITLE
Remove support for providing output format via `format` option

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -4,10 +4,10 @@
 
 ### The format option cannot be used to configure the output format
 
-Ruff previously used the `format` setting, `--format` CLI option, and `RUFF_FORMAT` environment variable to 
+Ruff previously used the `format` setting, `--format` CLI option, and `RUFF_FORMAT` environment variable to
 configure the output format of the CLI. This usage was deprecated in `v0.0.291` — the `format` setting is now used
-to control Ruff's code formatting. Now, the `--format` CLI option has been removed and the `format` setting and 
-may no longer be used to set the output format. Use the `output-format` setting, the `--output-format` CLI option, 
+to control Ruff's code formatting. Now, the `--format` CLI option has been removed and the `format` setting and
+may no longer be used to set the output format. Use the `output-format` setting, the `--output-format` CLI option,
 or the `RUFF_OUTPUT_FORMAT` environment variable instead.
 
 ### Unsafe fixes are not applied by default ([#7769](https://github.com/astral-sh/ruff/pull/7769))

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -2,13 +2,15 @@
 
 ## 0.1.0
 
-### The format option cannot be used to configure the output format
+### The deprecated `format` setting has been removed
 
 Ruff previously used the `format` setting, `--format` CLI option, and `RUFF_FORMAT` environment variable to
 configure the output format of the CLI. This usage was deprecated in `v0.0.291` — the `format` setting is now used
-to control Ruff's code formatting. Now, the `--format` CLI option has been removed and the `format` setting and
-may no longer be used to set the output format. Use the `output-format` setting, the `--output-format` CLI option,
-or the `RUFF_OUTPUT_FORMAT` environment variable instead.
+to control Ruff's code formatting. As of this release:
+
+- The `format` setting cannot be used to configure the output format, use `output-format` instead
+- The `RUFF_FORMAT` environment variable is ignored, use `RUFF_OUTPUT_FORMAT` instead
+- The `--format` option has been removed from `ruff check`, use `--output-format` instead
 
 ### Unsafe fixes are not applied by default ([#7769](https://github.com/astral-sh/ruff/pull/7769))
 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -2,6 +2,14 @@
 
 ## 0.1.0
 
+### The format option cannot be used to configure the output format
+
+Ruff previously used the `format` setting, `--format` CLI option, and `RUFF_FORMAT` environment variable to 
+configure the output format of the CLI. This usage was deprecated in `v0.0.291` — the `format` setting is now used
+to control Ruff's code formatting. Now, the `--format` CLI option has been removed and the `format` setting and 
+may no longer be used to set the output format. Use the `output-format` setting, the `--output-format` CLI option, 
+or the `RUFF_OUTPUT_FORMAT` environment variable instead.
+
 ### Unsafe fixes are not applied by default ([#7769](https://github.com/astral-sh/ruff/pull/7769))
 
 Ruff labels fixes as "safe" and "unsafe". The meaning and intent of your code will be retained when applying safe

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -117,16 +117,6 @@ pub struct CheckCommand {
     #[arg(long)]
     ignore_noqa: bool,
 
-    /// Output serialization format for violations. (Deprecated: Use `--output-format` instead).
-    #[arg(
-        long,
-        value_enum,
-        env = "RUFF_FORMAT",
-        conflicts_with = "output_format",
-        hide = true
-    )]
-    pub format: Option<SerializationFormat>,
-
     /// Output serialization format for violations.
     #[arg(long, value_enum, env = "RUFF_OUTPUT_FORMAT")]
     pub output_format: Option<SerializationFormat>,
@@ -507,7 +497,7 @@ impl CheckCommand {
                 unsafe_fixes: resolve_bool_arg(self.unsafe_fixes, self.no_unsafe_fixes)
                     .map(UnsafeFixes::from),
                 force_exclude: resolve_bool_arg(self.force_exclude, self.no_force_exclude),
-                output_format: self.output_format.or(self.format),
+                output_format: self.output_format,
                 show_fixes: resolve_bool_arg(self.show_fixes, self.no_show_fixes),
             },
         )

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -177,14 +177,6 @@ fn format(args: FormatCommand, log_level: LogLevel) -> Result<ExitStatus> {
 }
 
 pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
-    if args.format.is_some() {
-        if std::env::var("RUFF_FORMAT").is_ok() {
-            warn_user!("The environment variable `RUFF_FORMAT` is deprecated. Use `RUFF_OUTPUT_FORMAT` instead.");
-        } else {
-            warn_user!("The argument `--format=<FORMAT>` is deprecated. Use `--output-format=<FORMAT>` instead.");
-        }
-    }
-
     let (cli, overrides) = args.partition();
 
     // Construct the "default" settings. These are used when no `pyproject.toml`

--- a/crates/ruff_cli/tests/format.rs
+++ b/crates/ruff_cli/tests/format.rs
@@ -157,7 +157,7 @@ format = "json"
     )?;
 
     insta::with_settings!({filters => vec![
-        (&*regex::escape(tempdir.path().to_str().unwrap()), "[TMPDIR]"),
+        (&*regex::escape(ruff_toml.to_str().unwrap()), "[RUFF-TOML-PATH]"),
     ]}, {
         assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .args(["check", "--select", "F401", "--no-cache", "--config"])
@@ -172,7 +172,7 @@ format = "json"
 
         ----- stderr -----
         ruff failed
-          Cause: Failed to parse `[TMPDIR]/ruff.toml`: TOML parse error at line 2, column 10
+          Cause: Failed to parse `[RUFF-TOML-PATH]`: TOML parse error at line 2, column 10
           |
         2 | format = "json"
           |          ^^^^^^

--- a/crates/ruff_cli/tests/format.rs
+++ b/crates/ruff_cli/tests/format.rs
@@ -144,7 +144,7 @@ if condition:
     Ok(())
 }
 
-/// Tests that the legacy `format` option continues to work but emits a warning.
+/// Since 0.1.0 the legacy format option is no longer supported
 #[test]
 fn legacy_format_option() -> Result<()> {
     let tempdir = TempDir::new()?;
@@ -164,45 +164,17 @@ format = "json"
 import os
 "#), @r###"
     success: false
-    exit_code: 1
+    exit_code: 2
     ----- stdout -----
-    [
-      {
-        "cell": null,
-        "code": "F401",
-        "end_location": {
-          "column": 10,
-          "row": 2
-        },
-        "filename": "-",
-        "fix": {
-          "applicability": "safe",
-          "edits": [
-            {
-              "content": "",
-              "end_location": {
-                "column": 1,
-                "row": 3
-              },
-              "location": {
-                "column": 1,
-                "row": 2
-              }
-            }
-          ],
-          "message": "Remove unused import: `os`"
-        },
-        "location": {
-          "column": 8,
-          "row": 2
-        },
-        "message": "`os` imported but unused",
-        "noqa_row": 2,
-        "url": "https://docs.astral.sh/ruff/rules/unused-import"
-      }
-    ]
+
     ----- stderr -----
-    warning: The option `format` has been deprecated to avoid ambiguity with Ruff's upcoming formatter. Use `output-format` instead.
+    ruff failed
+      Cause: Failed to parse `/var/folders/bc/qlsk3t6x7c9fhhbvvcg68k9c0000gp/T/.tmpTaP0Od/ruff.toml`: TOML parse error at line 2, column 10
+      |
+    2 | format = "json"
+      |          ^^^^^^
+    invalid type: string "json", expected struct FormatOptions
+
     "###);
     Ok(())
 }

--- a/crates/ruff_cli/tests/format.rs
+++ b/crates/ruff_cli/tests/format.rs
@@ -156,25 +156,29 @@ format = "json"
 "#,
     )?;
 
-    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-        .args(["check", "--select", "F401", "--no-cache", "--config"])
-        .arg(&ruff_toml)
-        .arg("-")
-        .pass_stdin(r#"
-import os
-"#), @r###"
-    success: false
-    exit_code: 2
-    ----- stdout -----
+    insta::with_settings!({filters => vec![
+        (&*regex::escape(tempdir.path().to_str().unwrap()), "[TMPDIR]"),
+    ]}, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .args(["check", "--select", "F401", "--no-cache", "--config"])
+            .arg(&ruff_toml)
+            .arg("-")
+            .pass_stdin(r#"
+    import os
+    "#), @r###"
+        success: false
+        exit_code: 2
+        ----- stdout -----
 
-    ----- stderr -----
-    ruff failed
-      Cause: Failed to parse `/var/folders/bc/qlsk3t6x7c9fhhbvvcg68k9c0000gp/T/.tmpTaP0Od/ruff.toml`: TOML parse error at line 2, column 10
-      |
-    2 | format = "json"
-      |          ^^^^^^
-    invalid type: string "json", expected struct FormatOptions
+        ----- stderr -----
+        ruff failed
+          Cause: Failed to parse `[TMPDIR]/ruff.toml`: TOML parse error at line 2, column 10
+          |
+        2 | format = "json"
+          |          ^^^^^^
+        invalid type: string "json", expected struct FormatOptions
 
-    "###);
+        "###);
+    });
     Ok(())
 }

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -22,7 +22,7 @@ use ruff_python_trivia::CommentRanges;
 use ruff_source_file::{Locator, SourceLocation};
 use ruff_text_size::Ranged;
 use ruff_workspace::configuration::Configuration;
-use ruff_workspace::options::{FormatOptions, FormatOrOutputFormat, LintOptions, Options};
+use ruff_workspace::options::{FormatOptions, LintOptions, Options};
 use ruff_workspace::Settings;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -140,11 +140,11 @@ impl Workspace {
 
                 ..LintOptions::default()
             }),
-            format: Some(FormatOrOutputFormat::Format(FormatOptions {
+            format: Some(FormatOptions {
                 indent_style: Some(IndentStyle::Space),
                 quote_style: Some(QuoteStyle::Double),
                 ..FormatOptions::default()
-            })),
+            }),
             ..Options::default()
         })
         .map_err(into_error)

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -39,9 +39,9 @@ use crate::options::{
     Flake8ComprehensionsOptions, Flake8CopyrightOptions, Flake8ErrMsgOptions, Flake8GetTextOptions,
     Flake8ImplicitStrConcatOptions, Flake8ImportConventionsOptions, Flake8PytestStyleOptions,
     Flake8QuotesOptions, Flake8SelfOptions, Flake8TidyImportsOptions, Flake8TypeCheckingOptions,
-    Flake8UnusedArgumentsOptions, FormatOptions, FormatOrOutputFormat, IsortOptions, LintOptions,
-    McCabeOptions, Options, Pep8NamingOptions, PyUpgradeOptions, PycodestyleOptions,
-    PydocstyleOptions, PyflakesOptions, PylintOptions,
+    Flake8UnusedArgumentsOptions, FormatOptions, IsortOptions, LintOptions, McCabeOptions, Options,
+    Pep8NamingOptions, PyUpgradeOptions, PycodestyleOptions, PydocstyleOptions, PyflakesOptions,
+    PylintOptions,
 };
 use crate::settings::{
     FileResolverSettings, FormatterSettings, LineEnding, Settings, EXCLUDE, INCLUDE,
@@ -435,12 +435,7 @@ impl Configuration {
             fix: options.fix,
             fix_only: options.fix_only,
             unsafe_fixes: options.unsafe_fixes.map(UnsafeFixes::from),
-            output_format: options.output_format.or_else(|| {
-                options
-                    .format
-                    .as_ref()
-                    .and_then(FormatOrOutputFormat::as_output_format)
-            }),
+            output_format: options.output_format,
             force_exclude: options.force_exclude,
             line_length: options.line_length,
             tab_size: options.tab_size,
@@ -460,11 +455,7 @@ impl Configuration {
             target_version: options.target_version,
 
             lint: LintConfiguration::from_options(lint, project_root)?,
-            format: if let Some(FormatOrOutputFormat::Format(format)) = options.format {
-                FormatConfiguration::from_options(format)?
-            } else {
-                FormatConfiguration::default()
-            },
+            format: FormatConfiguration::from_options(options.format.unwrap_or_default())?,
         })
     }
 

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -29,7 +29,6 @@ use ruff_linter::{warn_user_once, RuleSelector};
 use ruff_macros::{CombineOptions, OptionsMetadata};
 use ruff_python_formatter::QuoteStyle;
 
-use crate::options_base::{OptionsMetadata, Visit};
 use crate::settings::LineEnding;
 
 #[derive(Debug, PartialEq, Eq, Default, OptionsMetadata, Serialize, Deserialize)]
@@ -380,19 +379,9 @@ pub struct Options {
     #[serde(flatten)]
     pub lint_top_level: LintOptions,
 
-    /// Options to configure the code formatting.
-    ///
-    /// Previously:
-    /// The style in which violation messages should be formatted: `"text"`
-    /// (default), `"grouped"` (group messages by file), `"json"`
-    /// (machine-readable), `"junit"` (machine-readable XML), `"github"` (GitHub
-    /// Actions annotations), `"gitlab"` (GitLab CI code quality report),
-    /// `"pylint"` (Pylint text format) or `"azure"` (Azure Pipeline logging commands).
-    ///
-    /// This option has been **deprecated** in favor of `output-format`
-    /// to avoid ambiguity with Ruff's upcoming formatter.
+    /// Options to configure code formatting.
     #[option_group]
-    pub format: Option<FormatOrOutputFormat>,
+    pub format: Option<FormatOptions>,
 }
 
 /// Experimental section to configure Ruff's linting. This new section will eventually
@@ -2465,38 +2454,11 @@ impl PyUpgradeOptions {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub enum FormatOrOutputFormat {
-    Format(FormatOptions),
-    OutputFormat(SerializationFormat),
-}
-
-impl FormatOrOutputFormat {
-    pub const fn as_output_format(&self) -> Option<SerializationFormat> {
-        match self {
-            FormatOrOutputFormat::Format(_) => None,
-            FormatOrOutputFormat::OutputFormat(format) => Some(*format),
-        }
-    }
-}
-
-impl OptionsMetadata for FormatOrOutputFormat {
-    fn record(visit: &mut dyn Visit) {
-        FormatOptions::record(visit);
-    }
-
-    fn documentation() -> Option<&'static str> {
-        FormatOptions::documentation()
-    }
-}
-
 /// Experimental: Configures how `ruff format` formats your code.
 ///
 /// Please provide feedback in [this discussion](https://github.com/astral-sh/ruff/discussions/7310).
 #[derive(
-    Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
+    Debug, PartialEq, Eq, Default, Deserialize, Serialize, OptionsMetadata, CombineOptions,
 )]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -13,8 +13,8 @@ use log::debug;
 use path_absolutize::path_dedot;
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use ruff_linter::fs;
 use ruff_linter::packaging::is_package;
-use ruff_linter::{fs};
 
 use crate::configuration::Configuration;
 use crate::pyproject;

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -14,10 +14,9 @@ use path_absolutize::path_dedot;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use ruff_linter::packaging::is_package;
-use ruff_linter::{fs, warn_user_once};
+use ruff_linter::{fs};
 
 use crate::configuration::Configuration;
-use crate::options::FormatOrOutputFormat;
 use crate::pyproject;
 use crate::pyproject::settings_toml;
 use crate::settings::Settings;
@@ -220,10 +219,6 @@ fn resolve_configuration(
         // Resolve the current path.
         let options = pyproject::load_options(&path)
             .map_err(|err| anyhow!("Failed to parse `{}`: {}", path.display(), err))?;
-
-        if matches!(options.format, Some(FormatOrOutputFormat::OutputFormat(_))) {
-            warn_user_once!("The option `format` has been deprecated to avoid ambiguity with Ruff's upcoming formatter. Use `output-format` instead.");
-        }
 
         let project_root = relativity.resolve(&path);
         let configuration = Configuration::from_options(options, &project_root)?;

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -355,10 +355,10 @@
       ]
     },
     "format": {
-      "description": "Options to configure the code formatting.\n\nPreviously: The style in which violation messages should be formatted: `\"text\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report), `\"pylint\"` (Pylint text format) or `\"azure\"` (Azure Pipeline logging commands).\n\nThis option has been **deprecated** in favor of `output-format` to avoid ambiguity with Ruff's upcoming formatter.",
+      "description": "Options to configure code formatting.",
       "anyOf": [
         {
-          "$ref": "#/definitions/FormatOrOutputFormat"
+          "$ref": "#/definitions/FormatOptions"
         },
         {
           "type": "null"
@@ -1258,16 +1258,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "FormatOrOutputFormat": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/FormatOptions"
-        },
-        {
-          "$ref": "#/definitions/SerializationFormat"
-        }
-      ]
     },
     "ImportSection": {
       "anyOf": [


### PR DESCRIPTION
See the provided breaking changes note for details.

Removes support for the deprecated `--format`option in the `ruff check` CLI, `format` inference as `output-format` in the configuration file, and the `RUFF_FORMAT` environment variable.

The error message for use of `format` in the configuration file could be better, but would require some awkward serde wrappers and it seems hard to present the correct schema to the user still.

