### PR TITLE
Avoid un-setting bracket flag in logical lines

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E21.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E21.py
@@ -12,3 +12,19 @@ dict['key'] = list[index]
 # This is not prohibited by PEP8, but avoid it.
 class Foo (Bar, Baz):
     pass
+
+
+def fetch_name () -> Union[str, None]:
+    """Fetch name from --person-name in sys.argv.
+
+   Returns:
+        name of the person if available, otherwise None
+    """
+    test = len(5)
+    Logger.info(test)
+    # test commented code
+    # Logger.info("test code")
+    for i in range (0, len (sys.argv)) :
+        if sys.argv[i] == "--name" :
+            return sys.argv[i + 1]
+    return None

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
@@ -432,18 +432,17 @@ impl LogicalLinesBuilder {
         } else if kind.is_operator() {
             line.flags.insert(TokenFlags::OPERATOR);
 
-            line.flags.set(
-                TokenFlags::BRACKET,
-                matches!(
-                    kind,
-                    TokenKind::Lpar
-                        | TokenKind::Lsqb
-                        | TokenKind::Lbrace
-                        | TokenKind::Rpar
-                        | TokenKind::Rsqb
-                        | TokenKind::Rbrace
-                ),
-            );
+            if matches!(
+                kind,
+                TokenKind::Lpar
+                    | TokenKind::Lsqb
+                    | TokenKind::Lbrace
+                    | TokenKind::Rpar
+                    | TokenKind::Rsqb
+                    | TokenKind::Rbrace
+            ) {
+                line.flags.insert(TokenFlags::BRACKET);
+            }
         }
 
         if matches!(kind, TokenKind::Comma | TokenKind::Semi | TokenKind::Colon) {
@@ -452,17 +451,16 @@ impl LogicalLinesBuilder {
             line.flags.insert(TokenFlags::KEYWORD);
         }
 
-        line.flags.set(
-            TokenFlags::NON_TRIVIA,
-            !matches!(
-                kind,
-                TokenKind::Comment
-                    | TokenKind::Newline
-                    | TokenKind::NonLogicalNewline
-                    | TokenKind::Dedent
-                    | TokenKind::Indent
-            ),
-        );
+        if !matches!(
+            kind,
+            TokenKind::Comment
+                | TokenKind::Newline
+                | TokenKind::NonLogicalNewline
+                | TokenKind::Dedent
+                | TokenKind::Indent
+        ) {
+            line.flags.insert(TokenFlags::NON_TRIVIA);
+        }
 
         self.tokens.push(LogicalLineToken { kind, range });
     }

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E211_E21.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E211_E21.py.snap
@@ -82,4 +82,64 @@ E21.py:6:12: E211 [*] Whitespace before '['
 8 8 | spam(1)
 9 9 | dict['key'] = list[index]
 
+E21.py:17:15: E211 [*] Whitespace before '('
+   |
+17 | def fetch_name () -> Union[str, None]:
+   |               ^ E211
+18 |     """Fetch name from --person-name in sys.argv.
+   |
+   = help: Removed whitespace before '('
+
+ℹ Fix
+14 14 |     pass
+15 15 | 
+16 16 | 
+17    |-def fetch_name () -> Union[str, None]:
+   17 |+def fetch_name() -> Union[str, None]:
+18 18 |     """Fetch name from --person-name in sys.argv.
+19 19 | 
+20 20 |    Returns:
+
+E21.py:27:19: E211 [*] Whitespace before '('
+   |
+25 |     # test commented code
+26 |     # Logger.info("test code")
+27 |     for i in range (0, len (sys.argv)) :
+   |                   ^ E211
+28 |         if sys.argv[i] == "--name" :
+29 |             return sys.argv[i + 1]
+   |
+   = help: Removed whitespace before '('
+
+ℹ Fix
+24 24 |     Logger.info(test)
+25 25 |     # test commented code
+26 26 |     # Logger.info("test code")
+27    |-    for i in range (0, len (sys.argv)) :
+   27 |+    for i in range(0, len (sys.argv)) :
+28 28 |         if sys.argv[i] == "--name" :
+29 29 |             return sys.argv[i + 1]
+30 30 |     return None
+
+E21.py:27:27: E211 [*] Whitespace before '('
+   |
+25 |     # test commented code
+26 |     # Logger.info("test code")
+27 |     for i in range (0, len (sys.argv)) :
+   |                           ^ E211
+28 |         if sys.argv[i] == "--name" :
+29 |             return sys.argv[i + 1]
+   |
+   = help: Removed whitespace before '('
+
+ℹ Fix
+24 24 |     Logger.info(test)
+25 25 |     # test commented code
+26 26 |     # Logger.info("test code")
+27    |-    for i in range (0, len (sys.argv)) :
+   27 |+    for i in range (0, len(sys.argv)) :
+28 28 |         if sys.argv[i] == "--name" :
+29 29 |             return sys.argv[i + 1]
+30 30 |     return None
+
 


### PR DESCRIPTION
## Summary

By using `set`, we were setting the bracket flag to `false` if another operator was visited.

Closes https://github.com/astral-sh/ruff/issues/8379.

## Test Plan

`cargo test`
