### PR TITLE
Indent lambda parameters if parameters wrap

### DIFF
--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2313,6 +2313,14 @@ impl Parameters {
             && self.vararg.is_none()
             && self.kwarg.is_none()
     }
+
+    pub fn len(&self) -> usize {
+        self.posonlyargs.len()
+            + self.args.len()
+            + usize::from(self.vararg.is_some())
+            + self.kwonlyargs.len()
+            + usize::from(self.kwarg.is_some())
+    }
 }
 
 /// An alternative type of AST `arg`. This is used for each function argument that might have a default value.

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.options.json
@@ -1,0 +1,8 @@
+[
+  {
+    "preview": "disabled"
+  },
+  {
+    "preview": "enabled"
+  }
+]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
@@ -127,6 +127,13 @@ lambda a, /, c: a
 
 (
     lambda
+    # comment
+    *x,
+    **y: x
+)
+
+(
+    lambda
     # comment 1
     *
     # comment 2
@@ -136,9 +143,28 @@ lambda a, /, c: a
 )
 
 (
+    lambda
+    # comment 1
+    *
+    # comment 2
+    x,
+    **y:
+    # comment 3
+    x
+)
+
+(
     lambda # comment 1
     * # comment 2
     x: # comment 3
+    x
+)
+
+(
+    lambda # comment 1
+        * # comment 2
+        x,
+        y: # comment 3
     x
 )
 
@@ -197,12 +223,88 @@ lambda: ( # comment
 )
 
 (
+    lambda  # 1
+    # 2
+    x,  # 3
+    # 4
+    y
+    :  # 5
+    # 6
+    x
+)
+
+(
     lambda
     x,
     # comment
     y:
     z
 )
+
+
+# Leading
+lambda x: (
+    lambda y: lambda z: x
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + z  # Trailing
+)  # Trailing
+
+
+# Leading
+lambda x: lambda y: lambda z: [
+    x,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    z
+] # Trailing
+# Trailing
 
 lambda self, araa, kkkwargs=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(*args, **kwargs), e=1, f=2, g=2: d
 

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
@@ -203,3 +203,28 @@ lambda: ( # comment
     y:
     z
 )
+
+lambda self, araa, kkkwargs=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(*args, **kwargs), e=1, f=2, g=2: d
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/8179
+def a():
+    return b(
+        c,
+        d,
+        e,
+        f=lambda self, *args, **kwargs: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(
+            *args, **kwargs
+        ),
+    )
+
+def a():
+    return b(
+        c,
+        d,
+        e,
+        f=lambda self, araa, kkkwargs,aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+                 args,kwargs,
+                 e=1, f=2, g=2: d,
+        g = 10
+    )
+

--- a/crates/ruff_python_formatter/src/context.rs
+++ b/crates/ruff_python_formatter/src/context.rs
@@ -43,6 +43,14 @@ impl<'a> PyFormatContext<'a> {
     pub(crate) fn comments(&self) -> &Comments<'a> {
         &self.comments
     }
+
+    pub(crate) const fn is_preview(&self) -> bool {
+        self.options.preview().is_enabled()
+    }
+
+    pub(crate) const fn is_stable(&self) -> bool {
+        !self.is_preview()
+    }
 }
 
 impl FormatContext for PyFormatContext<'_> {

--- a/crates/ruff_python_formatter/src/expression/expr_lambda.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_lambda.rs
@@ -1,10 +1,11 @@
-use ruff_formatter::write;
+use ruff_formatter::{format_args, write};
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprLambda;
 use ruff_text_size::Ranged;
 
-use crate::comments::{dangling_comments, SourceComment};
-use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
+use crate::comments::{dangling_comments, leading_comments, SourceComment};
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses, Parenthesize};
+use crate::expression::{has_own_parentheses, maybe_parenthesize_expression};
 use crate::other::parameters::ParametersParentheses;
 use crate::prelude::*;
 
