### PR TITLE
Use `line-length` setting for isort

### DIFF
--- a/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/organize_imports.rs
@@ -120,7 +120,7 @@ pub(crate) fn organize_imports(
         block,
         comments,
         locator,
-        settings.pycodestyle.max_line_length,
+        settings.line_length,
         LineWidthBuilder::new(settings.tab_size).add_str(indentation),
         stylist,
         &settings.src,

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -14,6 +14,7 @@ use rustc_hash::FxHashSet;
 use crate::codes::RuleCodePrefix;
 use ruff_macros::CacheKey;
 
+use crate::line_width::LineLength;
 use crate::registry::{Linter, Rule, RuleSet};
 use crate::rules::{
     flake8_annotations, flake8_bandit, flake8_bugbear, flake8_builtins, flake8_comprehensions,
@@ -59,6 +60,7 @@ pub struct LinterSettings {
     pub namespace_packages: Vec<PathBuf>,
     pub src: Vec<PathBuf>,
     pub tab_size: IndentWidth,
+    pub line_length: LineLength,
     pub task_tags: Vec<String>,
     pub typing_modules: Vec<String>,
 
@@ -155,6 +157,7 @@ impl LinterSettings {
             src: vec![path_dedot::CWD.clone()],
             // Needs duplicating
             tab_size: IndentWidth::default(),
+            line_length: LineLength::default(),
 
             task_tags: TASK_TAGS.iter().map(ToString::to_string).collect(),
             typing_modules: vec![],

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -228,6 +228,7 @@ impl Configuration {
                     .unwrap_or_else(|| DUMMY_VARIABLE_RGX.clone()),
                 external: lint.external.unwrap_or_default(),
                 ignore_init_module_imports: lint.ignore_init_module_imports.unwrap_or_default(),
+                line_length,
                 tab_size: self.indent_width.unwrap_or_default(),
                 namespace_packages: self.namespace_packages.unwrap_or_default(),
                 per_file_ignores: resolve_per_file_ignores(

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -352,7 +352,7 @@ pub struct Options {
 
     // Global Formatting options
     /// The line length to use when enforcing long-lines violations (like `E501`)
-    /// and at which the formatter prefers to wrap lines.
+    /// and at which `isort` and the formatter prefers to wrap lines.
     ///
     /// The length is determined by the number of characters per line, except for lines containing East Asian characters or emojis.
     /// For these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -436,7 +436,7 @@
       ]
     },
     "line-length": {
-      "description": "The line length to use when enforcing long-lines violations (like `E501`) and at which the formatter prefers to wrap lines.\n\nThe length is determined by the number of characters per line, except for lines containing East Asian characters or emojis. For these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.\n\nThe value must be greater than `0` and less than or equal to `320`.\n\nNote: While the formatter will attempt to format lines such that they remain within the `line-length`, it isn't a hard upper bound, and formatted lines may exceed the `line-length`.\n\nSee [`pycodestyle.max-line-length`](#pycodestyle-max-line-length) to configure different lengths for `E501` and the formatter.",
+      "description": "The line length to use when enforcing long-lines violations (like `E501`) and at which `isort` and the formatter prefers to wrap lines.\n\nThe length is determined by the number of characters per line, except for lines containing East Asian characters or emojis. For these lines, the [unicode width](https://unicode.org/reports/tr11/) of each character is added up to determine the length.\n\nThe value must be greater than `0` and less than or equal to `320`.\n\nNote: While the formatter will attempt to format lines such that they remain within the `line-length`, it isn't a hard upper bound, and formatted lines may exceed the `line-length`.\n\nSee [`pycodestyle.max-line-length`](#pycodestyle-max-line-length) to configure different lengths for `E501` and the formatter.",
       "anyOf": [
         {
           "$ref": "#/definitions/LineLength"


### PR DESCRIPTION
## Summary

I incorrectly changed all `line-length` usages in the linter to use the `pycodestyle.max-line-length` setting. However, this is incorrect for `isort` that should use the same line length as the formatter (to ensure compatibility). 

## Test Plan

I tested in the playground that setting `line-length` to a lower limit than `pycodestyle.max-line-length` raises `I001`. Increasing the `line-length` makes the warning disappear again. Verified that `E501` continues to use the `pycodestyle.max-line-length` option.
