### PR TITLE
Fix Rust toolchain for sdist testing in CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
           args: --out dist
       - name: "Test sdist"
         run: |
-          rustup default $(cat rust-toolchain)
+          rustup default $(grep -oP 'channel = "\K[^"]+' rust-toolchain.toml)
           pip install dist/${{ env.PACKAGE_NAME }}-*.tar.gz --force-reinstall
           ruff --help
           python -m ruff --help


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I noticed the CI step sets the default Rust toolchain by calling `rustup default ($cat rust-toolchain)`. However, this fails, as there is no `rust-toolchain` file.

The CI currently continues without setting the default toolchain. Seems like this hasn't tripped anyone up yet, but it might in the future.

I replaced `($cat rust-toolchain)` with a command to read the `rust-toolchain.toml` file. 

## Test Plan

You can verify that the command works by running it locally.

Since this triggered the workflow, you can compare and see that it works.

The previous release workflow is here:
https://github.com/astral-sh/ruff/actions/runs/6658624231/job/18095891817

In the logs for the `test-sdist` step:
```
cat: rust-toolchain: No such file or directory
stable-x86_64-unknown-linux-gnu (default)
```

In the workflow triggered by this PR:
https://github.com/astral-sh/ruff/actions/runs/6711771325/job/18239884406?pr=8389

```
info: using existing install for '1.73-x86_64-unknown-linux-gnu'
info: default toolchain set to '1.73-x86_64-unknown-linux-gnu'
```

EDIT: Seems like I melted some icebergs by triggering your release workflow this way 😕 I'm sorry about that.