### PR TITLE
[docs] fix `extend-unsafe-fixes` and `extend-safe-fixes` example error

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -566,7 +566,7 @@ pub struct LintCommonOptions {
         value_type = "list[RuleSelector]",
         example = r#"
             # Allow applying all unsafe fixes in the `E` rules and `F401` without the `--unsafe-fixes` flag
-            extend_safe_fixes = ["E", "F401"]
+            extend-safe-fixes = ["E", "F401"]
         "#
     )]
     pub extend_safe_fixes: Option<Vec<RuleSelector>>,
@@ -578,7 +578,7 @@ pub struct LintCommonOptions {
         value_type = "list[RuleSelector]",
         example = r#"
             # Require the `--unsafe-fixes` flag when fixing the `E` rules and `F401`
-            extend_unsafe_fixes = ["E", "F401"]
+            extend-unsafe-fixes = ["E", "F401"]
         "#
     )]
     pub extend_unsafe_fixes: Option<Vec<RuleSelector>>,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
![image](https://github.com/astral-sh/ruff/assets/66515297/11260250-c2f1-4306-b76d-639fc3ed4bcd)
![image](https://github.com/astral-sh/ruff/assets/66515297/3ee954e4-7a25-4eec-a91d-1f4a8c855d7a)


## Test Plan

Nothing

<!-- How was it tested? -->
