### PR TITLE
Change default format for ecosystem checks to `markdown`

### DIFF
--- a/python/ruff-ecosystem/README.md
+++ b/python/ruff-ecosystem/README.md
@@ -31,8 +31,8 @@ Run `ruff format` ecosystem checks comparing your debug build to your system Ruf
 ruff-ecosystem format ruff "./target/debug/ruff"
 ```
 
-The default output format is markdown, but you can use `--output-format json` to get raw data — this is
-particularly useful when developing.
+The default output format is markdown, which includes nice summaries of the changes. You can use `--output-format json` to display the raw data — this is
+particularly useful when making changes to the ecosystem checks.
 
 ## Development
 

--- a/python/ruff-ecosystem/README.md
+++ b/python/ruff-ecosystem/README.md
@@ -31,6 +31,9 @@ Run `ruff format` ecosystem checks comparing your debug build to your system Ruf
 ruff-ecosystem format ruff "./target/debug/ruff"
 ```
 
+The default output format is markdown, but you can use `--output-format json` to get raw data — this is
+particularly useful when developing.
+
 ## Development
 
 When developing, it can be useful to set the `--pdb` flag to drop into a debugger on failure:

--- a/python/ruff-ecosystem/ruff_ecosystem/cli.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/cli.py
@@ -121,7 +121,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--output-format",
         choices=[option.name for option in OutputFormat],
-        default="json",
+        default="markdown",
         help="Location for caching cloned repositories",
     )
     parser.add_argument(


### PR DESCRIPTION
To facilitate easier local runs
