### PR TITLE
WIP: Add unterminated f-string range in `Indexer`

### DIFF
--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -156,10 +156,10 @@ fn extract_noqa_line_for(lxr: &[LexResult], locator: &Locator, indexer: &Indexer
     // the inner f-strings.
     let mut last_fstring_range: TextRange = TextRange::default();
     for fstring_range in indexer.fstring_ranges().values() {
-        if !locator.contains_line_break(*fstring_range) {
+        if !locator.contains_line_break(fstring_range.range()) {
             continue;
         }
-        if last_fstring_range.contains_range(*fstring_range) {
+        if last_fstring_range.contains_range(fstring_range.range()) {
             continue;
         }
         let new_range = TextRange::new(

--- a/crates/ruff_python_index/src/indexer.rs
+++ b/crates/ruff_python_index/src/indexer.rs
@@ -72,7 +72,7 @@ impl Indexer {
         Self {
             comment_ranges: comment_ranges_builder.finish(),
             continuation_lines,
-            fstring_ranges: fstring_ranges_builder.finish(),
+            fstring_ranges: fstring_ranges_builder.finish(locator.text_len()),
         }
     }
 


### PR DESCRIPTION
## Summary

WIP: This PR adds support for adding unterminated f-string range in the
`Indexer`. The main challenge is to consider the range while computing the NoQA
offsets and tell the caller that there is no offset where the NoQA comment can
be added. This will not only help in unterminated f-string, but also in other
cases where there's syntax error but the range exists in the `Indexer`.

## Test Plan


Discussion: https://github.com/astral-sh/ruff/pull/8154