### PR TITLE
Add `[format|lint].exclude` options

### DIFF
--- a/crates/flake8_to_ruff/src/converter.rs
+++ b/crates/flake8_to_ruff/src/converter.rs
@@ -17,8 +17,8 @@ use ruff_linter::settings::DEFAULT_SELECTORS;
 use ruff_linter::warn_user;
 use ruff_workspace::options::{
     Flake8AnnotationsOptions, Flake8BugbearOptions, Flake8BuiltinsOptions, Flake8ErrMsgOptions,
-    Flake8PytestStyleOptions, Flake8QuotesOptions, Flake8TidyImportsOptions, LintOptions,
-    McCabeOptions, Options, Pep8NamingOptions, PydocstyleOptions,
+    Flake8PytestStyleOptions, Flake8QuotesOptions, Flake8TidyImportsOptions, LintCommonOptions,
+    LintOptions, McCabeOptions, Options, Pep8NamingOptions, PydocstyleOptions,
 };
 use ruff_workspace::pyproject::Pyproject;
 
@@ -99,7 +99,7 @@ pub(crate) fn convert(
 
     // Parse each supported option.
     let mut options = Options::default();
-    let mut lint_options = LintOptions::default();
+    let mut lint_options = LintCommonOptions::default();
     let mut flake8_annotations = Flake8AnnotationsOptions::default();
     let mut flake8_bugbear = Flake8BugbearOptions::default();
     let mut flake8_builtins = Flake8BuiltinsOptions::default();
@@ -433,8 +433,11 @@ pub(crate) fn convert(
         }
     }
 
