### PR TITLE
Add `#[automatically_derived]` to derived impls

### DIFF
--- a/crates/ruff_macros/src/cache_key.rs
+++ b/crates/ruff_macros/src/cache_key.rs
@@ -101,6 +101,7 @@ pub(crate) fn derive_cache_key(item: &DeriveInput) -> syn::Result<TokenStream> {
     let (impl_generics, ty_generics, where_clause) = &item.generics.split_for_impl();
 
     Ok(quote!(
+        #[automatically_derived]
         impl #impl_generics ruff_cache::CacheKey for #name #ty_generics #where_clause {
             fn cache_key(&self, key: &mut ruff_cache::CacheKeyHasher) {
                 use std::hash::Hasher;

--- a/crates/ruff_macros/src/combine_options.rs
+++ b/crates/ruff_macros/src/combine_options.rs
@@ -16,6 +16,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
                 .collect::<Result<Vec<_>, _>>()?;
 
             Ok(quote! {
+                #[automatically_derived]
                 impl crate::configuration::CombinePluginOptions for #ident {
                     fn combine(self, other: Self) -> Self {
                         #[allow(deprecated)]

--- a/crates/ruff_macros/src/config.rs
+++ b/crates/ruff_macros/src/config.rs
@@ -87,6 +87,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
             };
 
             Ok(quote! {
+                #[automatically_derived]
                 impl crate::options_base::OptionsMetadata for #ident {
                     fn record(visit: &mut dyn crate::options_base::Visit) {
                         #(#output);*

--- a/crates/ruff_macros/src/rule_namespace.rs
+++ b/crates/ruff_macros/src/rule_namespace.rs
@@ -111,6 +111,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
     }
 
     Ok(quote! {
+        #[automatically_derived]
         impl crate::registry::RuleNamespace for #ident {
             fn parse_code(code: &str) -> Option<(Self, &str)> {
                 #if_statements

--- a/crates/ruff_macros/src/violation.rs
+++ b/crates/ruff_macros/src/violation.rs
@@ -53,6 +53,7 @@ pub(crate) fn violation(violation: &ItemStruct) -> Result<TokenStream> {
             #[derive(Debug, PartialEq, Eq)]
             #violation
 
+            #[automatically_derived]
             impl From<#ident> for ruff_diagnostics::DiagnosticKind {
                 fn from(value: #ident) -> Self {
                     use ruff_diagnostics::Violation;
@@ -76,6 +77,7 @@ pub(crate) fn violation(violation: &ItemStruct) -> Result<TokenStream> {
                 }
             }
 
+            #[automatically_derived]
             impl From<#ident> for ruff_diagnostics::DiagnosticKind {
                 fn from(value: #ident) -> Self {
                     use ruff_diagnostics::Violation;


### PR DESCRIPTION

## Summary

Add the `#[automatically_derived]` attribute to derived implementations to guide tools. See https://doc.rust-lang.org/beta/reference/attributes/derive.html#the-automatically_derived-attribute

## Test Plan

`cargo build`
