### PR TITLE
Options: Support `#[serde(alias = name)]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,6 +2259,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "ruff_python_trivia",
+ "serde_derive_internals 0.29.0",
  "syn 2.0.38",
 ]
 
@@ -2624,7 +2625,7 @@ checksum = "e85e2a16b12bdb763244c69ab79363d71db2b4b918a2def53f80b02e0574b13c"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals",
+ "serde_derive_internals 0.26.0",
  "syn 1.0.109",
 ]
 
@@ -2664,9 +2665,9 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
@@ -2684,9 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2702,6 +2703,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ quote = { version = "1.0.23" }
 regex = { version = "1.10.2" }
 rustc-hash = { version = "1.1.0" }
 schemars = { version = "0.8.15" }
-serde = { version = "1.0.152", features = ["derive"] }
+serde = { version = "1.0.189", features = ["derive"] }
 serde_json = { version = "1.0.107" }
 shellexpand = { version = "3.0.0" }
 similar = { version = "2.3.0", features = ["inline"] }

--- a/crates/ruff_cli/tests/format.rs
+++ b/crates/ruff_cli/tests/format.rs
@@ -50,6 +50,9 @@ fn format_options() -> Result<()> {
     fs::write(
         &ruff_toml,
         r#"
+tab-size = 8
+line-length = 84
+
 [format]
 indent-style = "tab"
 quote-style = "single"
@@ -64,7 +67,7 @@ line-ending = "cr-lf"
         .arg("-")
         .pass_stdin(r#"
 def foo(arg1, arg2,):
-    print("Shouldn't change quotes")
+    print("Shouldn't change quotes. It exceeds the line width with the tab size 8")
 
 
 if condition:
@@ -76,7 +79,9 @@ if condition:
     exit_code: 0
     ----- stdout -----
     def foo(arg1, arg2):
-    	print("Shouldn't change quotes")
+    	print(
+    		"Shouldn't change quotes. It exceeds the line width with the tab size 8"
+    	)
 
 
     if condition:

--- a/crates/ruff_dev/src/generate_options.rs
+++ b/crates/ruff_dev/src/generate_options.rs
@@ -1,6 +1,7 @@
 //! Generate a Markdown-compatible listing of configuration options for `pyproject.toml`.
 //!
 //! Used for <https://docs.astral.sh/ruff/settings/>.
+use itertools::Itertools;
 use std::fmt::Write;
 
 use ruff_workspace::options::Options;
@@ -107,6 +108,24 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, parent_set: 
     output.push('\n');
     output.push_str(&format!("**Type**: `{}`\n", field.value_type));
     output.push('\n');
+
+    if !field.aliases.is_empty() {
+        let title = if field.aliases.len() == 1 {
+            "Alias"
+        } else {
+            "Aliases"
+        };
+        output.push_str(&format!(
+            "**{title}**: {}\n",
+            field
+                .aliases
+                .iter()
+                .map(|alias| format!("`{alias}`"))
+                .join(", ")
+        ));
+        output.push('\n');
+    }
+
     output.push_str(&format!(
         "**Example usage**:\n\n```toml\n[tool.ruff{}]\n{}\n```\n",
         if let Some(set_name) = parent_set.name() {

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -95,7 +95,7 @@ impl std::fmt::Display for IndentStyle {
 ///
 /// Determines the visual width of a tab character (`\t`) and the number of
 /// spaces per indent when using [`IndentStyle::Space`].
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, CacheKey)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct IndentWidth(NonZeroU8);

--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -253,3 +253,9 @@ impl From<NonZeroU8> for TabSize {
         Self(tab_size)
     }
 }
+
+impl From<TabSize> for NonZeroU8 {
+    fn from(value: TabSize) -> Self {
+        value.0
+    }
+}

--- a/crates/ruff_macros/Cargo.toml
+++ b/crates/ruff_macros/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 
 [dependencies]
 ruff_python_trivia = { path = "../ruff_python_trivia" }
+serde_derive_internals = "0.29.0"
 
 proc-macro2 = { workspace = true }
 quote = { workspace = true }

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -4,7 +4,7 @@
 
 use std::borrow::Cow;
 use std::env::VarError;
-use std::num::NonZeroU16;
+use std::num::{NonZeroU16, NonZeroU8};
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
@@ -16,7 +16,7 @@ use shellexpand::LookupError;
 use strum::IntoEnumIterator;
 
 use ruff_cache::cache_dir;
-use ruff_formatter::{IndentStyle, LineWidth};
+use ruff_formatter::{IndentStyle, IndentWidth, LineWidth};
 use ruff_linter::line_width::{LineLength, TabSize};
 use ruff_linter::registry::RuleNamespace;
 use ruff_linter::registry::{Rule, RuleSet, INCOMPATIBLE_CODES};
@@ -155,7 +155,7 @@ impl Configuration {
 
         let format = self.format;
         let format_defaults = FormatterSettings::default();
-        // TODO(micha): Support changing the tab-width but disallow changing the number of spaces
+
         let formatter = FormatterSettings {
             exclude: FilePatternSet::try_from_iter(format.exclude.unwrap_or_default())?,
             preview: match format.preview.unwrap_or(global_preview) {
@@ -169,6 +169,11 @@ impl Configuration {
                 }),
             line_ending: format.line_ending.unwrap_or(format_defaults.line_ending),
             indent_style: format.indent_style.unwrap_or(format_defaults.indent_style),
+            indent_width: self
+                .tab_size
+                .map_or(format_defaults.indent_width, |tab_size| {
+                    IndentWidth::from(NonZeroU8::from(tab_size))
+                }),
             quote_style: format.quote_style.unwrap_or(format_defaults.quote_style),
             magic_trailing_comma: format
                 .magic_trailing_comma

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -363,7 +363,11 @@ pub struct Options {
     )]
     pub line_length: Option<LineLength>,
 
-    /// The tabulation size to calculate line length.
+    /// The number of spaces a tab is equal to when enforcing long-line violations (like `E501`)
+    /// or formatting code with the formatter.
+    ///
+    /// This option changes the number of spaces inserted by the formatter when
+    /// using soft-tabs (`indent-style = space`).
     #[option(
         default = "4",
         value_type = "int",

--- a/crates/ruff_workspace/src/options_base.rs
+++ b/crates/ruff_workspace/src/options_base.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fmt::{Debug, Display, Formatter};
 
 /// Visits [`OptionsMetadata`].
@@ -89,7 +90,8 @@ impl OptionSet {
     /// ### Test for the existence of a child option
     ///
     /// ```rust
