### PR TITLE
Change extend_unsafe_fixes to override extend_safe_fixes per Specificity

### DIFF
--- a/crates/ruff_linter/src/settings/fix_safety_table.rs
+++ b/crates/ruff_linter/src/settings/fix_safety_table.rs
@@ -1,0 +1,166 @@
+use std::fmt::Debug;
+
+use ruff_macros::CacheKey;
+use rustc_hash::FxHashMap;
+use strum::IntoEnumIterator;
+
+use crate::{
+    registry::{Rule, RuleSet},
+    rule_selector::{PreviewOptions, Specificity},
+    RuleSelector,
+};
+
+/// A table to keep track of which rules fixes should have
+/// their safety overridden.
+#[derive(Debug, CacheKey, Default)]
+pub struct FixSafetyTable {
+    forced_safe: RuleSet,
+    forced_unsafe: RuleSet,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FixSafety {
+    ForcedSafe,
+    ForcedUnsafe,
+    Default,
+}
+
+impl FixSafetyTable {
+    pub const fn resolve_rule(&self, rule: Rule) -> FixSafety {
+        if self.forced_safe.contains(rule) {
+            FixSafety::ForcedSafe
+        } else if self.forced_unsafe.contains(rule) {
+            FixSafety::ForcedUnsafe
+        } else {
+            FixSafety::Default
+        }
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.forced_safe.is_empty() && self.forced_unsafe.is_empty()
+    }
+
+    pub fn from_rule_selectors(
+        extend_safe_fixes: &[RuleSelector],
+        extend_unsafe_fixes: &[RuleSelector],
+        preview_options: &PreviewOptions,
+    ) -> Self {
+        enum Override {
+            Safe,
+            Unsafe,
+        }
+        use Override::{Safe, Unsafe};
+
+        let safety_override_map: FxHashMap<Rule, Override> = {
+            Specificity::iter()
+                .flat_map(|spec| {
+                    let safe_overrides = extend_safe_fixes
+                        .iter()
+                        .filter(|selector| selector.specificity() == spec)
+                        .flat_map(|selector| selector.rules(preview_options))
+                        .map(|rule| (rule, Safe));
+
+                    let unsafe_overrides = extend_unsafe_fixes
+                        .iter()
+                        .filter(|selector| selector.specificity() == spec)
+                        .flat_map(|selector| selector.rules(preview_options))
+                        .map(|rule| (rule, Unsafe));
+
+                    // Unsafe overrides take precedence over safe overrides
+                    safe_overrides.chain(unsafe_overrides).collect::<Vec<_>>()
+                })
+                // More specified selectors take precedence over less specified selectors
+                .collect()
+        };
+
+        FixSafetyTable {
+            forced_safe: safety_override_map
+                .iter()
+                .filter_map(|(rule, o)| match o {
+                    Safe => Some(*rule),
+                    Unsafe => None,
+                })
+                .collect(),
+            forced_unsafe: safety_override_map
+                .iter()
+                .filter_map(|(rule, o)| match o {
+                    Unsafe => Some(*rule),
+                    Safe => None,
+                })
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_rule() {
+        let table = FixSafetyTable {
+            forced_safe: RuleSet::from_iter([Rule::RedefinedWhileUnused]),
+            forced_unsafe: RuleSet::from_iter([Rule::UnusedImport]),
+        };
+
+        assert_eq!(
+            table.resolve_rule(Rule::RedefinedWhileUnused),
+            FixSafety::ForcedSafe
+        );
+        assert_eq!(
+            table.resolve_rule(Rule::UnusedImport),
+            FixSafety::ForcedUnsafe
+        );
+        assert_eq!(table.resolve_rule(Rule::UndefinedName), FixSafety::Default);
+    }
+
+    fn mk_table(safe_fixes: &[&str], unsafe_fixes: &[&str]) -> FixSafetyTable {
+        FixSafetyTable::from_rule_selectors(
+            &safe_fixes
+                .iter()
+                .map(|s| s.parse().unwrap())
+                .collect::<Vec<_>>(),
+            &unsafe_fixes
+                .iter()
+                .map(|s| s.parse().unwrap())
+                .collect::<Vec<_>>(),
+            &PreviewOptions::default(),
+        )
+    }
+
+    fn assert_rules_safety(table: &FixSafetyTable, assertions: &[(&str, FixSafety)]) {
+        for (code, expected) in assertions {
+            assert_eq!(
+                table.resolve_rule(Rule::from_code(code).unwrap()),
+                *expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_from_rule_selectors_specificity() {
+        let table = mk_table(&["UP"], &["ALL", "UP001"]);
+
+        assert_rules_safety(
+            &table,
+            &[
+                ("E101", FixSafety::ForcedUnsafe),
+                ("UP001", FixSafety::ForcedUnsafe),
+                ("UP003", FixSafety::ForcedSafe),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_from_rule_selectors_unsafe_over_safe() {
+        let table = mk_table(&["UP"], &["UP"]);
+
+        assert_rules_safety(
+            &table,
+            &[
+                ("E101", FixSafety::Default),
+                ("UP001", FixSafety::ForcedUnsafe),
+            ],
+        );
+    }
+}

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -28,10 +28,12 @@ use crate::{codes, RuleSelector};
 
 use super::line_width::IndentWidth;
 
+use self::fix_safety_table::FixSafetyTable;
 use self::rule_table::RuleTable;
 use self::types::PreviewMode;
 use crate::rule_selector::PreviewOptions;
 
+pub mod fix_safety_table;
 pub mod flags;
 pub mod rule_table;
 pub mod types;
@@ -43,8 +45,7 @@ pub struct LinterSettings {
 
     pub rules: RuleTable,
     pub per_file_ignores: Vec<(GlobMatcher, GlobMatcher, RuleSet)>,
-    pub extend_unsafe_fixes: RuleSet,
-    pub extend_safe_fixes: RuleSet,
+    pub fix_safety_table: FixSafetyTable,
 
     pub target_version: PythonVersion,
     pub preview: PreviewMode,
@@ -151,8 +152,7 @@ impl LinterSettings {
             namespace_packages: vec![],
 
             per_file_ignores: vec![],
-            extend_safe_fixes: RuleSet::empty(),
-            extend_unsafe_fixes: RuleSet::empty(),
+            fix_safety_table: FixSafetyTable::default(),
 
             src: vec![path_dedot::CWD.clone()],
             // Needs duplicating

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Result};
 use glob::{glob, GlobError, Paths, PatternError};
 use regex::Regex;
+use ruff_linter::settings::fix_safety_table::FixSafetyTable;
 use rustc_hash::{FxHashMap, FxHashSet};
 use shellexpand;
 use shellexpand::LookupError;
@@ -239,26 +240,14 @@ impl Configuration {
                         .collect(),
                 )?,
 
-                extend_safe_fixes: lint
-                    .extend_safe_fixes
-                    .iter()
-                    .flat_map(|selector| {
-                        selector.rules(&PreviewOptions {
-                            mode: lint_preview,
-                            require_explicit: false,
-                        })
-                    })
-                    .collect(),
-                extend_unsafe_fixes: lint
-                    .extend_unsafe_fixes
-                    .iter()
-                    .flat_map(|selector| {
-                        selector.rules(&PreviewOptions {
-                            mode: lint_preview,
-                            require_explicit: false,
-                        })
-                    })
-                    .collect(),
+                fix_safety_table: FixSafetyTable::from_rule_selectors(
+                    &lint.extend_safe_fixes,
+                    &lint.extend_unsafe_fixes,
+                    &PreviewOptions {
+                        mode: lint_preview,
+                        require_explicit: false,
+                    },
+                ),
 
                 src: self.src.unwrap_or_else(|| vec![project_root.to_path_buf()]),
                 explicit_preview_rules: lint.explicit_preview_rules.unwrap_or_default(),


### PR DESCRIPTION
## Summary

Prior to this change `extend_unsafe_fixes` took precedence over `extend_safe_fixes` selectors, so any conflicts were resolved in favour of `extend_unsafe_fixes`. Thanks to that ruff were conservatively assuming that if configs conlict the fix corresponding to selected rule will be treated as unsafe.

After this change we take into account Specificity of the selectors. For conflicts between selectors of the same Specificity we will treat the corresponding fixes as unsafe. But if the conflicting selectors are of different specificity the more specific one will win.

## Test Plan

Tests were added for the `FixSafetyTable` struct. The `check_extend_unsafe_fixes_conflict_with_extend_safe_fixes_by_specificity` integration test was added to test conflicting rules of different specificity.

Fixes #8404
