### PR TITLE
Change `line-ending` default to `auto`

### DIFF
--- a/crates/ruff_cli/tests/format.rs
+++ b/crates/ruff_cli/tests/format.rs
@@ -95,6 +95,35 @@ if condition:
 }
 
 #[test]
+fn mixed_line_endings() -> Result<()> {
+    let tempdir = TempDir::new()?;
+
+    fs::write(
+        tempdir.path().join("main.py"),
+        "from test import say_hy\n\nif __name__ == \"__main__\":\n    say_hy(\"dear Ruff contributor\")\n",
+    )?;
+
+    fs::write(
+        tempdir.path().join("test.py"),
+        "def say_hy(name: str):\r\n    print(f\"Hy {name}\")\r\n",
+    )?;
+
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .current_dir(tempdir.path())
+        .args(["format", "--diff", "--isolated"])
+        .arg("."), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `ruff format` is not yet stable, and subject to change in future versions.
+    2 files left unchanged
+    "###);
+    Ok(())
+}
+
+#[test]
 fn exclude() -> Result<()> {
     let tempdir = TempDir::new()?;
     let ruff_toml = tempdir.path().join("ruff.toml");

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2623,16 +2623,16 @@ pub struct FormatOptions {
 
     /// The character Ruff uses at the end of a line.
     ///
+    /// * `auto`: The newline style is detected automatically on a file per file basis. Files with mixed line endings will be converted to the first detected line ending. Defaults to `\n` for files that contain no line endings.
     /// * `lf`: Line endings will be converted to `\n`. The default line ending on Unix.
     /// * `cr-lf`: Line endings will be converted to `\r\n`. The default line ending on Windows.
-    /// * `auto`: The newline style is detected automatically on a file per file basis. Files with mixed line endings will be converted to the first detected line ending. Defaults to `\n` for files that contain no line endings.
     /// * `native`: Line endings will be converted to `\n` on Unix and `\r\n` on Windows.
     #[option(
-        default = r#"lf"#,
-        value_type = r#""lf" | "cr-lf" | "auto" | "native""#,
+        default = r#"auto"#,
+        value_type = r#""auto" | "lf" | "cr-lf" | "native""#,
         example = r#"
-            # Automatically detect the line ending on a file per file basis.
-            line-ending = "auto"
+            # Use `\n` line endings for all files
+            line-ending = "lf"
         "#
     )]
     pub line_ending: Option<LineEnding>,

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -168,7 +168,7 @@ impl Default for FormatterSettings {
             exclude: FilePatternSet::default(),
             preview: PreviewMode::Disabled,
             line_width: default_options.line_width(),
-            line_ending: LineEnding::Lf,
+            line_ending: LineEnding::Auto,
             indent_style: default_options.indent_style(),
             indent_width: default_options.indent_width(),
             quote_style: default_options.quote_style(),
@@ -183,17 +183,17 @@ impl Default for FormatterSettings {
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum LineEnding {
-    ///  Line endings will be converted to `\n` as is common on Unix.
+    /// The newline style is detected automatically on a file per file basis.
+    /// Files with mixed line endings will be converted to the first detected line ending.
+    /// Defaults to [`LineEnding::Lf`] for a files that contain no line endings.
     #[default]
+    Auto,
+
+    ///  Line endings will be converted to `\n` as is common on Unix.
     Lf,
 
     /// Line endings will be converted to `\r\n` as is common on Windows.
     CrLf,
-
-    /// The newline style is detected automatically on a file per file basis.
-    /// Files with mixed line endings will be converted to the first detected line ending.
-    /// Defaults to [`LineEnding::Lf`] for a files that contain no line endings.
-    Auto,
 
     /// Line endings will be converted to `\n` on Unix and `\r\n` on Windows.
     Native,

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1253,7 +1253,7 @@
           ]
         },
         "line-ending": {
-          "description": "The character Ruff uses at the end of a line.\n\n* `lf`: Line endings will be converted to `\\n`. The default line ending on Unix. * `cr-lf`: Line endings will be converted to `\\r\\n`. The default line ending on Windows. * `auto`: The newline style is detected automatically on a file per file basis. Files with mixed line endings will be converted to the first detected line ending. Defaults to `\\n` for files that contain no line endings. * `native`: Line endings will be converted to `\\n` on Unix and `\\r\\n` on Windows.",
+          "description": "The character Ruff uses at the end of a line.\n\n* `auto`: The newline style is detected automatically on a file per file basis. Files with mixed line endings will be converted to the first detected line ending. Defaults to `\\n` for files that contain no line endings. * `lf`: Line endings will be converted to `\\n`. The default line ending on Unix. * `cr-lf`: Line endings will be converted to `\\r\\n`. The default line ending on Windows. * `native`: Line endings will be converted to `\\n` on Unix and `\\r\\n` on Windows.",
           "anyOf": [
             {
               "$ref": "#/definitions/LineEnding"
@@ -1565,6 +1565,13 @@
     "LineEnding": {
       "oneOf": [
         {
+          "description": "The newline style is detected automatically on a file per file basis. Files with mixed line endings will be converted to the first detected line ending. Defaults to [`LineEnding::Lf`] for a files that contain no line endings.",
+          "type": "string",
+          "enum": [
+            "auto"
+          ]
+        },
+        {
           "description": "Line endings will be converted to `\\n` as is common on Unix.",
           "type": "string",
           "enum": [
@@ -1576,13 +1583,6 @@
           "type": "string",
           "enum": [
             "cr-lf"
-          ]
-        },
-        {
-          "description": "The newline style is detected automatically on a file per file basis. Files with mixed line endings will be converted to the first detected line ending. Defaults to [`LineEnding::Lf`] for a files that contain no line endings.",
-          "type": "string",
-          "enum": [
-            "auto"
           ]
         },
         {


### PR DESCRIPTION
## Summary

This PR changes the `format.line-ending` default from `lf` to `auto`. 

The motivation for defaulting to `lf` is to ensure all files in a project use the same line ending, regardless of the file author's platform. However, it has the downside that it results in unexpected line-ending changes for existing projects that use a mixture of `\n` and `\r\n` and projects that use windows only.
We haven't received much feedback on the `lf` default, but there has been at least one occurrence where a user was confused about why Ruff changed all lines. 
They struggled to understand the changes because many diff viewers hide whitespace changes by default. 
We also put them in an uncomfortable position because they were unfamiliar with line endings (the difference between `\n` and `\r\n`) and didn't know what option to choose. So they defaulted to `auto` because it seems like the most clever option that hopefully does the right thing for them. 

## Breaking Change

While this is a breaking change because it changes the configuration, it doesn't require a new minor version because the formatter is still in alpha (excluded from versioning).

## Test Plan
I added a new integration test that ensures the formatter preserves the line ending choice when run without any options.
