### PR TITLE
Detect `sys.version_info` slices in `outdated-version-block`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP036_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP036_0.py
@@ -202,3 +202,16 @@ if sys.version_info > (3,12):
 
 if sys.version_info >= (3,12):
     print("py3")
+
+# Slices on `sys.version_info` should be treated equivalently.
+if sys.version_info[:2] >= (3,0):
+    print("py3")
+
+if sys.version_info[:3] >= (3,0):
+    print("py3")
+
+if sys.version_info[:2] > (3,13):
+    print("py3")
+
+if sys.version_info[:3] > (3,13):
+    print("py3")

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use anyhow::Result;
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::helpers::map_subscript;
 use ruff_python_ast::stmt_if::{if_elif_branches, BranchKind, IfElifBranch};
 use ruff_python_ast::whitespace::indentation;
 use ruff_python_ast::{self as ast, CmpOp, Constant, ElifElseClause, Expr, Int, StmtIf};
@@ -94,9 +95,10 @@ pub(crate) fn outdated_version_block(checker: &mut Checker, stmt_if: &StmtIf) {
             continue;
         };
 
+        // Detect `sys.version_info`, along with slices (like `sys.version_info[:2]`).
         if !checker
             .semantic()
-            .resolve_call_path(left)
+            .resolve_call_path(map_subscript(left))
             .is_some_and(|call_path| matches!(call_path.as_slice(), ["sys", "version_info"]))
         {
             continue;

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_0.py.snap
@@ -729,5 +729,49 @@ UP036_0.py:203:4: UP036 [*] Version block is outdated for minimum Python version
 203     |-if sys.version_info >= (3,12):
 204     |-    print("py3")
     203 |+print("py3")
+205 204 | 
+206 205 | # Slices on `sys.version_info` should be treated equivalently.
+207 206 | if sys.version_info[:2] >= (3,0):
+
+UP036_0.py:207:4: UP036 [*] Version block is outdated for minimum Python version
+    |
+206 | # Slices on `sys.version_info` should be treated equivalently.
+207 | if sys.version_info[:2] >= (3,0):
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP036
+208 |     print("py3")
+    |
+    = help: Remove outdated version block
+
+ℹ Suggested fix
+204 204 |     print("py3")
+205 205 | 
+206 206 | # Slices on `sys.version_info` should be treated equivalently.
+207     |-if sys.version_info[:2] >= (3,0):
+208     |-    print("py3")
+    207 |+print("py3")
+209 208 | 
+210 209 | if sys.version_info[:3] >= (3,0):
+211 210 |     print("py3")
+
+UP036_0.py:210:4: UP036 [*] Version block is outdated for minimum Python version
+    |
+208 |     print("py3")
+209 | 
+210 | if sys.version_info[:3] >= (3,0):
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP036
+211 |     print("py3")
+    |
+    = help: Remove outdated version block
+
+ℹ Suggested fix
+207 207 | if sys.version_info[:2] >= (3,0):
+208 208 |     print("py3")
+209 209 | 
+210     |-if sys.version_info[:3] >= (3,0):
+211     |-    print("py3")
+    210 |+print("py3")
+212 211 | 
+213 212 | if sys.version_info[:2] > (3,13):
+214 213 |     print("py3")
 
 


### PR DESCRIPTION
## Summary

Given `sys.version_info[:2] >= (3,0)`, we should treat this equivalently to `sys.version_info >= (3,0)`.

Closes https://github.com/astral-sh/ruff/issues/8095.
