### PR TITLE
Document `lint.preview` and `format.preview`

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -399,7 +399,7 @@ pub struct FormatCommand {
     /// Use `--no-preview` to disable.
     #[arg(long, overrides_with("no_preview"))]
     preview: bool,
-    #[clap(long, overrides_with("preview"))]
+    #[clap(long, overrides_with("preview"), hide = true)]
     no_preview: bool,
 }
 

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -399,7 +399,7 @@ pub struct FormatCommand {
     /// Use `--no-preview` to disable.
     #[arg(long, overrides_with("no_preview"))]
     preview: bool,
-    #[clap(long, overrides_with("preview"), hide = true)]
+    #[clap(long, overrides_with("preview"))]
     no_preview: bool,
 }
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -10,7 +10,7 @@ Preview mode enables a collection of newer rules and fixes that are considered e
 Preview mode can be enabled with the `--preview` flag on the CLI or by setting `preview = true` in your Ruff
 configuration file (e.g. `pyproject.toml`).
 
-Preview mode can be configured separately for linting and formatting (Ruff version 0.1.1 or newer). To enable preview lint rules without preview style formatting:
+Preview mode can be configured separately for linting and formatting (requires Ruff v0.1.1+). To enable preview lint rules without preview style formatting:
 
 ```toml
 [lint]

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -10,6 +10,20 @@ Preview mode enables a collection of newer rules and fixes that are considered e
 Preview mode can be enabled with the `--preview` flag on the CLI or by setting `preview = true` in your Ruff
 configuration file (e.g. `pyproject.toml`).
 
+Preview mode can be configured separately for linting and formatting. To only enable preview lint rules without preview style formatting:
+
+```toml
+[lint]
+preview = true
+```
+
+To enable preview style formatting without enabling any preview lint rules
+
+```toml
+[format]
+preview = true
+```
+
 ## Using rules that are in preview
 
 If a rule is marked as preview, it can only be selected if preview mode is enabled. For example, consider a

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -17,7 +17,7 @@ Preview mode can be configured separately for linting and formatting. To only en
 preview = true
 ```
 
-To enable preview style formatting without enabling any preview lint rules
+To enable preview style formatting without enabling any preview lint rules:
 
 ```toml
 [format]

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -10,7 +10,7 @@ Preview mode enables a collection of newer rules and fixes that are considered e
 Preview mode can be enabled with the `--preview` flag on the CLI or by setting `preview = true` in your Ruff
 configuration file (e.g. `pyproject.toml`).
 
-Preview mode can be configured separately for linting and formatting. To only enable preview lint rules without preview style formatting:
+Preview mode can be configured separately for linting and formatting (Ruff version 0.1.1 or newer). To enable preview lint rules without preview style formatting:
 
 ```toml
 [lint]


### PR DESCRIPTION

## Summary

The documentation for https://github.com/astral-sh/ruff/pull/8002. I separated it to a separate PR to unblock landing the code changes but still get the documentation reviewed.


