### PR TITLE
Allow multiline `#!` and `#%%` comments in E265

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E26.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E26.py
@@ -72,3 +72,8 @@ a = 42  #  (Two spaces)
 # EF  Means test is giving error and Failing
 #!   Means test is segfaulting
 # 8   Means test runs forever
+
+#%%
+# %%
+# This is a comment
+# This is another comment

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
@@ -167,10 +167,10 @@ pub(crate) fn whitespace_before_comment(
             let symbol = parts.next().unwrap_or("");
             let comment = parts.next().unwrap_or("");
 
-            let bad_prefix = if symbol != "#" && symbol != "#:" {
-                Some(symbol.trim_start_matches('#').chars().next().unwrap_or('#'))
-            } else {
+            let bad_prefix = if matches!(symbol, "#" | "#:" | "#!" | "#%%") {
                 None
+            } else {
+                Some(symbol.trim_start_matches('#').chars().next().unwrap_or('#'))
             };
 
             if is_inline_comment {

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E265_E26.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E265_E26.py.snap
@@ -11,16 +11,6 @@ E26.py:10:1: E265 Block comment should start with `# `
 12 | #: E265:2:1
    |
 
-E26.py:14:1: E265 Block comment should start with `# `
-   |
-12 | #: E265:2:1
-13 | m = 42
-14 | #! This is important
-   | ^^^^^^^^^^^^^^^^^^^^ E265
-15 | mx = 42 - 42
-16 | #: E266:3:5 E266:6:5
-   |
-
 E26.py:25:1: E265 Block comment should start with `# `
    |
 23 |     return
@@ -38,15 +28,6 @@ E26.py:32:1: E265 Block comment should start with `# `
    | ^^^^^^^^^^^^^^^^^^^^^ E265
 33 | 
 34 | pass  # an inline comment
-   |
-
-E26.py:73:1: E265 Block comment should start with `# `
-   |
-71 | # F   Means test is failing (F)
-72 | # EF  Means test is giving error and Failing
-73 | #!   Means test is segfaulting
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E265
-74 | # 8   Means test runs forever
    |
 
 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__shebang.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__shebang.snap
@@ -1,13 +1,4 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-shebang.py:3:1: E265 Block comment should start with `# `
-  |
-1 | #!/usr/bin/python
-2 | #
-3 | #!
-  | ^^ E265
-4 | #:
-  |
-
 


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff/issues/8003. After reading that issue, I then found several requests for multiline shebangs and code cell separators (`#%%`) in the Pycodestyle repo, so added both.
