### PR TITLE
Use `SourceKind::diff` for formatter

### DIFF
--- a/crates/ruff_cli/tests/format.rs
+++ b/crates/ruff_cli/tests/format.rs
@@ -509,21 +509,27 @@ fn test_diff() {
         success: false
         exit_code: 1
         ----- stdout -----
-        --- resources/test/fixtures/unformatted.ipynb
-        +++ resources/test/fixtures/unformatted.ipynb
-        @@ -1,12 +1,20 @@
+        --- resources/test/fixtures/unformatted.ipynb:cell 1
+        +++ resources/test/fixtures/unformatted.ipynb:cell 1
+        @@ -1,3 +1,4 @@
          import numpy
         -maths = (numpy.arange(100)**2).sum()
         -stats= numpy.asarray([1,2,3,4]).median()
         +
         +maths = (numpy.arange(100) ** 2).sum()
         +stats = numpy.asarray([1, 2, 3, 4]).median()
+        --- resources/test/fixtures/unformatted.ipynb:cell 3
+        +++ resources/test/fixtures/unformatted.ipynb:cell 3
+        @@ -1,4 +1,6 @@
          # A cell with IPython escape command
          def some_function(foo, bar):
              pass
         +
         +
          %matplotlib inline
+        --- resources/test/fixtures/unformatted.ipynb:cell 4
+        +++ resources/test/fixtures/unformatted.ipynb:cell 4
+        @@ -1,5 +1,10 @@
          foo = %pwd
         -def some_function(foo,bar,):
         +
@@ -535,6 +541,7 @@ fn test_diff() {
              # Another cell with IPython escape command
              foo = %pwd
              print(foo)
+
         --- resources/test/fixtures/unformatted.py
         +++ resources/test/fixtures/unformatted.py
         @@ -1,3 +1,3 @@
@@ -542,6 +549,7 @@ fn test_diff() {
         -y=2
         +y = 2
          z = 3
+
 
         ----- stderr -----
         2 files would be reformatted, 1 file left unchanged
@@ -571,6 +579,7 @@ fn test_diff_no_change() {
         -y=2
         +y = 2
          z = 3
+
 
         ----- stderr -----
         1 file would be reformatted
@@ -604,6 +613,7 @@ fn test_diff_stdin_unformatted() {
     -y=2
     +y = 2
      z = 3
+
 
     ----- stderr -----
     "###);

--- a/crates/ruff_linter/src/source_kind.rs
+++ b/crates/ruff_linter/src/source_kind.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::io::Write;
 use std::path::Path;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use similar::TextDiff;
 use thiserror::Error;
 
@@ -88,7 +88,12 @@ impl SourceKind {
     }
 
     /// Write a diff of the transformed source file to `stdout`.
-    pub fn diff(&self, other: &Self, path: Option<&Path>, writer: &mut dyn Write) -> Result<()> {
+    pub fn diff(
+        &self,
+        other: &Self,
+        path: Option<&Path>,
+        writer: &mut dyn Write,
+    ) -> io::Result<()> {
         match (self, other) {
             (SourceKind::Python(src), SourceKind::Python(dst)) => {
                 let text_diff = TextDiff::from_lines(src, dst);
@@ -154,7 +159,7 @@ impl SourceKind {
 
                 Ok(())
             }
-            _ => bail!("cannot diff Python source code with Jupyter notebook source code"),
+            _ => panic!("cannot diff Python source code with Jupyter notebook source code"),
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR refactors the formatter diff code to reuse the `SourceKind::diff` logic. This has the benefit that the Notebook diff now includes the cell numbers which was not present before.

## Test Plan

Update the snapshots and verified the cell numbers.
