### PR TITLE
Improve calculation of max display per rule in ecosystem checks

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/check.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/check.py
@@ -99,14 +99,6 @@ def markdown_check_result(result: Result) -> str:
         )
     lines.append("")
 
-    # Limit the number of items displayed per rule to between 5 and 50
-    max_display_per_rule = max(
-        5,
-        # Calculate the number of affected rules that we would display to increase
-        # the maximum if there are less rules affected
-        50 // total_affected_rules,
-    )
-
     # Display per project changes
     for project, comparison in result.completed:
         # TODO: This is not a performant way to check the length but the whole
@@ -136,8 +128,14 @@ def markdown_check_result(result: Result) -> str:
         )
 
         # Limit the number of items displayed per project to between 10 and 50
-        # based on the number of total changes present in this project
+        # based on the proportion of total changes present in this project
         max_display_per_project = max(10, int((project_changes / total_changes) * 50))
+
+        # Limit the number of items displayed per rule to between 5 and the max for
+        # the project based on the number of rules affected (less rules, more per rule)
+        max_display_per_rule = max(
+            5, max_display_per_project // len(rule_changes.rule_codes())
+        )
 
         # Display the diff
         displayed_changes_per_rule = Counter()


### PR DESCRIPTION
Fixes bug where `total_affected_rules` is empty, a division by zero error can occur if there are only errors and no rule changes. Calculates the maximum display per rule with the calculated project maximum as the upper bound instead of 50, this should show more rule variety when project maximums are lower. 

This commit was meant to be in #8223 but I missed it.