@@ -25,31 +26,49 @@ impl FormatNodeRule<ExprLambda> for FormatExprLambda {
         write!(f, [token("lambda")])?;
 
         if let Some(parameters) = parameters {
-            // In this context, a dangling comment can either be a comment between the `lambda` the
+            // In this context, a dangling comment can either be a comment between the `lambda` and the
             // parameters, or a comment between the parameters and the body.
             let (dangling_before_parameters, dangling_after_parameters) = dangling
                 .split_at(dangling.partition_point(|comment| comment.end() < parameters.start()));
 
             if dangling_before_parameters.is_empty() {
                 write!(f, [space()])?;
-            } else {
-                write!(f, [dangling_comments(dangling_before_parameters)])?;
             }
 
-            write!(
-                f,
-                [parameters
-                    .format()
-                    .with_options(ParametersParentheses::Never)]
-            )?;
+            group(&format_with(|f: &mut PyFormatter| {
+                if f.context().node_level().is_parenthesized()
+                    && (parameters.len() > 1 || !dangling_before_parameters.is_empty())
+                {
+                    let end_of_line_start = dangling_before_parameters
+                        .partition_point(|comment| comment.line_position().is_end_of_line());
+                    let (same_line_comments, own_line_comments) =
+                        dangling_before_parameters.split_at(end_of_line_start);
 
-            write!(f, [token(":")])?;
+                    dangling_comments(same_line_comments).fmt(f)?;
 
-            if dangling_after_parameters.is_empty() {
-                write!(f, [space()])?;
-            } else {
-                write!(f, [dangling_comments(dangling_after_parameters)])?;
-            }
+                    soft_block_indent(&format_args![
+                        leading_comments(own_line_comments),
+                        parameters
+                            .format()
+                            .with_options(ParametersParentheses::Never),
+                    ])
+                    .fmt(f)
+                } else {
+                    parameters
+                        .format()
+                        .with_options(ParametersParentheses::Never)
+                        .fmt(f)
+                }?;
+
+                token(":").fmt(f)?;
+
+                if dangling_after_parameters.is_empty() {
+                    space().fmt(f)
+                } else {
+                    dangling_comments(dangling_after_parameters).fmt(f)
+                }
+            }))
+            .fmt(f)?;
         } else {
             write!(f, [token(":")])?;
 
@@ -61,7 +80,12 @@ impl FormatNodeRule<ExprLambda> for FormatExprLambda {
             }
         }
 
-        write!(f, [body.format()])
+        // Avoid parenthesizing lists, dictionaries, etc.
+        if f.context().is_stable() || has_own_parentheses(body, f.context()).is_some() {
+            body.format().fmt(f)
+        } else {
+            maybe_parenthesize_expression(body, item, Parenthesize::IfBreaksOrIfRequired).fmt(f)
+        }
     }
 
     fn fmt_dangling_comments(

--- a/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
@@ -69,6 +69,7 @@ impl NeedsParentheses for ExprNamedExpr {
             || parent.is_stmt_delete()
             || parent.is_stmt_for()
             || parent.is_stmt_function_def()
+            || parent.is_expr_lambda()
         {
             OptionalParentheses::Always
         } else {

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -108,7 +108,7 @@ impl PyFormatOptions {
         self.line_ending
     }
 
-    pub fn preview(&self) -> PreviewMode {
+    pub const fn preview(&self) -> PreviewMode {
         self.preview
     }
 

--- a/crates/ruff_python_formatter/src/other/parameters.rs
+++ b/crates/ruff_python_formatter/src/other/parameters.rs
@@ -240,14 +240,10 @@ impl FormatNodeRule<Parameters> for FormatParameters {
             Ok(())
         });
 
-        let num_parameters = posonlyargs.len()
-            + args.len()
-            + usize::from(vararg.is_some())
-            + kwonlyargs.len()
-            + usize::from(kwarg.is_some());
+        let num_parameters = item.len();
 
         if self.parentheses == ParametersParentheses::Never {
-            write!(f, [group(&format_inner), dangling_comments(dangling)])
+            write!(f, [format_inner, dangling_comments(dangling)])
         } else if num_parameters == 0 {
             let mut f = WithNodeLevel::new(NodeLevel::ParenthesizedExpression, f);
             // No parameters, format any dangling comments between `()`

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
@@ -133,6 +133,13 @@ lambda a, /, c: a
 
 (
     lambda
+    # comment
+    *x,
+    **y: x
+)
+
+(
+    lambda
     # comment 1
     *
     # comment 2
@@ -142,9 +149,28 @@ lambda a, /, c: a
 )
 
 (
+    lambda
+    # comment 1
+    *
+    # comment 2
+    x,
+    **y:
+    # comment 3
+    x
+)
+
+(
     lambda # comment 1
     * # comment 2
     x: # comment 3
+    x
+)
+
+(
+    lambda # comment 1
+        * # comment 2
+        x,
+        y: # comment 3
     x
 )
 
@@ -203,12 +229,88 @@ lambda: ( # comment
 )
 
 (
+    lambda  # 1
+    # 2
+    x,  # 3
+    # 4
+    y
+    :  # 5
+    # 6
+    x
+)
+
+(
     lambda
     x,
     # comment
     y:
     z
 )
+
+
+# Leading
+lambda x: (
+    lambda y: lambda z: x
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + y
+                        + z  # Trailing
+)  # Trailing
+
+
+# Leading
+lambda x: lambda y: lambda z: [
+    x,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    z
+] # Trailing
+# Trailing
 
 lambda self, araa, kkkwargs=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(*args, **kwargs), e=1, f=2, g=2: d
 
@@ -236,7 +338,17 @@ def a():
 
 ```
 
-## Output
+## Outputs
+### Output 1
+```
+indent-style            = space
+line-width              = 88
+indent-width            = 4
+quote-style             = Double
+magic-trailing-comma    = Respect
+preview                 = Disabled
+```
+
 ```py
 # Leading
 lambda x: x  # Trailing
@@ -300,8 +412,10 @@ a = (
 )
 
 a = (
-    lambda x,  # Dangling
-    y: 1
+    lambda 
+        x,  # Dangling
+        y
+    : 1
 )
 
 # Regression test: lambda empty arguments ranges were too long, leading to unstable
@@ -362,23 +476,54 @@ lambda a, /, c: a
 
 (
     lambda
-    # comment
-    *x: x
+        # comment
+        *x
+    : x
 )
 
 (
     lambda
-    # comment 1
-    # comment 2
-    *x:
+        # comment
+        *x,
+        **y
+    : x
+)
+
+(
+    lambda
+        # comment 1
+        # comment 2
+        *x
+    :
+    # comment 3
+    x
+)
+
+(
+    lambda
+        # comment 1
+        # comment 2
+        *x,
+        **y
+    :
     # comment 3
     x
 )
 
 (
     lambda  # comment 1
-    # comment 2
-    *x:  # comment 3
+        # comment 2
+        *x
+    :  # comment 3
+    x
+)
+
+(
+    lambda  # comment 1
+        # comment 2
+        *x,
+        y
+    :  # comment 3
     x
 )
 
@@ -386,8 +531,9 @@ lambda *x: x
 
 (
     lambda
-    # comment
-    *x: x
+        # comment
+        *x
+    : x
 )
 
 lambda: (  # comment
@@ -425,8 +571,9 @@ lambda: (  # comment
 
 (
     lambda  # 1
-    # 2
-    x:  # 3
+        # 2
+        x
+    :  # 3
     # 4
     # 5
     # 6
@@ -434,10 +581,88 @@ lambda: (  # comment
 )
 
 (
-    lambda x,
-    # comment
-    y: z
+    lambda  # 1
+        # 2
+        x,  # 3
+        # 4
+        y
+    :  # 5
+    # 6
+    x
 )
+
+(
+    lambda 
+        x,
+        # comment
+        y
+    : z
+)
+
+
+# Leading
+lambda x: (
+    lambda y: lambda z: x
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + y
+    + z  # Trailing
+)  # Trailing
+
+
+# Leading
+lambda x: lambda y: lambda z: [
+    x,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    y,
+    z,
+]  # Trailing
+# Trailing
 
 lambda self, araa, kkkwargs=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(
     *args, **kwargs
@@ -450,9 +675,11 @@ def a():
         c,
         d,
         e,
-        f=lambda self,
-        *args,
-        **kwargs: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(*args, **kwargs),
+        f=lambda 
+            self,
+            *args,
+            **kwargs
+        : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(*args, **kwargs),
     )
 
 
@@ -461,15 +688,372 @@ def a():
         c,
         d,
         e,
-        f=lambda self,
-        araa,
-        kkkwargs,
-        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
-        args,
-        kwargs,
-        e=1,
-        f=2,
-        g=2: d,
+        f=lambda 
+            self,
+            araa,
+            kkkwargs,
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+            args,
+            kwargs,
+            e=1,
+            f=2,
+            g=2
+        : d,
+        g=10,
+    )
+```
+
+
+### Output 2
+```
+indent-style            = space
+line-width              = 88
+indent-width            = 4
+quote-style             = Double
+magic-trailing-comma    = Respect
+preview                 = Enabled
+```
+
+```py
+# Leading
+lambda x: x  # Trailing
+# Trailing
+
+# Leading
+lambda x, y: x  # Trailing
+# Trailing
+
+# Leading
+lambda x, y: x, y  # Trailing
+# Trailing
+
+# Leading
+lambda x, /, y: x  # Trailing
+# Trailing
+
+# Leading
+lambda x: lambda y: lambda z: x  # Trailing
+# Trailing
+
+# Leading
+lambda x: lambda y: lambda z: (x, y, z)  # Trailing
+# Trailing
+
+# Leading
+lambda x: lambda y: lambda z: (x, y, z)  # Trailing
+# Trailing
+
+# Leading
+lambda x: (
+    lambda y: (
+        lambda z: (x, y, y, y, y, y, y, y, y, y, y, y, y, y, y, y, y, y, y, y, y, y, z)
+    )
+)  # Trailing
+# Trailing
+
+a = (
+    lambda:  # Dangling
+    1
+)
+
+a = (
+    lambda 
+        x,  # Dangling
+        y
+    : 1
+)
+
+# Regression test: lambda empty arguments ranges were too long, leading to unstable
+# formatting
+(
+    lambda: (  #
+    ),
+)
+
+
+# lambda arguments don't have parentheses, so we never add a magic trailing comma ...
+def f(
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = lambda x: (
+        y
+    ),
+):
+    pass
+
+
+# ...but we do preserve a trailing comma after the arguments
+a = lambda b,: 0
+
+lambda a,: 0
+lambda *args,: 0
+lambda **kwds,: 0
+lambda a, *args,: 0
+lambda a, **kwds,: 0
+lambda *args, b,: 0
+lambda *, b,: 0
+lambda *args, **kwds,: 0
+lambda a, *args, b,: 0
+lambda a, *, b,: 0
+lambda a, *args, **kwds,: 0
+lambda *args, b, **kwds,: 0
+lambda *, b, **kwds,: 0
+lambda a, *args, b, **kwds,: 0
+lambda a, *, b, **kwds,: 0
+lambda a, /: a
+lambda a, /, c: a
+
+# Dangling comments without parameters.
+(
+    lambda:  # 3
+    None
+)
+
+(
+    lambda:
+    # 3
+    None
+)
+
+(
+    lambda:  # 1
+    # 2
+    # 3
+    # 4
+    None  # 5
+)
+
+(
+    lambda
+        # comment
+        *x
+    : x
+)
+
+(
+    lambda
+        # comment
+        *x,
+        **y
+    : x
+)
+
+(
+    lambda
+        # comment 1
+        # comment 2
+        *x
+    :
+    # comment 3
+    x
+)
+
+(
+    lambda
+        # comment 1
+        # comment 2
+        *x,
+        **y
+    :
+    # comment 3
+    x
+)
+
+(
+    lambda  # comment 1
+        # comment 2
+        *x
+    :  # comment 3
+    x
+)
+
+(
+    lambda  # comment 1
+        # comment 2
+        *x,
+        y
+    :  # comment 3
+    x
+)
+
+lambda *x: x
+
+(
+    lambda
+        # comment
+        *x
+    : x
+)
+
+lambda: (  # comment
+    x
+)
+
+(
+    lambda:  # comment
+    x
+)
+
+(
+    lambda:
+    # comment
+    x
+)
+
+(
+    lambda:  # comment
+    x
+)
+
+(
+    lambda:
+    # comment
+    x
+)
+
+(
+    lambda:  # comment
+    (  # comment
+        x
+    )
+)
+
+(
+    lambda  # 1
+        # 2
+        x
+    :  # 3
+    # 4
+    # 5
+    # 6
+    x
+)
+
+(
+    lambda  # 1
+        # 2
+        x,  # 3
+        # 4
+        y
+    :  # 5
+    # 6
+    x
+)
+
+(
+    lambda 
+        x,
+        # comment
+        y
+    : z
+)
+
+
+# Leading
+lambda x: (
+    lambda y: (
+        lambda z: (
+            x
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + y
+            + z
+        )
+    )  # Trailing
+)  # Trailing
+
+
+# Leading
+lambda x: (
+    lambda y: (
+        lambda z: [
+            x,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            y,
+            z,
+        ]
+    )
+)  # Trailing
+# Trailing
+
+lambda self, araa, kkkwargs=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(
+    *args, **kwargs
+), e=1, f=2, g=2: d
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/8179
+def a():
+    return b(
+        c,
+        d,
+        e,
+        f=lambda 
+            self,
+            *args,
+            **kwargs
+        : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(*args, **kwargs),
+    )
+
+
+def a():
+    return b(
+        c,
+        d,
+        e,
+        f=lambda 
+            self,
+            araa,
+            kkkwargs,
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+            args,
+            kwargs,
+            e=1,
+            f=2,
+            g=2
+        : d,
         g=10,
     )
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
@@ -209,6 +209,31 @@ lambda: ( # comment
     y:
     z
 )
+
+lambda self, araa, kkkwargs=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(*args, **kwargs), e=1, f=2, g=2: d
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/8179
+def a():
+    return b(
+        c,
+        d,
+        e,
+        f=lambda self, *args, **kwargs: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(
+            *args, **kwargs
+        ),
+    )
+
+def a():
+    return b(
+        c,
+        d,
+        e,
+        f=lambda self, araa, kkkwargs,aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+                 args,kwargs,
+                 e=1, f=2, g=2: d,
+        g = 10
+    )
+
 ```
 
 ## Output
@@ -413,6 +438,40 @@ lambda: (  # comment
     # comment
     y: z
 )
+
+lambda self, araa, kkkwargs=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(
+    *args, **kwargs
+), e=1, f=2, g=2: d
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/8179
+def a():
+    return b(
+        c,
+        d,
+        e,
+        f=lambda self,
+        *args,
+        **kwargs: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(*args, **kwargs),
+    )
+
+
+def a():
+    return b(
+        c,
+        d,
+        e,
+        f=lambda self,
+        araa,
+        kkkwargs,
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        args,
+        kwargs,
+        e=1,
+        f=2,
+        g=2: d,
+        g=10,
+    )
 ```
 
 


### PR DESCRIPTION
## Summary

A non-black compatible approach to https://github.com/astral-sh/ruff/issues/8179

The black-compatible formatting would enforce spaces when formatting parameters with the `ParameterParentheses::Never`. However, this doesn't work when using comments (which black doesn't support [playground](https://black.vercel.app/?version=stable&state=_Td6WFoAAATm1rRGAgAhARYAAAB0L-Wj4ACOAGBdAD2IimZxl1N_WhQ8R5sgERcjE4CA79XBQnYhkNIGX378uPpzJVCf3opcwNZ5N4_s5GR-d6S0M12O66BmJ9d2BIpKmRsn-5XXsdd5l9RAxvUQiFV4AOsopTANF-mxwYxCAADlTL2qgfqd_wABfI8BAAAAQVm_NLHEZ_sCAAAAAARZWg==)?)

This PR implements two changes (we may want to split it in two):

a) It indents the lambda parameters if they don't fit on a single line: 

```python
def a():
    return b(
        c,
        d,
        e,
        f=lambda 
            self,
            *args,
            **kwargs
        : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(*args, **kwargs),
        b=d,
        e=f,
    )

```

b) Preview style that parenthesizes the lambda body if it expands. 

```diff
         return {
             **super().get_event_triggers(),
             EventTriggers.ON_CHANGE: (
-                lambda e0: [
-                    Var.create_safe(f"{e0}.map(e => e.value)", _var_is_local=True)
-                ]
-                if self.is_multi.equals(Var.create_safe(True))
-                else lambda e0: [e0]
+                lambda e0: (
+                    [Var.create_safe(f"{e0}.map(e => e.value)", _var_is_local=True)]
+                    if self.is_multi.equals(Var.create_safe(True))
+                    else lambda e0: [e0]
+                )
             ),
         }
```


## Alternatives

Favor black compatibility and enforce using `space` in the parameters formatting when the `ParameterParentheses::Never` is used. Requires finding a comment placement that produces stable results. 

Unclear how we want to support 

```python
(
    lambda
    x,
    # comment
    y:
    z
)
```

## Notes

It's probably worth to split out the body changes. They seem to generally improve readability

## Test Plan

The non-preview changes don't seem to change the similarity index (at least after only indenting if there are 2 or more parameters). 

The preview changes regress the similarity index across the board

Main
| project        | similarity index  | total files       | changed files     |
|----------------|------------------:|------------------:|------------------:|
| cpython        |           0.75804 |              1799 |              1648 |
| django         |           0.99984 |              2772 |                34 |
| home-assistant |           0.99963 |             10596 |               143 |
| poetry         |           0.99925 |               317 |                12 |
| transformers   |           0.99967 |              2657 |               322 |
| twine          |           1.00000 |                33 |                 0 |
| typeshed       |           0.99980 |              3669 |                18 |
| warehouse      |           0.99977 |               654 |                13 |
| zulip          |           0.99970 |              1459 |                21 |



Preview

| project        | similarity index  | total files       | changed files     |
|----------------|------------------:|------------------:|------------------:|
| cpython        |           0.75804 |              1799 |              1648 |
| django         |           0.99978 |              2772 |                40 |
| home-assistant |           0.99957 |             10596 |               174 |
| poetry         |           0.99925 |               317 |                12 |
| transformers   |           0.99965 |              2657 |               328 |
| twine          |           1.00000 |                33 |                 0 |
| typeshed       |           0.99980 |              3669 |                18 |
| warehouse      |           0.99968 |               654 |                16 |
| zulip          |           0.99970 |              1459 |                21 |

Here a few examples

```diff
index 9aa78a281f..499bc0dfb9 100644
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -366,21 +366,21 @@ class BaseExpression:
         internal_type = field.get_internal_type()
         if internal_type == "FloatField":
             return (
-                lambda value, expression, connection: None
-                if value is None
-                else float(value)
+                lambda value, expression, connection: (
+                    None if value is None else float(value)
+                )
             )
         elif internal_type.endswith("IntegerField"):
             return (
-                lambda value, expression, connection: None
-                if value is None
-                else int(value)
+                lambda value, expression, connection: (
+                    None if value is None else int(value)
+                )
             )
         elif internal_type == "DecimalField":
             return (
-                lambda value, expression, connection: None
-                if value is None
-                else Decimal(value)
+                lambda value, expression, connection: (
+                    None if value is None else Decimal(value)
+                )
             )
         return self._convert_value_noop
 
index 889c1cfe84..8555f08cb3 100644
--- a/django/contrib/gis/db/models/fields.py
+++ b/django/contrib/gis/db/models/fields.py
@@ -48,9 +48,9 @@ def get_srid_info(srid, connection):
     alias, get_srs = (
         (
             connection.alias,
-            lambda srid: SpatialRefSys.objects.using(connection.alias)
-            .get(srid=srid)
-            .srs,
+            lambda srid: (
+                SpatialRefSys.objects.using(connection.alias).get(srid=srid).srs
+            ),
         )
         if SpatialRefSys
         else (None, SpatialReference)


index dc857055b1..b45a8bb10e 100644
--- a/django/contrib/admin/tests.py
+++ b/django/contrib/admin/tests.py
@@ -110,8 +110,9 @@ class AdminSeleniumTestCase(SeleniumTestCase, StaticLiveServerTestCase):
         Block until the  page is ready.
         """
         self.wait_until(
-            lambda driver: driver.execute_script("return document.readyState;")
-            == "complete",
+            lambda driver: (
+                driver.execute_script("return document.readyState;") == "complete"
+            ),
             timeout,
         )
 
@@ -196,8 +197,8 @@ class AdminSeleniumTestCase(SeleniumTestCase, StaticLiveServerTestCase):
             # to be the case.
             with self.disable_implicit_wait():
                 self.wait_until(
-                    lambda driver: not driver.find_elements(
-                        By.CSS_SELECTOR, options_selector
+                    lambda driver: (
+                        not driver.find_elements(By.CSS_SELECTOR, options_selector)
                     )
                 )

index 9855c318be..fd7770eb2e 100644
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1470,8 +1470,10 @@ def skipIfDBFeature(*features):
 def skipUnlessDBFeature(*features):
     """Skip a test unless a database has all the named features."""
     return _deferredSkip(
-        lambda: not all(
-            getattr(connection.features, feature, False) for feature in features
+        lambda: (
+            not all(
+                getattr(connection.features, feature, False) for feature in features
+            )
         ),
         "Database doesn't support feature(s): %s" % ", ".join(features),
         "skipUnlessDBFeature",
@@ -1481,8 +1483,10 @@ def skipUnlessDBFeature(*features):
 def skipUnlessAnyDBFeature(*features):
     """Skip a test unless a database has any of the named features."""
     return _deferredSkip(
-        lambda: not any(
-            getattr(connection.features, feature, False) for feature in features
+        lambda: (
+            not any(
+                getattr(connection.features, feature, False) for feature in features
+            )
         ),
         "Database doesn't support any of the feature(s): %s" % ", ".join(features),
         "skipUnlessAnyDBFeature",

index b9a7e4cd64..a69ebd31cb 100644
--- a/tests/absolute_url_overrides/tests.py
+++ b/tests/absolute_url_overrides/tests.py
@@ -29,8 +29,9 @@ class AbsoluteUrlOverrideTests(SimpleTestCase):
 
         with self.settings(
             ABSOLUTE_URL_OVERRIDES={
-                "absolute_url_overrides.testb": lambda o: "/overridden-test-b/%s/"
-                % o.pk,
+                "absolute_url_overrides.testb": lambda o: (
+                    "/overridden-test-b/%s/" % o.pk
+                ),
             },
         ):

index 4d85d15065..9aec0a68e8 100644
--- a/tests/contenttypes_tests/test_views.py
+++ b/tests/contenttypes_tests/test_views.py
@@ -151,9 +151,9 @@ class ContentTypesViewsSiteRelTests(TestCase):
         The shortcut view works if a model's ForeignKey to site is None.
         """
         get_model.side_effect = (
-            lambda *args, **kwargs: MockSite
-            if args[0] == "sites.Site"
-            else ModelWithNullFKToSite
+            lambda *args, **kwargs: (
+                MockSite if args[0] == "sites.Site" else ModelWithNullFKToSite
+            )
         )
 
         obj = ModelWithNullFKToSite.objects.create(title="title")
@@ -173,9 +173,9 @@ class ContentTypesViewsSiteRelTests(TestCase):
         found in the m2m relationship.
         """
         get_model.side_effect = (
-            lambda *args, **kwargs: MockSite
-            if args[0] == "sites.Site"
-            else ModelWithM2MToSite
+            lambda *args, **kwargs: (
+                MockSite if args[0] == "sites.Site" else ModelWithM2MToSite
+            )
         )
```

Most of these seem clear improvements to me. 