### PR TITLE
Byte strings aren't docstrings

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring.py
@@ -93,6 +93,10 @@ def docstring_that_ends_with_quote_and_a_line_break3():
     """
 
 
+class ByteDocstring:
+    b"""   has leading whitespace"""
+    first_statement = 1
+
 class TabbedIndent:
 	def tabbed_indent(self):
 		"""check for correct tabbed formatting

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -554,7 +554,6 @@ impl<'a> DocstringStmt<'a> {
 
         match value.as_ref() {
             Expr::StringLiteral(value) if !value.implicit_concatenated => Some(DocstringStmt(stmt)),
-            Expr::BytesLiteral(value) if !value.implicit_concatenated => Some(DocstringStmt(stmt)),
             _ => None,
         }
     }

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring.py.snap
@@ -99,6 +99,10 @@ def docstring_that_ends_with_quote_and_a_line_break3():
     """
 
 
+class ByteDocstring:
+    b"""   has leading whitespace"""
+    first_statement = 1
+
 class TabbedIndent:
 	def tabbed_indent(self):
 		"""check for correct tabbed formatting
@@ -211,6 +215,11 @@ def docstring_that_ends_with_quote_and_a_line_break2():
 
 def docstring_that_ends_with_quote_and_a_line_break3():
     """he said "the news of my death have been greatly exaggerated" """
+
+
+class ByteDocstring:
+    b"""   has leading whitespace"""
+    first_statement = 1
 
 
 class TabbedIndent:
@@ -327,6 +336,11 @@ def docstring_that_ends_with_quote_and_a_line_break3():
   """he said "the news of my death have been greatly exaggerated" """
 
 
+class ByteDocstring:
+  b"""   has leading whitespace"""
+  first_statement = 1
+
+
 class TabbedIndent:
   def tabbed_indent(self):
     """check for correct tabbed formatting
@@ -441,6 +455,11 @@ def docstring_that_ends_with_quote_and_a_line_break3():
 	"""he said "the news of my death have been greatly exaggerated" """
 
 
+class ByteDocstring:
+	b"""   has leading whitespace"""
+	first_statement = 1
+
+
 class TabbedIndent:
 	def tabbed_indent(self):
 		"""check for correct tabbed formatting
@@ -553,6 +572,11 @@ def docstring_that_ends_with_quote_and_a_line_break2():
 
 def docstring_that_ends_with_quote_and_a_line_break3():
 	"""he said "the news of my death have been greatly exaggerated" """
+
+
+class ByteDocstring:
+	b"""   has leading whitespace"""
+	first_statement = 1
 
 
 class TabbedIndent:


### PR DESCRIPTION
We previously incorrectly treated byte strings in docstring position as docstrings because black does so (https://github.com/astral-sh/ruff/pull/8283#discussion_r1375682931, https://github.com/psf/black/issues/4002), even CPython doesn't recognize them:

```console
$ python3.12
Python 3.12.0 (main, Oct  6 2023, 17:57:44) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> def f():
...     b""" a"""
...
>>> print(str(f.__doc__))
None
```

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
