### PR TITLE
Refine warning about incompatible `isort` settings

### DIFF
--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -250,6 +250,10 @@ impl MagicTrailingComma {
     pub const fn is_respect(self) -> bool {
         matches!(self, Self::Respect)
     }
+
+    pub const fn is_ignore(self) -> bool {
+        matches!(self, Self::Ignore)
+    }
 }
 
 impl FromStr for MagicTrailingComma {

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1683,6 +1683,9 @@ pub struct IsortOptions {
     /// `combine-as-imports = true`. When `combine-as-imports` isn't
     /// enabled, every aliased `import from` will be given its own line, in
     /// which case, wrapping is not necessary.
+    ///
+    /// When using the formatter, ensure that `format.skip-magic-trailing-comma` is set to `false` (default)
+    /// when enabling `force-wrap-aliases` to avoid that the formatter collapses members if they all fit on a single line.
     #[option(
         default = r#"false"#,
         value_type = "bool",
@@ -1726,6 +1729,9 @@ pub struct IsortOptions {
     /// the imports will never be folded into one line.
     ///
     /// See isort's [`split-on-trailing-comma`](https://pycqa.github.io/isort/docs/configuration/options.html#split-on-trailing-comma) option.
+    ///
+    /// When using the formatter, ensure that `format.skip-magic-trailing-comma` is set to `false` (default) when enabling `split-on-trailing-comma`
+    /// to avoid that the formatter removes the trailing commas.
     #[option(
         default = r#"true"#,
         value_type = "bool",
@@ -1907,6 +1913,9 @@ pub struct IsortOptions {
 
     /// The number of blank lines to place after imports.
     /// Use `-1` for automatic determination.
+    ///
+    /// When using the formatter, only the values `-1`, `1`, and `2` are compatible because
+    /// it enforces at least one empty and at most two empty lines after imports.
     #[option(
         default = r#"-1"#,
         value_type = "int",
@@ -1918,6 +1927,9 @@ pub struct IsortOptions {
     pub lines_after_imports: Option<isize>,
 
     /// The number of lines to place between "direct" and `import from` imports.
+    ///
+    /// When using the formatter, only the values `0` and `1` are compatible because
+    /// it preserves up to one empty line after imports in nested blocks.
     #[option(
         default = r#"0"#,
         value_type = "int",

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1424,7 +1424,7 @@
           }
         },
         "force-wrap-aliases": {
-          "description": "Force `import from` statements with multiple members and at least one alias (e.g., `import A as B`) to wrap such that every line contains exactly one member. For example, this formatting would be retained, rather than condensing to a single line:\n\n```python from .utils import ( test_directory as test_directory, test_id as test_id ) ```\n\nNote that this setting is only effective when combined with `combine-as-imports = true`. When `combine-as-imports` isn't enabled, every aliased `import from` will be given its own line, in which case, wrapping is not necessary.",
+          "description": "Force `import from` statements with multiple members and at least one alias (e.g., `import A as B`) to wrap such that every line contains exactly one member. For example, this formatting would be retained, rather than condensing to a single line:\n\n```python from .utils import ( test_directory as test_directory, test_id as test_id ) ```\n\nNote that this setting is only effective when combined with `combine-as-imports = true`. When `combine-as-imports` isn't enabled, every aliased `import from` will be given its own line, in which case, wrapping is not necessary.\n\nWhen using the formatter, ensure that `format.skip-magic-trailing-comma` is set to `false` (default) when enabling `force-wrap-aliases` to avoid that the formatter collapses members if they all fit on a single line.",
           "type": [
             "boolean",
             "null"
@@ -1471,7 +1471,7 @@
           }
         },
         "lines-after-imports": {
-          "description": "The number of blank lines to place after imports. Use `-1` for automatic determination.",
+          "description": "The number of blank lines to place after imports. Use `-1` for automatic determination.\n\nWhen using the formatter, only the values `-1`, `1`, and `2` are compatible because it enforces at least one empty and at most two empty lines after imports.",
           "type": [
             "integer",
             "null"
@@ -1479,7 +1479,7 @@
           "format": "int"
         },
         "lines-between-types": {
-          "description": "The number of lines to place between \"direct\" and `import from` imports.",
+          "description": "The number of lines to place between \"direct\" and `import from` imports.\n\nWhen using the formatter, only the values `0` and `1` are compatible because it preserves up to one empty line after imports in nested blocks.",
           "type": [
             "integer",
             "null"
@@ -1559,7 +1559,7 @@
           }
         },
         "split-on-trailing-comma": {
-          "description": "If a comma is placed after the last member in a multi-line import, then the imports will never be folded into one line.\n\nSee isort's [`split-on-trailing-comma`](https://pycqa.github.io/isort/docs/configuration/options.html#split-on-trailing-comma) option.",
+          "description": "If a comma is placed after the last member in a multi-line import, then the imports will never be folded into one line.\n\nSee isort's [`split-on-trailing-comma`](https://pycqa.github.io/isort/docs/configuration/options.html#split-on-trailing-comma) option.\n\nWhen using the formatter, ensure that `format.skip-magic-trailing-comma` is set to `false` (default) when enabling `split-on-trailing-comma` to avoid that the formatter removes the trailing commas.",
           "type": [
             "boolean",
             "null"


### PR DESCRIPTION
## Summary

This PR refines the warning shown when running `ruff format` about incompatible `isort` settings:

* Only warn if `I001` (unsorted imports) is enabled. 
* `lines-after-imports: Warn about values other than `-1`, `1`, and `2` because the formatter enforces at least one empty and at most two empty lines after imports. 
* `lines-between-types`: Warn about values > 1 because the formatter preserves at most one empty line in nested import blocks. 
* `split_on_trailing_comma`: Only warn when `skip-magic-trailing-comma` is `true` to ensure the formatter preserves the trailing commas.
* Remove `force-single-line`: I think removing the warnings is safe. The setting seems to mainly be about removing parentheses around alieses:
  ```python
  from .utils2 import (
    test_directory as test_directory,
  )
  from .utils2 import (
      test_id as test_id,
  )

   # isorted
  from .utils import (
    test_directory as teeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee,
  )
  from .utils import test_id as t2
  from .utils2 import test_directory as test_directory
  from .utils2 import test_id as test_id  
  ```
  
  which the formatter leaves unchanged
* Only warn about `force_wrap_aliases` when `skip-magic-trailing-comma` is `true`. Isort inserts trailing commas that the formatter respects, except when `skip-magic-trailing-comma` isn't set to `true`.


## Test Plan

Added test plans. Played around with different examples in the playground to identify the `isort` behavior. 
