### PR TITLE
Allow selective caching for `--fix` and `--diff`

### DIFF
--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -188,13 +188,8 @@ pub(crate) fn lint_path(
     unsafe_fixes: UnsafeFixes,
 ) -> Result<Diagnostics> {
     // Check the cache.
-    // TODO(charlie): `fixer::Mode::Apply` and `fixer::Mode::Diff` both have
-    // side-effects that aren't captured in the cache. (In practice, it's fine
-    // to cache `fixer::Mode::Apply`, since a file either has no fixes, or we'll
-    // write the fixes to disk, thus invalidating the cache. But it's a bit hard
-    // to reason about. We need to come up with a better solution here.)
     let caching = match cache {
-        Some(cache) if noqa.into() && fix_mode.is_generate() => {
+        Some(cache) if noqa.into() => {
             let relative_path = cache
                 .relative_path(path)
                 .expect("wrong package cache for file");
@@ -204,7 +199,17 @@ pub(crate) fn lint_path(
                 .get(relative_path, &cache_key)
                 .and_then(|entry| entry.to_diagnostics(path));
             if let Some(diagnostics) = cached_diagnostics {
-                return Ok(diagnostics);
+                // `FixMode::Generate` and `FixMode::Diff` rely on side-effects (writing to disk,
+                // and writing the diff to stdout, respectively). If a file has diagnostics, we
+                // need to avoid reading from and writing to the cache in these modes.
+                if match fix_mode {
+                    flags::FixMode::Generate => true,
+                    flags::FixMode::Apply | flags::FixMode::Diff => {
+                        diagnostics.messages.is_empty() && diagnostics.fixed.is_empty()
+                    }
+                } {
+                    return Ok(diagnostics);
+                }
             }
 
             // Stash the file metadata for later so when we update the cache it reflects the prerun
@@ -304,15 +309,25 @@ pub(crate) fn lint_path(
     if let Some((cache, relative_path, key)) = caching {
         // We don't cache parsing errors.
         if parse_error.is_none() {
-            cache.update_lint(
-                relative_path.to_owned(),
-                &key,
-                LintCacheData::from_messages(
-                    &messages,
-                    imports.clone(),
-                    source_kind.as_ipy_notebook().map(Notebook::index).cloned(),
-                ),
-            );
+            // `FixMode::Generate` and `FixMode::Diff` rely on side-effects (writing to disk,
+            // and writing the diff to stdout, respectively). If a file has diagnostics, we
+            // need to avoid reading from and writing to the cache in these modes.
+            if match fix_mode {
+                flags::FixMode::Generate => true,
+                flags::FixMode::Apply | flags::FixMode::Diff => {
+                    messages.is_empty() && fixed.is_empty()
+                }
+            } {
+                cache.update_lint(
+                    relative_path.to_owned(),
+                    &key,
+                    LintCacheData::from_messages(
+                        &messages,
+                        imports.clone(),
+                        source_kind.as_ipy_notebook().map(Notebook::index).cloned(),
+                    ),
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

If a file has no diagnostics, then we can read and write that information from and to the cache, even if the fix mode is `--fix` or `--diff`. (Typically, we can't read or write such results from or to the cache, because `--fix` and `--diff` have side effects that take place during diagnostic analysis (writing to disk or outputting the diff).) This greatly improves performance when running `--fix` on a codebase in the common case (few diagnostics).

Closes #8311.
Closes https://github.com/astral-sh/ruff/issues/8315.