### PR TITLE
Add new ecosystem comparison modes for the formatter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,12 +191,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Configure Git
-        run: |
-          # We need a valid Git user to commit changes in the `ruff format` checks
-          git config --global user.name "$GITHUB_ACTOR"
-          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
       - uses: actions/download-artifact@v3
         name: Download comparison Ruff binary
         id: ruff-target

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,6 +191,12 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Configure Git
+        run: |
+          # We need a valid Git user to commit changes in the `ruff format` checks
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
       - uses: actions/download-artifact@v3
         name: Download comparison Ruff binary
         id: ruff-target

--- a/python/ruff-ecosystem/README.md
+++ b/python/ruff-ecosystem/README.md
@@ -31,6 +31,12 @@ Run `ruff format` ecosystem checks comparing your debug build to your system Ruf
 ruff-ecosystem format ruff "./target/debug/ruff"
 ```
 
+Run `ruff format` ecosystem checks comparing with changes to code that is already formatted:
+
+```shell
+ruff-ecosystem format ruff "./target/debug/ruff" --format-comparison ruff-then-ruff
+```
+
 The default output format is markdown, which includes nice summaries of the changes. You can use `--output-format json` to display the raw data — this is
 particularly useful when making changes to the ecosystem checks.
 

--- a/python/ruff-ecosystem/ruff_ecosystem/cli.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/cli.py
@@ -12,6 +12,7 @@ from signal import SIGINT, SIGTERM
 
 from ruff_ecosystem import logger
 from ruff_ecosystem.defaults import DEFAULT_TARGETS
+from ruff_ecosystem.format import FormatComparison
 from ruff_ecosystem.main import OutputFormat, main
 from ruff_ecosystem.projects import RuffCommand
 
@@ -77,6 +78,12 @@ def entrypoint():
     if args.force_preview:
         targets = [target.with_preview_enabled() for target in targets]
 
+    format_comparison = (
+        FormatComparison(args.format_comparison)
+        if args.ruff_command == RuffCommand.format.value
+        else None
+    )
+
     with cache_context as cache:
         loop = asyncio.get_event_loop()
         main_task = asyncio.ensure_future(
@@ -88,6 +95,7 @@ def entrypoint():
                 format=OutputFormat(args.output_format),
                 project_dir=Path(cache),
                 raise_on_failure=args.pdb,
+                format_comparison=format_comparison,
             )
         )
         # https://stackoverflow.com/a/58840987/3549270
@@ -139,6 +147,12 @@ def parse_args() -> argparse.Namespace:
         "--force-preview",
         action="store_true",
         help="Force preview mode to be enabled for all projects",
+    )
+    parser.add_argument(
+        "--format-comparison",
+        choices=[option.name for option in FormatComparison],
+        default=FormatComparison.ruff_and_ruff,
+        help="Type of comparison to make when checking formatting.",
     )
     parser.add_argument(
         "ruff_command",

--- a/python/ruff-ecosystem/ruff_ecosystem/cli.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/cli.py
@@ -128,7 +128,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--output-format",
-        choices=[option.name for option in OutputFormat],
+        choices=[option.value for option in OutputFormat],
         default="markdown",
         help="Location for caching cloned repositories",
     )
@@ -150,13 +150,13 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--format-comparison",
-        choices=[option.name for option in FormatComparison],
+        choices=[option.value for option in FormatComparison],
         default=FormatComparison.ruff_and_ruff,
         help="Type of comparison to make when checking formatting.",
     )
     parser.add_argument(
         "ruff_command",
-        choices=[option.name for option in RuffCommand],
+        choices=[option.value for option in RuffCommand],
         help="The Ruff command to test",
     )
     parser.add_argument(

--- a/python/ruff-ecosystem/ruff_ecosystem/format.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/format.py
@@ -237,14 +237,25 @@ async def ruff_format(
 
 
 class FormatComparison(Enum):
-    # Run Ruff baseline then Ruff comparison; checks for changes in behavior when formatting previously "formatted" code
     ruff_then_ruff = "ruff-then-ruff"
-    # Run Ruff baseline then reset and run Ruff comparison; checks changes in behavior when formatting "unformatted" code
+    """
+    Run Ruff baseline then Ruff comparison; checks for changes in behavior when formatting previously "formatted" code
+    """
+
     ruff_and_ruff = "ruff-and-ruff"
-    # Run Black baseline then Ruff comparison; checks for changes in behavior when formatting previously "formatted" code
+    """
+    Run Ruff baseline then reset and run Ruff comparison; checks changes in behavior when formatting "unformatted" code
+    """
+
     black_then_ruff = "black-then-ruff"
-    # Run Black baseline then reset and run Ruff comparison; checks changes in behavior when formatting "unformatted" code
+    """
+    Run Black baseline then Ruff comparison; checks for changes in behavior when formatting previously "formatted" code
+    """
+
     black_and_ruff = "black-and-ruff"
+    """"
+    Run Black baseline then reset and run Ruff comparison; checks changes in behavior when formatting "unformatted" code
+    """
 
 
 class Formatter(Enum):

--- a/python/ruff-ecosystem/ruff_ecosystem/format.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/format.py
@@ -244,7 +244,7 @@ class FormatComparison(Enum):
     # Run Black baseline then Ruff comparison; checks for changes in behavior when formatting previously "formatted" code
     black_then_ruff = "black-then-ruff"
     # Run Black baseline then reset and run Ruff comparison; checks changes in behavior when formatting "unformatted" code
-    black_and_ruff = "black-then-ruff"
+    black_and_ruff = "black-and-ruff"
 
 
 class Formatter(Enum):

--- a/python/ruff-ecosystem/ruff_ecosystem/projects.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/projects.py
@@ -10,7 +10,7 @@ from asyncio import create_subprocess_exec
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from subprocess import PIPE
+from subprocess import DEVNULL, PIPE
 from typing import Self
 
 from ruff_ecosystem import logger
@@ -182,6 +182,28 @@ class Repository(Serializable):
         logger.debug(
             f"Finished cloning {self.fullname} with status {status_code}",
         )
+
+        # Configure git user — needed for `self.commit` to work
+        await (
+            await create_subprocess_exec(
+                ["git", "config", "user.email", "ecosystem@astral.sh"],
+                cwd=checkout_dir,
+                env={"GIT_TERMINAL_PROMPT": "0"},
+                stdout=DEVNULL,
+                stderr=DEVNULL,
+            )
+        ).wait()
+
+        await (
+            await create_subprocess_exec(
+                ["git", "config", "user.name", "Ecosystem Bot"],
+                cwd=checkout_dir,
+                env={"GIT_TERMINAL_PROMPT": "0"},
+                stdout=DEVNULL,
+                stderr=DEVNULL,
+            )
+        ).wait()
+
         return await ClonedRepository.from_path(checkout_dir, self)
 
 

--- a/python/ruff-ecosystem/ruff_ecosystem/projects.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/projects.py
@@ -186,7 +186,7 @@ class Repository(Serializable):
         # Configure git user — needed for `self.commit` to work
         await (
             await create_subprocess_exec(
-                ["git", "config", "user.email", "ecosystem@astral.sh"],
+                *["git", "config", "user.email", "ecosystem@astral.sh"],
                 cwd=checkout_dir,
                 env={"GIT_TERMINAL_PROMPT": "0"},
                 stdout=DEVNULL,
@@ -196,7 +196,7 @@ class Repository(Serializable):
 
         await (
             await create_subprocess_exec(
-                ["git", "config", "user.name", "Ecosystem Bot"],
+                *["git", "config", "user.name", "Ecosystem Bot"],
                 cwd=checkout_dir,
                 env={"GIT_TERMINAL_PROMPT": "0"},
                 stdout=DEVNULL,


### PR DESCRIPTION
Previously, the ecosystem checks formatted with the baseline then formatted again with `--diff` to get the changed files.

Now, the ecosystem checks support a new mode where we:
- Format with the baseline
- Commit the changes
- Reset to the target ref
- Format again
- Check the diff from the baseline commit

This effectively tests Ruff changes on unformatted code rather than changes in previously formatted code (unless, of course, the project is already using Ruff).

While this mode is the new default, I've retained the old one for local checks. The mode can be toggled with `--format-comparison <type>`.

Includes some more aggressive resetting of the GitHub repositories when cached.

Here, I've also stubbed comparison modes in which `black` is used as the baseline. While these do nothing here, #8419 adds support.

I tested this with the commit from #8216 and ecosystem changes appear https://gist.github.com/zanieb/a982ec8c392939043613267474471a6e