### PR TITLE
Add newline after module docstrings in preview style

### DIFF
--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -143,6 +143,8 @@ impl FormatRule<Suite, PyFormatContext<'_>> for FormatSuite {
             )
         } else {
             first.fmt(f)?;
+
+            #[allow(clippy::if_same_then_else)]
             let empty_line_after_docstring = if matches!(first, SuiteChildStatement::Docstring(_))
                 && self.kind == SuiteKind::Class
             {
@@ -157,6 +159,7 @@ impl FormatRule<Suite, PyFormatContext<'_>> for FormatSuite {
             } else {
                 false
             };
+
             (first.statement(), empty_line_after_docstring)
         };
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__number.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__number.py.snap
@@ -25,17 +25,4 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression
 ```
 
 
-## Preview changes
-```diff
---- Stable
-+++ Preview
-@@ -1,4 +1,5 @@
- 0.1
-+
- 1.0
- 1e1
- 1e-1
-```
-
-
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__number.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__number.py.snap
@@ -25,4 +25,17 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression
 ```
 
 
+## Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -1,4 +1,5 @@
+ 0.1
++
+ 1.0
+ 1e1
+ 1e-1
+```
+
+
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@preview.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@preview.py.snap
@@ -166,6 +166,7 @@ preview                 = Enabled
 """
 Black's `Preview.module_docstring_newlines`
 """
+
 first_stmt_after_module_level_docstring = 1
 
 


### PR DESCRIPTION
Change
```python
"""Test docstring"""
a = 1
```
to
```python
"""Test docstring"""

a = 1
```
in preview style, but don't touch the docstring otherwise.

Do we want to ask black to also format the content of module level docstrings? Seems inconsistent to me that we change function and class docstring indentation/contents but not module docstrings.

Fixes https://github.com/astral-sh/ruff/issues/7995