### PR TITLE
Update rule B005 docs

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
@@ -34,7 +34,7 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Example
 /// ```python
-/// "text.txt".strip(".txt")  # "ex"
+/// "text.txt".strip(".txt")  # "e"
 /// ```
 ///
 /// Use instead:


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Rule B005 of flake8-bugbear docs has a typo in one of the examples that leads to a confusion in the correctness of `.strip()`  method

![image](https://github.com/astral-sh/ruff/assets/104530599/b4e19751-558e-4ebb-b82f-25c321ddc32b)

```python
# Wrong output (used in docs) 
"text.txt".strip(".txt")  # "ex" 

# Correct output
"text.txt".strip(".txt")  # "e"
```
