### PR TITLE
Add `--line-length` option to `format` command

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -409,6 +409,9 @@ pub struct FormatCommand {
     force_exclude: bool,
     #[clap(long, overrides_with("force_exclude"), hide = true)]
     no_force_exclude: bool,
+    /// Set the line-length.
+    #[arg(long, help_heading = "Rule configuration", hide = true)]
+    pub line_length: Option<LineLength>,
     /// Ignore all configuration files.
     #[arg(long, conflicts_with = "config", help_heading = "Miscellaneous")]
     pub isolated: bool,
@@ -552,6 +555,7 @@ impl FormatCommand {
                 stdin_filename: self.stdin_filename,
             },
             CliOverrides {
+                line_length: self.line_length,
                 respect_gitignore: resolve_bool_arg(
                     self.respect_gitignore,
                     self.no_respect_gitignore,

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -410,7 +410,7 @@ pub struct FormatCommand {
     #[clap(long, overrides_with("force_exclude"), hide = true)]
     no_force_exclude: bool,
     /// Set the line-length.
-    #[arg(long, help_heading = "Rule configuration", hide = true)]
+    #[arg(long, help_heading = "Format configuration")]
     pub line_length: Option<LineLength>,
     /// Ignore all configuration files.
     #[arg(long, conflicts_with = "config", help_heading = "Miscellaneous")]

--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -117,10 +117,11 @@ quote-style = "single"
 ```
 
 The Ruff formatter also respects Ruff's [`line-length`](https://docs.astral.sh/ruff/settings/#line-length)
-setting, which also can be provided via a `pyproject.toml` or `ruff.toml` file.
+setting, which also can be provided via a `pyproject.toml` or `ruff.toml` file, or on the CLI, as
+in:
 
-```toml
-line-length = 80
+```console
+ruff format --line-length 100 /path/to/file.py
 ```
 
 ### Excluding code from formatting

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -402,6 +402,9 @@ File selection:
       --exclude <FILE_PATTERN>  List of paths, used to omit files and/or directories from analysis
       --force-exclude           Enforce exclusions, even for paths passed to Ruff directly on the command-line. Use `--no-force-exclude` to disable
 
+Format configuration:
+      --line-length <LINE_LENGTH>  Set the line-length
+
 Log levels:
   -v, --verbose  Enable verbose logging
   -q, --quiet    Print diagnostics, but nothing else


### PR DESCRIPTION
Restores the `--line-length` option removed in https://github.com/astral-sh/ruff/pull/8131

Closes #8362
Closes #8352 

We removed this option because we did not feel it made sense for the format CLI to expose a single configuration option but not others.

However, there are a few arguments in favor of restoring this option:

1. It is the most asked for option (nobody has pointed out the other options are missing)
2. It is also available via the `ruff check` CLI
3. It is also available via the Black CLI
4. There is no way for a user to configure the line width without a configuration file yet
5. The line length is a unique formatter option; in that it is the most "restrictive" and not a toggle

While we intend to introduce override of general configuration options via the CLI, we have not built it yet. If we replace `ruff check --line-length=...` with a generic `ruff check --setting line-length=...` we'll need to manage a deprecation period anyway.

There remain some arguments against restoring this option:

1. If/when we deprecate this option in favor of a `--setting` flag, more users will be affected
2. Inconsistencies of the availability of configuration options via the CLI could be confusing
3. Should this be `--line-width` to match our terminology for measuring enforced line length?

