### PR TITLE
Ensure that ecosystem check job fails if the tooling encounters an unexpected error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -215,6 +215,9 @@ jobs:
           # Make executable, since artifact download doesn't preserve this
           chmod +x ./ruff ${{ steps.ruff-target.outputs.download-path }}/ruff
 
+          # Set pipefail to avoid hiding errors with tee
+          set -eo pipefail
+
           ruff-ecosystem check ./ruff ${{ steps.ruff-target.outputs.download-path }}/ruff --cache ./checkouts --output-format markdown | tee ecosystem-result-check
 
           cat ecosystem-result-check > $GITHUB_STEP_SUMMARY
@@ -226,6 +229,9 @@ jobs:
         run: |
           # Make executable, since artifact download doesn't preserve this
           chmod +x ./ruff ${{ steps.ruff-target.outputs.download-path }}/ruff
+
+          # Set pipefail to avoid hiding errors with tee
+          set -eo pipefail
 
           ruff-ecosystem format ./ruff ${{ steps.ruff-target.outputs.download-path }}/ruff --cache ./checkouts --output-format markdown | tee ecosystem-result-format
 

--- a/python/ruff-ecosystem/ruff_ecosystem/cli.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/cli.py
@@ -30,7 +30,6 @@ def excepthook(type, value, tb):
 
 
 def entrypoint():
-    sys.exit(1)
     args = parse_args()
 
     if args.pdb:

--- a/python/ruff-ecosystem/ruff_ecosystem/cli.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/cli.py
@@ -30,6 +30,7 @@ def excepthook(type, value, tb):
 
 
 def entrypoint():
+    sys.exit(1)
     args = parse_args()
 
     if args.pdb:


### PR DESCRIPTION
Previously, `| tee` would hide bad exit codes from `ruff-ecosystem ...`

See poc failure at https://github.com/astral-sh/ruff/actions/runs/6698487019/job/18200852648?pr=8365