### PR TITLE
Preserve trailing semicolons when using `fmt: off`

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/trailing_semicolon.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/trailing_semicolon.py
@@ -1,0 +1,27 @@
+def f():
+    # fmt: off
+    a = 10
+
+    if True:
+        with_semicolon = 10   \
+            ;
+
+formatted   = true;
+
+
+def f():
+    # fmt: off
+
+    if True:
+        with_semicolon = 20 \
+            ; # comment
+
+
+# fmt: off
+statement = 0 \
+    ;
+# fmt: on
+a = 10
+
+# fmt: off
+last_statement_with_semi   ;

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -206,13 +206,13 @@ if True:
     #[test]
     fn quick_test() {
         let source = r#"
-def f():
-    # fmt: off
-
+def main() -> None:
     if True:
-        with_semicolon = 20 \
-            ; # comment
-
+        some_very_long_variable_name_abcdefghijk = Foo()
+        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
+            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
+            == "This is a very long string abcdefghijk"
+        ]
 
 "#;
         let source_type = PySourceType::Python;

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -206,13 +206,13 @@ if True:
     #[test]
     fn quick_test() {
         let source = r#"
-def main() -> None:
+def f():
+    # fmt: off
+
     if True:
-        some_very_long_variable_name_abcdefghijk = Foo()
-        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
-            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
-            == "This is a very long string abcdefghijk"
-        ]
+        with_semicolon = 20 \
+            ; # comment
+
 
 "#;
         let source_type = PySourceType::Python;

--- a/crates/ruff_python_formatter/src/verbatim.rs
+++ b/crates/ruff_python_formatter/src/verbatim.rs
@@ -400,7 +400,7 @@ fn write_suppressed_statements<'a>(
             let end = loop {
                 if let Some(comment) = comments.trailing(current).last() {
                     break comment.end();
-                } else if let Some(child) = AnyNodeRef::from(current).last_child_in_body() {
+                } else if let Some(child) = current.last_child_in_body() {
                     current = child;
                 } else {
                     break trailing_semicolon(current, source)

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__trailing_semicolon.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__trailing_semicolon.py.snap
@@ -1,0 +1,69 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/trailing_semicolon.py
+---
+## Input
+```py
+def f():
+    # fmt: off
+    a = 10
+
+    if True:
+        with_semicolon = 10   \
+            ;
+
+formatted   = true;
+
+
+def f():
+    # fmt: off
+
+    if True:
+        with_semicolon = 20 \
+            ; # comment
+
+
+# fmt: off
+statement = 0 \
+    ;
+# fmt: on
+a = 10
+
+# fmt: off
+last_statement_with_semi   ;
+```
+
+## Output
+```py
+def f():
+    # fmt: off
+    a = 10
+
+    if True:
+        with_semicolon = 10   \
+            ;
+
+
+formatted = true
+
+
+def f():
+    # fmt: off
+
+    if True:
+        with_semicolon = 20 \
+            ; # comment
+
+
+# fmt: off
+statement = 0 \
+    ;
+# fmt: on
+a = 10
+
+# fmt: off
+last_statement_with_semi   ;
+```
+
+
+


### PR DESCRIPTION
## Summary

Preserve the semicolons terminating statements when using `fmt: off`

## Test Plan

Added test. Verified that the similarity index is unchanged.
