### PR TITLE
Extend `bad-dunder-method-name` to permit `__index__`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
@@ -70,6 +70,10 @@ class Apples:
     def __html__(self):
         pass
 
+    # Allow Python's __index__
+    def __index__(self):
+        pass
+
     # Allow _missing_, used by enum.Enum.
     @classmethod
     def _missing_(cls, value):

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_dunder_method_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_dunder_method_name.rs
@@ -132,6 +132,7 @@ fn is_known_dunder_method(method: &str) -> bool {
             | "__imatmul__"
             | "__imod__"
             | "__imul__"
+            | "__index__"
             | "__init__"
             | "__init_subclass__"
             | "__instancecheck__"


### PR DESCRIPTION
## Summary

Fixes #8282

## Test Plan

`cargo test`
