### PR TITLE
Don't warn about magic trailing comma when `isort.force-single-line` is true

### DIFF
--- a/crates/ruff_cli/src/commands/format.rs
+++ b/crates/ruff_cli/src/commands/format.rs
@@ -792,7 +792,10 @@ pub(super) fn warn_incompatible_formatter_settings(
             }
 
             // isort inserts a trailing comma which the formatter preserves, but only if `skip-magic-trailing-comma` isn't false.
-            if setting.formatter.magic_trailing_comma.is_ignore() {
+            // This isn't relevant when using `force-single-line`, since isort will never include a trailing comma in that case.
+            if setting.formatter.magic_trailing_comma.is_ignore()
+                && !setting.linter.isort.force_single_line
+            {
                 if setting.linter.isort.force_wrap_aliases {
                     warn!("The isort option `isort.force-wrap-aliases` is incompatible with the formatter `format.skip-magic-trailing-comma=true` option. To avoid unexpected behavior, we recommend either setting `isort.force-wrap-aliases=false` or `format.skip-magic-trailing-comma=false`.");
                 }


### PR DESCRIPTION

## Summary

Based on [this feedback](https://github.com/astral-sh/ruff/issues/8185#issuecomment-1780092525). Avoid warning about `force-wrap-aliases` and `split-on-trailing-comma` if `force-single-line` is true (which creates a dedicated import for each imported member).

## Test Plan

Ran `ruff format . --no-cache` and verified that the warning show up when `force-single-line=false` and aren't shown when `force-single-line=true`
