### PR TITLE
Fix panic with 8 in octal escape

### DIFF
--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__dont_panic_on_8_in_octal_escape.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__dont_panic_on_8_in_octal_escape.snap
@@ -1,0 +1,28 @@
+---
+source: crates/ruff_python_parser/src/string.rs
+expression: parse_ast
+---
+[
+    Assign(
+        StmtAssign {
+            range: 0..16,
+            targets: [
+                Name(
+                    ExprName {
+                        range: 0..4,
+                        id: "bold",
+                        ctx: Store,
+                    },
+                ),
+            ],
+            value: StringLiteral(
+                ExprStringLiteral {
+                    range: 7..16,
+                    value: "\u{3}8[1m",
+                    unicode: false,
+                    implicit_concatenated: false,
+                },
+            ),
+        },
+    ),
+]

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -885,10 +885,10 @@ mod tests {
         insta::assert_debug_snapshot!(parse_ast);
     }
 
-    /// https://github.com/astral-sh/ruff/issues/8355
+    /// <https://github.com/astral-sh/ruff/issues/8355>
     #[test]
     fn test_dont_panic_on_8_in_octal_escape() {
-        let source = r#"bold = '\038[1m'"#;
+        let source = r"bold = '\038[1m'";
         let parse_ast = parse_suite(source, "<test>").unwrap();
 
         insta::assert_debug_snapshot!(parse_ast);

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -114,7 +114,7 @@ impl<'a> StringParser<'a> {
         let mut len = 1;
 
         while len < 3 {
-            let Some(b'0'..=b'8') = self.peek_byte() else {
+            let Some(b'0'..=b'7') = self.peek_byte() else {
                 break;
             };
 
@@ -880,6 +880,15 @@ mod tests {
     #[test]
     fn test_parse_fstring_nested_concatenation_string_spec() {
         let source = r#"f"{foo:{'' ''}}""#;
+        let parse_ast = parse_suite(source, "<test>").unwrap();
+
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    /// https://github.com/astral-sh/ruff/issues/8355
+    #[test]
+    fn test_dont_panic_on_8_in_octal_escape() {
+        let source = r#"bold = '\038[1m'"#;
         let parse_ast = parse_suite(source, "<test>").unwrap();
 
         insta::assert_debug_snapshot!(parse_ast);


### PR DESCRIPTION
**Summary** The digits for an octal escape are 0 to 7, not 0 to 8, fixing the panic in #8355

**Test plan** Regression test parser fixture