### PR TITLE
Release 0.1.1

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -13,3 +13,8 @@ MD041: false
 
 # MD013/line-length
 MD013: false
+
+# MD024/no-duplicate-heading
+MD024:
+  # Allow when nested under different parents e.g. CHANGELOG.md
+  allow_different_nesting: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,54 @@
 # Changelog
 
+## 0.1.1
+
+### Rule changes
+- Add unsafe fix for `escape-sequence-in-docstring` (`D301`) (#7970)
+- Add fix for `triple-single-quotes` (`D300`) (#7967)
+
+### Configuration
+- Respect `#(deprecated)` attribute in configuration options (#8035)
+- Add `[format|lint].exclude` options (#8000)
+- Respect `tab-size` setting in formatter (#8006)
+- Add `lint.preview` (#8002)
+
+## Preview features
+- [`pylint`] Implement `literal-membership` (`PLR6201`) (#7973)
+- [`pylint`] Implement `too-many-boolean-expressions` (`PLR0916`) (#7975)
+- [`pylint`] Implement `misplaced-bare-raise` (`E0704`) (#7961)
+- [`pylint`] Implement `global-at-module-level` (`W0604`) (#8058)
+- [`pylint`] Implement `unspecified-encoding` (`PLW1514`) (#7939)
+
+
+### Formatter
+- New code style badge for `ruff format` (#7878)
+- Fix comments outside expression parentheses (#7873)
+- Add `--target-version` to `ruff format` (#8055)
+- Skip over parentheses when detecting `in` keyword (#8054)
+- Add `--diff` option to `ruff format` (#7937)
+- Insert newline after nested function or class statements (#7946)
+- Use `pass` over ellipsis in non-function/class contexts (#8049)
+
+### Bug fixes
+- Lazily evaluate all PEP 695 type alias values (#8033)
+- Avoid failed assertion when showing fixes from stdin (#8029)
+- Avoid flagging HTTP and HTTPS literals in urllib-open (#8046)
+- Avoid flagging `bad-dunder-method-name` for `_` (#8015)
+- Remove Python 2-only methods from `URLOpen` audit (#8047)
+- Use set bracket replacement for `iteration-over-set` to preserve whitespace and comments (#8001)
+
+### Documentation
+- Update tutorial to match revised Ruff defaults (#8066)
+- Update rule `B005` docs (#8028)
+- Update GitHub actions example in docs to use `--output-format` (#8014)
+- Document `lint.preview` and `format.preview` (#8032)
+- Clarify that new rules should be added to `RuleGroup::Preview`. (#7989)
+
+## 0.1.0
+
 This is the first release which uses the `CHANGELOG` file. See [GitHub Releases](https://github.com/astral-sh/ruff/releases) for prior changelog entries.
 
 Read Ruff's new [versioning policy](https://docs.astral.sh/ruff/versioning/).
-
-## 0.1.0
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,24 +3,27 @@
 ## 0.1.1
 
 ### Rule changes
+
 - Add unsafe fix for `escape-sequence-in-docstring` (`D301`) (#7970)
 
 ### Configuration
+
 - Respect `#(deprecated)` attribute in configuration options (#8035)
 - Add `[format|lint].exclude` options (#8000)
 - Respect `tab-size` setting in formatter (#8006)
 - Add `lint.preview` (#8002)
 
 ## Preview features
-- [`pylint`] Implement `literal-membership` (`PLR6201`) (#7973)
-- [`pylint`] Implement `too-many-boolean-expressions` (`PLR0916`) (#7975)
-- [`pylint`] Implement `misplaced-bare-raise` (`E0704`) (#7961)
-- [`pylint`] Implement `global-at-module-level` (`W0604`) (#8058)
-- [`pylint`] Implement `unspecified-encoding` (`PLW1514`) (#7939)
+
+- \[`pylint`\] Implement `literal-membership` (`PLR6201`) (#7973)
+- \[`pylint`\] Implement `too-many-boolean-expressions` (`PLR0916`) (#7975)
+- \[`pylint`\] Implement `misplaced-bare-raise` (`E0704`) (#7961)
+- \[`pylint`\] Implement `global-at-module-level` (`W0604`) (#8058)
+- \[`pylint`\] Implement `unspecified-encoding` (`PLW1514`) (#7939)
 - Add fix for `triple-single-quotes` (`D300`) (#7967)
 
-
 ### Formatter
+
 - New code style badge for `ruff format` (#7878)
 - Fix comments outside expression parentheses (#7873)
 - Add `--target-version` to `ruff format` (#8055)
@@ -30,6 +33,7 @@
 - Use `pass` over ellipsis in non-function/class contexts (#8049)
 
 ### Bug fixes
+
 - Lazily evaluate all PEP 695 type alias values (#8033)
 - Avoid failed assertion when showing fixes from stdin (#8029)
 - Avoid flagging HTTP and HTTPS literals in urllib-open (#8046)
@@ -38,6 +42,7 @@
 - Use set bracket replacement for `iteration-over-set` to preserve whitespace and comments (#8001)
 
 ### Documentation
+
 - Update tutorial to match revised Ruff defaults (#8066)
 - Update rule `B005` docs (#8028)
 - Update GitHub actions example in docs to use `--output-format` (#8014)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Rule changes
 - Add unsafe fix for `escape-sequence-in-docstring` (`D301`) (#7970)
-- Add fix for `triple-single-quotes` (`D300`) (#7967)
 
 ### Configuration
 - Respect `#(deprecated)` attribute in configuration options (#8035)
@@ -18,6 +17,7 @@
 - [`pylint`] Implement `misplaced-bare-raise` (`E0704`) (#7961)
 - [`pylint`] Implement `global-at-module-level` (`W0604`) (#8058)
 - [`pylint`] Implement `unspecified-encoding` (`PLW1514`) (#7939)
+- Add fix for `triple-single-quotes` (`D300`) (#7967)
 
 
 ### Formatter

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flake8-to-ruff"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "annotate-snippets 0.9.1",
  "anyhow",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_linter"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aho-corasick",
  "annotate-snippets 0.9.1",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_shrinking"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Ruff can also be used as a [pre-commit](https://pre-commit.com) hook:
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.1.0
+  rev: v0.1.1
   hooks:
     - id: ruff
 ```

--- a/crates/flake8_to_ruff/Cargo.toml
+++ b/crates/flake8_to_ruff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flake8-to-ruff"
-version = "0.1.0"
+version = "0.1.1"
 description = """
 Convert Flake8 configuration files to Ruff configuration files.
 """

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_cli"
-version = "0.1.0"
+version = "0.1.1"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_linter"
-version = "0.1.0"
+version = "0.1.1"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_linter/src/rules/pydocstyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/mod.rs
@@ -12,6 +12,7 @@ mod tests {
     use test_case::test_case;
 
     use crate::registry::Rule;
+    use crate::settings::types::PreviewMode;
     use crate::test::test_path;
     use crate::{assert_messages, settings};
 
@@ -100,6 +101,33 @@ mod tests {
                         "gi.repository.GObject.Property".to_string()
                     ]),
                 },
+                ..settings::LinterSettings::for_rule(rule_code)
+            },
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Rule::TripleSingleQuotes, Path::new("D.py"))]
+    #[test_case(Rule::TripleSingleQuotes, Path::new("D300.py"))]
+    fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
+        // Tests for rules with preview features
+        let snapshot = format!(
+            "preview__{}_{}",
+            rule_code.noqa_code(),
+            path.to_string_lossy()
+        );
+        let diagnostics = test_path(
+            Path::new("pydocstyle").join(path).as_path(),
+            &settings::LinterSettings {
+                pydocstyle: Settings {
+                    convention: None,
+                    ignore_decorators: BTreeSet::from_iter(["functools.wraps".to_string()]),
+                    property_decorators: BTreeSet::from_iter([
+                        "gi.repository.GObject.Property".to_string()
+                    ]),
+                },
+                preview: PreviewMode::Enabled,
                 ..settings::LinterSettings::for_rule(rule_code)
             },
         )?;

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/triple_quotes.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/triple_quotes.rs
@@ -78,12 +78,14 @@ pub(crate) fn triple_quotes(checker: &mut Checker, docstring: &Docstring) {
                 let mut diagnostic =
                     Diagnostic::new(TripleSingleQuotes { expected_quote }, docstring.range());
 
-                let body = docstring.body().as_str();
-                if !body.ends_with('\'') {
-                    diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
-                        format!("{prefixes}'''{body}'''"),
-                        docstring.range(),
-                    )));
+                if checker.settings.preview.is_enabled() {
+                    let body = docstring.body().as_str();
+                    if !body.ends_with('\'') {
+                        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
+                            format!("{prefixes}'''{body}'''"),
+                            docstring.range(),
+                        )));
+                    }
                 }
 
                 checker.diagnostics.push(diagnostic);
@@ -94,12 +96,14 @@ pub(crate) fn triple_quotes(checker: &mut Checker, docstring: &Docstring) {
                 let mut diagnostic =
                     Diagnostic::new(TripleSingleQuotes { expected_quote }, docstring.range());
 
-                let body = docstring.body().as_str();
-                if !body.ends_with('"') {
-                    diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
-                        format!("{prefixes}\"\"\"{body}\"\"\""),
-                        docstring.range(),
-                    )));
+                if checker.settings.preview.is_enabled() {
+                    let body = docstring.body().as_str();
+                    if !body.ends_with('"') {
+                        diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
+                            format!("{prefixes}\"\"\"{body}\"\"\""),
+                            docstring.range(),
+                        )));
+                    }
                 }
 
                 checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D300_D.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D300_D.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pydocstyle/mod.rs
 ---
-D.py:307:5: D300 [*] Use triple double quotes `"""`
+D.py:307:5: D300 Use triple double quotes `"""`
     |
 305 | @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
 306 | def triple_single_quotes_raw():
@@ -10,17 +10,7 @@ D.py:307:5: D300 [*] Use triple double quotes `"""`
     |
     = help: Convert to triple double quotes
 
-ℹ Fix
-304 304 | 
-305 305 | @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
-306 306 | def triple_single_quotes_raw():
-307     |-    r'''Summary.'''
-    307 |+    r"""Summary."""
-308 308 | 
-309 309 | 
-310 310 | @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
-
-D.py:312:5: D300 [*] Use triple double quotes `"""`
+D.py:312:5: D300 Use triple double quotes `"""`
     |
 310 | @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
 311 | def triple_single_quotes_raw_uppercase():
@@ -29,17 +19,7 @@ D.py:312:5: D300 [*] Use triple double quotes `"""`
     |
     = help: Convert to triple double quotes
 
-ℹ Fix
-309 309 | 
-310 310 | @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
-311 311 | def triple_single_quotes_raw_uppercase():
-312     |-    R'''Summary.'''
-    312 |+    R"""Summary."""
-313 313 | 
-314 314 | 
-315 315 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
-
-D.py:317:5: D300 [*] Use triple double quotes `"""`
+D.py:317:5: D300 Use triple double quotes `"""`
     |
 315 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
 316 | def single_quotes_raw():
@@ -48,17 +28,7 @@ D.py:317:5: D300 [*] Use triple double quotes `"""`
     |
     = help: Convert to triple double quotes
 
-ℹ Fix
-314 314 | 
-315 315 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
-316 316 | def single_quotes_raw():
-317     |-    r'Summary.'
-    317 |+    r"""Summary."""
-318 318 | 
-319 319 | 
-320 320 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
-
-D.py:322:5: D300 [*] Use triple double quotes `"""`
+D.py:322:5: D300 Use triple double quotes `"""`
     |
 320 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
 321 | def single_quotes_raw_uppercase():
@@ -67,17 +37,7 @@ D.py:322:5: D300 [*] Use triple double quotes `"""`
     |
     = help: Convert to triple double quotes
 
-ℹ Fix
-319 319 | 
-320 320 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
-321 321 | def single_quotes_raw_uppercase():
-322     |-    R'Summary.'
-    322 |+    R"""Summary."""
-323 323 | 
-324 324 | 
-325 325 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
-
-D.py:328:5: D300 [*] Use triple double quotes `"""`
+D.py:328:5: D300 Use triple double quotes `"""`
     |
 326 | @expect('D301: Use r""" if any backslashes in a docstring')
 327 | def single_quotes_raw_uppercase_backslash():
@@ -86,17 +46,7 @@ D.py:328:5: D300 [*] Use triple double quotes `"""`
     |
     = help: Convert to triple double quotes
 
-ℹ Fix
-325 325 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
-326 326 | @expect('D301: Use r""" if any backslashes in a docstring')
-327 327 | def single_quotes_raw_uppercase_backslash():
-328     |-    R'Sum\mary.'
-    328 |+    R"""Sum\mary."""
-329 329 | 
-330 330 | 
-331 331 | @expect('D301: Use r""" if any backslashes in a docstring')
-
-D.py:645:5: D300 [*] Use triple double quotes `"""`
+D.py:645:5: D300 Use triple double quotes `"""`
     |
 644 |   def single_line_docstring_with_an_escaped_backslash():
 645 |       "\
@@ -108,19 +58,7 @@ D.py:645:5: D300 [*] Use triple double quotes `"""`
     |
     = help: Convert to triple double quotes
 
-ℹ Fix
-642 642 | 
-643 643 | 
-644 644 | def single_line_docstring_with_an_escaped_backslash():
-645     |-    "\
-646     |-    "
-    645 |+    """\
-    646 |+    """
-647 647 | 
-648 648 | class StatementOnSameLineAsDocstring:
-649 649 |     "After this docstring there's another statement on the same line separated by a semicolon." ; priorities=1
-
-D.py:649:5: D300 [*] Use triple double quotes `"""`
+D.py:649:5: D300 Use triple double quotes `"""`
     |
 648 | class StatementOnSameLineAsDocstring:
 649 |     "After this docstring there's another statement on the same line separated by a semicolon." ; priorities=1
@@ -130,17 +68,7 @@ D.py:649:5: D300 [*] Use triple double quotes `"""`
     |
     = help: Convert to triple double quotes
 
-ℹ Fix
-646 646 |     "
-647 647 | 
-648 648 | class StatementOnSameLineAsDocstring:
-649     |-    "After this docstring there's another statement on the same line separated by a semicolon." ; priorities=1
-    649 |+    """After this docstring there's another statement on the same line separated by a semicolon.""" ; priorities=1
-650 650 |     def sort_services(self):
-651 651 |         pass
-652 652 | 
-
-D.py:654:5: D300 [*] Use triple double quotes `"""`
+D.py:654:5: D300 Use triple double quotes `"""`
     |
 653 | class StatementOnSameLineAsDocstring:
 654 |     "After this docstring there's another statement on the same line separated by a semicolon."; priorities=1
@@ -148,17 +76,7 @@ D.py:654:5: D300 [*] Use triple double quotes `"""`
     |
     = help: Convert to triple double quotes
 
-ℹ Fix
-651 651 |         pass
-652 652 | 
-653 653 | class StatementOnSameLineAsDocstring:
-654     |-    "After this docstring there's another statement on the same line separated by a semicolon."; priorities=1
-    654 |+    """After this docstring there's another statement on the same line separated by a semicolon."""; priorities=1
-655 655 | 
-656 656 | 
-657 657 | class CommentAfterDocstring:
-
-D.py:658:5: D300 [*] Use triple double quotes `"""`
+D.py:658:5: D300 Use triple double quotes `"""`
     |
 657 | class CommentAfterDocstring:
 658 |     "After this docstring there's a comment."  # priorities=1
@@ -168,17 +86,7 @@ D.py:658:5: D300 [*] Use triple double quotes `"""`
     |
     = help: Convert to triple double quotes
 
-ℹ Fix
-655 655 | 
-656 656 | 
-657 657 | class CommentAfterDocstring:
-658     |-    "After this docstring there's a comment."  # priorities=1
-    658 |+    """After this docstring there's a comment."""  # priorities=1
-659 659 |     def sort_services(self):
-660 660 |         pass
-661 661 | 
-
-D.py:664:5: D300 [*] Use triple double quotes `"""`
+D.py:664:5: D300 Use triple double quotes `"""`
     |
 663 |   def newline_after_closing_quote(self):
 664 |       "We enforce a newline after the closing quote for a multi-line docstring \
@@ -187,14 +95,5 @@ D.py:664:5: D300 [*] Use triple double quotes `"""`
     | |_________________________________________________________^ D300
     |
     = help: Convert to triple double quotes
-
-ℹ Fix
-661 661 | 
-662 662 | 
-663 663 | def newline_after_closing_quote(self):
-664     |-    "We enforce a newline after the closing quote for a multi-line docstring \
-665     |-    but continuations shouldn't be considered multi-line"
-    664 |+    """We enforce a newline after the closing quote for a multi-line docstring \
-    665 |+    but continuations shouldn't be considered multi-line"""
 
 

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__bom.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__bom.snap
@@ -1,15 +1,11 @@
 ---
 source: crates/ruff_linter/src/rules/pydocstyle/mod.rs
 ---
-bom.py:1:1: D300 [*] Use triple double quotes `"""`
+bom.py:1:1: D300 Use triple double quotes `"""`
   |
 1 | ﻿''' SAM macro definitions '''
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ D300
   |
   = help: Convert to triple double quotes
-
-ℹ Fix
-1   |-﻿''' SAM macro definitions '''
-  1 |+﻿""" SAM macro definitions """
 
 

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__preview__D300_D.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__preview__D300_D.py.snap
@@ -1,0 +1,200 @@
+---
+source: crates/ruff_linter/src/rules/pydocstyle/mod.rs
+---
+D.py:307:5: D300 [*] Use triple double quotes `"""`
+    |
+305 | @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+306 | def triple_single_quotes_raw():
+307 |     r'''Summary.'''
+    |     ^^^^^^^^^^^^^^^ D300
+    |
+    = help: Convert to triple double quotes
+
+ℹ Fix
+304 304 | 
+305 305 | @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+306 306 | def triple_single_quotes_raw():
+307     |-    r'''Summary.'''
+    307 |+    r"""Summary."""
+308 308 | 
+309 309 | 
+310 310 | @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+
+D.py:312:5: D300 [*] Use triple double quotes `"""`
+    |
+310 | @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+311 | def triple_single_quotes_raw_uppercase():
+312 |     R'''Summary.'''
+    |     ^^^^^^^^^^^^^^^ D300
+    |
+    = help: Convert to triple double quotes
+
+ℹ Fix
+309 309 | 
+310 310 | @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+311 311 | def triple_single_quotes_raw_uppercase():
+312     |-    R'''Summary.'''
+    312 |+    R"""Summary."""
+313 313 | 
+314 314 | 
+315 315 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+
+D.py:317:5: D300 [*] Use triple double quotes `"""`
+    |
+315 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+316 | def single_quotes_raw():
+317 |     r'Summary.'
+    |     ^^^^^^^^^^^ D300
+    |
+    = help: Convert to triple double quotes
+
+ℹ Fix
+314 314 | 
+315 315 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+316 316 | def single_quotes_raw():
+317     |-    r'Summary.'
+    317 |+    r"""Summary."""
+318 318 | 
+319 319 | 
+320 320 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+
+D.py:322:5: D300 [*] Use triple double quotes `"""`
+    |
+320 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+321 | def single_quotes_raw_uppercase():
+322 |     R'Summary.'
+    |     ^^^^^^^^^^^ D300
+    |
+    = help: Convert to triple double quotes
+
+ℹ Fix
+319 319 | 
+320 320 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+321 321 | def single_quotes_raw_uppercase():
+322     |-    R'Summary.'
+    322 |+    R"""Summary."""
+323 323 | 
+324 324 | 
+325 325 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+
+D.py:328:5: D300 [*] Use triple double quotes `"""`
+    |
+326 | @expect('D301: Use r""" if any backslashes in a docstring')
+327 | def single_quotes_raw_uppercase_backslash():
+328 |     R'Sum\mary.'
+    |     ^^^^^^^^^^^^ D300
+    |
+    = help: Convert to triple double quotes
+
+ℹ Fix
+325 325 | @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+326 326 | @expect('D301: Use r""" if any backslashes in a docstring')
+327 327 | def single_quotes_raw_uppercase_backslash():
+328     |-    R'Sum\mary.'
+    328 |+    R"""Sum\mary."""
+329 329 | 
+330 330 | 
+331 331 | @expect('D301: Use r""" if any backslashes in a docstring')
+
+D.py:645:5: D300 [*] Use triple double quotes `"""`
+    |
+644 |   def single_line_docstring_with_an_escaped_backslash():
+645 |       "\
+    |  _____^
+646 | |     "
+    | |_____^ D300
+647 |   
+648 |   class StatementOnSameLineAsDocstring:
+    |
+    = help: Convert to triple double quotes
+
+ℹ Fix
+642 642 | 
+643 643 | 
+644 644 | def single_line_docstring_with_an_escaped_backslash():
+645     |-    "\
+646     |-    "
+    645 |+    """\
+    646 |+    """
+647 647 | 
+648 648 | class StatementOnSameLineAsDocstring:
+649 649 |     "After this docstring there's another statement on the same line separated by a semicolon." ; priorities=1
+
+D.py:649:5: D300 [*] Use triple double quotes `"""`
+    |
+648 | class StatementOnSameLineAsDocstring:
+649 |     "After this docstring there's another statement on the same line separated by a semicolon." ; priorities=1
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ D300
+650 |     def sort_services(self):
+651 |         pass
+    |
+    = help: Convert to triple double quotes
+
+ℹ Fix
+646 646 |     "
+647 647 | 
+648 648 | class StatementOnSameLineAsDocstring:
+649     |-    "After this docstring there's another statement on the same line separated by a semicolon." ; priorities=1
+    649 |+    """After this docstring there's another statement on the same line separated by a semicolon.""" ; priorities=1
+650 650 |     def sort_services(self):
+651 651 |         pass
+652 652 | 
+
+D.py:654:5: D300 [*] Use triple double quotes `"""`
+    |
+653 | class StatementOnSameLineAsDocstring:
+654 |     "After this docstring there's another statement on the same line separated by a semicolon."; priorities=1
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ D300
+    |
+    = help: Convert to triple double quotes
+
+ℹ Fix
+651 651 |         pass
+652 652 | 
+653 653 | class StatementOnSameLineAsDocstring:
+654     |-    "After this docstring there's another statement on the same line separated by a semicolon."; priorities=1
+    654 |+    """After this docstring there's another statement on the same line separated by a semicolon."""; priorities=1
+655 655 | 
+656 656 | 
+657 657 | class CommentAfterDocstring:
+
+D.py:658:5: D300 [*] Use triple double quotes `"""`
+    |
+657 | class CommentAfterDocstring:
+658 |     "After this docstring there's a comment."  # priorities=1
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ D300
+659 |     def sort_services(self):
+660 |         pass
+    |
+    = help: Convert to triple double quotes
+
+ℹ Fix
+655 655 | 
+656 656 | 
+657 657 | class CommentAfterDocstring:
+658     |-    "After this docstring there's a comment."  # priorities=1
+    658 |+    """After this docstring there's a comment."""  # priorities=1
+659 659 |     def sort_services(self):
+660 660 |         pass
+661 661 | 
+
+D.py:664:5: D300 [*] Use triple double quotes `"""`
+    |
+663 |   def newline_after_closing_quote(self):
+664 |       "We enforce a newline after the closing quote for a multi-line docstring \
+    |  _____^
+665 | |     but continuations shouldn't be considered multi-line"
+    | |_________________________________________________________^ D300
+    |
+    = help: Convert to triple double quotes
+
+ℹ Fix
+661 661 | 
+662 662 | 
+663 663 | def newline_after_closing_quote(self):
+664     |-    "We enforce a newline after the closing quote for a multi-line docstring \
+665     |-    but continuations shouldn't be considered multi-line"
+    664 |+    """We enforce a newline after the closing quote for a multi-line docstring \
+    665 |+    but continuations shouldn't be considered multi-line"""
+
+

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__preview__D300_D300.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__preview__D300_D300.py.snap
@@ -9,12 +9,19 @@ D300.py:6:5: D300 Use triple double quotes `"""`
   |
   = help: Convert to triple double quotes
 
-D300.py:10:5: D300 Use triple double quotes `"""`
+D300.py:10:5: D300 [*] Use triple double quotes `"""`
    |
  9 | def contains_quote():
 10 |     'Sum"\\mary.'
    |     ^^^^^^^^^^^^^ D300
    |
    = help: Convert to triple double quotes
+
+ℹ Fix
+7  7  | 
+8  8  | 
+9  9  | def contains_quote():
+10    |-    'Sum"\\mary.'
+   10 |+    """Sum"\\mary."""
 
 

--- a/crates/ruff_shrinking/Cargo.toml
+++ b/crates/ruff_shrinking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_shrinking"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -249,7 +249,7 @@ This tutorial has focused on Ruff's command-line interface, but Ruff can also be
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.1.0
+  rev: v0.1.1
   hooks:
     - id: ruff
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,7 +23,7 @@ Ruff can also be used as a [pre-commit](https://pre-commit.com) hook:
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.1.0
+  rev: v0.1.1
   hooks:
     - id: ruff
 ```
@@ -33,7 +33,7 @@ Or, to enable fixes:
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.1.0
+  rev: v0.1.1
   hooks:
     - id: ruff
       args: [ --fix, --exit-non-zero-on-fix ]
@@ -44,7 +44,7 @@ Or, to run the hook on Jupyter Notebooks too:
 ```yaml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.1.0
+  rev: v0.1.1
   hooks:
     - id: ruff
       types_or: [python, pyi, jupyter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,20 @@ force-exclude = '''
   | crates/ruff_python_formatter/resources
 )/
 '''
+
+[tool.rooster]
+major_labels = []  # Ruff never uses the major version number
+minor_labels = ["breaking"]
+patch_labels = ["bug", "rule", "preview"]
+
+changelog_sections.breaking = "Breaking changes"
+changelog_sections.preview = "Preview features"
+changelog_sections.rule = "Rule changes"
+changelog_sections.cli = "CLI"
+changelog_sections.configuration = "Configuration"
+changelog_sections.formatter = "Formatter"
+changelog_sections.bug = "Bug fixes"
+changelog_sections.__unknown__ = "Other changes"
+
+changelog_ignore_labels = ["internal"]
+change_template = "- {pull_request.title} (#{pull_request.number})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,20 +66,3 @@ force-exclude = '''
   | crates/ruff_python_formatter/resources
 )/
 '''
-
-[tool.rooster]
-major_labels = []  # Ruff never uses the major version number
-minor_labels = ["breaking"]
-patch_labels = ["bug", "rule", "preview"]
-
-changelog_sections.breaking = "Breaking changes"
-changelog_sections.preview = "Preview features"
-changelog_sections.rule = "Rule changes"
-changelog_sections.cli = "CLI"
-changelog_sections.configuration = "Configuration"
-changelog_sections.formatter = "Formatter"
-changelog_sections.bug = "Bug fixes"
-changelog_sections.__unknown__ = "Other changes"
-
-changelog_ignore_labels = ["internal"]
-change_template = "- {pull_request.title} (#{pull_request.number})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ruff"
-version = "0.1.0"
+version = "0.1.1"
 description = "An extremely fast Python linter, written in Rust."
 authors = [{ name = "Astral Software Inc.", email = "hey@astral.sh" }]
 readme = "README.md"

--- a/scripts/benchmarks/pyproject.toml
+++ b/scripts/benchmarks/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scripts"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["Charles Marsh <charlie.r.marsh@gmail.com>"]
 


### PR DESCRIPTION
- Add changelog entry for 0.1.1
- Bump version to 0.1.1
- Require preview for fix added in #7967 
- Allow duplicate headings in changelog (markdownlint setting) 