### PR TITLE
Formatter: Remove unnecessary `group`

### DIFF
--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2516,32 +2516,9 @@ impl Parameters {
     }
 }
 
-#[allow(clippy::borrowed_box)] // local utility
-fn clone_boxed_expr(expr: &Box<Expr>) -> Box<Expr> {
-    let expr: &Expr = expr.as_ref();
-    Box::new(expr.clone())
-}
-
 impl ParameterWithDefault {
     pub fn as_parameter(&self) -> &Parameter {
         &self.parameter
-    }
-
-    pub fn to_parameter(&self) -> (Parameter, Option<Box<Expr>>) {
-        let ParameterWithDefault {
-            range: _,
-            parameter,
-            default,
-        } = self;
-        (parameter.clone(), default.as_ref().map(clone_boxed_expr))
-    }
-    pub fn into_parameter(self) -> (Parameter, Option<Box<Expr>>) {
-        let ParameterWithDefault {
-            range: _,
-            parameter,
-            default,
-        } = self;
-        (parameter, default)
     }
 }
 

--- a/crates/ruff_python_formatter/src/other/parameter_with_default.rs
+++ b/crates/ruff_python_formatter/src/other/parameter_with_default.rs
@@ -62,7 +62,7 @@ impl FormatNodeRule<ParameterWithDefault> for FormatParameterWithDefault {
                     token("="),
                     (!needs_line_break).then_some(space),
                     needs_line_break.then_some(hard_line_break()),
-                    group(&default.format())
+                    default.format()
                 ]
             )?;
         }


### PR DESCRIPTION
## Summary

Small internal refactor that removes an unnecessary `group` around the default value.

## Test Plan

`cargo test`, similarity index remains unchanged (let's wait for the ecosystem check)
