### PR TITLE
Fix range of unparenthesized tuple subject in match statement

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
@@ -564,3 +564,17 @@ match pattern:
         # comment
         a, b,):
         pass
+
+# Tuple subject.
+match n % 3, n % 5:
+    case 0, 0:
+        # n is divisible by both 3 and 5
+        print("FizzBuzz")
+    case 0, _:
+        # n is divisible by 3, but not 5
+        print("Fizz")
+    case _, 0:
+        # n is divisible by 5, but not 3
+        print("Buzz")
+    case _:
+        print(n)

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -570,6 +570,20 @@ match pattern:
         # comment
         a, b,):
         pass
+
+# Tuple subject.
+match n % 3, n % 5:
+    case 0, 0:
+        # n is divisible by both 3 and 5
+        print("FizzBuzz")
+    case 0, _:
+        # n is divisible by 3, but not 5
+        print("Fizz")
+    case _, 0:
+        # n is divisible by 5, but not 3
+        print("Buzz")
+    case _:
+        print(n)
 ```
 
 ## Output
@@ -1182,6 +1196,20 @@ match pattern:
         b,
     ):
         pass
+
+# Tuple subject.
+match n % 3, n % 5:
+    case 0, 0:
+        # n is divisible by both 3 and 5
+        print("FizzBuzz")
+    case 0, _:
+        # n is divisible by 3, but not 5
+        print("Fizz")
+    case _, 0:
+        # n is divisible by 5, but not 3
+        print("Buzz")
+    case _:
+        print(n)
 ```
 
 

--- a/crates/ruff_python_parser/src/parser.rs
+++ b/crates/ruff_python_parser/src/parser.rs
@@ -1136,6 +1136,15 @@ match x:
 match x:
     case (0,):
         y = 0
+match x,:
+    case z:
+        pass
+match x, y:
+    case z:
+        pass
+match x, y,:
+    case z:
+        pass
 "#,
             "<test>",
         )

--- a/crates/ruff_python_parser/src/python.lalrpop
+++ b/crates/ruff_python_parser/src/python.lalrpop
@@ -466,7 +466,7 @@ MatchStatement: ast::Stmt = {
             }
         )
     },
-    <location:@L> "match" <subject:TestOrStarNamedExpr> "," ":" "\n" Indent <cases:MatchCase+> Dedent => {
+    <location:@L> "match" <tuple_location:@L> <subject:TestOrStarNamedExpr> "," <tuple_end_location:@R> ":" "\n" Indent <cases:MatchCase+> Dedent => {
        let end_location = cases
             .last()
             .unwrap()
@@ -476,13 +476,19 @@ MatchStatement: ast::Stmt = {
             .end();
         ast::Stmt::Match(
             ast::StmtMatch {
-                subject: Box::new(subject.into()),
+                subject: Box::new(ast::Expr::Tuple(
+                    ast::ExprTuple {
+                        elts: vec![subject.into()],
+                        ctx: ast::ExprContext::Load,
+                        range: (tuple_location..tuple_end_location).into()
+                    },
+                )),
                 cases,
                 range: (location..end_location).into()
             }
         )
     },
-    <location:@L> "match" <elts:TwoOrMore<TestOrStarNamedExpr, ",">> ","? ":" "\n" Indent <cases:MatchCase+> Dedent => {
+    <location:@L> "match" <tuple_location:@L> <elts:TwoOrMore<TestOrStarNamedExpr, ",">> ","? <tuple_end_location:@R> ":" "\n" Indent <cases:MatchCase+> Dedent => {
         let end_location = cases
             .last()
             .unwrap()
@@ -497,7 +503,7 @@ MatchStatement: ast::Stmt = {
                     ast::ExprTuple {
                         elts,
                         ctx: ast::ExprContext::Load,
-                        range: (location..end_location).into()
+                        range: (tuple_location..tuple_end_location).into()
                     },
                 )),
                 cases,

--- a/crates/ruff_python_parser/src/python.rs
+++ b/crates/ruff_python_parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 4615d1de345ecffb47457b6c6e5acd3859c2cc0dffa0187ff99d65d0ce1c6b80
+// sha3: 01c7c57ce067fcf07c9a5450511cc48a2dd08cf821a5ff3b0f649e87d3c67022
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
 use crate::{
@@ -12809,14 +12809,14 @@ mod __parse__Top {
                 __reduce160(source_code, mode, __lookahead_start, __symbols, core::marker::PhantomData::<()>)
             }
             161 => {
-                // Arguments = "(", FunctionArgument, ")" => ActionFn(1534);
+                // Arguments = "(", FunctionArgument, ")" => ActionFn(1537);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant31(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1534::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1537::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -12824,13 +12824,13 @@ mod __parse__Top {
                 (3, 84)
             }
             162 => {
-                // Arguments = "(", ")" => ActionFn(1535);
+                // Arguments = "(", ")" => ActionFn(1538);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1535::<>(source_code, mode, __sym0, __sym1) {
+                let __nt = match super::__action1538::<>(source_code, mode, __sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -12838,7 +12838,7 @@ mod __parse__Top {
                 (2, 84)
             }
             163 => {
-                // Arguments = "(", (<FunctionArgument> ",")+, FunctionArgument, ")" => ActionFn(1536);
+                // Arguments = "(", (<FunctionArgument> ",")+, FunctionArgument, ")" => ActionFn(1539);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant31(__symbols);
@@ -12846,7 +12846,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1536::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1539::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -12854,14 +12854,14 @@ mod __parse__Top {
                 (4, 84)
             }
             164 => {
-                // Arguments = "(", (<FunctionArgument> ",")+, ")" => ActionFn(1537);
+                // Arguments = "(", (<FunctionArgument> ",")+, ")" => ActionFn(1540);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant32(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1537::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1540::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13826,7 +13826,7 @@ mod __parse__Top {
                 __reduce383(source_code, mode, __lookahead_start, __symbols, core::marker::PhantomData::<()>)
             }
             384 => {
-                // FStringReplacementField = "{", TestListOrYieldExpr, "=", FStringConversion, FStringFormatSpecSuffix, "}" => ActionFn(1574);
+                // FStringReplacementField = "{", TestListOrYieldExpr, "=", FStringConversion, FStringFormatSpecSuffix, "}" => ActionFn(1577);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant44(__symbols);
@@ -13836,7 +13836,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1574::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1577::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13844,61 +13844,11 @@ mod __parse__Top {
                 (6, 150)
             }
             385 => {
-                // FStringReplacementField = "{", TestListOrYieldExpr, "=", FStringConversion, "}" => ActionFn(1575);
+                // FStringReplacementField = "{", TestListOrYieldExpr, "=", FStringConversion, "}" => ActionFn(1578);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant68(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant15(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym4.2;
-                let __nt = match super::__action1575::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
-                (5, 150)
-            }
-            386 => {
-                // FStringReplacementField = "{", TestListOrYieldExpr, "=", FStringFormatSpecSuffix, "}" => ActionFn(1576);
-                assert!(__symbols.len() >= 5);
-                let __sym4 = __pop_Variant0(__symbols);
-                let __sym3 = __pop_Variant44(__symbols);
-                let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant15(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym4.2;
-                let __nt = match super::__action1576::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
-                (5, 150)
-            }
-            387 => {
-                // FStringReplacementField = "{", TestListOrYieldExpr, "=", "}" => ActionFn(1577);
-                assert!(__symbols.len() >= 4);
-                let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant15(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym3.2;
-                let __nt = match super::__action1577::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
-                (4, 150)
-            }
-            388 => {
-                // FStringReplacementField = "{", TestListOrYieldExpr, FStringConversion, FStringFormatSpecSuffix, "}" => ActionFn(1578);
-                assert!(__symbols.len() >= 5);
-                let __sym4 = __pop_Variant0(__symbols);
-                let __sym3 = __pop_Variant44(__symbols);
-                let __sym2 = __pop_Variant68(__symbols);
                 let __sym1 = __pop_Variant15(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -13910,27 +13860,28 @@ mod __parse__Top {
                 __symbols.push((__start, __Symbol::Variant44(__nt), __end));
                 (5, 150)
             }
-            389 => {
-                // FStringReplacementField = "{", TestListOrYieldExpr, FStringConversion, "}" => ActionFn(1579);
-                assert!(__symbols.len() >= 4);
-                let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant68(__symbols);
+            386 => {
+                // FStringReplacementField = "{", TestListOrYieldExpr, "=", FStringFormatSpecSuffix, "}" => ActionFn(1579);
+                assert!(__symbols.len() >= 5);
+                let __sym4 = __pop_Variant0(__symbols);
+                let __sym3 = __pop_Variant44(__symbols);
+                let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant15(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
-                let __end = __sym3.2;
-                let __nt = match super::__action1579::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __end = __sym4.2;
+                let __nt = match super::__action1579::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
                 __symbols.push((__start, __Symbol::Variant44(__nt), __end));
-                (4, 150)
+                (5, 150)
             }
-            390 => {
-                // FStringReplacementField = "{", TestListOrYieldExpr, FStringFormatSpecSuffix, "}" => ActionFn(1580);
+            387 => {
+                // FStringReplacementField = "{", TestListOrYieldExpr, "=", "}" => ActionFn(1580);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant44(__symbols);
+                let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant15(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -13942,15 +13893,64 @@ mod __parse__Top {
                 __symbols.push((__start, __Symbol::Variant44(__nt), __end));
                 (4, 150)
             }
+            388 => {
+                // FStringReplacementField = "{", TestListOrYieldExpr, FStringConversion, FStringFormatSpecSuffix, "}" => ActionFn(1581);
+                assert!(__symbols.len() >= 5);
+                let __sym4 = __pop_Variant0(__symbols);
+                let __sym3 = __pop_Variant44(__symbols);
+                let __sym2 = __pop_Variant68(__symbols);
+                let __sym1 = __pop_Variant15(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym4.2;
+                let __nt = match super::__action1581::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+                (5, 150)
+            }
+            389 => {
+                // FStringReplacementField = "{", TestListOrYieldExpr, FStringConversion, "}" => ActionFn(1582);
+                assert!(__symbols.len() >= 4);
+                let __sym3 = __pop_Variant0(__symbols);
+                let __sym2 = __pop_Variant68(__symbols);
+                let __sym1 = __pop_Variant15(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym3.2;
+                let __nt = match super::__action1582::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+                (4, 150)
+            }
+            390 => {
+                // FStringReplacementField = "{", TestListOrYieldExpr, FStringFormatSpecSuffix, "}" => ActionFn(1583);
+                assert!(__symbols.len() >= 4);
+                let __sym3 = __pop_Variant0(__symbols);
+                let __sym2 = __pop_Variant44(__symbols);
+                let __sym1 = __pop_Variant15(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym3.2;
+                let __nt = match super::__action1583::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+                (4, 150)
+            }
             391 => {
-                // FStringReplacementField = "{", TestListOrYieldExpr, "}" => ActionFn(1581);
+                // FStringReplacementField = "{", TestListOrYieldExpr, "}" => ActionFn(1584);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant15(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1581::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1584::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14209,7 +14209,7 @@ mod __parse__Top {
                 __reduce465(source_code, mode, __lookahead_start, __symbols, core::marker::PhantomData::<()>)
             }
             466 => {
-                // LambdaDef = "lambda", ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter>, ":", fstring_middle, Test<"all"> => ActionFn(1778);
+                // LambdaDef = "lambda", ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter>, ":", fstring_middle, Test<"all"> => ActionFn(1781);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant15(__symbols);
                 let __sym3 = __pop_Variant3(__symbols);
@@ -14218,7 +14218,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1778::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1781::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14226,7 +14226,7 @@ mod __parse__Top {
                 (5, 177)
             }
             467 => {
-                // LambdaDef = "lambda", ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter>, ":", Test<"all"> => ActionFn(1779);
+                // LambdaDef = "lambda", ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter>, ":", Test<"all"> => ActionFn(1782);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant15(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
@@ -14234,7 +14234,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1779::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1782::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14242,7 +14242,7 @@ mod __parse__Top {
                 (4, 177)
             }
             468 => {
-                // LambdaDef = "lambda", ":", fstring_middle, Test<"all"> => ActionFn(1780);
+                // LambdaDef = "lambda", ":", fstring_middle, Test<"all"> => ActionFn(1783);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant15(__symbols);
                 let __sym2 = __pop_Variant3(__symbols);
@@ -14250,7 +14250,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1780::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1783::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14258,14 +14258,14 @@ mod __parse__Top {
                 (4, 177)
             }
             469 => {
-                // LambdaDef = "lambda", ":", Test<"all"> => ActionFn(1781);
+                // LambdaDef = "lambda", ":", Test<"all"> => ActionFn(1784);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant15(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1781::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1784::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14594,7 +14594,7 @@ mod __parse__Top {
                 __reduce570(source_code, mode, __lookahead_start, __symbols, core::marker::PhantomData::<()>)
             }
             571 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1600);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1603);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant9(__symbols);
@@ -14605,7 +14605,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1600::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1603::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14613,7 +14613,7 @@ mod __parse__Top {
                 (7, 219)
             }
             572 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1601);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1604);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant9(__symbols);
@@ -14626,7 +14626,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1601::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1604::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14634,7 +14634,7 @@ mod __parse__Top {
                 (9, 219)
             }
             573 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1602);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1605);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant0(__symbols);
                 let __sym8 = __pop_Variant9(__symbols);
@@ -14648,7 +14648,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1602::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1605::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14656,7 +14656,7 @@ mod __parse__Top {
                 (10, 219)
             }
             574 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1603);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1606);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant9(__symbols);
@@ -14666,7 +14666,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1603::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1606::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14674,7 +14674,7 @@ mod __parse__Top {
                 (6, 219)
             }
             575 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1604);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1607);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant9(__symbols);
@@ -14686,7 +14686,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1604::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1607::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14694,7 +14694,7 @@ mod __parse__Top {
                 (8, 219)
             }
             576 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1605);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1608);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant9(__symbols);
@@ -14707,7 +14707,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1605::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1608::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14715,7 +14715,7 @@ mod __parse__Top {
                 (9, 219)
             }
             577 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1606);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1609);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant9(__symbols);
@@ -14727,7 +14727,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1606::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1609::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14735,7 +14735,7 @@ mod __parse__Top {
                 (8, 219)
             }
             578 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1607);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1610);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant0(__symbols);
                 let __sym8 = __pop_Variant9(__symbols);
@@ -14749,7 +14749,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1607::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1610::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14757,7 +14757,7 @@ mod __parse__Top {
                 (10, 219)
             }
             579 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1608);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1611);
                 assert!(__symbols.len() >= 11);
                 let __sym10 = __pop_Variant0(__symbols);
                 let __sym9 = __pop_Variant9(__symbols);
@@ -14772,7 +14772,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym10.2;
-                let __nt = match super::__action1608::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9, __sym10) {
+                let __nt = match super::__action1611::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9, __sym10) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14780,7 +14780,7 @@ mod __parse__Top {
                 (11, 219)
             }
             580 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1609);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1612);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant9(__symbols);
@@ -14791,7 +14791,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1609::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1612::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14799,7 +14799,7 @@ mod __parse__Top {
                 (7, 219)
             }
             581 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1610);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1613);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant9(__symbols);
@@ -14812,7 +14812,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1610::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1613::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14820,7 +14820,7 @@ mod __parse__Top {
                 (9, 219)
             }
             582 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1611);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1614);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant0(__symbols);
                 let __sym8 = __pop_Variant9(__symbols);
@@ -14834,7 +14834,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1611::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1614::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14842,7 +14842,7 @@ mod __parse__Top {
                 (10, 219)
             }
             583 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, "," => ActionFn(1612);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, "," => ActionFn(1615);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant64(__symbols);
@@ -14851,7 +14851,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1612::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1615::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14859,7 +14859,7 @@ mod __parse__Top {
                 (5, 219)
             }
             584 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, "," => ActionFn(1613);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, "," => ActionFn(1616);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant64(__symbols);
@@ -14870,7 +14870,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1613::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1616::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14878,7 +14878,7 @@ mod __parse__Top {
                 (7, 219)
             }
             585 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, "," => ActionFn(1614);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, "," => ActionFn(1617);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant64(__symbols);
@@ -14890,7 +14890,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1614::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1617::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14898,7 +14898,7 @@ mod __parse__Top {
                 (8, 219)
             }
             586 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", "," => ActionFn(1615);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", "," => ActionFn(1618);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
@@ -14906,7 +14906,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1615::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1618::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14914,7 +14914,7 @@ mod __parse__Top {
                 (4, 219)
             }
             587 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", "," => ActionFn(1616);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", "," => ActionFn(1619);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
@@ -14924,7 +14924,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1616::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1619::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14932,7 +14932,7 @@ mod __parse__Top {
                 (6, 219)
             }
             588 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", "," => ActionFn(1617);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", "," => ActionFn(1620);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -14943,7 +14943,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1617::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1620::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14951,7 +14951,7 @@ mod __parse__Top {
                 (7, 219)
             }
             589 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1618);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1621);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant12(__symbols);
@@ -14961,7 +14961,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1618::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1621::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14969,7 +14969,7 @@ mod __parse__Top {
                 (6, 219)
             }
             590 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1619);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1622);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant12(__symbols);
@@ -14981,7 +14981,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1619::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1622::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14989,7 +14989,7 @@ mod __parse__Top {
                 (8, 219)
             }
             591 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1620);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1623);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant12(__symbols);
@@ -15002,7 +15002,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1620::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1623::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15010,7 +15010,7 @@ mod __parse__Top {
                 (9, 219)
             }
             592 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1621);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1624);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
@@ -15019,7 +15019,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1621::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1624::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15027,7 +15027,7 @@ mod __parse__Top {
                 (5, 219)
             }
             593 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1622);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1625);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant12(__symbols);
@@ -15038,7 +15038,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1622::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1625::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15046,7 +15046,7 @@ mod __parse__Top {
                 (7, 219)
             }
             594 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1623);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1626);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant12(__symbols);
@@ -15058,7 +15058,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1623::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1626::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15066,13 +15066,13 @@ mod __parse__Top {
                 (8, 219)
             }
             595 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, "," => ActionFn(1624);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, "," => ActionFn(1627);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1624::<>(source_code, mode, __sym0, __sym1) {
+                let __nt = match super::__action1627::<>(source_code, mode, __sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15080,7 +15080,7 @@ mod __parse__Top {
                 (2, 219)
             }
             596 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", "," => ActionFn(1625);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", "," => ActionFn(1628);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
@@ -15088,7 +15088,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1625::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1628::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15096,7 +15096,7 @@ mod __parse__Top {
                 (4, 219)
             }
             597 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1626);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1629);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
@@ -15105,7 +15105,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1626::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1629::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15113,7 +15113,7 @@ mod __parse__Top {
                 (5, 219)
             }
             598 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1627);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1630);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
@@ -15123,7 +15123,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1627::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1630::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15131,7 +15131,7 @@ mod __parse__Top {
                 (6, 219)
             }
             599 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1628);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1631);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant9(__symbols);
                 let __sym6 = __pop_Variant0(__symbols);
@@ -15143,7 +15143,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1628::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1631::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15151,7 +15151,7 @@ mod __parse__Top {
                 (8, 219)
             }
             600 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1629);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1632);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
@@ -15164,7 +15164,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1629::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1632::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15172,7 +15172,7 @@ mod __parse__Top {
                 (9, 219)
             }
             601 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1630);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1633);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
@@ -15181,7 +15181,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1630::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1633::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15189,7 +15189,7 @@ mod __parse__Top {
                 (5, 219)
             }
             602 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1631);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1634);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant9(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -15200,7 +15200,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1631::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1634::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15208,7 +15208,7 @@ mod __parse__Top {
                 (7, 219)
             }
             603 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1632);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1635);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant9(__symbols);
                 let __sym6 = __pop_Variant0(__symbols);
@@ -15220,7 +15220,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1632::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1635::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15228,7 +15228,7 @@ mod __parse__Top {
                 (8, 219)
             }
             604 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1633);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1636);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant9(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -15239,7 +15239,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1633::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1636::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15247,7 +15247,7 @@ mod __parse__Top {
                 (7, 219)
             }
             605 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1634);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1637);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
@@ -15260,7 +15260,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1634::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1637::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15268,7 +15268,7 @@ mod __parse__Top {
                 (9, 219)
             }
             606 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1635);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1638);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant9(__symbols);
                 let __sym8 = __pop_Variant0(__symbols);
@@ -15282,7 +15282,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1635::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1638::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15290,7 +15290,7 @@ mod __parse__Top {
                 (10, 219)
             }
             607 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1636);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1639);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
@@ -15300,7 +15300,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1636::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1639::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15308,7 +15308,7 @@ mod __parse__Top {
                 (6, 219)
             }
             608 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1637);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1640);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant9(__symbols);
                 let __sym6 = __pop_Variant0(__symbols);
@@ -15320,7 +15320,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1637::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1640::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15328,7 +15328,7 @@ mod __parse__Top {
                 (8, 219)
             }
             609 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1638);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1641);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
@@ -15341,7 +15341,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1638::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1641::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15349,7 +15349,7 @@ mod __parse__Top {
                 (9, 219)
             }
             610 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter => ActionFn(1639);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter => ActionFn(1642);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant64(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
@@ -15357,7 +15357,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1639::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1642::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15365,7 +15365,7 @@ mod __parse__Top {
                 (4, 219)
             }
             611 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter => ActionFn(1640);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter => ActionFn(1643);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant64(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
@@ -15375,7 +15375,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1640::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1643::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15383,7 +15383,7 @@ mod __parse__Top {
                 (6, 219)
             }
             612 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter => ActionFn(1641);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter => ActionFn(1644);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant64(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -15394,7 +15394,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1641::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1644::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15402,14 +15402,14 @@ mod __parse__Top {
                 (7, 219)
             }
             613 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*" => ActionFn(1642);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*" => ActionFn(1645);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1642::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1645::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15417,7 +15417,7 @@ mod __parse__Top {
                 (3, 219)
             }
             614 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*" => ActionFn(1643);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*" => ActionFn(1646);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
@@ -15426,7 +15426,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1643::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1646::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15434,7 +15434,7 @@ mod __parse__Top {
                 (5, 219)
             }
             615 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*" => ActionFn(1644);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*" => ActionFn(1647);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
@@ -15444,7 +15444,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1644::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1647::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15452,7 +15452,7 @@ mod __parse__Top {
                 (6, 219)
             }
             616 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1645);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1648);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant12(__symbols);
                 let __sym3 = __pop_Variant64(__symbols);
@@ -15461,7 +15461,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1645::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1648::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15469,7 +15469,7 @@ mod __parse__Top {
                 (5, 219)
             }
             617 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1646);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1649);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant12(__symbols);
                 let __sym5 = __pop_Variant64(__symbols);
@@ -15480,7 +15480,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1646::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1649::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15488,7 +15488,7 @@ mod __parse__Top {
                 (7, 219)
             }
             618 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1647);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1650);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant12(__symbols);
                 let __sym6 = __pop_Variant64(__symbols);
@@ -15500,7 +15500,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1647::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1650::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15508,7 +15508,7 @@ mod __parse__Top {
                 (8, 219)
             }
             619 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1648);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1651);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
@@ -15516,7 +15516,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1648::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1651::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15524,7 +15524,7 @@ mod __parse__Top {
                 (4, 219)
             }
             620 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1649);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1652);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant12(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
@@ -15534,7 +15534,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1649::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1652::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15542,7 +15542,7 @@ mod __parse__Top {
                 (6, 219)
             }
             621 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1650);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1653);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant12(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -15553,7 +15553,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1650::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1653::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15561,11 +15561,11 @@ mod __parse__Top {
                 (7, 219)
             }
             622 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>> => ActionFn(1651);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>> => ActionFn(1654);
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
-                let __nt = match super::__action1651::<>(source_code, mode, __sym0) {
+                let __nt = match super::__action1654::<>(source_code, mode, __sym0) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15573,14 +15573,14 @@ mod __parse__Top {
                 (1, 219)
             }
             623 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/" => ActionFn(1652);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/" => ActionFn(1655);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1652::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1655::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15588,7 +15588,7 @@ mod __parse__Top {
                 (3, 219)
             }
             624 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1653);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1656);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
@@ -15596,7 +15596,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1653::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1656::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15604,7 +15604,7 @@ mod __parse__Top {
                 (4, 219)
             }
             625 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1654);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1657);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant9(__symbols);
@@ -15612,7 +15612,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1654::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1657::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15620,7 +15620,7 @@ mod __parse__Top {
                 (4, 219)
             }
             626 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1655);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1658);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant9(__symbols);
@@ -15630,7 +15630,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1655::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1658::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15638,7 +15638,7 @@ mod __parse__Top {
                 (6, 219)
             }
             627 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1656);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1659);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant9(__symbols);
@@ -15649,7 +15649,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1656::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1659::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15657,14 +15657,14 @@ mod __parse__Top {
                 (7, 219)
             }
             628 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1657);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1660);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant9(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1657::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1660::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15672,7 +15672,7 @@ mod __parse__Top {
                 (3, 219)
             }
             629 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1658);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1661);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
@@ -15681,7 +15681,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1658::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1661::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15689,7 +15689,7 @@ mod __parse__Top {
                 (5, 219)
             }
             630 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1659);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1662);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
@@ -15699,7 +15699,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1659::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1662::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15707,63 +15707,12 @@ mod __parse__Top {
                 (6, 219)
             }
             631 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1399);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1402);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant9(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant64(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym4.2;
-                let __nt = match super::__action1399::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
-                (5, 219)
-            }
-            632 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1400);
-                assert!(__symbols.len() >= 4);
-                let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant9(__symbols);
-                let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym3.2;
-                let __nt = match super::__action1400::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
-                (4, 219)
-            }
-            633 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1401);
-                assert!(__symbols.len() >= 6);
-                let __sym5 = __pop_Variant0(__symbols);
-                let __sym4 = __pop_Variant9(__symbols);
-                let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant64(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym5.2;
-                let __nt = match super::__action1401::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
-                (6, 219)
-            }
-            634 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1402);
-                assert!(__symbols.len() >= 5);
-                let __sym4 = __pop_Variant0(__symbols);
-                let __sym3 = __pop_Variant9(__symbols);
-                let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant12(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
@@ -15774,56 +15723,62 @@ mod __parse__Top {
                 __symbols.push((__start, __Symbol::Variant46(__nt), __end));
                 (5, 219)
             }
-            635 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter, "," => ActionFn(1403);
-                assert!(__symbols.len() >= 3);
-                let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant64(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym2.2;
-                let __nt = match super::__action1403::<>(source_code, mode, __sym0, __sym1, __sym2) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
-                (3, 219)
-            }
-            636 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", "," => ActionFn(1404);
-                assert!(__symbols.len() >= 2);
+            632 => {
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1403);
+                assert!(__symbols.len() >= 4);
+                let __sym3 = __pop_Variant0(__symbols);
+                let __sym2 = __pop_Variant9(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
-                let __end = __sym1.2;
-                let __nt = match super::__action1404::<>(source_code, mode, __sym0, __sym1) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
-                (2, 219)
-            }
-            637 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1405);
-                assert!(__symbols.len() >= 4);
-                let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant64(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1405::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1403::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
                 __symbols.push((__start, __Symbol::Variant46(__nt), __end));
                 (4, 219)
             }
