### PR TITLE
Introduce `LiteralExpressionRef` for all literals

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{self as ast, Expr};
+use ruff_python_ast::{self as ast, Expr, LiteralExpressionRef};
 use ruff_python_semantic::SemanticModel;
 use ruff_text_size::Ranged;
 
@@ -59,7 +59,7 @@ impl Violation for RedundantLiteralUnion {
 
 /// PYI051
 pub(crate) fn redundant_literal_union<'a>(checker: &mut Checker, union: &'a Expr) {
-    let mut literal_exprs = Vec::new();
+    let mut typing_literal_exprs = Vec::new();
     let mut builtin_types_in_union = FxHashSet::default();
 
     // Adds a member to `literal_exprs` for each value in a `Literal`, and any builtin types
@@ -68,9 +68,9 @@ pub(crate) fn redundant_literal_union<'a>(checker: &mut Checker, union: &'a Expr
         if let Expr::Subscript(ast::ExprSubscript { value, slice, .. }) = expr {
             if checker.semantic().match_typing_expr(value, "Literal") {
                 if let Expr::Tuple(ast::ExprTuple { elts, .. }) = slice.as_ref() {
-                    literal_exprs.extend(elts.iter());
+                    typing_literal_exprs.extend(elts.iter());
                 } else {
-                    literal_exprs.push(slice);
+                    typing_literal_exprs.push(slice);
                 }
             }
             return;
@@ -84,18 +84,20 @@ pub(crate) fn redundant_literal_union<'a>(checker: &mut Checker, union: &'a Expr
 
     traverse_union(&mut func, checker.semantic(), union, None);
 
-    for literal_expr in literal_exprs {
-        let Some(constant_type) = match_constant_type(literal_expr) else {
+    for typing_literal_expr in typing_literal_exprs {
+        let Some(literal_type) = match_literal_type(typing_literal_expr) else {
             continue;
         };
 
-        if builtin_types_in_union.contains(&constant_type) {
+        if builtin_types_in_union.contains(&literal_type) {
             checker.diagnostics.push(Diagnostic::new(
                 RedundantLiteralUnion {
-                    literal: SourceCodeSnippet::from_str(checker.locator().slice(literal_expr)),
-                    builtin_type: constant_type,
+                    literal: SourceCodeSnippet::from_str(
+                        checker.locator().slice(typing_literal_expr),
+                    ),
+                    builtin_type: literal_type,
                 },
-                literal_expr.range(),
+                typing_literal_expr.range(),
             ));
         }
     }
@@ -143,19 +145,24 @@ fn match_builtin_type(expr: &Expr, semantic: &SemanticModel) -> Option<ExprType>
     Some(result)
 }
 
-/// Return the [`ExprType`] of an [`Expr]` if it is a constant (e.g., an `int`, like `1`, or a
+/// Return the [`ExprType`] of an [`Expr`] if it is a literal (e.g., an `int`, like `1`, or a
 /// `bool`, like `True`).
-fn match_constant_type(expr: &Expr) -> Option<ExprType> {
-    let result = match expr {
-        Expr::BooleanLiteral(_) => ExprType::Bool,
-        Expr::StringLiteral(_) => ExprType::Str,
-        Expr::BytesLiteral(_) => ExprType::Bytes,
-        Expr::NumberLiteral(ast::ExprNumberLiteral { value, .. }) => match value {
+fn match_literal_type(expr: &Expr) -> Option<ExprType> {
+    let Some(literal_expr) = expr.as_literal_expr() else {
+        return None;
+    };
+    let result = match literal_expr {
+        LiteralExpressionRef::BooleanLiteral(_) => ExprType::Bool,
+        LiteralExpressionRef::StringLiteral(_) => ExprType::Str,
+        LiteralExpressionRef::BytesLiteral(_) => ExprType::Bytes,
+        LiteralExpressionRef::NumberLiteral(ast::ExprNumberLiteral { value, .. }) => match value {
             ast::Number::Int(_) => ExprType::Int,
             ast::Number::Float(_) => ExprType::Float,
             ast::Number::Complex { .. } => ExprType::Complex,
         },
-        _ => return None,
+        LiteralExpressionRef::NoneLiteral(_) | LiteralExpressionRef::EllipsisLiteral(_) => {
+            return None;
+        }
     };
     Some(result)
 }

--- a/crates/ruff_linter/src/rules/pylint/settings.rs
+++ b/crates/ruff_linter/src/rules/pylint/settings.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use ruff_macros::CacheKey;
-use ruff_python_ast::{Expr, ExprNumberLiteral, Number};
+use ruff_python_ast::{ExprNumberLiteral, LiteralExpressionRef, Number};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, CacheKey)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
@@ -17,16 +17,18 @@ pub enum ConstantType {
 }
 
 impl ConstantType {
-    pub fn try_from_expr(expr: &Expr) -> Option<Self> {
-        match expr {
-            Expr::StringLiteral(_) => Some(Self::Str),
-            Expr::BytesLiteral(_) => Some(Self::Bytes),
-            Expr::NumberLiteral(ExprNumberLiteral { value, .. }) => match value {
+    pub fn try_from_literal_expr(literal_expr: LiteralExpressionRef<'_>) -> Option<Self> {
+        match literal_expr {
+            LiteralExpressionRef::StringLiteral(_) => Some(Self::Str),
+            LiteralExpressionRef::BytesLiteral(_) => Some(Self::Bytes),
+            LiteralExpressionRef::NumberLiteral(ExprNumberLiteral { value, .. }) => match value {
                 Number::Int(_) => Some(Self::Int),
                 Number::Float(_) => Some(Self::Float),
                 Number::Complex { .. } => Some(Self::Complex),
             },
-            _ => None,
+            LiteralExpressionRef::BooleanLiteral(_)
+            | LiteralExpressionRef::NoneLiteral(_)
+            | LiteralExpressionRef::EllipsisLiteral(_) => None,
         }
     }
 }

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -645,6 +645,39 @@ pub struct ExprFString<'a> {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
+pub enum ComparableLiteral<'a> {
+    None,
+    Ellipsis,
+    Bool(&'a bool),
+    Str { value: &'a str, unicode: &'a bool },
+    Bytes { value: &'a [u8] },
+    Number(ComparableNumber<'a>),
+}
+
+impl<'a> From<ast::LiteralExpressionRef<'a>> for ComparableLiteral<'a> {
+    fn from(literal: ast::LiteralExpressionRef<'a>) -> Self {
+        match literal {
+            ast::LiteralExpressionRef::NoneLiteral(_) => Self::None,
+            ast::LiteralExpressionRef::EllipsisLiteral(_) => Self::Ellipsis,
+            ast::LiteralExpressionRef::BooleanLiteral(ast::ExprBooleanLiteral {
+                value, ..
+            }) => Self::Bool(value),
+            ast::LiteralExpressionRef::StringLiteral(ast::ExprStringLiteral {
+                value,
+                unicode,
+                ..
+            }) => Self::Str { value, unicode },
+            ast::LiteralExpressionRef::BytesLiteral(ast::ExprBytesLiteral { value, .. }) => {
+                Self::Bytes { value }
+            }
+            ast::LiteralExpressionRef::NumberLiteral(ast::ExprNumberLiteral { value, .. }) => {
+                Self::Number(value.into())
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct ExprStringLiteral<'a> {
     value: &'a str,
     unicode: &'a bool,

--- a/crates/ruff_python_ast/src/expression.rs
+++ b/crates/ruff_python_ast/src/expression.rs
@@ -336,3 +336,28 @@ impl Ranged for ExpressionRef<'_> {
         }
     }
 }
+
+/// Unowned pendant to all the literal variants of [`ast::Expr`] that stores a
+/// reference instead of an owned value.
+#[derive(Copy, Clone, Debug, PartialEq, is_macro::Is)]
+pub enum LiteralExpressionRef<'a> {
+    StringLiteral(&'a ast::ExprStringLiteral),
+    BytesLiteral(&'a ast::ExprBytesLiteral),
+    NumberLiteral(&'a ast::ExprNumberLiteral),
+    BooleanLiteral(&'a ast::ExprBooleanLiteral),
+    NoneLiteral(&'a ast::ExprNoneLiteral),
+    EllipsisLiteral(&'a ast::ExprEllipsisLiteral),
+}
+
+impl Ranged for LiteralExpressionRef<'_> {
+    fn range(&self) -> TextRange {
+        match self {
+            LiteralExpressionRef::StringLiteral(expression) => expression.range(),
+            LiteralExpressionRef::BytesLiteral(expression) => expression.range(),
+            LiteralExpressionRef::NumberLiteral(expression) => expression.range(),
+            LiteralExpressionRef::BooleanLiteral(expression) => expression.range(),
+            LiteralExpressionRef::NoneLiteral(expression) => expression.range(),
+            LiteralExpressionRef::EllipsisLiteral(expression) => expression.range(),
+        }
+    }
+}

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::fmt::Debug;
 use std::ops::Deref;
 
-use crate::int;
+use crate::{int, LiteralExpressionRef};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 /// See also [mod](https://docs.python.org/3/library/ast.html#ast.mod)
@@ -638,6 +638,18 @@ impl Expr {
                 | Expr::NoneLiteral(_)
                 | Expr::EllipsisLiteral(_)
         )
+    }
+
+    pub fn as_literal_expr(&self) -> Option<LiteralExpressionRef<'_>> {
+        match self {
+            Expr::StringLiteral(expr) => Some(LiteralExpressionRef::StringLiteral(expr)),
+            Expr::BytesLiteral(expr) => Some(LiteralExpressionRef::BytesLiteral(expr)),
+            Expr::NumberLiteral(expr) => Some(LiteralExpressionRef::NumberLiteral(expr)),
+            Expr::BooleanLiteral(expr) => Some(LiteralExpressionRef::BooleanLiteral(expr)),
+            Expr::NoneLiteral(expr) => Some(LiteralExpressionRef::NoneLiteral(expr)),
+            Expr::EllipsisLiteral(expr) => Some(LiteralExpressionRef::EllipsisLiteral(expr)),
+            _ => None,
+        }
     }
 
     pub fn is_implicit_concatenated_string(&self) -> bool {


### PR DESCRIPTION
## Summary

This PR adds a new `LiteralExpressionRef` which wraps all of the literal expression nodes in a single enum. This allows for a narrow type when working exclusively with a literal node. Additionally, it also implements a `Expr::as_literal_expr` method to return the new enum if the expression is indeed a literal one.

A few rules have been updated to account for the new enum:
1. `redundant_literal_union`
2. `if_else_block_instead_of_dict_lookup`
3. `magic_value_comparison`

To account for the change in (2), a new `ComparableLiteral` has been added which can be constructed from the new enum (`ComparableLiteral::from(<LiteralExpressionRef>)`).

### Open Questions

1. The new `ComparableLiteral` can be exclusively used via the `LiteralExpressionRef` enum. Should we remove all of the literal variants from `ComparableExpr` and instead have a single `ComparableExpr::Literal(ComparableLiteral)` variant instead?

## Test Plan

`cargo test`