### PR TITLE
Remove leftover constant tuple reference

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/settings.rs
+++ b/crates/ruff_linter/src/rules/pylint/settings.rs
@@ -15,7 +15,6 @@ pub enum ConstantType {
     Float,
     Int,
     Str,
-    Tuple,
 }
 
 impl TryFrom<&Constant> for ConstantType {

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -333,7 +333,6 @@ pub enum ComparableConstant<'a> {
     Str { value: &'a str, unicode: bool },
     Bytes(&'a [u8]),
     Int(&'a ast::Int),
-    Tuple(Vec<ComparableConstant<'a>>),
     Float(u64),
     Complex { real: u64, imag: u64 },
     Ellipsis,

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2392,7 +2392,7 @@ pub struct PylintOptions {
     /// Constant types to ignore when used as "magic values" (see: `PLR2004`).
     #[option(
         default = r#"["str", "bytes"]"#,
-        value_type = r#"list["str" | "bytes" | "complex" | "float" | "int" | "tuple"]"#,
+        value_type = r#"list["str" | "bytes" | "complex" | "float" | "int"]"#,
         example = r#"
             allow-magic-value-types = ["int"]
         "#

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -708,8 +708,7 @@
         "complex",
         "float",
         "int",
-        "str",
-        "tuple"
+        "str"
       ]
     },
     "Convention": {


### PR DESCRIPTION
This PR removes the leftover reference to the tuple variant in `Constant`.