### PR TITLE
Use `pass` over ellipsis in non-function/class contexts

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
@@ -75,7 +75,7 @@ if [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ] & aaaaaaaaaaaaaaaaaaaaaaaaaa:
-    ...
+    pass
 
 if [
     aaaaaaaaaaaaa,
@@ -84,7 +84,7 @@ if [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ] & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
-    ...
+    pass
 
 # Right only can break
 if aaaaaaaaaaaaaaaaaaaaaaaaaa & [
@@ -94,7 +94,7 @@ if aaaaaaaaaaaaaaaaaaaaaaaaaa & [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ]:
-    ...
+    pass
 
 if aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & [
     aaaaaaaaaaaaa,
@@ -103,7 +103,7 @@ if aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     dddddddddddddddddddd,
     eeeeeeeeee,
 ]:
-    ...
+    pass
 
 
 # Left or right can break
@@ -114,7 +114,7 @@ if [2222, 333] & [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ]:
-    ...
+    pass
 
 if [
     aaaaaaaaaaaaa,
@@ -123,7 +123,7 @@ if [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ] & [2222, 333]:
-    ...
+    pass
 
 if [
     aaaaaaaaaaaaa,
@@ -132,7 +132,7 @@ if [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ] & [fffffffffffffffff, gggggggggggggggggggg, hhhhhhhhhhhhhhhhhhhhh, iiiiiiiiiiiiiiii, jjjjjjjjjjjjj]:
-    ...
+    pass
 
 if (
     # comment
@@ -152,7 +152,7 @@ if (
 ]:
     pass
 
-    ...
+    pass
 
 # Nesting
 if (aaaa + b) & [
@@ -162,7 +162,7 @@ if (aaaa + b) & [
     iiiiiiiiiiiiiiii,
     jjjjjjjjjjjjj,
 ]:
-    ...
+    pass
 
 if [
     fffffffffffffffff,
@@ -171,7 +171,7 @@ if [
     iiiiiiiiiiiiiiii,
     jjjjjjjjjjjjj,
 ] & (a + b):
-    ...
+    pass
 
 
 if [
@@ -185,7 +185,7 @@ if [
     a
     + b
 ):
-    ...
+    pass
 
 if (
     [
@@ -199,7 +199,7 @@ if (
     # comment
     a + b
 ):
-    ...
+    pass
 
 
 # Unstable formatting in https://github.com/realtyem/synapse-unraid/blob/unraid_develop/synapse/handlers/presence.py

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/boolean_operation.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/boolean_operation.py
@@ -16,7 +16,7 @@ if (
     and self._returncode
     and self._proc.poll()
 ):
-    ...
+    pass
 
 if (
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -26,14 +26,14 @@ if (
     and aaaaaaaaaaaaaaaaaaaaaaaaaa
     and aaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ):
-    ...
+    pass
 
 
 if (
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaas
     and aaaaaaaaaaaaaaaaa
 ):
-    ...
+    pass
 
 
 if [2222, 333] and [
@@ -43,7 +43,7 @@ if [2222, 333] and [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ]:
-    ...
+    pass
 
 if [
     aaaaaaaaaaaaa,

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/slice.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/slice.py
@@ -65,7 +65,7 @@ d3 = "d"[
 
 # Spacing around the colon(s)
 def a():
-    ...
+    pass
 
 e00 = "e"[:]
 e01 = "e"[:1]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unary.py
@@ -139,18 +139,18 @@ if not \
 
 # Regression: https://github.com/astral-sh/ruff/issues/5338
 if a and not aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
-    ...
+    pass
 
 if (
   not
   # comment
   a):
-    ...
+    pass
 
 if (
   not  # comment
   a):
-    ...
+    pass
 
 # Regression test for: https://github.com/astral-sh/ruff/issues/7423
 if True:

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unsplittable.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unsplittable.py
@@ -51,7 +51,7 @@ aaaaaaaa = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbb
 for converter in connection.ops.get_db_converters(
     expression
 ) + expression.get_db_converters(connection):
-    ...
+    pass
 
 
 aaa = (

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/for.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/for.py
@@ -15,23 +15,23 @@ for aVeryLongNameThatSpillsOverToTheNextLineBecauseItIsExtremelyLongAndGoesOnAnd
     pass
 
 else:
-    ...
+    pass
 
 for (
     x,
     y,
     ) in z: # comment
-    ...
+    pass
 
 
 # remove brackets around x,y but keep them around z,w
 for (x, y) in (z, w):
-    ...
+    pass
 
 
 # type comment
 for x in (): # type: int
-    ...
+    pass
 
 # Tuple parentheses for iterable.
 for x in 1, 2, 3:

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/if.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/if.py
@@ -19,12 +19,12 @@ else:  # 12 trailing else condition
 
 if x == y:
     if y == z:
-        ...
+        pass
 
     if a == b:
-        ...
+        pass
     else: # trailing comment
-        ...
+        pass
 
     # trailing else comment
 
@@ -34,11 +34,11 @@ elif aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + 
     2222222222222222222222,
     3333333333
     ]:
-    ...
+    pass
 
 
 else:
-    ...
+    pass
 
 # Regression test: Don't drop the trailing comment by associating it with the elif
 # instead of the else.

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
@@ -206,9 +206,9 @@ match pattern_singleton:
     case (
         True  # trailing
     ):
-        ...
+        pass
     case False:
-        ...
+        pass
 
 
 match foo:
@@ -406,39 +406,39 @@ match pattern_match_class:
     case Point2D(
             # own line
             ):
-        ...
+        pass
 
     case (
         Point2D
         # own line
         ()
     ):
-        ...
+        pass
 
     case Point2D(  # end of line line
             ):
-        ...
+        pass
 
     case Point2D(  # end of line
         0, 0
     ):
-        ...
+        pass
 
     case Point2D(0, 0):
-        ...
+        pass
 
     case Point2D(
         (  # end of line
         # own line
         0
         ), 0):
-        ...
+        pass
 
     case Point3D(x=0, y=0, z=000000000000000000000000000000000000000000000000000000000000000000000000000000000):
-        ...
+        pass
 
     case Bar(0, a=None, b="hello"):
-        ...
+        pass
 
     case FooBar(# leading
 # leading
@@ -449,7 +449,7 @@ match pattern_match_class:
     # trailing
         # trailing
             ):
-        ...
+        pass
 
     case A(
         b # b
@@ -481,26 +481,26 @@ match pattern_match_or:
           # own line 4
           c # trailing 5
             ):
-        ...
+        pass
 
     case (
         (a)
         | # trailing
         ( b )
     ):
-        ...
+        pass
 
     case (a|b|c):
-        ...
+        pass
 
     case foo | bar | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh:
-        ...
+        pass
 
     case ( # end of line
           a | b
     # own line
     ):
-        ...
+        pass
 
 
 # Single-element tuples.

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/try.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/try.py
@@ -1,72 +1,72 @@
 try:
-    ...
+    pass
 except:
-    ...
+    pass
 
 try:
-    ...
+    pass
 except (KeyError):  # should remove brackets and be a single line
-    ...
+    pass
 
 
 try: # try
-    ...
+    pass
     # end of body
 # before except
 except (Exception, ValueError) as exc:  # except line
-    ...
+    pass
 # before except 2
 except KeyError as key:  # except line 2
-    ...
+    pass
     # in body 2
 # before else
 else:
-    ...
+    pass
 # before finally
 finally:
-    ...
+    pass
 
 
 
 # with line breaks
 try: # try
-    ...
+    pass
     # end of body
 
 # before except
 except (Exception, ValueError) as exc:  # except line
-    ...
+    pass
 
 # before except 2
 except KeyError as key:  # except line 2
-    ...
+    pass
     # in body 2
 
 # before else
 else:
-    ...
+    pass
 
 # before finally
 finally:
-    ...
+    pass
 
 
 # with line breaks
 try:
-    ...
+    pass
 
 except:
-    ...
+    pass
 
 
 try:
-    ...
+    pass
 except (Exception, Exception, Exception, Exception, Exception, Exception, Exception) as exc:  # splits exception over multiple lines
-    ...
+    pass
 
 
 try:
-    ...
+    pass
 except:
     a = 10 # trailing comment1
     b = 11 # trailing comment2
@@ -74,21 +74,21 @@ except:
 
 # try/except*, mostly the same as try
 try: # try
-    ...
+    pass
     # end of body
 # before except
 except* (Exception, ValueError) as exc:  # except line
-    ...
+    pass
 # before except 2
 except* KeyError as key:  # except line 2
-    ...
+    pass
     # in body 2
 # before else
 else:
-    ...
+    pass
 # before finally
 finally:
-    ...
+    pass
 
 # try and try star are statements with body
 # Minimized from https://github.com/python/cpython/blob/99b00efd5edfd5b26bf9e2a35cbfc96277fdcbb1/Lib/getpass.py#L68-L91

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/while.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/while.py
@@ -15,7 +15,7 @@ while aVeryLongConditionThatSpillsOverToTheNextLineBecauseItIsExtremelyLongAndGo
     pass
 
 else:
-    ...
+    pass
 
 while (
     some_condition(unformatted, args) and anotherCondition or aThirdCondition

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
@@ -1,16 +1,16 @@
 with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
-    ...
+    pass
     # trailing
 
 with a, a:  # after colon
-    ...
+    pass
     # trailing
 
 with (
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
 ):
-    ...
+    pass
     # trailing
 
 
@@ -19,7 +19,7 @@ with (
         ,  # comma
         b  # c
         ): # colon
-    ...
+    pass
 
 
 with (
@@ -30,7 +30,7 @@ with (
         ,  # comma
         c  # c
         ): # colon
-    ...  # body
+    pass  # body
     # body trailing own
 
 with (
@@ -42,14 +42,14 @@ with (
 
 
 with (a,):  # magic trailing comma
-    ...
+    pass
 
 
 with (a):  # should remove brackets
-    ...
+    pass
 
 with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as c:
-    ...
+    pass
 
 
 # currently unparsable by black: https://github.com/psf/black/issues/3678
@@ -60,45 +60,45 @@ with (a, *b):
 
 with (
     # leading comment
-    a) as b: ...
+    a) as b: pass
 
 with (
     # leading comment
     a as b
-): ...
+): pass
 
 with (
     a as b
     # trailing comment
-): ...
+): pass
 
 with (
     a as (
         # leading comment
         b
     )
-): ...
+): pass
 
 with (
     a as (
         b
         # trailing comment
     )
-): ...
+): pass
 
 with (a # trailing same line comment
     # trailing own line comment
-    ) as b: ...
+    ) as b: pass
 
 with (
     a # trailing same line comment
     # trailing own line comment
     as b
-): ...
+): pass
 
 with (a # trailing same line comment
     # trailing own line comment
-) as b: ...
+) as b: pass
 
 with (
     (a
@@ -106,7 +106,7 @@ with (
     )
     as # trailing as same line comment
     b # trailing b same line comment
-): ...
+): pass
 
 with (
     # comment
@@ -157,7 +157,7 @@ with (
     CtxManager2() as example2,
     CtxManager2() as example2,
 ):
-    ...
+    pass
 
 with [
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -165,7 +165,7 @@ with [
     "cccccccccccccccccccccccccccccccccccccccccc",
     dddddddddddddddddddddddddddddddd,
 ] as example1, aaaaaaaaaaaaaaaaaaaaaaaaaa * bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb * cccccccccccccccccccccccccccc + ddddddddddddddddd as example2, CtxManager222222222222222() as example2:
-    ...
+    pass
 
 # Comments on open parentheses
 with (  # comment
@@ -173,7 +173,7 @@ with (  # comment
     CtxManager2() as example2,
     CtxManager3() as example3,
 ):
-    ...
+    pass
 
 with (  # outer comment
     (  # inner comment
@@ -182,25 +182,25 @@ with (  # outer comment
     CtxManager2() as example2,
     CtxManager3() as example3,
 ):
-    ...
+    pass
 
 with (  # outer comment
     CtxManager()
 ) as example:
-    ...
+    pass
 
 with (  # outer comment
     CtxManager()
 ) as example, (  # inner comment
     CtxManager2()
 ) as example2:
-    ...
+    pass
 
 with (  # outer comment
     CtxManager1(),
     CtxManager2(),
 ) as example:
-    ...
+    pass
 
 with (  # outer comment
     (  # inner comment
@@ -208,7 +208,7 @@ with (  # outer comment
     ),
     CtxManager2(),
 ) as example:
-    ...
+    pass
 
 # Breaking of with items.
 with (test  # bar

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/trivia.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/trivia.py
@@ -17,7 +17,7 @@ class Test:
 c = 30
 
 while a == 10:
-    ...
+    print(a)
 
     # trailing comment with one line before
 
@@ -26,7 +26,7 @@ while a == 10:
 d = 40
 
 while b == 20:
-    ...
+    print(b)
     # no empty line before
 
 e = 50  # one empty line before

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
@@ -81,7 +81,7 @@ if [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ] & aaaaaaaaaaaaaaaaaaaaaaaaaa:
-    ...
+    pass
 
 if [
     aaaaaaaaaaaaa,
@@ -90,7 +90,7 @@ if [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ] & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
-    ...
+    pass
 
 # Right only can break
 if aaaaaaaaaaaaaaaaaaaaaaaaaa & [
@@ -100,7 +100,7 @@ if aaaaaaaaaaaaaaaaaaaaaaaaaa & [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ]:
-    ...
+    pass
 
 if aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & [
     aaaaaaaaaaaaa,
@@ -109,7 +109,7 @@ if aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     dddddddddddddddddddd,
     eeeeeeeeee,
 ]:
-    ...
+    pass
 
 
 # Left or right can break
@@ -120,7 +120,7 @@ if [2222, 333] & [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ]:
-    ...
+    pass
 
 if [
     aaaaaaaaaaaaa,
@@ -129,7 +129,7 @@ if [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ] & [2222, 333]:
-    ...
+    pass
 
 if [
     aaaaaaaaaaaaa,
@@ -138,7 +138,7 @@ if [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ] & [fffffffffffffffff, gggggggggggggggggggg, hhhhhhhhhhhhhhhhhhhhh, iiiiiiiiiiiiiiii, jjjjjjjjjjjjj]:
-    ...
+    pass
 
 if (
     # comment
@@ -158,7 +158,7 @@ if (
 ]:
     pass
 
-    ...
+    pass
 
 # Nesting
 if (aaaa + b) & [
@@ -168,7 +168,7 @@ if (aaaa + b) & [
     iiiiiiiiiiiiiiii,
     jjjjjjjjjjjjj,
 ]:
-    ...
+    pass
 
 if [
     fffffffffffffffff,
@@ -177,7 +177,7 @@ if [
     iiiiiiiiiiiiiiii,
     jjjjjjjjjjjjj,
 ] & (a + b):
-    ...
+    pass
 
 
 if [
@@ -191,7 +191,7 @@ if [
     a
     + b
 ):
-    ...
+    pass
 
 if (
     [
@@ -205,7 +205,7 @@ if (
     # comment
     a + b
 ):
-    ...
+    pass
 
 
 # Unstable formatting in https://github.com/realtyem/synapse-unraid/blob/unraid_develop/synapse/handlers/presence.py
@@ -532,7 +532,7 @@ if [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ] & aaaaaaaaaaaaaaaaaaaaaaaaaa:
-    ...
+    pass
 
 if (
     [
@@ -544,7 +544,7 @@ if (
     ]
     & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ):
-    ...
+    pass
 
 # Right only can break
 if aaaaaaaaaaaaaaaaaaaaaaaaaa & [
@@ -554,7 +554,7 @@ if aaaaaaaaaaaaaaaaaaaaaaaaaa & [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ]:
-    ...
+    pass
 
 if (
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -566,7 +566,7 @@ if (
         eeeeeeeeee,
     ]
 ):
-    ...
+    pass
 
 
 # Left or right can break
@@ -577,7 +577,7 @@ if [2222, 333] & [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ]:
-    ...
+    pass
 
 if [
     aaaaaaaaaaaaa,
@@ -586,7 +586,7 @@ if [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ] & [2222, 333]:
-    ...
+    pass
 
 if [
     aaaaaaaaaaaaa,
@@ -601,7 +601,7 @@ if [
     iiiiiiiiiiiiiiii,
     jjjjjjjjjjjjj,
 ]:
-    ...
+    pass
 
 if (
     # comment
@@ -621,7 +621,7 @@ if (
 ]:
     pass
 
-    ...
+    pass
 
 # Nesting
 if (aaaa + b) & [
@@ -631,7 +631,7 @@ if (aaaa + b) & [
     iiiiiiiiiiiiiiii,
     jjjjjjjjjjjjj,
 ]:
-    ...
+    pass
 
 if [
     fffffffffffffffff,
@@ -640,7 +640,7 @@ if [
     iiiiiiiiiiiiiiii,
     jjjjjjjjjjjjj,
 ] & (a + b):
-    ...
+    pass
 
 
 if [
@@ -653,7 +653,7 @@ if [
     # comment
     a + b
 ):
-    ...
+    pass
 
 if (
     [
@@ -667,7 +667,7 @@ if (
     # comment
     a + b
 ):
-    ...
+    pass
 
 
 # Unstable formatting in https://github.com/realtyem/synapse-unraid/blob/unraid_develop/synapse/handlers/presence.py

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__boolean_operation.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__boolean_operation.py.snap
@@ -22,7 +22,7 @@ if (
     and self._returncode
     and self._proc.poll()
 ):
-    ...
+    pass
 
 if (
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -32,14 +32,14 @@ if (
     and aaaaaaaaaaaaaaaaaaaaaaaaaa
     and aaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ):
-    ...
+    pass
 
 
 if (
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaas
     and aaaaaaaaaaaaaaaaa
 ):
-    ...
+    pass
 
 
 if [2222, 333] and [
@@ -49,7 +49,7 @@ if [2222, 333] and [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ]:
-    ...
+    pass
 
 if [
     aaaaaaaaaaaaa,
@@ -213,7 +213,7 @@ if (
     and self._returncode
     and self._proc.poll()
 ):
-    ...
+    pass
 
 if (
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -223,14 +223,14 @@ if (
     and aaaaaaaaaaaaaaaaaaaaaaaaaa
     and aaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ):
-    ...
+    pass
 
 
 if (
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaas
     and aaaaaaaaaaaaaaaaa
 ):
-    ...
+    pass
 
 
 if [2222, 333] and [
@@ -240,7 +240,7 @@ if [2222, 333] and [
     dddddddddddddddddddd,
     eeeeeeeeee,
 ]:
-    ...
+    pass
 
 if [
     aaaaaaaaaaaaa,

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__slice.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__slice.py.snap
@@ -71,7 +71,7 @@ d3 = "d"[
 
 # Spacing around the colon(s)
 def a():
-    ...
+    pass
 
 e00 = "e"[:]
 e01 = "e"[:1]
@@ -184,7 +184,7 @@ d3 = "d"[
 
 # Spacing around the colon(s)
 def a():
-    ...
+    pass
 
 
 e00 = "e"[:]

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__unary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__unary.py.snap
@@ -145,18 +145,18 @@ if not \
 
 # Regression: https://github.com/astral-sh/ruff/issues/5338
 if a and not aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
-    ...
+    pass
 
 if (
   not
   # comment
   a):
-    ...
+    pass
 
 if (
   not  # comment
   a):
-    ...
+    pass
 
 # Regression test for: https://github.com/astral-sh/ruff/issues/7423
 if True:
@@ -324,17 +324,17 @@ if (
     and not aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ):
-    ...
+    pass
 
 if (
     not
     # comment
     a
 ):
-    ...
+    pass
 
 if not a:  # comment
-    ...
+    pass
 
 # Regression test for: https://github.com/astral-sh/ruff/issues/7423
 if True:

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__unsplittable.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__unsplittable.py.snap
@@ -57,7 +57,7 @@ aaaaaaaa = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbb
 for converter in connection.ops.get_db_converters(
     expression
 ) + expression.get_db_converters(connection):
-    ...
+    pass
 
 
 aaa = (
@@ -161,7 +161,7 @@ aaaaaaaa = (
 for converter in connection.ops.get_db_converters(
     expression
 ) + expression.get_db_converters(connection):
-    ...
+    pass
 
 
 aaa = (

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__for.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__for.py.snap
@@ -21,23 +21,23 @@ for aVeryLongNameThatSpillsOverToTheNextLineBecauseItIsExtremelyLongAndGoesOnAnd
     pass
 
 else:
-    ...
+    pass
 
 for (
     x,
     y,
     ) in z: # comment
-    ...
+    pass
 
 
 # remove brackets around x,y but keep them around z,w
 for (x, y) in (z, w):
-    ...
+    pass
 
 
 # type comment
 for x in (): # type: int
-    ...
+    pass
 
 # Tuple parentheses for iterable.
 for x in 1, 2, 3:
@@ -97,23 +97,23 @@ for aVeryLongNameThatSpillsOverToTheNextLineBecauseItIsExtremelyLongAndGoesOnAnd
     pass
 
 else:
-    ...
+    pass
 
 for (
     x,
     y,
 ) in z:  # comment
-    ...
+    pass
 
 
 # remove brackets around x,y but keep them around z,w
 for x, y in (z, w):
-    ...
+    pass
 
 
 # type comment
 for x in ():  # type: int
-    ...
+    pass
 
 # Tuple parentheses for iterable.
 for x in 1, 2, 3:

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__if.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__if.py.snap
@@ -25,12 +25,12 @@ else:  # 12 trailing else condition
 
 if x == y:
     if y == z:
-        ...
+        pass
 
     if a == b:
-        ...
+        pass
     else: # trailing comment
-        ...
+        pass
 
     # trailing else comment
 
@@ -40,11 +40,11 @@ elif aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + 
     2222222222222222222222,
     3333333333
     ]:
-    ...
+    pass
 
 
 else:
-    ...
+    pass
 
 # Regression test: Don't drop the trailing comment by associating it with the elif
 # instead of the else.
@@ -325,12 +325,12 @@ else:  # 12 trailing else condition
 
 if x == y:
     if y == z:
-        ...
+        pass
 
     if a == b:
-        ...
+        pass
     else:  # trailing comment
-        ...
+        pass
 
     # trailing else comment
 
@@ -340,11 +340,11 @@ elif aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + 
     2222222222222222222222,
     3333333333,
 ]:
-    ...
+    pass
 
 
 else:
-    ...
+    pass
 
 # Regression test: Don't drop the trailing comment by associating it with the elif
 # instead of the else.

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -212,9 +212,9 @@ match pattern_singleton:
     case (
         True  # trailing
     ):
-        ...
+        pass
     case False:
-        ...
+        pass
 
 
 match foo:
@@ -412,39 +412,39 @@ match pattern_match_class:
     case Point2D(
             # own line
             ):
-        ...
+        pass
 
     case (
         Point2D
         # own line
         ()
     ):
-        ...
+        pass
 
     case Point2D(  # end of line line
             ):
-        ...
+        pass
 
     case Point2D(  # end of line
         0, 0
     ):
-        ...
+        pass
 
     case Point2D(0, 0):
-        ...
+        pass
 
     case Point2D(
         (  # end of line
         # own line
         0
         ), 0):
-        ...
+        pass
 
     case Point3D(x=0, y=0, z=000000000000000000000000000000000000000000000000000000000000000000000000000000000):
-        ...
+        pass
 
     case Bar(0, a=None, b="hello"):
-        ...
+        pass
 
     case FooBar(# leading
 # leading
@@ -455,7 +455,7 @@ match pattern_match_class:
     # trailing
         # trailing
             ):
-        ...
+        pass
 
     case A(
         b # b
@@ -487,26 +487,26 @@ match pattern_match_or:
           # own line 4
           c # trailing 5
             ):
-        ...
+        pass
 
     case (
         (a)
         | # trailing
         ( b )
     ):
-        ...
+        pass
 
     case (a|b|c):
-        ...
+        pass
 
     case foo | bar | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh:
-        ...
+        pass
 
     case ( # end of line
           a | b
     # own line
     ):
-        ...
+        pass
 
 
 # Single-element tuples.
@@ -770,9 +770,9 @@ match pattern_singleton:
     ):
         pass
     case True:  # trailing
-        ...
+        pass
     case False:
-        ...
+        pass
 
 
 match foo:
@@ -996,26 +996,26 @@ match pattern_match_class:
     case Point2D(
         # own line
     ):
-        ...
+        pass
 
     case (
         Point2D
         # own line
         ()
     ):
-        ...
+        pass
 
     case Point2D(  # end of line line
     ):
-        ...
+        pass
 
     case Point2D(  # end of line
         0, 0
     ):
-        ...
+        pass
 
     case Point2D(0, 0):
-        ...
+        pass
 
     case Point2D(
         (  # end of line
@@ -1024,17 +1024,17 @@ match pattern_match_class:
         ),
         0,
     ):
-        ...
+        pass
 
     case Point3D(
         x=0,
         y=0,
         z=000000000000000000000000000000000000000000000000000000000000000000000000000000000,
     ):
-        ...
+        pass
 
     case Bar(0, a=None, b="hello"):
-        ...
+        pass
 
     case FooBar(  # leading
         # leading
@@ -1045,7 +1045,7 @@ match pattern_match_class:
         # trailing
         # trailing
     ):
-        ...
+        pass
 
     case A(
         # b
@@ -1075,7 +1075,7 @@ match pattern_match_or:
         # own line 4
         | c  # trailing 5
     ):
-        ...
+        pass
 
     case (
         (
@@ -1083,24 +1083,24 @@ match pattern_match_or:
         )
         | (b)
     ):
-        ...
+        pass
 
     case a | b | c:
-        ...
+        pass
 
     case (
         foo
         | bar
         | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh
     ):
-        ...
+        pass
 
     case (  # end of line
         a
         | b
         # own line
     ):
-        ...
+        pass
 
 
 # Single-element tuples.

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__try.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__try.py.snap
@@ -5,74 +5,74 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/
 ## Input
 ```py
 try:
-    ...
+    pass
 except:
-    ...
+    pass
 
 try:
-    ...
+    pass
 except (KeyError):  # should remove brackets and be a single line
-    ...
+    pass
 
 
 try: # try
-    ...
+    pass
     # end of body
 # before except
 except (Exception, ValueError) as exc:  # except line
-    ...
+    pass
 # before except 2
 except KeyError as key:  # except line 2
-    ...
+    pass
     # in body 2
 # before else
 else:
-    ...
+    pass
 # before finally
 finally:
-    ...
+    pass
 
 
 
 # with line breaks
 try: # try
-    ...
+    pass
     # end of body
 
 # before except
 except (Exception, ValueError) as exc:  # except line
-    ...
+    pass
 
 # before except 2
 except KeyError as key:  # except line 2
-    ...
+    pass
     # in body 2
 
 # before else
 else:
-    ...
+    pass
 
 # before finally
 finally:
-    ...
+    pass
 
 
 # with line breaks
 try:
-    ...
+    pass
 
 except:
-    ...
+    pass
 
 
 try:
-    ...
+    pass
 except (Exception, Exception, Exception, Exception, Exception, Exception, Exception) as exc:  # splits exception over multiple lines
-    ...
+    pass
 
 
 try:
-    ...
+    pass
 except:
     a = 10 # trailing comment1
     b = 11 # trailing comment2
@@ -80,21 +80,21 @@ except:
 
 # try/except*, mostly the same as try
 try: # try
-    ...
+    pass
     # end of body
 # before except
 except* (Exception, ValueError) as exc:  # except line
-    ...
+    pass
 # before except 2
 except* KeyError as key:  # except line 2
-    ...
+    pass
     # in body 2
 # before else
 else:
-    ...
+    pass
 # before finally
 finally:
-    ...
+    pass
 
 # try and try star are statements with body
 # Minimized from https://github.com/python/cpython/blob/99b00efd5edfd5b26bf9e2a35cbfc96277fdcbb1/Lib/getpass.py#L68-L91
@@ -177,67 +177,67 @@ finally:
 ## Output
 ```py
 try:
-    ...
+    pass
 except:
-    ...
+    pass
 
 try:
-    ...
+    pass
 except KeyError:  # should remove brackets and be a single line
-    ...
+    pass
 
 
 try:  # try
-    ...
+    pass
     # end of body
 # before except
 except (Exception, ValueError) as exc:  # except line
-    ...
+    pass
 # before except 2
 except KeyError as key:  # except line 2
-    ...
+    pass
     # in body 2
 # before else
 else:
-    ...
+    pass
 # before finally
 finally:
-    ...
+    pass
 
 
 # with line breaks
 try:  # try
-    ...
+    pass
     # end of body
 
 # before except
 except (Exception, ValueError) as exc:  # except line
-    ...
+    pass
 
 # before except 2
 except KeyError as key:  # except line 2
-    ...
+    pass
     # in body 2
 
 # before else
 else:
-    ...
+    pass
 
 # before finally
 finally:
-    ...
+    pass
 
 
 # with line breaks
 try:
-    ...
+    pass
 
 except:
-    ...
+    pass
 
 
 try:
-    ...
+    pass
 except (
     Exception,
     Exception,
@@ -247,11 +247,11 @@ except (
     Exception,
     Exception,
 ) as exc:  # splits exception over multiple lines
-    ...
+    pass
 
 
 try:
-    ...
+    pass
 except:
     a = 10  # trailing comment1
     b = 11  # trailing comment2
@@ -259,21 +259,21 @@ except:
 
 # try/except*, mostly the same as try
 try:  # try
-    ...
+    pass
     # end of body
 # before except
 except* (Exception, ValueError) as exc:  # except line
-    ...
+    pass
 # before except 2
 except* KeyError as key:  # except line 2
-    ...
+    pass
     # in body 2
 # before else
 else:
-    ...
+    pass
 # before finally
 finally:
-    ...
+    pass
 
 # try and try star are statements with body
 # Minimized from https://github.com/python/cpython/blob/99b00efd5edfd5b26bf9e2a35cbfc96277fdcbb1/Lib/getpass.py#L68-L91

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__while.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__while.py.snap
@@ -21,7 +21,7 @@ while aVeryLongConditionThatSpillsOverToTheNextLineBecauseItIsExtremelyLongAndGo
     pass
 
 else:
-    ...
+    pass
 
 while (
     some_condition(unformatted, args) and anotherCondition or aThirdCondition
@@ -55,7 +55,7 @@ while aVeryLongConditionThatSpillsOverToTheNextLineBecauseItIsExtremelyLongAndGo
     pass
 
 else:
-    ...
+    pass
 
 while (
     some_condition(unformatted, args) and anotherCondition or aThirdCondition

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
@@ -5,18 +5,18 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/
 ## Input
 ```py
 with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
-    ...
+    pass
     # trailing
 
 with a, a:  # after colon
-    ...
+    pass
     # trailing
 
 with (
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
 ):
-    ...
+    pass
     # trailing
 
 
@@ -25,7 +25,7 @@ with (
         ,  # comma
         b  # c
         ): # colon
-    ...
+    pass
 
 
 with (
@@ -36,7 +36,7 @@ with (
         ,  # comma
         c  # c
         ): # colon
-    ...  # body
+    pass  # body
     # body trailing own
 
 with (
@@ -48,14 +48,14 @@ with (
 
 
 with (a,):  # magic trailing comma
-    ...
+    pass
 
 
 with (a):  # should remove brackets
-    ...
+    pass
 
 with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as c:
-    ...
+    pass
 
 
 # currently unparsable by black: https://github.com/psf/black/issues/3678
@@ -66,45 +66,45 @@ with (a, *b):
 
 with (
     # leading comment
-    a) as b: ...
+    a) as b: pass
 
 with (
     # leading comment
     a as b
-): ...
+): pass
 
 with (
     a as b
     # trailing comment
-): ...
+): pass
 
 with (
     a as (
         # leading comment
         b
     )
-): ...
+): pass
 
 with (
     a as (
         b
         # trailing comment
     )
-): ...
+): pass
 
 with (a # trailing same line comment
     # trailing own line comment
-    ) as b: ...
+    ) as b: pass
 
 with (
     a # trailing same line comment
     # trailing own line comment
     as b
-): ...
+): pass
 
 with (a # trailing same line comment
     # trailing own line comment
-) as b: ...
+) as b: pass
 
 with (
     (a
@@ -112,7 +112,7 @@ with (
     )
     as # trailing as same line comment
     b # trailing b same line comment
-): ...
+): pass
 
 with (
     # comment
@@ -163,7 +163,7 @@ with (
     CtxManager2() as example2,
     CtxManager2() as example2,
 ):
-    ...
+    pass
 
 with [
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -171,7 +171,7 @@ with [
     "cccccccccccccccccccccccccccccccccccccccccc",
     dddddddddddddddddddddddddddddddd,
 ] as example1, aaaaaaaaaaaaaaaaaaaaaaaaaa * bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb * cccccccccccccccccccccccccccc + ddddddddddddddddd as example2, CtxManager222222222222222() as example2:
-    ...
+    pass
 
 # Comments on open parentheses
 with (  # comment
@@ -179,7 +179,7 @@ with (  # comment
     CtxManager2() as example2,
     CtxManager3() as example3,
 ):
-    ...
+    pass
 
 with (  # outer comment
     (  # inner comment
@@ -188,25 +188,25 @@ with (  # outer comment
     CtxManager2() as example2,
     CtxManager3() as example3,
 ):
-    ...
+    pass
 
 with (  # outer comment
     CtxManager()
 ) as example:
-    ...
+    pass
 
 with (  # outer comment
     CtxManager()
 ) as example, (  # inner comment
     CtxManager2()
 ) as example2:
-    ...
+    pass
 
 with (  # outer comment
     CtxManager1(),
     CtxManager2(),
 ) as example:
-    ...
+    pass
 
 with (  # outer comment
     (  # inner comment
@@ -214,7 +214,7 @@ with (  # outer comment
     ),
     CtxManager2(),
 ) as example:
-    ...
+    pass
 
 # Breaking of with items.
 with (test  # bar
@@ -318,18 +318,18 @@ if True:
 ## Output
 ```py
 with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
-    ...
+    pass
     # trailing
 
 with a, a:  # after colon
-    ...
+    pass
     # trailing
 
 with (
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
 ):
-    ...
+    pass
     # trailing
 
 
@@ -337,7 +337,7 @@ with (
     a,  # a  # comma
     b,  # c
 ):  # colon
-    ...
+    pass
 
 
 with (
@@ -347,7 +347,7 @@ with (
     ),  # b  # comma
     c,  # c
 ):  # colon
-    ...  # body
+    pass  # body
     # body trailing own
 
 with (
@@ -362,14 +362,14 @@ with (
 with (
     a,
 ):  # magic trailing comma
-    ...
+    pass
 
 
 with a:  # should remove brackets
-    ...
+    pass
 
 with aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as c:
-    ...
+    pass
 
 
 # currently unparsable by black: https://github.com/psf/black/issues/3678
@@ -382,49 +382,49 @@ with (
     # leading comment
     a
 ) as b:
-    ...
+    pass
 
 with (
     # leading comment
     a as b
 ):
-    ...
+    pass
 
 with (
     a as b
     # trailing comment
 ):
-    ...
+    pass
 
 with a as (
     # leading comment
     b
 ):
-    ...
+    pass
 
 with a as (
     b
     # trailing comment
 ):
-    ...
+    pass
 
 with (
     a  # trailing same line comment
     # trailing own line comment
 ) as b:
-    ...
+    pass
 
 with (
     a  # trailing same line comment
     # trailing own line comment
 ) as b:
-    ...
+    pass
 
 with (
     a  # trailing same line comment
     # trailing own line comment
 ) as b:
-    ...
+    pass
 
 with (
     (
@@ -434,7 +434,7 @@ with (
         b
     )  # trailing b same line comment
 ):
-    ...
+    pass
 
 with (
     # comment
@@ -485,7 +485,7 @@ with (
     CtxManager2() as example2,
     CtxManager2() as example2,
 ):
-    ...
+    pass
 
 with [
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -493,7 +493,7 @@ with [
     "cccccccccccccccccccccccccccccccccccccccccc",
     dddddddddddddddddddddddddddddddd,
 ] as example1, aaaaaaaaaaaaaaaaaaaaaaaaaa * bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb * cccccccccccccccccccccccccccc + ddddddddddddddddd as example2, CtxManager222222222222222() as example2:
-    ...
+    pass
 
 # Comments on open parentheses
 with (  # comment
@@ -501,7 +501,7 @@ with (  # comment
     CtxManager2() as example2,
     CtxManager3() as example3,
 ):
-    ...
+    pass
 
 with (  # outer comment
     (  # inner comment
@@ -510,25 +510,25 @@ with (  # outer comment
     CtxManager2() as example2,
     CtxManager3() as example3,
 ):
-    ...
+    pass
 
 with (  # outer comment
     CtxManager()
 ) as example:
-    ...
+    pass
 
 with (  # outer comment
     CtxManager()
 ) as example, (  # inner comment
     CtxManager2()
 ) as example2:
-    ...
+    pass
 
 with (  # outer comment
     CtxManager1(),
     CtxManager2(),
 ) as example:
-    ...
+    pass
 
 with (  # outer comment
     (  # inner comment
@@ -536,7 +536,7 @@ with (  # outer comment
     ),
     CtxManager2(),
 ) as example:
-    ...
+    pass
 
 # Breaking of with items.
 with test as (  # bar  # foo

--- a/crates/ruff_python_formatter/tests/snapshots/format@trivia.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@trivia.py.snap
@@ -23,7 +23,7 @@ class Test:
 c = 30
 
 while a == 10:
-    ...
+    print(a)
 
     # trailing comment with one line before
 
@@ -32,7 +32,7 @@ while a == 10:
 d = 40
 
 while b == 20:
-    ...
+    print(b)
     # no empty line before
 
 e = 50  # one empty line before
@@ -61,7 +61,7 @@ class Test:
 c = 30
 
 while a == 10:
-    ...
+    print(a)
 
     # trailing comment with one line before
 
@@ -70,7 +70,7 @@ while a == 10:
 d = 40
 
 while b == 20:
-    ...
+    print(b)
     # no empty line before
 
 e = 50  # one empty line before


### PR DESCRIPTION
Split out of #8044: In preview style, ellipsis are also collapsed in non-stub files. This should only affect function/class contexts since for other statements stub are generally not used. I've updated our tests to use `pass` instead to reflect this, which makes tracking the preview style changes much easier.

