### PR TITLE
Include `backports.strenum` in `deprecated-imports`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
@@ -80,11 +80,14 @@ from typing import cast
 # OK
 from a import b
 
-# Ok: `typing_extensions` contains backported improvements.
+# OK: `typing_extensions` contains backported improvements.
 from typing_extensions import SupportsIndex
 
-# Ok: `typing_extensions` contains backported improvements.
+# OK: `typing_extensions` contains backported improvements.
 from typing_extensions import NamedTuple
 
-# Ok: `typing_extensions` supports `frozen_default` (backported from 3.12).
+# OK: `typing_extensions` supports `frozen_default` (backported from 3.12).
 from typing_extensions import dataclass_transform
+
+# UP035
+from backports.strenum import StrEnum

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -100,7 +100,13 @@ impl Violation for DeprecatedImport {
 fn is_relevant_module(module: &str) -> bool {
     matches!(
         module,
-        "collections" | "pipes" | "mypy_extensions" | "typing_extensions" | "typing" | "typing.re"
+        "collections"
+            | "pipes"
+            | "mypy_extensions"
+            | "typing_extensions"
+            | "typing"
+            | "typing.re"
+            | "backports.strenum"
     )
 }
 
@@ -320,6 +326,8 @@ const TYPING_EXTENSIONS_TO_TYPING_311: &[&str] = &[
     "reveal_type",
 ];
 
+const BACKPORTS_STR_ENUM_TO_ENUM_311: &[&str] = &["StrEnum"];
+
 // Python 3.12+
 
 // Members of `typing_extensions` that were moved to `typing`.
@@ -479,6 +487,11 @@ impl<'a> ImportReplacer<'a> {
             }
             "typing.re" if self.version >= PythonVersion::Py39 => {
                 if let Some(operation) = self.try_replace(TYPING_RE_TO_RE_39, "re") {
+                    operations.push(operation);
+                }
+            }
+            "backports.strenum" if self.version >= PythonVersion::Py311 => {
+                if let Some(operation) = self.try_replace(BACKPORTS_STR_ENUM_TO_ENUM_311, "enum") {
                     operations.push(operation);
                 }
             }

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
@@ -997,37 +997,57 @@ UP035.py:77:1: UP035 [*] Import from `collections.abc` instead: `Callable`
 
 UP035.py:87:1: UP035 [*] Import from `typing` instead: `NamedTuple`
    |
-86 | # Ok: `typing_extensions` contains backported improvements.
+86 | # OK: `typing_extensions` contains backported improvements.
 87 | from typing_extensions import NamedTuple
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP035
 88 | 
-89 | # Ok: `typing_extensions` supports `frozen_default` (backported from 3.12).
+89 | # OK: `typing_extensions` supports `frozen_default` (backported from 3.12).
    |
    = help: Import from `typing`
 
 ℹ Fix
 84 84 | from typing_extensions import SupportsIndex
 85 85 | 
-86 86 | # Ok: `typing_extensions` contains backported improvements.
+86 86 | # OK: `typing_extensions` contains backported improvements.
 87    |-from typing_extensions import NamedTuple
    87 |+from typing import NamedTuple
 88 88 | 
-89 89 | # Ok: `typing_extensions` supports `frozen_default` (backported from 3.12).
+89 89 | # OK: `typing_extensions` supports `frozen_default` (backported from 3.12).
 90 90 | from typing_extensions import dataclass_transform
 
 UP035.py:90:1: UP035 [*] Import from `typing` instead: `dataclass_transform`
    |
-89 | # Ok: `typing_extensions` supports `frozen_default` (backported from 3.12).
+89 | # OK: `typing_extensions` supports `frozen_default` (backported from 3.12).
 90 | from typing_extensions import dataclass_transform
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP035
+91 | 
+92 | # UP035
    |
    = help: Import from `typing`
 
 ℹ Fix
 87 87 | from typing_extensions import NamedTuple
 88 88 | 
-89 89 | # Ok: `typing_extensions` supports `frozen_default` (backported from 3.12).
+89 89 | # OK: `typing_extensions` supports `frozen_default` (backported from 3.12).
 90    |-from typing_extensions import dataclass_transform
    90 |+from typing import dataclass_transform
+91 91 | 
+92 92 | # UP035
+93 93 | from backports.strenum import StrEnum
+
+UP035.py:93:1: UP035 [*] Import from `enum` instead: `StrEnum`
+   |
+92 | # UP035
+93 | from backports.strenum import StrEnum
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP035
+   |
+   = help: Import from `enum`
+
+ℹ Fix
+90 90 | from typing_extensions import dataclass_transform
+91 91 | 
+92 92 | # UP035
+93    |-from backports.strenum import StrEnum
+   93 |+from enum import StrEnum
 
 


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/8102.