### PR TITLE
[docs] Clarify that new rules should be added to `RuleGroup::Preview`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,8 @@ At a high level, the steps involved in adding a new lint rule are as follows:
     statements, like imports) or `analyze/expression.rs` (if your rule is based on analyzing
     expressions, like function calls).
 
-1. Map the violation struct to a rule code in `crates/ruff_linter/src/codes.rs` (e.g., `B011`).
+1. Map the violation struct to a rule code in `crates/ruff_linter/src/codes.rs` (e.g., `B011`). New rules
+    should be added in `RuleGroup::Preview`.
 
 1. Add proper [testing](#rule-testing-fixtures-and-snapshots) for your rule.
 


### PR DESCRIPTION
In the contributing page, clarify that new rules must be added to `RuleGroup::Preview` when mapping their code.