### PR TITLE
Respect `tab-size` setting in formatter

### DIFF
--- a/crates/ruff_cli/tests/format.rs
+++ b/crates/ruff_cli/tests/format.rs
@@ -50,6 +50,9 @@ fn format_options() -> Result<()> {
     fs::write(
         &ruff_toml,
         r#"
+tab-size = 8
+line-length = 84
+
 [format]
 indent-style = "tab"
 quote-style = "single"
@@ -64,7 +67,7 @@ line-ending = "cr-lf"
         .arg("-")
         .pass_stdin(r#"
 def foo(arg1, arg2,):
-    print("Shouldn't change quotes")
+    print("Shouldn't change quotes. It exceeds the line width with the tab size 8")
 
 
 if condition:
@@ -76,7 +79,9 @@ if condition:
     exit_code: 0
     ----- stdout -----
     def foo(arg1, arg2):
-    	print("Shouldn't change quotes")
+    	print(
+    		"Shouldn't change quotes. It exceeds the line width with the tab size 8"
+    	)
 
 
     if condition:

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -95,7 +95,7 @@ impl std::fmt::Display for IndentStyle {
 ///
 /// Determines the visual width of a tab character (`\t`) and the number of
 /// spaces per indent when using [`IndentStyle::Space`].
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, CacheKey)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct IndentWidth(NonZeroU8);

--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -253,3 +253,9 @@ impl From<NonZeroU8> for TabSize {
         Self(tab_size)
     }
 }
+
+impl From<TabSize> for NonZeroU8 {
+    fn from(value: TabSize) -> Self {
+        value.0
+    }
+}

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -4,7 +4,7 @@
 
 use std::borrow::Cow;
 use std::env::VarError;
-use std::num::NonZeroU16;
+use std::num::{NonZeroU16, NonZeroU8};
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
@@ -16,7 +16,7 @@ use shellexpand::LookupError;
 use strum::IntoEnumIterator;
 
 use ruff_cache::cache_dir;
-use ruff_formatter::{IndentStyle, LineWidth};
+use ruff_formatter::{IndentStyle, IndentWidth, LineWidth};
 use ruff_linter::line_width::{LineLength, TabSize};
 use ruff_linter::registry::RuleNamespace;
 use ruff_linter::registry::{Rule, RuleSet, INCOMPATIBLE_CODES};
@@ -155,7 +155,7 @@ impl Configuration {
 
         let format = self.format;
         let format_defaults = FormatterSettings::default();
-        // TODO(micha): Support changing the tab-width but disallow changing the number of spaces
+
         let formatter = FormatterSettings {
             exclude: FilePatternSet::try_from_iter(format.exclude.unwrap_or_default())?,
             preview: match format.preview.unwrap_or(global_preview) {
@@ -169,6 +169,11 @@ impl Configuration {
                 }),
             line_ending: format.line_ending.unwrap_or(format_defaults.line_ending),
             indent_style: format.indent_style.unwrap_or(format_defaults.indent_style),
+            indent_width: self
+                .tab_size
+                .map_or(format_defaults.indent_width, |tab_size| {
+                    IndentWidth::from(NonZeroU8::from(tab_size))
+                }),
             quote_style: format.quote_style.unwrap_or(format_defaults.quote_style),
             magic_trailing_comma: format
                 .magic_trailing_comma

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -363,7 +363,11 @@ pub struct Options {
     )]
     pub line_length: Option<LineLength>,
 
-    /// The tabulation size to calculate line length.
+    /// The number of spaces a tab is equal to when enforcing long-line violations (like `E501`)
+    /// or formatting code with the formatter.
+    ///
+    /// This option changes the number of spaces inserted by the formatter when
+    /// using soft-tabs (`indent-style = space`).
     #[option(
         default = "4",
         value_type = "int",

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -1,6 +1,6 @@
 use path_absolutize::path_dedot;
 use ruff_cache::cache_dir;
-use ruff_formatter::{FormatOptions, IndentStyle, LineWidth};
+use ruff_formatter::{FormatOptions, IndentStyle, IndentWidth, LineWidth};
 use ruff_linter::settings::types::{FilePattern, FilePatternSet, SerializationFormat, UnsafeFixes};
 use ruff_linter::settings::LinterSettings;
 use ruff_macros::CacheKey;
@@ -117,6 +117,7 @@ pub struct FormatterSettings {
     pub line_width: LineWidth,
 
     pub indent_style: IndentStyle,
+    pub indent_width: IndentWidth,
 
     pub quote_style: QuoteStyle,
 
@@ -150,6 +151,7 @@ impl FormatterSettings {
 
         PyFormatOptions::from_source_type(source_type)
             .with_indent_style(self.indent_style)
+            .with_indent_width(self.indent_width)
             .with_quote_style(self.quote_style)
             .with_magic_trailing_comma(self.magic_trailing_comma)
             .with_preview(self.preview)
@@ -164,10 +166,11 @@ impl Default for FormatterSettings {
 
         Self {
             exclude: FilePatternSet::default(),
-            preview: ruff_python_formatter::PreviewMode::Disabled,
+            preview: PreviewMode::Disabled,
             line_width: default_options.line_width(),
             line_ending: LineEnding::Lf,
             indent_style: default_options.indent_style(),
+            indent_width: default_options.indent_width(),
             quote_style: default_options.quote_style(),
             magic_trailing_comma: default_options.magic_trailing_comma(),
         }

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -605,7 +605,7 @@
       }
     },
     "tab-size": {
-      "description": "The tabulation size to calculate line length.",
+      "description": "The number of spaces a tab is equal to when enforcing long-line violations (like `E501`) or formatting code with the formatter.\n\nThis option changes the number of spaces inserted by the formatter when using soft-tabs (`indent-style = space`).",
       "anyOf": [
         {
           "$ref": "#/definitions/TabSize"


### PR DESCRIPTION
## Summary

This PR changes the formatter to use the global `tab-size` to configure the number of spaces used for soft-tabs or width of a hard-tab character. 

Closes https://github.com/astral-sh/ruff/issues/7648

## Open Questions

I'm still somewhat undecided whether we should support changing the number of spaces for soft tabs. I only found few projects that set `tab-size = 2` or `pyink-indentation = 2`. 
But we may as well support it for as long as we default to 4 spaces. 

## Test Plan

Changed integration test
