### PR TITLE
Rename `*-length` options to `-width`

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ exclude = [
     "venv",
 ]
 
-# Same as Black.
-line-length = 88
+# Same as Black's `line-length`.
+line-width = 88
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/crates/flake8_to_ruff/src/black.rs
+++ b/crates/flake8_to_ruff/src/black.rs
@@ -1,13 +1,13 @@
 //! Extract Black configuration settings from a pyproject.toml.
 
-use ruff_linter::line_width::LineLength;
+use ruff_linter::line_width::LineWidth;
 use ruff_linter::settings::types::PythonVersion;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub(crate) struct Black {
     #[serde(alias = "line-length", alias = "line_length")]
-    pub(crate) line_length: Option<LineLength>,
+    pub(crate) line_length: Option<LineWidth>,
     #[serde(alias = "target-version", alias = "target_version")]
     pub(crate) target_version: Option<Vec<PythonVersion>>,
 }

--- a/crates/flake8_to_ruff/src/converter.rs
+++ b/crates/flake8_to_ruff/src/converter.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use itertools::Itertools;
 
-use ruff_linter::line_width::LineLength;
+use ruff_linter::line_width::LineWidth;
 use ruff_linter::registry::Linter;
 use ruff_linter::rule_selector::RuleSelector;
 use ruff_linter::rules::flake8_pytest_style::types::{
@@ -117,8 +117,8 @@ pub(crate) fn convert(
                 "builtins" => {
                     options.builtins = Some(parser::parse_strings(value.as_ref()));
                 }
-                "max-line-length" | "max_line_length" => match LineLength::from_str(value) {
-                    Ok(line_length) => options.line_length = Some(line_length),
+                "max-line-length" | "max_line_length" => match LineWidth::from_str(value) {
+                    Ok(line_length) => options.line_width = Some(line_length),
                     Err(e) => {
                         warn_user!("Unable to parse '{key}' property: {e}");
                     }
@@ -401,7 +401,7 @@ pub(crate) fn convert(
     // Extract any settings from the existing `pyproject.toml`.
     if let Some(black) = &external_config.black {
         if let Some(line_length) = &black.line_length {
-            options.line_length = Some(*line_length);
+            options.line_width = Some(*line_length);
         }
 
         if let Some(target_version) = &black.target_version {
@@ -462,7 +462,7 @@ mod tests {
     use pep440_rs::VersionSpecifiers;
 
     use pretty_assertions::assert_eq;
-    use ruff_linter::line_width::LineLength;
+    use ruff_linter::line_width::LineWidth;
     use ruff_linter::registry::Linter;
     use ruff_linter::rule_selector::RuleSelector;
     use ruff_linter::rules::flake8_quotes;
@@ -523,7 +523,7 @@ mod tests {
             Some(vec![]),
         );
         let expected = Pyproject::new(Options {
-            line_length: Some(LineLength::try_from(100).unwrap()),
+            line_width: Some(LineWidth::try_from(100).unwrap()),
             lint: Some(LintOptions {
                 common: lint_default_options([]),
                 ..LintOptions::default()
@@ -544,7 +544,7 @@ mod tests {
             Some(vec![]),
         );
         let expected = Pyproject::new(Options {
-            line_length: Some(LineLength::try_from(100).unwrap()),
+            line_width: Some(LineWidth::try_from(100).unwrap()),
             lint: Some(LintOptions {
                 common: lint_default_options([]),
                 ..LintOptions::default()

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -177,6 +177,11 @@ fn format(args: FormatCommand, log_level: LogLevel) -> Result<ExitStatus> {
 }
 
 pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
+    #[allow(deprecated)]
+    if args.line_length.is_some() {
+        warn_user_once!("The option `--line-length` has been renamed to `--line-width` to emphasize that the limit is the width of a line and not the number of characters. Use the option `--line-width` instead.");
+    }
+
     let (cli, overrides) = args.partition();
 
     // Construct the "default" settings. These are used when no `pyproject.toml`

--- a/crates/ruff_cli/tests/format.rs
+++ b/crates/ruff_cli/tests/format.rs
@@ -52,7 +52,7 @@ fn format_options() -> Result<()> {
         &ruff_toml,
         r#"
 tab-size = 8
-line-length = 84
+line-width = 84
 
 [format]
 indent-style = "tab"

--- a/crates/ruff_linter/resources/test/fixtures/isort/detect_same_package/pyproject.toml
+++ b/crates/ruff_linter/resources/test/fixtures/isort/detect_same_package/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.ruff]
-line-length = 88
+line-width = 88

--- a/crates/ruff_linter/resources/test/fixtures/isort/pyproject.toml
+++ b/crates/ruff_linter/resources/test/fixtures/isort/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-line-length = 88
+line-width = 88
 
 [tool.ruff.isort]
 lines-after-imports = 3

--- a/crates/ruff_linter/resources/test/fixtures/pyproject.toml
+++ b/crates/ruff_linter/resources/test/fixtures/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-line-length = 88
+line-width = 88
 extend-exclude = [
   "excluded_file.py",
   "migrations",

--- a/crates/ruff_linter/resources/test/fixtures/ruff/pyproject_toml/maturin/pyproject.toml
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/pyproject_toml/maturin/pyproject.toml
@@ -47,7 +47,7 @@ extend-exclude = '''
 '''
 
 [tool.ruff]
-line-length = 120
+line-width = 120
 target-version = "py37"
 
 [tool.mypy]

--- a/crates/ruff_linter/src/checkers/physical_lines.rs
+++ b/crates/ruff_linter/src/checkers/physical_lines.rs
@@ -93,7 +93,7 @@ mod tests {
     use ruff_python_parser::Mode;
     use ruff_source_file::Locator;
 
-    use crate::line_width::LineLength;
+    use crate::line_width::LineWidth;
     use crate::registry::Rule;
     use crate::settings::LinterSettings;
 
@@ -107,19 +107,19 @@ mod tests {
         let indexer = Indexer::from_tokens(&tokens, &locator);
         let stylist = Stylist::from_tokens(&tokens, &locator);
 
-        let check_with_max_line_length = |line_length: LineLength| {
+        let check_with_max_line_length = |line_width: LineWidth| {
             check_physical_lines(
                 &locator,
                 &stylist,
                 &indexer,
                 &[],
                 &LinterSettings {
-                    line_length,
+                    line_width,
                     ..LinterSettings::for_rule(Rule::LineTooLong)
                 },
             )
         };
-        let line_length = LineLength::try_from(8).unwrap();
+        let line_length = LineWidth::try_from(8).unwrap();
         assert_eq!(check_with_max_line_length(line_length), vec![]);
         assert_eq!(check_with_max_line_length(line_length), vec![]);
     }

--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -15,15 +15,15 @@ use ruff_text_size::TextSize;
 /// The allowed range of values is 1..=320
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub struct LineLength(
+pub struct LineWidth(
     #[cfg_attr(feature = "schemars", schemars(range(min = 1, max = 320)))] NonZeroU16,
 );
 
-impl LineLength {
-    /// Maximum allowed value for a valid [`LineLength`]
+impl LineWidth {
+    /// Maximum allowed value for a valid [`LineWidth`]
     pub const MAX: u16 = 320;
 
-    /// Return the numeric value for this [`LineLength`]
+    /// Return the numeric value for this [`LineWidth`]
     pub fn value(&self) -> u16 {
         self.0.get()
     }
@@ -33,23 +33,23 @@ impl LineLength {
     }
 }
 
-impl Default for LineLength {
+impl Default for LineWidth {
     fn default() -> Self {
         Self(NonZeroU16::new(88).unwrap())
     }
 }
 
-impl CacheKey for LineLength {
+impl CacheKey for LineWidth {
     fn cache_key(&self, state: &mut CacheKeyHasher) {
         state.write_u16(self.0.get());
     }
 }
 
-/// Error type returned when parsing a [`LineLength`] from a string fails
+/// Error type returned when parsing a [`LineWidth`] from a string fails
 pub enum ParseLineWidthError {
     /// The string could not be parsed as a valid [u16]
     ParseError(ParseIntError),
-    /// The [u16] value of the string is not a valid [LineLength]
+    /// The [u16] value of the string is not a valid [LineWidth]
     TryFromIntError(LineLengthFromIntError),
 }
 
@@ -70,7 +70,7 @@ impl std::fmt::Display for ParseLineWidthError {
 
 impl Error for ParseLineWidthError {}
 
-impl FromStr for LineLength {
+impl FromStr for LineWidth {
     type Err = ParseLineWidthError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -80,16 +80,16 @@ impl FromStr for LineLength {
     }
 }
 
-/// Error type returned when converting a u16 to a [`LineLength`] fails
+/// Error type returned when converting a u16 to a [`LineWidth`] fails
 #[derive(Clone, Copy, Debug)]
 pub struct LineLengthFromIntError(pub u16);
 
-impl TryFrom<u16> for LineLength {
+impl TryFrom<u16> for LineWidth {
     type Error = LineLengthFromIntError;
 
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         match NonZeroU16::try_from(value) {
-            Ok(value) if value.get() <= Self::MAX => Ok(LineLength(value)),
+            Ok(value) if value.get() <= Self::MAX => Ok(LineWidth(value)),
             Ok(_) | Err(_) => Err(LineLengthFromIntError(value)),
         }
     }
@@ -100,19 +100,19 @@ impl std::fmt::Display for LineLengthFromIntError {
         writeln!(
             f,
             "The line width must be a value between 1 and {}.",
-            LineLength::MAX
+            LineWidth::MAX
         )
     }
 }
 
-impl From<LineLength> for u16 {
-    fn from(value: LineLength) -> Self {
+impl From<LineWidth> for u16 {
+    fn from(value: LineWidth) -> Self {
         value.0.get()
     }
 }
 
-impl From<LineLength> for NonZeroU16 {
-    fn from(value: LineLength) -> Self {
+impl From<LineWidth> for NonZeroU16 {
+    fn from(value: LineWidth) -> Self {
         value.0
     }
 }
@@ -120,7 +120,7 @@ impl From<LineLength> for NonZeroU16 {
 /// A measure of the width of a line of text.
 ///
 /// This is used to determine if a line is too long.
-/// It should be compared to a [`LineLength`].
+/// It should be compared to a [`LineWidth`].
 #[derive(Clone, Copy, Debug)]
 pub struct LineWidthBuilder {
     /// The width of the line.
@@ -219,14 +219,14 @@ impl LineWidthBuilder {
     }
 }
 
-impl PartialEq<LineLength> for LineWidthBuilder {
-    fn eq(&self, other: &LineLength) -> bool {
+impl PartialEq<LineWidth> for LineWidthBuilder {
+    fn eq(&self, other: &LineWidth) -> bool {
         self.width == (other.value() as usize)
     }
 }
 
-impl PartialOrd<LineLength> for LineWidthBuilder {
-    fn partial_cmp(&self, other: &LineLength) -> Option<std::cmp::Ordering> {
+impl PartialOrd<LineWidth> for LineWidthBuilder {
+    fn partial_cmp(&self, other: &LineWidth) -> Option<std::cmp::Ordering> {
         self.width.partial_cmp(&(other.value() as usize))
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
@@ -139,7 +139,7 @@ pub(crate) fn multiple_with_statements(
                             content,
                             with_stmt.into(),
                             checker.locator(),
-                            checker.settings.line_length,
+                            checker.settings.line_width,
                             checker.settings.tab_size,
                         )
                     }) {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
@@ -128,7 +128,7 @@ pub(crate) fn nested_if_statements(
                         content,
                         (&nested_if).into(),
                         checker.locator(),
-                        checker.settings.line_length,
+                        checker.settings.line_width,
                         checker.settings.tab_size,
                     )
                 }) {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
@@ -182,7 +182,7 @@ pub(crate) fn if_else_block_instead_of_dict_get(checker: &mut Checker, stmt_if: 
         &contents,
         stmt_if.into(),
         checker.locator(),
-        checker.settings.line_length,
+        checker.settings.line_width,
         checker.settings.tab_size,
     ) {
         return;

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_if_exp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_if_exp.rs
@@ -130,7 +130,7 @@ pub(crate) fn if_else_block_instead_of_if_exp(checker: &mut Checker, stmt_if: &a
         &contents,
         stmt_if.into(),
         checker.locator(),
-        checker.settings.line_length,
+        checker.settings.line_width,
         checker.settings.tab_size,
     ) {
         return;

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -101,7 +101,7 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt) {
                 &contents,
                 stmt.into(),
                 checker.locator(),
-                checker.settings.line_length,
+                checker.settings.line_width,
                 checker.settings.tab_size,
             ) {
                 return;
@@ -188,7 +188,7 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt) {
                         .slice(TextRange::new(line_start, stmt.start())),
                 )
                 .add_str(&contents)
-                > checker.settings.line_length
+                > checker.settings.line_width
             {
                 return;
             }

--- a/crates/ruff_linter/src/rules/isort/format.rs
+++ b/crates/ruff_linter/src/rules/isort/format.rs
@@ -1,6 +1,6 @@
 use ruff_python_codegen::Stylist;
 
-use crate::line_width::{LineLength, LineWidthBuilder};
+use crate::line_width::{LineWidth, LineWidthBuilder};
 
 use super::types::{AliasData, CommentSet, ImportFromData, Importable};
 
@@ -45,7 +45,7 @@ pub(crate) fn format_import_from(
     import_from: &ImportFromData,
     comments: &CommentSet,
     aliases: &[(AliasData, CommentSet)],
-    line_length: LineLength,
+    line_length: LineWidth,
     indentation_width: LineWidthBuilder,
     stylist: &Stylist,
     force_wrap_aliases: bool,

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -18,7 +18,7 @@ use sorting::cmp_either_import;
 use types::EitherImport::{Import, ImportFrom};
 use types::{AliasData, EitherImport, ImportBlock, TrailingComma};
 
-use crate::line_width::{LineLength, LineWidthBuilder};
+use crate::line_width::{LineWidth, LineWidthBuilder};
 use crate::settings::types::PythonVersion;
 
 mod annotate;
@@ -65,7 +65,7 @@ pub(crate) fn format_imports(
     block: &Block,
     comments: Vec<Comment>,
     locator: &Locator,
-    line_length: LineLength,
+    line_length: LineWidth,
     indentation_width: LineWidthBuilder,
     stylist: &Stylist,
     src: &[PathBuf],
@@ -138,7 +138,7 @@ pub(crate) fn format_imports(
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 fn format_import_block(
     block: ImportBlock,
-    line_length: LineLength,
+    line_length: LineWidth,
     indentation_width: LineWidthBuilder,
     stylist: &Stylist,
     src: &[PathBuf],

--- a/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
@@ -120,7 +120,7 @@ pub(crate) fn organize_imports(
         block,
         comments,
         locator,
-        settings.line_length,
+        settings.line_width,
         LineWidthBuilder::new(settings.tab_size).add_str(indentation),
         stylist,
         &settings.src,

--- a/crates/ruff_linter/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/mod.rs
@@ -14,7 +14,7 @@ mod tests {
 
     use test_case::test_case;
 
-    use crate::line_width::LineLength;
+    use crate::line_width::LineWidth;
     use crate::registry::Rule;
     use crate::test::test_path;
     use crate::{assert_messages, settings};
@@ -174,7 +174,7 @@ mod tests {
             Path::new("pycodestyle/W505.py"),
             &settings::LinterSettings {
                 pycodestyle: Settings {
-                    max_doc_length: Some(LineLength::try_from(50).unwrap()),
+                    max_doc_width: Some(LineWidth::try_from(50).unwrap()),
                     ..Settings::default()
                 },
                 ..settings::LinterSettings::for_rule(Rule::DocLineTooLong)
@@ -190,7 +190,7 @@ mod tests {
             Path::new("pycodestyle/W505_utf_8.py"),
             &settings::LinterSettings {
                 pycodestyle: Settings {
-                    max_doc_length: Some(LineLength::try_from(50).unwrap()),
+                    max_doc_width: Some(LineWidth::try_from(50).unwrap()),
                     ..Settings::default()
                 },
                 ..settings::LinterSettings::for_rule(Rule::DocLineTooLong)
@@ -210,7 +210,7 @@ mod tests {
             Path::new("pycodestyle/E501_2.py"),
             &settings::LinterSettings {
                 tab_size: NonZeroU8::new(tab_size).unwrap().into(),
-                line_length: LineLength::try_from(6).unwrap(),
+                line_width: LineWidth::try_from(6).unwrap(),
                 ..settings::LinterSettings::for_rule(Rule::LineTooLong)
             },
         )?;

--- a/crates/ruff_linter/src/rules/pycodestyle/overlong.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/overlong.rs
@@ -7,7 +7,7 @@ use ruff_python_trivia::is_pragma_comment;
 use ruff_source_file::Line;
 use ruff_text_size::{TextLen, TextRange};
 
-use crate::line_width::{LineLength, LineWidthBuilder, TabSize};
+use crate::line_width::{LineWidth, LineWidthBuilder, TabSize};
 
 #[derive(Debug)]
 pub(super) struct Overlong {
@@ -21,7 +21,7 @@ impl Overlong {
     pub(super) fn try_from_line(
         line: &Line,
         indexer: &Indexer,
-        limit: LineLength,
+        limit: LineWidth,
         task_tags: &[String],
         tab_size: TabSize,
     ) -> Option<Self> {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/doc_line_too_long.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/doc_line_too_long.rs
@@ -7,13 +7,13 @@ use crate::rules::pycodestyle::overlong::Overlong;
 use crate::settings::LinterSettings;
 
 /// ## What it does
-/// Checks for doc lines that exceed the specified maximum character length.
+/// Checks for doc lines that exceed the specified maximum width.
 ///
 /// ## Why is this bad?
 /// For flowing long blocks of text (docstrings or comments), overlong lines
 /// can hurt readability. [PEP 8], for example, recommends that such lines be
 /// limited to 72 characters, while this rule enforces the limit specified by
-/// the [`pycodestyle.max-doc-length`] setting. (If no value is provided, this
+/// the [`pycodestyle.max-doc-width`] setting. (If no value is provided, this
 /// rule will be ignored, even if it's added to your `--select` list.)
 ///
 /// In the context of this rule, a "doc line" is defined as a line consisting
@@ -25,11 +25,11 @@ use crate::settings::LinterSettings;
 /// 1. Ignores lines that consist of a single "word" (i.e., without any
 ///    whitespace between its characters).
 /// 2. Ignores lines that end with a URL, as long as the URL starts before
-///    the line-length threshold.
+///    the line-width threshold.
 /// 3. Ignores line that end with a pragma comment (e.g., `# type: ignore`
 ///    or `# noqa`), as long as the pragma comment starts before the
-///    line-length threshold. That is, a line will not be flagged as
-///    overlong if a pragma comment _causes_ it to exceed the line length.
+///    line-width threshold. That is, a line will not be flagged as
+///    overlong if a pragma comment _causes_ it to exceed the line width.
 ///    (This behavior aligns with that of the Ruff formatter.)
 ///
 /// If [`pycodestyle.ignore-overlong-task-comments`] is `true`, this rule will
@@ -53,7 +53,7 @@ use crate::settings::LinterSettings;
 ///
 /// ## Options
 /// - `task-tags`
-/// - `pycodestyle.max-doc-length`
+/// - `pycodestyle.max-doc-width`
 /// - `pycodestyle.ignore-overlong-task-comments`
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#maximum-line-length
@@ -64,7 +64,7 @@ impl Violation for DocLineTooLong {
     #[derive_message_formats]
     fn message(&self) -> String {
         let DocLineTooLong(width, limit) = self;
-        format!("Doc line too long ({width} > {limit} characters)")
+        format!("Doc line too long ({width} > {limit} width)")
     }
 }
 
@@ -74,7 +74,7 @@ pub(crate) fn doc_line_too_long(
     indexer: &Indexer,
     settings: &LinterSettings,
 ) -> Option<Diagnostic> {
-    let Some(limit) = settings.pycodestyle.max_doc_length else {
+    let Some(limit) = settings.pycodestyle.max_doc_width else {
         return None;
     };
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/line_too_long.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/line_too_long.rs
@@ -7,13 +7,13 @@ use crate::rules::pycodestyle::overlong::Overlong;
 use crate::settings::LinterSettings;
 
 /// ## What it does
-/// Checks for lines that exceed the specified maximum character length.
+/// Checks for lines that exceed the specified maximum width.
 ///
 /// ## Why is this bad?
 /// Overlong lines can hurt readability. [PEP 8], for example, recommends
-/// limiting lines to 79 characters. By default, this rule enforces a limit
-/// of 88 characters for compatibility with Black, though that limit is
-/// configurable via the [`line-length`] setting.
+/// limiting lines to 79 characters. By default, this rule enforces a [display-width](http://www.unicode.org/reports/tr11/#Overview)
+/// of 88 for compatibility with Black, though that limit is
+/// configurable via the [`line-width`] setting.
 ///
 /// In the interest of pragmatism, this rule makes a few exceptions when
 /// determining whether a line is overlong. Namely, it:
@@ -21,11 +21,11 @@ use crate::settings::LinterSettings;
 /// 1. Ignores lines that consist of a single "word" (i.e., without any
 ///    whitespace between its characters).
 /// 2. Ignores lines that end with a URL, as long as the URL starts before
-///    the line-length threshold.
+///    the `line-width` threshold.
 /// 3. Ignores line that end with a pragma comment (e.g., `# type: ignore`
 ///    or `# noqa`), as long as the pragma comment starts before the
-///    line-length threshold. That is, a line will not be flagged as
-///    overlong if a pragma comment _causes_ it to exceed the line length.
+///    `line-width` threshold. That is, a line will not be flagged as
+///    overlong if a pragma comment _causes_ it to exceed the line width.
 ///    (This behavior aligns with that of the Ruff formatter.)
 ///
 /// If [`pycodestyle.ignore-overlong-task-comments`] is `true`, this rule will
@@ -46,7 +46,7 @@ use crate::settings::LinterSettings;
 /// ```
 ///
 /// ## Options
-/// - `line-length`
+/// - `line-width`
 /// - `task-tags`
 /// - `pycodestyle.ignore-overlong-task-comments`
 ///
@@ -58,7 +58,7 @@ impl Violation for LineTooLong {
     #[derive_message_formats]
     fn message(&self) -> String {
         let LineTooLong(width, limit) = self;
-        format!("Line too long ({width} > {limit} characters)")
+        format!("Line too long ({width} > {limit} width)")
     }
 }
 
@@ -68,7 +68,7 @@ pub(crate) fn line_too_long(
     indexer: &Indexer,
     settings: &LinterSettings,
 ) -> Option<Diagnostic> {
-    let limit = settings.line_length;
+    let limit = settings.line_width;
 
     Overlong::try_from_line(
         line,

--- a/crates/ruff_linter/src/rules/pycodestyle/settings.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/settings.rs
@@ -2,10 +2,10 @@
 
 use ruff_macros::CacheKey;
 
-use crate::line_width::LineLength;
+use crate::line_width::LineWidth;
 
 #[derive(Debug, Default, CacheKey)]
 pub struct Settings {
-    pub max_doc_length: Option<LineLength>,
+    pub max_doc_width: Option<LineWidth>,
     pub ignore_overlong_task_comments: bool,
 }

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E501_E501.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E501_E501.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E501.py:5:89: E501 Line too long (123 > 88 characters)
+E501.py:5:89: E501 Line too long (123 > 88 width)
   |
 3 |     https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533
 4 | 
@@ -10,14 +10,14 @@ E501.py:5:89: E501 Line too long (123 > 88 characters)
 6 | """
   |
 
-E501.py:16:85: E501 Line too long (95 > 88 characters)
+E501.py:16:85: E501 Line too long (95 > 88 width)
    |
 15 | _ = "---------------------------------------------------------------------------AAAAAAA"
 16 | _ = "---------------------------------------------------------------------------亜亜亜亜亜亜亜"
    |                                                                                         ^^^^^^^ E501
    |
 
-E501.py:25:89: E501 Line too long (127 > 88 characters)
+E501.py:25:89: E501 Line too long (127 > 88 width)
    |
 23 | caller(
 24 |     """
@@ -27,7 +27,7 @@ E501.py:25:89: E501 Line too long (127 > 88 characters)
 27 | )
    |
 
-E501.py:40:89: E501 Line too long (132 > 88 characters)
+E501.py:40:89: E501 Line too long (132 > 88 width)
    |
 38 |     "Lorem ipsum dolor": "sit amet",
 39 |     # E501 Line too long
@@ -37,7 +37,7 @@ E501.py:40:89: E501 Line too long (132 > 88 characters)
 42 |     "Lorem ipsum dolor": """
    |
 
-E501.py:43:89: E501 Line too long (105 > 88 characters)
+E501.py:43:89: E501 Line too long (105 > 88 width)
    |
 41 |     # E501 Line too long
 42 |     "Lorem ipsum dolor": """
@@ -47,7 +47,7 @@ E501.py:43:89: E501 Line too long (105 > 88 characters)
 45 |     # OK
    |
 
-E501.py:83:89: E501 Line too long (147 > 88 characters)
+E501.py:83:89: E501 Line too long (147 > 88 width)
    |
 81 | class Bar:
 82 |     """

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E501_E501_3.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E501_E501_3.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E501_3.py:11:89: E501 Line too long (89 > 88 characters)
+E501_3.py:11:89: E501 Line too long (89 > 88 width)
    |
 10 | # Error (89 characters)
 11 | "shape:" + "shape:" + "shape:" + "shape:" + "shape:" + "shape:" + "shape:" + "shape:aaaa"  # type: ignore

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__max_doc_length.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__max_doc_length.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-W505.py:2:51: W505 Doc line too long (57 > 50 characters)
+W505.py:2:51: W505 Doc line too long (57 > 50 width)
   |
 1 | #!/usr/bin/env python3
 2 | """Here's a top-level docstring that's over the limit."""
   |                                                   ^^^^^^^ W505
   |
 
-W505.py:6:51: W505 Doc line too long (56 > 50 characters)
+W505.py:6:51: W505 Doc line too long (56 > 50 width)
   |
 5 | def f1():
 6 |     """Here's a docstring that's also over the limit."""
@@ -17,7 +17,7 @@ W505.py:6:51: W505 Doc line too long (56 > 50 characters)
 8 |     x = 1  # Here's a comment that's over the limit, but it's not standalone.
   |
 
-W505.py:10:51: W505 Doc line too long (56 > 50 characters)
+W505.py:10:51: W505 Doc line too long (56 > 50 width)
    |
  8 |     x = 1  # Here's a comment that's over the limit, but it's not standalone.
  9 | 
@@ -27,7 +27,7 @@ W505.py:10:51: W505 Doc line too long (56 > 50 characters)
 12 |     x = 2
    |
 
-W505.py:13:51: W505 Doc line too long (93 > 50 characters)
+W505.py:13:51: W505 Doc line too long (93 > 50 width)
    |
 12 |     x = 2
 13 |     # Another standalone that is preceded by a newline and indent toke and is over the limit.
@@ -36,13 +36,13 @@ W505.py:13:51: W505 Doc line too long (93 > 50 characters)
 15 |     print("Here's a string that's over the limit, but it's not a docstring.")
    |
 
-W505.py:18:51: W505 Doc line too long (61 > 50 characters)
+W505.py:18:51: W505 Doc line too long (61 > 50 width)
    |
 18 | "This is also considered a docstring, and is over the limit."
    |                                                   ^^^^^^^^^^^ W505
    |
 
-W505.py:24:51: W505 Doc line too long (82 > 50 characters)
+W505.py:24:51: W505 Doc line too long (82 > 50 width)
    |
 22 |     """Here's a multi-line docstring.
 23 | 
@@ -51,7 +51,7 @@ W505.py:24:51: W505 Doc line too long (82 > 50 characters)
 25 |     """
    |
 
-W505.py:31:51: W505 Doc line too long (85 > 50 characters)
+W505.py:31:51: W505 Doc line too long (85 > 50 width)
    |
 29 |     """Here's a multi-line docstring.
 30 | 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__max_doc_length_with_utf_8.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__max_doc_length_with_utf_8.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-W505_utf_8.py:2:50: W505 Doc line too long (57 > 50 characters)
+W505_utf_8.py:2:50: W505 Doc line too long (57 > 50 width)
   |
 1 | #!/usr/bin/env python3
 2 | """Here's a top-level ß9💣2ℝing that's over theß9💣2ℝ."""
   |                                                    ^^^^^^ W505
   |
 
-W505_utf_8.py:6:49: W505 Doc line too long (56 > 50 characters)
+W505_utf_8.py:6:49: W505 Doc line too long (56 > 50 width)
   |
 5 | def f1():
 6 |     """Here's a ß9💣2ℝing that's also over theß9💣2ℝ."""
@@ -17,7 +17,7 @@ W505_utf_8.py:6:49: W505 Doc line too long (56 > 50 characters)
 8 |     x = 1  # Here's a comment that's over theß9💣2ℝ, but it's not standalone.
   |
 
-W505_utf_8.py:10:51: W505 Doc line too long (56 > 50 characters)
+W505_utf_8.py:10:51: W505 Doc line too long (56 > 50 width)
    |
  8 |     x = 1  # Here's a comment that's over theß9💣2ℝ, but it's not standalone.
  9 | 
@@ -27,7 +27,7 @@ W505_utf_8.py:10:51: W505 Doc line too long (56 > 50 characters)
 12 |     x = 2
    |
 
-W505_utf_8.py:13:51: W505 Doc line too long (93 > 50 characters)
+W505_utf_8.py:13:51: W505 Doc line too long (93 > 50 width)
    |
 12 |     x = 2
 13 |     # Another standalone that is preceded by a newline and indent toke and is over theß9💣2ℝ.
@@ -36,13 +36,13 @@ W505_utf_8.py:13:51: W505 Doc line too long (93 > 50 characters)
 15 |     print("Here's a string that's over theß9💣2ℝ, but it's not a ß9💣2ℝing.")
    |
 
-W505_utf_8.py:18:50: W505 Doc line too long (61 > 50 characters)
+W505_utf_8.py:18:50: W505 Doc line too long (61 > 50 width)
    |
 18 | "This is also considered a ß9💣2ℝing, and is over theß9💣2ℝ."
    |                                                   ^^^^^^^^^^^ W505
    |
 
-W505_utf_8.py:24:50: W505 Doc line too long (82 > 50 characters)
+W505_utf_8.py:24:50: W505 Doc line too long (82 > 50 width)
    |
 22 |     """Here's a multi-line ß9💣2ℝing.
 23 | 
@@ -51,7 +51,7 @@ W505_utf_8.py:24:50: W505 Doc line too long (82 > 50 characters)
 25 |     """
    |
 
-W505_utf_8.py:31:50: W505 Doc line too long (85 > 50 characters)
+W505_utf_8.py:31:50: W505 Doc line too long (85 > 50 width)
    |
 29 |     """Here's a multi-line ß9💣2ℝing.
 30 | 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_1.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_1.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E501_2.py:2:7: E501 Line too long (7 > 6 characters)
+E501_2.py:2:7: E501 Line too long (7 > 6 width)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -10,7 +10,7 @@ E501_2.py:2:7: E501 Line too long (7 > 6 characters)
 4 |     # a
   |
 
-E501_2.py:3:7: E501 Line too long (7 > 6 characters)
+E501_2.py:3:7: E501 Line too long (7 > 6 width)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -20,7 +20,7 @@ E501_2.py:3:7: E501 Line too long (7 > 6 characters)
 5 |     # aa
   |
 
-E501_2.py:7:7: E501 Line too long (7 > 6 characters)
+E501_2.py:7:7: E501 Line too long (7 > 6 width)
   |
 5 |     # aa
 6 |     # aaa
@@ -30,7 +30,7 @@ E501_2.py:7:7: E501 Line too long (7 > 6 characters)
 9 |         # aa
   |
 
-E501_2.py:10:7: E501 Line too long (7 > 6 characters)
+E501_2.py:10:7: E501 Line too long (7 > 6 width)
    |
  8 |         # a
  9 |         # aa
@@ -40,7 +40,7 @@ E501_2.py:10:7: E501 Line too long (7 > 6 characters)
 12 | if True: # noqa: E501
    |
 
-E501_2.py:16:7: E501 Line too long (7 > 6 characters)
+E501_2.py:16:7: E501 Line too long (7 > 6 width)
    |
 14 |     [12 ]
 15 |     [1,2]

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_2.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_2.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E501_2.py:2:7: E501 Line too long (7 > 6 characters)
+E501_2.py:2:7: E501 Line too long (7 > 6 width)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -10,7 +10,7 @@ E501_2.py:2:7: E501 Line too long (7 > 6 characters)
 4 |     # a
   |
 
-E501_2.py:3:7: E501 Line too long (7 > 6 characters)
+E501_2.py:3:7: E501 Line too long (7 > 6 width)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -20,7 +20,7 @@ E501_2.py:3:7: E501 Line too long (7 > 6 characters)
 5 |     # aa
   |
 
-E501_2.py:6:6: E501 Line too long (7 > 6 characters)
+E501_2.py:6:6: E501 Line too long (7 > 6 width)
   |
 4 |     # a
 5 |     # aa
@@ -30,7 +30,7 @@ E501_2.py:6:6: E501 Line too long (7 > 6 characters)
 8 |         # a
   |
 
-E501_2.py:7:6: E501 Line too long (8 > 6 characters)
+E501_2.py:7:6: E501 Line too long (8 > 6 width)
   |
 5 |     # aa
 6 |     # aaa
@@ -40,7 +40,7 @@ E501_2.py:7:6: E501 Line too long (8 > 6 characters)
 9 |         # aa
   |
 
-E501_2.py:8:5: E501 Line too long (7 > 6 characters)
+E501_2.py:8:5: E501 Line too long (7 > 6 width)
    |
  6 |     # aaa
  7 |     # aaaa
@@ -50,7 +50,7 @@ E501_2.py:8:5: E501 Line too long (7 > 6 characters)
 10 |         # aaa
    |
 
-E501_2.py:9:5: E501 Line too long (8 > 6 characters)
+E501_2.py:9:5: E501 Line too long (8 > 6 width)
    |
  7 |     # aaaa
  8 |         # a
@@ -59,7 +59,7 @@ E501_2.py:9:5: E501 Line too long (8 > 6 characters)
 10 |         # aaa
    |
 
-E501_2.py:10:5: E501 Line too long (9 > 6 characters)
+E501_2.py:10:5: E501 Line too long (9 > 6 width)
    |
  8 |         # a
  9 |         # aa
@@ -69,7 +69,7 @@ E501_2.py:10:5: E501 Line too long (9 > 6 characters)
 12 | if True: # noqa: E501
    |
 
-E501_2.py:14:6: E501 Line too long (7 > 6 characters)
+E501_2.py:14:6: E501 Line too long (7 > 6 width)
    |
 12 | if True: # noqa: E501
 13 |     [12]
@@ -79,7 +79,7 @@ E501_2.py:14:6: E501 Line too long (7 > 6 characters)
 16 |     [1, 2]
    |
 
-E501_2.py:16:6: E501 Line too long (8 > 6 characters)
+E501_2.py:16:6: E501 Line too long (8 > 6 width)
    |
 14 |     [12 ]
 15 |     [1,2]

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_4.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_4.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E501_2.py:2:7: E501 Line too long (7 > 6 characters)
+E501_2.py:2:7: E501 Line too long (7 > 6 width)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -10,7 +10,7 @@ E501_2.py:2:7: E501 Line too long (7 > 6 characters)
 4 |     # a
   |
 
-E501_2.py:3:7: E501 Line too long (7 > 6 characters)
+E501_2.py:3:7: E501 Line too long (7 > 6 width)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -20,7 +20,7 @@ E501_2.py:3:7: E501 Line too long (7 > 6 characters)
 5 |     # aa
   |
 
-E501_2.py:4:4: E501 Line too long (7 > 6 characters)
+E501_2.py:4:4: E501 Line too long (7 > 6 width)
   |
 2 | # aaaaa
 3 |     # a
@@ -30,7 +30,7 @@ E501_2.py:4:4: E501 Line too long (7 > 6 characters)
 6 |     # aaa
   |
 
-E501_2.py:5:4: E501 Line too long (8 > 6 characters)
+E501_2.py:5:4: E501 Line too long (8 > 6 width)
   |
 3 |     # a
 4 |     # a
@@ -40,7 +40,7 @@ E501_2.py:5:4: E501 Line too long (8 > 6 characters)
 7 |     # aaaa
   |
 
-E501_2.py:6:4: E501 Line too long (9 > 6 characters)
+E501_2.py:6:4: E501 Line too long (9 > 6 width)
   |
 4 |     # a
 5 |     # aa
@@ -50,7 +50,7 @@ E501_2.py:6:4: E501 Line too long (9 > 6 characters)
 8 |         # a
   |
 
-E501_2.py:7:4: E501 Line too long (10 > 6 characters)
+E501_2.py:7:4: E501 Line too long (10 > 6 width)
   |
 5 |     # aa
 6 |     # aaa
@@ -60,7 +60,7 @@ E501_2.py:7:4: E501 Line too long (10 > 6 characters)
 9 |         # aa
   |
 
-E501_2.py:8:3: E501 Line too long (11 > 6 characters)
+E501_2.py:8:3: E501 Line too long (11 > 6 width)
    |
  6 |     # aaa
  7 |     # aaaa
@@ -70,7 +70,7 @@ E501_2.py:8:3: E501 Line too long (11 > 6 characters)
 10 |         # aaa
    |
 
-E501_2.py:9:3: E501 Line too long (12 > 6 characters)
+E501_2.py:9:3: E501 Line too long (12 > 6 width)
    |
  7 |     # aaaa
  8 |         # a
@@ -79,7 +79,7 @@ E501_2.py:9:3: E501 Line too long (12 > 6 characters)
 10 |         # aaa
    |
 
-E501_2.py:10:3: E501 Line too long (13 > 6 characters)
+E501_2.py:10:3: E501 Line too long (13 > 6 width)
    |
  8 |         # a
  9 |         # aa
@@ -89,7 +89,7 @@ E501_2.py:10:3: E501 Line too long (13 > 6 characters)
 12 | if True: # noqa: E501
    |
 
-E501_2.py:14:4: E501 Line too long (9 > 6 characters)
+E501_2.py:14:4: E501 Line too long (9 > 6 width)
    |
 12 | if True: # noqa: E501
 13 |     [12]
@@ -99,7 +99,7 @@ E501_2.py:14:4: E501 Line too long (9 > 6 characters)
 16 |     [1, 2]
    |
 
-E501_2.py:16:4: E501 Line too long (10 > 6 characters)
+E501_2.py:16:4: E501 Line too long (10 > 6 width)
    |
 14 |     [12 ]
 15 |     [1,2]

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_8.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_8.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E501_2.py:2:7: E501 Line too long (7 > 6 characters)
+E501_2.py:2:7: E501 Line too long (7 > 6 width)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -10,7 +10,7 @@ E501_2.py:2:7: E501 Line too long (7 > 6 characters)
 4 |     # a
   |
 
-E501_2.py:3:7: E501 Line too long (7 > 6 characters)
+E501_2.py:3:7: E501 Line too long (7 > 6 width)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -20,7 +20,7 @@ E501_2.py:3:7: E501 Line too long (7 > 6 characters)
 5 |     # aa
   |
 
-E501_2.py:4:2: E501 Line too long (11 > 6 characters)
+E501_2.py:4:2: E501 Line too long (11 > 6 width)
   |
 2 | # aaaaa
 3 |     # a
@@ -30,7 +30,7 @@ E501_2.py:4:2: E501 Line too long (11 > 6 characters)
 6 |     # aaa
   |
 
-E501_2.py:5:2: E501 Line too long (12 > 6 characters)
+E501_2.py:5:2: E501 Line too long (12 > 6 width)
   |
 3 |     # a
 4 |     # a
@@ -40,7 +40,7 @@ E501_2.py:5:2: E501 Line too long (12 > 6 characters)
 7 |     # aaaa
   |
 
-E501_2.py:6:2: E501 Line too long (13 > 6 characters)
+E501_2.py:6:2: E501 Line too long (13 > 6 width)
   |
 4 |     # a
 5 |     # aa
@@ -50,7 +50,7 @@ E501_2.py:6:2: E501 Line too long (13 > 6 characters)
 8 |         # a
   |
 
-E501_2.py:7:2: E501 Line too long (14 > 6 characters)
+E501_2.py:7:2: E501 Line too long (14 > 6 width)
   |
 5 |     # aa
 6 |     # aaa
@@ -60,7 +60,7 @@ E501_2.py:7:2: E501 Line too long (14 > 6 characters)
 9 |         # aa
   |
 
-E501_2.py:8:2: E501 Line too long (19 > 6 characters)
+E501_2.py:8:2: E501 Line too long (19 > 6 width)
    |
  6 |     # aaa
  7 |     # aaaa
@@ -70,7 +70,7 @@ E501_2.py:8:2: E501 Line too long (19 > 6 characters)
 10 |         # aaa
    |
 
-E501_2.py:9:2: E501 Line too long (20 > 6 characters)
+E501_2.py:9:2: E501 Line too long (20 > 6 width)
    |
  7 |     # aaaa
  8 |         # a
@@ -79,7 +79,7 @@ E501_2.py:9:2: E501 Line too long (20 > 6 characters)
 10 |         # aaa
    |
 
-E501_2.py:10:2: E501 Line too long (21 > 6 characters)
+E501_2.py:10:2: E501 Line too long (21 > 6 width)
    |
  8 |         # a
  9 |         # aa
@@ -89,7 +89,7 @@ E501_2.py:10:2: E501 Line too long (21 > 6 characters)
 12 | if True: # noqa: E501
    |
 
-E501_2.py:14:2: E501 Line too long (13 > 6 characters)
+E501_2.py:14:2: E501 Line too long (13 > 6 width)
    |
 12 | if True: # noqa: E501
 13 |     [12]
@@ -99,7 +99,7 @@ E501_2.py:14:2: E501 Line too long (13 > 6 characters)
 16 |     [1, 2]
    |
 
-E501_2.py:16:2: E501 Line too long (14 > 6 characters)
+E501_2.py:16:2: E501 Line too long (14 > 6 width)
    |
 14 |     [12 ]
 15 |     [1,2]

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__task_tags_false.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__task_tags_false.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E501_1.py:1:89: E501 Line too long (149 > 88 characters)
+E501_1.py:1:89: E501 Line too long (149 > 88 width)
   |
 1 | # TODO: comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |                                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E501
@@ -9,7 +9,7 @@ E501_1.py:1:89: E501 Line too long (149 > 88 characters)
 3 | # TODO comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |
 
-E501_1.py:2:89: E501 Line too long (158 > 88 characters)
+E501_1.py:2:89: E501 Line too long (158 > 88 width)
   |
 1 | # TODO: comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
 2 | # TODO(charlie): comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
@@ -18,7 +18,7 @@ E501_1.py:2:89: E501 Line too long (158 > 88 characters)
 4 | #     TODO    comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |
 
-E501_1.py:3:89: E501 Line too long (148 > 88 characters)
+E501_1.py:3:89: E501 Line too long (148 > 88 width)
   |
 1 | # TODO: comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
 2 | # TODO(charlie): comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
@@ -28,7 +28,7 @@ E501_1.py:3:89: E501 Line too long (148 > 88 characters)
 5 | # FIXME: comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |
 
-E501_1.py:4:89: E501 Line too long (155 > 88 characters)
+E501_1.py:4:89: E501 Line too long (155 > 88 width)
   |
 2 | # TODO(charlie): comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
 3 | # TODO comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
@@ -38,7 +38,7 @@ E501_1.py:4:89: E501 Line too long (155 > 88 characters)
 6 | # FIXME comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |
 
-E501_1.py:5:89: E501 Line too long (150 > 88 characters)
+E501_1.py:5:89: E501 Line too long (150 > 88 width)
   |
 3 | # TODO comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
 4 | #     TODO    comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
@@ -48,7 +48,7 @@ E501_1.py:5:89: E501 Line too long (150 > 88 characters)
 7 | #     FIXME    comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |
 
-E501_1.py:6:89: E501 Line too long (149 > 88 characters)
+E501_1.py:6:89: E501 Line too long (149 > 88 width)
   |
 4 | #     TODO    comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
 5 | # FIXME: comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
@@ -58,7 +58,7 @@ E501_1.py:6:89: E501 Line too long (149 > 88 characters)
 8 | # FIXME(charlie): comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |
 
-E501_1.py:7:89: E501 Line too long (156 > 88 characters)
+E501_1.py:7:89: E501 Line too long (156 > 88 width)
   |
 5 | # FIXME: comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
 6 | # FIXME comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
@@ -67,7 +67,7 @@ E501_1.py:7:89: E501 Line too long (156 > 88 characters)
 8 | # FIXME(charlie): comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |
 
-E501_1.py:8:89: E501 Line too long (159 > 88 characters)
+E501_1.py:8:89: E501 Line too long (159 > 88 width)
   |
 6 | # FIXME comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
 7 | #     FIXME    comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -399,7 +399,7 @@ pub(crate) fn f_strings(
         &contents,
         template.into(),
         checker.locator(),
-        checker.settings.line_length,
+        checker.settings.line_width,
         checker.settings.tab_size,
     ) {
         return;

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
@@ -237,7 +237,7 @@ RUF100_0.py:85:8: F401 [*] `shelve` imported but unused
 87 86 | 
 88 87 | print(sys.path)
 
-RUF100_0.py:90:89: E501 Line too long (89 > 88 characters)
+RUF100_0.py:90:89: E501 Line too long (89 > 88 width)
    |
 88 | print(sys.path)
 89 | 

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -26,7 +26,7 @@ use crate::rules::{
 use crate::settings::types::{FilePatternSet, PerFileIgnore, PythonVersion};
 use crate::{codes, RuleSelector};
 
-use super::line_width::{LineLength, TabSize};
+use super::line_width::{LineWidth, TabSize};
 
 use self::rule_table::RuleTable;
 use self::types::PreviewMode;
@@ -56,7 +56,7 @@ pub struct LinterSettings {
     pub dummy_variable_rgx: Regex,
     pub external: FxHashSet<String>,
     pub ignore_init_module_imports: bool,
-    pub line_length: LineLength,
+    pub line_width: LineWidth,
     pub logger_objects: Vec<String>,
     pub namespace_packages: Vec<PathBuf>,
     pub src: Vec<PathBuf>,
@@ -147,7 +147,7 @@ impl LinterSettings {
 
             external: HashSet::default(),
             ignore_init_module_imports: false,
-            line_length: LineLength::default(),
+            line_width: LineWidth::default(),
             logger_objects: vec![],
             namespace_packages: vec![],
 

--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -117,12 +117,11 @@ indent-style = "tab"
 quote-style = "single"
 ```
 
-The Ruff formatter also respects Ruff's [`line-length`](https://docs.astral.sh/ruff/settings/#line-length)
-setting, which also can be provided via a `pyproject.toml` or `ruff.toml` file, or on the CLI, as
-in:
+The Ruff formatter also respects Ruff's [`line-width`](https://docs.astral.sh/ruff/settings/#line-width)
+setting, which also can be provided via a `pyproject.toml` or `ruff.toml` file:
 
-```console
-ruff format --line-length 100 /path/to/file.py
+```toml
+line-width = 100
 ```
 
 ### Excluding code from formatting

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -6,7 +6,7 @@ use wasm_bindgen::prelude::*;
 
 use ruff_formatter::{FormatResult, Formatted, IndentStyle};
 use ruff_linter::directives;
-use ruff_linter::line_width::{LineLength, TabSize};
+use ruff_linter::line_width::{LineWidth, TabSize};
 use ruff_linter::linter::{check_path, LinterResult};
 use ruff_linter::registry::AsRule;
 use ruff_linter::settings::types::PythonVersion;
@@ -124,7 +124,7 @@ impl Workspace {
             // Propagate defaults.
             builtins: Some(Vec::default()),
 
-            line_length: Some(LineLength::default()),
+            line_width: Some(LineWidth::default()),
 
             tab_size: Some(TabSize::default()),
             target_version: Some(PythonVersion::default()),

--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -158,7 +158,7 @@ mod tests {
     use rustc_hash::FxHashMap;
 
     use ruff_linter::codes;
-    use ruff_linter::line_width::LineLength;
+    use ruff_linter::line_width::LineWidth;
     use ruff_linter::settings::types::PatternPrefixPair;
 
     use crate::options::{LintCommonOptions, Options};
@@ -195,14 +195,14 @@ mod tests {
             r#"
 [tool.black]
 [tool.ruff]
-line-length = 79
+line-width = 79
 "#,
         )?;
         assert_eq!(
             pyproject.tool,
             Some(Tools {
                 ruff: Some(Options {
-                    line_length: Some(LineLength::try_from(79).unwrap()),
+                    line_width: Some(LineWidth::try_from(79).unwrap()),
                     ..Options::default()
                 })
             })
@@ -289,7 +289,7 @@ select = ["E123"]
             r#"
 [tool.black]
 [tool.ruff]
-line-length = 79
+line-width = 79
 other-attribute = 1
 "#,
         )
@@ -308,7 +308,7 @@ other-attribute = 1
         assert_eq!(
             config,
             Options {
-                line_length: Some(LineLength::try_from(88).unwrap()),
+                line_width: Some(LineWidth::try_from(88).unwrap()),
                 extend_exclude: Some(vec![
                     "excluded_file.py".to_string(),
                     "migrations".to_string(),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,8 +47,8 @@ exclude = [
 ]
 per-file-ignores = {}
 
-# Same as Black.
-line-length = 88
+# Same as Black's line-length.
+line-width = 88
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
@@ -305,8 +305,8 @@ supports an [`extend`](settings.md#extend) field, which allows you to inherit th
 ```toml
 # Extend the `pyproject.toml` file in the parent directory.
 extend = "../pyproject.toml"
-# But use a different line length.
-line-length = 100
+# But use a different line width.
+line-width = 100
 ```
 
 All of the above rules apply equivalently to `ruff.toml` and `.ruff.toml` files. If Ruff detects

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,7 +3,7 @@
 ## Is Ruff compatible with Black?
 
 Yes. Ruff is compatible with [Black](https://github.com/psf/black) out-of-the-box, as long as
-the `line-length` setting is consistent between the two.
+Ruff's `line-width` setting is consistent with Black's `line-length` setting.
 
 As a project, Ruff is designed to be used alongside Black and, as such, will defer implementing
 stylistic lint rules that are obviated by automated formatting.
@@ -11,7 +11,7 @@ stylistic lint rules that are obviated by automated formatting.
 Note that Ruff and Black treat line-length enforcement a little differently. Black makes a
 best-effort attempt to adhere to the `line-length`, but avoids automatic line-wrapping in some cases
 (e.g., within comments). Ruff, on the other hand, will flag rule `E501` for any line that exceeds
-the `line-length` setting. As such, if `E501` is enabled, Ruff can still trigger line-length
+the `line-width` setting. As such, if `E501` is enabled, Ruff can still trigger line-width
 violations even when Black is enabled.
 
 ## How does Ruff compare to Flake8?
@@ -404,7 +404,7 @@ For example, given this `pyproject.toml`:
 
 ```toml
 [tool.ruff]
-line-length = 88
+line-width = 88
 
 [tool.ruff.pydocstyle]
 convention = "google"
@@ -413,7 +413,7 @@ convention = "google"
 You could instead use a `ruff.toml` file like so:
 
 ```toml
-line-length = 88
+line-width = 88
 
 [pydocstyle]
 convention = "google"

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -81,15 +81,15 @@ Let's create a `pyproject.toml` file in our project's root directory:
 # overlap with the use of a formatter, like Black, but we can override this behavior by
 # explicitly adding the rule.
 extend-select = ["E501"]
-# Set the maximum line length to 79 characters.
-line-length = 79
+# Set the maximum line width to 79 characters.
+line-width = 79
 ```
 
 Running Ruff again, we can see that it now enforces a line length of 79 characters:
 
 ```shell
 ❯ ruff check .
-numbers/numbers.py:5:80: E501 Line too long (90 > 79 characters)
+numbers/numbers.py:5:80: E501 Line too long (90 > 79 width)
 Found 1 error.
 ```
 
@@ -104,8 +104,8 @@ requires-python = ">=3.10"
 [tool.ruff]
 # Add the `line-too-long` rule to the enforced rule set.
 extend-select = ["E501"]
-# Set the maximum line length to 79 characters.
-line-length = 79
+# Set the maximum line width to 79.
+line-width = 79
 ```
 
 ### Rule Selection

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -425,10 +425,22 @@
       ]
     },
     "line-length": {
-      "description": "The line length to use when enforcing long-lines violations (like `E501`). Must be greater than `0` and less than or equal to `320`.",
+      "description": "The maximum [width](http://www.unicode.org/reports/tr11/#Overview) of each line when formatting code and when enforcing long-lines violations (like `E501`).\n\nMust be greater than `0` and less than or equal to `320`.\n\nNote: Formatted code may exceed the configured line width when it can't automatically split the line into shorter lines, e.g. because it is a too long comment or identifier.",
+      "deprecated": true,
       "anyOf": [
         {
-          "$ref": "#/definitions/LineLength"
+          "$ref": "#/definitions/LineWidth"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "line-width": {
+      "description": "The maximum [width](http://www.unicode.org/reports/tr11/#Overview) of a line when formatting code and when enforcing long-lines violations (like `E501`).\n\nMust be greater than `0` and less than or equal to `320`.\n\nNote: Formatted code may exceed the configured line width when it can't automatically split the line into shorter lines, e.g. because it is a too long comment or identifier.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LineWidth"
         },
         {
           "type": "null"
@@ -1592,7 +1604,7 @@
         }
       ]
     },
-    "LineLength": {
+    "LineWidth": {
       "description": "The length of a line of text that is considered too long.\n\nThe allowed range of values is 1..=320",
       "type": "integer",
       "format": "uint16",
@@ -2196,9 +2208,21 @@
         },
         "max-doc-length": {
           "description": "The maximum line length to allow for line-length violations within documentation (`W505`), including standalone comments. By default, this is set to null which disables reporting violations.\n\nSee the [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) rule for more information.",
+          "deprecated": true,
           "anyOf": [
             {
-              "$ref": "#/definitions/LineLength"
+              "$ref": "#/definitions/LineWidth"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max-doc-width": {
+          "description": "The maximum [width](http://www.unicode.org/reports/tr11/#Overview) to allow for [`doc-line-too-long`] violations within documentation (`W505`), including standalone comments. By default, this is set to null which disables reporting violations.\n\nSee the [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) rule for more information.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LineWidth"
             },
             {
               "type": "null"

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.8"
 line-length = 88
 
 [tool.ruff]
-line-length = 88
+line-width = 88
 select = ["ALL"]
 ignore = [
   "C901",  # McCabe complexity


### PR DESCRIPTION
## Summary

This PR deprecates the `line-length` and `pycodestyle.max-doc-length` options in favor of the new `line-width` and `pycodestyle.max-line-width` options. The motivation behind the rename is that the new options better emphasize the fact that the unit is the unicode display width and not the characters per line. 

I used this PR to change the diagnostic text for `E501` and `W505` to use the term `width` instead of `characters` in the diagnostic messages.

The old options act as aliases (including `ruff check --line-length`) until we decide to remove them for good. Ruff prints a warning when it detects the usage of a deprecated configuration option. The deprecated options remain visible on the website but are marked as deprecated. The same is true when showing the options with `ruff config`.

This PR doesn't yet rename `tab-size` because I'm yet undecided whether it should be `tab-width` or `tab-spaces`.

Closes https://github.com/astral-sh/ruff/issues/7574
Closes https://github.com/astral-sh/ruff/issues/7573

## Considerations
We may want to consider holding off on this rename, considering that `line-length` is one of the most often used settings and the 0.1.0 was about stabilization. Deprecating the option is in line with our versioning policy (patch release is fine), but it may give the impression that Ruff isn't as stable as we claimed it to be with the 0.1 release.

## Test Plan

Newly added integration tests.

<img width="1120" alt="Screenshot 2023-10-19 at 10 07 45" src="https://github.com/astral-sh/ruff/assets/1203881/142db855-bebb-43d1-a418-c2488e35befe">
<img width="1109" alt="Screenshot 2023-10-19 at 10 07 35" src="https://github.com/astral-sh/ruff/assets/1203881/497c72be-a57d-45af-8e49-20415282bec3">
