### PR TITLE
Split tuples in return positions by comma first

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/return.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/return.py
@@ -14,3 +14,35 @@ return (
     len(node.parents) for node in self.node_map.values()
     )
 )
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/8042
+def f():
+    return (
+        self.get_filename() + ".csv" +
+        "text/csv" +
+        output.getvalue().encode("utf-8----------------"),
+    )
+
+
+def f():
+    return (
+        self.get_filename() + ".csv" + "text/csv",
+        output.getvalue().encode("utf-8----------------")
+    )
+
+def f():
+    return (
+        self.get_filename() + ".csv",
+        "text/csv",
+        output.getvalue().encode("utf-8----------------")
+    )
+
+
+def f():
+    return self.get_filename() + ".csv" + "text/csv" + output.getvalue().encode("utf-8----------------"),
+
+def f():
+    return self.get_filename() + ".csv" + "text/csv", output.getvalue().encode("utf-8----------------")
+
+def f():
+    return self.get_filename() + ".csv", "text/csv", output.getvalue().encode("utf-8----------------")

--- a/crates/ruff_python_formatter/src/expression/expr_tuple.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_tuple.rs
@@ -172,10 +172,13 @@ impl FormatNodeRule<ExprTuple> for FormatExprTuple {
                         .finish()
                 }
                 TupleParentheses::Preserve => group(&ExprSequence::new(item)).fmt(f),
-                TupleParentheses::NeverPreserve | TupleParentheses::OptionalParentheses => {
+                TupleParentheses::NeverPreserve => {
                     optional_parentheses(&ExprSequence::new(item)).fmt(f)
                 }
-                TupleParentheses::Default => {
+                TupleParentheses::OptionalParentheses if item.elts.len() == 2 => {
+                    optional_parentheses(&ExprSequence::new(item)).fmt(f)
+                }
+                TupleParentheses::Default | TupleParentheses::OptionalParentheses => {
                     parenthesize_if_expands(&ExprSequence::new(item)).fmt(f)
                 }
             },

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -206,13 +206,10 @@ if True:
     #[test]
     fn quick_test() {
         let source = r#"
-def main() -> None:
-    if True:
-        some_very_long_variable_name_abcdefghijk = Foo()
-        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
-            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
-            == "This is a very long string abcdefghijk"
-        ]
+if True:
+    return await a and b and bbbbb, ccc, len(
+        self.cddddddddddddeeeeeeeaaafffffffgggggghhhhiiiiikkkkllllmmmmmnn
+    )
 
 "#;
         let source_type = PySourceType::Python;

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -206,10 +206,13 @@ if True:
     #[test]
     fn quick_test() {
         let source = r#"
-if True:
-    return await a and b and bbbbb, ccc, len(
-        self.cddddddddddddeeeeeeeaaafffffffgggggghhhhiiiiikkkkllllmmmmmnn
-    )
+def main() -> None:
+    if True:
+        some_very_long_variable_name_abcdefghijk = Foo()
+        some_very_long_variable_name_abcdefghijk = some_very_long_variable_name_abcdefghijk[
+            some_very_long_variable_name_abcdefghijk.some_very_long_attribute_name
+            == "This is a very long string abcdefghijk"
+        ]
 
 "#;
         let source_type = PySourceType::Python;

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__return.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__return.py.snap
@@ -20,6 +20,38 @@ return (
     len(node.parents) for node in self.node_map.values()
     )
 )
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/8042
+def f():
+    return (
+        self.get_filename() + ".csv" +
+        "text/csv" +
+        output.getvalue().encode("utf-8----------------"),
+    )
+
+
+def f():
+    return (
+        self.get_filename() + ".csv" + "text/csv",
+        output.getvalue().encode("utf-8----------------")
+    )
+
+def f():
+    return (
+        self.get_filename() + ".csv",
+        "text/csv",
+        output.getvalue().encode("utf-8----------------")
+    )
+
+
+def f():
+    return self.get_filename() + ".csv" + "text/csv" + output.getvalue().encode("utf-8----------------"),
+
+def f():
+    return self.get_filename() + ".csv" + "text/csv", output.getvalue().encode("utf-8----------------")
+
+def f():
+    return self.get_filename() + ".csv", "text/csv", output.getvalue().encode("utf-8----------------")
 ```
 
 ## Output
@@ -38,6 +70,54 @@ return (
     len(self.nodeseeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee),
     sum(len(node.parents) for node in self.node_map.values()),
 )
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/8042
+def f():
+    return (
+        self.get_filename()
+        + ".csv"
+        + "text/csv"
+        + output.getvalue().encode("utf-8----------------"),
+    )
+
+
+def f():
+    return (
+        self.get_filename() + ".csv" + "text/csv",
+        output.getvalue().encode("utf-8----------------"),
+    )
+
+
+def f():
+    return (
+        self.get_filename() + ".csv",
+        "text/csv",
+        output.getvalue().encode("utf-8----------------"),
+    )
+
+
+def f():
+    return (
+        self.get_filename()
+        + ".csv"
+        + "text/csv"
+        + output.getvalue().encode("utf-8----------------"),
+    )
+
+
+def f():
+    return self.get_filename() + ".csv" + "text/csv", output.getvalue().encode(
+        "utf-8----------------"
+    )
+
+
+def f():
+    return (
+        self.get_filename() + ".csv",
+        "text/csv",
+        output.getvalue().encode("utf-8----------------"),
+    )
 ```
 
 


### PR DESCRIPTION
## Summary

Split tuples with two elements by comma first (does not apply to 1 or three element tuples for some reason).

Closes https://github.com/astral-sh/ruff/issues/8042


## Test Plan

Added tests, verified that the similarity index is unchanged
