### PR TITLE
WIP/RFC: Wildcards for `banned_api`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,12 +2293,16 @@ dependencies = [
 name = "ruff_python_ast"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "bitflags 2.4.0",
+ "glob",
  "insta",
  "is-macro",
  "itertools 0.11.0",
  "memchr",
  "once_cell",
+ "ruff_cache",
+ "ruff_macros",
  "ruff_python_parser",
  "ruff_python_trivia",
  "ruff_source_file",

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -570,15 +570,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     }
                 }
                 if checker.enabled(Rule::BannedApi) {
-                    flake8_tidy_imports::rules::banned_api(
-                        checker,
-                        &flake8_tidy_imports::matchers::NameMatchPolicy::MatchNameOrParent(
-                            flake8_tidy_imports::matchers::MatchNameOrParent {
-                                module: &alias.name,
-                            },
-                        ),
-                        &alias,
-                    );
+                    flake8_tidy_imports::rules::banned_api(checker, &alias.name, &alias, true);
                 }
 
                 if checker.enabled(Rule::BannedModuleLevelImports) {
@@ -751,28 +743,20 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 if let Some(module) =
                     helpers::resolve_imported_module_path(level, module, checker.module_path)
                 {
-                    flake8_tidy_imports::rules::banned_api(
-                        checker,
-                        &flake8_tidy_imports::matchers::NameMatchPolicy::MatchNameOrParent(
-                            flake8_tidy_imports::matchers::MatchNameOrParent { module: &module },
-                        ),
-                        &stmt,
-                    );
+                    flake8_tidy_imports::rules::banned_api(checker, &module, &stmt, true);
 
                     for alias in names {
                         if &alias.name == "*" {
                             continue;
                         }
+                        /* TODO(akx): re-enable
                         flake8_tidy_imports::rules::banned_api(
                             checker,
-                            &flake8_tidy_imports::matchers::NameMatchPolicy::MatchName(
-                                flake8_tidy_imports::matchers::MatchName {
-                                    module: &module,
-                                    member: &alias.name,
-                                },
-                            ),
+                            format!("{}.{}", module, alias.name),
                             &alias,
+                            false,
                         );
+                         */
                     }
                 }
             }

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/mod.rs
@@ -8,7 +8,7 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-    use rustc_hash::FxHashMap;
+    use ruff_python_ast::call_path_pattern;
 
     use crate::assert_messages;
     use crate::registry::Rule;
