### PR TITLE
add instructions on line-level suppression to file-level suppression warning

### DIFF
--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -253,7 +253,7 @@ impl FileExemption {
                         #[allow(deprecated)]
                         let line = locator.compute_line_index(range.start());
                         let path_display = relativize_path(path);
-                        warn!("Unexpected `# ruff: noqa` directive at {path_display}:{line}. File-level suppression comments must appear on their own line.");
+                        warn!("Unexpected `# ruff: noqa` directive at {path_display}:{line}. File-level suppression comments must appear on their own line. For line-level suppression, omit the `ruff:` prefix.");
                         continue;
                     }
 


### PR DESCRIPTION
## Summary

In #6157 a warning was introduced when users use `ruff: noqa` suppression in-line instead of at the file-level. I had this trigger today after forgetting about it, and the warning is an excellent improvement.

I knew immediately what the issue was because I raised it previously, but on reading the warning I'm not sure it would be so obvious to all users. This PR extends the error with a short sentence explaining that line-level suppression should omit the `ruff:` prefix.

## Test Plan

Not sure it's necessary for such a trivial change :)
