### PR TITLE
Update ecosystem pull request comment to post when unrelated jobs fail

### DIFF
--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -41,6 +41,7 @@ jobs:
           workflow: ci.yaml
           pr: ${{ steps.pr-number.outputs.pr-number }}
           path: pr/ecosystem
+          workflow_conclusion: completed
           if_no_artifact_found: ignore
 
       - name: Generate Comment


### PR DESCRIPTION
While we ran the `pr-comment` workflow on `completed` workflows (i.e. instead of `success`, it can have failed) we used the default artifact download behavior which required `success` workflows (https://github.com/dawidd6/action-download-artifact) which meant that if any jobs failed the ecosystem checks would not be reported.

For example, a successful ecosystem run at https://github.com/astral-sh/ruff/actions/runs/6672033727/job/18135290880 was not posted at https://github.com/astral-sh/ruff/actions/runs/6672153598/job/18135534008 because no artifacts met the success criterion.

You can see this is "valid" with a manual dispatch at https://github.com/astral-sh/ruff/actions/runs/6672278055/job/18135883849 but it pulls from the latest commit rather than the one with the failed one mentioned above so you can't see verification it'll work for failed jobs. Another manual dispatch at https://github.com/astral-sh/ruff/actions/runs/6672349316/job/18136082917 shows it works great for successful jobs still.