### PR TITLE
Fix skipping formatting examples

### DIFF
--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -164,10 +164,10 @@ elif False: # fmt: skip
     pass
 
 @Test
-@Test2 # fmt: off
+@Test2 # fmt: skip
 def test(): ...
 
-a = [1, 2, 3, 4, 5] # fmt: off
+a = [1, 2, 3, 4, 5] # fmt: skip
 
 def test(a, b, c, d, e, f) -> int: # fmt: skip
     pass


### PR DESCRIPTION
Previously, `# fmt: off` was used instead of `# fmt: skip`

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