-            638 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1406);
-                assert!(__symbols.len() >= 3);
+            633 => {
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1404);
+                assert!(__symbols.len() >= 6);
+                let __sym5 = __pop_Variant0(__symbols);
+                let __sym4 = __pop_Variant9(__symbols);
+                let __sym3 = __pop_Variant0(__symbols);
+                let __sym2 = __pop_Variant12(__symbols);
+                let __sym1 = __pop_Variant64(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym5.2;
+                let __nt = match super::__action1404::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
+                (6, 219)
+            }
+            634 => {
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1405);
+                assert!(__symbols.len() >= 5);
+                let __sym4 = __pop_Variant0(__symbols);
+                let __sym3 = __pop_Variant9(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant12(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym4.2;
+                let __nt = match super::__action1405::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
+                (5, 219)
+            }
+            635 => {
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter, "," => ActionFn(1406);
+                assert!(__symbols.len() >= 3);
+                let __sym2 = __pop_Variant0(__symbols);
+                let __sym1 = __pop_Variant64(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
@@ -15834,60 +15789,57 @@ mod __parse__Top {
                 __symbols.push((__start, __Symbol::Variant46(__nt), __end));
                 (3, 219)
             }
-            639 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1407);
+            636 => {
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", "," => ActionFn(1407);
+                assert!(__symbols.len() >= 2);
+                let __sym1 = __pop_Variant0(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym1.2;
+                let __nt = match super::__action1407::<>(source_code, mode, __sym0, __sym1) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
+                (2, 219)
+            }
+            637 => {
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1408);
                 assert!(__symbols.len() >= 4);
-                let __sym3 = __pop_Variant9(__symbols);
-                let __sym2 = __pop_Variant0(__symbols);
+                let __sym3 = __pop_Variant0(__symbols);
+                let __sym2 = __pop_Variant12(__symbols);
                 let __sym1 = __pop_Variant64(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1407::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1408::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
                 __symbols.push((__start, __Symbol::Variant46(__nt), __end));
                 (4, 219)
             }
-            640 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1408);
+            638 => {
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1409);
                 assert!(__symbols.len() >= 3);
-                let __sym2 = __pop_Variant9(__symbols);
-                let __sym1 = __pop_Variant0(__symbols);
+                let __sym2 = __pop_Variant0(__symbols);
+                let __sym1 = __pop_Variant12(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1408::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1409::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
                 __symbols.push((__start, __Symbol::Variant46(__nt), __end));
                 (3, 219)
             }
-            641 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1409);
-                assert!(__symbols.len() >= 5);
-                let __sym4 = __pop_Variant9(__symbols);
-                let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant64(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym4.2;
-                let __nt = match super::__action1409::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
-                (5, 219)
-            }
-            642 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1410);
+            639 => {
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1410);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant9(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant12(__symbols);
+                let __sym1 = __pop_Variant64(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
@@ -15898,14 +15850,62 @@ mod __parse__Top {
                 __symbols.push((__start, __Symbol::Variant46(__nt), __end));
                 (4, 219)
             }
+            640 => {
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1411);
+                assert!(__symbols.len() >= 3);
+                let __sym2 = __pop_Variant9(__symbols);
+                let __sym1 = __pop_Variant0(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym2.2;
+                let __nt = match super::__action1411::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
+                (3, 219)
+            }
+            641 => {
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1412);
+                assert!(__symbols.len() >= 5);
+                let __sym4 = __pop_Variant9(__symbols);
+                let __sym3 = __pop_Variant0(__symbols);
+                let __sym2 = __pop_Variant12(__symbols);
+                let __sym1 = __pop_Variant64(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym4.2;
+                let __nt = match super::__action1412::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
+                (5, 219)
+            }
+            642 => {
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<DoubleStarTypedParameter> => ActionFn(1413);
+                assert!(__symbols.len() >= 4);
+                let __sym3 = __pop_Variant9(__symbols);
+                let __sym2 = __pop_Variant0(__symbols);
+                let __sym1 = __pop_Variant12(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym3.2;
+                let __nt = match super::__action1413::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
+                (4, 219)
+            }
             643 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter => ActionFn(1411);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter => ActionFn(1414);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant64(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1411::<>(source_code, mode, __sym0, __sym1) {
+                let __nt = match super::__action1414::<>(source_code, mode, __sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15913,11 +15913,11 @@ mod __parse__Top {
                 (2, 219)
             }
             644 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*" => ActionFn(1412);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*" => ActionFn(1415);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
-                let __nt = match super::__action1412::<>(source_code, mode, __sym0) {
+                let __nt = match super::__action1415::<>(source_code, mode, __sym0) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15925,14 +15925,14 @@ mod __parse__Top {
                 (1, 219)
             }
             645 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1413);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1416);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant12(__symbols);
                 let __sym1 = __pop_Variant64(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1413::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1416::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15940,13 +15940,13 @@ mod __parse__Top {
                 (3, 219)
             }
             646 => {
-                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1414);
+                // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1417);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant12(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1414::<>(source_code, mode, __sym0, __sym1) {
+                let __nt = match super::__action1417::<>(source_code, mode, __sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15960,7 +15960,7 @@ mod __parse__Top {
                 __reduce648(source_code, mode, __lookahead_start, __symbols, core::marker::PhantomData::<()>)
             }
             649 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1660);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1663);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant9(__symbols);
@@ -15971,7 +15971,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1660::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1663::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15979,7 +15979,7 @@ mod __parse__Top {
                 (7, 220)
             }
             650 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1661);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1664);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant9(__symbols);
@@ -15992,7 +15992,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1661::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1664::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16000,7 +16000,7 @@ mod __parse__Top {
                 (9, 220)
             }
             651 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1662);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1665);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant0(__symbols);
                 let __sym8 = __pop_Variant9(__symbols);
@@ -16014,7 +16014,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1662::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1665::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16022,7 +16022,7 @@ mod __parse__Top {
                 (10, 220)
             }
             652 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1663);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1666);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant9(__symbols);
@@ -16032,7 +16032,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1663::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1666::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16040,7 +16040,7 @@ mod __parse__Top {
                 (6, 220)
             }
             653 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1664);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1667);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant9(__symbols);
@@ -16052,7 +16052,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1664::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1667::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16060,7 +16060,7 @@ mod __parse__Top {
                 (8, 220)
             }
             654 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1665);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1668);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant9(__symbols);
@@ -16073,7 +16073,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1665::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1668::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16081,7 +16081,7 @@ mod __parse__Top {
                 (9, 220)
             }
             655 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1666);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1669);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant9(__symbols);
@@ -16093,7 +16093,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1666::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1669::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16101,7 +16101,7 @@ mod __parse__Top {
                 (8, 220)
             }
             656 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1667);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1670);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant0(__symbols);
                 let __sym8 = __pop_Variant9(__symbols);
@@ -16115,7 +16115,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1667::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1670::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16123,7 +16123,7 @@ mod __parse__Top {
                 (10, 220)
             }
             657 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1668);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1671);
                 assert!(__symbols.len() >= 11);
                 let __sym10 = __pop_Variant0(__symbols);
                 let __sym9 = __pop_Variant9(__symbols);
@@ -16138,7 +16138,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym10.2;
-                let __nt = match super::__action1668::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9, __sym10) {
+                let __nt = match super::__action1671::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9, __sym10) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16146,7 +16146,7 @@ mod __parse__Top {
                 (11, 220)
             }
             658 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1669);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1672);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant9(__symbols);
@@ -16157,7 +16157,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1669::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1672::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16165,7 +16165,7 @@ mod __parse__Top {
                 (7, 220)
             }
             659 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1670);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1673);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant9(__symbols);
@@ -16178,7 +16178,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1670::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1673::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16186,7 +16186,7 @@ mod __parse__Top {
                 (9, 220)
             }
             660 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1671);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1674);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant0(__symbols);
                 let __sym8 = __pop_Variant9(__symbols);
@@ -16200,7 +16200,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1671::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1674::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16208,7 +16208,7 @@ mod __parse__Top {
                 (10, 220)
             }
             661 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter, "," => ActionFn(1672);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter, "," => ActionFn(1675);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant64(__symbols);
@@ -16217,7 +16217,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1672::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1675::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16225,7 +16225,7 @@ mod __parse__Top {
                 (5, 220)
             }
             662 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter, "," => ActionFn(1673);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter, "," => ActionFn(1676);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant64(__symbols);
@@ -16236,7 +16236,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1673::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1676::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16244,7 +16244,7 @@ mod __parse__Top {
                 (7, 220)
             }
             663 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter, "," => ActionFn(1674);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter, "," => ActionFn(1677);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant64(__symbols);
@@ -16256,7 +16256,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1674::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1677::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16264,7 +16264,7 @@ mod __parse__Top {
                 (8, 220)
             }
             664 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", "," => ActionFn(1675);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", "," => ActionFn(1678);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
@@ -16272,7 +16272,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1675::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1678::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16280,7 +16280,7 @@ mod __parse__Top {
                 (4, 220)
             }
             665 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", "," => ActionFn(1676);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", "," => ActionFn(1679);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
@@ -16290,7 +16290,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1676::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1679::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16298,7 +16298,7 @@ mod __parse__Top {
                 (6, 220)
             }
             666 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", "," => ActionFn(1677);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", "," => ActionFn(1680);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -16309,7 +16309,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1677::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1680::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16317,7 +16317,7 @@ mod __parse__Top {
                 (7, 220)
             }
             667 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1678);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1681);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant12(__symbols);
@@ -16327,7 +16327,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1678::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1681::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16335,7 +16335,7 @@ mod __parse__Top {
                 (6, 220)
             }
             668 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1679);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1682);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant12(__symbols);
@@ -16347,7 +16347,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1679::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1682::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16355,7 +16355,7 @@ mod __parse__Top {
                 (8, 220)
             }
             669 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1680);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1683);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant12(__symbols);
@@ -16368,7 +16368,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1680::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1683::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16376,7 +16376,7 @@ mod __parse__Top {
                 (9, 220)
             }
             670 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1681);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1684);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
@@ -16385,7 +16385,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1681::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1684::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16393,7 +16393,7 @@ mod __parse__Top {
                 (5, 220)
             }
             671 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1682);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1685);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant12(__symbols);
@@ -16404,7 +16404,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1682::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1685::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16412,7 +16412,7 @@ mod __parse__Top {
                 (7, 220)
             }
             672 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1683);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1686);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant12(__symbols);
@@ -16424,7 +16424,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1683::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1686::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16432,13 +16432,13 @@ mod __parse__Top {
                 (8, 220)
             }
             673 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, "," => ActionFn(1684);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, "," => ActionFn(1687);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1684::<>(source_code, mode, __sym0, __sym1) {
+                let __nt = match super::__action1687::<>(source_code, mode, __sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16446,7 +16446,7 @@ mod __parse__Top {
                 (2, 220)
             }
             674 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", "," => ActionFn(1685);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", "," => ActionFn(1688);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
@@ -16454,7 +16454,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1685::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1688::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16462,7 +16462,7 @@ mod __parse__Top {
                 (4, 220)
             }
             675 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1686);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1689);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
@@ -16471,7 +16471,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1686::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1689::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16479,7 +16479,7 @@ mod __parse__Top {
                 (5, 220)
             }
             676 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter> => ActionFn(1687);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter> => ActionFn(1690);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
@@ -16489,7 +16489,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1687::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1690::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16497,7 +16497,7 @@ mod __parse__Top {
                 (6, 220)
             }
             677 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter> => ActionFn(1688);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter> => ActionFn(1691);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant9(__symbols);
                 let __sym6 = __pop_Variant0(__symbols);
@@ -16509,7 +16509,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1688::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1691::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16517,7 +16517,7 @@ mod __parse__Top {
                 (8, 220)
             }
             678 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter> => ActionFn(1689);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter> => ActionFn(1692);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
@@ -16530,7 +16530,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1689::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1692::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16538,7 +16538,7 @@ mod __parse__Top {
                 (9, 220)
             }
             679 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ",", KwargParameter<StarUntypedParameter> => ActionFn(1690);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ",", KwargParameter<StarUntypedParameter> => ActionFn(1693);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
@@ -16547,7 +16547,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1690::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1693::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16555,7 +16555,7 @@ mod __parse__Top {
                 (5, 220)
             }
             680 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<StarUntypedParameter> => ActionFn(1691);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<StarUntypedParameter> => ActionFn(1694);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant9(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -16566,7 +16566,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1691::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1694::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16574,7 +16574,7 @@ mod __parse__Top {
                 (7, 220)
             }
             681 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ",", KwargParameter<StarUntypedParameter> => ActionFn(1692);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ",", KwargParameter<StarUntypedParameter> => ActionFn(1695);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant9(__symbols);
                 let __sym6 = __pop_Variant0(__symbols);
@@ -16586,7 +16586,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1692::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1695::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16594,7 +16594,7 @@ mod __parse__Top {
                 (8, 220)
             }
             682 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1693);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1696);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant9(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -16605,7 +16605,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1693::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1696::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16613,7 +16613,7 @@ mod __parse__Top {
                 (7, 220)
             }
             683 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1694);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1697);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
@@ -16626,7 +16626,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1694::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1697::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16634,7 +16634,7 @@ mod __parse__Top {
                 (9, 220)
             }
             684 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1695);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1698);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant9(__symbols);
                 let __sym8 = __pop_Variant0(__symbols);
@@ -16648,7 +16648,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1695::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1698::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16656,7 +16656,7 @@ mod __parse__Top {
                 (10, 220)
             }
             685 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1696);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1699);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
@@ -16666,7 +16666,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1696::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1699::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16674,7 +16674,7 @@ mod __parse__Top {
                 (6, 220)
             }
             686 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1697);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1700);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant9(__symbols);
                 let __sym6 = __pop_Variant0(__symbols);
@@ -16686,7 +16686,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1697::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1700::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16694,7 +16694,7 @@ mod __parse__Top {
                 (8, 220)
             }
             687 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1698);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1701);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
@@ -16707,7 +16707,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1698::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1701::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16715,7 +16715,7 @@ mod __parse__Top {
                 (9, 220)
             }
             688 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter => ActionFn(1699);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter => ActionFn(1702);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant64(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
@@ -16723,7 +16723,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1699::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1702::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16731,7 +16731,7 @@ mod __parse__Top {
                 (4, 220)
             }
             689 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter => ActionFn(1700);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter => ActionFn(1703);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant64(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
@@ -16741,7 +16741,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1700::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1703::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16749,7 +16749,7 @@ mod __parse__Top {
                 (6, 220)
             }
             690 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter => ActionFn(1701);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter => ActionFn(1704);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant64(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -16760,7 +16760,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1701::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1704::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16768,14 +16768,14 @@ mod __parse__Top {
                 (7, 220)
             }
             691 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*" => ActionFn(1702);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*" => ActionFn(1705);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1702::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1705::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16783,7 +16783,7 @@ mod __parse__Top {
                 (3, 220)
             }
             692 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*" => ActionFn(1703);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*" => ActionFn(1706);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
@@ -16792,7 +16792,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1703::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1706::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16800,7 +16800,7 @@ mod __parse__Top {
                 (5, 220)
             }
             693 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*" => ActionFn(1704);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*" => ActionFn(1707);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
@@ -16810,7 +16810,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1704::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1707::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16818,7 +16818,7 @@ mod __parse__Top {
                 (6, 220)
             }
             694 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1705);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1708);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant12(__symbols);
                 let __sym3 = __pop_Variant64(__symbols);
@@ -16827,7 +16827,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1705::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1708::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16835,7 +16835,7 @@ mod __parse__Top {
                 (5, 220)
             }
             695 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1706);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1709);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant12(__symbols);
                 let __sym5 = __pop_Variant64(__symbols);
@@ -16846,7 +16846,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1706::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1709::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16854,7 +16854,7 @@ mod __parse__Top {
                 (7, 220)
             }
             696 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1707);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1710);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant12(__symbols);
                 let __sym6 = __pop_Variant64(__symbols);
@@ -16866,7 +16866,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1707::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1710::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16874,7 +16874,7 @@ mod __parse__Top {
                 (8, 220)
             }
             697 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1708);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1711);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
@@ -16882,7 +16882,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1708::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1711::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16890,7 +16890,7 @@ mod __parse__Top {
                 (4, 220)
             }
             698 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1709);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1712);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant12(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
@@ -16900,7 +16900,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1709::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1712::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16908,7 +16908,7 @@ mod __parse__Top {
                 (6, 220)
             }
             699 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1710);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1713);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant12(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -16919,7 +16919,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1710::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1713::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16927,11 +16927,11 @@ mod __parse__Top {
                 (7, 220)
             }
             700 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>> => ActionFn(1711);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>> => ActionFn(1714);
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
-                let __nt = match super::__action1711::<>(source_code, mode, __sym0) {
+                let __nt = match super::__action1714::<>(source_code, mode, __sym0) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16939,14 +16939,14 @@ mod __parse__Top {
                 (1, 220)
             }
             701 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/" => ActionFn(1712);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/" => ActionFn(1715);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1712::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1715::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16954,7 +16954,7 @@ mod __parse__Top {
                 (3, 220)
             }
             702 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1713);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1716);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
@@ -16962,7 +16962,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1713::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1716::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16970,7 +16970,7 @@ mod __parse__Top {
                 (4, 220)
             }
             703 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1714);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1717);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant9(__symbols);
@@ -16978,7 +16978,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1714::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1717::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16986,7 +16986,7 @@ mod __parse__Top {
                 (4, 220)
             }
             704 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1715);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1718);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant9(__symbols);
@@ -16996,7 +16996,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1715::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1718::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -17004,7 +17004,7 @@ mod __parse__Top {
                 (6, 220)
             }
             705 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1716);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1719);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant9(__symbols);
@@ -17015,7 +17015,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1716::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1719::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -17023,14 +17023,14 @@ mod __parse__Top {
                 (7, 220)
             }
             706 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", KwargParameter<StarUntypedParameter> => ActionFn(1717);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", KwargParameter<StarUntypedParameter> => ActionFn(1720);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant9(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1717::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1720::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -17038,7 +17038,7 @@ mod __parse__Top {
                 (3, 220)
             }
             707 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", KwargParameter<StarUntypedParameter> => ActionFn(1718);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", KwargParameter<StarUntypedParameter> => ActionFn(1721);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
@@ -17047,7 +17047,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1718::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1721::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -17055,7 +17055,7 @@ mod __parse__Top {
                 (5, 220)
             }
             708 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1719);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1722);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
@@ -17065,7 +17065,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant85(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1719::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1722::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -17073,63 +17073,12 @@ mod __parse__Top {
                 (6, 220)
             }
             709 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1437);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1440);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant9(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant64(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym4.2;
-                let __nt = match super::__action1437::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
-                (5, 220)
-            }
-            710 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1438);
-                assert!(__symbols.len() >= 4);
-                let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant9(__symbols);
-                let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym3.2;
-                let __nt = match super::__action1438::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
-                (4, 220)
-            }
-            711 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1439);
-                assert!(__symbols.len() >= 6);
-                let __sym5 = __pop_Variant0(__symbols);
-                let __sym4 = __pop_Variant9(__symbols);
-                let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant64(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym5.2;
-                let __nt = match super::__action1439::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
-                (6, 220)
-            }
-            712 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1440);
-                assert!(__symbols.len() >= 5);
-                let __sym4 = __pop_Variant0(__symbols);
-                let __sym3 = __pop_Variant9(__symbols);
-                let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant12(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
@@ -17140,56 +17089,62 @@ mod __parse__Top {
                 __symbols.push((__start, __Symbol::Variant46(__nt), __end));
                 (5, 220)
             }
-            713 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter, "," => ActionFn(1441);
-                assert!(__symbols.len() >= 3);
-                let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant64(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym2.2;
-                let __nt = match super::__action1441::<>(source_code, mode, __sym0, __sym1, __sym2) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
-                (3, 220)
-            }
-            714 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", "," => ActionFn(1442);
-                assert!(__symbols.len() >= 2);
+            710 => {
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1441);
+                assert!(__symbols.len() >= 4);
+                let __sym3 = __pop_Variant0(__symbols);
+                let __sym2 = __pop_Variant9(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
-                let __end = __sym1.2;
-                let __nt = match super::__action1442::<>(source_code, mode, __sym0, __sym1) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
-                (2, 220)
-            }
-            715 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1443);
-                assert!(__symbols.len() >= 4);
-                let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant64(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1443::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1441::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
                 __symbols.push((__start, __Symbol::Variant46(__nt), __end));
                 (4, 220)
             }
-            716 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1444);
-                assert!(__symbols.len() >= 3);
+            711 => {
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1442);
+                assert!(__symbols.len() >= 6);
+                let __sym5 = __pop_Variant0(__symbols);
+                let __sym4 = __pop_Variant9(__symbols);
+                let __sym3 = __pop_Variant0(__symbols);
+                let __sym2 = __pop_Variant12(__symbols);
+                let __sym1 = __pop_Variant64(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym5.2;
+                let __nt = match super::__action1442::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
+                (6, 220)
+            }
+            712 => {
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter>, "," => ActionFn(1443);
+                assert!(__symbols.len() >= 5);
+                let __sym4 = __pop_Variant0(__symbols);
+                let __sym3 = __pop_Variant9(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant12(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym4.2;
+                let __nt = match super::__action1443::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
+                (5, 220)
+            }
+            713 => {
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter, "," => ActionFn(1444);
+                assert!(__symbols.len() >= 3);
+                let __sym2 = __pop_Variant0(__symbols);
+                let __sym1 = __pop_Variant64(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
@@ -17200,60 +17155,57 @@ mod __parse__Top {
                 __symbols.push((__start, __Symbol::Variant46(__nt), __end));
                 (3, 220)
             }
-            717 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter> => ActionFn(1445);
+            714 => {
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", "," => ActionFn(1445);
+                assert!(__symbols.len() >= 2);
+                let __sym1 = __pop_Variant0(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym1.2;
+                let __nt = match super::__action1445::<>(source_code, mode, __sym0, __sym1) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
+                (2, 220)
+            }
+            715 => {
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1446);
                 assert!(__symbols.len() >= 4);
-                let __sym3 = __pop_Variant9(__symbols);
-                let __sym2 = __pop_Variant0(__symbols);
+                let __sym3 = __pop_Variant0(__symbols);
+                let __sym2 = __pop_Variant12(__symbols);
                 let __sym1 = __pop_Variant64(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1445::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1446::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
                 __symbols.push((__start, __Symbol::Variant46(__nt), __end));
                 (4, 220)
             }
-            718 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", ",", KwargParameter<StarUntypedParameter> => ActionFn(1446);
+            716 => {
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1447);
                 assert!(__symbols.len() >= 3);
-                let __sym2 = __pop_Variant9(__symbols);
-                let __sym1 = __pop_Variant0(__symbols);
+                let __sym2 = __pop_Variant0(__symbols);
+                let __sym1 = __pop_Variant12(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1446::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1447::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
                 __symbols.push((__start, __Symbol::Variant46(__nt), __end));
                 (3, 220)
             }
-            719 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1447);
-                assert!(__symbols.len() >= 5);
-                let __sym4 = __pop_Variant9(__symbols);
-                let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant64(__symbols);
-                let __sym0 = __pop_Variant0(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym4.2;
-                let __nt = match super::__action1447::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
-                (5, 220)
-            }
-            720 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1448);
+            717 => {
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter, ",", KwargParameter<StarUntypedParameter> => ActionFn(1448);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant9(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant12(__symbols);
+                let __sym1 = __pop_Variant64(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
@@ -17264,14 +17216,62 @@ mod __parse__Top {
                 __symbols.push((__start, __Symbol::Variant46(__nt), __end));
                 (4, 220)
             }
+            718 => {
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", ",", KwargParameter<StarUntypedParameter> => ActionFn(1449);
+                assert!(__symbols.len() >= 3);
+                let __sym2 = __pop_Variant9(__symbols);
+                let __sym1 = __pop_Variant0(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym2.2;
+                let __nt = match super::__action1449::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
+                (3, 220)
+            }
+            719 => {
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1450);
+                assert!(__symbols.len() >= 5);
+                let __sym4 = __pop_Variant9(__symbols);
+                let __sym3 = __pop_Variant0(__symbols);
+                let __sym2 = __pop_Variant12(__symbols);
+                let __sym1 = __pop_Variant64(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym4.2;
+                let __nt = match super::__action1450::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
+                (5, 220)
+            }
+            720 => {
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<StarUntypedParameter> => ActionFn(1451);
+                assert!(__symbols.len() >= 4);
+                let __sym3 = __pop_Variant9(__symbols);
+                let __sym2 = __pop_Variant0(__symbols);
+                let __sym1 = __pop_Variant12(__symbols);
+                let __sym0 = __pop_Variant0(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym3.2;
+                let __nt = match super::__action1451::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant46(__nt), __end));
+                (4, 220)
+            }
             721 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter => ActionFn(1449);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter => ActionFn(1452);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant64(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1449::<>(source_code, mode, __sym0, __sym1) {
+                let __nt = match super::__action1452::<>(source_code, mode, __sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -17279,11 +17279,11 @@ mod __parse__Top {
                 (2, 220)
             }
             722 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*" => ActionFn(1450);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*" => ActionFn(1453);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
-                let __nt = match super::__action1450::<>(source_code, mode, __sym0) {
+                let __nt = match super::__action1453::<>(source_code, mode, __sym0) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -17291,14 +17291,14 @@ mod __parse__Top {
                 (1, 220)
             }
             723 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1451);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", StarUntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1454);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant12(__symbols);
                 let __sym1 = __pop_Variant64(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1451::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1454::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -17306,13 +17306,13 @@ mod __parse__Top {
                 (3, 220)
             }
             724 => {
-                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1452);
+                // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1455);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant12(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1452::<>(source_code, mode, __sym0, __sym1) {
+                let __nt = match super::__action1455::<>(source_code, mode, __sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -17570,14 +17570,14 @@ mod __parse__Top {
                 (2, 223)
             }
             745 => {
-                // Parameters = "(", ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter>, ")" => ActionFn(1455);
+                // Parameters = "(", ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter>, ")" => ActionFn(1458);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant46(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1455::<>(source_code, mode, __sym0, __sym1, __sym2) {
+                let __nt = match super::__action1458::<>(source_code, mode, __sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -17585,13 +17585,13 @@ mod __parse__Top {
                 (3, 224)
             }
             746 => {
-                // Parameters = "(", ")" => ActionFn(1456);
+                // Parameters = "(", ")" => ActionFn(1459);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1456::<>(source_code, mode, __sym0, __sym1) {
+                let __nt = match super::__action1459::<>(source_code, mode, __sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -21916,14 +21916,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"all"> = "[", ListLiteralValues, "]" => ActionFn(1596);
+        // Atom<"all"> = "[", ListLiteralValues, "]" => ActionFn(1599);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant33(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1596::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1599::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 94)
     }
@@ -21936,13 +21936,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"all"> = "[", "]" => ActionFn(1597);
+        // Atom<"all"> = "[", "]" => ActionFn(1600);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1597::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1600::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 94)
     }
@@ -22077,14 +22077,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"all"> = "{", DictLiteralValues, "}" => ActionFn(1564);
+        // Atom<"all"> = "{", DictLiteralValues, "}" => ActionFn(1567);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant62(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1564::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1567::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 94)
     }
@@ -22097,13 +22097,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"all"> = "{", "}" => ActionFn(1565);
+        // Atom<"all"> = "{", "}" => ActionFn(1568);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1565::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1568::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 94)
     }
@@ -22280,14 +22280,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"no-withitems"> = "[", ListLiteralValues, "]" => ActionFn(1598);
+        // Atom<"no-withitems"> = "[", ListLiteralValues, "]" => ActionFn(1601);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant33(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1598::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1601::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 95)
     }
@@ -22300,13 +22300,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"no-withitems"> = "[", "]" => ActionFn(1599);
+        // Atom<"no-withitems"> = "[", "]" => ActionFn(1602);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1599::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1602::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 95)
     }
@@ -22400,14 +22400,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"no-withitems"> = "{", DictLiteralValues, "}" => ActionFn(1566);
+        // Atom<"no-withitems"> = "{", DictLiteralValues, "}" => ActionFn(1569);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant62(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1566::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1569::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 95)
     }
@@ -22420,13 +22420,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"no-withitems"> = "{", "}" => ActionFn(1567);
+        // Atom<"no-withitems"> = "{", "}" => ActionFn(1570);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1567::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1570::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 95)
     }
@@ -23033,7 +23033,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ClassDef = "class", Identifier, TypeParams, Arguments, ":", Suite => ActionFn(1752);
+        // ClassDef = "class", Identifier, TypeParams, Arguments, ":", Suite => ActionFn(1755);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant25(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
@@ -23043,7 +23043,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1752::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1755::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (6, 102)
     }
@@ -23056,7 +23056,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ClassDef = "class", Identifier, Arguments, ":", Suite => ActionFn(1753);
+        // ClassDef = "class", Identifier, Arguments, ":", Suite => ActionFn(1756);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant25(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -23065,7 +23065,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1753::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1756::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (5, 102)
     }
@@ -23078,7 +23078,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ClassDef = Decorator+, "class", Identifier, TypeParams, Arguments, ":", Suite => ActionFn(1754);
+        // ClassDef = Decorator+, "class", Identifier, TypeParams, Arguments, ":", Suite => ActionFn(1757);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
@@ -23089,7 +23089,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1754::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1757::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (7, 102)
     }
@@ -23102,7 +23102,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ClassDef = Decorator+, "class", Identifier, Arguments, ":", Suite => ActionFn(1755);
+        // ClassDef = Decorator+, "class", Identifier, Arguments, ":", Suite => ActionFn(1758);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant25(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
@@ -23112,7 +23112,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1755::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1758::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (6, 102)
     }
@@ -23125,7 +23125,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ClassDef = "class", Identifier, TypeParams, ":", Suite => ActionFn(1756);
+        // ClassDef = "class", Identifier, TypeParams, ":", Suite => ActionFn(1759);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant25(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -23134,7 +23134,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1756::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1759::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (5, 102)
     }
@@ -23147,7 +23147,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ClassDef = "class", Identifier, ":", Suite => ActionFn(1757);
+        // ClassDef = "class", Identifier, ":", Suite => ActionFn(1760);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant25(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -23155,7 +23155,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1757::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1760::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (4, 102)
     }
@@ -23168,7 +23168,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ClassDef = Decorator+, "class", Identifier, TypeParams, ":", Suite => ActionFn(1758);
+        // ClassDef = Decorator+, "class", Identifier, TypeParams, ":", Suite => ActionFn(1761);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant25(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
@@ -23178,7 +23178,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1758::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1761::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (6, 102)
     }
@@ -23191,7 +23191,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ClassDef = Decorator+, "class", Identifier, ":", Suite => ActionFn(1759);
+        // ClassDef = Decorator+, "class", Identifier, ":", Suite => ActionFn(1762);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant25(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -23200,7 +23200,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1759::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1762::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (5, 102)
     }
@@ -23370,11 +23370,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<FunctionArgument> = FunctionArgument => ActionFn(1530);
+        // Comma<FunctionArgument> = FunctionArgument => ActionFn(1533);
         let __sym0 = __pop_Variant31(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1530::<>(source_code, mode, __sym0);
+        let __nt = super::__action1533::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant52(__nt), __end));
         (1, 105)
     }
