### PR TITLE
Fix message for `too-many-arguments` lint

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_arguments.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_arguments.rs
@@ -53,7 +53,7 @@ impl Violation for TooManyArguments {
     #[derive_message_formats]
     fn message(&self) -> String {
         let TooManyArguments { c_args, max_args } = self;
-        format!("Too many arguments to function call ({c_args} > {max_args})")
+        format!("Too many arguments to function definition ({c_args} > {max_args})")
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_arguments.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_arguments.rs
@@ -53,7 +53,7 @@ impl Violation for TooManyArguments {
     #[derive_message_formats]
     fn message(&self) -> String {
         let TooManyArguments { c_args, max_args } = self;
-        format!("Too many arguments to function definition ({c_args} > {max_args})")
+        format!("Too many arguments in function definition ({c_args} > {max_args})")
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR0913_too_many_arguments.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR0913_too_many_arguments.py.snap
@@ -1,35 +1,35 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-too_many_arguments.py:1:5: PLR0913 Too many arguments to function call (8 > 5)
+too_many_arguments.py:1:5: PLR0913 Too many arguments to function definition (8 > 5)
   |
 1 | def f(x, y, z, t, u, v, w, r):  # Too many arguments (8/5)
   |     ^ PLR0913
 2 |     pass
   |
 
-too_many_arguments.py:17:5: PLR0913 Too many arguments to function call (6 > 5)
+too_many_arguments.py:17:5: PLR0913 Too many arguments to function definition (6 > 5)
    |
 17 | def f(x, y, z, u=1, v=1, r=1):  # Too many arguments (6/5)
    |     ^ PLR0913
 18 |     pass
    |
 
-too_many_arguments.py:25:5: PLR0913 Too many arguments to function call (6 > 5)
+too_many_arguments.py:25:5: PLR0913 Too many arguments to function definition (6 > 5)
    |
 25 | def f(x, y, z, /, u, v, w):  # Too many arguments (6/5)
    |     ^ PLR0913
 26 |     pass
    |
 
-too_many_arguments.py:29:5: PLR0913 Too many arguments to function call (6 > 5)
+too_many_arguments.py:29:5: PLR0913 Too many arguments to function definition (6 > 5)
    |
 29 | def f(x, y, z, *, u, v, w):  # Too many arguments (6/5)
    |     ^ PLR0913
 30 |     pass
    |
 
-too_many_arguments.py:33:5: PLR0913 Too many arguments to function call (9 > 5)
+too_many_arguments.py:33:5: PLR0913 Too many arguments to function definition (9 > 5)
    |
 33 | def f(x, y, z, a, b, c, *, u, v, w):  # Too many arguments (9/5)
    |     ^ PLR0913

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR0913_too_many_arguments.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR0913_too_many_arguments.py.snap
@@ -1,35 +1,35 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-too_many_arguments.py:1:5: PLR0913 Too many arguments to function definition (8 > 5)
+too_many_arguments.py:1:5: PLR0913 Too many arguments in function definition (8 > 5)
   |
 1 | def f(x, y, z, t, u, v, w, r):  # Too many arguments (8/5)
   |     ^ PLR0913
 2 |     pass
   |
 
-too_many_arguments.py:17:5: PLR0913 Too many arguments to function definition (6 > 5)
+too_many_arguments.py:17:5: PLR0913 Too many arguments in function definition (6 > 5)
    |
 17 | def f(x, y, z, u=1, v=1, r=1):  # Too many arguments (6/5)
    |     ^ PLR0913
 18 |     pass
    |
 
-too_many_arguments.py:25:5: PLR0913 Too many arguments to function definition (6 > 5)
+too_many_arguments.py:25:5: PLR0913 Too many arguments in function definition (6 > 5)
    |
 25 | def f(x, y, z, /, u, v, w):  # Too many arguments (6/5)
    |     ^ PLR0913
 26 |     pass
    |
 
-too_many_arguments.py:29:5: PLR0913 Too many arguments to function definition (6 > 5)
+too_many_arguments.py:29:5: PLR0913 Too many arguments in function definition (6 > 5)
    |
 29 | def f(x, y, z, *, u, v, w):  # Too many arguments (6/5)
    |     ^ PLR0913
 30 |     pass
    |
 
-too_many_arguments.py:33:5: PLR0913 Too many arguments to function definition (9 > 5)
+too_many_arguments.py:33:5: PLR0913 Too many arguments in function definition (9 > 5)
    |
 33 | def f(x, y, z, a, b, c, *, u, v, w):  # Too many arguments (9/5)
    |     ^ PLR0913

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__max_args.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__max_args.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-too_many_arguments_params.py:3:5: PLR0913 Too many arguments to function call (6 > 4)
+too_many_arguments_params.py:3:5: PLR0913 Too many arguments to function definition (6 > 4)
   |
 1 | # Too many args (6/4) for max_args=4
 2 | # OK for dummy_variable_rgx ~ "skip_.*"
@@ -10,7 +10,7 @@ too_many_arguments_params.py:3:5: PLR0913 Too many arguments to function call (6
 4 |     pass
   |
 
-too_many_arguments_params.py:9:5: PLR0913 Too many arguments to function call (6 > 4)
+too_many_arguments_params.py:9:5: PLR0913 Too many arguments to function definition (6 > 4)
    |
  7 | # Too many args (6/4) for max_args=4
  8 | # Too many args (6/5) for dummy_variable_rgx ~ "skip_.*"

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__max_args.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__max_args.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-too_many_arguments_params.py:3:5: PLR0913 Too many arguments to function definition (6 > 4)
+too_many_arguments_params.py:3:5: PLR0913 Too many arguments in function definition (6 > 4)
   |
 1 | # Too many args (6/4) for max_args=4
 2 | # OK for dummy_variable_rgx ~ "skip_.*"
@@ -10,7 +10,7 @@ too_many_arguments_params.py:3:5: PLR0913 Too many arguments to function definit
 4 |     pass
   |
 
-too_many_arguments_params.py:9:5: PLR0913 Too many arguments to function definition (6 > 4)
+too_many_arguments_params.py:9:5: PLR0913 Too many arguments in function definition (6 > 4)
    |
  7 | # Too many args (6/4) for max_args=4
  8 | # Too many args (6/5) for dummy_variable_rgx ~ "skip_.*"

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__max_args_with_dummy_variables.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__max_args_with_dummy_variables.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-too_many_arguments_params.py:9:5: PLR0913 Too many arguments to function definition (6 > 5)
+too_many_arguments_params.py:9:5: PLR0913 Too many arguments in function definition (6 > 5)
    |
  7 | # Too many args (6/4) for max_args=4
  8 | # Too many args (6/5) for dummy_variable_rgx ~ "skip_.*"

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__max_args_with_dummy_variables.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__max_args_with_dummy_variables.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-too_many_arguments_params.py:9:5: PLR0913 Too many arguments to function call (6 > 5)
+too_many_arguments_params.py:9:5: PLR0913 Too many arguments to function definition (6 > 5)
    |
  7 | # Too many args (6/4) for max_args=4
  8 | # Too many args (6/5) for dummy_variable_rgx ~ "skip_.*"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The lint checks for number of arguments in a function *definition*, but the message says “function *call*”

## Test Plan

See what breaks and change the tests
