### PR TITLE
Update old ecosystem checks for formatter for clarity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -349,8 +349,8 @@ jobs:
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS != 'true' }}
         run: mkdocs build --strict -f mkdocs.generated.yml
 
-  check-formatter-ecosystem:
-    name: "Formatter ecosystem and progress checks"
+  check-formatter-instability-and-black-similarity:
+    name: "formatter instabilities and black similarity"
     runs-on: ubuntu-latest
     needs: determine_changes
     if: needs.determine_changes.outputs.formatter == 'true' || github.ref == 'refs/heads/main'

--- a/scripts/formatter_ecosystem_checks.sh
+++ b/scripts/formatter_ecosystem_checks.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# **NOTE**
+# This script is being replaced by the ruff-ecosystem package which is no
+# longer focused on black-compatibility but on changes in formatting between
+# ruff versions. ruff-ecosystem does not support instability checks yet.
+#
 # Check black compatibility and check for formatter instabilities and other
 # errors.
 #


### PR DESCRIPTION
Changes the title and adds some notes re the old formatter ecosystem checks in light of #8223 

Does not remove it as I'm not sure where else we test for instabilities.