### PR TITLE
Update plugins for Neovim integration docs

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -273,22 +273,34 @@ tools:
 
 <details>
 <summary>
-For neovim users using
-<a href="https://github.com/jose-elias-alvarez/null-ls.nvim">
-  <code>null-ls</code>
-</a>, Ruff is already <a href="https://github.com/jose-elias-alvarez/null-ls.nvim">integrated</a>.
+With the <a href="https://github.com/stevearc/conform.nvim"><code>conform.nvim</code></a> plugin for Neovim.
 </summary>
 <br>
 
 ```lua
-local null_ls = require("null-ls")
-
-null_ls.setup({
-    sources = {
-        null_ls.builtins.formatting.ruff,
-        null_ls.builtins.diagnostics.ruff,
-    }
+require("conform").setup({
+    formatters_by_ft = {
+        python = {
+          -- To fix lint errors.
+          "ruff_fix",
+          -- To run the Ruff formatter.
+          "ruff_format",
+        },
+    },
 })
+```
+
+</details>
+
+<details>
+<summary>
+With the <a href="https://github.com/mfussenegger/nvim-lint"><code>nvim-lint</code></a> plugin for Neovim.
+</summary>
+
+```lua
+require("lint").linters_by_ft = {
+  python = { "ruff" },
+}
 ```
 
 </details>


### PR DESCRIPTION
This PR updates the editor integration section of the documentation for Neovim.
* Removes the now archived `null-ls` plugin
* Add `nvim-lint` (for linters) and `conform.nvim` (for formatter) plugins

<img width="1792" alt="neovim-integration-section" src="https://github.com/astral-sh/ruff/assets/67177269/b7032228-57b1-4141-ae17-e186c4428b61">
