### PR TITLE
Editor integrations link fixed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ An extremely fast Python linter and code formatter, written in Rust.
 - 🔧 Fix support, for automatic error correction (e.g., automatically remove unused imports)
 - 📏 Over [700 built-in rules](https://docs.astral.sh/ruff/rules/), with native re-implementations
     of popular Flake8 plugins, like flake8-bugbear
-- ⌨️ First-party [editor integrations](https://docs.astral.sh/ruff/editor-integrations/) for
+- ⌨️ First-party [editor integrations](https://docs.astral.sh/ruff/integrations/) for
     [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](https://github.com/astral-sh/ruff-lsp)
 - 🌎 Monorepo-friendly, with [hierarchical and cascading configuration](https://docs.astral.sh/ruff/configuration/#pyprojecttoml-discovery)
 

--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -43,7 +43,7 @@ LINK_REWRITES: dict[str, str] = {
         "configuration.md#pyprojecttoml-discovery"
     ),
     "https://docs.astral.sh/ruff/contributing/": "contributing.md",
-    "https://docs.astral.sh/ruff/editor-integrations/": "integrations.md",
+    "https://docs.astral.sh/ruff/integrations/": "integrations.md",
     "https://docs.astral.sh/ruff/faq/#how-does-ruff-compare-to-flake8": (
         "faq.md#how-does-ruff-compare-to-flake8"
     ),


### PR DESCRIPTION
This PR fixes #8385 
Now it redirects to the correct link.

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
