### PR TITLE
Only omit optional parentheses for starting or ending with parentheses

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/unary.py
@@ -180,3 +180,16 @@ if "root" not in (
 ):
     msg = "Could not find root. Please try a different forest."
     raise ValueError(msg)
+
+# Regression for https://github.com/astral-sh/ruff/issues/8183
+def foo():
+    while (
+        not (aaaaaaaaaaaaaaaaaaaaa(bbbbbbbb, ccccccc)) and dddddddddd < eeeeeeeeeeeeeee
+    ):
+        pass
+
+def foo():
+    while (
+        not (aaaaaaaaaaaaaaaaaaaaa[bbbbbbbb, ccccccc]) and dddddddddd < eeeeeeeeeeeeeee
+    ):
+        pass

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -206,11 +206,14 @@ if True:
     #[test]
     fn quick_test() {
         let source = r#"
-def foo():
-    while (
-        aaaaaaaaaaaaaaaaaaaaa(bbbbbbbb, cccccccccccccc) and dddddddddd < eeeeeeeeeeeeeee
-    ):
-        pass
+def main() -> None:
+    if True:
+        some_very_long_variable_name_abcdefghijk = Foo()
+        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
+            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
+            == "This is a very long string abcdefghijk"
+        ]
+
 "#;
         let source_type = PySourceType::Python;
         let (tokens, comment_ranges) = tokens_and_ranges(source, source_type).unwrap();

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -206,14 +206,11 @@ if True:
     #[test]
     fn quick_test() {
         let source = r#"
-def main() -> None:
-    if True:
-        some_very_long_variable_name_abcdefghijk = Foo()
-        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
-            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
-            == "This is a very long string abcdefghijk"
-        ]
-
+def foo():
+    while (
+        aaaaaaaaaaaaaaaaaaaaa(bbbbbbbb, cccccccccccccc) and dddddddddd < eeeeeeeeeeeeeee
+    ):
+        pass
 "#;
         let source_type = PySourceType::Python;
         let (tokens, comment_ranges) = tokens_and_ranges(source, source_type).unwrap();

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__unary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__unary.py.snap
@@ -186,6 +186,19 @@ if "root" not in (
 ):
     msg = "Could not find root. Please try a different forest."
     raise ValueError(msg)
+
+# Regression for https://github.com/astral-sh/ruff/issues/8183
+def foo():
+    while (
+        not (aaaaaaaaaaaaaaaaaaaaa(bbbbbbbb, ccccccc)) and dddddddddd < eeeeeeeeeeeeeee
+    ):
+        pass
+
+def foo():
+    while (
+        not (aaaaaaaaaaaaaaaaaaaaa[bbbbbbbb, ccccccc]) and dddddddddd < eeeeeeeeeeeeeee
+    ):
+        pass
 ```
 
 ## Output
@@ -292,10 +305,13 @@ if aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & (
 ):
     pass
 
-if not (
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-) & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+if (
+    not (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    )
+    & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+):
     pass
 
 
@@ -383,6 +399,21 @@ if "root" not in (
 ):
     msg = "Could not find root. Please try a different forest."
     raise ValueError(msg)
+
+
+# Regression for https://github.com/astral-sh/ruff/issues/8183
+def foo():
+    while (
+        not (aaaaaaaaaaaaaaaaaaaaa(bbbbbbbb, ccccccc)) and dddddddddd < eeeeeeeeeeeeeee
+    ):
+        pass
+
+
+def foo():
+    while (
+        not (aaaaaaaaaaaaaaaaaaaaa[bbbbbbbb, ccccccc]) and dddddddddd < eeeeeeeeeeeeeee
+    ):
+        pass
 ```
 
 


### PR DESCRIPTION
## Summary

This PR fixes a black deviation where Ruff omitted parentheses for expressions that don't end with a parenthesized expression
but the "first" node was parenthesized:

```python
def foo():
    while (
        not (aaaaaaaaaaaaaaaaaaaaa(bbbbbbbb, ccccccc)) and dddddddddd < eeeeeeeeeeeeeee
    ):
        pass
```

Ruff ommitted parentheses for this expression because it assumed that the expression starts with `(aaaaa...(bbbb, ccc)` which is parenthesized.
However, this is incorrect. The expression starts with the `not` keyword which isn't a parentheses and Ruff should thus add parentheses. 

 

Closes https://github.com/astral-sh/ruff/issues/8183

## Test Plan

Added tests. 

**PR**
| project        | similarity index  | total files       | changed files     |
|----------------|------------------:|------------------:|------------------:|
| cpython        |           0.75803 |              1799 |              1648 |
| **django**         |           0.99984 |              2772 |                33 | 
| **home-assistant** |           0.99955 |             10596 |               178 |
| poetry         |           0.99891 |               317 |                17 |
| **transformers**   |           0.99967 |              2657 |               328 |
| twine          |           1.00000 |                33 |                 0 |
| typeshed       |           0.99978 |              3669 |                20 |
| warehouse      |           0.99977 |               654 |                13 |
| zulip          |           0.99970 |              1459 |                22 |


**main**

| project        | similarity index  | total files       | changed files     |
|----------------|------------------:|------------------:|------------------:|
| cpython        |           0.75803 |              1799 |              1648 |
| django         |           0.99983 |              2772 |                34 | <- improved
| home-assistant |           0.99953 |             10596 |               186 | <- improved
| poetry         |           0.99891 |               317 |                17 |
| transformers   |           0.99966 |              2657 |               330 | <- improved
| twine          |           1.00000 |                33 |                 0 |
| typeshed       |           0.99978 |              3669 |                20 |
| warehouse      |           0.99977 |               654 |                13 |
| zulip          |           0.99970 |              1459 |                22 |

