### PR TITLE
Preserve trailing statement semicolons when using `fmt: skip`

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_skip/trailing_semi.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_skip/trailing_semi.py
@@ -1,0 +1,10 @@
+x = 1;  # fmt: skip
+
+x = 1   ; # fmt: skip
+
+x = 1 \
+    ;   # fmt: skip
+
+x = 1 # ; # fmt: skip
+
+_;  #unrelated semicolon

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_skip__trailing_semi.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_skip__trailing_semi.py.snap
@@ -1,0 +1,34 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_skip/trailing_semi.py
+---
+## Input
+```py
+x = 1;  # fmt: skip
+
+x = 1   ; # fmt: skip
+
+x = 1 \
+    ;   # fmt: skip
+
+x = 1 # ; # fmt: skip
+
+_;  #unrelated semicolon
+```
+
+## Output
+```py
+x = 1;  # fmt: skip
+
+x = 1   ;  # fmt: skip
+
+x = 1 \
+    ;  # fmt: skip
+
+x = 1  # ; # fmt: skip
+
+_  # unrelated semicolon
+```
+
+
+

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -473,7 +473,7 @@ pub enum SimpleTokenKind {
 }
 
 impl SimpleTokenKind {
-    const fn is_trivia(self) -> bool {
+    pub const fn is_trivia(self) -> bool {
         matches!(
             self,
             SimpleTokenKind::Whitespace
@@ -481,6 +481,10 @@ impl SimpleTokenKind {
                 | SimpleTokenKind::Comment
                 | SimpleTokenKind::Continuation
         )
+    }
+
+    pub const fn is_comment(self) -> bool {
+        matches!(self, SimpleTokenKind::Comment)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/8263

We have the same problem with `fmt: off`. I'll look into this separately

## Test Plan

Added tests, verified that the similarity index is unchanged

<!-- How was it tested? -->
