### PR TITLE
Avoid failed assertion when showing fixes from stdin

### DIFF
--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -7,11 +7,9 @@ use anyhow::Result;
 use bitflags::bitflags;
 use colored::Colorize;
 use itertools::{iterate, Itertools};
-use rustc_hash::FxHashMap;
 use serde::Serialize;
 
 use ruff_linter::fs::relativize_path;
-use ruff_linter::linter::FixTable;
 use ruff_linter::logging::LogLevel;
 use ruff_linter::message::{
     AzureEmitter, Emitter, EmitterContext, GithubEmitter, GitlabEmitter, GroupedEmitter,
@@ -22,7 +20,7 @@ use ruff_linter::registry::{AsRule, Rule};
 use ruff_linter::settings::flags::{self};
 use ruff_linter::settings::types::{SerializationFormat, UnsafeFixes};
 
-use crate::diagnostics::Diagnostics;
+use crate::diagnostics::{Diagnostics, FixMap};
 
 bitflags! {
     #[derive(Default, Debug, Copy, Clone)]
@@ -462,7 +460,7 @@ fn show_fix_status(fix_mode: flags::FixMode, fixables: Option<&FixableStatistics
     (!fix_mode.is_apply()) && fixables.is_some_and(FixableStatistics::any_applicable_fixes)
 }
 
-fn print_fix_summary(writer: &mut dyn Write, fixed: &FxHashMap<String, FixTable>) -> Result<()> {
+fn print_fix_summary(writer: &mut dyn Write, fixed: &FixMap) -> Result<()> {
     let total = fixed
         .values()
         .map(|table| table.values().sum::<usize>())

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -1252,8 +1252,8 @@ fn diff_does_not_show_display_only_fixes_with_unsafe_fixes_enabled() {
             ])
             .pass_stdin("def add_to_list(item, some_list=[]): ..."),
             @r###"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
@@ -1276,8 +1276,8 @@ fn diff_only_unsafe_fixes_available() {
         ])
         .pass_stdin("x = {'a': 1, 'a': 1}\nprint(('foo'))\n"),
         @r###"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----


### PR DESCRIPTION
## Summary

When linting, we store a map from file path to fixes, which we then use to show a fix summary in the printer.

In the printer, we assume that if the map is non-empty, then we have at least one fix. But this isn't enforced by the fix struct, since you can have an entry from (file path) to (empty fix table). In practice, this only bites us when linting from `stdin`, since when linting across multiple files, we have an `AddAssign` on `Diagnostics` that avoids adding empty entries to the map. When linting from `stdin`, we create the map directly, and so it _is_ possible to have a non-empty map that doesn't contain any fixes, leading to a panic.

This PR introduces a dedicated struct to make these constraints part of the formal interface.

Closes https://github.com/astral-sh/ruff/issues/8027.

## Test Plan

`cargo test` (notice two failures are removed)
