### PR TITLE
Docs: add `.lint` on generating options examples.

### DIFF
--- a/crates/ruff_dev/src/generate_options.rs
+++ b/crates/ruff_dev/src/generate_options.rs
@@ -128,7 +128,11 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, parent_set: 
     output.push_str(&format!(
         "**Example usage**:\n\n```toml\n[tool.ruff{}]\n{}\n```\n",
         if let Some(set_name) = parent_set.name() {
-            format!(if set_name == "format" {".format"} else {".lint.{set_name}"})
+            format!(if set_name == "format" {
+                ".format"
+            } else {
+                ".lint.{set_name}"
+            })
         } else {
             String::new()
         },

--- a/crates/ruff_dev/src/generate_options.rs
+++ b/crates/ruff_dev/src/generate_options.rs
@@ -128,7 +128,7 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, parent_set: 
     output.push_str(&format!(
         "**Example usage**:\n\n```toml\n[tool.ruff{}]\n{}\n```\n",
         if let Some(set_name) = parent_set.name() {
-            format!(if set_name == "format" {
+            format!("{}", if set_name == "format" {
                 ".format"
             } else {
                 ".lint.{set_name}"

--- a/crates/ruff_dev/src/generate_options.rs
+++ b/crates/ruff_dev/src/generate_options.rs
@@ -129,7 +129,7 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, parent_set: 
         "**Example usage**:\n\n```toml\n[tool.ruff{}]\n{}\n```\n",
         if let Some(set_name) = parent_set.name() {
             if set_name == "format" {
-                ".format"
+                String::from(".format")
             } else {
                 format!(".lint.{set_name}")
             }

--- a/crates/ruff_dev/src/generate_options.rs
+++ b/crates/ruff_dev/src/generate_options.rs
@@ -128,11 +128,11 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, parent_set: 
     output.push_str(&format!(
         "**Example usage**:\n\n```toml\n[tool.ruff{}]\n{}\n```\n",
         if let Some(set_name) = parent_set.name() {
-            format!("{}", if set_name == "format" {
+            if set_name == "format" {
                 ".format"
             } else {
-                ".lint.{set_name}"
-            })
+                format!(".lint.{set_name}")
+            }
         } else {
             String::new()
         },

--- a/crates/ruff_dev/src/generate_options.rs
+++ b/crates/ruff_dev/src/generate_options.rs
@@ -128,7 +128,7 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, parent_set: 
     output.push_str(&format!(
         "**Example usage**:\n\n```toml\n[tool.ruff{}]\n{}\n```\n",
         if let Some(set_name) = parent_set.name() {
-            format!(".{set_name}")
+            format!(if set_name == "format" {".format"} else {".lint.{set_name}"})
         } else {
             String::new()
         },


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

In continue of #8317 
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
