### PR TITLE
Fix `Options` JSON schema description

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -388,6 +388,10 @@ pub struct Options {
     pub format: Option<FormatOptions>,
 }
 
+/// Experimental section to configure Ruff's linting. This new section will eventually
+/// replace the top-level linting options.
+///
+/// Options specified in the `lint` section take precedence over the top-level settings.
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug, PartialEq, Eq, Default, OptionsMetadata, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
@@ -433,10 +437,6 @@ pub struct LintOptions {
 // Note: This struct should be inlined into [`LintOptions`] once support for the top-level lint settings
 // is removed.
 
-/// Experimental section to configure Ruff's linting. This new section will eventually
-/// replace the top-level linting options.
-///
-/// Options specified in the `lint` section take precedence over the top-level settings.
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(
     Debug, PartialEq, Eq, Default, OptionsMetadata, CombineOptions, Serialize, Deserialize,

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Options",
-  "description": "Experimental section to configure Ruff's linting. This new section will eventually replace the top-level linting options.\n\nOptions specified in the `lint` section take precedence over the top-level settings.",
   "type": "object",
   "properties": {
     "allowed-confusables": {


### PR DESCRIPTION
## Summary

It's seems that `schemars` uses the comment of a flattened struct for the enclosing struct. 
In our case, the comment on `CommonLintOptions` was used for `Options`.

I moved the `lint` section comment to `LintOptions` which avoids this undesired inheritance.

## Test Plan

Reviewed the json schema changes
