### PR TITLE
Remove `--line-length` option from `format` command

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -402,9 +402,6 @@ pub struct FormatCommand {
     force_exclude: bool,
     #[clap(long, overrides_with("force_exclude"), hide = true)]
     no_force_exclude: bool,
-    /// Set the line-length.
-    #[arg(long, help_heading = "Rule configuration", hide = true)]
-    pub line_length: Option<LineLength>,
     /// Ignore all configuration files.
     #[arg(long, conflicts_with = "config", help_heading = "Miscellaneous")]
     pub isolated: bool,
@@ -547,7 +544,6 @@ impl FormatCommand {
                 stdin_filename: self.stdin_filename,
             },
             CliOverrides {
-                line_length: self.line_length,
                 respect_gitignore: resolve_bool_arg(
                     self.respect_gitignore,
                     self.no_respect_gitignore,

--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -118,11 +118,10 @@ quote-style = "single"
 ```
 
 The Ruff formatter also respects Ruff's [`line-length`](https://docs.astral.sh/ruff/settings/#line-length)
-setting, which also can be provided via a `pyproject.toml` or `ruff.toml` file, or on the CLI, as
-in:
+setting, which also can be provided via a `pyproject.toml` or `ruff.toml` file.
 
-```console
-ruff format --line-length 100 /path/to/file.py
+```toml
+line-length = 80
 ```
 
 ### Excluding code from formatting


### PR DESCRIPTION
## Summary

This PR removes the undocumented `--line-length` setting from the `format` command.
The main reason is that we should either support all formatter options or none of them. I would prefer not supporting formatter options via the CLI.  

We can reintroduce the option in the beta based on user feedback.

## Test Plan

```bash
cargo run --bin ruff -q -- format . --line-length=100
error: unexpected argument '--line-length' found
```