@@ -23387,10 +23387,10 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<FunctionArgument> =  => ActionFn(1531);
+        // Comma<FunctionArgument> =  => ActionFn(1534);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
-        let __nt = super::__action1531::<>(source_code, mode, &__start, &__end);
+        let __nt = super::__action1534::<>(source_code, mode, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant52(__nt), __end));
         (0, 105)
     }
@@ -23403,13 +23403,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<FunctionArgument> = (<FunctionArgument> ",")+, FunctionArgument => ActionFn(1532);
+        // Comma<FunctionArgument> = (<FunctionArgument> ",")+, FunctionArgument => ActionFn(1535);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant31(__symbols);
         let __sym0 = __pop_Variant32(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1532::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1535::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant52(__nt), __end));
         (2, 105)
     }
@@ -23422,11 +23422,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<FunctionArgument> = (<FunctionArgument> ",")+ => ActionFn(1533);
+        // Comma<FunctionArgument> = (<FunctionArgument> ",")+ => ActionFn(1536);
         let __sym0 = __pop_Variant32(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1533::<>(source_code, mode, __sym0);
+        let __nt = super::__action1536::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant52(__nt), __end));
         (1, 105)
     }
@@ -23439,11 +23439,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<Pattern> = Pattern => ActionFn(1538);
+        // Comma<Pattern> = Pattern => ActionFn(1541);
         let __sym0 = __pop_Variant35(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1538::<>(source_code, mode, __sym0);
+        let __nt = super::__action1541::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant53(__nt), __end));
         (1, 106)
     }
@@ -23456,10 +23456,10 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<Pattern> =  => ActionFn(1539);
+        // Comma<Pattern> =  => ActionFn(1542);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
-        let __nt = super::__action1539::<>(source_code, mode, &__start, &__end);
+        let __nt = super::__action1542::<>(source_code, mode, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant53(__nt), __end));
         (0, 106)
     }
@@ -23472,13 +23472,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<Pattern> = (<Pattern> ",")+, Pattern => ActionFn(1540);
+        // Comma<Pattern> = (<Pattern> ",")+, Pattern => ActionFn(1543);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant35(__symbols);
         let __sym0 = __pop_Variant36(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1540::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1543::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant53(__nt), __end));
         (2, 106)
     }
@@ -23491,11 +23491,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<Pattern> = (<Pattern> ",")+ => ActionFn(1541);
+        // Comma<Pattern> = (<Pattern> ",")+ => ActionFn(1544);
         let __sym0 = __pop_Variant36(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1541::<>(source_code, mode, __sym0);
+        let __nt = super::__action1544::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant53(__nt), __end));
         (1, 106)
     }
@@ -24471,7 +24471,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ExceptClause = "except", Test<"all">, ":", Suite => ActionFn(1724);
+        // ExceptClause = "except", Test<"all">, ":", Suite => ActionFn(1727);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant25(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -24479,7 +24479,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1724::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1727::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant66(__nt), __end));
         (4, 130)
     }
@@ -24492,14 +24492,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ExceptClause = "except", ":", Suite => ActionFn(1725);
+        // ExceptClause = "except", ":", Suite => ActionFn(1728);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant25(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1725::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1728::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant66(__nt), __end));
         (3, 130)
     }
@@ -24831,11 +24831,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ExpressionStatement = GenericList<TestOrStarExpr> => ActionFn(1749);
+        // ExpressionStatement = GenericList<TestOrStarExpr> => ActionFn(1752);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1749::<>(source_code, mode, __sym0);
+        let __nt = super::__action1752::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (1, 140)
     }
@@ -24848,13 +24848,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ExpressionStatement = GenericList<TestOrStarExpr>, AssignSuffix+ => ActionFn(1750);
+        // ExpressionStatement = GenericList<TestOrStarExpr>, AssignSuffix+ => ActionFn(1753);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant17(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1750::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1753::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (2, 140)
     }
@@ -24867,14 +24867,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ExpressionStatement = GenericList<TestOrStarExpr>, AugAssign, TestListOrYieldExpr => ActionFn(1751);
+        // ExpressionStatement = GenericList<TestOrStarExpr>, AugAssign, TestListOrYieldExpr => ActionFn(1754);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant49(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1751::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1754::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (3, 140)
     }
@@ -24887,7 +24887,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ExpressionStatement = Test<"all">, ":", Test<"all">, AssignSuffix => ActionFn(1528);
+        // ExpressionStatement = Test<"all">, ":", Test<"all">, AssignSuffix => ActionFn(1531);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant15(__symbols);
         let __sym2 = __pop_Variant15(__symbols);
@@ -24895,7 +24895,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1528::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1531::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (4, 140)
     }
@@ -24908,14 +24908,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ExpressionStatement = Test<"all">, ":", Test<"all"> => ActionFn(1529);
+        // ExpressionStatement = Test<"all">, ":", Test<"all"> => ActionFn(1532);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1529::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1532::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (3, 140)
     }
@@ -24961,13 +24961,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FStringExpr = FStringStart, FStringEnd => ActionFn(1582);
+        // FStringExpr = FStringStart, FStringEnd => ActionFn(1585);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1582::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1585::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant70(__nt), __end));
         (2, 143)
     }
@@ -24980,14 +24980,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FStringExpr = FStringStart, FStringMiddlePattern+, FStringEnd => ActionFn(1583);
+        // FStringExpr = FStringStart, FStringMiddlePattern+, FStringEnd => ActionFn(1586);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant71(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1583::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1586::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant70(__nt), __end));
         (3, 143)
     }
@@ -25000,10 +25000,10 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FStringFormatSpec =  => ActionFn(1584);
+        // FStringFormatSpec =  => ActionFn(1587);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
-        let __nt = super::__action1584::<>(source_code, mode, &__start, &__end);
+        let __nt = super::__action1587::<>(source_code, mode, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant44(__nt), __end));
         (0, 144)
     }
@@ -25016,11 +25016,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FStringFormatSpec = FStringMiddlePattern+ => ActionFn(1585);
+        // FStringFormatSpec = FStringMiddlePattern+ => ActionFn(1588);
         let __sym0 = __pop_Variant71(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1585::<>(source_code, mode, __sym0);
+        let __nt = super::__action1588::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant44(__nt), __end));
         (1, 144)
     }
@@ -25277,13 +25277,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FlowStatement = "return", GenericList<TestOrStarExpr> => ActionFn(1745);
+        // FlowStatement = "return", GenericList<TestOrStarExpr> => ActionFn(1748);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1745::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1748::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (2, 153)
     }
@@ -25296,11 +25296,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FlowStatement = "return" => ActionFn(1746);
+        // FlowStatement = "return" => ActionFn(1749);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1746::<>(source_code, mode, __sym0);
+        let __nt = super::__action1749::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (1, 153)
     }
@@ -25347,7 +25347,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ForStatement = "async", "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite, "else", ":", Suite => ActionFn(1736);
+        // ForStatement = "async", "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite, "else", ":", Suite => ActionFn(1739);
         assert!(__symbols.len() >= 10);
         let __sym9 = __pop_Variant25(__symbols);
         let __sym8 = __pop_Variant0(__symbols);
@@ -25361,7 +25361,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym9.2;
-        let __nt = super::__action1736::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        let __nt = super::__action1739::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (10, 154)
     }
@@ -25374,7 +25374,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ForStatement = "async", "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite => ActionFn(1737);
+        // ForStatement = "async", "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite => ActionFn(1740);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
@@ -25385,7 +25385,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1737::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1740::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (7, 154)
     }
@@ -25398,7 +25398,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ForStatement = "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite, "else", ":", Suite => ActionFn(1738);
+        // ForStatement = "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite, "else", ":", Suite => ActionFn(1741);
         assert!(__symbols.len() >= 9);
         let __sym8 = __pop_Variant25(__symbols);
         let __sym7 = __pop_Variant0(__symbols);
@@ -25411,7 +25411,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym8.2;
-        let __nt = super::__action1738::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8);
+        let __nt = super::__action1741::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (9, 154)
     }
@@ -25424,7 +25424,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ForStatement = "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite => ActionFn(1739);
+        // ForStatement = "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite => ActionFn(1742);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant25(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
@@ -25434,7 +25434,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1739::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1742::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (6, 154)
     }
@@ -25447,7 +25447,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = "async", "def", Identifier, TypeParams, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1760);
+        // FuncDef = "async", "def", Identifier, TypeParams, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1763);
         assert!(__symbols.len() >= 9);
         let __sym8 = __pop_Variant25(__symbols);
         let __sym7 = __pop_Variant0(__symbols);
@@ -25460,7 +25460,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym8.2;
-        let __nt = super::__action1760::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8);
+        let __nt = super::__action1763::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (9, 155)
     }
@@ -25473,7 +25473,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = "async", "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1761);
+        // FuncDef = "async", "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1764);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant25(__symbols);
         let __sym6 = __pop_Variant0(__symbols);
@@ -25485,7 +25485,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action1761::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action1764::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (8, 155)
     }
@@ -25498,7 +25498,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = Decorator+, "async", "def", Identifier, TypeParams, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1762);
+        // FuncDef = Decorator+, "async", "def", Identifier, TypeParams, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1765);
         assert!(__symbols.len() >= 10);
         let __sym9 = __pop_Variant25(__symbols);
         let __sym8 = __pop_Variant0(__symbols);
@@ -25512,7 +25512,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym9.2;
-        let __nt = super::__action1762::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        let __nt = super::__action1765::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (10, 155)
     }
@@ -25525,7 +25525,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = Decorator+, "async", "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1763);
+        // FuncDef = Decorator+, "async", "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1766);
         assert!(__symbols.len() >= 9);
         let __sym8 = __pop_Variant25(__symbols);
         let __sym7 = __pop_Variant0(__symbols);
@@ -25538,7 +25538,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym8.2;
-        let __nt = super::__action1763::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8);
+        let __nt = super::__action1766::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (9, 155)
     }
@@ -25551,7 +25551,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = "async", "def", Identifier, TypeParams, Parameters, ":", Suite => ActionFn(1764);
+        // FuncDef = "async", "def", Identifier, TypeParams, Parameters, ":", Suite => ActionFn(1767);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
@@ -25562,7 +25562,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1764::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1767::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (7, 155)
     }
@@ -25575,7 +25575,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = "async", "def", Identifier, Parameters, ":", Suite => ActionFn(1765);
+        // FuncDef = "async", "def", Identifier, Parameters, ":", Suite => ActionFn(1768);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant25(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
@@ -25585,7 +25585,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1765::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1768::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (6, 155)
     }
@@ -25598,7 +25598,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = Decorator+, "async", "def", Identifier, TypeParams, Parameters, ":", Suite => ActionFn(1766);
+        // FuncDef = Decorator+, "async", "def", Identifier, TypeParams, Parameters, ":", Suite => ActionFn(1769);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant25(__symbols);
         let __sym6 = __pop_Variant0(__symbols);
@@ -25610,7 +25610,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action1766::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action1769::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (8, 155)
     }
@@ -25623,7 +25623,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = Decorator+, "async", "def", Identifier, Parameters, ":", Suite => ActionFn(1767);
+        // FuncDef = Decorator+, "async", "def", Identifier, Parameters, ":", Suite => ActionFn(1770);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
@@ -25634,7 +25634,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1767::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1770::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (7, 155)
     }
@@ -25647,7 +25647,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = "def", Identifier, TypeParams, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1768);
+        // FuncDef = "def", Identifier, TypeParams, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1771);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant25(__symbols);
         let __sym6 = __pop_Variant0(__symbols);
@@ -25659,7 +25659,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action1768::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action1771::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (8, 155)
     }
@@ -25672,7 +25672,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1769);
+        // FuncDef = "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1772);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
@@ -25683,7 +25683,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1769::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1772::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (7, 155)
     }
@@ -25696,7 +25696,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = Decorator+, "def", Identifier, TypeParams, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1770);
+        // FuncDef = Decorator+, "def", Identifier, TypeParams, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1773);
         assert!(__symbols.len() >= 9);
         let __sym8 = __pop_Variant25(__symbols);
         let __sym7 = __pop_Variant0(__symbols);
@@ -25709,7 +25709,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym8.2;
-        let __nt = super::__action1770::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8);
+        let __nt = super::__action1773::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (9, 155)
     }
@@ -25722,7 +25722,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = Decorator+, "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1771);
+        // FuncDef = Decorator+, "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1774);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant25(__symbols);
         let __sym6 = __pop_Variant0(__symbols);
@@ -25734,7 +25734,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action1771::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action1774::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (8, 155)
     }
@@ -25747,7 +25747,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = "def", Identifier, TypeParams, Parameters, ":", Suite => ActionFn(1772);
+        // FuncDef = "def", Identifier, TypeParams, Parameters, ":", Suite => ActionFn(1775);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant25(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
@@ -25757,7 +25757,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1772::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1775::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (6, 155)
     }
@@ -25770,7 +25770,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = "def", Identifier, Parameters, ":", Suite => ActionFn(1773);
+        // FuncDef = "def", Identifier, Parameters, ":", Suite => ActionFn(1776);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant25(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -25779,7 +25779,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1773::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1776::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (5, 155)
     }
@@ -25792,7 +25792,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = Decorator+, "def", Identifier, TypeParams, Parameters, ":", Suite => ActionFn(1774);
+        // FuncDef = Decorator+, "def", Identifier, TypeParams, Parameters, ":", Suite => ActionFn(1777);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
@@ -25803,7 +25803,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1774::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1777::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (7, 155)
     }
@@ -25816,7 +25816,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = Decorator+, "def", Identifier, Parameters, ":", Suite => ActionFn(1775);
+        // FuncDef = Decorator+, "def", Identifier, Parameters, ":", Suite => ActionFn(1778);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant25(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
@@ -25826,7 +25826,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1775::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1778::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (6, 155)
     }
@@ -25839,13 +25839,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FunctionArgument = NamedExpressionTest, CompFor => ActionFn(1546);
+        // FunctionArgument = NamedExpressionTest, CompFor => ActionFn(1549);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant54(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1546::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1549::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant31(__nt), __end));
         (2, 156)
     }
@@ -25858,11 +25858,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FunctionArgument = NamedExpressionTest => ActionFn(1547);
+        // FunctionArgument = NamedExpressionTest => ActionFn(1550);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1547::<>(source_code, mode, __sym0);
+        let __nt = super::__action1550::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant31(__nt), __end));
         (1, 156)
     }
@@ -26437,11 +26437,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ImportFromLocation = DottedName => ActionFn(1594);
+        // ImportFromLocation = DottedName => ActionFn(1597);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1594::<>(source_code, mode, __sym0);
+        let __nt = super::__action1597::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant77(__nt), __end));
         (1, 170)
     }
@@ -26454,13 +26454,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ImportFromLocation = ImportDots+, DottedName => ActionFn(1595);
+        // ImportFromLocation = ImportDots+, DottedName => ActionFn(1598);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant23(__symbols);
         let __sym0 = __pop_Variant76(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1595::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1598::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant77(__nt), __end));
         (2, 170)
     }
@@ -26530,13 +26530,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // KwargParameter<DoubleStarTypedParameter> = "**", DoubleStarTypedParameter => ActionFn(1568);
+        // KwargParameter<DoubleStarTypedParameter> = "**", DoubleStarTypedParameter => ActionFn(1571);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant64(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1568::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1571::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (2, 175)
     }
@@ -26549,11 +26549,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // KwargParameter<DoubleStarTypedParameter> = "**" => ActionFn(1569);
+        // KwargParameter<DoubleStarTypedParameter> = "**" => ActionFn(1572);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1569::<>(source_code, mode, __sym0);
+        let __nt = super::__action1572::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (1, 175)
     }
@@ -27208,7 +27208,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MatchStatement = "match", TestOrStarNamedExpr, ",", ":", "\n", Indent, MatchCase+, Dedent => ActionFn(864);
+        // MatchStatement = "match", TestOrStarNamedExpr, ",", ":", "\n", Indent, MatchCase+, Dedent => ActionFn(1369);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
         let __sym6 = __pop_Variant79(__symbols);
@@ -27220,7 +27220,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action864::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action1369::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (8, 189)
     }
@@ -27233,7 +27233,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MatchStatement = "match", TwoOrMore<TestOrStarNamedExpr, ",">, ",", ":", "\n", Indent, MatchCase+, Dedent => ActionFn(865);
+        // MatchStatement = "match", TwoOrMore<TestOrStarNamedExpr, ",">, ",", ":", "\n", Indent, MatchCase+, Dedent => ActionFn(1370);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
         let __sym6 = __pop_Variant79(__symbols);
@@ -27245,7 +27245,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action865::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action1370::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (8, 189)
     }
@@ -27258,7 +27258,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MatchStatement = "match", TwoOrMore<TestOrStarNamedExpr, ",">, ":", "\n", Indent, MatchCase+, Dedent => ActionFn(866);
+        // MatchStatement = "match", TwoOrMore<TestOrStarNamedExpr, ",">, ":", "\n", Indent, MatchCase+, Dedent => ActionFn(1371);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant0(__symbols);
         let __sym5 = __pop_Variant79(__symbols);
@@ -27269,7 +27269,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action866::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1371::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (7, 189)
     }
@@ -27367,14 +27367,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // NamedExpression = NamedExpressionName, ":=", Test<"all"> => ActionFn(1369);
+        // NamedExpression = NamedExpressionName, ":=", Test<"all"> => ActionFn(1372);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1369::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1372::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 191)
     }
@@ -27387,11 +27387,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // NamedExpressionName = Identifier => ActionFn(1370);
+        // NamedExpressionName = Identifier => ActionFn(1373);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1370::<>(source_code, mode, __sym0);
+        let __nt = super::__action1373::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 192)
     }
@@ -27472,13 +27472,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // NonlocalStatement = "nonlocal", OneOrMore<Identifier> => ActionFn(1371);
+        // NonlocalStatement = "nonlocal", OneOrMore<Identifier> => ActionFn(1374);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant82(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1371::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1374::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (2, 195)
     }
@@ -27491,13 +27491,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // NotTest<"all"> = "not", NotTest<"all"> => ActionFn(1372);
+        // NotTest<"all"> = "not", NotTest<"all"> => ActionFn(1375);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1372::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1375::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 196)
     }
@@ -27527,13 +27527,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // NotTest<"no-withitems"> = "not", NotTest<"all"> => ActionFn(1373);
+        // NotTest<"no-withitems"> = "not", NotTest<"all"> => ActionFn(1376);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1373::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1376::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 197)
     }
@@ -27674,14 +27674,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<DottedName>> = DottedName, "as", Identifier => ActionFn(1586);
+        // OneOrMore<ImportAsAlias<DottedName>> = DottedName, "as", Identifier => ActionFn(1589);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1586::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1589::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant74(__nt), __end));
         (3, 201)
     }
@@ -27694,11 +27694,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<DottedName>> = DottedName => ActionFn(1587);
+        // OneOrMore<ImportAsAlias<DottedName>> = DottedName => ActionFn(1590);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1587::<>(source_code, mode, __sym0);
+        let __nt = super::__action1590::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant74(__nt), __end));
         (1, 201)
     }
@@ -27711,7 +27711,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<DottedName>> = OneOrMore<ImportAsAlias<DottedName>>, ",", DottedName, "as", Identifier => ActionFn(1588);
+        // OneOrMore<ImportAsAlias<DottedName>> = OneOrMore<ImportAsAlias<DottedName>>, ",", DottedName, "as", Identifier => ActionFn(1591);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant23(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -27720,7 +27720,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant74(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1588::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1591::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant74(__nt), __end));
         (5, 201)
     }
@@ -27733,14 +27733,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<DottedName>> = OneOrMore<ImportAsAlias<DottedName>>, ",", DottedName => ActionFn(1589);
+        // OneOrMore<ImportAsAlias<DottedName>> = OneOrMore<ImportAsAlias<DottedName>>, ",", DottedName => ActionFn(1592);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant74(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1589::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1592::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant74(__nt), __end));
         (3, 201)
     }
@@ -27753,14 +27753,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<Identifier>> = Identifier, "as", Identifier => ActionFn(1590);
+        // OneOrMore<ImportAsAlias<Identifier>> = Identifier, "as", Identifier => ActionFn(1593);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1590::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1593::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant74(__nt), __end));
         (3, 202)
     }
@@ -27773,11 +27773,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<Identifier>> = Identifier => ActionFn(1591);
+        // OneOrMore<ImportAsAlias<Identifier>> = Identifier => ActionFn(1594);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1591::<>(source_code, mode, __sym0);
+        let __nt = super::__action1594::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant74(__nt), __end));
         (1, 202)
     }
@@ -27790,7 +27790,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<Identifier>> = OneOrMore<ImportAsAlias<Identifier>>, ",", Identifier, "as", Identifier => ActionFn(1592);
+        // OneOrMore<ImportAsAlias<Identifier>> = OneOrMore<ImportAsAlias<Identifier>>, ",", Identifier, "as", Identifier => ActionFn(1595);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant23(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -27799,7 +27799,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant74(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1592::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1595::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant74(__nt), __end));
         (5, 202)
     }
@@ -27812,14 +27812,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<Identifier>> = OneOrMore<ImportAsAlias<Identifier>>, ",", Identifier => ActionFn(1593);
+        // OneOrMore<ImportAsAlias<Identifier>> = OneOrMore<ImportAsAlias<Identifier>>, ",", Identifier => ActionFn(1596);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant74(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1593::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1596::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant74(__nt), __end));
         (3, 202)
     }
@@ -28182,11 +28182,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OrPattern = TwoOrMore<ClosedPattern, "|"> => ActionFn(1374);
+        // OrPattern = TwoOrMore<ClosedPattern, "|"> => ActionFn(1377);
         let __sym0 = __pop_Variant53(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1374::<>(source_code, mode, __sym0);
+        let __nt = super::__action1377::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (1, 212)
     }
@@ -28199,13 +28199,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OrTest<"all"> = (<AndTest<"all">> "or")+, AndTest<"all"> => ActionFn(1375);
+        // OrTest<"all"> = (<AndTest<"all">> "or")+, AndTest<"all"> => ActionFn(1378);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant17(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1375::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1378::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 213)
     }
@@ -28235,13 +28235,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OrTest<"no-withitems"> = (<AndTest<"all">> "or")+, AndTest<"all"> => ActionFn(1376);
+        // OrTest<"no-withitems"> = (<AndTest<"all">> "or")+, AndTest<"all"> => ActionFn(1379);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant17(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1376::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1379::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 214)
     }
@@ -28288,14 +28288,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ParameterDef<TypedParameter> = TypedParameter, "=", Test<"all"> => ActionFn(1377);
+        // ParameterDef<TypedParameter> = TypedParameter, "=", Test<"all"> => ActionFn(1380);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1377::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1380::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 215)
     }
@@ -28325,14 +28325,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ParameterDef<UntypedParameter> = UntypedParameter, "=", Test<"all"> => ActionFn(1378);
+        // ParameterDef<UntypedParameter> = UntypedParameter, "=", Test<"all"> => ActionFn(1381);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1378::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1381::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 216)
     }
@@ -28461,13 +28461,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1415);
+        // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = KwargParameter<DoubleStarTypedParameter>, "," => ActionFn(1418);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1415::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1418::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant46(__nt), __end));
         (2, 219)
     }
@@ -28480,11 +28480,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = KwargParameter<DoubleStarTypedParameter> => ActionFn(1416);
+        // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = KwargParameter<DoubleStarTypedParameter> => ActionFn(1419);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1416::<>(source_code, mode, __sym0);
+        let __nt = super::__action1419::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant46(__nt), __end));
         (1, 219)
     }
@@ -28497,13 +28497,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = KwargParameter<StarUntypedParameter>, "," => ActionFn(1453);
+        // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = KwargParameter<StarUntypedParameter>, "," => ActionFn(1456);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1453::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1456::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant46(__nt), __end));
         (2, 220)
     }
@@ -28516,11 +28516,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = KwargParameter<StarUntypedParameter> => ActionFn(1454);
+        // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = KwargParameter<StarUntypedParameter> => ActionFn(1457);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1454::<>(source_code, mode, __sym0);
+        let __nt = super::__action1457::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant46(__nt), __end));
         (1, 220)
     }
@@ -28566,11 +28566,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // PassStatement = "pass" => ActionFn(1457);
+        // PassStatement = "pass" => ActionFn(1460);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1457::<>(source_code, mode, __sym0);
+        let __nt = super::__action1460::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (1, 225)
     }
@@ -28650,7 +28650,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // PatternArguments = "(", OneOrMore<Pattern>, ",", OneOrMore<MatchKeywordEntry>, ",", ")" => ActionFn(1458);
+        // PatternArguments = "(", OneOrMore<Pattern>, ",", OneOrMore<MatchKeywordEntry>, ",", ")" => ActionFn(1461);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
@@ -28660,7 +28660,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1458::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1461::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant89(__nt), __end));
         (6, 228)
     }
@@ -28673,7 +28673,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // PatternArguments = "(", OneOrMore<Pattern>, ",", OneOrMore<MatchKeywordEntry>, ")" => ActionFn(1459);
+        // PatternArguments = "(", OneOrMore<Pattern>, ",", OneOrMore<MatchKeywordEntry>, ")" => ActionFn(1462);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant83(__symbols);
@@ -28682,7 +28682,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1459::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1462::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant89(__nt), __end));
         (5, 228)
     }
@@ -28695,7 +28695,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // PatternArguments = "(", OneOrMore<Pattern>, ",", ")" => ActionFn(1460);
+        // PatternArguments = "(", OneOrMore<Pattern>, ",", ")" => ActionFn(1463);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -28703,7 +28703,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1460::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1463::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant89(__nt), __end));
         (4, 228)
     }
@@ -28716,14 +28716,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // PatternArguments = "(", OneOrMore<Pattern>, ")" => ActionFn(1461);
+        // PatternArguments = "(", OneOrMore<Pattern>, ")" => ActionFn(1464);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant53(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1461::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1464::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant89(__nt), __end));
         (3, 228)
     }
@@ -28736,7 +28736,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // PatternArguments = "(", OneOrMore<MatchKeywordEntry>, ",", ")" => ActionFn(1462);
+        // PatternArguments = "(", OneOrMore<MatchKeywordEntry>, ",", ")" => ActionFn(1465);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -28744,7 +28744,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1462::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1465::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant89(__nt), __end));
         (4, 228)
     }
@@ -28757,14 +28757,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // PatternArguments = "(", OneOrMore<MatchKeywordEntry>, ")" => ActionFn(1463);
+        // PatternArguments = "(", OneOrMore<MatchKeywordEntry>, ")" => ActionFn(1466);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant83(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1463::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1466::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant89(__nt), __end));
         (3, 228)
     }
@@ -28777,13 +28777,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // PatternArguments = "(", ")" => ActionFn(1464);
+        // PatternArguments = "(", ")" => ActionFn(1467);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1464::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1467::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant89(__nt), __end));
         (2, 228)
     }
@@ -28796,13 +28796,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Patterns = Pattern, "," => ActionFn(1465);
+        // Patterns = Pattern, "," => ActionFn(1468);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant35(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1465::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1468::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (2, 229)
     }
@@ -28815,13 +28815,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Patterns = TwoOrMore<Pattern, ",">, "," => ActionFn(1466);
+        // Patterns = TwoOrMore<Pattern, ",">, "," => ActionFn(1469);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant53(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1466::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1469::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (2, 229)
     }
@@ -28834,11 +28834,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Patterns = TwoOrMore<Pattern, ","> => ActionFn(1467);
+        // Patterns = TwoOrMore<Pattern, ","> => ActionFn(1470);
         let __sym0 = __pop_Variant53(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1467::<>(source_code, mode, __sym0);
+        let __nt = super::__action1470::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (1, 229)
     }
@@ -28868,14 +28868,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Power<"all"> = AtomExpr<"all">, "**", Factor<"all"> => ActionFn(1468);
+        // Power<"all"> = AtomExpr<"all">, "**", Factor<"all"> => ActionFn(1471);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1468::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1471::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 230)
     }
@@ -28905,14 +28905,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Power<"no-withitems"> = AtomExpr<"all">, "**", Factor<"all"> => ActionFn(1469);
+        // Power<"no-withitems"> = AtomExpr<"all">, "**", Factor<"all"> => ActionFn(1472);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1469::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1472::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 231)
     }
@@ -29080,11 +29080,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // RaiseStatement = "raise" => ActionFn(1470);
+        // RaiseStatement = "raise" => ActionFn(1473);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1470::<>(source_code, mode, __sym0);
+        let __nt = super::__action1473::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (1, 233)
     }
@@ -29097,7 +29097,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // RaiseStatement = "raise", Test<"all">, "from", Test<"all"> => ActionFn(1471);
+        // RaiseStatement = "raise", Test<"all">, "from", Test<"all"> => ActionFn(1474);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant15(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -29105,7 +29105,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1471::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1474::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (4, 233)
     }
@@ -29118,13 +29118,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // RaiseStatement = "raise", Test<"all"> => ActionFn(1472);
+        // RaiseStatement = "raise", Test<"all"> => ActionFn(1475);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1472::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1475::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (2, 233)
     }
