### PR TITLE
Update pyproject-toml to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "pyproject-toml"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "569e259cd132eb8cec5df8b672d187c5260f82ad352156b5da9549d4472e64b0"
+checksum = "0774c13ff0b8b7ebb4791c050c497aefcfe3f6a222c0829c7017161ed38391ff"
 dependencies = [
  "indexmap",
  "pep440_rs",

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -53,7 +53,7 @@ path-absolutize = { workspace = true, features = [
 ] }
 pathdiff = { version = "0.2.1" }
 pep440_rs = { version = "0.3.12", features = ["serde"] }
-pyproject-toml = { version = "0.7.0" }
+pyproject-toml = { version = "0.8.0" }
 quick-junit = { version = "0.3.2" }
 regex = { workspace = true }
 result-like = { version = "0.4.6" }

--- a/crates/ruff_linter/src/pyproject_toml.rs
+++ b/crates/ruff_linter/src/pyproject_toml.rs
@@ -1,8 +1,7 @@
 use colored::Colorize;
 use log::warn;
-use pyproject_toml::{BuildSystem, Project};
+use pyproject_toml::PyProjectToml;
 use ruff_text_size::{TextRange, TextSize};
-use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::Diagnostic;
 use ruff_source_file::SourceFile;
@@ -12,16 +11,6 @@ use crate::registry::Rule;
 use crate::rules::ruff::rules::InvalidPyprojectToml;
 use crate::settings::LinterSettings;
 use crate::IOError;
-
-/// Unlike [`pyproject_toml::PyProjectToml`], in our case `build_system` is also optional
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
-struct PyProjectToml {
-    /// Build-related data
-    build_system: Option<BuildSystem>,
-    /// Project metadata
-    project: Option<Project>,
-}
 
 pub fn lint_pyproject_toml(source_file: SourceFile, settings: &LinterSettings) -> Vec<Message> {
     let Some(err) = toml::from_str::<PyProjectToml>(source_file.source_text()).err() else {


### PR DESCRIPTION
`build-system` is now also optional upstream.

Closes #8343
