### PR TITLE
Add formatter to `line-length` documentation

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/doc_line_too_long.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/doc_line_too_long.rs
@@ -64,7 +64,7 @@ impl Violation for DocLineTooLong {
     #[derive_message_formats]
     fn message(&self) -> String {
         let DocLineTooLong(width, limit) = self;
-        format!("Doc line too long ({width} > {limit} characters)")
+        format!("Doc line too long ({width} > {limit})")
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/line_too_long.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/line_too_long.rs
@@ -58,7 +58,7 @@ impl Violation for LineTooLong {
     #[derive_message_formats]
     fn message(&self) -> String {
         let LineTooLong(width, limit) = self;
-        format!("Line too long ({width} > {limit} characters)")
+        format!("Line too long ({width} > {limit})")
     }
 }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E501_E501.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E501_E501.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E501.py:5:89: E501 Line too long (123 > 88 characters)
+E501.py:5:89: E501 Line too long (123 > 88)
   |
 3 |     https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533
 4 | 
@@ -10,14 +10,14 @@ E501.py:5:89: E501 Line too long (123 > 88 characters)
 6 | """
   |
 
-E501.py:16:85: E501 Line too long (95 > 88 characters)
+E501.py:16:85: E501 Line too long (95 > 88)
    |
 15 | _ = "---------------------------------------------------------------------------AAAAAAA"
 16 | _ = "---------------------------------------------------------------------------亜亜亜亜亜亜亜"
    |                                                                                         ^^^^^^^ E501
    |
 
-E501.py:25:89: E501 Line too long (127 > 88 characters)
+E501.py:25:89: E501 Line too long (127 > 88)
    |
 23 | caller(
 24 |     """
@@ -27,7 +27,7 @@ E501.py:25:89: E501 Line too long (127 > 88 characters)
 27 | )
    |
 
-E501.py:40:89: E501 Line too long (132 > 88 characters)
+E501.py:40:89: E501 Line too long (132 > 88)
    |
 38 |     "Lorem ipsum dolor": "sit amet",
 39 |     # E501 Line too long
@@ -37,7 +37,7 @@ E501.py:40:89: E501 Line too long (132 > 88 characters)
 42 |     "Lorem ipsum dolor": """
    |
 
-E501.py:43:89: E501 Line too long (105 > 88 characters)
+E501.py:43:89: E501 Line too long (105 > 88)
    |
 41 |     # E501 Line too long
 42 |     "Lorem ipsum dolor": """
@@ -47,7 +47,7 @@ E501.py:43:89: E501 Line too long (105 > 88 characters)
 45 |     # OK
    |
 
-E501.py:83:89: E501 Line too long (147 > 88 characters)
+E501.py:83:89: E501 Line too long (147 > 88)
    |
 81 | class Bar:
 82 |     """

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E501_E501_3.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E501_E501_3.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E501_3.py:11:89: E501 Line too long (89 > 88 characters)
+E501_3.py:11:89: E501 Line too long (89 > 88)
    |
 10 | # Error (89 characters)
 11 | "shape:" + "shape:" + "shape:" + "shape:" + "shape:" + "shape:" + "shape:" + "shape:aaaa"  # type: ignore

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__max_doc_length.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__max_doc_length.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-W505.py:2:51: W505 Doc line too long (57 > 50 characters)
+W505.py:2:51: W505 Doc line too long (57 > 50)
   |
 1 | #!/usr/bin/env python3
 2 | """Here's a top-level docstring that's over the limit."""
   |                                                   ^^^^^^^ W505
   |
 
-W505.py:6:51: W505 Doc line too long (56 > 50 characters)
+W505.py:6:51: W505 Doc line too long (56 > 50)
   |
 5 | def f1():
 6 |     """Here's a docstring that's also over the limit."""
@@ -17,7 +17,7 @@ W505.py:6:51: W505 Doc line too long (56 > 50 characters)
 8 |     x = 1  # Here's a comment that's over the limit, but it's not standalone.
   |
 
-W505.py:10:51: W505 Doc line too long (56 > 50 characters)
+W505.py:10:51: W505 Doc line too long (56 > 50)
    |
  8 |     x = 1  # Here's a comment that's over the limit, but it's not standalone.
  9 | 
@@ -27,7 +27,7 @@ W505.py:10:51: W505 Doc line too long (56 > 50 characters)
 12 |     x = 2
    |
 
-W505.py:13:51: W505 Doc line too long (93 > 50 characters)
+W505.py:13:51: W505 Doc line too long (93 > 50)
    |
 12 |     x = 2
 13 |     # Another standalone that is preceded by a newline and indent toke and is over the limit.
@@ -36,13 +36,13 @@ W505.py:13:51: W505 Doc line too long (93 > 50 characters)
 15 |     print("Here's a string that's over the limit, but it's not a docstring.")
    |
 
-W505.py:18:51: W505 Doc line too long (61 > 50 characters)
+W505.py:18:51: W505 Doc line too long (61 > 50)
    |
 18 | "This is also considered a docstring, and is over the limit."
    |                                                   ^^^^^^^^^^^ W505
    |
 
-W505.py:24:51: W505 Doc line too long (82 > 50 characters)
+W505.py:24:51: W505 Doc line too long (82 > 50)
    |
 22 |     """Here's a multi-line docstring.
 23 | 
@@ -51,7 +51,7 @@ W505.py:24:51: W505 Doc line too long (82 > 50 characters)
 25 |     """
    |
 
-W505.py:31:51: W505 Doc line too long (85 > 50 characters)
+W505.py:31:51: W505 Doc line too long (85 > 50)
    |
 29 |     """Here's a multi-line docstring.
 30 | 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__max_doc_length_with_utf_8.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__max_doc_length_with_utf_8.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-W505_utf_8.py:2:50: W505 Doc line too long (57 > 50 characters)
+W505_utf_8.py:2:50: W505 Doc line too long (57 > 50)
   |
 1 | #!/usr/bin/env python3
 2 | """Here's a top-level ß9💣2ℝing that's over theß9💣2ℝ."""
   |                                                    ^^^^^^ W505
   |
 
-W505_utf_8.py:6:49: W505 Doc line too long (56 > 50 characters)
+W505_utf_8.py:6:49: W505 Doc line too long (56 > 50)
   |
 5 | def f1():
 6 |     """Here's a ß9💣2ℝing that's also over theß9💣2ℝ."""
@@ -17,7 +17,7 @@ W505_utf_8.py:6:49: W505 Doc line too long (56 > 50 characters)
 8 |     x = 1  # Here's a comment that's over theß9💣2ℝ, but it's not standalone.
   |
 
-W505_utf_8.py:10:51: W505 Doc line too long (56 > 50 characters)
+W505_utf_8.py:10:51: W505 Doc line too long (56 > 50)
    |
  8 |     x = 1  # Here's a comment that's over theß9💣2ℝ, but it's not standalone.
  9 | 
@@ -27,7 +27,7 @@ W505_utf_8.py:10:51: W505 Doc line too long (56 > 50 characters)
 12 |     x = 2
    |
 
-W505_utf_8.py:13:51: W505 Doc line too long (93 > 50 characters)
+W505_utf_8.py:13:51: W505 Doc line too long (93 > 50)
    |
 12 |     x = 2
 13 |     # Another standalone that is preceded by a newline and indent toke and is over theß9💣2ℝ.
@@ -36,13 +36,13 @@ W505_utf_8.py:13:51: W505 Doc line too long (93 > 50 characters)
 15 |     print("Here's a string that's over theß9💣2ℝ, but it's not a ß9💣2ℝing.")
    |
 
-W505_utf_8.py:18:50: W505 Doc line too long (61 > 50 characters)
+W505_utf_8.py:18:50: W505 Doc line too long (61 > 50)
    |
 18 | "This is also considered a ß9💣2ℝing, and is over theß9💣2ℝ."
    |                                                   ^^^^^^^^^^^ W505
    |
 
-W505_utf_8.py:24:50: W505 Doc line too long (82 > 50 characters)
+W505_utf_8.py:24:50: W505 Doc line too long (82 > 50)
    |
 22 |     """Here's a multi-line ß9💣2ℝing.
 23 | 
@@ -51,7 +51,7 @@ W505_utf_8.py:24:50: W505 Doc line too long (82 > 50 characters)
 25 |     """
    |
 
-W505_utf_8.py:31:50: W505 Doc line too long (85 > 50 characters)
+W505_utf_8.py:31:50: W505 Doc line too long (85 > 50)
    |
 29 |     """Here's a multi-line ß9💣2ℝing.
 30 | 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_1.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_1.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E501_2.py:2:7: E501 Line too long (7 > 6 characters)
+E501_2.py:2:7: E501 Line too long (7 > 6)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -10,7 +10,7 @@ E501_2.py:2:7: E501 Line too long (7 > 6 characters)
 4 |     # a
   |
 
-E501_2.py:3:7: E501 Line too long (7 > 6 characters)
+E501_2.py:3:7: E501 Line too long (7 > 6)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -20,7 +20,7 @@ E501_2.py:3:7: E501 Line too long (7 > 6 characters)
 5 |     # aa
   |
 
-E501_2.py:7:7: E501 Line too long (7 > 6 characters)
+E501_2.py:7:7: E501 Line too long (7 > 6)
   |
 5 |     # aa
 6 |     # aaa
@@ -30,7 +30,7 @@ E501_2.py:7:7: E501 Line too long (7 > 6 characters)
 9 |         # aa
   |
 
-E501_2.py:10:7: E501 Line too long (7 > 6 characters)
+E501_2.py:10:7: E501 Line too long (7 > 6)
    |
  8 |         # a
  9 |         # aa
@@ -40,7 +40,7 @@ E501_2.py:10:7: E501 Line too long (7 > 6 characters)
 12 | if True: # noqa: E501
    |
 
-E501_2.py:16:7: E501 Line too long (7 > 6 characters)
+E501_2.py:16:7: E501 Line too long (7 > 6)
    |
 14 |     [12 ]
 15 |     [1,2]

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_2.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_2.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E501_2.py:2:7: E501 Line too long (7 > 6 characters)
+E501_2.py:2:7: E501 Line too long (7 > 6)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -10,7 +10,7 @@ E501_2.py:2:7: E501 Line too long (7 > 6 characters)
 4 |     # a
   |
 
-E501_2.py:3:7: E501 Line too long (7 > 6 characters)
+E501_2.py:3:7: E501 Line too long (7 > 6)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -20,7 +20,7 @@ E501_2.py:3:7: E501 Line too long (7 > 6 characters)
 5 |     # aa
   |
 
-E501_2.py:6:6: E501 Line too long (7 > 6 characters)
+E501_2.py:6:6: E501 Line too long (7 > 6)
   |
 4 |     # a
 5 |     # aa
@@ -30,7 +30,7 @@ E501_2.py:6:6: E501 Line too long (7 > 6 characters)
 8 |         # a
   |
 
-E501_2.py:7:6: E501 Line too long (8 > 6 characters)
+E501_2.py:7:6: E501 Line too long (8 > 6)
   |
 5 |     # aa
 6 |     # aaa
@@ -40,7 +40,7 @@ E501_2.py:7:6: E501 Line too long (8 > 6 characters)
 9 |         # aa
   |
 
-E501_2.py:8:5: E501 Line too long (7 > 6 characters)
+E501_2.py:8:5: E501 Line too long (7 > 6)
    |
  6 |     # aaa
  7 |     # aaaa
@@ -50,7 +50,7 @@ E501_2.py:8:5: E501 Line too long (7 > 6 characters)
 10 |         # aaa
    |
 
-E501_2.py:9:5: E501 Line too long (8 > 6 characters)
+E501_2.py:9:5: E501 Line too long (8 > 6)
    |
  7 |     # aaaa
  8 |         # a
@@ -59,7 +59,7 @@ E501_2.py:9:5: E501 Line too long (8 > 6 characters)
 10 |         # aaa
    |
 
-E501_2.py:10:5: E501 Line too long (9 > 6 characters)
+E501_2.py:10:5: E501 Line too long (9 > 6)
    |
  8 |         # a
  9 |         # aa
@@ -69,7 +69,7 @@ E501_2.py:10:5: E501 Line too long (9 > 6 characters)
 12 | if True: # noqa: E501
    |
 
-E501_2.py:14:6: E501 Line too long (7 > 6 characters)
+E501_2.py:14:6: E501 Line too long (7 > 6)
    |
 12 | if True: # noqa: E501
 13 |     [12]
@@ -79,7 +79,7 @@ E501_2.py:14:6: E501 Line too long (7 > 6 characters)
 16 |     [1, 2]
    |
 
-E501_2.py:16:6: E501 Line too long (8 > 6 characters)
+E501_2.py:16:6: E501 Line too long (8 > 6)
    |
 14 |     [12 ]
 15 |     [1,2]

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_4.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_4.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E501_2.py:2:7: E501 Line too long (7 > 6 characters)
+E501_2.py:2:7: E501 Line too long (7 > 6)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -10,7 +10,7 @@ E501_2.py:2:7: E501 Line too long (7 > 6 characters)
 4 |     # a
   |
 
-E501_2.py:3:7: E501 Line too long (7 > 6 characters)
+E501_2.py:3:7: E501 Line too long (7 > 6)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -20,7 +20,7 @@ E501_2.py:3:7: E501 Line too long (7 > 6 characters)
 5 |     # aa
   |
 
-E501_2.py:4:4: E501 Line too long (7 > 6 characters)
+E501_2.py:4:4: E501 Line too long (7 > 6)
   |
 2 | # aaaaa
 3 |     # a
@@ -30,7 +30,7 @@ E501_2.py:4:4: E501 Line too long (7 > 6 characters)
 6 |     # aaa
   |
 
-E501_2.py:5:4: E501 Line too long (8 > 6 characters)
+E501_2.py:5:4: E501 Line too long (8 > 6)
   |
 3 |     # a
 4 |     # a
@@ -40,7 +40,7 @@ E501_2.py:5:4: E501 Line too long (8 > 6 characters)
 7 |     # aaaa
   |
 
-E501_2.py:6:4: E501 Line too long (9 > 6 characters)
+E501_2.py:6:4: E501 Line too long (9 > 6)
   |
 4 |     # a
 5 |     # aa
@@ -50,7 +50,7 @@ E501_2.py:6:4: E501 Line too long (9 > 6 characters)
 8 |         # a
   |
 
-E501_2.py:7:4: E501 Line too long (10 > 6 characters)
+E501_2.py:7:4: E501 Line too long (10 > 6)
   |
 5 |     # aa
 6 |     # aaa
@@ -60,7 +60,7 @@ E501_2.py:7:4: E501 Line too long (10 > 6 characters)
 9 |         # aa
   |
 
-E501_2.py:8:3: E501 Line too long (11 > 6 characters)
+E501_2.py:8:3: E501 Line too long (11 > 6)
    |
  6 |     # aaa
  7 |     # aaaa
@@ -70,7 +70,7 @@ E501_2.py:8:3: E501 Line too long (11 > 6 characters)
 10 |         # aaa
    |
 
-E501_2.py:9:3: E501 Line too long (12 > 6 characters)
+E501_2.py:9:3: E501 Line too long (12 > 6)
    |
  7 |     # aaaa
  8 |         # a
@@ -79,7 +79,7 @@ E501_2.py:9:3: E501 Line too long (12 > 6 characters)
 10 |         # aaa
    |
 
-E501_2.py:10:3: E501 Line too long (13 > 6 characters)
+E501_2.py:10:3: E501 Line too long (13 > 6)
    |
  8 |         # a
  9 |         # aa
@@ -89,7 +89,7 @@ E501_2.py:10:3: E501 Line too long (13 > 6 characters)
 12 | if True: # noqa: E501
    |
 
-E501_2.py:14:4: E501 Line too long (9 > 6 characters)
+E501_2.py:14:4: E501 Line too long (9 > 6)
    |
 12 | if True: # noqa: E501
 13 |     [12]
@@ -99,7 +99,7 @@ E501_2.py:14:4: E501 Line too long (9 > 6 characters)
 16 |     [1, 2]
    |
 
-E501_2.py:16:4: E501 Line too long (10 > 6 characters)
+E501_2.py:16:4: E501 Line too long (10 > 6)
    |
 14 |     [12 ]
 15 |     [1,2]

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_8.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__tab_size_8.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E501_2.py:2:7: E501 Line too long (7 > 6 characters)
+E501_2.py:2:7: E501 Line too long (7 > 6)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -10,7 +10,7 @@ E501_2.py:2:7: E501 Line too long (7 > 6 characters)
 4 |     # a
   |
 
-E501_2.py:3:7: E501 Line too long (7 > 6 characters)
+E501_2.py:3:7: E501 Line too long (7 > 6)
   |
 1 | # aaaa
 2 | # aaaaa
@@ -20,7 +20,7 @@ E501_2.py:3:7: E501 Line too long (7 > 6 characters)
 5 |     # aa
   |
 
-E501_2.py:4:2: E501 Line too long (11 > 6 characters)
+E501_2.py:4:2: E501 Line too long (11 > 6)
   |
 2 | # aaaaa
 3 |     # a
@@ -30,7 +30,7 @@ E501_2.py:4:2: E501 Line too long (11 > 6 characters)
 6 |     # aaa
   |
 
-E501_2.py:5:2: E501 Line too long (12 > 6 characters)
+E501_2.py:5:2: E501 Line too long (12 > 6)
   |
 3 |     # a
 4 |     # a
@@ -40,7 +40,7 @@ E501_2.py:5:2: E501 Line too long (12 > 6 characters)
 7 |     # aaaa
   |
 
-E501_2.py:6:2: E501 Line too long (13 > 6 characters)
+E501_2.py:6:2: E501 Line too long (13 > 6)
   |
 4 |     # a
 5 |     # aa
@@ -50,7 +50,7 @@ E501_2.py:6:2: E501 Line too long (13 > 6 characters)
 8 |         # a
   |
 
-E501_2.py:7:2: E501 Line too long (14 > 6 characters)
+E501_2.py:7:2: E501 Line too long (14 > 6)
   |
 5 |     # aa
 6 |     # aaa
@@ -60,7 +60,7 @@ E501_2.py:7:2: E501 Line too long (14 > 6 characters)
 9 |         # aa
   |
 
-E501_2.py:8:2: E501 Line too long (19 > 6 characters)
+E501_2.py:8:2: E501 Line too long (19 > 6)
    |
  6 |     # aaa
  7 |     # aaaa
@@ -70,7 +70,7 @@ E501_2.py:8:2: E501 Line too long (19 > 6 characters)
 10 |         # aaa
    |
 
-E501_2.py:9:2: E501 Line too long (20 > 6 characters)
+E501_2.py:9:2: E501 Line too long (20 > 6)
    |
  7 |     # aaaa
  8 |         # a
@@ -79,7 +79,7 @@ E501_2.py:9:2: E501 Line too long (20 > 6 characters)
 10 |         # aaa
    |
 
-E501_2.py:10:2: E501 Line too long (21 > 6 characters)
+E501_2.py:10:2: E501 Line too long (21 > 6)
    |
  8 |         # a
  9 |         # aa
@@ -89,7 +89,7 @@ E501_2.py:10:2: E501 Line too long (21 > 6 characters)
 12 | if True: # noqa: E501
    |
 
-E501_2.py:14:2: E501 Line too long (13 > 6 characters)
+E501_2.py:14:2: E501 Line too long (13 > 6)
    |
 12 | if True: # noqa: E501
 13 |     [12]
@@ -99,7 +99,7 @@ E501_2.py:14:2: E501 Line too long (13 > 6 characters)
 16 |     [1, 2]
    |
 
-E501_2.py:16:2: E501 Line too long (14 > 6 characters)
+E501_2.py:16:2: E501 Line too long (14 > 6)
    |
 14 |     [12 ]
 15 |     [1,2]

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__task_tags_false.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__task_tags_false.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E501_1.py:1:89: E501 Line too long (149 > 88 characters)
+E501_1.py:1:89: E501 Line too long (149 > 88)
   |
 1 | # TODO: comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |                                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E501
@@ -9,7 +9,7 @@ E501_1.py:1:89: E501 Line too long (149 > 88 characters)
 3 | # TODO comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |
 
-E501_1.py:2:89: E501 Line too long (158 > 88 characters)
+E501_1.py:2:89: E501 Line too long (158 > 88)
   |
 1 | # TODO: comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
 2 | # TODO(charlie): comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
@@ -18,7 +18,7 @@ E501_1.py:2:89: E501 Line too long (158 > 88 characters)
 4 | #     TODO    comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |
 
-E501_1.py:3:89: E501 Line too long (148 > 88 characters)
+E501_1.py:3:89: E501 Line too long (148 > 88)
   |
 1 | # TODO: comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
 2 | # TODO(charlie): comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
@@ -28,7 +28,7 @@ E501_1.py:3:89: E501 Line too long (148 > 88 characters)
 5 | # FIXME: comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |
 
-E501_1.py:4:89: E501 Line too long (155 > 88 characters)
+E501_1.py:4:89: E501 Line too long (155 > 88)
   |
 2 | # TODO(charlie): comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
 3 | # TODO comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
@@ -38,7 +38,7 @@ E501_1.py:4:89: E501 Line too long (155 > 88 characters)
 6 | # FIXME comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |
 
-E501_1.py:5:89: E501 Line too long (150 > 88 characters)
+E501_1.py:5:89: E501 Line too long (150 > 88)
   |
 3 | # TODO comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
 4 | #     TODO    comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
@@ -48,7 +48,7 @@ E501_1.py:5:89: E501 Line too long (150 > 88 characters)
 7 | #     FIXME    comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |
 
-E501_1.py:6:89: E501 Line too long (149 > 88 characters)
+E501_1.py:6:89: E501 Line too long (149 > 88)
   |
 4 | #     TODO    comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
 5 | # FIXME: comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
@@ -58,7 +58,7 @@ E501_1.py:6:89: E501 Line too long (149 > 88 characters)
 8 | # FIXME(charlie): comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |
 
-E501_1.py:7:89: E501 Line too long (156 > 88 characters)
+E501_1.py:7:89: E501 Line too long (156 > 88)
   |
 5 | # FIXME: comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
 6 | # FIXME comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
@@ -67,7 +67,7 @@ E501_1.py:7:89: E501 Line too long (156 > 88 characters)
 8 | # FIXME(charlie): comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
   |
 
-E501_1.py:8:89: E501 Line too long (159 > 88 characters)
+E501_1.py:8:89: E501 Line too long (159 > 88)
   |
 6 | # FIXME comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`
 7 | #     FIXME    comments starting with one of the configured task-tags sometimes are longer than line-length so that you can easily find them with `git grep`

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0.snap
@@ -237,7 +237,7 @@ RUF100_0.py:85:8: F401 [*] `shelve` imported but unused
 87 86 | 
 88 87 | print(sys.path)
 
-RUF100_0.py:90:89: E501 Line too long (89 > 88 characters)
+RUF100_0.py:90:89: E501 Line too long (89 > 88)
    |
 88 | print(sys.path)
 89 | 

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -351,13 +351,22 @@ pub struct Options {
     pub src: Option<Vec<String>>,
 
     // Global Formatting options
-    /// The line length to use when enforcing long-lines violations (like
-    /// `E501`). Must be greater than `0` and less than or equal to `320`.
+    /// The line length to use when enforcing long-lines violations (like `E501`)
+    /// and at which the formatter prefers to wrap lines.
+    ///
+    /// The length is determined by the number of characters per line, except for lines containing East Asian characters or emojis.
+    /// For these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.
+    ///
+    /// The value must be greater than `0` and less than or equal to `320`.
+    ///
+    /// Note: While the formatter will attempt to format lines such that they remain
+    /// within the `line-length`, it isn't a hard upper bound, and formatted lines may
+    /// exceed the `line-length`.
     #[option(
         default = "88",
         value_type = "int",
         example = r#"
-        # Allow lines to be as long as 120 characters.
+        # Allow lines to be as long as 120.
         line-length = 120
         "#
     )]
@@ -2238,9 +2247,12 @@ impl Pep8NamingOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PycodestyleOptions {
-    /// The maximum line length to allow for line-length violations within
+    /// The maximum line length to allow for [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) violations within
     /// documentation (`W505`), including standalone comments. By default,
     /// this is set to null which disables reporting violations.
+    ///
+    /// The length is determined by the number of characters per line, except for lines containinAsian characters or emojis.
+    /// For these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.
     ///
     /// See the [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) rule for more information.
     #[option(
@@ -2597,7 +2609,7 @@ pub struct FormatOptions {
     /// If this option is set to `true`, the magic trailing comma is ignored.
     ///
     /// For example, Ruff leaves the arguments separate even though
-    /// collapsing the arguments to a single line doesn't exceed the line width if `skip-magic-trailing-comma = false`:
+    /// collapsing the arguments to a single line doesn't exceed the line length if `skip-magic-trailing-comma = false`:
     ///
     /// ```python
     ///  # The arguments remain on separate lines because of the trailing comma after `b`

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -107,7 +107,7 @@ To configure Ruff, let's create a `pyproject.toml` file in our project's root di
 
 ```toml
 [tool.ruff]
-# Set the maximum line length to 79 characters.
+# Set the maximum line length to 79.
 line-length = 79
 
 [tool.ruff.linter]
@@ -117,11 +117,11 @@ line-length = 79
 extend-select = ["E501"]
 ```
 
-Running Ruff again, we see that it now enforces a maximum line width, with a limit of 79 characters:
+Running Ruff again, we see that it now enforces a maximum line width, with a limit of 79:
 
 ```shell
 ❯ ruff check .
-numbers/numbers.py:5:80: E501 Line too long (90 > 79 characters)
+numbers/numbers.py:5:80: E501 Line too long (90 > 79)
 Found 1 error.
 ```
 
@@ -134,7 +134,7 @@ specifically, we'll want to make note of the minimum supported Python version:
 requires-python = ">=3.10"
 
 [tool.ruff]
-# Set the maximum line length to 79 characters.
+# Set the maximum line length to 79.
 line-length = 79
 
 [tool.ruff.linter]

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -425,7 +425,7 @@
       ]
     },
     "line-length": {
-      "description": "The line length to use when enforcing long-lines violations (like `E501`). Must be greater than `0` and less than or equal to `320`.",
+      "description": "The line length to use when enforcing long-lines violations (like `E501`) and at which the formatter prefers to wrap lines.\n\nThe length is determined by the number of characters per line, except for lines containing East Asian characters or emojis. For these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.\n\nThe value must be greater than `0` and less than or equal to `320`.\n\nNote: While the formatter will attempt to format lines such that they remain within the `line-length`, it isn't a hard upper bound, and formatted lines may exceed the `line-length`.",
       "anyOf": [
         {
           "$ref": "#/definitions/LineLength"
@@ -1280,7 +1280,7 @@
           ]
         },
         "skip-magic-trailing-comma": {
-          "description": "Ruff uses existing trailing commas as an indication that short lines should be left separate. If this option is set to `true`, the magic trailing comma is ignored.\n\nFor example, Ruff leaves the arguments separate even though collapsing the arguments to a single line doesn't exceed the line width if `skip-magic-trailing-comma = false`:\n\n```python # The arguments remain on separate lines because of the trailing comma after `b` def test( a, b, ): pass ```\n\nSetting `skip-magic-trailing-comma = true` changes the formatting to:\n\n```python # The arguments remain on separate lines because of the trailing comma after `b` def test(a, b): pass ```",
+          "description": "Ruff uses existing trailing commas as an indication that short lines should be left separate. If this option is set to `true`, the magic trailing comma is ignored.\n\nFor example, Ruff leaves the arguments separate even though collapsing the arguments to a single line doesn't exceed the line length if `skip-magic-trailing-comma = false`:\n\n```python # The arguments remain on separate lines because of the trailing comma after `b` def test( a, b, ): pass ```\n\nSetting `skip-magic-trailing-comma = true` changes the formatting to:\n\n```python # The arguments remain on separate lines because of the trailing comma after `b` def test(a, b): pass ```",
           "type": [
             "boolean",
             "null"
@@ -2195,7 +2195,7 @@
           ]
         },
         "max-doc-length": {
-          "description": "The maximum line length to allow for line-length violations within documentation (`W505`), including standalone comments. By default, this is set to null which disables reporting violations.\n\nSee the [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) rule for more information.",
+          "description": "The maximum line length to allow for [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) violations within documentation (`W505`), including standalone comments. By default, this is set to null which disables reporting violations.\n\nThe length is determined by the number of characters per line, except for lines containinAsian characters or emojis. For these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.\n\nSee the [`doc-line-too-long`](https://docs.astral.sh/ruff/rules/doc-line-too-long/) rule for more information.",
           "anyOf": [
             {
               "$ref": "#/definitions/LineLength"


### PR DESCRIPTION
## Summary

This PR updates the `line-length` option documentation to mention its usage in the formatter. 

I used this as an opportunity to clarify how the line-length is measured (using unicode width rather than characters) and removed the `(characters)` unit from the `line-too-long` and `doc-line-too-long` lints. 

Closes #7574
Closes #7573

Note: I decided not to rename the options to `-width`, at least for now. Mainly because performing the renaming causes other inconsistencies: 
* The rule `line-too-long` would need to be renamed to `line-too-wide`. Same for `doc-line-too-long`
* The `ignore-overlong-task-comments` option would need to be renamed to `ignore-overwide-task-comments`. 


While I like `width` more, it seemed out of scope to rush these changes before the formatter release (and change it as part of a patch release). 



## Test Plan

I generated and reviewed the build documentation.
