### PR TITLE
Delete redundant branch in `NeedsParentheses`

### DIFF
--- a/crates/ruff_python_formatter/src/expression/expr_attribute.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_attribute.rs
@@ -150,8 +150,6 @@ impl NeedsParentheses for ExprAttribute {
             OptionalParentheses::Multiline
         } else if context.comments().has_dangling(self) {
             OptionalParentheses::Always
-        } else if self.value.is_name_expr() {
-            OptionalParentheses::BestFit
         } else if is_expression_parenthesized(
             self.value.as_ref().into(),
             context.comments().ranges(),


### PR DESCRIPTION

## Summary

Delete an unnecessary branch in the `NeedsParentheses` implementation of `ExprAttribute`. 

The branch isn't required because `ExprName::needs_parentheses` always returns `BestFit`

## Test Plan

`cargo test`, The similarity index remains unchanged
