### PR TITLE
Match rule prefixes from `external` codes setting in `unused-noqa`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_0.py
@@ -21,6 +21,9 @@ def f() -> None:
     # Invalid (but external)
     d = 1  # noqa: F841, V101
 
+    # Invalid (but external)
+    d = 1  # noqa: V500
+
     # fmt: off
     # Invalid - no space before #
     d = 1# noqa: E501

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -128,9 +128,6 @@ pub(crate) fn check_noqa(
                         }
 
                         if line.matches.iter().any(|match_| *match_ == code)
-                            // Perform a fast-check for exact matches first
-                            || settings.external.contains(code)
-                            // then check for matching prefixes
                             || settings
                                 .external
                                 .iter()

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -128,7 +128,13 @@ pub(crate) fn check_noqa(
                         }
 
                         if line.matches.iter().any(|match_| *match_ == code)
+                            // Perform a fast-check for exact matches first
                             || settings.external.contains(code)
+                            // then check for matching prefixes
+                            || settings
+                                .external
+                                .iter()
+                                .any(|external| code.starts_with(external))
                         {
                             valid_codes.push(code);
                         } else {

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -106,7 +106,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("ruff/RUF100_0.py"),
             &settings::LinterSettings {
-                external: FxHashSet::from_iter(vec!["V101".to_string()]),
+                external: vec!["V101".to_string()],
                 ..settings::LinterSettings::for_rules(vec![
                     Rule::UnusedNOQA,
                     Rule::LineTooLong,
@@ -125,7 +125,7 @@ mod tests {
         let diagnostics = test_path(
             Path::new("ruff/RUF100_0.py"),
             &settings::LinterSettings {
-                external: FxHashSet::from_iter(vec!["V".to_string()]),
+                external: vec!["V".to_string()],
                 ..settings::LinterSettings::for_rules(vec![
                     Rule::UnusedNOQA,
                     Rule::LineTooLong,

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -121,6 +121,25 @@ mod tests {
     }
 
     #[test]
+    fn ruf100_0_prefix() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("ruff/RUF100_0.py"),
+            &settings::LinterSettings {
+                external: FxHashSet::from_iter(vec!["V".to_string()]),
+                ..settings::LinterSettings::for_rules(vec![
+                    Rule::UnusedNOQA,
+                    Rule::LineTooLong,
+                    Rule::UnusedImport,
+                    Rule::UnusedVariable,
+                    Rule::TabIndentation,
+                ])
+            },
+        )?;
+        assert_messages!(diagnostics);
+        Ok(())
+    }
+
+    #[test]
     fn ruf100_1() -> Result<()> {
         let diagnostics = test_path(
             Path::new("ruff/RUF100_1.py"),

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0_prefix.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_0_prefix.snap
@@ -100,26 +100,6 @@ RUF100_0.py:22:12: RUF100 [*] Unused `noqa` directive (unused: `F841`)
 24 24 |     # Invalid (but external)
 25 25 |     d = 1  # noqa: V500
 
-RUF100_0.py:25:12: RUF100 [*] Unused `noqa` directive (unknown: `V500`)
-   |
-24 |     # Invalid (but external)
-25 |     d = 1  # noqa: V500
-   |            ^^^^^^^^^^^^ RUF100
-26 | 
-27 |     # fmt: off
-   |
-   = help: Remove unused `noqa` directive
-
-ℹ Fix
-22 22 |     d = 1  # noqa: F841, V101
-23 23 | 
-24 24 |     # Invalid (but external)
-25    |-    d = 1  # noqa: V500
-   25 |+    d = 1
-26 26 | 
-27 27 |     # fmt: off
-28 28 |     # Invalid - no space before #
-
 RUF100_0.py:29:10: RUF100 [*] Unused `noqa` directive (unused: `E501`)
    |
 27 |     # fmt: off

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -2,7 +2,6 @@
 //! command-line options. Structure is optimized for internal usage, as opposed
 //! to external visibility or parsing.
 
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -54,7 +53,7 @@ pub struct LinterSettings {
     pub allowed_confusables: FxHashSet<char>,
     pub builtins: Vec<String>,
     pub dummy_variable_rgx: Regex,
-    pub external: FxHashSet<String>,
+    pub external: Vec<String>,
     pub ignore_init_module_imports: bool,
     pub logger_objects: Vec<String>,
     pub namespace_packages: Vec<PathBuf>,
@@ -144,7 +143,7 @@ impl LinterSettings {
             builtins: vec![],
             dummy_variable_rgx: DUMMY_VARIABLE_RGX.clone(),
 
-            external: HashSet::default(),
+            external: vec![],
             ignore_init_module_imports: false,
             logger_objects: vec![],
             namespace_packages: vec![],

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -226,7 +226,7 @@ impl Configuration {
                 dummy_variable_rgx: lint
                     .dummy_variable_rgx
                     .unwrap_or_else(|| DUMMY_VARIABLE_RGX.clone()),
-                external: FxHashSet::from_iter(lint.external.unwrap_or_default()),
+                external: lint.external.unwrap_or_default(),
                 ignore_init_module_imports: lint.ignore_init_module_imports.unwrap_or_default(),
                 tab_size: self.indent_width.unwrap_or_default(),
                 namespace_packages: self.namespace_packages.unwrap_or_default(),

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -548,7 +548,7 @@ pub struct LintCommonOptions {
     )]
     pub extend_unfixable: Option<Vec<RuleSelector>>,
 
-    /// A list of rule codes that are unsupported by Ruff, but should be
+    /// A list of rule codes or prefixes that are unsupported by Ruff, but should be
     /// preserved when (e.g.) validating `# noqa` directives. Useful for
     /// retaining `# noqa` directives that cover plugins not yet implemented
     /// by Ruff.
@@ -556,9 +556,9 @@ pub struct LintCommonOptions {
         default = "[]",
         value_type = "list[str]",
         example = r#"
-            # Avoiding flagging (and removing) `V101` from any `# noqa`
-            # directives, despite Ruff's lack of support for `vulture`.
-            external = ["V101"]
+            # Avoiding flagging (and removing) any codes starting with `V` from any
+            # `# noqa` directives, despite Ruff's lack of support for `vulture`.
+            external = ["V"]
         "#
     )]
     pub external: Option<Vec<String>>,

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -159,7 +159,7 @@
       }
     },
     "external": {
-      "description": "A list of rule codes that are unsupported by Ruff, but should be preserved when (e.g.) validating `# noqa` directives. Useful for retaining `# noqa` directives that cover plugins not yet implemented by Ruff.",
+      "description": "A list of rule codes or prefixes that are unsupported by Ruff, but should be preserved when (e.g.) validating `# noqa` directives. Useful for retaining `# noqa` directives that cover plugins not yet implemented by Ruff.",
       "type": [
         "array",
         "null"
@@ -1733,7 +1733,7 @@
           }
         },
         "external": {
-          "description": "A list of rule codes that are unsupported by Ruff, but should be preserved when (e.g.) validating `# noqa` directives. Useful for retaining `# noqa` directives that cover plugins not yet implemented by Ruff.",
+          "description": "A list of rule codes or prefixes that are unsupported by Ruff, but should be preserved when (e.g.) validating `# noqa` directives. Useful for retaining `# noqa` directives that cover plugins not yet implemented by Ruff.",
           "type": [
             "array",
             "null"


### PR DESCRIPTION
Supersedes https://github.com/astral-sh/ruff/pull/8176
Closes https://github.com/astral-sh/ruff/pull/8174

## Test plan

Old snapshot contains the new / unmatched `V` code
New snapshot contains no `V` prefixed codes