### PR TITLE
Include rust-toolchain in source distribution

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,6 @@ jobs:
           args: --out dist
       - name: "Test sdist"
         run: |
-          rustup default $(cat rust-toolchain)
           pip install dist/${{ env.PACKAGE_NAME }}-*.tar.gz --force-reinstall
           ruff --help
           python -m ruff --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ exclude = [
   "crates/ruff_linter/resources/test/fixtures/**/*",
   "crates/ruff_linter/src/rules/*/snapshots/**/*"
 ]
+include = [
+  "rust-toolchain.toml"
+]
 
 [tool.ruff]
 extend-exclude = [


### PR DESCRIPTION
**Summary** Simplify CI by ensuring that the source distribution is always built with the rust version that has been explicitly tested. See discussion in #8389

Closes #8389