### PR TITLE
Refactor `get_mark_decorators` to return a marker name

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -900,10 +900,9 @@ fn check_fixture_addfinalizer(checker: &mut Checker, parameters: &Parameters, bo
 
 /// PT024, PT025
 fn check_fixture_marks(checker: &mut Checker, decorators: &[Decorator]) {
-    for (expr, call_path) in get_mark_decorators(decorators) {
-        let name = call_path.last().expect("Expected a mark name");
+    for (expr, marker) in get_mark_decorators(decorators) {
         if checker.enabled(Rule::PytestUnnecessaryAsyncioMarkOnFixture) {
-            if *name == "asyncio" {
+            if marker == "asyncio" {
                 let mut diagnostic =
                     Diagnostic::new(PytestUnnecessaryAsyncioMarkOnFixture, expr.range());
                 let range = checker.locator().full_lines_range(expr.range());
@@ -913,7 +912,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Decorator]) {
         }
 
         if checker.enabled(Rule::PytestErroneousUseFixturesOnFixture) {
-            if *name == "usefixtures" {
+            if marker == "usefixtures" {
                 let mut diagnostic =
                     Diagnostic::new(PytestErroneousUseFixturesOnFixture, expr.range());
                 let line_range = checker.locator().full_lines_range(expr.range());

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -12,10 +12,10 @@ pub(super) fn get_mark_decorators(
         let Some(call_path) = collect_call_path(map_callable(&decorator.expression)) else {
             return None;
         };
-        match call_path.as_slice() {
-            ["pytest", "mark", marker, ..] => Some((decorator, *marker)),
-            _ => None,
-        }
+        let ["pytest", "mark", marker, ..] = call_path.as_slice() else {
+            return None;
+        };
+        Some((decorator, *marker))
     })
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -12,7 +12,7 @@ pub(super) fn get_mark_decorators(
         let Some(call_path) = collect_call_path(map_callable(&decorator.expression)) else {
             return None;
         };
-        let ["pytest", "mark", marker, ..] = call_path.as_slice() else {
+        let ["pytest", "mark", marker] = call_path.as_slice() else {
             return None;
         };
         Some((decorator, *marker))

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -1,21 +1,20 @@
 use ruff_python_ast::{self as ast, Constant, Decorator, Expr, Keyword};
 
-use ruff_python_ast::call_path::{collect_call_path, CallPath};
+use ruff_python_ast::call_path::collect_call_path;
 use ruff_python_ast::helpers::map_callable;
 use ruff_python_semantic::SemanticModel;
 use ruff_python_trivia::PythonWhitespace;
 
 pub(super) fn get_mark_decorators(
     decorators: &[Decorator],
-) -> impl Iterator<Item = (&Decorator, CallPath)> {
+) -> impl Iterator<Item = (&Decorator, &str)> {
     decorators.iter().filter_map(|decorator| {
         let Some(call_path) = collect_call_path(map_callable(&decorator.expression)) else {
             return None;
         };
-        if call_path.len() > 2 && call_path.as_slice()[..2] == ["pytest", "mark"] {
-            Some((decorator, call_path))
-        } else {
-            None
+        match call_path.as_slice() {
+            ["pytest", "mark", marker, ..] => Some((decorator, *marker)),
+            _ => None,
         }
     })
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Refactor `get_mark_decorators` to return a marker name to remove `.call_path.last().{unpack|expect}`.

## Test Plan

<!-- How was it tested? -->

Existing tests.