@@ -29137,14 +29137,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "(", Pattern, ")" => ActionFn(1473);
+        // SequencePattern = "(", Pattern, ")" => ActionFn(1476);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant35(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1473::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1476::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (3, 234)
     }
@@ -29157,13 +29157,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "(", ")" => ActionFn(1474);
+        // SequencePattern = "(", ")" => ActionFn(1477);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1474::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1477::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (2, 234)
     }
@@ -29176,7 +29176,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "(", Pattern, ",", ")" => ActionFn(1475);
+        // SequencePattern = "(", Pattern, ",", ")" => ActionFn(1478);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -29184,7 +29184,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1475::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1478::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (4, 234)
     }
@@ -29197,7 +29197,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "(", (<Pattern> ",")+, Pattern, ",", ")" => ActionFn(1476);
+        // SequencePattern = "(", (<Pattern> ",")+, Pattern, ",", ")" => ActionFn(1479);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -29206,7 +29206,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1476::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1479::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (5, 234)
     }
@@ -29219,7 +29219,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "(", (<Pattern> ",")+, Pattern, ")" => ActionFn(1477);
+        // SequencePattern = "(", (<Pattern> ",")+, Pattern, ")" => ActionFn(1480);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant35(__symbols);
@@ -29227,7 +29227,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1477::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1480::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (4, 234)
     }
@@ -29240,14 +29240,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "[", Pattern, "]" => ActionFn(1542);
+        // SequencePattern = "[", Pattern, "]" => ActionFn(1545);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant35(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1542::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1545::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (3, 234)
     }
@@ -29260,13 +29260,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "[", "]" => ActionFn(1543);
+        // SequencePattern = "[", "]" => ActionFn(1546);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1543::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1546::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (2, 234)
     }
@@ -29279,7 +29279,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "[", (<Pattern> ",")+, Pattern, "]" => ActionFn(1544);
+        // SequencePattern = "[", (<Pattern> ",")+, Pattern, "]" => ActionFn(1547);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant35(__symbols);
@@ -29287,7 +29287,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1544::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1547::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (4, 234)
     }
@@ -29300,14 +29300,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "[", (<Pattern> ",")+, "]" => ActionFn(1545);
+        // SequencePattern = "[", (<Pattern> ",")+, "]" => ActionFn(1548);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant36(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1545::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1548::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (3, 234)
     }
@@ -29356,14 +29356,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ShiftExpression<"all"> = ShiftExpression<"all">, ShiftOp, ArithmeticExpression<"all"> => ActionFn(1479);
+        // ShiftExpression<"all"> = ShiftExpression<"all">, ShiftOp, ArithmeticExpression<"all"> => ActionFn(1482);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant49(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1479::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1482::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 236)
     }
@@ -29393,14 +29393,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ShiftExpression<"no-withitems"> = ShiftExpression<"all">, ShiftOp, ArithmeticExpression<"all"> => ActionFn(1480);
+        // ShiftExpression<"no-withitems"> = ShiftExpression<"all">, ShiftOp, ArithmeticExpression<"all"> => ActionFn(1483);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant49(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1480::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1483::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 237)
     }
@@ -29464,7 +29464,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SingleForComprehension = "async", "for", ExpressionList, "in", OrTest<"all"> => ActionFn(1548);
+        // SingleForComprehension = "async", "for", ExpressionList, "in", OrTest<"all"> => ActionFn(1551);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant15(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -29473,7 +29473,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1548::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1551::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant90(__nt), __end));
         (5, 239)
     }
@@ -29486,7 +29486,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SingleForComprehension = "async", "for", ExpressionList, "in", OrTest<"all">, ComprehensionIf+ => ActionFn(1549);
+        // SingleForComprehension = "async", "for", ExpressionList, "in", OrTest<"all">, ComprehensionIf+ => ActionFn(1552);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant17(__symbols);
         let __sym4 = __pop_Variant15(__symbols);
@@ -29496,7 +29496,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1549::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1552::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant90(__nt), __end));
         (6, 239)
     }
@@ -29509,7 +29509,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SingleForComprehension = "for", ExpressionList, "in", OrTest<"all"> => ActionFn(1550);
+        // SingleForComprehension = "for", ExpressionList, "in", OrTest<"all"> => ActionFn(1553);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant15(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -29517,7 +29517,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1550::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1553::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant90(__nt), __end));
         (4, 239)
     }
@@ -29530,7 +29530,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SingleForComprehension = "for", ExpressionList, "in", OrTest<"all">, ComprehensionIf+ => ActionFn(1551);
+        // SingleForComprehension = "for", ExpressionList, "in", OrTest<"all">, ComprehensionIf+ => ActionFn(1554);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant17(__symbols);
         let __sym3 = __pop_Variant15(__symbols);
@@ -29539,7 +29539,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1551::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1554::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant90(__nt), __end));
         (5, 239)
     }
@@ -29588,13 +29588,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SliceOp = ":", Test<"all"> => ActionFn(1726);
+        // SliceOp = ":", Test<"all"> => ActionFn(1729);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1726::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1729::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant92(__nt), __end));
         (2, 241)
     }
@@ -29607,11 +29607,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SliceOp = ":" => ActionFn(1727);
+        // SliceOp = ":" => ActionFn(1730);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1727::<>(source_code, mode, __sym0);
+        let __nt = super::__action1730::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant92(__nt), __end));
         (1, 241)
     }
@@ -29844,13 +29844,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // StarExpr = "*", Expression<"all"> => ActionFn(1483);
+        // StarExpr = "*", Expression<"all"> => ActionFn(1486);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1483::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1486::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 244)
     }
@@ -29863,13 +29863,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // StarPattern = "*", Identifier => ActionFn(1484);
+        // StarPattern = "*", Identifier => ActionFn(1487);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant23(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1484::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1487::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (2, 245)
     }
@@ -29882,14 +29882,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // StarTypedParameter = Identifier, ":", TestOrStarExpr => ActionFn(1485);
+        // StarTypedParameter = Identifier, ":", TestOrStarExpr => ActionFn(1488);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1485::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1488::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant64(__nt), __end));
         (3, 246)
     }
@@ -29902,11 +29902,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // StarTypedParameter = Identifier => ActionFn(1486);
+        // StarTypedParameter = Identifier => ActionFn(1489);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1486::<>(source_code, mode, __sym0);
+        let __nt = super::__action1489::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant64(__nt), __end));
         (1, 246)
     }
@@ -29952,11 +29952,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // StarUntypedParameter = Identifier => ActionFn(1487);
+        // StarUntypedParameter = Identifier => ActionFn(1490);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1487::<>(source_code, mode, __sym0);
+        let __nt = super::__action1490::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant64(__nt), __end));
         (1, 248)
     }
@@ -30325,7 +30325,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = Test<"all">, ":", Test<"all">, SliceOp => ActionFn(1728);
+        // Subscript = Test<"all">, ":", Test<"all">, SliceOp => ActionFn(1731);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant92(__symbols);
         let __sym2 = __pop_Variant15(__symbols);
@@ -30333,7 +30333,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1728::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1731::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (4, 255)
     }
@@ -30346,14 +30346,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = Test<"all">, ":", SliceOp => ActionFn(1729);
+        // Subscript = Test<"all">, ":", SliceOp => ActionFn(1732);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant92(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1729::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1732::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 255)
     }
@@ -30366,14 +30366,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = ":", Test<"all">, SliceOp => ActionFn(1730);
+        // Subscript = ":", Test<"all">, SliceOp => ActionFn(1733);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant92(__symbols);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1730::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1733::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 255)
     }
@@ -30386,13 +30386,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = ":", SliceOp => ActionFn(1731);
+        // Subscript = ":", SliceOp => ActionFn(1734);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant92(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1731::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1734::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 255)
     }
@@ -30405,14 +30405,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = Test<"all">, ":", Test<"all"> => ActionFn(1732);
+        // Subscript = Test<"all">, ":", Test<"all"> => ActionFn(1735);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1732::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1735::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 255)
     }
@@ -30425,13 +30425,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = Test<"all">, ":" => ActionFn(1733);
+        // Subscript = Test<"all">, ":" => ActionFn(1736);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1733::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1736::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 255)
     }
@@ -30444,13 +30444,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = ":", Test<"all"> => ActionFn(1734);
+        // Subscript = ":", Test<"all"> => ActionFn(1737);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1734::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1737::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 255)
     }
@@ -30463,11 +30463,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = ":" => ActionFn(1735);
+        // Subscript = ":" => ActionFn(1738);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1735::<>(source_code, mode, __sym0);
+        let __nt = super::__action1738::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 255)
     }
@@ -30497,13 +30497,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SubscriptList = Subscript, "," => ActionFn(1489);
+        // SubscriptList = Subscript, "," => ActionFn(1492);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1489::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1492::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 256)
     }
@@ -30516,13 +30516,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SubscriptList = TwoOrMore<Subscript, ",">, "," => ActionFn(1490);
+        // SubscriptList = TwoOrMore<Subscript, ",">, "," => ActionFn(1493);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant33(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1490::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1493::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 256)
     }
@@ -30535,11 +30535,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SubscriptList = TwoOrMore<Subscript, ","> => ActionFn(1491);
+        // SubscriptList = TwoOrMore<Subscript, ","> => ActionFn(1494);
         let __sym0 = __pop_Variant33(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1491::<>(source_code, mode, __sym0);
+        let __nt = super::__action1494::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 256)
     }
@@ -30653,14 +30653,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Term<"all"> = Term<"all">, MulOp, Factor<"all"> => ActionFn(1492);
+        // Term<"all"> = Term<"all">, MulOp, Factor<"all"> => ActionFn(1495);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant49(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1492::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1495::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 258)
     }
@@ -30690,14 +30690,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Term<"no-withitems"> = Term<"all">, MulOp, Factor<"all"> => ActionFn(1493);
+        // Term<"no-withitems"> = Term<"all">, MulOp, Factor<"all"> => ActionFn(1496);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant49(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1493::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1496::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 259)
     }
@@ -30727,7 +30727,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Test<"all"> = OrTest<"all">, "if", OrTest<"all">, "else", Test<"all"> => ActionFn(1494);
+        // Test<"all"> = OrTest<"all">, "if", OrTest<"all">, "else", Test<"all"> => ActionFn(1497);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant15(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -30736,7 +30736,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1494::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1497::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (5, 260)
     }
@@ -30816,7 +30816,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Test<"no-withitems"> = OrTest<"all">, "if", OrTest<"all">, "else", Test<"all"> => ActionFn(1495);
+        // Test<"no-withitems"> = OrTest<"all">, "if", OrTest<"all">, "else", Test<"all"> => ActionFn(1498);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant15(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -30825,7 +30825,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1495::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1498::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (5, 262)
     }
@@ -30889,11 +30889,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TestList? = GenericList<TestOrStarExpr> => ActionFn(1740);
+        // TestList? = GenericList<TestOrStarExpr> => ActionFn(1743);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1740::<>(source_code, mode, __sym0);
+        let __nt = super::__action1743::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant16(__nt), __end));
         (1, 264)
     }
@@ -30922,11 +30922,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TestListOrYieldExpr = GenericList<TestOrStarExpr> => ActionFn(1741);
+        // TestListOrYieldExpr = GenericList<TestOrStarExpr> => ActionFn(1744);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1741::<>(source_code, mode, __sym0);
+        let __nt = super::__action1744::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 265)
     }
@@ -30990,11 +30990,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TestOrStarExprList = GenericList<TestOrStarExpr> => ActionFn(1742);
+        // TestOrStarExprList = GenericList<TestOrStarExpr> => ActionFn(1745);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1742::<>(source_code, mode, __sym0);
+        let __nt = super::__action1745::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 267)
     }
@@ -31041,13 +31041,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Top = StartModule, Program => ActionFn(1496);
+        // Top = StartModule, Program => ActionFn(1499);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant25(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1496::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1499::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant96(__nt), __end));
         (2, 269)
     }
@@ -31060,13 +31060,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Top = StartExpression, GenericList<TestOrStarExpr> => ActionFn(1743);
+        // Top = StartExpression, GenericList<TestOrStarExpr> => ActionFn(1746);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1743::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1746::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant96(__nt), __end));
         (2, 269)
     }
@@ -31079,14 +31079,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Top = StartExpression, GenericList<TestOrStarExpr>, ("\n")+ => ActionFn(1744);
+        // Top = StartExpression, GenericList<TestOrStarExpr>, ("\n")+ => ActionFn(1747);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant22(__symbols);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1744::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1747::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant96(__nt), __end));
         (3, 269)
     }
@@ -31099,7 +31099,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TryStatement = "try", ":", Suite, ExceptClause+, "else", ":", Suite, "finally", ":", Suite => ActionFn(1499);
+        // TryStatement = "try", ":", Suite, ExceptClause+, "else", ":", Suite, "finally", ":", Suite => ActionFn(1502);
         assert!(__symbols.len() >= 10);
         let __sym9 = __pop_Variant25(__symbols);
         let __sym8 = __pop_Variant0(__symbols);
@@ -31113,7 +31113,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym9.2;
-        let __nt = super::__action1499::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        let __nt = super::__action1502::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (10, 270)
     }
@@ -31126,7 +31126,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TryStatement = "try", ":", Suite, ExceptClause+, "else", ":", Suite => ActionFn(1500);
+        // TryStatement = "try", ":", Suite, ExceptClause+, "else", ":", Suite => ActionFn(1503);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
@@ -31137,7 +31137,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1500::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1503::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (7, 270)
     }
@@ -31150,79 +31150,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TryStatement = "try", ":", Suite, ExceptClause+, "finally", ":", Suite => ActionFn(1501);
-        assert!(__symbols.len() >= 7);
-        let __sym6 = __pop_Variant25(__symbols);
-        let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant67(__symbols);
-        let __sym2 = __pop_Variant25(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym6.2;
-        let __nt = super::__action1501::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
-        __symbols.push((__start, __Symbol::Variant37(__nt), __end));
-        (7, 270)
-    }
-    pub(crate) fn __reduce887<
-    >(
-        source_code: &str,
-        mode: Mode,
-        __lookahead_start: Option<&TextSize>,
-        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>,
-        _: core::marker::PhantomData<()>,
-    ) -> (usize, usize)
-    {
-        // TryStatement = "try", ":", Suite, ExceptClause+ => ActionFn(1502);
-        assert!(__symbols.len() >= 4);
-        let __sym3 = __pop_Variant67(__symbols);
-        let __sym2 = __pop_Variant25(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym3.2;
-        let __nt = super::__action1502::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant37(__nt), __end));
-        (4, 270)
-    }
-    pub(crate) fn __reduce888<
-    >(
-        source_code: &str,
-        mode: Mode,
-        __lookahead_start: Option<&TextSize>,
-        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>,
-        _: core::marker::PhantomData<()>,
-    ) -> (usize, usize)
-    {
-        // TryStatement = "try", ":", Suite, ExceptStarClause+, "else", ":", Suite, "finally", ":", Suite => ActionFn(1503);
-        assert!(__symbols.len() >= 10);
-        let __sym9 = __pop_Variant25(__symbols);
-        let __sym8 = __pop_Variant0(__symbols);
-        let __sym7 = __pop_Variant0(__symbols);
-        let __sym6 = __pop_Variant25(__symbols);
-        let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant67(__symbols);
-        let __sym2 = __pop_Variant25(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym9.2;
-        let __nt = super::__action1503::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
-        __symbols.push((__start, __Symbol::Variant37(__nt), __end));
-        (10, 270)
-    }
-    pub(crate) fn __reduce889<
-    >(
-        source_code: &str,
-        mode: Mode,
-        __lookahead_start: Option<&TextSize>,
-        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>,
-        _: core::marker::PhantomData<()>,
-    ) -> (usize, usize)
-    {
-        // TryStatement = "try", ":", Suite, ExceptStarClause+, "else", ":", Suite => ActionFn(1504);
+        // TryStatement = "try", ":", Suite, ExceptClause+, "finally", ":", Suite => ActionFn(1504);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
@@ -31237,7 +31165,7 @@ mod __parse__Top {
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (7, 270)
     }
-    pub(crate) fn __reduce890<
+    pub(crate) fn __reduce887<
     >(
         source_code: &str,
         mode: Mode,
@@ -31246,7 +31174,55 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TryStatement = "try", ":", Suite, ExceptStarClause+, "finally", ":", Suite => ActionFn(1505);
+        // TryStatement = "try", ":", Suite, ExceptClause+ => ActionFn(1505);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant67(__symbols);
+        let __sym2 = __pop_Variant25(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym3.2;
+        let __nt = super::__action1505::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant37(__nt), __end));
+        (4, 270)
+    }
+    pub(crate) fn __reduce888<
+    >(
+        source_code: &str,
+        mode: Mode,
+        __lookahead_start: Option<&TextSize>,
+        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>,
+        _: core::marker::PhantomData<()>,
+    ) -> (usize, usize)
+    {
+        // TryStatement = "try", ":", Suite, ExceptStarClause+, "else", ":", Suite, "finally", ":", Suite => ActionFn(1506);
+        assert!(__symbols.len() >= 10);
+        let __sym9 = __pop_Variant25(__symbols);
+        let __sym8 = __pop_Variant0(__symbols);
+        let __sym7 = __pop_Variant0(__symbols);
+        let __sym6 = __pop_Variant25(__symbols);
+        let __sym5 = __pop_Variant0(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant67(__symbols);
+        let __sym2 = __pop_Variant25(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym9.2;
+        let __nt = super::__action1506::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        __symbols.push((__start, __Symbol::Variant37(__nt), __end));
+        (10, 270)
+    }
+    pub(crate) fn __reduce889<
+    >(
+        source_code: &str,
+        mode: Mode,
+        __lookahead_start: Option<&TextSize>,
+        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>,
+        _: core::marker::PhantomData<()>,
+    ) -> (usize, usize)
+    {
+        // TryStatement = "try", ":", Suite, ExceptStarClause+, "else", ":", Suite => ActionFn(1507);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
@@ -31257,7 +31233,31 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1505::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1507::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        __symbols.push((__start, __Symbol::Variant37(__nt), __end));
+        (7, 270)
+    }
+    pub(crate) fn __reduce890<
+    >(
+        source_code: &str,
+        mode: Mode,
+        __lookahead_start: Option<&TextSize>,
+        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>,
+        _: core::marker::PhantomData<()>,
+    ) -> (usize, usize)
+    {
+        // TryStatement = "try", ":", Suite, ExceptStarClause+, "finally", ":", Suite => ActionFn(1508);
+        assert!(__symbols.len() >= 7);
+        let __sym6 = __pop_Variant25(__symbols);
+        let __sym5 = __pop_Variant0(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant67(__symbols);
+        let __sym2 = __pop_Variant25(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym6.2;
+        let __nt = super::__action1508::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (7, 270)
     }
@@ -31270,7 +31270,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TryStatement = "try", ":", Suite, ExceptStarClause+ => ActionFn(1506);
+        // TryStatement = "try", ":", Suite, ExceptStarClause+ => ActionFn(1509);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant67(__symbols);
         let __sym2 = __pop_Variant25(__symbols);
@@ -31278,7 +31278,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1506::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1509::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (4, 270)
     }
@@ -31474,11 +31474,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TypeAliasName = Identifier => ActionFn(1507);
+        // TypeAliasName = Identifier => ActionFn(1510);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1507::<>(source_code, mode, __sym0);
+        let __nt = super::__action1510::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant44(__nt), __end));
         (1, 275)
     }
@@ -31491,7 +31491,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TypeAliasStatement = "type", TypeAliasName, TypeParams, "=", Test<"all"> => ActionFn(1776);
+        // TypeAliasStatement = "type", TypeAliasName, TypeParams, "=", Test<"all"> => ActionFn(1779);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant15(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -31500,7 +31500,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1776::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1779::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (5, 276)
     }
@@ -31513,7 +31513,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TypeAliasStatement = "type", TypeAliasName, "=", Test<"all"> => ActionFn(1777);
+        // TypeAliasStatement = "type", TypeAliasName, "=", Test<"all"> => ActionFn(1780);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant15(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -31521,7 +31521,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1777::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1780::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant37(__nt), __end));
         (4, 276)
     }
@@ -31534,14 +31534,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TypeParam = Identifier, ":", Test<"all"> => ActionFn(1509);
+        // TypeParam = Identifier, ":", Test<"all"> => ActionFn(1512);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1509::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1512::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant97(__nt), __end));
         (3, 277)
     }
@@ -31554,11 +31554,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TypeParam = Identifier => ActionFn(1510);
+        // TypeParam = Identifier => ActionFn(1513);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1510::<>(source_code, mode, __sym0);
+        let __nt = super::__action1513::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant97(__nt), __end));
         (1, 277)
     }
@@ -31571,13 +31571,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TypeParam = "*", Identifier => ActionFn(1511);
+        // TypeParam = "*", Identifier => ActionFn(1514);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant23(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1511::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1514::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant97(__nt), __end));
         (2, 277)
     }
@@ -31590,13 +31590,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TypeParam = "**", Identifier => ActionFn(1512);
+        // TypeParam = "**", Identifier => ActionFn(1515);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant23(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1512::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1515::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant97(__nt), __end));
         (2, 277)
     }
@@ -31609,7 +31609,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TypeParams = "[", OneOrMore<TypeParam>, ",", "]" => ActionFn(1513);
+        // TypeParams = "[", OneOrMore<TypeParam>, ",", "]" => ActionFn(1516);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -31617,7 +31617,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1513::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1516::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant98(__nt), __end));
         (4, 278)
     }
@@ -31630,14 +31630,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TypeParams = "[", OneOrMore<TypeParam>, "]" => ActionFn(1514);
+        // TypeParams = "[", OneOrMore<TypeParam>, "]" => ActionFn(1517);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant86(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1514::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1517::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant98(__nt), __end));
         (3, 278)
     }
@@ -31683,14 +31683,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TypedParameter = Identifier, ":", Test<"all"> => ActionFn(1515);
+        // TypedParameter = Identifier, ":", Test<"all"> => ActionFn(1518);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1515::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1518::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 280)
     }
@@ -31703,11 +31703,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TypedParameter = Identifier => ActionFn(1516);
+        // TypedParameter = Identifier => ActionFn(1519);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1516::<>(source_code, mode, __sym0);
+        let __nt = super::__action1519::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 280)
     }
@@ -31771,11 +31771,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // UntypedParameter = Identifier => ActionFn(1517);
+        // UntypedParameter = Identifier => ActionFn(1520);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1517::<>(source_code, mode, __sym0);
+        let __nt = super::__action1520::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 282)
     }
@@ -31788,11 +31788,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ValuePattern = MatchNameOrAttr => ActionFn(1518);
+        // ValuePattern = MatchNameOrAttr => ActionFn(1521);
         let __sym0 = __pop_Variant44(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1518::<>(source_code, mode, __sym0);
+        let __nt = super::__action1521::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (1, 283)
     }
@@ -31918,14 +31918,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItemAs = Test<"all">, "as", Expression<"all"> => ActionFn(1519);
+        // WithItemAs = Test<"all">, "as", Expression<"all"> => ActionFn(1522);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1519::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1522::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (3, 287)
     }
@@ -32251,14 +32251,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // XorExpression<"all"> = XorExpression<"all">, "^", AndExpression<"all"> => ActionFn(1520);
+        // XorExpression<"all"> = XorExpression<"all">, "^", AndExpression<"all"> => ActionFn(1523);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1520::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1523::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 291)
     }
@@ -32288,14 +32288,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // XorExpression<"no-withitems"> = XorExpression<"all">, "^", AndExpression<"all"> => ActionFn(1521);
+        // XorExpression<"no-withitems"> = XorExpression<"all">, "^", AndExpression<"all"> => ActionFn(1524);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1521::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1524::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 292)
     }
@@ -32325,13 +32325,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // YieldExpr = "yield", GenericList<TestOrStarExpr> => ActionFn(1747);
+        // YieldExpr = "yield", GenericList<TestOrStarExpr> => ActionFn(1750);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1747::<>(source_code, mode, __sym0, __sym1);
+        let __nt = super::__action1750::<>(source_code, mode, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 293)
     }
@@ -32344,11 +32344,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // YieldExpr = "yield" => ActionFn(1748);
+        // YieldExpr = "yield" => ActionFn(1751);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1748::<>(source_code, mode, __sym0);
+        let __nt = super::__action1751::<>(source_code, mode, __sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 293)
     }
@@ -32361,14 +32361,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // YieldExpr = "yield", "from", Test<"all"> => ActionFn(1523);
+        // YieldExpr = "yield", "from", Test<"all"> => ActionFn(1526);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1523::<>(source_code, mode, __sym0, __sym1, __sym2);
+        let __nt = super::__action1526::<>(source_code, mode, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 293)
     }
@@ -33803,8 +33803,10 @@ fn __action86<
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
+    (_, tuple_location, _): (TextSize, TextSize, TextSize),
     (_, subject, _): (TextSize, ast::ParenthesizedExpr, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
+    (_, tuple_end_location, _): (TextSize, TextSize, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
@@ -33822,7 +33824,13 @@ fn __action86<
             .end();
         ast::Stmt::Match(
             ast::StmtMatch {
-                subject: Box::new(subject.into()),
+                subject: Box::new(ast::Expr::Tuple(
+                    ast::ExprTuple {
+                        elts: vec![subject.into()],
+                        ctx: ast::ExprContext::Load,
+                        range: (tuple_location..tuple_end_location).into()
+                    },
+                )),
                 cases,
                 range: (location..end_location).into()
             }
@@ -33838,8 +33846,10 @@ fn __action87<
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
+    (_, tuple_location, _): (TextSize, TextSize, TextSize),
     (_, elts, _): (TextSize, Vec<ast::ParenthesizedExpr>, TextSize),
     (_, _, _): (TextSize, core::option::Option<token::Tok>, TextSize),
+    (_, tuple_end_location, _): (TextSize, TextSize, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
@@ -33862,7 +33872,7 @@ fn __action87<
                     ast::ExprTuple {
                         elts,
                         ctx: ast::ExprContext::Load,
-                        range: (location..end_location).into()
+                        range: (tuple_location..tuple_end_location).into()
                     },
                 )),
                 cases,
@@ -42865,21 +42875,23 @@ fn __action630<
     mode: Mode,
     __0: (TextSize, TextSize, TextSize),
     __1: (TextSize, token::Tok, TextSize),
-    __2: (TextSize, Vec<ast::ParenthesizedExpr>, TextSize),
-    __3: (TextSize, token::Tok, TextSize),
+    __2: (TextSize, TextSize, TextSize),
+    __3: (TextSize, Vec<ast::ParenthesizedExpr>, TextSize),
     __4: (TextSize, token::Tok, TextSize),
-    __5: (TextSize, token::Tok, TextSize),
+    __5: (TextSize, TextSize, TextSize),
     __6: (TextSize, token::Tok, TextSize),
-    __7: (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize),
+    __7: (TextSize, token::Tok, TextSize),
     __8: (TextSize, token::Tok, TextSize),
+    __9: (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize),
+    __10: (TextSize, token::Tok, TextSize),
 ) -> ast::Stmt
 {
-    let __start0 = __3.0;
-    let __end0 = __3.2;
+    let __start0 = __4.0;
+    let __end0 = __4.2;
     let __temp0 = __action381(
         source_code,
         mode,
-        __3,
+        __4,
     );
     let __temp0 = (__start0, __temp0, __end0);
     __action87(
@@ -42888,12 +42900,14 @@ fn __action630<
         __0,
         __1,
         __2,
+        __3,
         __temp0,
-        __4,
         __5,
         __6,
         __7,
         __8,
+        __9,
+        __10,
     )
 }
 
@@ -42905,16 +42919,18 @@ fn __action631<
     mode: Mode,
     __0: (TextSize, TextSize, TextSize),
     __1: (TextSize, token::Tok, TextSize),
-    __2: (TextSize, Vec<ast::ParenthesizedExpr>, TextSize),
-    __3: (TextSize, token::Tok, TextSize),
-    __4: (TextSize, token::Tok, TextSize),
+    __2: (TextSize, TextSize, TextSize),
+    __3: (TextSize, Vec<ast::ParenthesizedExpr>, TextSize),
+    __4: (TextSize, TextSize, TextSize),
     __5: (TextSize, token::Tok, TextSize),
-    __6: (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize),
+    __6: (TextSize, token::Tok, TextSize),
     __7: (TextSize, token::Tok, TextSize),
+    __8: (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize),
+    __9: (TextSize, token::Tok, TextSize),
 ) -> ast::Stmt
 {
-    let __start0 = __2.2;
-    let __end0 = __3.0;
+    let __start0 = __3.2;
+    let __end0 = __4.0;
     let __temp0 = __action382(
         source_code,
         mode,
@@ -42928,12 +42944,14 @@ fn __action631<
         __0,
         __1,
         __2,
-        __temp0,
         __3,
+        __temp0,
         __4,
         __5,
         __6,
         __7,
+        __8,
+        __9,
     )
 }
 
@@ -50316,15 +50334,18 @@ fn __action864<
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::ParenthesizedExpr, TextSize),
     __2: (TextSize, token::Tok, TextSize),
-    __3: (TextSize, token::Tok, TextSize),
+    __3: (TextSize, TextSize, TextSize),
     __4: (TextSize, token::Tok, TextSize),
     __5: (TextSize, token::Tok, TextSize),