@@ -23,20 +23,21 @@ mod tests {
             Path::new("flake8_tidy_imports/TID251.py"),
             &LinterSettings {
                 flake8_tidy_imports: flake8_tidy_imports::settings::Settings {
-                    banned_api: FxHashMap::from_iter([
+                    banned_api: vec![
                         (
-                            "cgi".to_string(),
+                            call_path_pattern::from_qualified_name("cgi")?,
                             ApiBan {
                                 msg: "The cgi module is deprecated.".to_string(),
                             },
                         ),
                         (
-                            "typing.TypedDict".to_string(),
+                            call_path_pattern::from_qualified_name("typing.TypedDict")?,
                             ApiBan {
                                 msg: "Use typing_extensions.TypedDict instead.".to_string(),
                             },
                         ),
-                    ]),
+                    ],
+                    // TODO(akx): add wildcard tests
                     ..Default::default()
                 },
                 ..LinterSettings::for_rules(vec![Rule::BannedApi])
@@ -52,20 +53,21 @@ mod tests {
             Path::new("flake8_tidy_imports/TID/my_package/sublib/api/application.py"),
             &LinterSettings {
                 flake8_tidy_imports: flake8_tidy_imports::settings::Settings {
-                    banned_api: FxHashMap::from_iter([
+                    banned_api: vec![
                         (
-                            "attrs".to_string(),
+                            call_path_pattern::from_qualified_name("attrs")?,
                             ApiBan {
                                 msg: "The attrs module is deprecated.".to_string(),
                             },
                         ),
                         (
-                            "my_package.sublib.protocol".to_string(),
+                            call_path_pattern::from_qualified_name("my_package.sublib.protocol")?,
                             ApiBan {
                                 msg: "The protocol module is deprecated.".to_string(),
                             },
                         ),
-                    ]),
+                    ],
+                    // TODO(akx): add wildcard tests
                     ..Default::default()
                 },
                 namespace_packages: vec![Path::new("my_package").to_path_buf()],

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/settings.rs
@@ -1,7 +1,7 @@
-use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 use ruff_macros::CacheKey;
+use ruff_python_ast::call_path_pattern::CallPathPattern;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, CacheKey)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
@@ -25,6 +25,7 @@ pub enum Strictness {
 #[derive(Debug, CacheKey, Default)]
 pub struct Settings {
     pub ban_relative_imports: Strictness,
-    pub banned_api: FxHashMap<String, ApiBan>,
+    // #[cache_key(ignore)] // TODO(akx): definitely shouldn't be ignoring this
+    pub banned_api: Vec<(CallPathPattern, ApiBan)>,
     pub banned_module_level_imports: Vec<String>,
 }

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -13,11 +13,15 @@ license = { workspace = true }
 [lib]
 
 [dependencies]
+ruff_cache = { path = "../ruff_cache" }
+ruff_macros = { path = "../ruff_macros" }
 ruff_python_trivia = { path = "../ruff_python_trivia" }
 ruff_source_file = { path = "../ruff_source_file" }
 ruff_text_size = { path = "../ruff_text_size" }
 
+anyhow = { workspace = true }
 bitflags = { workspace = true }
+glob = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }

--- a/crates/ruff_python_ast/src/call_path_pattern.rs
+++ b/crates/ruff_python_ast/src/call_path_pattern.rs
@@ -1,0 +1,99 @@
+use anyhow::Result;
+use glob::Pattern;
+use ruff_macros::CacheKey;
+use smallvec::{smallvec, SmallVec};
+use std::fmt;
+
+use crate::call_path::CallPath;
+
+#[derive(CacheKey, Debug)]
+enum CallPathPatternPart {
+    String(String),
+    Pattern(Pattern),
+}
+
+/// A representation of an expression to match a qualified name, like `os.set*`.
+/// TODO: CallPathPatterns currently don't do `**` well.
+#[derive(CacheKey, Debug)]
+pub struct CallPathPattern {
+    parts: SmallVec<[CallPathPatternPart; 8]>,
+}
+
+fn to_call_path_pattern_part(part: &str) -> Result<CallPathPatternPart> {
+    if part.contains(|c| c == '*' || c == '?' || c == '[' || c == ']') {
+        Ok(CallPathPatternPart::Pattern(Pattern::new(part)?))
+    } else {
+        Ok(CallPathPatternPart::String(String::from(part)))
+    }
+}
+
+/// Create a [`CallPathPattern`] from a fully-qualified name.
+/// ```rust
+/// # use ruff_python_ast::call_path;
+/// # use ruff_python_ast::call_path_pattern;
+///
+/// let pat1 = call_path_pattern::from_qualified_name("http.client.HTTP*").unwrap();
+/// let pat2 = call_path_pattern::from_qualified_name("http.client").unwrap();
+/// let pat3 = call_path_pattern::from_qualified_name("http.*.HTTP*").unwrap();
+/// let pth1 = call_path::from_qualified_name("http.client.HTTPConnection");
+/// let pth2 = call_path::from_qualified_name("http.click");
+/// assert!(pat1.matches_call_path(&pth1, false));
+/// assert!(pat2.matches_call_path(&pth1, true));
+/// assert!(pat3.matches_call_path(&pth1, false));
+/// assert!(!pat1.matches_call_path(&pth2, false));
+/// assert!(!pat2.matches_call_path(&pth2, true));
+/// ```
+pub fn from_qualified_name(name: &str) -> Result<CallPathPattern> {
+    if name.contains('.') {
+        let parts = name
+            .split('.')
+            .map(to_call_path_pattern_part)
+            .collect::<Result<_>>()?;
+        Ok(CallPathPattern { parts })
+    } else {
+        // Special-case: for builtins, return `["", "int"]` instead of `["int"]`.
+        let part = to_call_path_pattern_part(name)?;
+        Ok(CallPathPattern {
+            parts: smallvec![CallPathPatternPart::String(String::from("")), part],
+        })
+    }
+}
+
+impl CallPathPattern {
+    pub fn matches_call_path(&self, call_path: &CallPath, prefix: bool) -> bool {
+        if !prefix {
+            if self.parts.len() > call_path.len() {
+                return false;
+            }
+        }
+        for (part, segment) in self.parts.iter().zip(call_path.iter()) {
+            match part {
+                CallPathPatternPart::String(part) => {
+                    if part != segment {
+                        return false;
+                    }
+                }
+                CallPathPatternPart::Pattern(pattern) => {
+                    if !pattern.matches(segment) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+}
+impl fmt::Display for CallPathPattern {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for (i, part) in self.parts.iter().enumerate() {
+            if i > 0 {
+                write!(f, ".")?;
+            }
+            match part {
+                CallPathPatternPart::String(part) => write!(f, "{}", part)?,
+                CallPathPatternPart::Pattern(pattern) => write!(f, "{}", pattern)?,
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -7,6 +7,7 @@ pub use nodes::*;
 
 pub mod all;
 pub mod call_path;
+pub mod call_path_pattern;
 pub mod comparable;
 pub mod docstrings;
 mod expression;

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -27,6 +27,7 @@ use ruff_linter::settings::types::{
 };
 use ruff_linter::{warn_user_once, RuleSelector};
 use ruff_macros::{CombineOptions, OptionsMetadata};
+use ruff_python_ast::call_path_pattern;
 use ruff_python_formatter::QuoteStyle;
 
 use crate::settings::LineEnding;
@@ -1567,7 +1568,17 @@ impl Flake8TidyImportsOptions {
     pub fn into_settings(self) -> flake8_tidy_imports::settings::Settings {
         flake8_tidy_imports::settings::Settings {
             ban_relative_imports: self.ban_relative_imports.unwrap_or(Strictness::Parents),
-            banned_api: self.banned_api.unwrap_or_default(),
+            banned_api: self
+                .banned_api
+                .unwrap_or_default()
+                .iter()
+                .map(|(pattern, ban)| {
+                    (
+                        call_path_pattern::from_qualified_name(pattern).unwrap(), // TODO: panic? not good
+                        ban.clone(),
+                    )
+                })
+                .collect(),
             banned_module_level_imports: self.banned_module_level_imports.unwrap_or_default(),
         }
     }


### PR DESCRIPTION
## Summary

This PR is a heavy WIP and RFC for adding support for wildcard paths for [`banned-api`](https://docs.astral.sh/ruff/rules/banned-api/).

In short, the goal would be to be able to do

```
[tool.ruff.flake8-tidy-imports.banned-api]
"some_package.ANCIENT*".msg = "None of the ancient powers of `some_package` may be invoked"
```
instead of having to spell out all of the ancients' names in the config.

## How?!

This PR implements this by way of a new `CallPathPattern` struct, which is basically a `CallPath` but with possible wildcard segments (`glob.Pattern`s; I looked at `wildmatch` and decided not to introduce another dependency) and can be matched against a qualified name `CallPath`. I'm not 100% sure that's the best way here, and especially e.g. config parsing becomes a bit hairier since turning the strings in the config to CallPathPatterns could fail (e.g. `some_package.ANCI[` is invalid).  
(I also noticed there's a NameMatchPolicy thing in the `flake8_tidy_imports` linter that kind-of does the same thing.)

Then, there's a possible concern about performance, since we can no longer just use an FxHashMap for looking up bans. (Since this is very much a WIP (and who knows, maybe this is deemed a Bad Idea all in all), I haven't measured things.)

Of course we could come up with a smarter data structure that's both an FxHashMap for the exact-match happy path, and a vector of CallPathPatterns for other situations?

## Test Plan

<!-- How was it tested? -->

Not very well yet. It's probably buggy (but compiles!). The patch is currently also peppered with TODOs.