### PR TITLE
Skip over parentheses when detecting `in` keyword

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/list_comp.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/list_comp.py
@@ -102,3 +102,6 @@ aaaaaaaaaaaaaaaaaaaaa = [
      c  # negative decimal
 ]
 
+# Parenthesized targets and iterators.
+[x for (x) in y]
+[x for x in (y)]

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__list_comp.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__list_comp.py.snap
@@ -108,6 +108,9 @@ aaaaaaaaaaaaaaaaaaaaa = [
      c  # negative decimal
 ]
 
+# Parenthesized targets and iterators.
+[x for (x) in y]
+[x for x in (y)]
 ```
 
 ## Output
@@ -247,6 +250,10 @@ aaaaaaaaaaaaaaaaaaaaa = [
     for components in b  # pylint: disable=undefined-loop-variable  # integer 1 may only have decimal 01-09
     + c  # negative decimal
 ]
+
+# Parenthesized targets and iterators.
+[x for (x) in y]
+[x for x in (y)]
 ```
 
 


### PR DESCRIPTION
## Summary

Given an expression like `[x for (x) in y]`, we weren't skipping over parentheses when searching for the `in` between `(x)` and `y`.

Closes https://github.com/astral-sh/ruff/issues/8053.