-    __6: (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize),
-    __7: (TextSize, token::Tok, TextSize),
+    __6: (TextSize, token::Tok, TextSize),
+    __7: (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize),
+    __8: (TextSize, token::Tok, TextSize),
 ) -> ast::Stmt
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
+    let __start1 = __0.2;
+    let __end1 = __1.0;
     let __temp0 = __action414(
         source_code,
         mode,
@@ -50332,11 +50353,19 @@ fn __action864<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
+    let __temp1 = __action414(
+        source_code,
+        mode,
+        &__start1,
+        &__end1,
+    );
+    let __temp1 = (__start1, __temp1, __end1);
     __action86(
         source_code,
         mode,
         __temp0,
         __0,
+        __temp1,
         __1,
         __2,
         __3,
@@ -50344,6 +50373,7 @@ fn __action864<
         __5,
         __6,
         __7,
+        __8,
     )
 }
 
@@ -50356,15 +50386,18 @@ fn __action865<
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::ParenthesizedExpr>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
-    __3: (TextSize, token::Tok, TextSize),
+    __3: (TextSize, TextSize, TextSize),
     __4: (TextSize, token::Tok, TextSize),
     __5: (TextSize, token::Tok, TextSize),
-    __6: (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize),
-    __7: (TextSize, token::Tok, TextSize),
+    __6: (TextSize, token::Tok, TextSize),
+    __7: (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize),
+    __8: (TextSize, token::Tok, TextSize),
 ) -> ast::Stmt
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
+    let __start1 = __0.2;
+    let __end1 = __1.0;
     let __temp0 = __action414(
         source_code,
         mode,
@@ -50372,11 +50405,19 @@ fn __action865<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
+    let __temp1 = __action414(
+        source_code,
+        mode,
+        &__start1,
+        &__end1,
+    );
+    let __temp1 = (__start1, __temp1, __end1);
     __action630(
         source_code,
         mode,
         __temp0,
         __0,
+        __temp1,
         __1,
         __2,
         __3,
@@ -50384,6 +50425,7 @@ fn __action865<
         __5,
         __6,
         __7,
+        __8,
     )
 }
 
@@ -50395,15 +50437,18 @@ fn __action866<
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::ParenthesizedExpr>, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
+    __2: (TextSize, TextSize, TextSize),
     __3: (TextSize, token::Tok, TextSize),
     __4: (TextSize, token::Tok, TextSize),
-    __5: (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize),
-    __6: (TextSize, token::Tok, TextSize),
+    __5: (TextSize, token::Tok, TextSize),
+    __6: (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize),
+    __7: (TextSize, token::Tok, TextSize),
 ) -> ast::Stmt
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
+    let __start1 = __0.2;
+    let __end1 = __1.0;
     let __temp0 = __action414(
         source_code,
         mode,
@@ -50411,17 +50456,26 @@ fn __action866<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
+    let __temp1 = __action414(
+        source_code,
+        mode,
+        &__start1,
+        &__end1,
+    );
+    let __temp1 = (__start1, __temp1, __end1);
     __action631(
         source_code,
         mode,
         __temp0,
         __0,
+        __temp1,
         __1,
         __2,
         __3,
         __4,
         __5,
         __6,
+        __7,
     )
 }
 
