### PR TITLE
docs: remove incorrect setting from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,6 @@ quote-style = "double"
 # Like Black, indent with spaces, rather than tabs.
 indent-style = "space"
 
-# Like Black, respect magic trailing commas.
-magic-trailing-comma = "respect"
-
 # Like Black, automatically detect the appropriate line ending.
 line-ending = "auto"
 ```


### PR DESCRIPTION
Fix issue #8199 https://github.com/astral-sh/ruff/issues/8199

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Remove 'magic-trailing-comma' setting from readme file. It raises an error. see #8199 

## Test Plan

Removed 'magic-trailing-comma' and was able to run ruff format.
