### PR TITLE
Avoid flagging `bad-dunder-method-name` for `_`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
@@ -68,6 +68,10 @@ class Apples:
     def _missing_(cls, value):
         pass
 
+    # Allow anonymous functions.
+    def _(self):
+        pass
+
 
 def __foo_bar__():  # this is not checked by the [bad-dunder-name] rule
     ...

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_dunder_method_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_dunder_method_name.rs
@@ -54,7 +54,7 @@ pub(crate) fn bad_dunder_method_name(checker: &mut Checker, class_body: &[Stmt])
         .iter()
         .filter_map(ruff_python_ast::Stmt::as_function_def_stmt)
         .filter(|method| {
-            if is_known_dunder_method(&method.name) {
+            if is_known_dunder_method(&method.name) || matches!(method.name.as_str(), "_") {
                 return false;
             }
             method.name.starts_with('_') && method.name.ends_with('_')


### PR DESCRIPTION
This is almost certainly _not_ an accidentally mistyped dunder method. Closes https://github.com/astral-sh/ruff/issues/8005.