### PR TITLE
Add `lint.preview`

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -395,9 +395,9 @@ pub struct FormatCommand {
     #[arg(long, help_heading = "Miscellaneous")]
     pub stdin_filename: Option<PathBuf>,
 
-    /// Enable preview mode; checks will include unstable rules and fixes.
+    /// Enable preview mode; enables unstable formatting.
     /// Use `--no-preview` to disable.
-    #[arg(long, overrides_with("no_preview"), hide = true)]
+    #[arg(long, overrides_with("no_preview"))]
     preview: bool,
     #[clap(long, overrides_with("preview"), hide = true)]
     no_preview: bool,
@@ -668,6 +668,8 @@ impl ConfigurationTransformer for CliOverrides {
         }
         if let Some(preview) = &self.preview {
             config.preview = Some(*preview);
+            config.lint.preview = Some(*preview);
+            config.format.preview = Some(*preview);
         }
         if let Some(per_file_ignores) = &self.per_file_ignores {
             config.lint.per_file_ignores = Some(collect_per_file_ignores(per_file_ignores.clone()));

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -141,7 +141,7 @@ pub struct Options {
     pub required_version: Option<Version>,
 
     /// Whether to enable preview mode. When preview mode is enabled, Ruff will
-    /// use unstable rules and fixes.
+    /// use unstable rules, fixes, and formatting.
     #[option(
         default = "false",
         value_type = "bool",
@@ -412,6 +412,18 @@ pub struct LintOptions {
         "#
     )]
     pub exclude: Option<Vec<String>>,
+
+    /// Whether to enable preview mode. When preview mode is enabled, Ruff will
+    /// use unstable rules and fixes.
+    #[option(
+        default = "false",
+        value_type = "bool",
+        example = r#"
+            # Enable preview features.
+            preview = true
+        "#
+    )]
+    pub preview: Option<bool>,
 }
 
 // Note: This struct should be inlined into [`LintOptions`] once support for the top-level lint settings

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -491,7 +491,7 @@
       }
     },
     "preview": {
-      "description": "Whether to enable preview mode. When preview mode is enabled, Ruff will use unstable rules and fixes.",
+      "description": "Whether to enable preview mode. When preview mode is enabled, Ruff will use unstable rules, fixes, and formatting.",
       "type": [
         "boolean",
         "null"
@@ -1940,6 +1940,13 @@
               "$ref": "#/definitions/RuleSelector"
             }
           }
+        },
+        "preview": {
+          "description": "Whether to enable preview mode. When preview mode is enabled, Ruff will use unstable rules and fixes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "pycodestyle": {
           "description": "Options for the `pycodestyle` plugin.",


### PR DESCRIPTION
## Summary

This PR adds a new `lint.preview` option similar to `format.preview` that controls whether preview mode is enabled for the linter. 

Closes https://github.com/astral-sh/ruff/issues/7649

## Test Plan

I wrapped the `into_settings` of the formatter and linter in `dbg` expressions and verified that:

* `lint.preview = true` -> Preview mode is enabled for the linter only
* `format.preview = true` -> Preview mode is enabled for the formatter only
* `preview = true` -> Preview mode is enabled for both the linter and the formatter. 
* `--preview` overrides the `preview`, `lint.preview`, and `format.preview` option
* `preview = true` and `lint.preview = false` enables preview for the formatter only (same test for the linter)
