### PR TITLE
New `Singleton` enum for `PatternMatchSingleton` node

### DIFF
--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -185,8 +185,8 @@ pub struct PatternMatchValue<'a> {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct PatternMatchSingleton<'a> {
-    value: ComparableConstant<'a>,
+pub struct PatternMatchSingleton {
+    value: ComparableSingleton,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -227,7 +227,7 @@ pub struct PatternMatchOr<'a> {
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum ComparablePattern<'a> {
     MatchValue(PatternMatchValue<'a>),
-    MatchSingleton(PatternMatchSingleton<'a>),
+    MatchSingleton(PatternMatchSingleton),
     MatchSequence(PatternMatchSequence<'a>),
     MatchMapping(PatternMatchMapping<'a>),
     MatchClass(PatternMatchClass<'a>),
@@ -322,6 +322,23 @@ impl<'a> From<&'a ast::Decorator> for ComparableDecorator<'a> {
     fn from(decorator: &'a ast::Decorator) -> Self {
         Self {
             expression: (&decorator.expression).into(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum ComparableSingleton {
+    None,
+    True,
+    False,
+}
+
+impl From<&ast::Singleton> for ComparableSingleton {
+    fn from(singleton: &ast::Singleton) -> Self {
+        match singleton {
+            ast::Singleton::None => Self::None,
+            ast::Singleton::True => Self::True,
+            ast::Singleton::False => Self::False,
         }
     }
 }

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -3139,7 +3139,7 @@ impl AstNode for ast::PatternMatchSingleton {
         V: PreorderVisitor<'a> + ?Sized,
     {
         let ast::PatternMatchSingleton { value, range: _ } = self;
-        visitor.visit_constant(value);
+        visitor.visit_singleton(value);
     }
 }
 impl AstNode for ast::PatternMatchSequence {

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1923,7 +1923,7 @@ impl From<PatternMatchValue> for Pattern {
 #[derive(Clone, Debug, PartialEq)]
 pub struct PatternMatchSingleton {
     pub range: TextRange,
-    pub value: Constant,
+    pub value: Singleton,
 }
 
 impl From<PatternMatchSingleton> for Pattern {
@@ -2575,6 +2575,23 @@ impl From<Identifier> for String {
 impl Ranged for Identifier {
     fn range(&self) -> TextRange {
         self.range
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Singleton {
+    None,
+    True,
+    False,
+}
+
+impl From<bool> for Singleton {
+    fn from(value: bool) -> Self {
+        if value {
+            Singleton::True
+        } else {
+            Singleton::False
+        }
     }
 }
 

--- a/crates/ruff_python_ast/src/visitor/preorder.rs
+++ b/crates/ruff_python_ast/src/visitor/preorder.rs
@@ -1,8 +1,8 @@
 use crate::{
     Alias, Arguments, BoolOp, CmpOp, Comprehension, Constant, Decorator, ElifElseClause,
     ExceptHandler, Expr, Keyword, MatchCase, Mod, Operator, Parameter, ParameterWithDefault,
-    Parameters, Pattern, PatternArguments, PatternKeyword, Stmt, TypeParam, TypeParams, UnaryOp,
-    WithItem,
+    Parameters, Pattern, PatternArguments, PatternKeyword, Singleton, Stmt, TypeParam, TypeParams,
+    UnaryOp, WithItem,
 };
 use crate::{AnyNodeRef, AstNode};
 
@@ -43,6 +43,9 @@ pub trait PreorderVisitor<'a> {
 
     #[inline]
     fn visit_constant(&mut self, _constant: &'a Constant) {}
+
+    #[inline]
+    fn visit_singleton(&mut self, _singleton: &'a Singleton) {}
 
     #[inline]
     fn visit_bool_op(&mut self, bool_op: &'a BoolOp) {

--- a/crates/ruff_python_ast/tests/preorder.rs
+++ b/crates/ruff_python_ast/tests/preorder.rs
@@ -10,7 +10,7 @@ use ruff_python_ast::visitor::preorder::{
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::{
     Alias, BoolOp, CmpOp, Comprehension, Constant, ExceptHandler, Expr, Keyword, MatchCase, Mod,
-    Operator, Parameter, Parameters, Pattern, Stmt, TypeParam, UnaryOp, WithItem,
+    Operator, Parameter, Parameters, Pattern, Singleton, Stmt, TypeParam, UnaryOp, WithItem,
 };
 use ruff_python_parser::lexer::lex;
 use ruff_python_parser::{parse_tokens, Mode};
@@ -195,6 +195,10 @@ impl PreorderVisitor<'_> for RecordVisitor {
 
     fn visit_constant(&mut self, constant: &Constant) {
         self.emit(&constant);
+    }
+
+    fn visit_singleton(&mut self, singleton: &Singleton) {
+        self.emit(&singleton);
     }
 
     fn visit_bool_op(&mut self, bool_op: &BoolOp) {

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -5,8 +5,8 @@ use std::ops::Deref;
 use ruff_python_ast::{
     self as ast, Alias, ArgOrKeyword, BoolOp, CmpOp, Comprehension, Constant, ConversionFlag,
     DebugText, ExceptHandler, Expr, Identifier, MatchCase, Operator, Parameter, Parameters,
-    Pattern, Stmt, Suite, TypeParam, TypeParamParamSpec, TypeParamTypeVar, TypeParamTypeVarTuple,
-    WithItem,
+    Pattern, Singleton, Stmt, Suite, TypeParam, TypeParamParamSpec, TypeParamTypeVar,
+    TypeParamTypeVarTuple, WithItem,
 };
 use ruff_python_ast::{ParameterWithDefault, TypeParams};
 use ruff_python_literal::escape::{AsciiEscape, Escape, UnicodeEscape};
@@ -672,7 +672,7 @@ impl<'a> Generator<'a> {
                 self.unparse_expr(value, precedence::MAX);
             }
             Pattern::MatchSingleton(ast::PatternMatchSingleton { value, range: _ }) => {
-                self.unparse_constant(value);
+                self.unparse_singleton(value);
             }
             Pattern::MatchSequence(ast::PatternMatchSequence { patterns, range: _ }) => {
                 self.p("[");
@@ -1163,6 +1163,14 @@ impl<'a> Generator<'a> {
             Expr::IpyEscapeCommand(ast::ExprIpyEscapeCommand { kind, value, .. }) => {
                 self.p(&format!("{kind}{value}"));
             }
+        }
+    }
+
+    pub(crate) fn unparse_singleton(&mut self, singleton: &Singleton) {
+        match singleton {
+            Singleton::None => self.p("None"),
+            Singleton::True => self.p("True"),
+            Singleton::False => self.p("False"),
         }
     }
 

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_singleton.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_singleton.rs
@@ -1,5 +1,5 @@
 use ruff_python_ast::AnyNodeRef;
-use ruff_python_ast::{Constant, PatternMatchSingleton};
+use ruff_python_ast::{PatternMatchSingleton, Singleton};
 
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
@@ -10,10 +10,9 @@ pub struct FormatPatternMatchSingleton;
 impl FormatNodeRule<PatternMatchSingleton> for FormatPatternMatchSingleton {
     fn fmt_fields(&self, item: &PatternMatchSingleton, f: &mut PyFormatter) -> FormatResult<()> {
         match item.value {
-            Constant::None => token("None").fmt(f),
-            Constant::Bool(true) => token("True").fmt(f),
-            Constant::Bool(false) => token("False").fmt(f),
-            _ => unreachable!(),
+            Singleton::None => token("None").fmt(f),
+            Singleton::True => token("True").fmt(f),
+            Singleton::False => token("False").fmt(f),
         }
     }
 }

--- a/crates/ruff_python_parser/src/python.lalrpop
+++ b/crates/ruff_python_parser/src/python.lalrpop
@@ -655,7 +655,7 @@ AddOpExpr: ast::ParenthesizedExpr = {
 
 LiteralPattern: ast::Pattern = {
     <location:@L> "None" <end_location:@R> => ast::PatternMatchSingleton {
-        value: ast::Constant::None,
+        value: ast::Singleton::None,
         range: (location..end_location).into()
     }.into(),
     <location:@L> "True" <end_location:@R> => ast::PatternMatchSingleton {

--- a/crates/ruff_python_parser/src/python.rs
+++ b/crates/ruff_python_parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 01c7c57ce067fcf07c9a5450511cc48a2dd08cf821a5ff3b0f649e87d3c67022
+// sha3: 5c061590e81d6c0a6b543c9e8d8d30e7d7a44ed6b20f2ac72ca61a0e33d0e647
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
 use crate::{
@@ -34346,7 +34346,7 @@ fn __action115<
 ) -> ast::Pattern
 {
     ast::PatternMatchSingleton {
-        value: ast::Constant::None,
+        value: ast::Singleton::None,
         range: (location..end_location).into()
     }.into()
 }

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__patma.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__patma.snap
@@ -719,9 +719,7 @@ expression: parse_ast
                                                         MatchSingleton(
                                                             PatternMatchSingleton {
                                                                 range: 621..625,
-                                                                value: Bool(
-                                                                    true,
-                                                                ),
+                                                                value: True,
                                                             },
                                                         ),
                                                     ],
@@ -2402,9 +2400,7 @@ expression: parse_ast
                     pattern: MatchSingleton(
                         PatternMatchSingleton {
                             range: 1947..1952,
-                            value: Bool(
-                                false,
-                            ),
+                            value: False,
                         },
                     ),
                     guard: None,
@@ -3051,9 +3047,7 @@ expression: parse_ast
                                                         MatchSingleton(
                                                             PatternMatchSingleton {
                                                                 range: 2405..2410,
-                                                                value: Bool(
-                                                                    false,
-                                                                ),
+                                                                value: False,
                                                             },
                                                         ),
                                                     ],


### PR DESCRIPTION
## Summary

This PR adds a new `Singleton` enum for the `PatternMatchSingleton` node.

Earlier the node was using the `Constant` enum but the value for this pattern can only be either `None`, `True` or `False`. With the coming PR to remove the `Constant`, this node required a new type to fill in.

This also has the benefit of narrowing the type down to only the possible values for the node as evident by the removal of `unreachable`.

## Test Plan

Update the AST snapshots and run `cargo test`.