@@ -65947,6 +66001,124 @@ fn __action1369<
 >(
     source_code: &str,
     mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, ast::ParenthesizedExpr, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
+    __3: (TextSize, token::Tok, TextSize),
+    __4: (TextSize, token::Tok, TextSize),
+    __5: (TextSize, token::Tok, TextSize),
+    __6: (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize),
+    __7: (TextSize, token::Tok, TextSize),
+) -> ast::Stmt
+{
+    let __start0 = __2.2;
+    let __end0 = __3.0;
+    let __temp0 = __action413(
+        source_code,
+        mode,
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action864(
+        source_code,
+        mode,
+        __0,
+        __1,
+        __2,
+        __temp0,
+        __3,
+        __4,
+        __5,
+        __6,
+        __7,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1370<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, Vec<ast::ParenthesizedExpr>, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
+    __3: (TextSize, token::Tok, TextSize),
+    __4: (TextSize, token::Tok, TextSize),
+    __5: (TextSize, token::Tok, TextSize),
+    __6: (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize),
+    __7: (TextSize, token::Tok, TextSize),
+) -> ast::Stmt
+{
+    let __start0 = __2.2;
+    let __end0 = __3.0;
+    let __temp0 = __action413(
+        source_code,
+        mode,
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action865(
+        source_code,
+        mode,
+        __0,
+        __1,
+        __2,
+        __temp0,
+        __3,
+        __4,
+        __5,
+        __6,
+        __7,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1371<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, Vec<ast::ParenthesizedExpr>, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
+    __3: (TextSize, token::Tok, TextSize),
+    __4: (TextSize, token::Tok, TextSize),
+    __5: (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize),
+    __6: (TextSize, token::Tok, TextSize),
+) -> ast::Stmt
+{
+    let __start0 = __1.2;
+    let __end0 = __2.0;
+    let __temp0 = __action413(
+        source_code,
+        mode,
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action866(
+        source_code,
+        mode,
+        __0,
+        __1,
+        __temp0,
+        __2,
+        __3,
+        __4,
+        __5,
+        __6,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1372<
+>(
+    source_code: &str,
+    mode: Mode,
     __0: (TextSize, ast::ParenthesizedExpr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, ast::ParenthesizedExpr, TextSize),
@@ -65973,7 +66145,7 @@ fn __action1369<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1370<
+fn __action1373<
 >(
     source_code: &str,
     mode: Mode,
@@ -65999,7 +66171,7 @@ fn __action1370<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1371<
+fn __action1374<
 >(
     source_code: &str,
     mode: Mode,
@@ -66027,7 +66199,7 @@ fn __action1371<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1372<
+fn __action1375<
 >(
     source_code: &str,
     mode: Mode,
@@ -66055,7 +66227,7 @@ fn __action1372<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1373<
+fn __action1376<
 >(
     source_code: &str,
     mode: Mode,
@@ -66083,7 +66255,7 @@ fn __action1373<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1374<
+fn __action1377<
 >(
     source_code: &str,
     mode: Mode,
@@ -66109,7 +66281,7 @@ fn __action1374<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1375<
+fn __action1378<
 >(
     source_code: &str,
     mode: Mode,
@@ -66137,7 +66309,7 @@ fn __action1375<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1376<
+fn __action1379<
 >(
     source_code: &str,
     mode: Mode,
@@ -66165,7 +66337,7 @@ fn __action1376<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1377<
+fn __action1380<
 >(
     source_code: &str,
     mode: Mode,
@@ -66195,7 +66367,7 @@ fn __action1377<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1378<
+fn __action1381<
 >(
     source_code: &str,
     mode: Mode,
@@ -66225,7 +66397,7 @@ fn __action1378<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1379<
+fn __action1382<
 >(
     source_code: &str,
     mode: Mode,
@@ -66263,7 +66435,7 @@ fn __action1379<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1380<
+fn __action1383<
 >(
     source_code: &str,
     mode: Mode,
@@ -66299,7 +66471,7 @@ fn __action1380<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1381<
+fn __action1384<
 >(
     source_code: &str,
     mode: Mode,
@@ -66339,7 +66511,7 @@ fn __action1381<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1382<
+fn __action1385<
 >(
     source_code: &str,
     mode: Mode,
@@ -66377,7 +66549,7 @@ fn __action1382<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1383<
+fn __action1386<
 >(
     source_code: &str,
     mode: Mode,
@@ -66411,7 +66583,7 @@ fn __action1383<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1384<
+fn __action1387<
 >(
     source_code: &str,
     mode: Mode,
@@ -66443,7 +66615,7 @@ fn __action1384<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1385<
+fn __action1388<
 >(
     source_code: &str,
     mode: Mode,
@@ -66479,7 +66651,7 @@ fn __action1385<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1386<
+fn __action1389<
 >(
     source_code: &str,
     mode: Mode,
@@ -66513,7 +66685,7 @@ fn __action1386<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1387<
+fn __action1390<
 >(
     source_code: &str,
     mode: Mode,
@@ -66541,7 +66713,7 @@ fn __action1387<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1388<
+fn __action1391<
 >(
     source_code: &str,
     mode: Mode,
@@ -66577,7 +66749,7 @@ fn __action1388<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1389<
+fn __action1392<
 >(
     source_code: &str,
     mode: Mode,
@@ -66611,7 +66783,7 @@ fn __action1389<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1390<
+fn __action1393<
 >(
     source_code: &str,
     mode: Mode,
@@ -66649,7 +66821,7 @@ fn __action1390<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1391<
+fn __action1394<
 >(
     source_code: &str,
     mode: Mode,
@@ -66685,7 +66857,7 @@ fn __action1391<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1392<
+fn __action1395<
 >(
     source_code: &str,
     mode: Mode,
@@ -66717,7 +66889,7 @@ fn __action1392<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1393<
+fn __action1396<
 >(
     source_code: &str,
     mode: Mode,
@@ -66747,7 +66919,7 @@ fn __action1393<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1394<
+fn __action1397<
 >(
     source_code: &str,
     mode: Mode,
@@ -66781,7 +66953,7 @@ fn __action1394<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1395<
+fn __action1398<
 >(
     source_code: &str,
     mode: Mode,
@@ -66813,7 +66985,7 @@ fn __action1395<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1396<
+fn __action1399<
 >(
     source_code: &str,
     mode: Mode,
@@ -66839,7 +67011,7 @@ fn __action1396<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1397<
+fn __action1400<
 >(
     source_code: &str,
     mode: Mode,
@@ -66871,7 +67043,7 @@ fn __action1397<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1398<
+fn __action1401<
 >(
     source_code: &str,
     mode: Mode,
@@ -66901,7 +67073,7 @@ fn __action1398<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1399<
+fn __action1402<
 >(
     source_code: &str,
     mode: Mode,
@@ -66935,7 +67107,7 @@ fn __action1399<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1400<
+fn __action1403<
 >(
     source_code: &str,
     mode: Mode,
@@ -66967,7 +67139,7 @@ fn __action1400<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1401<
+fn __action1404<
 >(
     source_code: &str,
     mode: Mode,
@@ -67003,7 +67175,7 @@ fn __action1401<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1402<
+fn __action1405<
 >(
     source_code: &str,
     mode: Mode,
@@ -67037,7 +67209,7 @@ fn __action1402<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1403<
+fn __action1406<
 >(
     source_code: &str,
     mode: Mode,
@@ -67067,7 +67239,7 @@ fn __action1403<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1404<
+fn __action1407<
 >(
     source_code: &str,
     mode: Mode,
@@ -67095,7 +67267,7 @@ fn __action1404<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1405<
+fn __action1408<
 >(
     source_code: &str,
     mode: Mode,
@@ -67127,7 +67299,7 @@ fn __action1405<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1406<
+fn __action1409<
 >(
     source_code: &str,
     mode: Mode,
@@ -67157,7 +67329,7 @@ fn __action1406<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1407<
+fn __action1410<
 >(
     source_code: &str,
     mode: Mode,
@@ -67189,7 +67361,7 @@ fn __action1407<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1408<
+fn __action1411<
 >(
     source_code: &str,
     mode: Mode,
@@ -67219,7 +67391,7 @@ fn __action1408<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1409<
+fn __action1412<
 >(
     source_code: &str,
     mode: Mode,
@@ -67253,7 +67425,7 @@ fn __action1409<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1410<
+fn __action1413<
 >(
     source_code: &str,
     mode: Mode,
@@ -67285,7 +67457,7 @@ fn __action1410<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1411<
+fn __action1414<
 >(
     source_code: &str,
     mode: Mode,
@@ -67313,7 +67485,7 @@ fn __action1411<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1412<
+fn __action1415<
 >(
     source_code: &str,
     mode: Mode,
@@ -67339,7 +67511,7 @@ fn __action1412<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1413<
+fn __action1416<
 >(
     source_code: &str,
     mode: Mode,
@@ -67369,7 +67541,7 @@ fn __action1413<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1414<
+fn __action1417<
 >(
     source_code: &str,
     mode: Mode,
@@ -67397,7 +67569,7 @@ fn __action1414<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1415<
+fn __action1418<
 >(
     source_code: &str,
     mode: Mode,
@@ -67425,7 +67597,7 @@ fn __action1415<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1416<
+fn __action1419<
 >(
     source_code: &str,
     mode: Mode,
@@ -67451,7 +67623,7 @@ fn __action1416<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1417<
+fn __action1420<
 >(
     source_code: &str,
     mode: Mode,
@@ -67489,7 +67661,7 @@ fn __action1417<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1418<
+fn __action1421<
 >(
     source_code: &str,
     mode: Mode,
@@ -67525,7 +67697,7 @@ fn __action1418<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1419<
+fn __action1422<
 >(
     source_code: &str,
     mode: Mode,
@@ -67565,7 +67737,7 @@ fn __action1419<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1420<
+fn __action1423<
 >(
     source_code: &str,
     mode: Mode,
@@ -67603,7 +67775,7 @@ fn __action1420<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1421<
+fn __action1424<
 >(
     source_code: &str,
     mode: Mode,
@@ -67637,7 +67809,7 @@ fn __action1421<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1422<
+fn __action1425<
 >(
     source_code: &str,
     mode: Mode,
@@ -67669,7 +67841,7 @@ fn __action1422<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1423<
+fn __action1426<
 >(
     source_code: &str,
     mode: Mode,
@@ -67705,7 +67877,7 @@ fn __action1423<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1424<
+fn __action1427<
 >(
     source_code: &str,
     mode: Mode,
@@ -67739,7 +67911,7 @@ fn __action1424<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1425<
+fn __action1428<
 >(
     source_code: &str,
     mode: Mode,
@@ -67767,7 +67939,7 @@ fn __action1425<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1426<
+fn __action1429<
 >(
     source_code: &str,
     mode: Mode,
@@ -67803,7 +67975,7 @@ fn __action1426<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1427<
+fn __action1430<
 >(
     source_code: &str,
     mode: Mode,
@@ -67837,7 +68009,7 @@ fn __action1427<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1428<
+fn __action1431<
 >(
     source_code: &str,
     mode: Mode,
@@ -67875,7 +68047,7 @@ fn __action1428<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1429<
+fn __action1432<
 >(
     source_code: &str,
     mode: Mode,
@@ -67911,7 +68083,7 @@ fn __action1429<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1430<
+fn __action1433<
 >(
     source_code: &str,
     mode: Mode,
@@ -67943,7 +68115,7 @@ fn __action1430<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1431<
+fn __action1434<
 >(
     source_code: &str,
     mode: Mode,
@@ -67973,7 +68145,7 @@ fn __action1431<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1432<
+fn __action1435<
 >(
     source_code: &str,
     mode: Mode,
@@ -68007,7 +68179,7 @@ fn __action1432<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1433<
+fn __action1436<
 >(
     source_code: &str,
     mode: Mode,
@@ -68039,7 +68211,7 @@ fn __action1433<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1434<
+fn __action1437<
 >(
     source_code: &str,
     mode: Mode,
@@ -68065,7 +68237,7 @@ fn __action1434<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1435<
+fn __action1438<
 >(
     source_code: &str,
     mode: Mode,
@@ -68097,7 +68269,7 @@ fn __action1435<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1436<
+fn __action1439<
 >(
     source_code: &str,
     mode: Mode,
@@ -68127,7 +68299,7 @@ fn __action1436<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1437<
+fn __action1440<
 >(
     source_code: &str,
     mode: Mode,
@@ -68161,7 +68333,7 @@ fn __action1437<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1438<
+fn __action1441<
 >(
     source_code: &str,
     mode: Mode,
@@ -68193,7 +68365,7 @@ fn __action1438<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1439<
+fn __action1442<
 >(
     source_code: &str,
     mode: Mode,
@@ -68229,7 +68401,7 @@ fn __action1439<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1440<
+fn __action1443<
 >(
     source_code: &str,
     mode: Mode,
@@ -68263,7 +68435,7 @@ fn __action1440<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1441<
+fn __action1444<
 >(
     source_code: &str,
     mode: Mode,
@@ -68293,7 +68465,7 @@ fn __action1441<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1442<
+fn __action1445<
 >(
     source_code: &str,
     mode: Mode,
@@ -68321,7 +68493,7 @@ fn __action1442<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1443<
+fn __action1446<
 >(
     source_code: &str,
     mode: Mode,
@@ -68353,7 +68525,7 @@ fn __action1443<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1444<
+fn __action1447<
 >(
     source_code: &str,
     mode: Mode,
@@ -68383,7 +68555,7 @@ fn __action1444<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1445<
+fn __action1448<
 >(
     source_code: &str,
     mode: Mode,
@@ -68415,7 +68587,7 @@ fn __action1445<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1446<
+fn __action1449<
 >(
     source_code: &str,
     mode: Mode,
@@ -68445,7 +68617,7 @@ fn __action1446<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1447<
+fn __action1450<
 >(
     source_code: &str,
     mode: Mode,
@@ -68479,7 +68651,7 @@ fn __action1447<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1448<
+fn __action1451<
 >(
     source_code: &str,
     mode: Mode,
@@ -68511,7 +68683,7 @@ fn __action1448<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1449<
+fn __action1452<
 >(
     source_code: &str,
     mode: Mode,
@@ -68539,7 +68711,7 @@ fn __action1449<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1450<
+fn __action1453<
 >(
     source_code: &str,
     mode: Mode,
@@ -68565,7 +68737,7 @@ fn __action1450<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1451<
+fn __action1454<
 >(
     source_code: &str,
     mode: Mode,
@@ -68595,7 +68767,7 @@ fn __action1451<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1452<
+fn __action1455<
 >(
     source_code: &str,
     mode: Mode,
@@ -68623,7 +68795,7 @@ fn __action1452<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1453<
+fn __action1456<
 >(
     source_code: &str,
     mode: Mode,
@@ -68651,7 +68823,7 @@ fn __action1453<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1454<
+fn __action1457<
 >(
     source_code: &str,
     mode: Mode,
@@ -68677,7 +68849,7 @@ fn __action1454<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1455<
+fn __action1458<
 >(
     source_code: &str,
     mode: Mode,
@@ -68707,7 +68879,7 @@ fn __action1455<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1456<
+fn __action1459<
 >(
     source_code: &str,
     mode: Mode,
@@ -68735,7 +68907,7 @@ fn __action1456<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1457<
+fn __action1460<
 >(
     source_code: &str,
     mode: Mode,
@@ -68761,7 +68933,7 @@ fn __action1457<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1458<
+fn __action1461<
 >(
     source_code: &str,
     mode: Mode,
@@ -68797,7 +68969,7 @@ fn __action1458<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1459<
+fn __action1462<
 >(
     source_code: &str,
     mode: Mode,
@@ -68831,7 +69003,7 @@ fn __action1459<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1460<
+fn __action1463<
 >(
     source_code: &str,
     mode: Mode,
@@ -68863,7 +69035,7 @@ fn __action1460<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1461<
+fn __action1464<
 >(
     source_code: &str,
     mode: Mode,
@@ -68893,7 +69065,7 @@ fn __action1461<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1462<
+fn __action1465<
 >(
     source_code: &str,
     mode: Mode,
@@ -68925,7 +69097,7 @@ fn __action1462<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1463<
+fn __action1466<
 >(
     source_code: &str,
     mode: Mode,
@@ -68955,7 +69127,7 @@ fn __action1463<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1464<
+fn __action1467<
 >(
     source_code: &str,
     mode: Mode,
@@ -68983,7 +69155,7 @@ fn __action1464<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1465<
+fn __action1468<
 >(
     source_code: &str,
     mode: Mode,
@@ -69011,7 +69183,7 @@ fn __action1465<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1466<
+fn __action1469<
 >(
     source_code: &str,
     mode: Mode,
@@ -69039,7 +69211,7 @@ fn __action1466<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1467<
+fn __action1470<
 >(
     source_code: &str,
     mode: Mode,
@@ -69065,7 +69237,7 @@ fn __action1467<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1468<
+fn __action1471<
 >(
     source_code: &str,
     mode: Mode,
@@ -69095,7 +69267,7 @@ fn __action1468<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1469<
+fn __action1472<
 >(
     source_code: &str,
     mode: Mode,
@@ -69125,7 +69297,7 @@ fn __action1469<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1470<
+fn __action1473<
 >(
     source_code: &str,
     mode: Mode,
@@ -69151,7 +69323,7 @@ fn __action1470<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1471<
+fn __action1474<
 >(
     source_code: &str,
     mode: Mode,
@@ -69183,7 +69355,7 @@ fn __action1471<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1472<
+fn __action1475<
 >(
     source_code: &str,
     mode: Mode,
@@ -69211,7 +69383,7 @@ fn __action1472<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1473<
+fn __action1476<
 >(
     source_code: &str,
     mode: Mode,
@@ -69241,7 +69413,7 @@ fn __action1473<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1474<
+fn __action1477<
 >(
     source_code: &str,
     mode: Mode,
@@ -69269,7 +69441,7 @@ fn __action1474<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1475<
+fn __action1478<
 >(
     source_code: &str,
     mode: Mode,
@@ -69301,7 +69473,7 @@ fn __action1475<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1476<
+fn __action1479<
 >(
     source_code: &str,
     mode: Mode,
@@ -69335,7 +69507,7 @@ fn __action1476<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1477<
+fn __action1480<
 >(
     source_code: &str,
     mode: Mode,
@@ -69367,7 +69539,7 @@ fn __action1477<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1478<
+fn __action1481<
 >(
     source_code: &str,
     mode: Mode,
@@ -69397,7 +69569,7 @@ fn __action1478<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1479<
+fn __action1482<
 >(
     source_code: &str,
     mode: Mode,
@@ -69427,7 +69599,7 @@ fn __action1479<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1480<
+fn __action1483<
 >(
     source_code: &str,
     mode: Mode,
@@ -69457,7 +69629,7 @@ fn __action1480<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1481<
+fn __action1484<
 >(
     source_code: &str,
     mode: Mode,
@@ -69493,7 +69665,7 @@ fn __action1481<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1482<
+fn __action1485<
 >(
     source_code: &str,
     mode: Mode,
@@ -69527,7 +69699,7 @@ fn __action1482<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1483<
+fn __action1486<
 >(
     source_code: &str,
     mode: Mode,
@@ -69555,7 +69727,7 @@ fn __action1483<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1484<
+fn __action1487<
 >(
     source_code: &str,
     mode: Mode,
@@ -69583,7 +69755,7 @@ fn __action1484<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1485<
+fn __action1488<
 >(
     source_code: &str,
     mode: Mode,
@@ -69613,7 +69785,7 @@ fn __action1485<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1486<
+fn __action1489<
 >(
     source_code: &str,
     mode: Mode,
@@ -69639,7 +69811,7 @@ fn __action1486<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1487<
+fn __action1490<
 >(
     source_code: &str,
     mode: Mode,
@@ -69665,7 +69837,7 @@ fn __action1487<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1488<
+fn __action1491<
 >(
     source_code: &str,
     mode: Mode,
@@ -69697,7 +69869,7 @@ fn __action1488<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1489<
+fn __action1492<
 >(
     source_code: &str,
     mode: Mode,
@@ -69725,7 +69897,7 @@ fn __action1489<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1490<
+fn __action1493<
 >(
     source_code: &str,
     mode: Mode,
@@ -69753,7 +69925,7 @@ fn __action1490<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1491<
+fn __action1494<
 >(
     source_code: &str,
     mode: Mode,
@@ -69779,7 +69951,7 @@ fn __action1491<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1492<
+fn __action1495<
 >(
     source_code: &str,
     mode: Mode,
@@ -69809,7 +69981,7 @@ fn __action1492<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1493<
+fn __action1496<
 >(
     source_code: &str,
     mode: Mode,
@@ -69839,7 +70011,7 @@ fn __action1493<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1494<
+fn __action1497<
 >(
     source_code: &str,
     mode: Mode,
@@ -69873,7 +70045,7 @@ fn __action1494<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1495<
+fn __action1498<
 >(
     source_code: &str,
     mode: Mode,
@@ -69907,7 +70079,7 @@ fn __action1495<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1496<
+fn __action1499<
 >(
     source_code: &str,
     mode: Mode,
@@ -69935,7 +70107,7 @@ fn __action1496<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1497<
+fn __action1500<
 >(
     source_code: &str,
     mode: Mode,
@@ -69963,7 +70135,7 @@ fn __action1497<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1498<
+fn __action1501<
 >(
     source_code: &str,
     mode: Mode,
@@ -69993,7 +70165,7 @@ fn __action1498<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1499<
+fn __action1502<
 >(
     source_code: &str,
     mode: Mode,
@@ -70037,7 +70209,7 @@ fn __action1499<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1500<
+fn __action1503<
 >(
     source_code: &str,
     mode: Mode,
@@ -70075,7 +70247,7 @@ fn __action1500<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1501<
+fn __action1504<
 >(
     source_code: &str,
     mode: Mode,
@@ -70113,7 +70285,7 @@ fn __action1501<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1502<
+fn __action1505<
 >(
     source_code: &str,
     mode: Mode,
@@ -70145,7 +70317,7 @@ fn __action1502<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1503<
+fn __action1506<
 >(
     source_code: &str,
     mode: Mode,
@@ -70189,7 +70361,7 @@ fn __action1503<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1504<
+fn __action1507<
 >(
     source_code: &str,
     mode: Mode,
@@ -70227,7 +70399,7 @@ fn __action1504<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1505<
+fn __action1508<
 >(
     source_code: &str,
     mode: Mode,
@@ -70265,7 +70437,7 @@ fn __action1505<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1506<
+fn __action1509<
 >(
     source_code: &str,
     mode: Mode,
@@ -70297,7 +70469,7 @@ fn __action1506<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1507<
+fn __action1510<
 >(
     source_code: &str,
     mode: Mode,
@@ -70323,7 +70495,7 @@ fn __action1507<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1508<
+fn __action1511<
 >(
     source_code: &str,
     mode: Mode,
@@ -70357,7 +70529,7 @@ fn __action1508<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1509<
+fn __action1512<
 >(
     source_code: &str,
     mode: Mode,
@@ -70387,7 +70559,7 @@ fn __action1509<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1510<
+fn __action1513<
 >(
     source_code: &str,
     mode: Mode,
@@ -70413,7 +70585,7 @@ fn __action1510<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1511<
+fn __action1514<
 >(
     source_code: &str,
     mode: Mode,
@@ -70441,7 +70613,7 @@ fn __action1511<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1512<
+fn __action1515<
 >(
     source_code: &str,
     mode: Mode,
@@ -70469,7 +70641,7 @@ fn __action1512<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1513<
+fn __action1516<
 >(
     source_code: &str,
     mode: Mode,
@@ -70501,7 +70673,7 @@ fn __action1513<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1514<
+fn __action1517<
 >(
     source_code: &str,
     mode: Mode,
@@ -70531,7 +70703,7 @@ fn __action1514<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1515<
+fn __action1518<
 >(
     source_code: &str,
     mode: Mode,
@@ -70561,7 +70733,7 @@ fn __action1515<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1516<
+fn __action1519<
 >(
     source_code: &str,
     mode: Mode,
@@ -70587,7 +70759,7 @@ fn __action1516<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1517<
+fn __action1520<
 >(
     source_code: &str,
     mode: Mode,
@@ -70613,7 +70785,7 @@ fn __action1517<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1518<
+fn __action1521<
 >(
     source_code: &str,
     mode: Mode,
@@ -70639,7 +70811,7 @@ fn __action1518<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1519<
+fn __action1522<
 >(
     source_code: &str,
     mode: Mode,
@@ -70669,7 +70841,7 @@ fn __action1519<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1520<
+fn __action1523<
 >(
     source_code: &str,
     mode: Mode,
@@ -70699,7 +70871,7 @@ fn __action1520<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1521<
+fn __action1524<
 >(
     source_code: &str,
     mode: Mode,
@@ -70729,7 +70901,7 @@ fn __action1521<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1522<
+fn __action1525<
 >(
     source_code: &str,
     mode: Mode,
@@ -70757,7 +70929,7 @@ fn __action1522<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1523<
+fn __action1526<
 >(
     source_code: &str,
     mode: Mode,
@@ -70787,7 +70959,7 @@ fn __action1523<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1524<
+fn __action1527<
 >(
     source_code: &str,
     mode: Mode,
@@ -70823,7 +70995,7 @@ fn __action1524<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1525<
+fn __action1528<
 >(
     source_code: &str,
     mode: Mode,
@@ -70859,7 +71031,7 @@ fn __action1525<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1526<
+fn __action1529<
 >(
     source_code: &str,
     mode: Mode,
@@ -70885,7 +71057,7 @@ fn __action1526<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1527<
+fn __action1530<
 >(
     source_code: &str,
     mode: Mode,
@@ -70911,7 +71083,7 @@ fn __action1527<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1528<
+fn __action1531<
 >(
     source_code: &str,
     mode: Mode,
@@ -70941,7 +71113,7 @@ fn __action1528<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1529<
+fn __action1532<
 >(
     source_code: &str,
     mode: Mode,
@@ -70971,7 +71143,7 @@ fn __action1529<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1530<
+fn __action1533<
 >(
     source_code: &str,
     mode: Mode,
@@ -70995,7 +71167,7 @@ fn __action1530<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1531<
+fn __action1534<
 >(
     source_code: &str,
     mode: Mode,
@@ -71021,7 +71193,7 @@ fn __action1531<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1532<
+fn __action1535<
 >(
     source_code: &str,
     mode: Mode,
@@ -71047,7 +71219,7 @@ fn __action1532<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1533<
+fn __action1536<
 >(
     source_code: &str,
     mode: Mode,
@@ -71073,98 +71245,12 @@ fn __action1533<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1534<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, (Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr), TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
-{
-    let __start0 = __1.0;
-    let __end0 = __1.2;
-    let __temp0 = __action1530(
-        source_code,
-        mode,
-        __1,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1230(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-        __2,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1535<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
-{
-    let __start0 = __0.2;
-    let __end0 = __1.0;
-    let __temp0 = __action1531(
-        source_code,
-        mode,
-        &__start0,
-        &__end0,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1230(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-        __1,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1536<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, alloc::vec::Vec<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>, TextSize),
-    __2: (TextSize, (Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr), TextSize),
-    __3: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
-{
-    let __start0 = __1.0;
-    let __end0 = __2.2;
-    let __temp0 = __action1532(
-        source_code,
-        mode,
-        __1,
-        __2,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1230(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-        __3,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
 fn __action1537<
 >(
     source_code: &str,
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, alloc::vec::Vec<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>, TextSize),
+    __1: (TextSize, (Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr), TextSize),
     __2: (TextSize, token::Tok, TextSize),
 ) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
@@ -71191,6 +71277,92 @@ fn __action1538<
 >(
     source_code: &str,
     mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+{
+    let __start0 = __0.2;
+    let __end0 = __1.0;
+    let __temp0 = __action1534(
+        source_code,
+        mode,
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1230(
+        source_code,
+        mode,
+        __0,
+        __temp0,
+        __1,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1539<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, alloc::vec::Vec<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>, TextSize),
+    __2: (TextSize, (Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr), TextSize),
+    __3: (TextSize, token::Tok, TextSize),
+) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+{
+    let __start0 = __1.0;
+    let __end0 = __2.2;
+    let __temp0 = __action1535(
+        source_code,
+        mode,
+        __1,
+        __2,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1230(
+        source_code,
+        mode,
+        __0,
+        __temp0,
+        __3,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1540<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, alloc::vec::Vec<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
+) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+{
+    let __start0 = __1.0;
+    let __end0 = __1.2;
+    let __temp0 = __action1536(
+        source_code,
+        mode,
+        __1,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1230(
+        source_code,
+        mode,
+        __0,
+        __temp0,
+        __2,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1541<
+>(
+    source_code: &str,
+    mode: Mode,
     __0: (TextSize, ast::Pattern, TextSize),
 ) -> Vec<ast::Pattern>
 {
@@ -71211,7 +71383,7 @@ fn __action1538<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1539<
+fn __action1542<
 >(
     source_code: &str,
     mode: Mode,
@@ -71237,7 +71409,7 @@ fn __action1539<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1540<
+fn __action1543<
 >(
     source_code: &str,
     mode: Mode,
@@ -71263,7 +71435,7 @@ fn __action1540<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1541<
+fn __action1544<
 >(
     source_code: &str,
     mode: Mode,
@@ -71289,98 +71461,12 @@ fn __action1541<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1542<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, ast::Pattern, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-) -> ast::Pattern
-{
-    let __start0 = __1.0;
-    let __end0 = __1.2;
-    let __temp0 = __action1538(
-        source_code,
-        mode,
-        __1,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1478(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-        __2,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1543<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
-) -> ast::Pattern
-{
-    let __start0 = __0.2;
-    let __end0 = __1.0;
-    let __temp0 = __action1539(
-        source_code,
-        mode,
-        &__start0,
-        &__end0,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1478(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-        __1,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1544<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, alloc::vec::Vec<ast::Pattern>, TextSize),
-    __2: (TextSize, ast::Pattern, TextSize),
-    __3: (TextSize, token::Tok, TextSize),
-) -> ast::Pattern
-{
-    let __start0 = __1.0;
-    let __end0 = __2.2;
-    let __temp0 = __action1540(
-        source_code,
-        mode,
-        __1,
-        __2,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1478(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-        __3,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
 fn __action1545<
 >(
     source_code: &str,
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, alloc::vec::Vec<ast::Pattern>, TextSize),
+    __1: (TextSize, ast::Pattern, TextSize),
     __2: (TextSize, token::Tok, TextSize),
 ) -> ast::Pattern
 {
@@ -71392,7 +71478,7 @@ fn __action1545<
         __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1478(
+    __action1481(
         source_code,
         mode,
         __0,
@@ -71404,6 +71490,92 @@ fn __action1545<
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
 fn __action1546<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+) -> ast::Pattern
+{
+    let __start0 = __0.2;
+    let __end0 = __1.0;
+    let __temp0 = __action1542(
+        source_code,
+        mode,
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1481(
+        source_code,
+        mode,
+        __0,
+        __temp0,
+        __1,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1547<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::Pattern>, TextSize),
+    __2: (TextSize, ast::Pattern, TextSize),
+    __3: (TextSize, token::Tok, TextSize),
+) -> ast::Pattern
+{
+    let __start0 = __1.0;
+    let __end0 = __2.2;
+    let __temp0 = __action1543(
+        source_code,
+        mode,
+        __1,
+        __2,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1481(
+        source_code,
+        mode,
+        __0,
+        __temp0,
+        __3,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1548<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::Pattern>, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
+) -> ast::Pattern
+{
+    let __start0 = __1.0;
+    let __end0 = __1.2;
+    let __temp0 = __action1544(
+        source_code,
+        mode,
+        __1,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1481(
+        source_code,
+        mode,
+        __0,
+        __temp0,
+        __2,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1549<
 >(
     source_code: &str,
     mode: Mode,
@@ -71429,7 +71601,7 @@ fn __action1546<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1547<
+fn __action1550<
 >(
     source_code: &str,
     mode: Mode,
@@ -71455,7 +71627,7 @@ fn __action1547<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1548<
+fn __action1551<
 >(
     source_code: &str,
     mode: Mode,
@@ -71475,7 +71647,7 @@ fn __action1548<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1481(
+    __action1484(
         source_code,
         mode,
         __0,
@@ -71489,7 +71661,7 @@ fn __action1548<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1549<
+fn __action1552<
 >(
     source_code: &str,
     mode: Mode,
@@ -71509,7 +71681,7 @@ fn __action1549<
         __5,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1481(
+    __action1484(
         source_code,
         mode,
         __0,
@@ -71523,7 +71695,7 @@ fn __action1549<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1550<
+fn __action1553<
 >(
     source_code: &str,
     mode: Mode,
@@ -71542,7 +71714,7 @@ fn __action1550<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1482(
+    __action1485(
         source_code,
         mode,
         __0,
@@ -71555,7 +71727,7 @@ fn __action1550<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1551<
+fn __action1554<
 >(
     source_code: &str,
     mode: Mode,
@@ -71574,7 +71746,7 @@ fn __action1551<
         __4,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1482(
+    __action1485(
         source_code,
         mode,
         __0,
@@ -71587,7 +71759,7 @@ fn __action1551<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1552<
+fn __action1555<
 >(
     source_code: &str,
     mode: Mode,
@@ -71608,7 +71780,7 @@ fn __action1552<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1524(
+    __action1527(
         source_code,
         mode,
         __temp0,
@@ -71623,7 +71795,7 @@ fn __action1552<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1553<
+fn __action1556<
 >(
     source_code: &str,
     mode: Mode,
@@ -71644,7 +71816,7 @@ fn __action1553<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1524(
+    __action1527(
         source_code,
         mode,
         __temp0,
@@ -71659,7 +71831,7 @@ fn __action1553<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1554<
+fn __action1557<
 >(
     source_code: &str,
     mode: Mode,
@@ -71679,7 +71851,7 @@ fn __action1554<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1525(
+    __action1528(
         source_code,
         mode,
         __temp0,
@@ -71693,7 +71865,7 @@ fn __action1554<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1555<
+fn __action1558<
 >(
     source_code: &str,
     mode: Mode,
@@ -71713,7 +71885,7 @@ fn __action1555<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1525(
+    __action1528(
         source_code,
         mode,
         __temp0,
@@ -71727,7 +71899,7 @@ fn __action1555<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1556<
+fn __action1559<
 >(
     source_code: &str,
     mode: Mode,
@@ -71769,7 +71941,7 @@ fn __action1556<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1557<
+fn __action1560<
 >(
     source_code: &str,
     mode: Mode,
@@ -71811,7 +71983,7 @@ fn __action1557<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1558<
+fn __action1561<
 >(
     source_code: &str,
     mode: Mode,
@@ -71849,7 +72021,7 @@ fn __action1558<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1559<
+fn __action1562<
 >(
     source_code: &str,
     mode: Mode,
@@ -71887,7 +72059,7 @@ fn __action1559<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1560<
+fn __action1563<
 >(
     source_code: &str,
     mode: Mode,
@@ -71927,7 +72099,7 @@ fn __action1560<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1561<
+fn __action1564<
 >(
     source_code: &str,
     mode: Mode,
@@ -71967,7 +72139,7 @@ fn __action1561<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1562<
+fn __action1565<
 >(
     source_code: &str,
     mode: Mode,
@@ -72003,7 +72175,7 @@ fn __action1562<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1563<
+fn __action1566<
 >(
     source_code: &str,
     mode: Mode,
@@ -72039,119 +72211,119 @@ fn __action1563<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1564<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, Vec<(Option<Box<ast::ParenthesizedExpr>>, ast::ParenthesizedExpr)>, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-) -> ast::ParenthesizedExpr
-{
-    let __start0 = __1.0;
-    let __end0 = __1.2;
-    let __temp0 = __action564(
-        source_code,
-        mode,
-        __1,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1255(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-        __2,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1565<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
-) -> ast::ParenthesizedExpr
-{
-    let __start0 = __0.2;
-    let __end0 = __1.0;
-    let __temp0 = __action565(
-        source_code,
-        mode,
-        &__start0,
-        &__end0,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1255(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-        __1,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1566<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, Vec<(Option<Box<ast::ParenthesizedExpr>>, ast::ParenthesizedExpr)>, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-) -> ast::ParenthesizedExpr
-{
-    let __start0 = __1.0;
-    let __end0 = __1.2;
-    let __temp0 = __action564(
-        source_code,
-        mode,
-        __1,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1280(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-        __2,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
 fn __action1567<
 >(
     source_code: &str,
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, Vec<(Option<Box<ast::ParenthesizedExpr>>, ast::ParenthesizedExpr)>, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
 ) -> ast::ParenthesizedExpr
 {
-    let __start0 = __0.2;
-    let __end0 = __1.0;
-    let __temp0 = __action565(
+    let __start0 = __1.0;
+    let __end0 = __1.2;
+    let __temp0 = __action564(
         source_code,
         mode,
-        &__start0,
-        &__end0,
+        __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1280(
+    __action1255(
         source_code,
         mode,
         __0,
         __temp0,
-        __1,
+        __2,
     )
 }
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
 fn __action1568<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+) -> ast::ParenthesizedExpr
+{
+    let __start0 = __0.2;
+    let __end0 = __1.0;
+    let __temp0 = __action565(
+        source_code,
+        mode,
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1255(
+        source_code,
+        mode,
+        __0,
+        __temp0,
+        __1,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1569<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, Vec<(Option<Box<ast::ParenthesizedExpr>>, ast::ParenthesizedExpr)>, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
+) -> ast::ParenthesizedExpr
+{
+    let __start0 = __1.0;
+    let __end0 = __1.2;
+    let __temp0 = __action564(
+        source_code,
+        mode,
+        __1,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1280(
+        source_code,
+        mode,
+        __0,
+        __temp0,
+        __2,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1570<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+) -> ast::ParenthesizedExpr
+{
+    let __start0 = __0.2;
+    let __end0 = __1.0;
+    let __temp0 = __action565(
+        source_code,
+        mode,
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1280(
+        source_code,
+        mode,
+        __0,
+        __temp0,
+        __1,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1571<
 >(
     source_code: &str,
     mode: Mode,
@@ -72177,7 +72349,7 @@ fn __action1568<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1569<
+fn __action1572<
 >(
     source_code: &str,
     mode: Mode,
@@ -72203,7 +72375,7 @@ fn __action1569<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1570<
+fn __action1573<
 >(
     source_code: &str,
     mode: Mode,
@@ -72237,7 +72409,7 @@ fn __action1570<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1571<
+fn __action1574<
 >(
     source_code: &str,
     mode: Mode,
@@ -72271,7 +72443,7 @@ fn __action1571<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1572<
+fn __action1575<
 >(
     source_code: &str,
     mode: Mode,
@@ -72303,7 +72475,7 @@ fn __action1572<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1573<
+fn __action1576<
 >(
     source_code: &str,
     mode: Mode,
@@ -72335,7 +72507,7 @@ fn __action1573<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1574<
+fn __action1577<
 >(
     source_code: &str,
     mode: Mode,
@@ -72355,7 +72527,7 @@ fn __action1574<
         __4,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1570(
+    __action1573(
         source_code,
         mode,
         __0,
@@ -72369,7 +72541,7 @@ fn __action1574<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1575<
+fn __action1578<
 >(
     source_code: &str,
     mode: Mode,
@@ -72389,109 +72561,13 @@ fn __action1575<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1570(
+    __action1573(
         source_code,
         mode,
         __0,
         __1,
         __2,
         __3,
-        __temp0,
-        __4,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1576<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, ast::ParenthesizedExpr, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-    __3: (TextSize, ast::Expr, TextSize),
-    __4: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
-{
-    let __start0 = __3.0;
-    let __end0 = __3.2;
-    let __temp0 = __action264(
-        source_code,
-        mode,
-        __3,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1571(
-        source_code,
-        mode,
-        __0,
-        __1,
-        __2,
-        __temp0,
-        __4,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1577<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, ast::ParenthesizedExpr, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-    __3: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
-{
-    let __start0 = __2.2;
-    let __end0 = __3.0;
-    let __temp0 = __action265(
-        source_code,
-        mode,
-        &__start0,
-        &__end0,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1571(
-        source_code,
-        mode,
-        __0,
-        __1,
-        __2,
-        __temp0,
-        __3,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1578<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, ast::ParenthesizedExpr, TextSize),
-    __2: (TextSize, (TextSize, ast::ConversionFlag), TextSize),
-    __3: (TextSize, ast::Expr, TextSize),
-    __4: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
-{
-    let __start0 = __3.0;
-    let __end0 = __3.2;
-    let __temp0 = __action264(
-        source_code,
-        mode,
-        __3,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1572(
-        source_code,
-        mode,
-        __0,
-        __1,
-        __2,
         __temp0,
         __4,
     )
@@ -72505,6 +72581,102 @@ fn __action1579<
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::ParenthesizedExpr, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
+    __3: (TextSize, ast::Expr, TextSize),
+    __4: (TextSize, token::Tok, TextSize),
+) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+{
+    let __start0 = __3.0;
+    let __end0 = __3.2;
+    let __temp0 = __action264(
+        source_code,
+        mode,
+        __3,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1574(
+        source_code,
+        mode,
+        __0,
+        __1,
+        __2,
+        __temp0,
+        __4,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1580<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, ast::ParenthesizedExpr, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
+    __3: (TextSize, token::Tok, TextSize),
+) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+{
+    let __start0 = __2.2;
+    let __end0 = __3.0;
+    let __temp0 = __action265(
+        source_code,
+        mode,
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1574(
+        source_code,
+        mode,
+        __0,
+        __1,
+        __2,
+        __temp0,
+        __3,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1581<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, ast::ParenthesizedExpr, TextSize),
+    __2: (TextSize, (TextSize, ast::ConversionFlag), TextSize),
+    __3: (TextSize, ast::Expr, TextSize),
+    __4: (TextSize, token::Tok, TextSize),
+) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+{
+    let __start0 = __3.0;
+    let __end0 = __3.2;
+    let __temp0 = __action264(
+        source_code,
+        mode,
+        __3,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1575(
+        source_code,
+        mode,
+        __0,
+        __1,
+        __2,
+        __temp0,
+        __4,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1582<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, ast::ParenthesizedExpr, TextSize),
     __2: (TextSize, (TextSize, ast::ConversionFlag), TextSize),
     __3: (TextSize, token::Tok, TextSize),
 ) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
@@ -72518,7 +72690,7 @@ fn __action1579<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1572(
+    __action1575(
         source_code,
         mode,
         __0,
@@ -72531,7 +72703,7 @@ fn __action1579<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1580<
+fn __action1583<
 >(
     source_code: &str,
     mode: Mode,
@@ -72549,7 +72721,7 @@ fn __action1580<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1573(
+    __action1576(
         source_code,
         mode,
         __0,
@@ -72561,7 +72733,7 @@ fn __action1580<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1581<
+fn __action1584<
 >(
     source_code: &str,
     mode: Mode,
@@ -72579,7 +72751,7 @@ fn __action1581<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1573(
+    __action1576(
         source_code,
         mode,
         __0,
@@ -72591,7 +72763,7 @@ fn __action1581<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1582<
+fn __action1585<
 >(
     source_code: &str,
     mode: Mode,
@@ -72619,7 +72791,7 @@ fn __action1582<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1583<
+fn __action1586<
 >(
     source_code: &str,
     mode: Mode,
@@ -72647,7 +72819,7 @@ fn __action1583<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1584<
+fn __action1587<
 >(
     source_code: &str,
     mode: Mode,
@@ -72673,7 +72845,7 @@ fn __action1584<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1585<
+fn __action1588<
 >(
     source_code: &str,
     mode: Mode,
@@ -72697,7 +72869,7 @@ fn __action1585<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1586<
+fn __action1589<
 >(
     source_code: &str,
     mode: Mode,
@@ -72725,7 +72897,7 @@ fn __action1586<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1587<
+fn __action1590<
 >(
     source_code: &str,
     mode: Mode,
@@ -72749,7 +72921,7 @@ fn __action1587<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1588<
+fn __action1591<
 >(
     source_code: &str,
     mode: Mode,
@@ -72775,86 +72947,6 @@ fn __action1588<
         mode,
         __0,
         __1,
-        __temp0,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1589<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, Vec<ast::Alias>, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
-    __2: (TextSize, ast::Identifier, TextSize),
-) -> Vec<ast::Alias>
-{
-    let __start0 = __2.0;
-    let __end0 = __2.2;
-    let __temp0 = __action1335(
-        source_code,
-        mode,
-        __2,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action391(
-        source_code,
-        mode,
-        __0,
-        __1,
-        __temp0,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1590<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, ast::Identifier, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
-    __2: (TextSize, ast::Identifier, TextSize),
-) -> Vec<ast::Alias>
-{
-    let __start0 = __0.0;
-    let __end0 = __2.2;
-    let __temp0 = __action1336(
-        source_code,
-        mode,
-        __0,
-        __1,
-        __2,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action383(
-        source_code,
-        mode,
-        __temp0,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1591<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, ast::Identifier, TextSize),
-) -> Vec<ast::Alias>
-{
-    let __start0 = __0.0;
-    let __end0 = __0.2;
-    let __temp0 = __action1337(
-        source_code,
-        mode,
-        __0,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action383(
-        source_code,
-        mode,
         __temp0,
     )
 }
@@ -72868,21 +72960,17 @@ fn __action1592<
     __0: (TextSize, Vec<ast::Alias>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, ast::Identifier, TextSize),
-    __3: (TextSize, token::Tok, TextSize),
-    __4: (TextSize, ast::Identifier, TextSize),
 ) -> Vec<ast::Alias>
 {
     let __start0 = __2.0;
-    let __end0 = __4.2;
-    let __temp0 = __action1336(
+    let __end0 = __2.2;
+    let __temp0 = __action1335(
         source_code,
         mode,
         __2,
-        __3,
-        __4,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action384(
+    __action391(
         source_code,
         mode,
         __0,
@@ -72897,6 +72985,90 @@ fn __action1593<
 >(
     source_code: &str,
     mode: Mode,
+    __0: (TextSize, ast::Identifier, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+    __2: (TextSize, ast::Identifier, TextSize),
+) -> Vec<ast::Alias>
+{
+    let __start0 = __0.0;
+    let __end0 = __2.2;
+    let __temp0 = __action1336(
+        source_code,
+        mode,
+        __0,
+        __1,
+        __2,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action383(
+        source_code,
+        mode,
+        __temp0,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1594<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, ast::Identifier, TextSize),
+) -> Vec<ast::Alias>
+{
+    let __start0 = __0.0;
+    let __end0 = __0.2;
+    let __temp0 = __action1337(
+        source_code,
+        mode,
+        __0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action383(
+        source_code,
+        mode,
+        __temp0,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1595<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, Vec<ast::Alias>, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+    __2: (TextSize, ast::Identifier, TextSize),
+    __3: (TextSize, token::Tok, TextSize),
+    __4: (TextSize, ast::Identifier, TextSize),
+) -> Vec<ast::Alias>
+{
+    let __start0 = __2.0;
+    let __end0 = __4.2;
+    let __temp0 = __action1336(
+        source_code,
+        mode,
+        __2,
+        __3,
+        __4,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action384(
+        source_code,
+        mode,
+        __0,
+        __1,
+        __temp0,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1596<
+>(
+    source_code: &str,
+    mode: Mode,
     __0: (TextSize, Vec<ast::Alias>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, ast::Identifier, TextSize),
@@ -72921,7 +73093,7 @@ fn __action1593<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1594<
+fn __action1597<
 >(
     source_code: &str,
     mode: Mode,
@@ -72947,7 +73119,7 @@ fn __action1594<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1595<
+fn __action1598<
 >(
     source_code: &str,
     mode: Mode,
@@ -72973,119 +73145,119 @@ fn __action1595<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1596<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, Vec<ast::ParenthesizedExpr>, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-) -> ast::ParenthesizedExpr
-{
-    let __start0 = __1.0;
-    let __end0 = __1.2;
-    let __temp0 = __action572(
-        source_code,
-        mode,
-        __1,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1239(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-        __2,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1597<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
-) -> ast::ParenthesizedExpr
-{
-    let __start0 = __0.2;
-    let __end0 = __1.0;
-    let __temp0 = __action573(
-        source_code,
-        mode,
-        &__start0,
-        &__end0,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1239(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-        __1,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1598<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, Vec<ast::ParenthesizedExpr>, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-) -> ast::ParenthesizedExpr
-{
-    let __start0 = __1.0;
-    let __end0 = __1.2;
-    let __temp0 = __action572(
-        source_code,
-        mode,
-        __1,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1266(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-        __2,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
 fn __action1599<
 >(
     source_code: &str,
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, Vec<ast::ParenthesizedExpr>, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
 ) -> ast::ParenthesizedExpr
 {
-    let __start0 = __0.2;
-    let __end0 = __1.0;
-    let __temp0 = __action573(
+    let __start0 = __1.0;
+    let __end0 = __1.2;
+    let __temp0 = __action572(
         source_code,
         mode,
-        &__start0,
-        &__end0,
+        __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1266(
+    __action1239(
         source_code,
         mode,
         __0,
         __temp0,
-        __1,
+        __2,
     )
 }
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
 fn __action1600<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+) -> ast::ParenthesizedExpr
+{
+    let __start0 = __0.2;
+    let __end0 = __1.0;
+    let __temp0 = __action573(
+        source_code,
+        mode,
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1239(
+        source_code,
+        mode,
+        __0,
+        __temp0,
+        __1,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1601<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, Vec<ast::ParenthesizedExpr>, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
+) -> ast::ParenthesizedExpr
+{
+    let __start0 = __1.0;
+    let __end0 = __1.2;
+    let __temp0 = __action572(
+        source_code,
+        mode,
+        __1,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1266(
+        source_code,
+        mode,
+        __0,
+        __temp0,
+        __2,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1602<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+) -> ast::ParenthesizedExpr
+{
+    let __start0 = __0.2;
+    let __end0 = __1.0;
+    let __temp0 = __action573(
+        source_code,
+        mode,
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1266(
+        source_code,
+        mode,
+        __0,
+        __temp0,
+        __1,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1603<
 >(
     source_code: &str,
     mode: Mode,
@@ -73106,7 +73278,7 @@ fn __action1600<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1379(
+    __action1382(
         source_code,
         mode,
         __temp0,
@@ -73121,7 +73293,7 @@ fn __action1600<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1601<
+fn __action1604<
 >(
     source_code: &str,
     mode: Mode,
@@ -73146,7 +73318,7 @@ fn __action1601<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1379(
+    __action1382(
         source_code,
         mode,
         __temp0,
@@ -73156,120 +73328,6 @@ fn __action1601<
         __6,
         __7,
         __8,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1602<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, Vec<ast::ParameterWithDefault>, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-    __3: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
-    __4: (TextSize, token::Tok, TextSize),
-    __5: (TextSize, token::Tok, TextSize),
-    __6: (TextSize, ast::Parameter, TextSize),
-    __7: (TextSize, token::Tok, TextSize),
-    __8: (TextSize, Option<Box<ast::Parameter>>, TextSize),
-    __9: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Parameters,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
-{
-    let __start0 = __0.0;
-    let __end0 = __3.2;
-    let __temp0 = __action699(
-        source_code,
-        mode,
-        __0,
-        __1,
-        __2,
-        __3,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1379(
-        source_code,
-        mode,
-        __temp0,
-        __4,
-        __5,
-        __6,
-        __7,
-        __8,
-        __9,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1603<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, Vec<ast::ParameterWithDefault>, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-    __3: (TextSize, token::Tok, TextSize),
-    __4: (TextSize, Option<Box<ast::Parameter>>, TextSize),
-    __5: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Parameters,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
-{
-    let __start0 = __0.0;
-    let __end0 = __0.2;
-    let __temp0 = __action443(
-        source_code,
-        mode,
-        __0,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1380(
-        source_code,
-        mode,
-        __temp0,
-        __1,
-        __2,
-        __3,
-        __4,
-        __5,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1604<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, Vec<ast::ParameterWithDefault>, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-    __3: (TextSize, token::Tok, TextSize),
-    __4: (TextSize, token::Tok, TextSize),
-    __5: (TextSize, token::Tok, TextSize),
-    __6: (TextSize, Option<Box<ast::Parameter>>, TextSize),
-    __7: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Parameters,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
-{
-    let __start0 = __0.0;
-    let __end0 = __2.2;
-    let __temp0 = __action698(
-        source_code,
-        mode,
-        __0,
-        __1,
-        __2,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1380(
-        source_code,
-        mode,
-        __temp0,
-        __3,
-        __4,
-        __5,
-        __6,
-        __7,
     )
 }
 
@@ -73285,9 +73343,10 @@ fn __action1605<
     __3: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
     __4: (TextSize, token::Tok, TextSize),
     __5: (TextSize, token::Tok, TextSize),
-    __6: (TextSize, token::Tok, TextSize),
-    __7: (TextSize, Option<Box<ast::Parameter>>, TextSize),
-    __8: (TextSize, token::Tok, TextSize),
+    __6: (TextSize, ast::Parameter, TextSize),
+    __7: (TextSize, token::Tok, TextSize),
+    __8: (TextSize, Option<Box<ast::Parameter>>, TextSize),
+    __9: (TextSize, token::Tok, TextSize),
 ) -> Result<ast::Parameters,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
@@ -73301,7 +73360,7 @@ fn __action1605<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1380(
+    __action1382(
         source_code,
         mode,
         __temp0,
@@ -73310,6 +73369,7 @@ fn __action1605<
         __6,
         __7,
         __8,
+        __9,
     )
 }
 
@@ -73322,11 +73382,9 @@ fn __action1606<
     __0: (TextSize, Vec<ast::ParameterWithDefault>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, token::Tok, TextSize),
-    __3: (TextSize, ast::Parameter, TextSize),
-    __4: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
+    __3: (TextSize, token::Tok, TextSize),
+    __4: (TextSize, Option<Box<ast::Parameter>>, TextSize),
     __5: (TextSize, token::Tok, TextSize),
-    __6: (TextSize, Option<Box<ast::Parameter>>, TextSize),
-    __7: (TextSize, token::Tok, TextSize),
 ) -> Result<ast::Parameters,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
@@ -73337,7 +73395,7 @@ fn __action1606<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1381(
+    __action1383(
         source_code,
         mode,
         __temp0,
@@ -73346,8 +73404,6 @@ fn __action1606<
         __3,
         __4,
         __5,
-        __6,
-        __7,
     )
 }
 
@@ -73362,11 +73418,9 @@ fn __action1607<
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, token::Tok, TextSize),
     __4: (TextSize, token::Tok, TextSize),
-    __5: (TextSize, ast::Parameter, TextSize),
-    __6: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
+    __5: (TextSize, token::Tok, TextSize),
+    __6: (TextSize, Option<Box<ast::Parameter>>, TextSize),
     __7: (TextSize, token::Tok, TextSize),
-    __8: (TextSize, Option<Box<ast::Parameter>>, TextSize),
-    __9: (TextSize, token::Tok, TextSize),
 ) -> Result<ast::Parameters,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
@@ -73379,7 +73433,7 @@ fn __action1607<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1381(
+    __action1383(
         source_code,
         mode,
         __temp0,
@@ -73388,8 +73442,6 @@ fn __action1607<
         __5,
         __6,
         __7,
-        __8,
-        __9,
     )
 }
 
@@ -73405,11 +73457,9 @@ fn __action1608<
     __3: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
     __4: (TextSize, token::Tok, TextSize),
     __5: (TextSize, token::Tok, TextSize),
-    __6: (TextSize, ast::Parameter, TextSize),
-    __7: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
+    __6: (TextSize, token::Tok, TextSize),
+    __7: (TextSize, Option<Box<ast::Parameter>>, TextSize),
     __8: (TextSize, token::Tok, TextSize),
-    __9: (TextSize, Option<Box<ast::Parameter>>, TextSize),
-    __10: (TextSize, token::Tok, TextSize),
 ) -> Result<ast::Parameters,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
@@ -73423,7 +73473,7 @@ fn __action1608<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1381(
+    __action1383(
         source_code,
         mode,
         __temp0,
@@ -73432,8 +73482,6 @@ fn __action1608<
         __6,
         __7,
         __8,
-        __9,
-        __10,
     )
 }
 
@@ -73446,10 +73494,11 @@ fn __action1609<
     __0: (TextSize, Vec<ast::ParameterWithDefault>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, token::Tok, TextSize),
-    __3: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
-    __4: (TextSize, token::Tok, TextSize),
-    __5: (TextSize, Option<Box<ast::Parameter>>, TextSize),
-    __6: (TextSize, token::Tok, TextSize),
+    __3: (TextSize, ast::Parameter, TextSize),
+    __4: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
+    __5: (TextSize, token::Tok, TextSize),
+    __6: (TextSize, Option<Box<ast::Parameter>>, TextSize),
+    __7: (TextSize, token::Tok, TextSize),
 ) -> Result<ast::Parameters,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
@@ -73460,7 +73509,7 @@ fn __action1609<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1382(
+    __action1384(
         source_code,
         mode,
         __temp0,
@@ -73470,6 +73519,7 @@ fn __action1609<
         __4,
         __5,
         __6,
+        __7,
     )
 }
 
@@ -73484,10 +73534,11 @@ fn __action1610<
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, token::Tok, TextSize),
     __4: (TextSize, token::Tok, TextSize),
-    __5: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
-    __6: (TextSize, token::Tok, TextSize),
-    __7: (TextSize, Option<Box<ast::Parameter>>, TextSize),
-    __8: (TextSize, token::Tok, TextSize),
+    __5: (TextSize, ast::Parameter, TextSize),
+    __6: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
+    __7: (TextSize, token::Tok, TextSize),
+    __8: (TextSize, Option<Box<ast::Parameter>>, TextSize),
+    __9: (TextSize, token::Tok, TextSize),
 ) -> Result<ast::Parameters,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
@@ -73500,7 +73551,7 @@ fn __action1610<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1382(
+    __action1384(
         source_code,
         mode,
         __temp0,
@@ -73510,6 +73561,7 @@ fn __action1610<
         __6,
         __7,
         __8,
+        __9,
     )
 }
 
@@ -73525,6 +73577,126 @@ fn __action1611<
     __3: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
     __4: (TextSize, token::Tok, TextSize),
     __5: (TextSize, token::Tok, TextSize),
+    __6: (TextSize, ast::Parameter, TextSize),
+    __7: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
+    __8: (TextSize, token::Tok, TextSize),
+    __9: (TextSize, Option<Box<ast::Parameter>>, TextSize),
+    __10: (TextSize, token::Tok, TextSize),
+) -> Result<ast::Parameters,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+{
+    let __start0 = __0.0;
+    let __end0 = __3.2;
+    let __temp0 = __action699(
+        source_code,
+        mode,
+        __0,
+        __1,
+        __2,
+        __3,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1384(
+        source_code,
+        mode,
+        __temp0,
+        __4,
+        __5,
+        __6,
+        __7,
+        __8,
+        __9,
+        __10,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1612<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, Vec<ast::ParameterWithDefault>, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
+    __3: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
+    __4: (TextSize, token::Tok, TextSize),
+    __5: (TextSize, Option<Box<ast::Parameter>>, TextSize),
+    __6: (TextSize, token::Tok, TextSize),
+) -> Result<ast::Parameters,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+{
+    let __start0 = __0.0;
+    let __end0 = __0.2;
+    let __temp0 = __action443(
+        source_code,
+        mode,
+        __0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1385(
+        source_code,
+        mode,
+        __temp0,
+        __1,
+        __2,
+        __3,
+        __4,
+        __5,
+        __6,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1613<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, Vec<ast::ParameterWithDefault>, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
+    __3: (TextSize, token::Tok, TextSize),
+    __4: (TextSize, token::Tok, TextSize),
+    __5: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
+    __6: (TextSize, token::Tok, TextSize),
+    __7: (TextSize, Option<Box<ast::Parameter>>, TextSize),
+    __8: (TextSize, token::Tok, TextSize),
+) -> Result<ast::Parameters,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+{
+    let __start0 = __0.0;
+    let __end0 = __2.2;
+    let __temp0 = __action698(
+        source_code,
+        mode,
+        __0,
+        __1,
+        __2,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1385(
+        source_code,
+        mode,
+        __temp0,
+        __3,
+        __4,
+        __5,
+        __6,
+        __7,
+        __8,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1614<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, Vec<ast::ParameterWithDefault>, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
+    __3: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
+    __4: (TextSize, token::Tok, TextSize),
+    __5: (TextSize, token::Tok, TextSize),
     __6: (TextSize, alloc::vec::Vec<ast::ParameterWithDefault>, TextSize),
     __7: (TextSize, token::Tok, TextSize),
     __8: (TextSize, Option<Box<ast::Parameter>>, TextSize),
@@ -73542,7 +73714,7 @@ fn __action1611<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1382(
+    __action1385(
         source_code,
         mode,
         __temp0,
@@ -73557,7 +73729,7 @@ fn __action1611<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1612<
+fn __action1615<
 >(
     source_code: &str,
     mode: Mode,
@@ -73576,7 +73748,7 @@ fn __action1612<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1383(
+    __action1386(
         source_code,
         mode,
         __temp0,
@@ -73589,7 +73761,7 @@ fn __action1612<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1613<
+fn __action1616<
 >(
     source_code: &str,
     mode: Mode,
@@ -73612,7 +73784,7 @@ fn __action1613<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1383(
+    __action1386(
         source_code,
         mode,
         __temp0,
@@ -73625,7 +73797,7 @@ fn __action1613<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1614<
+fn __action1617<
 >(
     source_code: &str,
     mode: Mode,
@@ -73650,7 +73822,7 @@ fn __action1614<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1383(
+    __action1386(
         source_code,
         mode,
         __temp0,
@@ -73663,7 +73835,7 @@ fn __action1614<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1615<
+fn __action1618<
 >(
     source_code: &str,
     mode: Mode,
@@ -73681,7 +73853,7 @@ fn __action1615<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1384(
+    __action1387(
         source_code,
         mode,
         __temp0,
@@ -73693,7 +73865,7 @@ fn __action1615<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1616<
+fn __action1619<
 >(
     source_code: &str,
     mode: Mode,
@@ -73715,7 +73887,7 @@ fn __action1616<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1384(
+    __action1387(
         source_code,
         mode,
         __temp0,
@@ -73727,7 +73899,7 @@ fn __action1616<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1617<
+fn __action1620<
 >(
     source_code: &str,
     mode: Mode,
@@ -73751,7 +73923,7 @@ fn __action1617<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1384(
+    __action1387(
         source_code,
         mode,
         __temp0,
@@ -73763,7 +73935,7 @@ fn __action1617<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1618<
+fn __action1621<
 >(
     source_code: &str,
     mode: Mode,
@@ -73783,7 +73955,7 @@ fn __action1618<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1385(
+    __action1388(
         source_code,
         mode,
         __temp0,
@@ -73797,7 +73969,7 @@ fn __action1618<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1619<
+fn __action1622<
 >(
     source_code: &str,
     mode: Mode,
@@ -73821,7 +73993,7 @@ fn __action1619<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1385(
+    __action1388(
         source_code,
         mode,
         __temp0,
@@ -73835,7 +74007,7 @@ fn __action1619<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1620<
+fn __action1623<
 >(
     source_code: &str,
     mode: Mode,
@@ -73861,7 +74033,7 @@ fn __action1620<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1385(
+    __action1388(
         source_code,
         mode,
         __temp0,
@@ -73875,7 +74047,7 @@ fn __action1620<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1621<
+fn __action1624<
 >(
     source_code: &str,
     mode: Mode,
@@ -73894,7 +74066,7 @@ fn __action1621<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1386(
+    __action1389(
         source_code,
         mode,
         __temp0,
@@ -73907,7 +74079,7 @@ fn __action1621<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1622<
+fn __action1625<
 >(
     source_code: &str,
     mode: Mode,
@@ -73930,7 +74102,7 @@ fn __action1622<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1386(
+    __action1389(
         source_code,
         mode,
         __temp0,
@@ -73943,7 +74115,7 @@ fn __action1622<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1623<
+fn __action1626<
 >(
     source_code: &str,
     mode: Mode,
@@ -73968,7 +74140,7 @@ fn __action1623<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1386(
+    __action1389(
         source_code,
         mode,
         __temp0,
@@ -73981,7 +74153,7 @@ fn __action1623<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1624<
+fn __action1627<
 >(
     source_code: &str,
     mode: Mode,
@@ -73997,7 +74169,7 @@ fn __action1624<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1387(
+    __action1390(
         source_code,
         mode,
         __temp0,
@@ -74007,7 +74179,7 @@ fn __action1624<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1625<
+fn __action1628<
 >(
     source_code: &str,
     mode: Mode,
@@ -74027,7 +74199,7 @@ fn __action1625<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1387(
+    __action1390(
         source_code,
         mode,
         __temp0,
@@ -74037,7 +74209,7 @@ fn __action1625<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1626<
+fn __action1629<
 >(
     source_code: &str,
     mode: Mode,
@@ -74059,7 +74231,7 @@ fn __action1626<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1387(
+    __action1390(
         source_code,
         mode,
         __temp0,
@@ -74069,7 +74241,7 @@ fn __action1626<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1627<
+fn __action1630<
 >(
     source_code: &str,
     mode: Mode,
@@ -74089,7 +74261,7 @@ fn __action1627<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1388(
+    __action1391(
         source_code,
         mode,
         __temp0,
@@ -74103,7 +74275,7 @@ fn __action1627<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1628<
+fn __action1631<
 >(
     source_code: &str,
     mode: Mode,
@@ -74127,7 +74299,7 @@ fn __action1628<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1388(
+    __action1391(
         source_code,
         mode,
         __temp0,
@@ -74141,7 +74313,7 @@ fn __action1628<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1629<
+fn __action1632<
 >(
     source_code: &str,
     mode: Mode,
@@ -74167,7 +74339,7 @@ fn __action1629<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1388(
+    __action1391(
         source_code,
         mode,
         __temp0,
@@ -74181,7 +74353,7 @@ fn __action1629<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1630<
+fn __action1633<
 >(
     source_code: &str,
     mode: Mode,
@@ -74200,7 +74372,7 @@ fn __action1630<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1389(
+    __action1392(
         source_code,
         mode,
         __temp0,
@@ -74213,7 +74385,7 @@ fn __action1630<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1631<
+fn __action1634<
 >(
     source_code: &str,
     mode: Mode,
@@ -74236,7 +74408,7 @@ fn __action1631<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1389(
+    __action1392(
         source_code,
         mode,
         __temp0,
@@ -74249,7 +74421,7 @@ fn __action1631<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1632<
+fn __action1635<
 >(
     source_code: &str,
     mode: Mode,
@@ -74274,7 +74446,7 @@ fn __action1632<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1389(
+    __action1392(
         source_code,
         mode,
         __temp0,
@@ -74287,7 +74459,7 @@ fn __action1632<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1633<
+fn __action1636<
 >(
     source_code: &str,
     mode: Mode,
@@ -74308,7 +74480,7 @@ fn __action1633<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1390(
+    __action1393(
         source_code,
         mode,
         __temp0,
@@ -74323,7 +74495,7 @@ fn __action1633<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1634<
+fn __action1637<
 >(
     source_code: &str,
     mode: Mode,
@@ -74348,7 +74520,7 @@ fn __action1634<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1390(
+    __action1393(
         source_code,
         mode,
         __temp0,
@@ -74363,7 +74535,7 @@ fn __action1634<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1635<
+fn __action1638<
 >(
     source_code: &str,
     mode: Mode,
@@ -74390,7 +74562,7 @@ fn __action1635<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1390(
+    __action1393(
         source_code,
         mode,
         __temp0,
@@ -74405,7 +74577,7 @@ fn __action1635<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1636<
+fn __action1639<
 >(
     source_code: &str,
     mode: Mode,
@@ -74425,7 +74597,7 @@ fn __action1636<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1391(
+    __action1394(
         source_code,
         mode,
         __temp0,
@@ -74439,7 +74611,7 @@ fn __action1636<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1637<
+fn __action1640<
 >(
     source_code: &str,
     mode: Mode,
@@ -74463,7 +74635,7 @@ fn __action1637<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1391(
+    __action1394(
         source_code,
         mode,
         __temp0,
@@ -74477,7 +74649,7 @@ fn __action1637<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1638<
+fn __action1641<
 >(
     source_code: &str,
     mode: Mode,
@@ -74503,7 +74675,7 @@ fn __action1638<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1391(
+    __action1394(
         source_code,
         mode,
         __temp0,
@@ -74517,7 +74689,7 @@ fn __action1638<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1639<
+fn __action1642<
 >(
     source_code: &str,
     mode: Mode,
@@ -74535,7 +74707,7 @@ fn __action1639<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1392(
+    __action1395(
         source_code,
         mode,
         __temp0,
@@ -74547,7 +74719,7 @@ fn __action1639<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1640<
+fn __action1643<
 >(
     source_code: &str,
     mode: Mode,
@@ -74569,7 +74741,7 @@ fn __action1640<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1392(
+    __action1395(
         source_code,
         mode,
         __temp0,
@@ -74581,7 +74753,7 @@ fn __action1640<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1641<
+fn __action1644<
 >(
     source_code: &str,
     mode: Mode,
@@ -74605,7 +74777,7 @@ fn __action1641<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1392(
+    __action1395(
         source_code,
         mode,
         __temp0,
@@ -74617,7 +74789,7 @@ fn __action1641<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1642<
+fn __action1645<
 >(
     source_code: &str,
     mode: Mode,
@@ -74634,7 +74806,7 @@ fn __action1642<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1393(
+    __action1396(
         source_code,
         mode,
         __temp0,
@@ -74645,7 +74817,7 @@ fn __action1642<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1643<
+fn __action1646<
 >(
     source_code: &str,
     mode: Mode,
@@ -74666,7 +74838,7 @@ fn __action1643<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1393(
+    __action1396(
         source_code,
         mode,
         __temp0,
@@ -74677,7 +74849,7 @@ fn __action1643<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1644<
+fn __action1647<
 >(
     source_code: &str,
     mode: Mode,
@@ -74700,7 +74872,7 @@ fn __action1644<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1393(
+    __action1396(
         source_code,
         mode,
         __temp0,
@@ -74711,7 +74883,7 @@ fn __action1644<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1645<
+fn __action1648<
 >(
     source_code: &str,
     mode: Mode,
@@ -74730,7 +74902,7 @@ fn __action1645<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1394(
+    __action1397(
         source_code,
         mode,
         __temp0,
@@ -74743,7 +74915,7 @@ fn __action1645<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1646<
+fn __action1649<
 >(
     source_code: &str,
     mode: Mode,
@@ -74766,7 +74938,7 @@ fn __action1646<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1394(
+    __action1397(
         source_code,
         mode,
         __temp0,
@@ -74779,7 +74951,7 @@ fn __action1646<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1647<
+fn __action1650<
 >(
     source_code: &str,
     mode: Mode,
@@ -74804,7 +74976,7 @@ fn __action1647<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1394(
+    __action1397(
         source_code,
         mode,
         __temp0,
@@ -74817,7 +74989,7 @@ fn __action1647<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1648<
+fn __action1651<
 >(
     source_code: &str,
     mode: Mode,
@@ -74835,7 +75007,7 @@ fn __action1648<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1395(
+    __action1398(
         source_code,
         mode,
         __temp0,
@@ -74847,7 +75019,7 @@ fn __action1648<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1649<
+fn __action1652<
 >(
     source_code: &str,
     mode: Mode,
@@ -74869,7 +75041,7 @@ fn __action1649<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1395(
+    __action1398(
         source_code,
         mode,
         __temp0,
@@ -74881,7 +75053,7 @@ fn __action1649<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1650<
+fn __action1653<
 >(
     source_code: &str,
     mode: Mode,
@@ -74905,7 +75077,7 @@ fn __action1650<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1395(
+    __action1398(
         source_code,
         mode,
         __temp0,
@@ -74917,7 +75089,7 @@ fn __action1650<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1651<
+fn __action1654<
 >(
     source_code: &str,
     mode: Mode,
@@ -74932,7 +75104,7 @@ fn __action1651<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1396(
+    __action1399(
         source_code,
         mode,
         __temp0,
@@ -74941,7 +75113,7 @@ fn __action1651<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1652<
+fn __action1655<
 >(
     source_code: &str,
     mode: Mode,
@@ -74960,7 +75132,7 @@ fn __action1652<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1396(
+    __action1399(
         source_code,
         mode,
         __temp0,
@@ -74969,7 +75141,7 @@ fn __action1652<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1653<
+fn __action1656<
 >(
     source_code: &str,
     mode: Mode,
@@ -74990,7 +75162,7 @@ fn __action1653<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1396(
+    __action1399(
         source_code,
         mode,
         __temp0,
@@ -74999,7 +75171,7 @@ fn __action1653<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1654<
+fn __action1657<
 >(
     source_code: &str,
     mode: Mode,
@@ -75017,7 +75189,7 @@ fn __action1654<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1397(
+    __action1400(
         source_code,
         mode,
         __temp0,
@@ -75029,7 +75201,7 @@ fn __action1654<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1655<
+fn __action1658<
 >(
     source_code: &str,
     mode: Mode,
@@ -75051,7 +75223,7 @@ fn __action1655<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1397(
+    __action1400(
         source_code,
         mode,
         __temp0,
@@ -75063,7 +75235,7 @@ fn __action1655<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1656<
+fn __action1659<
 >(
     source_code: &str,
     mode: Mode,
@@ -75087,7 +75259,7 @@ fn __action1656<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1397(
+    __action1400(
         source_code,
         mode,
         __temp0,
@@ -75099,7 +75271,7 @@ fn __action1656<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1657<
+fn __action1660<
 >(
     source_code: &str,
     mode: Mode,
@@ -75116,7 +75288,7 @@ fn __action1657<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1398(
+    __action1401(
         source_code,
         mode,
         __temp0,
@@ -75127,7 +75299,7 @@ fn __action1657<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1658<
+fn __action1661<
 >(
     source_code: &str,
     mode: Mode,
@@ -75148,7 +75320,7 @@ fn __action1658<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1398(
+    __action1401(
         source_code,
         mode,
         __temp0,
@@ -75159,7 +75331,7 @@ fn __action1658<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1659<
+fn __action1662<
 >(
     source_code: &str,
     mode: Mode,
@@ -75182,7 +75354,7 @@ fn __action1659<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1398(
+    __action1401(
         source_code,
         mode,
         __temp0,
@@ -75193,7 +75365,7 @@ fn __action1659<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1660<
+fn __action1663<
 >(
     source_code: &str,
     mode: Mode,
@@ -75214,7 +75386,7 @@ fn __action1660<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1417(
+    __action1420(
         source_code,
         mode,
         __temp0,
@@ -75229,7 +75401,7 @@ fn __action1660<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1661<
+fn __action1664<
 >(
     source_code: &str,
     mode: Mode,
@@ -75254,7 +75426,7 @@ fn __action1661<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1417(
+    __action1420(
         source_code,
         mode,
         __temp0,
@@ -75269,7 +75441,7 @@ fn __action1661<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1662<
+fn __action1665<
 >(
     source_code: &str,
     mode: Mode,
@@ -75296,7 +75468,7 @@ fn __action1662<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1417(
+    __action1420(
         source_code,
         mode,
         __temp0,
@@ -75311,7 +75483,7 @@ fn __action1662<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1663<
+fn __action1666<
 >(
     source_code: &str,
     mode: Mode,
@@ -75331,7 +75503,7 @@ fn __action1663<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1418(
+    __action1421(
         source_code,
         mode,
         __temp0,
@@ -75345,7 +75517,7 @@ fn __action1663<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1664<
+fn __action1667<
 >(
     source_code: &str,
     mode: Mode,
@@ -75369,7 +75541,7 @@ fn __action1664<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1418(
+    __action1421(
         source_code,
         mode,
         __temp0,
@@ -75383,7 +75555,7 @@ fn __action1664<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1665<
+fn __action1668<
 >(
     source_code: &str,
     mode: Mode,
@@ -75409,7 +75581,7 @@ fn __action1665<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1418(
+    __action1421(
         source_code,
         mode,
         __temp0,
@@ -75423,7 +75595,7 @@ fn __action1665<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1666<
+fn __action1669<
 >(
     source_code: &str,
     mode: Mode,
@@ -75445,7 +75617,7 @@ fn __action1666<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1419(
+    __action1422(
         source_code,
         mode,
         __temp0,
@@ -75461,7 +75633,7 @@ fn __action1666<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1667<
+fn __action1670<
 >(
     source_code: &str,
     mode: Mode,
@@ -75487,7 +75659,7 @@ fn __action1667<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1419(
+    __action1422(
         source_code,
         mode,
         __temp0,
@@ -75503,7 +75675,7 @@ fn __action1667<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1668<
+fn __action1671<
 >(
     source_code: &str,
     mode: Mode,
@@ -75531,7 +75703,7 @@ fn __action1668<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1419(
+    __action1422(
         source_code,
         mode,
         __temp0,
@@ -75547,7 +75719,7 @@ fn __action1668<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1669<
+fn __action1672<
 >(
     source_code: &str,
     mode: Mode,
@@ -75568,7 +75740,7 @@ fn __action1669<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1420(
+    __action1423(
         source_code,
         mode,
         __temp0,
@@ -75583,7 +75755,7 @@ fn __action1669<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1670<
+fn __action1673<
 >(
     source_code: &str,
     mode: Mode,
@@ -75608,7 +75780,7 @@ fn __action1670<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1420(
+    __action1423(
         source_code,
         mode,
         __temp0,
@@ -75623,7 +75795,7 @@ fn __action1670<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1671<
+fn __action1674<
 >(
     source_code: &str,
     mode: Mode,
@@ -75650,7 +75822,7 @@ fn __action1671<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1420(
+    __action1423(
         source_code,
         mode,
         __temp0,
@@ -75665,7 +75837,7 @@ fn __action1671<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1672<
+fn __action1675<
 >(
     source_code: &str,
     mode: Mode,
@@ -75684,7 +75856,7 @@ fn __action1672<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1421(
+    __action1424(
         source_code,
         mode,
         __temp0,
@@ -75697,7 +75869,7 @@ fn __action1672<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1673<
+fn __action1676<
 >(
     source_code: &str,
     mode: Mode,
@@ -75720,7 +75892,7 @@ fn __action1673<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1421(
+    __action1424(
         source_code,
         mode,
         __temp0,
@@ -75733,7 +75905,7 @@ fn __action1673<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1674<
+fn __action1677<
 >(
     source_code: &str,
     mode: Mode,
@@ -75758,7 +75930,7 @@ fn __action1674<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1421(
+    __action1424(
         source_code,
         mode,
         __temp0,
@@ -75771,7 +75943,7 @@ fn __action1674<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1675<
+fn __action1678<
 >(
     source_code: &str,
     mode: Mode,
@@ -75789,7 +75961,7 @@ fn __action1675<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1422(
+    __action1425(
         source_code,
         mode,
         __temp0,
@@ -75801,7 +75973,7 @@ fn __action1675<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1676<
+fn __action1679<
 >(
     source_code: &str,
     mode: Mode,
@@ -75823,7 +75995,7 @@ fn __action1676<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1422(
+    __action1425(
         source_code,
         mode,
         __temp0,
@@ -75835,7 +76007,7 @@ fn __action1676<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1677<
+fn __action1680<
 >(
     source_code: &str,
     mode: Mode,
@@ -75859,7 +76031,7 @@ fn __action1677<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1422(
+    __action1425(
         source_code,
         mode,
         __temp0,
@@ -75871,7 +76043,7 @@ fn __action1677<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1678<
+fn __action1681<
 >(
     source_code: &str,
     mode: Mode,
@@ -75891,7 +76063,7 @@ fn __action1678<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1423(
+    __action1426(
         source_code,
         mode,
         __temp0,
@@ -75905,7 +76077,7 @@ fn __action1678<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1679<
+fn __action1682<
 >(
     source_code: &str,
     mode: Mode,
@@ -75929,7 +76101,7 @@ fn __action1679<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1423(
+    __action1426(
         source_code,
         mode,
         __temp0,
@@ -75943,7 +76115,7 @@ fn __action1679<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1680<
+fn __action1683<
 >(
     source_code: &str,
     mode: Mode,
@@ -75969,7 +76141,7 @@ fn __action1680<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1423(
+    __action1426(
         source_code,
         mode,
         __temp0,
@@ -75983,7 +76155,7 @@ fn __action1680<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1681<
+fn __action1684<
 >(
     source_code: &str,
     mode: Mode,
@@ -76002,7 +76174,7 @@ fn __action1681<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1424(
+    __action1427(
         source_code,
         mode,
         __temp0,
@@ -76015,7 +76187,7 @@ fn __action1681<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1682<
+fn __action1685<
 >(
     source_code: &str,
     mode: Mode,
@@ -76038,7 +76210,7 @@ fn __action1682<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1424(
+    __action1427(
         source_code,
         mode,
         __temp0,
@@ -76051,7 +76223,7 @@ fn __action1682<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1683<
+fn __action1686<
 >(
     source_code: &str,
     mode: Mode,
@@ -76076,7 +76248,7 @@ fn __action1683<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1424(
+    __action1427(
         source_code,
         mode,
         __temp0,
@@ -76089,7 +76261,7 @@ fn __action1683<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1684<
+fn __action1687<
 >(
     source_code: &str,
     mode: Mode,
@@ -76105,7 +76277,7 @@ fn __action1684<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1425(
+    __action1428(
         source_code,
         mode,
         __temp0,
@@ -76115,7 +76287,7 @@ fn __action1684<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1685<
+fn __action1688<
 >(
     source_code: &str,
     mode: Mode,
@@ -76135,7 +76307,7 @@ fn __action1685<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1425(
+    __action1428(
         source_code,
         mode,
         __temp0,
@@ -76145,7 +76317,7 @@ fn __action1685<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1686<
+fn __action1689<
 >(
     source_code: &str,
     mode: Mode,
@@ -76167,7 +76339,7 @@ fn __action1686<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1425(
+    __action1428(
         source_code,
         mode,
         __temp0,
@@ -76177,7 +76349,7 @@ fn __action1686<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1687<
+fn __action1690<
 >(
     source_code: &str,
     mode: Mode,
@@ -76197,7 +76369,7 @@ fn __action1687<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1426(
+    __action1429(
         source_code,
         mode,
         __temp0,
@@ -76211,7 +76383,7 @@ fn __action1687<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1688<
+fn __action1691<
 >(
     source_code: &str,
     mode: Mode,
@@ -76235,7 +76407,7 @@ fn __action1688<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1426(
+    __action1429(
         source_code,
         mode,
         __temp0,
@@ -76249,7 +76421,7 @@ fn __action1688<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1689<
+fn __action1692<
 >(
     source_code: &str,
     mode: Mode,
@@ -76275,7 +76447,7 @@ fn __action1689<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1426(
+    __action1429(
         source_code,
         mode,
         __temp0,
@@ -76289,7 +76461,7 @@ fn __action1689<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1690<
+fn __action1693<
 >(
     source_code: &str,
     mode: Mode,
@@ -76308,7 +76480,7 @@ fn __action1690<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1427(
+    __action1430(
         source_code,
         mode,
         __temp0,
@@ -76321,7 +76493,7 @@ fn __action1690<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1691<
+fn __action1694<
 >(
     source_code: &str,
     mode: Mode,
@@ -76344,7 +76516,7 @@ fn __action1691<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1427(
+    __action1430(
         source_code,
         mode,
         __temp0,
@@ -76357,7 +76529,7 @@ fn __action1691<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1692<
+fn __action1695<
 >(
     source_code: &str,
     mode: Mode,
@@ -76382,7 +76554,7 @@ fn __action1692<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1427(
+    __action1430(
         source_code,
         mode,
         __temp0,
@@ -76395,7 +76567,7 @@ fn __action1692<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1693<
+fn __action1696<
 >(
     source_code: &str,
     mode: Mode,
@@ -76416,7 +76588,7 @@ fn __action1693<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1428(
+    __action1431(
         source_code,
         mode,
         __temp0,
@@ -76431,7 +76603,7 @@ fn __action1693<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1694<
+fn __action1697<
 >(
     source_code: &str,
     mode: Mode,
@@ -76456,7 +76628,7 @@ fn __action1694<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1428(
+    __action1431(
         source_code,
         mode,
         __temp0,
@@ -76471,7 +76643,7 @@ fn __action1694<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1695<
+fn __action1698<
 >(
     source_code: &str,
     mode: Mode,
@@ -76498,7 +76670,7 @@ fn __action1695<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1428(
+    __action1431(
         source_code,
         mode,
         __temp0,
@@ -76513,7 +76685,7 @@ fn __action1695<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1696<
+fn __action1699<
 >(
     source_code: &str,
     mode: Mode,
@@ -76533,7 +76705,7 @@ fn __action1696<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1429(
+    __action1432(
         source_code,
         mode,
         __temp0,
@@ -76547,7 +76719,7 @@ fn __action1696<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1697<
+fn __action1700<
 >(
     source_code: &str,
     mode: Mode,
@@ -76571,7 +76743,7 @@ fn __action1697<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1429(
+    __action1432(
         source_code,
         mode,
         __temp0,
@@ -76585,7 +76757,7 @@ fn __action1697<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1698<
+fn __action1701<
 >(
     source_code: &str,
     mode: Mode,
@@ -76611,7 +76783,7 @@ fn __action1698<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1429(
+    __action1432(
         source_code,
         mode,
         __temp0,
@@ -76625,7 +76797,7 @@ fn __action1698<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1699<
+fn __action1702<
 >(
     source_code: &str,
     mode: Mode,
@@ -76643,7 +76815,7 @@ fn __action1699<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1430(
+    __action1433(
         source_code,
         mode,
         __temp0,
@@ -76655,7 +76827,7 @@ fn __action1699<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1700<
+fn __action1703<
 >(
     source_code: &str,
     mode: Mode,
@@ -76677,7 +76849,7 @@ fn __action1700<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1430(
+    __action1433(
         source_code,
         mode,
         __temp0,
@@ -76689,7 +76861,7 @@ fn __action1700<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1701<
+fn __action1704<
 >(
     source_code: &str,
     mode: Mode,
@@ -76713,7 +76885,7 @@ fn __action1701<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1430(
+    __action1433(
         source_code,
         mode,
         __temp0,
@@ -76725,7 +76897,7 @@ fn __action1701<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1702<
+fn __action1705<
 >(
     source_code: &str,
     mode: Mode,
@@ -76742,7 +76914,7 @@ fn __action1702<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1431(
+    __action1434(
         source_code,
         mode,
         __temp0,
@@ -76753,7 +76925,7 @@ fn __action1702<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1703<
+fn __action1706<
 >(
     source_code: &str,
     mode: Mode,
@@ -76774,7 +76946,7 @@ fn __action1703<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1431(
+    __action1434(
         source_code,
         mode,
         __temp0,
@@ -76785,7 +76957,7 @@ fn __action1703<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1704<
+fn __action1707<
 >(
     source_code: &str,
     mode: Mode,
@@ -76808,7 +76980,7 @@ fn __action1704<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1431(
+    __action1434(
         source_code,
         mode,
         __temp0,
@@ -76819,7 +76991,7 @@ fn __action1704<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1705<
+fn __action1708<
 >(
     source_code: &str,
     mode: Mode,
@@ -76838,7 +77010,7 @@ fn __action1705<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1432(
+    __action1435(
         source_code,
         mode,
         __temp0,
@@ -76851,7 +77023,7 @@ fn __action1705<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1706<
+fn __action1709<
 >(
     source_code: &str,
     mode: Mode,
@@ -76874,7 +77046,7 @@ fn __action1706<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1432(
+    __action1435(
         source_code,
         mode,
         __temp0,
@@ -76887,7 +77059,7 @@ fn __action1706<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1707<
+fn __action1710<
 >(
     source_code: &str,
     mode: Mode,
@@ -76912,7 +77084,7 @@ fn __action1707<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1432(
+    __action1435(
         source_code,
         mode,
         __temp0,
@@ -76925,7 +77097,7 @@ fn __action1707<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1708<
+fn __action1711<
 >(
     source_code: &str,
     mode: Mode,
@@ -76943,7 +77115,7 @@ fn __action1708<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1433(
+    __action1436(
         source_code,
         mode,
         __temp0,
@@ -76955,7 +77127,7 @@ fn __action1708<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1709<
+fn __action1712<
 >(
     source_code: &str,
     mode: Mode,
@@ -76977,7 +77149,7 @@ fn __action1709<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1433(
+    __action1436(
         source_code,
         mode,
         __temp0,
@@ -76989,7 +77161,7 @@ fn __action1709<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1710<
+fn __action1713<
 >(
     source_code: &str,
     mode: Mode,
@@ -77013,7 +77185,7 @@ fn __action1710<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1433(
+    __action1436(
         source_code,
         mode,
         __temp0,
@@ -77025,7 +77197,7 @@ fn __action1710<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1711<
+fn __action1714<
 >(
     source_code: &str,
     mode: Mode,
@@ -77040,7 +77212,7 @@ fn __action1711<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1434(
+    __action1437(
         source_code,
         mode,
         __temp0,
@@ -77049,7 +77221,7 @@ fn __action1711<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1712<
+fn __action1715<
 >(
     source_code: &str,
     mode: Mode,
@@ -77068,7 +77240,7 @@ fn __action1712<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1434(
+    __action1437(
         source_code,
         mode,
         __temp0,
@@ -77077,7 +77249,7 @@ fn __action1712<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1713<
+fn __action1716<
 >(
     source_code: &str,
     mode: Mode,
@@ -77098,7 +77270,7 @@ fn __action1713<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1434(
+    __action1437(
         source_code,
         mode,
         __temp0,
@@ -77107,7 +77279,7 @@ fn __action1713<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1714<
+fn __action1717<
 >(
     source_code: &str,
     mode: Mode,
@@ -77125,7 +77297,7 @@ fn __action1714<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1435(
+    __action1438(
         source_code,
         mode,
         __temp0,
@@ -77137,7 +77309,7 @@ fn __action1714<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1715<
+fn __action1718<
 >(
     source_code: &str,
     mode: Mode,
@@ -77159,7 +77331,7 @@ fn __action1715<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1435(
+    __action1438(
         source_code,
         mode,
         __temp0,
@@ -77171,7 +77343,7 @@ fn __action1715<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1716<
+fn __action1719<
 >(
     source_code: &str,
     mode: Mode,
@@ -77195,7 +77367,7 @@ fn __action1716<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1435(
+    __action1438(
         source_code,
         mode,
         __temp0,
@@ -77207,7 +77379,7 @@ fn __action1716<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1717<
+fn __action1720<
 >(
     source_code: &str,
     mode: Mode,
@@ -77224,7 +77396,7 @@ fn __action1717<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1436(
+    __action1439(
         source_code,
         mode,
         __temp0,
@@ -77235,7 +77407,7 @@ fn __action1717<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1718<
+fn __action1721<
 >(
     source_code: &str,
     mode: Mode,
@@ -77256,7 +77428,7 @@ fn __action1718<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1436(
+    __action1439(
         source_code,
         mode,
         __temp0,
@@ -77267,7 +77439,7 @@ fn __action1718<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1719<
+fn __action1722<
 >(
     source_code: &str,
     mode: Mode,
@@ -77290,7 +77462,7 @@ fn __action1719<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1436(
+    __action1439(
         source_code,
         mode,
         __temp0,
@@ -77301,7 +77473,7 @@ fn __action1719<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1720<
+fn __action1723<
 >(
     source_code: &str,
     mode: Mode,
@@ -77333,7 +77505,7 @@ fn __action1720<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1721<
+fn __action1724<
 >(
     source_code: &str,
     mode: Mode,
@@ -77365,7 +77537,7 @@ fn __action1721<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1722<
+fn __action1725<
 >(
     source_code: &str,
     mode: Mode,
@@ -77383,7 +77555,7 @@ fn __action1722<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1488(
+    __action1491(
         source_code,
         mode,
         __0,
@@ -77395,7 +77567,7 @@ fn __action1722<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1723<
+fn __action1726<
 >(
     source_code: &str,
     mode: Mode,
@@ -77413,7 +77585,7 @@ fn __action1723<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1488(
+    __action1491(
         source_code,
         mode,
         __0,
@@ -77425,7 +77597,7 @@ fn __action1723<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1724<
+fn __action1727<
 >(
     source_code: &str,
     mode: Mode,
@@ -77455,7 +77627,7 @@ fn __action1724<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1725<
+fn __action1728<
 >(
     source_code: &str,
     mode: Mode,
@@ -77485,7 +77657,7 @@ fn __action1725<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1726<
+fn __action1729<
 >(
     source_code: &str,
     mode: Mode,
@@ -77511,7 +77683,7 @@ fn __action1726<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1727<
+fn __action1730<
 >(
     source_code: &str,
     mode: Mode,
@@ -77537,7 +77709,7 @@ fn __action1727<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1728<
+fn __action1731<
 >(
     source_code: &str,
     mode: Mode,
@@ -77563,7 +77735,7 @@ fn __action1728<
         __2,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1722(
+    __action1725(
         source_code,
         mode,
         __temp0,
@@ -77575,7 +77747,7 @@ fn __action1728<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1729<
+fn __action1732<
 >(
     source_code: &str,
     mode: Mode,
@@ -77601,7 +77773,7 @@ fn __action1729<
         &__end1,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1722(
+    __action1725(
         source_code,
         mode,
         __temp0,
@@ -77613,7 +77785,7 @@ fn __action1729<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1730<
+fn __action1733<
 >(
     source_code: &str,
     mode: Mode,
@@ -77639,7 +77811,7 @@ fn __action1730<
         __1,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1722(
+    __action1725(
         source_code,
         mode,
         __temp0,
@@ -77651,7 +77823,7 @@ fn __action1730<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1731<
+fn __action1734<
 >(
     source_code: &str,
     mode: Mode,
@@ -77677,7 +77849,7 @@ fn __action1731<
         &__end1,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1722(
+    __action1725(
         source_code,
         mode,
         __temp0,
@@ -77689,7 +77861,7 @@ fn __action1731<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1732<
+fn __action1735<
 >(
     source_code: &str,
     mode: Mode,
@@ -77714,7 +77886,7 @@ fn __action1732<
         __2,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1723(
+    __action1726(
         source_code,
         mode,
         __temp0,
@@ -77725,7 +77897,7 @@ fn __action1732<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1733<
+fn __action1736<
 >(
     source_code: &str,
     mode: Mode,
@@ -77750,7 +77922,7 @@ fn __action1733<
         &__end1,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1723(
+    __action1726(
         source_code,
         mode,
         __temp0,
@@ -77761,7 +77933,7 @@ fn __action1733<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1734<
+fn __action1737<
 >(
     source_code: &str,
     mode: Mode,
@@ -77786,7 +77958,7 @@ fn __action1734<
         __1,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1723(
+    __action1726(
         source_code,
         mode,
         __temp0,
@@ -77797,7 +77969,7 @@ fn __action1734<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1735<
+fn __action1738<
 >(
     source_code: &str,
     mode: Mode,
@@ -77822,7 +77994,7 @@ fn __action1735<
         &__end1,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1723(
+    __action1726(
         source_code,
         mode,
         __temp0,
@@ -77833,7 +78005,7 @@ fn __action1735<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1736<
+fn __action1739<
 >(
     source_code: &str,
     mode: Mode,
@@ -77875,7 +78047,7 @@ fn __action1736<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1737<
+fn __action1740<
 >(
     source_code: &str,
     mode: Mode,
@@ -77911,7 +78083,7 @@ fn __action1737<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1738<
+fn __action1741<
 >(
     source_code: &str,
     mode: Mode,
@@ -77951,7 +78123,7 @@ fn __action1738<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1739<
+fn __action1742<
 >(
     source_code: &str,
     mode: Mode,
@@ -77985,7 +78157,7 @@ fn __action1739<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1740<
+fn __action1743<
 >(
     source_code: &str,
     mode: Mode,
@@ -78009,7 +78181,7 @@ fn __action1740<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1741<
+fn __action1744<
 >(
     source_code: &str,
     mode: Mode,
@@ -78033,7 +78205,7 @@ fn __action1741<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1742<
+fn __action1745<
 >(
     source_code: &str,
     mode: Mode,
@@ -78057,7 +78229,7 @@ fn __action1742<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1743<
+fn __action1746<
 >(
     source_code: &str,
     mode: Mode,
@@ -78073,7 +78245,7 @@ fn __action1743<
         __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1497(
+    __action1500(
         source_code,
         mode,
         __0,
@@ -78083,7 +78255,7 @@ fn __action1743<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1744<
+fn __action1747<
 >(
     source_code: &str,
     mode: Mode,
@@ -78100,7 +78272,7 @@ fn __action1744<
         __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1498(
+    __action1501(
         source_code,
         mode,
         __0,
@@ -78111,101 +78283,23 @@ fn __action1744<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1745<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, ast::ParenthesizedExpr, TextSize),
-) -> ast::Stmt
-{
-    let __start0 = __1.0;
-    let __end0 = __1.2;
-    let __temp0 = __action1740(
-        source_code,
-        mode,
-        __1,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1322(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1746<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-) -> ast::Stmt
-{
-    let __start0 = __0.2;
-    let __end0 = __0.2;
-    let __temp0 = __action397(
-        source_code,
-        mode,
-        &__start0,
-        &__end0,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1322(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
-fn __action1747<
->(
-    source_code: &str,
-    mode: Mode,
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, ast::ParenthesizedExpr, TextSize),
-) -> ast::ParenthesizedExpr
-{
-    let __start0 = __1.0;
-    let __end0 = __1.2;
-    let __temp0 = __action1740(
-        source_code,
-        mode,
-        __1,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1522(
-        source_code,
-        mode,
-        __0,
-        __temp0,
-    )
-}
-
-#[allow(unused_variables)]
-#[allow(clippy::too_many_arguments)]
 fn __action1748<
 >(
     source_code: &str,
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
-) -> ast::ParenthesizedExpr
+    __1: (TextSize, ast::ParenthesizedExpr, TextSize),
+) -> ast::Stmt
 {
-    let __start0 = __0.2;
-    let __end0 = __0.2;
-    let __temp0 = __action397(
+    let __start0 = __1.0;
+    let __end0 = __1.2;
+    let __temp0 = __action1743(
         source_code,
         mode,
-        &__start0,
-        &__end0,
+        __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1522(
+    __action1322(
         source_code,
         mode,
         __0,
@@ -78219,20 +78313,22 @@ fn __action1749<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, ast::ParenthesizedExpr, TextSize),
+    __0: (TextSize, token::Tok, TextSize),
 ) -> ast::Stmt
 {
-    let __start0 = __0.0;
+    let __start0 = __0.2;
     let __end0 = __0.2;
-    let __temp0 = __action1742(
+    let __temp0 = __action397(
+        source_code,
+        mode,
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1322(
         source_code,
         mode,
         __0,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1526(
-        source_code,
-        mode,
         __temp0,
     )
 }
@@ -78243,19 +78339,95 @@ fn __action1750<
 >(
     source_code: &str,
     mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, ast::ParenthesizedExpr, TextSize),
+) -> ast::ParenthesizedExpr
+{
+    let __start0 = __1.0;
+    let __end0 = __1.2;
+    let __temp0 = __action1743(
+        source_code,
+        mode,
+        __1,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1525(
+        source_code,
+        mode,
+        __0,
+        __temp0,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1751<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, token::Tok, TextSize),
+) -> ast::ParenthesizedExpr
+{
+    let __start0 = __0.2;
+    let __end0 = __0.2;
+    let __temp0 = __action397(
+        source_code,
+        mode,
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1525(
+        source_code,
+        mode,
+        __0,
+        __temp0,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1752<
+>(
+    source_code: &str,
+    mode: Mode,
+    __0: (TextSize, ast::ParenthesizedExpr, TextSize),
+) -> ast::Stmt
+{
+    let __start0 = __0.0;
+    let __end0 = __0.2;
+    let __temp0 = __action1745(
+        source_code,
+        mode,
+        __0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1529(
+        source_code,
+        mode,
+        __temp0,
+    )
+}
+
+#[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
+fn __action1753<
+>(
+    source_code: &str,
+    mode: Mode,
     __0: (TextSize, ast::ParenthesizedExpr, TextSize),
     __1: (TextSize, alloc::vec::Vec<ast::ParenthesizedExpr>, TextSize),
 ) -> ast::Stmt
 {
     let __start0 = __0.0;
     let __end0 = __0.2;
-    let __temp0 = __action1742(
+    let __temp0 = __action1745(
         source_code,
         mode,
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1527(
+    __action1530(
         source_code,
         mode,
         __temp0,
@@ -78265,7 +78437,7 @@ fn __action1750<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1751<
+fn __action1754<
 >(
     source_code: &str,
     mode: Mode,
@@ -78276,7 +78448,7 @@ fn __action1751<
 {
     let __start0 = __0.0;
     let __end0 = __0.2;
-    let __temp0 = __action1742(
+    let __temp0 = __action1745(
         source_code,
         mode,
         __0,
@@ -78293,7 +78465,7 @@ fn __action1751<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1752<
+fn __action1755<
 >(
     source_code: &str,
     mode: Mode,
@@ -78313,7 +78485,7 @@ fn __action1752<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1552(
+    __action1555(
         source_code,
         mode,
         __0,
@@ -78327,7 +78499,7 @@ fn __action1752<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1753<
+fn __action1756<
 >(
     source_code: &str,
     mode: Mode,
@@ -78347,7 +78519,7 @@ fn __action1753<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1552(
+    __action1555(
         source_code,
         mode,
         __0,
@@ -78361,7 +78533,7 @@ fn __action1753<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1754<
+fn __action1757<
 >(
     source_code: &str,
     mode: Mode,
@@ -78382,7 +78554,7 @@ fn __action1754<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1553(
+    __action1556(
         source_code,
         mode,
         __0,
@@ -78397,7 +78569,7 @@ fn __action1754<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1755<
+fn __action1758<
 >(
     source_code: &str,
     mode: Mode,
@@ -78418,7 +78590,7 @@ fn __action1755<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1553(
+    __action1556(
         source_code,
         mode,
         __0,
@@ -78433,7 +78605,7 @@ fn __action1755<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1756<
+fn __action1759<
 >(
     source_code: &str,
     mode: Mode,
@@ -78452,7 +78624,7 @@ fn __action1756<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1554(
+    __action1557(
         source_code,
         mode,
         __0,
@@ -78465,7 +78637,7 @@ fn __action1756<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1757<
+fn __action1760<
 >(
     source_code: &str,
     mode: Mode,
@@ -78484,7 +78656,7 @@ fn __action1757<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1554(
+    __action1557(
         source_code,
         mode,
         __0,
@@ -78497,7 +78669,7 @@ fn __action1757<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1758<
+fn __action1761<
 >(
     source_code: &str,
     mode: Mode,
@@ -78517,7 +78689,7 @@ fn __action1758<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1555(
+    __action1558(
         source_code,
         mode,
         __0,
@@ -78531,7 +78703,7 @@ fn __action1758<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1759<
+fn __action1762<
 >(
     source_code: &str,
     mode: Mode,
@@ -78551,7 +78723,7 @@ fn __action1759<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1555(
+    __action1558(
         source_code,
         mode,
         __0,
@@ -78565,7 +78737,7 @@ fn __action1759<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1760<
+fn __action1763<
 >(
     source_code: &str,
     mode: Mode,
@@ -78588,7 +78760,7 @@ fn __action1760<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1556(
+    __action1559(
         source_code,
         mode,
         __0,
@@ -78605,7 +78777,7 @@ fn __action1760<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1761<
+fn __action1764<
 >(
     source_code: &str,
     mode: Mode,
@@ -78628,7 +78800,7 @@ fn __action1761<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1556(
+    __action1559(
         source_code,
         mode,
         __0,
@@ -78645,7 +78817,7 @@ fn __action1761<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1762<
+fn __action1765<
 >(
     source_code: &str,
     mode: Mode,
@@ -78669,7 +78841,7 @@ fn __action1762<
         __4,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1557(
+    __action1560(
         source_code,
         mode,
         __0,
@@ -78687,7 +78859,7 @@ fn __action1762<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1763<
+fn __action1766<
 >(
     source_code: &str,
     mode: Mode,
@@ -78711,7 +78883,7 @@ fn __action1763<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1557(
+    __action1560(
         source_code,
         mode,
         __0,
@@ -78729,7 +78901,7 @@ fn __action1763<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1764<
+fn __action1767<
 >(
     source_code: &str,
     mode: Mode,
@@ -78750,7 +78922,7 @@ fn __action1764<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1558(
+    __action1561(
         source_code,
         mode,
         __0,
@@ -78765,7 +78937,7 @@ fn __action1764<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1765<
+fn __action1768<
 >(
     source_code: &str,
     mode: Mode,
@@ -78786,7 +78958,7 @@ fn __action1765<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1558(
+    __action1561(
         source_code,
         mode,
         __0,
@@ -78801,7 +78973,7 @@ fn __action1765<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1766<
+fn __action1769<
 >(
     source_code: &str,
     mode: Mode,
@@ -78823,7 +78995,7 @@ fn __action1766<
         __4,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1559(
+    __action1562(
         source_code,
         mode,
         __0,
@@ -78839,7 +79011,7 @@ fn __action1766<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1767<
+fn __action1770<
 >(
     source_code: &str,
     mode: Mode,
@@ -78861,7 +79033,7 @@ fn __action1767<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1559(
+    __action1562(
         source_code,
         mode,
         __0,
@@ -78877,7 +79049,7 @@ fn __action1767<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1768<
+fn __action1771<
 >(
     source_code: &str,
     mode: Mode,
@@ -78899,7 +79071,7 @@ fn __action1768<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1560(
+    __action1563(
         source_code,
         mode,
         __0,
@@ -78915,7 +79087,7 @@ fn __action1768<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1769<
+fn __action1772<
 >(
     source_code: &str,
     mode: Mode,
@@ -78937,7 +79109,7 @@ fn __action1769<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1560(
+    __action1563(
         source_code,
         mode,
         __0,
@@ -78953,7 +79125,7 @@ fn __action1769<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1770<
+fn __action1773<
 >(
     source_code: &str,
     mode: Mode,
@@ -78976,7 +79148,7 @@ fn __action1770<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1561(
+    __action1564(
         source_code,
         mode,
         __0,
@@ -78993,7 +79165,7 @@ fn __action1770<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1771<
+fn __action1774<
 >(
     source_code: &str,
     mode: Mode,
@@ -79016,7 +79188,7 @@ fn __action1771<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1561(
+    __action1564(
         source_code,
         mode,
         __0,
@@ -79033,7 +79205,7 @@ fn __action1771<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1772<
+fn __action1775<
 >(
     source_code: &str,
     mode: Mode,
@@ -79053,7 +79225,7 @@ fn __action1772<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1562(
+    __action1565(
         source_code,
         mode,
         __0,
@@ -79067,7 +79239,7 @@ fn __action1772<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1773<
+fn __action1776<
 >(
     source_code: &str,
     mode: Mode,
@@ -79087,7 +79259,7 @@ fn __action1773<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1562(
+    __action1565(
         source_code,
         mode,
         __0,
@@ -79101,7 +79273,7 @@ fn __action1773<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1774<
+fn __action1777<
 >(
     source_code: &str,
     mode: Mode,
@@ -79122,7 +79294,7 @@ fn __action1774<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1563(
+    __action1566(
         source_code,
         mode,
         __0,
@@ -79137,7 +79309,7 @@ fn __action1774<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1775<
+fn __action1778<
 >(
     source_code: &str,
     mode: Mode,
@@ -79158,7 +79330,7 @@ fn __action1775<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1563(
+    __action1566(
         source_code,
         mode,
         __0,
@@ -79173,7 +79345,7 @@ fn __action1775<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1776<
+fn __action1779<
 >(
     source_code: &str,
     mode: Mode,
@@ -79192,7 +79364,7 @@ fn __action1776<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1508(
+    __action1511(
         source_code,
         mode,
         __0,
@@ -79205,7 +79377,7 @@ fn __action1776<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1777<
+fn __action1780<
 >(
     source_code: &str,
     mode: Mode,
@@ -79224,7 +79396,7 @@ fn __action1777<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1508(
+    __action1511(
         source_code,
         mode,
         __0,
@@ -79237,7 +79409,7 @@ fn __action1777<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1778<
+fn __action1781<
 >(
     source_code: &str,
     mode: Mode,
@@ -79256,7 +79428,7 @@ fn __action1778<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1720(
+    __action1723(
         source_code,
         mode,
         __0,
@@ -79269,7 +79441,7 @@ fn __action1778<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1779<
+fn __action1782<
 >(
     source_code: &str,
     mode: Mode,
@@ -79288,7 +79460,7 @@ fn __action1779<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1720(
+    __action1723(
         source_code,
         mode,
         __0,
@@ -79301,7 +79473,7 @@ fn __action1779<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1780<
+fn __action1783<
 >(
     source_code: &str,
     mode: Mode,
@@ -79319,7 +79491,7 @@ fn __action1780<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1721(
+    __action1724(
         source_code,
         mode,
         __0,
@@ -79331,7 +79503,7 @@ fn __action1780<
 
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
-fn __action1781<
+fn __action1784<
 >(
     source_code: &str,
     mode: Mode,
@@ -79349,7 +79521,7 @@ fn __action1781<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1721(
+    __action1724(
         source_code,
         mode,
         __0,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__match.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__match.snap
@@ -445,4 +445,153 @@ expression: parse_ast
             ],
         },
     ),
+    Match(
+        StmtMatch {
+            range: 298..332,
+            subject: Tuple(
+                ExprTuple {
+                    range: 304..306,
+                    elts: [
+                        Name(
+                            ExprName {
+                                range: 304..305,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ],
+                    ctx: Load,
+                },
+            ),
+            cases: [
+                MatchCase {
+                    range: 312..332,
+                    pattern: MatchAs(
+                        PatternMatchAs {
+                            range: 317..318,
+                            pattern: None,
+                            name: Some(
+                                Identifier {
+                                    id: "z",
+                                    range: 317..318,
+                                },
+                            ),
+                        },
+                    ),
+                    guard: None,
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 328..332,
+                            },
+                        ),
+                    ],
+                },
+            ],
+        },
+    ),
+    Match(
+        StmtMatch {
+            range: 333..369,
+            subject: Tuple(
+                ExprTuple {
+                    range: 339..343,
+                    elts: [
+                        Name(
+                            ExprName {
+                                range: 339..340,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                        Name(
+                            ExprName {
+                                range: 342..343,
+                                id: "y",
+                                ctx: Load,
+                            },
+                        ),
+                    ],
+                    ctx: Load,
+                },
+            ),
+            cases: [
+                MatchCase {
+                    range: 349..369,
+                    pattern: MatchAs(
+                        PatternMatchAs {
+                            range: 354..355,
+                            pattern: None,
+                            name: Some(
+                                Identifier {
+                                    id: "z",
+                                    range: 354..355,
+                                },
+                            ),
+                        },
+                    ),
+                    guard: None,
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 365..369,
+                            },
+                        ),
+                    ],
+                },
+            ],
+        },
+    ),
+    Match(
+        StmtMatch {
+            range: 370..407,
+            subject: Tuple(
+                ExprTuple {
+                    range: 376..381,
+                    elts: [
+                        Name(
+                            ExprName {
+                                range: 376..377,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                        Name(
+                            ExprName {
+                                range: 379..380,
+                                id: "y",
+                                ctx: Load,
+                            },
+                        ),
+                    ],
+                    ctx: Load,
+                },
+            ),
+            cases: [
+                MatchCase {
+                    range: 387..407,
+                    pattern: MatchAs(
+                        PatternMatchAs {
+                            range: 392..393,
+                            pattern: None,
+                            name: Some(
+                                Identifier {
+                                    id: "z",
+                                    range: 392..393,
+                                },
+                            ),
+                        },
+                    ),
+                    guard: None,
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 403..407,
+                            },
+                        ),
+                    ],
+                },
+            ],
+        },
+    ),
 ]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__patma.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__patma.snap
@@ -3449,10 +3449,18 @@ expression: parse_ast
     Match(
         StmtMatch {
             range: 2661..2697,
-            subject: Name(
-                ExprName {
-                    range: 2667..2668,
-                    id: "x",
+            subject: Tuple(
+                ExprTuple {
+                    range: 2667..2669,
+                    elts: [
+                        Name(
+                            ExprName {
+                                range: 2667..2668,
+                                id: "x",
+                                ctx: Load,
+                            },
+                        ),
+                    ],
                     ctx: Load,
                 },
             ),
@@ -3512,7 +3520,7 @@ expression: parse_ast
             range: 2720..2760,
             subject: Tuple(
                 ExprTuple {
-                    range: 2720..2760,
+                    range: 2726..2730,
                     elts: [
                         Name(
                             ExprName {
@@ -3598,23 +3606,31 @@ expression: parse_ast
     Match(
         StmtMatch {
             range: 2783..2829,
-            subject: NamedExpr(
-                ExprNamedExpr {
-                    range: 2789..2795,
-                    target: Name(
-                        ExprName {
-                            range: 2789..2790,
-                            id: "w",
-                            ctx: Store,
-                        },
-                    ),
-                    value: Name(
-                        ExprName {
-                            range: 2794..2795,
-                            id: "x",
-                            ctx: Load,
-                        },
-                    ),
+            subject: Tuple(
+                ExprTuple {
+                    range: 2789..2796,
+                    elts: [
+                        NamedExpr(
+                            ExprNamedExpr {
+                                range: 2789..2795,
+                                target: Name(
+                                    ExprName {
+                                        range: 2789..2790,
+                                        id: "w",
+                                        ctx: Store,
+                                    },
+                                ),
+                                value: Name(
+                                    ExprName {
+                                        range: 2794..2795,
+                                        id: "x",
+                                        ctx: Load,
+                                    },
+                                ),
+                            },
+                        ),
+                    ],
+                    ctx: Load,
                 },
             ),
             cases: [


### PR DESCRIPTION
## Summary

This was just a bug in the parser ranges, probably since it was initially implemented. Given `match n % 3, n % 5: ...`, the "subject" (i.e., the tuple of two binary operators) was using the entire range of the `match` statement.

Closes https://github.com/astral-sh/ruff/issues/8091.

## Test Plan

`cargo test`
