### PR TITLE
Add compatibility test for `ruff-lsp` to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -347,12 +347,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
+        name: "Download ruff-lsp source"
+        with:
+          repository: 'astral-sh/ruff-lsp'
+
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - uses: actions/download-artifact@v3
-        name: Download Ruff binary
+        name: Download ruff binary
         id: ruff-target
         with:
           name: ruff

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -337,6 +337,42 @@ jobs:
       - name: "Remove checkouts from cache"
         run: rm -r target/progress_projects
 
+  check-ruff-lsp:
+    name: "Check compatibility with ruff-lsp"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - uses: actions/download-artifact@v3
+        name: Download Ruff binary
+        id: ruff-target
+        with:
+          name: ruff
+          path: target/debug
+
+      - name: Install ruff-lsp dependencies
+        run: |
+          just install
+          
+      - name: Setup development ruff version
+        run: |
+          # Make executable and prepend to path
+          chmod +x ${{ steps.ruff-target.outputs.download-path }}/ruff
+          export PATH=${{ steps.ruff-target.outputs.download-path }}:$PATH
+
+          ruff --version
+
+      - name: Run ruff-lsp tests
+        run: |
+          just test
+    
   benchmarks:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -349,7 +349,7 @@ jobs:
       - uses: actions/checkout@v4
         name: "Download ruff-lsp source"
         with:
-          repository: 'astral-sh/ruff-lsp'
+          repository: "astral-sh/ruff-lsp"
 
       - uses: actions/setup-python@v4
         with:
@@ -365,7 +365,7 @@ jobs:
       - name: Install ruff-lsp dependencies
         run: |
           just install
-          
+
       - name: Setup development ruff version
         run: |
           # Make executable and prepend to path
@@ -377,7 +377,7 @@ jobs:
       - name: Run ruff-lsp tests
         run: |
           just test
-    
+
   benchmarks:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -340,6 +340,7 @@ jobs:
   check-ruff-lsp:
     name: "Check compatibility with ruff-lsp"
     runs-on: ubuntu-latest
+    needs: cargo-test
     steps:
       - uses: extractions/setup-just@v1
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -369,6 +369,7 @@ jobs:
       - name:  Run ruff-lsp tests
         run: |
           # Setup development binary
+          pip uninstall ruff
           chmod +x ${{ steps.ruff-target.outputs.download-path }}/ruff
           export PATH=${{ steps.ruff-target.outputs.download-path }}:$PATH
           ruff version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -338,7 +338,7 @@ jobs:
         run: rm -r target/progress_projects
 
   check-ruff-lsp:
-    name: "Check compatibility with ruff-lsp"
+    name: "test ruff-lsp"
     runs-on: ubuntu-latest
     needs: cargo-test
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -366,7 +366,7 @@ jobs:
         run: |
           just install
 
-      - name:  Run ruff-lsp tests
+      - name: Run ruff-lsp tests
         run: |
           # Setup development binary
           pip uninstall ruff

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -369,7 +369,7 @@ jobs:
       - name: Run ruff-lsp tests
         run: |
           # Setup development binary
-          pip uninstall --no-input ruff
+          pip uninstall --yes ruff
           chmod +x ${{ steps.ruff-target.outputs.download-path }}/ruff
           export PATH=${{ steps.ruff-target.outputs.download-path }}:$PATH
           ruff version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -372,7 +372,7 @@ jobs:
           chmod +x ${{ steps.ruff-target.outputs.download-path }}/ruff
           export PATH=${{ steps.ruff-target.outputs.download-path }}:$PATH
 
-          ruff --version
+          ruff version
 
       - name: Run ruff-lsp tests
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -356,7 +356,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - uses: actions/download-artifact@v3
-        name: Download ruff binary
+        name: Download development ruff binary
         id: ruff-target
         with:
           name: ruff
@@ -373,6 +373,9 @@ jobs:
           export PATH=${{ steps.ruff-target.outputs.download-path }}:$PATH
 
           ruff version
+
+          # Set the environment for subsequent jobs
+          echo "PATH=$PATH" >> "$GITHUB_ENV"
 
       - name: Run ruff-lsp tests
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -369,7 +369,7 @@ jobs:
       - name: Run ruff-lsp tests
         run: |
           # Setup development binary
-          pip uninstall ruff
+          pip uninstall --no-input ruff
           chmod +x ${{ steps.ruff-target.outputs.download-path }}/ruff
           export PATH=${{ steps.ruff-target.outputs.download-path }}:$PATH
           ruff version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -366,19 +366,13 @@ jobs:
         run: |
           just install
 
-      - name: Setup development ruff version
+      - name:  Run ruff-lsp tests
         run: |
-          # Make executable and prepend to path
+          # Setup development binary
           chmod +x ${{ steps.ruff-target.outputs.download-path }}/ruff
           export PATH=${{ steps.ruff-target.outputs.download-path }}:$PATH
-
           ruff version
 
-          # Set the environment for subsequent jobs
-          echo "PATH=$PATH" >> "$GITHUB_ENV"
-
-      - name: Run ruff-lsp tests
-        run: |
           just test
 
   benchmarks:


### PR DESCRIPTION
Adds a CI job which runs `ruff-lsp` tests against the current Ruff build.

Avoids rebuilding Ruff at the cost of running _after_ the cargo tests have finished. Might be worth the rebuild to get earlier feedback but I don't expect it to fail often?

xref https://github.com/astral-sh/ruff-lsp/pull/286

## Test plan

Verified use of the development version by inspecting version output in CI; supported by https://github.com/astral-sh/ruff-lsp/pull/289 and #8034 