### PR TITLE
Add NoneBot to user list

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Ruff is used by a number of major open-source projects and companies, including:
 - [Mypy](https://github.com/python/mypy)
 - Netflix ([Dispatch](https://github.com/Netflix/dispatch))
 - [Neon](https://github.com/neondatabase/neon)
+- [NoneBot](https://github.com/nonebot/nonebot2)
 - [ONNX](https://github.com/onnx/onnx)
 - [OpenBB](https://github.com/OpenBB-finance/OpenBBTerminal)
 - [PDM](https://github.com/pdm-project/pdm)


### PR DESCRIPTION
## Summary

Add [NoneBot](https://github.com/nonebot/nonebot2) to list of projects using ruff. NoneBot is an asynchronous multi-platform chatbot framework written in Python.
