### PR TITLE
Dedicated cache directory per ruff version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,7 +2072,6 @@ dependencies = [
  "insta-cmd",
  "is-macro",
  "itertools 0.11.0",
- "itoa",
  "log",
  "mimalloc",
  "notify",

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -44,7 +44,6 @@ glob = { workspace = true }
 ignore = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
-itoa = { version = "1.0.6" }
 log = { workspace = true }
 notify = { version = "6.1.1" }
 path-absolutize = { workspace = true, features = ["once_cell_cache"] }


### PR DESCRIPTION
## Summary

This PR changes our cache to use a dedicated cache directory per ruff version. 

* Before: `.ruff_cache/content`
* After: `.ruff_cache/0.1.3`



The motivation is that I want to rule out that hash collisions between cache keys causing ruff to load a cache created by another version.
Loading incompatible caches might be the root cause for https://github.com/astral-sh/ruff/issues/8147 (although unlikely, because users mention that they didn't upgrade ruff)
Other hash collissions are less problematic, because the Cache checks if the loaded file is for the same package, and otherwise clears the cache for that package. 


## Open questions

I'm unsure if this is considered a breaking change or not. It does change observable behavior of Ruff but we never included it in our public API.

## Test Plan

Verified that the cache is still used by comparing performance before/after

<!-- How was it tested? -->
