### PR TITLE
Add CI job to auto-update pre-commit dependencies weekly

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,36 @@
+# Until Dependabot support is released https://github.com/dependabot/dependabot-core/issues/1524
+name: Pre-commit update
+
+on:
+  # every week on monday
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run autoupdate
+        run: |
+          pre-commit autoupdate
+
+      - name: Commit and push
+        run: |
+          git add ".pre-commit-config.yaml"
+          git commit -m "Upgrade pre-commit dependencies"
+          git push origin upgrade/pre-commit
+
+      - name: Open pull request
+        run: |
+          gh pr create --fill


### PR DESCRIPTION
pre-commit provides an `autoupdate` command to bump dependency versions in the pre-commit configuration. Not only are our current versions all stale, with #8410 we'll want a reasonable way to update the Ruff version we are using.

Until Dependabot support is released https://github.com/dependabot/dependabot-core/issues/1524, using pre-commits command is the best option. 

Note pre-commit provides a service that does this, but I'm not interested in depending on it.

This job opens a new pull request with updates if there are any.