### PR TITLE
Add `ruff version` with long version display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,6 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -482,32 +481,6 @@ checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
 dependencies = [
  "log",
  "web-sys",
-]
-
-[[package]]
-name = "const_fn"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
-
-[[package]]
-name = "const_format"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
 ]
 
 [[package]]
@@ -922,19 +895,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
-dependencies = [
- "bitflags 2.4.0",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,12 +1144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_debug"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,15 +1166,6 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
-
-[[package]]
-name = "jobserver"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -1347,18 +1292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libgit2-sys"
-version = "0.16.1+1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libmimalloc-sys"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,18 +1299,6 @@ checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -1549,15 +1470,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1775,12 +1687,6 @@ name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "pmutil"
@@ -2189,7 +2095,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "shadow-rs",
  "shellexpand",
  "similar",
  "strum",
@@ -2569,6 +2474,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruff_version"
+version = "0.0.0"
+
+[[package]]
 name = "ruff_wasm"
 version = "0.0.0"
 dependencies = [
@@ -2851,19 +2760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shadow-rs"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9198caff1c94f1a5df6664bddbc379896b51b98a55b0b3fedcb23078fe00c77"
-dependencies = [
- "const_format",
- "git2",
- "is_debug",
- "time",
- "tzdb",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3132,12 +3028,8 @@ version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
- "itoa",
- "libc",
- "num_threads",
  "serde",
  "time-core",
- "time-macros",
 ]
 
 [[package]]
@@ -3145,15 +3037,6 @@ name = "time-core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
-
-[[package]]
-name = "time-macros"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
-dependencies = [
- "time-core",
-]
 
 [[package]]
 name = "tiny-keccak"
@@ -3302,25 +3185,6 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
-name = "tz-rs"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
-dependencies = [
- "const_fn",
-]
-
-[[package]]
-name = "tzdb"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec758958f2fb5069cd7fae385be95cc8eceb8cdfd270c7d14de6034f0108d99e"
-dependencies = [
- "iana-time-zone",
- "tz-rs",
-]
 
 [[package]]
 name = "unic-char-property"
@@ -3488,12 +3352,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,10 +2474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruff_version"
-version = "0.0.0"
-
-[[package]]
 name = "ruff_wasm"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -481,6 +482,32 @@ checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
 dependencies = [
  "log",
  "web-sys",
+]
+
+[[package]]
+name = "const_fn"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
+
+[[package]]
+name = "const_format"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -895,6 +922,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
+dependencies = [
+ "bitflags 2.4.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1184,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_debug"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1212,15 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1292,6 +1347,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.16.1+1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1366,18 @@ checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1470,6 +1549,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1687,6 +1775,12 @@ name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "pmutil"
@@ -2095,6 +2189,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "shadow-rs",
  "shellexpand",
  "similar",
  "strum",
@@ -2756,6 +2851,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shadow-rs"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9198caff1c94f1a5df6664bddbc379896b51b98a55b0b3fedcb23078fe00c77"
+dependencies = [
+ "const_format",
+ "git2",
+ "is_debug",
+ "time",
+ "tzdb",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,8 +3132,12 @@ version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -3033,6 +3145,15 @@ name = "time-core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -3181,6 +3302,25 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "tz-rs"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+dependencies = [
+ "const_fn",
+]
+
+[[package]]
+name = "tzdb"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec758958f2fb5069cd7fae385be95cc8eceb8cdfd270c7d14de6034f0108d99e"
+dependencies = [
+ "iana-time-zone",
+ "tz-rs",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -3348,6 +3488,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -10,7 +10,6 @@ documentation = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 readme = "../../README.md"
-build = "build.rs"
 
 [[bin]]
 name = "ruff"

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -66,7 +66,7 @@ wild = { version = "2" }
 assert_cmd = { version = "2.0.8" }
 # Avoid writing colored snapshots when running tests from the terminal
 colored = { workspace = true, features = ["no-color"]}
-insta = { workspace = true, features = ["filters"] }
+insta = { workspace = true, features = ["filters", "json"] }
 insta-cmd = { version = "0.4.0" }
 tempfile = "3.6.0"
 test-case = { workspace = true }

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -62,10 +62,6 @@ thiserror = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 walkdir = { version = "2.3.2" }
 wild = { version = "2" }
-shadow-rs = { version = "0.24.1" }
-
-[build-dependencies]
-shadow-rs = { version = "0.24.1" }
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.8" }

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -10,6 +10,7 @@ documentation = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 readme = "../../README.md"
+build = "build.rs"
 
 [[bin]]
 name = "ruff"
@@ -61,6 +62,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 walkdir = { version = "2.3.2" }
 wild = { version = "2" }
+shadow-rs = { version = "0.24.1" }
+
+[build-dependencies]
+shadow-rs = { version = "0.24.1" }
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.8" }

--- a/crates/ruff_cli/build.rs
+++ b/crates/ruff_cli/build.rs
@@ -1,0 +1,3 @@
+fn main() -> shadow_rs::SdResult<()> {
+    shadow_rs::new()
+}

--- a/crates/ruff_cli/build.rs
+++ b/crates/ruff_cli/build.rs
@@ -29,10 +29,10 @@ fn commit_info(workspace_root: PathBuf) {
     let git_head_contents = fs::read_to_string(git_head_path);
     if let Ok(git_head_contents) = git_head_contents {
         // The contents are either a commit or a reference in the following formats
-        // "<commit>""
-        // "ref <ref>""
+        // - "<commit>" when the head is detached
+        // - "ref <ref>" when working on a branch
         // If a commit, checking if the HEAD file has changed is sufficient
-        // If a ref we want to add the head file for that ref to rebuild on commit
+        // If a ref, we need to add the head file for that ref to rebuild on commit
         let mut git_ref_parts = git_head_contents.split_whitespace();
         git_ref_parts.next();
         if let Some(git_ref) = git_ref_parts.next() {

--- a/crates/ruff_cli/build.rs
+++ b/crates/ruff_cli/build.rs
@@ -1,3 +1,43 @@
-fn main() -> shadow_rs::SdResult<()> {
-    shadow_rs::new()
+use std::process::Command;
+
+fn main() {
+    commit_info();
+    #[allow(clippy::disallowed_methods)]
+    let target = std::env::var("TARGET").unwrap();
+    println!("cargo:rustc-env=RUST_HOST_TARGET={target}");
+}
+
+fn commit_info() {
+    let output = match Command::new("git")
+        .arg("log")
+        .arg("-1")
+        .arg("--date=short")
+        .arg("--abbrev=9")
+        .arg("--format=%H %h %cd %(describe)")
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        foo => foo.unwrap(),
+    };
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let mut parts = stdout.split_whitespace();
+    let mut next = || parts.next().unwrap();
+    println!("cargo:rustc-env=RUFF_COMMIT_HASH={}", next());
+    println!("cargo:rustc-env=RUFF_COMMIT_SHORT_HASH={}", next());
+    println!("cargo:rustc-env=RUFF_COMMIT_DATE={}", next());
+
+    // Describe can fail for some commits
+    // https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-emdescribeoptionsem
+    if let Some(describe) = parts.next() {
+        let mut describe_parts = describe.split('-');
+        println!(
+            "cargo:rustc-env=RUFF_LAST_TAG={}",
+            describe_parts.next().unwrap()
+        );
+        // If this is the tagged commit, this component will be missing
+        println!(
+            "cargo:rustc-env=RUFF_LAST_TAG_DISTANCE={}",
+            describe_parts.next().unwrap_or("0")
+        );
+    }
 }

--- a/crates/ruff_cli/build.rs
+++ b/crates/ruff_cli/build.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::Path, path::PathBuf, process::Command};
+use std::{fs, path::Path, process::Command};
 
 fn main() {
     // The workspace root directory is not available without walking up the tree
@@ -7,14 +7,15 @@ fn main() {
         .join("..")
         .join("..");
 
-    commit_info(workspace_root);
+    commit_info(&workspace_root);
 
     #[allow(clippy::disallowed_methods)]
     let target = std::env::var("TARGET").unwrap();
     println!("cargo:rustc-env=RUST_HOST_TARGET={target}");
 }
 
-fn commit_info(workspace_root: PathBuf) {
+fn commit_info(workspace_root: &Path) {
+    // If not in a git repository, do not attempt to retrieve commit information
     let git_dir = workspace_root.join(".git");
     if !git_dir.exists() {
         return;

--- a/crates/ruff_cli/build.rs
+++ b/crates/ruff_cli/build.rs
@@ -17,7 +17,7 @@ fn commit_info() {
         .output()
     {
         Ok(output) if output.status.success() => output,
-        foo => foo.unwrap(),
+        _ => return,
     };
     let stdout = String::from_utf8(output.stdout).unwrap();
     let mut parts = stdout.split_whitespace();

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -35,11 +35,6 @@ pub struct Args {
 pub enum Command {
     /// Run Ruff on the given files or directories (default).
     Check(CheckCommand),
-    /// Display Ruff's version
-    Version {
-        #[arg(long, value_enum, default_value = "text")]
-        output_format: HelpFormat,
-    },
     /// Explain a rule (or all rules).
     #[clap(alias = "--explain")]
     #[command(group = clap::ArgGroup::new("selector").multiple(false).required(true))]
@@ -74,6 +69,11 @@ pub enum Command {
     #[doc(hidden)]
     #[clap(hide = true)]
     Format(FormatCommand),
+    /// Display Ruff's version
+    Version {
+        #[arg(long, value_enum, default_value = "text")]
+        output_format: HelpFormat,
+    },
 }
 
 // The `Parser` derive is for ruff_dev, for ruff_cli `Args` would be sufficient

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -35,7 +35,7 @@ pub struct Args {
 pub enum Command {
     /// Run Ruff on the given files or directories (default).
     Check(CheckCommand),
-    /// Display full Ruff version information
+    /// Display Ruff's version
     Version {
         #[arg(long, value_enum, default_value = "text")]
         output_format: HelpFormat,

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -35,6 +35,11 @@ pub struct Args {
 pub enum Command {
     /// Run Ruff on the given files or directories (default).
     Check(CheckCommand),
+    /// Display full Ruff version information
+    Version {
+        #[arg(long, value_enum, default_value = "text")]
+        output_format: HelpFormat,
+    },
     /// Explain a rule (or all rules).
     #[clap(alias = "--explain")]
     #[command(group = clap::ArgGroup::new("selector").multiple(false).required(true))]

--- a/crates/ruff_cli/src/commands/mod.rs
+++ b/crates/ruff_cli/src/commands/mod.rs
@@ -9,3 +9,4 @@ pub(crate) mod linter;
 pub(crate) mod rule;
 pub(crate) mod show_files;
 pub(crate) mod show_settings;
+pub(crate) mod version;

--- a/crates/ruff_cli/src/commands/version.rs
+++ b/crates/ruff_cli/src/commands/version.rs
@@ -1,0 +1,82 @@
+use std::fmt::{Display, Formatter};
+use std::io::{self, BufWriter, Write};
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::args::HelpFormat;
+use crate::build;
+
+#[derive(Serialize)]
+struct VersionMetadata {
+    ruff_version: &'static str,
+    rust_version: &'static str,
+    build_time: &'static str,
+    cargo_version: &'static str,
+    build_os: &'static str,
+    commit: &'static str,
+    commit_time: &'static str,
+    target: &'static str,
+    dirty: bool,
+    release: bool,
+}
+
+impl VersionMetadata {
+    const fn from_build() -> Self {
+        Self {
+            ruff_version: build::PKG_VERSION,
+            rust_version: build::RUST_VERSION,
+            build_time: build::BUILD_TIME_3339,
+            cargo_version: build::CARGO_VERSION,
+            build_os: build::BUILD_OS,
+            target: build::BUILD_TARGET,
+            release: !build::TAG.is_empty(),
+            commit: build::SHORT_COMMIT,
+            commit_time: build::COMMIT_DATE_3339,
+            dirty: !build::GIT_CLEAN,
+        }
+    }
+}
+
+impl Display for VersionMetadata {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "ruff {}", self.ruff_version)
+    }
+}
+
+/// Display version information
+pub(crate) fn version(output_format: HelpFormat) -> Result<()> {
+    let mut stdout = BufWriter::new(io::stdout().lock());
+    let metadata = VersionMetadata::from_build();
+
+    let build_date = chrono::DateTime::parse_from_rfc3339(metadata.build_time)?;
+
+    match output_format {
+        HelpFormat::Text => {
+            let status = if metadata.dirty {
+                "-dirty"
+            } else {
+                if metadata.release {
+                    ""
+                } else {
+                    "-dev"
+                }
+            };
+
+            writeln!(
+                stdout,
+                "ruff {}{} ({} {})",
+                &metadata.ruff_version,
+                &status,
+                &metadata.commit,
+                build_date.format("%Y-%m-%d")
+            )?;
+            writeln!(stdout, "{}", &metadata.rust_version)?;
+            writeln!(stdout, "{}", &metadata.cargo_version)?;
+        }
+        HelpFormat::Json => {
+            serde_json::to_writer_pretty(stdout, &metadata)?;
+        }
+    };
+    Ok(())
+}

--- a/crates/ruff_cli/src/commands/version.rs
+++ b/crates/ruff_cli/src/commands/version.rs
@@ -11,7 +11,7 @@ pub(crate) fn version(output_format: HelpFormat) -> Result<()> {
 
     match output_format {
         HelpFormat::Text => {
-            writeln!(stdout, "{}", &version_info)?;
+            writeln!(stdout, "ruff {}", &version_info)?;
         }
         HelpFormat::Json => {
             serde_json::to_writer_pretty(stdout, &version_info)?;

--- a/crates/ruff_cli/src/commands/version.rs
+++ b/crates/ruff_cli/src/commands/version.rs
@@ -1,81 +1,20 @@
-use std::fmt::{Display, Formatter};
 use std::io::{self, BufWriter, Write};
 
 use anyhow::Result;
-use serde::Serialize;
 
 use crate::args::HelpFormat;
-use crate::build;
-
-#[derive(Serialize)]
-struct VersionMetadata {
-    ruff_version: &'static str,
-    rust_version: &'static str,
-    build_time: &'static str,
-    cargo_version: &'static str,
-    build_os: &'static str,
-    commit: &'static str,
-    commit_time: &'static str,
-    target: &'static str,
-    dirty: bool,
-    release: bool,
-}
-
-impl VersionMetadata {
-    const fn from_build() -> Self {
-        Self {
-            ruff_version: build::PKG_VERSION,
-            rust_version: build::RUST_VERSION,
-            build_time: build::BUILD_TIME_3339,
-            cargo_version: build::CARGO_VERSION,
-            build_os: build::BUILD_OS,
-            target: build::BUILD_TARGET,
-            release: !build::TAG.is_empty(),
-            commit: build::SHORT_COMMIT,
-            commit_time: build::COMMIT_DATE_3339,
-            dirty: !build::GIT_CLEAN,
-        }
-    }
-}
-
-impl Display for VersionMetadata {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "ruff {}", self.ruff_version)
-    }
-}
 
 /// Display version information
 pub(crate) fn version(output_format: HelpFormat) -> Result<()> {
     let mut stdout = BufWriter::new(io::stdout().lock());
-    let metadata = VersionMetadata::from_build();
-
-    let build_date = chrono::DateTime::parse_from_rfc3339(metadata.build_time)?;
+    let version_info = crate::version::version();
 
     match output_format {
         HelpFormat::Text => {
-            let status = if metadata.dirty {
-                "-dirty"
-            } else {
-                if metadata.release {
-                    ""
-                } else {
-                    "-dev"
-                }
-            };
-
-            writeln!(
-                stdout,
-                "ruff {}{} ({} {})",
-                &metadata.ruff_version,
-                &status,
-                &metadata.commit,
-                build_date.format("%Y-%m-%d")
-            )?;
-            writeln!(stdout, "{}", &metadata.rust_version)?;
-            writeln!(stdout, "{}", &metadata.cargo_version)?;
+            writeln!(stdout, "{}", &version_info)?;
         }
         HelpFormat::Json => {
-            serde_json::to_writer_pretty(stdout, &metadata)?;
+            serde_json::to_writer_pretty(stdout, &version_info)?;
         }
     };
     Ok(())

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::print_stdout)]
+
 use std::fs::File;
 use std::io::{self, stdout, BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -27,6 +29,10 @@ mod panic;
 mod printer;
 pub mod resolve;
 mod stdin;
+
+use shadow_rs::shadow;
+
+shadow!(build);
 
 #[derive(Copy, Clone)]
 pub enum ExitStatus {
@@ -134,6 +140,10 @@ pub fn run(
     set_up_logging(&log_level)?;
 
     match command {
+        Command::Version { output_format } => {
+            commands::version::version(output_format)?;
+            Ok(ExitStatus::Success)
+        }
         Command::Rule { rule, all, format } => {
             if all {
                 commands::rule::rules(format)?;

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -29,10 +29,7 @@ mod panic;
 mod printer;
 pub mod resolve;
 mod stdin;
-
-use shadow_rs::shadow;
-
-shadow!(build);
+mod version;
 
 #[derive(Copy, Clone)]
 pub enum ExitStatus {

--- a/crates/ruff_cli/src/snapshots/ruff_cli__version__tests__version_formatting.snap
+++ b/crates/ruff_cli/src/snapshots/ruff_cli__version__tests__version_formatting.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ruff_cli/src/version.rs
+expression: version
+---
+0.0.0

--- a/crates/ruff_cli/src/snapshots/ruff_cli__version__tests__version_formatting_with_commit_info.snap
+++ b/crates/ruff_cli/src/snapshots/ruff_cli__version__tests__version_formatting_with_commit_info.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ruff_cli/src/version.rs
+expression: version
+---
+0.0.0 (53b0f5d92 2023-10-19)

--- a/crates/ruff_cli/src/snapshots/ruff_cli__version__tests__version_formatting_with_commits_since_last_tag.snap
+++ b/crates/ruff_cli/src/snapshots/ruff_cli__version__tests__version_formatting_with_commits_since_last_tag.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ruff_cli/src/version.rs
+expression: version
+---
+0.0.0+24 (53b0f5d92 2023-10-19)

--- a/crates/ruff_cli/src/snapshots/ruff_cli__version__tests__version_serializable.snap
+++ b/crates/ruff_cli/src/snapshots/ruff_cli__version__tests__version_serializable.snap
@@ -1,0 +1,14 @@
+---
+source: crates/ruff_cli/src/version.rs
+expression: version
+---
+{
+  "version": "0.0.0",
+  "commit_info": {
+    "short_commit_hash": "53b0f5d92",
+    "commit_hash": "53b0f5d924110e5b26fbf09f6fd3a03d67b475b7",
+    "commit_date": "2023-10-19",
+    "last_tag": "v0.0.1",
+    "commits_since_last_tag": 0
+  }
+}

--- a/crates/ruff_cli/src/version.rs
+++ b/crates/ruff_cli/src/version.rs
@@ -1,0 +1,69 @@
+//! Code for representing Ruff's release version number.
+use serde::Serialize;
+use std::fmt;
+
+/// Information about the git repository where Ruff was built from.
+#[derive(Serialize)]
+pub(crate) struct CommitInfo {
+    short_commit_hash: String,
+    commit_hash: String,
+    commit_date: String,
+    last_tag: String,
+    commits_since_last_tag: u32,
+}
+
+/// Ruff's version.
+#[derive(Serialize)]
+pub(crate) struct VersionInfo {
+    /// Ruff's version, such as "0.5.1"
+    version: String,
+    /// Information about the git commit we may have been built from.
+    ///
+    /// `None` if not built from a git repo or if retrieval failed.
+    commit_info: Option<CommitInfo>,
+}
+
+impl fmt::Display for VersionInfo {
+    /// Formatted version information: "<version>[+<commits>] (<commit> <date>)"
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.version)?;
+
+        if let Some(ref ci) = self.commit_info {
+            if ci.commits_since_last_tag > 0 {
+                write!(f, "+{}", ci.commits_since_last_tag)?;
+            }
+            write!(f, " ({} {})", ci.short_commit_hash, ci.commit_date)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Returns information about Ruff's version.
+pub(crate) fn version() -> VersionInfo {
+    macro_rules! option_env_str {
+        ($name:expr) => {
+            option_env!($name).map(|s| s.to_string())
+        };
+    }
+
+    // This version is pulled from Cargo.toml and set by Cargo
+    let version = option_env_str!("CARGO_PKG_VERSION").unwrap();
+
+    // Commit info is pulled from git and set by `build.rs`
+    let commit_info = option_env_str!("RUFF_COMMIT_HASH").map(|commit_hash| CommitInfo {
+        short_commit_hash: option_env_str!("RUFF_COMMIT_SHORT_HASH").unwrap(),
+        commit_hash,
+        commit_date: option_env_str!("RUFF_COMMIT_DATE").unwrap(),
+        last_tag: option_env_str!("RUFF_LAST_TAG").unwrap(),
+        commits_since_last_tag: option_env_str!("RUFF_LAST_TAG_DISTANCE")
+            .unwrap()
+            .parse::<u32>()
+            .unwrap(),
+    });
+
+    VersionInfo {
+        version,
+        commit_info,
+    }
+}

--- a/crates/ruff_cli/src/version.rs
+++ b/crates/ruff_cli/src/version.rs
@@ -67,3 +67,49 @@ pub(crate) fn version() -> VersionInfo {
         commit_info,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_display_snapshot;
+
+    use super::{CommitInfo, VersionInfo};
+
+    #[test]
+    fn version_formatting() {
+        let version = VersionInfo {
+            version: "0.0.0".to_string(),
+            commit_info: None,
+        };
+        assert_display_snapshot!(version);
+    }
+
+    #[test]
+    fn version_formatting_with_commit_info() {
+        let version = VersionInfo {
+            version: "0.0.0".to_string(),
+            commit_info: Some(CommitInfo {
+                short_commit_hash: "53b0f5d92".to_string(),
+                commit_hash: "53b0f5d924110e5b26fbf09f6fd3a03d67b475b7".to_string(),
+                last_tag: "v0.0.1".to_string(),
+                commit_date: "2023-10-19".to_string(),
+                commits_since_last_tag: 0,
+            }),
+        };
+        assert_display_snapshot!(version);
+    }
+
+    #[test]
+    fn version_formatting_with_commits_since_last_tag() {
+        let version = VersionInfo {
+            version: "0.0.0".to_string(),
+            commit_info: Some(CommitInfo {
+                short_commit_hash: "53b0f5d92".to_string(),
+                commit_hash: "53b0f5d924110e5b26fbf09f6fd3a03d67b475b7".to_string(),
+                last_tag: "v0.0.1".to_string(),
+                commit_date: "2023-10-19".to_string(),
+                commits_since_last_tag: 24,
+            }),
+        };
+        assert_display_snapshot!(version);
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,11 +157,11 @@ Usage: ruff [OPTIONS] <COMMAND>
 
 Commands:
   check    Run Ruff on the given files or directories (default)
-  version  Display Ruff's version
   rule     Explain a rule (or all rules)
   config   List or describe the available configuration options
   linter   List all supported upstream linters
   clean    Clear any caches in the current directory and any subdirectories
+  version  Display Ruff's version
   help     Print this message or the help of the given subcommand(s)
 
 Options:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,12 +156,13 @@ Ruff: An extremely fast Python linter.
 Usage: ruff [OPTIONS] <COMMAND>
 
 Commands:
-  check   Run Ruff on the given files or directories (default)
-  rule    Explain a rule (or all rules)
-  config  List or describe the available configuration options
-  linter  List all supported upstream linters
-  clean   Clear any caches in the current directory and any subdirectories
-  help    Print this message or the help of the given subcommand(s)
+  check    Run Ruff on the given files or directories (default)
+  version  Display Ruff's version
+  rule     Explain a rule (or all rules)
+  config   List or describe the available configuration options
+  linter   List all supported upstream linters
+  clean    Clear any caches in the current directory and any subdirectories
+  help     Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help     Print help


### PR DESCRIPTION
Adds a new `ruff version` sub-command which displays long version information in the style of `cargo` and `rustc`. We include the number of commits since the last release tag if its a development build, in the style of Python's versioneer.

```
❯ ruff version
ruff 0.1.0+14 (947940e91 2023-10-18)
```

```
❯ ruff version --output-format json
{
  "version": "0.1.0",
  "commit_info": {
    "short_commit_hash": "947940e91",
    "commit_hash": "947940e91269f20f6b3f8f8c7c63f8e914680e80",
    "commit_date": "2023-10-18",
    "last_tag": "v0.1.0",
    "commits_since_last_tag": 14
  }
}%
```

```
❯ cargo version
cargo 1.72.1 (103a7ff2e 2023-08-15)
```
## Test plan

I've tested this manually locally, but want to at least add unit tests for the message formatting. We'd also want to check the next release to ensure the information is correct.

I checked build behavior with a detached head and branches.

## Future work

We could include rustc and cargo versions from the build, the current Python version, and other diagnostic information for bug reports.

The `--version` and `-V` output is unchanged. However, we could update it to display the long ruff version without the rust and cargo versions (this is what cargo does). We'll need to be careful to ensure this does not break downstream packages which parse our version string.

```
❯ ruff --version
ruff 0.1.0
```

The LSP should be updated to use `ruff version --output-format json` instead of parsing `ruff --version`.