### PR TITLE
Impl `Default` for `(String|Bytes|Boolean|None|Ellipsis)Literal`

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -326,9 +326,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                                 .map(|name| {
                                     Expr::StringLiteral(ast::ExprStringLiteral {
                                         value: (*name).to_string(),
-                                        unicode: false,
-                                        implicit_concatenated: false,
-                                        range: TextRange::default(),
+                                        ..ast::ExprStringLiteral::default()
                                     })
                                 })
                                 .collect(),
@@ -361,9 +359,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
                                 .map(|name| {
                                     Expr::StringLiteral(ast::ExprStringLiteral {
                                         value: (*name).to_string(),
-                                        unicode: false,
-                                        implicit_concatenated: false,
-                                        range: TextRange::default(),
+                                        ..ast::ExprStringLiteral::default()
                                     })
                                 })
                                 .collect(),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -1,5 +1,5 @@
 use ruff_python_ast::{self as ast, Arguments, Expr};
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::Ranged;
 
 use crate::fix::snippet::SourceCodeSnippet;
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix, FixAvailability, Violation};
@@ -219,8 +219,7 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
     let node = ast::ExprStringLiteral {
         value: capital_env_var,
         unicode: *unicode,
-        implicit_concatenated: false,
-        range: TextRange::default(),
+        ..ast::ExprStringLiteral::default()
     };
     let new_env_var = node.into();
     diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(

--- a/crates/ruff_linter/src/rules/flynt/helpers.rs
+++ b/crates/ruff_linter/src/rules/flynt/helpers.rs
@@ -17,9 +17,7 @@ fn to_formatted_value_expr(inner: &Expr) -> Expr {
 pub(super) fn to_constant_string(s: &str) -> Expr {
     let node = ast::ExprStringLiteral {
         value: s.to_owned(),
-        unicode: false,
-        implicit_concatenated: false,
-        range: TextRange::default(),
+        ..ast::ExprStringLiteral::default()
     };
     node.into()
 }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
@@ -35,19 +35,8 @@ impl FromStr for LiteralType {
 impl LiteralType {
     fn as_zero_value_expr(self) -> Expr {
         match self {
-            LiteralType::Str => ast::ExprStringLiteral {
-                value: String::new(),
-                unicode: false,
-                implicit_concatenated: false,
-                range: TextRange::default(),
-            }
-            .into(),
-            LiteralType::Bytes => ast::ExprBytesLiteral {
-                value: Vec::new(),
-                implicit_concatenated: false,
-                range: TextRange::default(),
-            }
-            .into(),
+            LiteralType::Str => ast::ExprStringLiteral::default().into(),
+            LiteralType::Bytes => ast::ExprBytesLiteral::default().into(),
             LiteralType::Int => ast::ExprNumberLiteral {
                 value: ast::Number::Int(0.into()),
                 range: TextRange::default(),
@@ -58,11 +47,7 @@ impl LiteralType {
                 range: TextRange::default(),
             }
             .into(),
-            LiteralType::Bool => ast::ExprBooleanLiteral {
-                value: false,
-                range: TextRange::default(),
-            }
-            .into(),
+            LiteralType::Bool => ast::ExprBooleanLiteral::default().into(),
         }
     }
 }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -131,9 +131,7 @@ fn optional(expr: &Expr) -> Expr {
     ast::ExprBinOp {
         left: Box::new(expr.clone()),
         op: Operator::BitOr,
-        right: Box::new(Expr::NoneLiteral(ast::ExprNoneLiteral {
-            range: TextRange::default(),
-        })),
+        right: Box::new(Expr::NoneLiteral(ast::ExprNoneLiteral::default())),
         range: TextRange::default(),
     }
     .into()

--- a/crates/ruff_linter/src/rules/refurb/rules/isinstance_type_none.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/isinstance_type_none.rs
@@ -130,9 +130,7 @@ fn generate_replacement(name: &str, generator: Generator) -> String {
     let compare = ast::ExprCompare {
         left: Box::new(var.into()),
         ops: vec![ast::CmpOp::Is],
-        comparators: vec![ast::Expr::NoneLiteral(ast::ExprNoneLiteral {
-            range: TextRange::default(),
-        })],
+        comparators: vec![ast::Expr::NoneLiteral(ast::ExprNoneLiteral::default())],
         range: TextRange::default(),
     };
     generator.expr(&compare.into())

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -127,9 +127,7 @@ fn generate_fix(checker: &Checker, conversion_type: ConversionType, expr: &Expr)
             let new_expr = Expr::BinOp(ast::ExprBinOp {
                 left: Box::new(expr.clone()),
                 op: Operator::BitOr,
-                right: Box::new(Expr::NoneLiteral(ast::ExprNoneLiteral {
-                    range: TextRange::default(),
-                })),
+                right: Box::new(Expr::NoneLiteral(ast::ExprNoneLiteral::default())),
                 range: TextRange::default(),
             });
             let content = checker.generator().expr(&new_expr);

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -987,7 +987,7 @@ impl From<ExprFString> for Expr {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ExprStringLiteral {
     pub range: TextRange,
     pub value: String,
@@ -1015,7 +1015,7 @@ impl Deref for ExprStringLiteral {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ExprBytesLiteral {
     pub range: TextRange,
     pub value: Vec<u8>,
@@ -1059,7 +1059,7 @@ pub enum Number {
     Complex { real: f64, imag: f64 },
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ExprBooleanLiteral {
     pub range: TextRange,
     pub value: bool,
@@ -1077,7 +1077,7 @@ impl Ranged for ExprBooleanLiteral {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ExprNoneLiteral {
     pub range: TextRange,
 }
@@ -1094,7 +1094,7 @@ impl Ranged for ExprNoneLiteral {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ExprEllipsisLiteral {
     pub range: TextRange,
 }


### PR DESCRIPTION
## Summary

This PR adds `Default` for the following literal nodes:
* `StringLiteral`
* `BytesLiteral`
* `BooleanLiteral`
* `NoneLiteral`
* `EllipsisLiteral`

The implementation creates the zero value of the respective literal nodes in
terms of the Python language.

## Test Plan

`cargo test`
