### PR TITLE
Place 'r' prefix before 'f' for raw format strings

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP032_0.py.snap
@@ -353,7 +353,7 @@ UP032_0.py:37:1: UP032 [*] Use f-string instead of `format` call
 35 35 | "foo{}".format(1)
 36 36 | 
 37    |-r"foo{}".format(1)
-   37 |+fr"foo{1}"
+   37 |+rf"foo{1}"
 38 38 | 
 39 39 | x = "{a}".format(a=1)
 40 40 | 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Currently, `UP032` applied to raw strings results in format strings with the prefix 'fr'. This gets changed to 'rf' by Ruff format (or Black). In order to avoid that, this PR uses the prefix 'rf' to begin with.

## Test Plan

<!-- How was it tested? -->
Updated the expectation on an existing test.