### PR TITLE
docs(configuration): replace `extend-exclude` with `exclude`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,13 +189,13 @@ When passed a path on the command-line, Ruff will automatically discover all Pyt
 path, taking into account the [`exclude`](settings.md#exclude) and [`extend-exclude`](settings.md#extend-exclude)
 settings in each directory's `pyproject.toml` file.
 
-Files can also be selectively excluded from linting or formatting by scoping the `exclude` and
-`extend-exclude` settings to the tool-specific configuration tables. For example, the following
-would prevent `ruff` from formatting `.pyi` files, but would continue to include them in linting:
+Files can also be selectively excluded from linting or formatting by scoping the `exclude` setting
+to the tool-specific configuration tables. For example, the following would prevent `ruff` from
+formatting `.pyi` files, but would continue to include them in linting:
 
 ```toml
 [tool.ruff.format]
-extend-exclude = ["*.pyi"]
+exclude = ["*.pyi"]
 ```
 
 By default, Ruff will also skip any files that are omitted via `.ignore`, `.gitignore`,


### PR DESCRIPTION
## Summary

Similarly to https://github.com/astral-sh/ruff/pull/8302, the configuration documentation mentions `extend-exclude` for tool specific configuration, although neither `format` nor `lint` supports it, since they only support `exclude`.