### PR TITLE
Fix a wrong setting in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,7 @@ quote-style = "double"
 indent-style = "space"
 
 # Like Black, respect magic trailing commas.
-magic-trailing-comma = "respect"
+skip-magic-trailing-comma = false
 
 # Like Black, automatically detect the appropriate line ending.
 line-ending = "auto"


### PR DESCRIPTION
## Summary

The previous configuration for `ruff` contained an unrecognized field `magic-trailing-comma` set to "respect". As of version 0.1.2 of `ruff`, this field was not recognized and resulted in a TOML parse error when running the `ruff format .` command. This change removes the `magic-trailing-comma` field and adds the recognized `skip-magic-trailing-comma` field set to `false`.

## Test Plan

Tested locally with `ruff` 0.1.2.
