### PR TITLE
Don't move type param opening parenthesis comment

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/type_alias.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/type_alias.py
@@ -81,6 +81,10 @@ type type_params_comments[ # trailing open bracket comment
     D, # trailing comment
     # leading close bracket comment
 ] = int  # trailing value comment
+type type_params_single_comment[ # trailing open bracket comment
+    A,
+    B
+] = int
 type type_params_all_kinds[type_var, *type_var_tuple, **param_spec] = int
 
 # type variable bounds

--- a/crates/ruff_python_formatter/src/type_param/type_params.rs
+++ b/crates/ruff_python_formatter/src/type_param/type_params.rs
@@ -1,11 +1,10 @@
-use ruff_formatter::write;
 use ruff_formatter::FormatResult;
 use ruff_python_ast::AstNode;
 use ruff_python_ast::TypeParams;
 use ruff_text_size::Ranged;
 
 use crate::builders::PyFormatterExtensions;
-use crate::comments::{trailing_comments, SourceComment};
+use crate::comments::SourceComment;
 use crate::expression::parentheses::parenthesized;
 use crate::prelude::*;
 
@@ -24,7 +23,6 @@ impl FormatNodeRule<TypeParams> for FormatTypeParams {
         // ] = ...
         let comments = f.context().comments().clone();
         let dangling_comments = comments.dangling(item.as_any_node_ref());
-        write!(f, [trailing_comments(dangling_comments)])?;
 
         let items = format_with(|f| {
             f.join_comma_separated(item.end())
@@ -32,7 +30,9 @@ impl FormatNodeRule<TypeParams> for FormatTypeParams {
                 .finish()
         });
 
-        parenthesized("[", &items, "]").fmt(f)
+        parenthesized("[", &items, "]")
+            .with_dangling_comments(dangling_comments)
+            .fmt(f)
     }
 
     fn fmt_dangling_comments(

--- a/crates/ruff_python_formatter/tests/snapshots/format@parentheses__opening_parentheses_comment_value.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@parentheses__opening_parentheses_comment_value.py.snap
@@ -327,7 +327,9 @@ f3 = {  # f3
 
 
 # Non-empty parentheses: These are not allowed without a value
-def f1[T]():  # f1
+def f1[  # f1
+    T
+]():
     pass
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__type_alias.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__type_alias.py.snap
@@ -87,6 +87,10 @@ type type_params_comments[ # trailing open bracket comment
     D, # trailing comment
     # leading close bracket comment
 ] = int  # trailing value comment
+type type_params_single_comment[ # trailing open bracket comment
+    A,
+    B
+] = int
 type type_params_all_kinds[type_var, *type_var_tuple, **param_spec] = int
 
 # type variable bounds
@@ -201,6 +205,10 @@ type type_params_comments[  # trailing open bracket comment
     D,  # trailing comment
     # leading close bracket comment
 ] = int  # trailing value comment
+type type_params_single_comment[  # trailing open bracket comment
+    A,
+    B,
+] = int
 type type_params_all_kinds[type_var, *type_var_tuple, **param_spec] = int
 
 # type variable bounds


### PR DESCRIPTION
## Summary

This PR fixes the issue to avoid collapsing the type param declaration if
there's a comment after the opening parenthesis. For example,

```python
type foo[  # comment
    A,
    B
] = int
```

Here, we'll preserve the comment on the same line as is being done for other
similar type of nodes.

## Test Plan

Add a new test case for it, update the snapshots, and validate the ecosystem
check.

### Formatter ecosystem

#### `main`

| project        | similarity index  | total files       | changed files     |
|----------------|------------------:|------------------:|------------------:|
| cpython        |           0.75803 |              1799 |              1647 |
| django         |           0.99983 |              2772 |                34 |
| home-assistant |           0.99953 |             10596 |               186 |
| poetry         |           0.99891 |               317 |                17 |
| transformers   |           0.99966 |              2657 |               330 |
| twine          |           1.00000 |                33 |                 0 |
| typeshed       |           0.99978 |              3669 |                20 |
| warehouse      |           0.99977 |               654 |                13 |
| zulip          |           0.99970 |              1459 |                22 |

#### `dhruv/type-params`

| project        | similarity index  | total files       | changed files     |
|----------------|------------------:|------------------:|------------------:|
| cpython        |           0.75803 |              1799 |              1647 |
| django         |           0.99983 |              2772 |                34 |
| home-assistant |           0.99953 |             10596 |               186 |
| poetry         |           0.99891 |               317 |                17 |
| transformers   |           0.99966 |              2657 |               330 |
| twine          |           1.00000 |                33 |                 0 |
| typeshed       |           0.99978 |              3669 |                20 |
| warehouse      |           0.99977 |               654 |                13 |
| zulip          |           0.99970 |              1459 |                22 |

fixes: #8162 