### PR TITLE
Add TRIO106 rule

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_trio/TRIO106.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_trio/TRIO106.py
@@ -1,0 +1,5 @@
+import trio
+
+import trio as asyncio
+
+from trio import move_on_after

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -549,6 +549,10 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 pyupgrade::rules::deprecated_mock_import(checker, stmt);
             }
 
+            if checker.enabled(Rule::TrioInvalidImportStyle) {
+                flake8_trio::rules::invalid_trio_import(checker, stmt);
+            }
+
             for alias in names {
                 if checker.enabled(Rule::NonAsciiImportName) {
                     pylint::rules::non_ascii_module_import(checker, alias);
@@ -741,6 +745,9 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             }
             if checker.enabled(Rule::DeprecatedImport) {
                 pyupgrade::rules::deprecated_import(checker, stmt, names, module, level);
+            }
+            if checker.enabled(Rule::TrioInvalidImportStyle) {
+                flake8_trio::rules::invalid_trio_import(checker, stmt);
             }
             if checker.enabled(Rule::UnnecessaryBuiltinImport) {
                 if let Some(module) = module {

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -292,6 +292,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
 
         // flake8-trio
         (Flake8Trio, "100") => (RuleGroup::Preview, rules::flake8_trio::rules::TrioTimeoutWithoutAwait),
+        (Flake8Trio, "106") => (RuleGroup::Preview, rules::flake8_trio::rules::TrioInvalidImportStyle),
 
         // flake8-builtins
         (Flake8Builtins, "001") => (RuleGroup::Stable, rules::flake8_builtins::rules::BuiltinVariableShadowing),

--- a/crates/ruff_linter/src/rules/flake8_trio/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_trio/mod.rs
@@ -14,6 +14,7 @@ mod tests {
     use crate::test::test_path;
 
     #[test_case(Rule::TrioTimeoutWithoutAwait, Path::new("TRIO100.py"))]
+    #[test_case(Rule::TrioInvalidImportStyle, Path::new("TRIO106.py"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/flake8_trio/rules/invalid_trio_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_trio/rules/invalid_trio_import.rs
@@ -1,0 +1,56 @@
+use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_macros::{derive_message_formats, violation};
+
+use crate::checkers::ast::Checker;
+use ruff_python_ast::{self as ast, Stmt};
+
+/// ## What it does
+/// Checks for incorrectly imported `trio`.
+///
+/// ## Why is this bad?
+/// When trio is imported under a different name, the rules do not apply.
+///
+/// ## Example
+/// ```python
+/// import trio as t
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import trio
+/// ```
+#[violation]
+pub struct TrioInvalidImportStyle;
+
+impl Violation for TrioInvalidImportStyle {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("trio must be imported with import trio for the linter to work")
+    }
+}
+
+pub(crate) fn invalid_trio_import(checker: &mut Checker, stmt: &Stmt) {
+    match stmt {
+        Stmt::Import(ast::StmtImport { names, range: _ }) => {
+            for name in names {
+                if &name.name == "trio" && name.asname.is_some() {
+                    checker
+                        .diagnostics
+                        .push(Diagnostic::new(TrioInvalidImportStyle, name.range));
+                }
+            }
+        }
+        Stmt::ImportFrom(ast::StmtImportFrom {
+            module: Some(module),
+            range,
+            ..
+        }) => {
+            if module == "trio" {
+                checker
+                    .diagnostics
+                    .push(Diagnostic::new(TrioInvalidImportStyle, *range));
+            }
+        }
+        _ => {}
+    };
+}

--- a/crates/ruff_linter/src/rules/flake8_trio/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_trio/rules/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) use invalid_trio_import::*;
 pub(crate) use timeout_without_await::*;
 
+mod invalid_trio_import;
 mod timeout_without_await;

--- a/crates/ruff_linter/src/rules/flake8_trio/snapshots/ruff_linter__rules__flake8_trio__tests__TRIO106_TRIO106.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_trio/snapshots/ruff_linter__rules__flake8_trio__tests__TRIO106_TRIO106.py.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff_linter/src/rules/flake8_trio/mod.rs
+---
+TRIO106.py:3:8: TRIO106 trio must be imported with import trio for the linter to work
+  |
+1 | import trio
+2 | 
+3 | import trio as asyncio
+  |        ^^^^^^^^^^^^^^^ TRIO106
+4 | 
+5 | from trio import move_on_after
+  |
+
+TRIO106.py:5:1: TRIO106 trio must be imported with import trio for the linter to work
+  |
+3 | import trio as asyncio
+4 | 
+5 | from trio import move_on_after
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRIO106
+  |
+
+

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -3472,6 +3472,7 @@
         "TRIO1",
         "TRIO10",
         "TRIO100",
+        "TRIO106",
         "TRY",
         "TRY0",
         "TRY00",


### PR DESCRIPTION
## Summary

This PR is a part of #8451 and adds TRIO106 rule.

Examples

Bad
```python
import trio as asyncio
```

Bad
```python
from trio import move_on_after
````

Good
```python
import trio
```