-    /// # use ruff_workspace::options_base::{OptionField, OptionsMetadata, Visit};
+    /// # use std::collections::BTreeSet;
+    /// use ruff_workspace::options_base::{OptionField, OptionsMetadata, Visit};
     ///
     /// struct WithOptions;
     ///
@@ -100,6 +102,7 @@ impl OptionSet {
     ///             default: "false",
     ///             value_type: "bool",
     ///             example: "",
+    ///             aliases: BTreeSet::new()
     ///         });
     ///     }
     /// }
@@ -110,7 +113,8 @@ impl OptionSet {
     /// ### Test for the existence of a nested option
     ///
     /// ```rust
-    /// # use ruff_workspace::options_base::{OptionField, OptionsMetadata, Visit};
+    /// # use std::collections::BTreeSet;
+    /// use ruff_workspace::options_base::{OptionField, OptionsMetadata, Visit};
     ///
     /// struct Root;
     ///
@@ -121,6 +125,7 @@ impl OptionSet {
     ///             default: "false",
     ///             value_type: "bool",
     ///             example: "",
+    ///             aliases: BTreeSet::new()
     ///         });
     ///
     ///         visit.record_set("format", Nested::metadata());
@@ -136,6 +141,7 @@ impl OptionSet {
     ///             default: "false",
     ///             value_type: "bool",
     ///             example: "",
+    ///             aliases: BTreeSet::new()
     ///         });
     ///     }
     /// }
@@ -157,7 +163,8 @@ impl OptionSet {
     /// ### Find a child option
     ///
     /// ```rust
-    /// # use ruff_workspace::options_base::{OptionEntry, OptionField, OptionsMetadata, Visit};
+    /// # use std::collections::BTreeSet;
+    /// use ruff_workspace::options_base::{OptionEntry, OptionField, OptionsMetadata, Visit};
     ///
     /// struct WithOptions;
     ///
@@ -166,6 +173,7 @@ impl OptionSet {
     ///     default: "false",
     ///     value_type: "bool",
     ///     example: "",
+    ///     aliases: BTreeSet::new()
     ///  };
     ///
     /// impl OptionsMetadata for WithOptions {
@@ -180,13 +188,15 @@ impl OptionSet {
     /// ### Find a nested option
     ///
     /// ```rust
-    /// # use ruff_workspace::options_base::{OptionEntry, OptionField, OptionsMetadata, Visit};
+    /// # use std::collections::BTreeSet;
+    /// use ruff_workspace::options_base::{OptionEntry, OptionField, OptionsMetadata, Visit};
     ///
     /// static HARD_TABS: OptionField = OptionField {
     ///     doc: "Use hard tabs for indentation and spaces for alignment.",
     ///     default: "false",
     ///     value_type: "bool",
     ///     example: "",
+    ///     aliases: BTreeSet::new()
     /// };
     ///
     /// struct Root;
@@ -198,6 +208,7 @@ impl OptionSet {
     ///             default: "false",
     ///             value_type: "bool",
     ///             example: "",
+    ///             aliases: BTreeSet::new()
     ///         });
     ///
     ///         visit.record_set("format", Nested::metadata());
@@ -307,6 +318,7 @@ pub struct OptionField {
     pub doc: &'static str,
     pub default: &'static str,
     pub value_type: &'static str,
+    pub aliases: BTreeSet<&'static str>,
     pub example: &'static str,
 }
 

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -1,6 +1,6 @@
 use path_absolutize::path_dedot;
 use ruff_cache::cache_dir;
-use ruff_formatter::{FormatOptions, IndentStyle, LineWidth};
+use ruff_formatter::{FormatOptions, IndentStyle, IndentWidth, LineWidth};
 use ruff_linter::settings::types::{FilePattern, FilePatternSet, SerializationFormat, UnsafeFixes};
 use ruff_linter::settings::LinterSettings;
 use ruff_macros::CacheKey;
@@ -117,6 +117,7 @@ pub struct FormatterSettings {
     pub line_width: LineWidth,
 
     pub indent_style: IndentStyle,
+    pub indent_width: IndentWidth,
 
     pub quote_style: QuoteStyle,
 
@@ -150,6 +151,7 @@ impl FormatterSettings {
 
         PyFormatOptions::from_source_type(source_type)
             .with_indent_style(self.indent_style)
+            .with_indent_width(self.indent_width)
             .with_quote_style(self.quote_style)
             .with_magic_trailing_comma(self.magic_trailing_comma)
             .with_preview(self.preview)
@@ -164,10 +166,11 @@ impl Default for FormatterSettings {
 
         Self {
             exclude: FilePatternSet::default(),
-            preview: ruff_python_formatter::PreviewMode::Disabled,
+            preview: PreviewMode::Disabled,
             line_width: default_options.line_width(),
             line_ending: LineEnding::Lf,
             indent_style: default_options.indent_style(),
+            indent_width: default_options.indent_width(),
             quote_style: default_options.quote_style(),
             magic_trailing_comma: default_options.magic_trailing_comma(),
         }

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -605,7 +605,7 @@
       }
     },
     "tab-size": {
-      "description": "The tabulation size to calculate line length.",
+      "description": "The number of spaces a tab is equal to when enforcing long-line violations (like `E501`) or formatting code with the formatter.\n\nThis option changes the number of spaces inserted by the formatter when using soft-tabs (`indent-style = space`).",
       "anyOf": [
         {
           "$ref": "#/definitions/TabSize"


### PR DESCRIPTION
## Summary

This PR adds support for serde's `#[serde(alias="name")]` field-attribute to our options code generator. Simplifying supporting aliases for the same setting. 

I'm unsure if we should land this change. I may not end up using it for `line-length` because I think it's better to actually deprecate these options rather than supporting both (by adding support for Rust's `deprecated` attribute). However, it is a neat feature and it already works. 

## Test Plan

I changed `line-length` to 


```rust
    /// The line length to use when enforcing long-lines violations (like
    /// `E501`). Must be greater than `0` and less than or equal to `320`.
    #[option(
        default = "88",
        value_type = "int",
        example = r#"
        # Allow lines to be as long as 120 characters.
        line-length = 120
        "#
    )]
    #[serde(alias = "line-width", alias = "max-line-length")]
    pub line_length: Option<LineLength>,
```

And generated the options markdown

<img width="607" alt="Screenshot 2023-10-18 at 08 51 25" src="https://github.com/astral-sh/ruff/assets/1203881/cec6774c-9c89-4a13-a98b-fa0722c42cb6">