-    if lint_options != LintOptions::default() {
-        options.lint = Some(lint_options);
+    if lint_options != LintCommonOptions::default() {
+        options.lint = Some(LintOptions {
+            common: lint_options,
+            ..LintOptions::default()
+        });
     }
 
     // Create the pyproject.toml.
@@ -465,7 +468,9 @@ mod tests {
     use ruff_linter::rules::flake8_quotes;
     use ruff_linter::rules::pydocstyle::settings::Convention;
     use ruff_linter::settings::types::PythonVersion;
-    use ruff_workspace::options::{Flake8QuotesOptions, LintOptions, Options, PydocstyleOptions};
+    use ruff_workspace::options::{
+        Flake8QuotesOptions, LintCommonOptions, LintOptions, Options, PydocstyleOptions,
+    };
     use ruff_workspace::pyproject::Pyproject;
 
     use crate::converter::DEFAULT_SELECTORS;
@@ -475,8 +480,8 @@ mod tests {
     use super::super::plugin::Plugin;
     use super::convert;
 
-    fn lint_default_options(plugins: impl IntoIterator<Item = RuleSelector>) -> LintOptions {
-        LintOptions {
+    fn lint_default_options(plugins: impl IntoIterator<Item = RuleSelector>) -> LintCommonOptions {
+        LintCommonOptions {
             ignore: Some(vec![]),
             select: Some(
                 DEFAULT_SELECTORS
@@ -486,7 +491,7 @@ mod tests {
                     .sorted_by_key(RuleSelector::prefix_and_code)
                     .collect(),
             ),
-            ..LintOptions::default()
+            ..LintCommonOptions::default()
         }
     }
 
@@ -498,7 +503,10 @@ mod tests {
             None,
         );
         let expected = Pyproject::new(Options {
-            lint: Some(lint_default_options([])),
+            lint: Some(LintOptions {
+                common: lint_default_options([]),
+                ..LintOptions::default()
+            }),
             ..Options::default()
         });
         assert_eq!(actual, expected);
@@ -516,7 +524,10 @@ mod tests {
         );
         let expected = Pyproject::new(Options {
             line_length: Some(LineLength::try_from(100).unwrap()),
-            lint: Some(lint_default_options([])),
+            lint: Some(LintOptions {
+                common: lint_default_options([]),
+                ..LintOptions::default()
+            }),
             ..Options::default()
         });
         assert_eq!(actual, expected);
@@ -534,7 +545,10 @@ mod tests {
         );
         let expected = Pyproject::new(Options {
             line_length: Some(LineLength::try_from(100).unwrap()),
-            lint: Some(lint_default_options([])),
+            lint: Some(LintOptions {
+                common: lint_default_options([]),
+                ..LintOptions::default()
+            }),
             ..Options::default()
         });
         assert_eq!(actual, expected);
@@ -551,7 +565,10 @@ mod tests {
             Some(vec![]),
         );
         let expected = Pyproject::new(Options {
-            lint: Some(lint_default_options([])),
+            lint: Some(LintOptions {
+                common: lint_default_options([]),
+                ..LintOptions::default()
+            }),
             ..Options::default()
         });
         assert_eq!(actual, expected);
@@ -569,13 +586,16 @@ mod tests {
         );
         let expected = Pyproject::new(Options {
             lint: Some(LintOptions {
-                flake8_quotes: Some(Flake8QuotesOptions {
-                    inline_quotes: Some(flake8_quotes::settings::Quote::Single),
-                    multiline_quotes: None,
-                    docstring_quotes: None,
-                    avoid_escape: None,
-                }),
-                ..lint_default_options([])
+                common: LintCommonOptions {
+                    flake8_quotes: Some(Flake8QuotesOptions {
+                        inline_quotes: Some(flake8_quotes::settings::Quote::Single),
+                        multiline_quotes: None,
+                        docstring_quotes: None,
+                        avoid_escape: None,
+                    }),
+                    ..lint_default_options([])
+                },
+                ..LintOptions::default()
             }),
             ..Options::default()
         });
@@ -597,12 +617,15 @@ mod tests {
         );
         let expected = Pyproject::new(Options {
             lint: Some(LintOptions {
-                pydocstyle: Some(PydocstyleOptions {
-                    convention: Some(Convention::Numpy),
-                    ignore_decorators: None,
-                    property_decorators: None,
-                }),
-                ..lint_default_options([Linter::Pydocstyle.into()])
+                common: LintCommonOptions {
+                    pydocstyle: Some(PydocstyleOptions {
+                        convention: Some(Convention::Numpy),
+                        ignore_decorators: None,
+                        property_decorators: None,
+                    }),
+                    ..lint_default_options([Linter::Pydocstyle.into()])
+                },
+                ..LintOptions::default()
             }),
             ..Options::default()
         });
@@ -621,13 +644,16 @@ mod tests {
         );
         let expected = Pyproject::new(Options {
             lint: Some(LintOptions {
-                flake8_quotes: Some(Flake8QuotesOptions {
-                    inline_quotes: Some(flake8_quotes::settings::Quote::Single),
-                    multiline_quotes: None,
-                    docstring_quotes: None,
-                    avoid_escape: None,
-                }),
-                ..lint_default_options([Linter::Flake8Quotes.into()])
+                common: LintCommonOptions {
+                    flake8_quotes: Some(Flake8QuotesOptions {
+                        inline_quotes: Some(flake8_quotes::settings::Quote::Single),
+                        multiline_quotes: None,
+                        docstring_quotes: None,
+                        avoid_escape: None,
+                    }),
+                    ..lint_default_options([Linter::Flake8Quotes.into()])
+                },
+                ..LintOptions::default()
             }),
             ..Options::default()
         });
@@ -648,7 +674,10 @@ mod tests {
         );
         let expected = Pyproject::new(Options {
             target_version: Some(PythonVersion::Py38),
-            lint: Some(lint_default_options([])),
+            lint: Some(LintOptions {
+                common: lint_default_options([]),
+                ..LintOptions::default()
+            }),
             ..Options::default()
         });
         assert_eq!(actual, expected);

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -366,6 +366,15 @@ pub struct FormatCommand {
     respect_gitignore: bool,
     #[clap(long, overrides_with("respect_gitignore"), hide = true)]
     no_respect_gitignore: bool,
+    /// List of paths, used to omit files and/or directories from analysis.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "FILE_PATTERN",
+        help_heading = "File selection"
+    )]
+    pub exclude: Option<Vec<FilePattern>>,
+
     /// Enforce exclusions, even for paths passed to Ruff directly on the command-line.
     /// Use `--no-force-exclude` to disable.
     #[arg(
@@ -522,6 +531,7 @@ impl FormatCommand {
                     self.respect_gitignore,
                     self.no_respect_gitignore,
                 ),
+                exclude: self.exclude,
                 preview: resolve_bool_arg(self.preview, self.no_preview).map(PreviewMode::from),
                 force_exclude: resolve_bool_arg(self.force_exclude, self.no_force_exclude),
                 // Unsupported on the formatter CLI, but required on `Overrides`.

--- a/crates/ruff_cli/src/commands/add_noqa.rs
+++ b/crates/ruff_cli/src/commands/add_noqa.rs
@@ -10,7 +10,7 @@ use ruff_linter::linter::add_noqa_to_path;
 use ruff_linter::source_kind::SourceKind;
 use ruff_linter::warn_user_once;
 use ruff_python_ast::{PySourceType, SourceType};
-use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig};
+use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig, ResolvedFile};
 
 use crate::args::CliOverrides;
 
@@ -36,7 +36,7 @@ pub(crate) fn add_noqa(
         &paths
             .iter()
             .flatten()
-            .map(ignore::DirEntry::path)
+            .map(ResolvedFile::path)
             .collect::<Vec<_>>(),
         pyproject_config,
     );
@@ -45,14 +45,15 @@ pub(crate) fn add_noqa(
     let modifications: usize = paths
         .par_iter()
         .flatten()
-        .filter_map(|entry| {
-            let path = entry.path();
+        .filter_map(|resolved_file| {
             let SourceType::Python(source_type @ (PySourceType::Python | PySourceType::Stub)) =
-                SourceType::from(path)
+                SourceType::from(resolved_file.path())
             else {
                 return None;
             };
-            let package = path
+            let path = resolved_file.path();
+            let package = resolved_file
+                .path()
                 .parent()
                 .and_then(|parent| package_roots.get(parent))
                 .and_then(|package| *package);

--- a/crates/ruff_cli/src/commands/check.rs
+++ b/crates/ruff_cli/src/commands/check.rs
@@ -22,7 +22,10 @@ use ruff_linter::{fs, warn_user_once, IOError};
 use ruff_python_ast::imports::ImportMap;
 use ruff_source_file::SourceFileBuilder;
 use ruff_text_size::{TextRange, TextSize};
-use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig, PyprojectDiscoveryStrategy};
+use ruff_workspace::resolver::{
+    match_exclusion, python_files_in_path, PyprojectConfig, PyprojectDiscoveryStrategy,
+    ResolvedFile,
+};
 
 use crate::args::CliOverrides;
 use crate::cache::{self, Cache};
@@ -42,8 +45,7 @@ pub(crate) fn check(
     // Collect all the Python files to check.
     let start = Instant::now();
     let (paths, resolver) = python_files_in_path(files, pyproject_config, overrides)?;
-    let duration = start.elapsed();
-    debug!("Identified files to lint in: {:?}", duration);
+    debug!("Identified files to lint in: {:?}", start.elapsed());
 
     if paths.is_empty() {
         warn_user_once!("No Python files found under the given path(s)");
@@ -77,7 +79,7 @@ pub(crate) fn check(
         &paths
             .iter()
             .flatten()
-            .map(ignore::DirEntry::path)
+            .map(ResolvedFile::path)
             .collect::<Vec<_>>(),
         pyproject_config,
     );
@@ -98,95 +100,114 @@ pub(crate) fn check(
     });
 
     let start = Instant::now();
-    let mut diagnostics: Diagnostics = paths
-        .par_iter()
-        .map(|entry| {
-            match entry {
-                Ok(entry) => {
-                    let path = entry.path();
-                    let package = path
-                        .parent()
-                        .and_then(|parent| package_roots.get(parent))
-                        .and_then(|package| *package);
+    let diagnostics_per_file = paths.par_iter().filter_map(|resolved_file| {
+        let result = match resolved_file {
+            Ok(resolved_file) => {
+                let path = resolved_file.path();
+                let package = path
+                    .parent()
+                    .and_then(|parent| package_roots.get(parent))
+                    .and_then(|package| *package);
 
-                    let settings = resolver.resolve(path, pyproject_config);
+                let settings = resolver.resolve(path, pyproject_config);
 
-                    let cache_root = package.unwrap_or_else(|| path.parent().unwrap_or(path));
-                    let cache = caches.as_ref().and_then(|caches| {
-                        if let Some(cache) = caches.get(&cache_root) {
-                            Some(cache)
-                        } else {
-                            debug!("No cache found for {}", cache_root.display());
-                            None
-                        }
-                    });
-
-                    lint_path(
-                        path,
-                        package,
-                        &settings.linter,
-                        cache,
-                        noqa,
-                        fix_mode,
-                        unsafe_fixes,
+                if !resolved_file.is_root()
+                    && match_exclusion(
+                        resolved_file.path(),
+                        resolved_file.file_name(),
+                        &settings.linter.exclude,
                     )
-                    .map_err(|e| {
-                        (Some(path.to_owned()), {
-                            let mut error = e.to_string();
-                            for cause in e.chain() {
-                                write!(&mut error, "\n  Cause: {cause}").unwrap();
-                            }
-                            error
-                        })
-                    })
+                {
+                    return None;
                 }
-                Err(e) => Err((
-                    if let Error::WithPath { path, .. } = e {
-                        Some(path.clone())
-                    } else {
-                        None
-                    },
-                    e.io_error()
-                        .map_or_else(|| e.to_string(), io::Error::to_string),
-                )),
-            }
-            .unwrap_or_else(|(path, message)| {
-                if let Some(path) = &path {
-                    let settings = resolver.resolve(path, pyproject_config);
-                    if settings.linter.rules.enabled(Rule::IOError) {
-                        let dummy =
-                            SourceFileBuilder::new(path.to_string_lossy().as_ref(), "").finish();
 
-                        Diagnostics::new(
-                            vec![Message::from_diagnostic(
-                                Diagnostic::new(IOError { message }, TextRange::default()),
-                                dummy,
-                                TextSize::default(),
-                            )],
-                            ImportMap::default(),
-                            FxHashMap::default(),
-                        )
+                let cache_root = package.unwrap_or_else(|| path.parent().unwrap_or(path));
+                let cache = caches.as_ref().and_then(|caches| {
+                    if let Some(cache) = caches.get(&cache_root) {
+                        Some(cache)
                     } else {
-                        warn!(
-                            "{}{}{} {message}",
-                            "Failed to lint ".bold(),
-                            fs::relativize_path(path).bold(),
-                            ":".bold()
-                        );
-                        Diagnostics::default()
+                        debug!("No cache found for {}", cache_root.display());
+                        None
                     }
+                });
+
+                lint_path(
+                    path,
+                    package,
+                    &settings.linter,
+                    cache,
+                    noqa,
+                    fix_mode,
+                    unsafe_fixes,
+                )
+                .map_err(|e| {
+                    (Some(path.to_path_buf()), {
+                        let mut error = e.to_string();
+                        for cause in e.chain() {
+                            write!(&mut error, "\n  Cause: {cause}").unwrap();
+                        }
+                        error
+                    })
+                })
+            }
+            Err(e) => Err((
+                if let Error::WithPath { path, .. } = e {
+                    Some(path.clone())
                 } else {
-                    warn!("{} {message}", "Encountered error:".bold());
+                    None
+                },
+                e.io_error()
+                    .map_or_else(|| e.to_string(), io::Error::to_string),
+            )),
+        };
+
+        Some(result.unwrap_or_else(|(path, message)| {
+            if let Some(path) = &path {
+                let settings = resolver.resolve(path, pyproject_config);
+                if settings.linter.rules.enabled(Rule::IOError) {
+                    let dummy =
+                        SourceFileBuilder::new(path.to_string_lossy().as_ref(), "").finish();
+
+                    Diagnostics::new(
+                        vec![Message::from_diagnostic(
+                            Diagnostic::new(IOError { message }, TextRange::default()),
+                            dummy,
+                            TextSize::default(),
+                        )],
+                        ImportMap::default(),
+                        FxHashMap::default(),
+                    )
+                } else {
+                    warn!(
+                        "{}{}{} {message}",
+                        "Failed to lint ".bold(),
+                        fs::relativize_path(path).bold(),
+                        ":".bold()
+                    );
                     Diagnostics::default()
                 }
-            })
-        })
-        .reduce(Diagnostics::default, |mut acc, item| {
-            acc += item;
-            acc
-        });
+            } else {
+                warn!("{} {message}", "Encountered error:".bold());
+                Diagnostics::default()
+            }
+        }))
+    });
 
-    diagnostics.messages.sort();
+    // Aggregate the diagnostics of all checked files and count the checked files.
+    // This can't be a regular for loop because we use `par_iter`.
+    let (mut all_diagnostics, checked_files) = diagnostics_per_file
+        .fold(
+            || (Diagnostics::default(), 0u64),
+            |(all_diagnostics, checked_files), file_diagnostics| {
+                (all_diagnostics + file_diagnostics, checked_files + 1)
+            },
+        )
+        .reduce(
+            || (Diagnostics::default(), 0u64),
+            |a, b| (a.0 + b.0, a.1 + b.1),
+        );
+
+    all_diagnostics.messages.sort();
 
     // Store the caches.
     if let Some(caches) = caches {
@@ -196,9 +217,9 @@ pub(crate) fn check(
     }
 
     let duration = start.elapsed();
-    debug!("Checked {:?} files in: {:?}", paths.len(), duration);
+    debug!("Checked {:?} files in: {:?}", checked_files, duration);
 
-    Ok(diagnostics)
+    Ok(all_diagnostics)
 }
 
 /// Wraps [`lint_path`](crate::diagnostics::lint_path) in a [`catch_unwind`](std::panic::catch_unwind) and emits

--- a/crates/ruff_cli/src/commands/check_stdin.rs
+++ b/crates/ruff_cli/src/commands/check_stdin.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 use ruff_linter::packaging;
 use ruff_linter::settings::flags;
-use ruff_workspace::resolver::{python_file_at_path, PyprojectConfig};
+use ruff_workspace::resolver::{match_exclusion, python_file_at_path, PyprojectConfig};
 
 use crate::args::CliOverrides;
 use crate::diagnostics::{lint_stdin, Diagnostics};
@@ -20,6 +20,14 @@ pub(crate) fn check_stdin(
 ) -> Result<Diagnostics> {
     if let Some(filename) = filename {
         if !python_file_at_path(filename, pyproject_config, overrides)? {
+            return Ok(Diagnostics::default());
+        }
+
+        let lint_settings = &pyproject_config.settings.linter;
+        if filename
+            .file_name()
+            .is_some_and(|name| match_exclusion(filename, name, &lint_settings.exclude))
+        {
             return Ok(Diagnostics::default());
         }
     }

--- a/crates/ruff_cli/src/commands/show_files.rs
+++ b/crates/ruff_cli/src/commands/show_files.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use itertools::Itertools;
 
 use ruff_linter::warn_user_once;
-use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig};
+use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig, ResolvedFile};
 
 use crate::args::CliOverrides;
 
@@ -25,12 +25,13 @@ pub(crate) fn show_files(
     }
 
     // Print the list of files.
-    for entry in paths
-        .iter()
+    for path in paths
+        .into_iter()
         .flatten()
-        .sorted_by(|a, b| a.path().cmp(b.path()))
+        .map(ResolvedFile::into_path)
+        .sorted_unstable()
     {
-        writeln!(writer, "{}", entry.path().to_string_lossy())?;
+        writeln!(writer, "{}", path.to_string_lossy())?;
     }
 
     Ok(())

--- a/crates/ruff_cli/src/commands/show_settings.rs
+++ b/crates/ruff_cli/src/commands/show_settings.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use anyhow::{bail, Result};
 use itertools::Itertools;
 
-use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig};
+use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig, ResolvedFile};
 
 use crate::args::CliOverrides;
 
@@ -19,16 +19,17 @@ pub(crate) fn show_settings(
     let (paths, resolver) = python_files_in_path(files, pyproject_config, overrides)?;
 
     // Print the list of files.
-    let Some(entry) = paths
-        .iter()
+    let Some(path) = paths
+        .into_iter()
         .flatten()
-        .sorted_by(|a, b| a.path().cmp(b.path()))
+        .map(ResolvedFile::into_path)
+        .sorted_unstable()
         .next()
     else {
         bail!("No files found under the given path");
     };
-    let path = entry.path();
-    let settings = resolver.resolve(path, pyproject_config);
+
+    let settings = resolver.resolve(&path, pyproject_config);
 
     writeln!(writer, "Resolved settings for: {path:?}")?;
     if let Some(settings_path) = pyproject_config.path.as_ref() {

--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -2,7 +2,7 @@
 
 use std::fs::File;
 use std::io;
-use std::ops::AddAssign;
+use std::ops::{Add, AddAssign};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
@@ -139,6 +139,15 @@ impl Diagnostics {
 
             Self::default()
         }
+    }
+}
+
+impl Add for Diagnostics {
+    type Output = Diagnostics;
+
+    fn add(mut self, other: Self) -> Self::Output {
+        self += other;
+        self
     }
 }
 

--- a/crates/ruff_cli/tests/lint.rs
+++ b/crates/ruff_cli/tests/lint.rs
@@ -31,14 +31,15 @@ inline-quotes = "single"
         .args(STDIN_BASE_OPTIONS)
         .arg("--config")
         .arg(&ruff_toml)
+        .args(["--stdin-filename", "test.py"])
         .arg("-")
         .pass_stdin(r#"a = "abcba".strip("aba")"#), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
-    -:1:5: Q000 [*] Double quotes found but single quotes preferred
-    -:1:5: B005 Using `.strip()` with multi-character strings is misleading
-    -:1:19: Q000 [*] Double quotes found but single quotes preferred
+    test.py:1:5: Q000 [*] Double quotes found but single quotes preferred
+    test.py:1:5: B005 Using `.strip()` with multi-character strings is misleading
+    test.py:1:19: Q000 [*] Double quotes found but single quotes preferred
     Found 3 errors.
     [*] 2 fixable with the `--fix` option.
 
@@ -150,6 +151,120 @@ inline-quotes = "single"
     -:1:19: Q000 [*] Double quotes found but single quotes preferred
     Found 3 errors.
     [*] 2 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###);
+    Ok(())
+}
+
+#[test]
+fn exclude() -> Result<()> {
+    let tempdir = TempDir::new()?;
+    let ruff_toml = tempdir.path().join("ruff.toml");
+    fs::write(
+        &ruff_toml,
+        r#"
+extend-select = ["B", "Q"]
+extend-exclude = ["out"]
+
+[lint]
+exclude = ["test.py", "generated.py"]
+
+[lint.flake8-quotes]
+inline-quotes = "single"
+"#,
+    )?;
+
+    fs::write(
+        tempdir.path().join("main.py"),
+        r#"
+from test import say_hy
+
+if __name__ == "__main__":
+    say_hy("dear Ruff contributor")
+"#,
+    )?;
+
+    // Excluded file but passed to the CLI directly, should be linted
+    let test_path = tempdir.path().join("test.py");
+    fs::write(
+        &test_path,
+        r#"
+def say_hy(name: str):
+        print(f"Hy {name}")"#,
+    )?;
+
+    fs::write(
+        tempdir.path().join("generated.py"),
+        r#"NUMBERS = [
+     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+    10, 11, 12, 13, 14, 15, 16, 17, 18, 19
+]
+OTHER = "OTHER"
+"#,
+    )?;
+
+    let out_dir = tempdir.path().join("out");
+    fs::create_dir(&out_dir)?;
+
+    fs::write(out_dir.join("a.py"), r#"a = "a""#)?;
+
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .current_dir(tempdir.path())
+        .arg("check")
+        .args(STDIN_BASE_OPTIONS)
+        .args(["--config", &ruff_toml.file_name().unwrap().to_string_lossy()])
+        // Explicitly pass test.py, should be linted regardless of it being excluded by lint.exclude
+        .arg(test_path.file_name().unwrap())
+        // Lint all other files in the directory, should respect the `exclude` and `lint.exclude` options
+        .arg("."), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    main.py:4:16: Q000 [*] Double quotes found but single quotes preferred
+    main.py:5:12: Q000 [*] Double quotes found but single quotes preferred
+    test.py:3:15: Q000 [*] Double quotes found but single quotes preferred
+    Found 3 errors.
+    [*] 3 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "###);
+    Ok(())
+}
+
+#[test]
+fn exclude_stdin() -> Result<()> {
+    let tempdir = TempDir::new()?;
+    let ruff_toml = tempdir.path().join("ruff.toml");
+    fs::write(
+        &ruff_toml,
+        r#"
+extend-select = ["B", "Q"]
+
+[lint]
+exclude = ["generated.py"]
+
+[lint.flake8-quotes]
+inline-quotes = "single"
+"#,
+    )?;
+
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .current_dir(tempdir.path())
+        .arg("check")
+        .args(STDIN_BASE_OPTIONS)
+        .args(["--config", &ruff_toml.file_name().unwrap().to_string_lossy()])
+        .args(["--stdin-filename", "generated.py"])
+        .arg("-")
+        .pass_stdin(r#"
+from test import say_hy
+
+if __name__ == "__main__":
+    say_hy("dear Ruff contributor")
+"#), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
     ----- stderr -----
     "###);

--- a/crates/ruff_dev/src/format_dev.rs
+++ b/crates/ruff_dev/src/format_dev.rs
@@ -11,7 +11,6 @@ use std::{fmt, fs, io, iter};
 
 use anyhow::{bail, format_err, Context, Error};
 use clap::{CommandFactory, FromArgMatches};
-use ignore::DirEntry;
 use imara_diff::intern::InternedInput;
 use imara_diff::sink::Counter;
 use imara_diff::{diff, Algorithm};
@@ -36,14 +35,14 @@ use ruff_linter::settings::types::{FilePattern, FilePatternSet};
 use ruff_python_formatter::{
     format_module_source, FormatModuleError, MagicTrailingComma, PyFormatOptions,
 };
-use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig, Resolver};
+use ruff_workspace::resolver::{python_files_in_path, PyprojectConfig, ResolvedFile, Resolver};
 
 /// Find files that ruff would check so we can format them. Adapted from `ruff_cli`.
 #[allow(clippy::type_complexity)]
 fn ruff_check_paths(
     dirs: &[PathBuf],
 ) -> anyhow::Result<(
-    Vec<Result<DirEntry, ignore::Error>>,
+    Vec<Result<ResolvedFile, ignore::Error>>,
     Resolver,
     PyprojectConfig,
 )> {
@@ -467,9 +466,9 @@ fn format_dev_project(
         let iter = { paths.into_par_iter() };
         #[cfg(feature = "singlethreaded")]
         let iter = { paths.into_iter() };
-        iter.map(|dir_entry| {
+        iter.map(|path| {
             let result = format_dir_entry(
-                dir_entry,
+                path,
                 stability_check,
                 write,
                 &black_options,
@@ -527,24 +526,20 @@ fn format_dev_project(
 
 /// Error handling in between walkdir and `format_dev_file`
 fn format_dir_entry(
-    dir_entry: Result<DirEntry, ignore::Error>,
+    resolved_file: Result<ResolvedFile, ignore::Error>,
     stability_check: bool,
     write: bool,
     options: &BlackOptions,
     resolver: &Resolver,
     pyproject_config: &PyprojectConfig,
 ) -> anyhow::Result<(Result<Statistics, CheckFileError>, PathBuf), Error> {
-    let dir_entry = match dir_entry.context("Iterating the files in the repository failed") {
-        Ok(dir_entry) => dir_entry,
-        Err(err) => return Err(err),
-    };
-    let file = dir_entry.path().to_path_buf();
+    let resolved_file = resolved_file.context("Iterating the files in the repository failed")?;
     // For some reason it does not filter in the beginning
-    if dir_entry.file_name() == "pyproject.toml" {
-        return Ok((Ok(Statistics::default()), file));
+    if resolved_file.file_name() == "pyproject.toml" {
+        return Ok((Ok(Statistics::default()), resolved_file.into_path()));
     }
 
-    let path = dir_entry.path().to_path_buf();
+    let path = resolved_file.into_path();
     let mut options = options.to_py_format_options(&path);
 
     let settings = resolver.resolve(&path, pyproject_config);

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -23,7 +23,7 @@ use crate::rules::{
     flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments, isort, mccabe, pep8_naming,
     pycodestyle, pydocstyle, pyflakes, pylint, pyupgrade,
 };
-use crate::settings::types::{PerFileIgnore, PythonVersion};
+use crate::settings::types::{FilePatternSet, PerFileIgnore, PythonVersion};
 use crate::{codes, RuleSelector};
 
 use super::line_width::{LineLength, TabSize};
@@ -38,6 +38,7 @@ pub mod types;
 
 #[derive(Debug, CacheKey)]
 pub struct LinterSettings {
+    pub exclude: FilePatternSet,
     pub project_root: PathBuf,
 
     pub rules: RuleTable,
@@ -131,6 +132,7 @@ impl LinterSettings {
 
     pub fn new(project_root: &Path) -> Self {
         Self {
+            exclude: FilePatternSet::default(),
             target_version: PythonVersion::default(),
             project_root: project_root.to_path_buf(),
             rules: DEFAULT_SELECTORS

--- a/crates/ruff_python_formatter/src/builders.rs
+++ b/crates/ruff_python_formatter/src/builders.rs
@@ -150,7 +150,7 @@ impl<'fmt, 'ast, 'buf> JoinCommaSeparatedBuilder<'fmt, 'ast, 'buf> {
         N: Ranged,
         Separator: Format<PyFormatContext<'ast>>,
     {
-        self.result = self.result.and_then(|_| {
+        self.result = self.result.and_then(|()| {
             if self.entries.is_one_or_more() {
                 write!(self.fmt, [token(","), separator])?;
             }
@@ -190,7 +190,7 @@ impl<'fmt, 'ast, 'buf> JoinCommaSeparatedBuilder<'fmt, 'ast, 'buf> {
     }
 
     pub(crate) fn finish(&mut self) -> FormatResult<()> {
-        self.result.and_then(|_| {
+        self.result.and_then(|()| {
             if let Some(last_end) = self.entries.position() {
                 let magic_trailing_comma = has_magic_trailing_comma(
                     TextRange::new(last_end, self.sequence_end),

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -22,7 +22,7 @@ use ruff_python_trivia::CommentRanges;
 use ruff_source_file::{Locator, SourceLocation};
 use ruff_text_size::Ranged;
 use ruff_workspace::configuration::Configuration;
-use ruff_workspace::options::{FormatOptions, LintOptions, Options};
+use ruff_workspace::options::{FormatOptions, LintCommonOptions, LintOptions, Options};
 use ruff_workspace::Settings;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -130,13 +130,16 @@ impl Workspace {
             target_version: Some(PythonVersion::default()),
 
             lint: Some(LintOptions {
-                allowed_confusables: Some(Vec::default()),
-                dummy_variable_rgx: Some(DUMMY_VARIABLE_RGX.as_str().to_string()),
-                ignore: Some(Vec::default()),
-                select: Some(DEFAULT_SELECTORS.to_vec()),
-                extend_fixable: Some(Vec::default()),
-                extend_select: Some(Vec::default()),
-                external: Some(Vec::default()),
+                common: LintCommonOptions {
+                    allowed_confusables: Some(Vec::default()),
+                    dummy_variable_rgx: Some(DUMMY_VARIABLE_RGX.as_str().to_string()),
+                    ignore: Some(Vec::default()),
+                    select: Some(DEFAULT_SELECTORS.to_vec()),
+                    extend_fixable: Some(Vec::default()),
+                    extend_select: Some(Vec::default()),
+                    external: Some(Vec::default()),
+                    ..LintCommonOptions::default()
+                },
 
                 ..LintOptions::default()
             }),

--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -161,7 +161,7 @@ mod tests {
     use ruff_linter::line_width::LineLength;
     use ruff_linter::settings::types::PatternPrefixPair;
 
-    use crate::options::{LintOptions, Options};
+    use crate::options::{LintCommonOptions, Options};
     use crate::pyproject::{find_settings_toml, parse_pyproject_toml, Pyproject, Tools};
     use crate::tests::test_resource_path;
 
@@ -236,9 +236,9 @@ select = ["E501"]
             pyproject.tool,
             Some(Tools {
                 ruff: Some(Options {
-                    lint_top_level: LintOptions {
+                    lint_top_level: LintCommonOptions {
                         select: Some(vec![codes::Pycodestyle::E501.into()]),
-                        ..LintOptions::default()
+                        ..LintCommonOptions::default()
                     },
                     ..Options::default()
                 })
@@ -257,10 +257,10 @@ ignore = ["E501"]
             pyproject.tool,
             Some(Tools {
                 ruff: Some(Options {
-                    lint_top_level: LintOptions {
+                    lint_top_level: LintCommonOptions {
                         extend_select: Some(vec![codes::Ruff::_100.into()]),
                         ignore: Some(vec![codes::Pycodestyle::E501.into()]),
-                        ..LintOptions::default()
+                        ..LintCommonOptions::default()
                     },
                     ..Options::default()
                 })
@@ -315,12 +315,12 @@ other-attribute = 1
                     "with_excluded_file/other_excluded_file.py".to_string(),
                 ]),
 
-                lint_top_level: LintOptions {
+                lint_top_level: LintCommonOptions {
                     per_file_ignores: Some(FxHashMap::from_iter([(
                         "__init__.py".to_string(),
                         vec![codes::Pyflakes::_401.into()]
                     )])),
-                    ..LintOptions::default()
+                    ..LintCommonOptions::default()
                 },
                 ..Options::default()
             }

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -111,6 +111,7 @@ impl FileResolverSettings {
 
 #[derive(CacheKey, Clone, Debug)]
 pub struct FormatterSettings {
+    pub exclude: FilePatternSet,
     pub preview: PreviewMode,
 
     pub line_width: LineWidth,
@@ -162,6 +163,7 @@ impl Default for FormatterSettings {
         let default_options = PyFormatOptions::default();
 
         Self {
+            exclude: FilePatternSet::default(),
             preview: ruff_python_formatter::PreviewMode::Disabled,
             line_width: default_options.line_width(),
             line_ending: LineEnding::Lf,

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -41,7 +41,7 @@
       ]
     },
     "exclude": {
-      "description": "A list of file patterns to exclude from linting.\n\nExclusions are based on globs, and can be either:\n\n- Single-path patterns, like `.mypy_cache` (to exclude any directory named `.mypy_cache` in the tree), `foo.py` (to exclude any file named `foo.py`), or `foo_*.py` (to exclude any file matching `foo_*.py` ). - Relative patterns, like `directory/foo.py` (to exclude that specific file) or `directory/*.py` (to exclude any Python files in `directory`). Note that these paths are relative to the project root (e.g., the directory containing your `pyproject.toml`).\n\nFor more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).\n\nNote that you'll typically want to use [`extend-exclude`](#extend-exclude) to modify the excluded paths.",
+      "description": "A list of file patterns to exclude from formatting and linting.\n\nExclusions are based on globs, and can be either:\n\n- Single-path patterns, like `.mypy_cache` (to exclude any directory named `.mypy_cache` in the tree), `foo.py` (to exclude any file named `foo.py`), or `foo_*.py` (to exclude any file matching `foo_*.py` ). - Relative patterns, like `directory/foo.py` (to exclude that specific file) or `directory/*.py` (to exclude any Python files in `directory`). Note that these paths are relative to the project root (e.g., the directory containing your `pyproject.toml`).\n\nFor more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).\n\nNote that you'll typically want to use [`extend-exclude`](#extend-exclude) to modify the excluded paths.",
       "type": [
         "array",
         "null"
@@ -65,7 +65,7 @@
       ]
     },
     "extend-exclude": {
-      "description": "A list of file patterns to omit from linting, in addition to those specified by `exclude`.\n\nExclusions are based on globs, and can be either:\n\n- Single-path patterns, like `.mypy_cache` (to exclude any directory named `.mypy_cache` in the tree), `foo.py` (to exclude any file named `foo.py`), or `foo_*.py` (to exclude any file matching `foo_*.py` ). - Relative patterns, like `directory/foo.py` (to exclude that specific file) or `directory/*.py` (to exclude any Python files in `directory`). Note that these paths are relative to the project root (e.g., the directory containing your `pyproject.toml`).\n\nFor more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
+      "description": "A list of file patterns to omit from formatting and linting, in addition to those specified by `exclude`.\n\nExclusions are based on globs, and can be either:\n\n- Single-path patterns, like `.mypy_cache` (to exclude any directory named `.mypy_cache` in the tree), `foo.py` (to exclude any file named `foo.py`), or `foo_*.py` (to exclude any file matching `foo_*.py` ). - Relative patterns, like `directory/foo.py` (to exclude that specific file) or `directory/*.py` (to exclude any Python files in `directory`). Note that these paths are relative to the project root (e.g., the directory containing your `pyproject.toml`).\n\nFor more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
       "type": [
         "array",
         "null"
@@ -1209,6 +1209,16 @@
       "description": "Experimental: Configures how `ruff format` formats your code.\n\nPlease provide feedback in [this discussion](https://github.com/astral-sh/ruff/discussions/7310).",
       "type": "object",
       "properties": {
+        "exclude": {
+          "description": "A list of file patterns to exclude from formatting in addition to the files excluded globally (see [`exclude`](#exclude), and [`extend-exclude`](#extend-exclude)).\n\nExclusions are based on globs, and can be either:\n\n- Single-path patterns, like `.mypy_cache` (to exclude any directory named `.mypy_cache` in the tree), `foo.py` (to exclude any file named `foo.py`), or `foo_*.py` (to exclude any file matching `foo_*.py` ). - Relative patterns, like `directory/foo.py` (to exclude that specific file) or `directory/*.py` (to exclude any Python files in `directory`). Note that these paths are relative to the project root (e.g., the directory containing your `pyproject.toml`).\n\nFor more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).\n\nNote that you'll typically want to use [`extend-exclude`](#extend-exclude) to modify the excluded paths.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "indent-style": {
           "description": "Whether to use 4 spaces or hard tabs for indenting code.\n\nDefaults to 4 spaces. We care about accessibility; if you do not need tabs for accessibility, we do not recommend you use them.",
           "anyOf": [
@@ -1591,6 +1601,16 @@
             "string",
             "null"
           ]
+        },
+        "exclude": {
+          "description": "A list of file patterns to exclude from linting in addition to the files excluded globally (see [`exclude`](#exclude), and [`extend-exclude`](#extend-exclude)).\n\nExclusions are based on globs, and can be either:\n\n- Single-path patterns, like `.mypy_cache` (to exclude any directory named `.mypy_cache` in the tree), `foo.py` (to exclude any file named `foo.py`), or `foo_*.py` (to exclude any file matching `foo_*.py` ). - Relative patterns, like `directory/foo.py` (to exclude that specific file) or `directory/*.py` (to exclude any Python files in `directory`). Note that these paths are relative to the project root (e.g., the directory containing your `pyproject.toml`).\n\nFor more information on the glob syntax, refer to the [`globset` documentation](https://docs.rs/globset/latest/globset/#syntax).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         },
         "explicit-preview-rules": {
           "description": "Whether to require exact codes to select preview rules. When enabled, preview rules will not be selected by prefixes — the full code of each preview rule will be required to enable the rule.",


### PR DESCRIPTION
## Summary

This PR introduces the new options `lint.exclude` and `format.exclude` that allow excluding files from linting or formatting only. 

Being able to exclude entire files is useful when:

* you have generated code that you only want to format but not lint (or the other way round)
* you have sub modules that you only want to lint because the code isn't using a formatter yet (but the rest of the project is)
 

Closes https://github.com/astral-sh/ruff/issues/7645

## Considerations

The `check` command (and now the format command) exposes the `exclude` option. This is the global `exclude` and not the `lint.exclude` or `format.exclude`. Only exposing the global `exclude` option should be sufficient and make little difference except if the user wants to clear out the `lint|format.exclude` option via the CLI. 

Only exposing the global `exclude` option makes sense for me, considering that we plan to unify linting and formatting under the `check` command in the future. Whether this is the right design for `format` is less clear to me but I think it's in line with `check` and we can still decide to add a `format-exclude` CLI option if it proves necessary.

## Test Plan

I added new integration tests that test the tool specific exclusion. 

I played around with the `airflow` repository and excluded files for linting or formatting only and verified that they are only excluded for the specific tool (and the result is the same as when excluding the files globally). Verified that a file passed directly gets linted/formated regardless if it is excluded or not.
