### PR TITLE
Fix `fmt:off` with trailing child comment

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/fmt_off_unclosed_deep_nested_trailing_comment.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/fmt_off_unclosed_deep_nested_trailing_comment.py
@@ -1,0 +1,8 @@
+# Regression test for https://github.com/astral-sh/ruff/issues/8211
+
+# fmt: off
+from dataclasses import dataclass
+
+if True:
+    if False:
+        x: int # Optional[int]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/fmt_off_unclosed_trailing_comment.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/fmt_off_unclosed_trailing_comment.py
@@ -1,0 +1,8 @@
+# Regression test for https://github.com/astral-sh/ruff/issues/8211
+
+# fmt: off
+from dataclasses import dataclass
+
+@dataclass
+class A:
+    x: int # Optional[int]

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -536,7 +536,7 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for Suite {
 }
 
 /// A statement representing a docstring.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub(crate) struct DocstringStmt<'a>(&'a Stmt);
 
 impl<'a> DocstringStmt<'a> {
@@ -589,7 +589,7 @@ impl Format<PyFormatContext<'_>> for DocstringStmt<'_> {
 }
 
 /// A Child of a suite.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub(crate) enum SuiteChildStatement<'a> {
     /// A docstring documenting a class or function definition.
     Docstring(DocstringStmt<'a>),

--- a/crates/ruff_python_formatter/src/verbatim.rs
+++ b/crates/ruff_python_formatter/src/verbatim.rs
@@ -327,7 +327,7 @@ fn write_suppressed_statements<'a>(
 
         for range in CommentRangeIter::in_suppression(comments.trailing(statement), source) {
             match range {
-                // All leading comments are suppressed
+                // All trailing comments are suppressed
                 // ```python
                 // statement
                 // # suppressed
@@ -394,10 +394,14 @@ fn write_suppressed_statements<'a>(
             statement = SuiteChildStatement::Other(next_statement);
             leading_node_comments = comments.leading(next_statement);
         } else {
-            let end = comments
-                .trailing(statement)
-                .last()
-                .map_or(statement.end(), Ranged::end);
+            let mut nodes =
+                std::iter::successors(Some(AnyNodeRef::from(statement.statement())), |statement| {
+                    statement.last_child_in_body()
+                });
+
+            let end = nodes
+                .find_map(|statement| comments.trailing(statement).last().map(Ranged::end))
+                .unwrap_or(statement.end());
 
             FormatVerbatimStatementRange {
                 verbatim_range: TextRange::new(format_off_comment.end(), end),

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__fmt_off_unclosed_deep_nested_trailing_comment.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__fmt_off_unclosed_deep_nested_trailing_comment.py.snap
@@ -1,0 +1,30 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/fmt_off_unclosed_deep_nested_trailing_comment.py
+---
+## Input
+```py
+# Regression test for https://github.com/astral-sh/ruff/issues/8211
+
+# fmt: off
+from dataclasses import dataclass
+
+if True:
+    if False:
+        x: int # Optional[int]
+```
+
+## Output
+```py
+# Regression test for https://github.com/astral-sh/ruff/issues/8211
+
+# fmt: off
+from dataclasses import dataclass
+
+if True:
+    if False:
+        x: int # Optional[int]
+```
+
+
+

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__fmt_off_unclosed_trailing_comment.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__fmt_off_unclosed_trailing_comment.py.snap
@@ -1,0 +1,30 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/fmt_off_unclosed_trailing_comment.py
+---
+## Input
+```py
+# Regression test for https://github.com/astral-sh/ruff/issues/8211
+
+# fmt: off
+from dataclasses import dataclass
+
+@dataclass
+class A:
+    x: int # Optional[int]
+```
+
+## Output
+```py
+# Regression test for https://github.com/astral-sh/ruff/issues/8211
+
+# fmt: off
+from dataclasses import dataclass
+
+@dataclass
+class A:
+    x: int # Optional[int]
+```
+
+
+


### PR DESCRIPTION
## Summary

This PR fixes the issue where Ruff dropped the trailing comment of the last child when using a `fmt: off` without a matching `fmt: on`.

```python
# fmt: off
from dataclasses import dataclass

@dataclass
class A:
    x: int # Optional[int]
```

Got formatted to 

```python
# fmt: off
from dataclasses import dataclass

@dataclass
class A:
    x: int
``` 

The source of this was once again, that the class range does not include the range of nested comments. 

Closes https://github.com/astral-sh/ruff/issues/8211

## Test Plan

Added tests. The similarity index is unchanged.
