### PR TITLE
Fix multiline lambda expression statement formating

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
@@ -203,3 +203,28 @@ lambda: ( # comment
     y:
     z
 )
+
+lambda self, araa, kkkwargs=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(*args, **kwargs), e=1, f=2, g=2: d
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/8179
+def a():
+    return b(
+        c,
+        d,
+        e,
+        f=lambda self, *args, **kwargs: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(
+            *args, **kwargs
+        ),
+    )
+
+def a():
+    return b(
+        c,
+        d,
+        e,
+        f=lambda self, araa, kkkwargs,aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+                 args,kwargs,
+                 e=1, f=2, g=2: d,
+        g = 10
+    )
+

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
@@ -209,6 +209,31 @@ lambda: ( # comment
     y:
     z
 )
+
+lambda self, araa, kkkwargs=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(*args, **kwargs), e=1, f=2, g=2: d
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/8179
+def a():
+    return b(
+        c,
+        d,
+        e,
+        f=lambda self, *args, **kwargs: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(
+            *args, **kwargs
+        ),
+    )
+
+def a():
+    return b(
+        c,
+        d,
+        e,
+        f=lambda self, araa, kkkwargs,aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+                 args,kwargs,
+                 e=1, f=2, g=2: d,
+        g = 10
+    )
+
 ```
 
 ## Output
@@ -413,6 +438,40 @@ lambda: (  # comment
     # comment
     y: z
 )
+
+lambda self, araa, kkkwargs=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(
+    *args, **kwargs
+), e=1, f=2, g=2: d
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/8179
+def a():
+    return b(
+        c,
+        d,
+        e,
+        f=lambda self,
+        *args,
+        **kwargs: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(*args, **kwargs),
+    )
+
+
+def a():
+    return b(
+        c,
+        d,
+        e,
+        f=lambda self,
+        araa,
+        kkkwargs,
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        args,
+        kwargs,
+        e=1,
+        f=2,
+        g=2: d,
+        g=10,
+    )
 ```
 
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in our formatter where a multiline lambda expression statement was formatted over multiple lines without adding parentheses. 

The PR "fixes" the problem by not splitting the lambda parameters if it is not parenthesized

## Test Plan

Added test
