### PR TITLE
Avoid loading files for cached format results

### DIFF
--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -571,7 +571,6 @@ mod tests {
     use ruff_cache::CACHE_DIR_NAME;
     use ruff_linter::settings::flags;
     use ruff_linter::settings::types::UnsafeFixes;
-    use ruff_linter::source_kind::SourceKind;
     use ruff_python_ast::PySourceType;
     use ruff_workspace::Settings;
 
@@ -1061,7 +1060,6 @@ mod tests {
             format_path(
                 &file_path,
                 &self.settings.formatter,
-                &SourceKind::Python(std::fs::read_to_string(&file_path).unwrap()),
                 PySourceType::Python,
                 FormatMode::Write,
                 Some(cache),


### PR DESCRIPTION
## Summary

Avoid loading the content of cached files during formatting

## Test Plan

Closes #8132

## Performance

This reduces the runtime for a hot formatting on airflow from ~105ms to ~90ms

Thanks @konstin for the find.