### PR TITLE
[`E721`] Flag comparisons to `memoryview`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E721.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E721.py
@@ -4,6 +4,9 @@ if type(res) == type(42):
 #: E721
 if type(res) != type(""):
     pass
+#: E721
+if type(res) == memoryview:
+    pass
 #: Okay
 import types
 
@@ -46,6 +49,8 @@ if isinstance(res, int):
 if isinstance(res, str):
     pass
 if isinstance(res, types.MethodType):
+    pass
+if isinstance(res, memoryview):
     pass
 #: Okay
 def func_histype(a, b, c):

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
@@ -138,6 +138,7 @@ fn deprecated_type_comparison(checker: &mut Checker, compare: &ast::ExprCompare)
                         | "list"
                         | "dict"
                         | "set"
+                        | "memoryview"
                 ) && checker.semantic().is_builtin(id)
                 {
                     checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
@@ -197,7 +197,16 @@ fn is_type(expr: &Expr, semantic: &SemanticModel) -> bool {
             // Ex) `type(obj) == int`
             matches!(
                 id.as_str(),
-                "int" | "str" | "float" | "bool" | "complex" | "bytes" | "list" | "dict" | "set"
+                "int"
+                    | "str"
+                    | "float"
+                    | "bool"
+                    | "complex"
+                    | "bytes"
+                    | "list"
+                    | "dict"
+                    | "set"
+                    | "memoryview"
             ) && semantic.is_builtin(id)
         }
         _ => false,

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E721_E721.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E721_E721.py.snap
@@ -17,144 +17,144 @@ E721.py:5:4: E721 Do not compare types, use `isinstance()`
 5 | if type(res) != type(""):
   |    ^^^^^^^^^^^^^^^^^^^^^ E721
 6 |     pass
-7 | #: Okay
+7 | #: E721
   |
 
-E721.py:15:4: E721 Do not compare types, use `isinstance()`
+E721.py:18:4: E721 Do not compare types, use `isinstance()`
    |
-13 | import types
-14 | 
-15 | if type(res) is not types.ListType:
+16 | import types
+17 | 
+18 | if type(res) is not types.ListType:
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
-16 |     pass
-17 | #: E721
+19 |     pass
+20 | #: E721
    |
 
-E721.py:18:8: E721 Do not compare types, use `isinstance()`
+E721.py:21:8: E721 Do not compare types, use `isinstance()`
    |
-16 |     pass
-17 | #: E721
-18 | assert type(res) == type(False) or type(res) == type(None)
+19 |     pass
+20 | #: E721
+21 | assert type(res) == type(False) or type(res) == type(None)
    |        ^^^^^^^^^^^^^^^^^^^^^^^^ E721
-19 | #: E721
-20 | assert type(res) == type([])
+22 | #: E721
+23 | assert type(res) == type([])
    |
 
-E721.py:20:8: E721 Do not compare types, use `isinstance()`
+E721.py:23:8: E721 Do not compare types, use `isinstance()`
    |
-18 | assert type(res) == type(False) or type(res) == type(None)
-19 | #: E721
-20 | assert type(res) == type([])
+21 | assert type(res) == type(False) or type(res) == type(None)
+22 | #: E721
+23 | assert type(res) == type([])
    |        ^^^^^^^^^^^^^^^^^^^^^ E721
-21 | #: E721
-22 | assert type(res) == type(())
+24 | #: E721
+25 | assert type(res) == type(())
    |
 
-E721.py:22:8: E721 Do not compare types, use `isinstance()`
+E721.py:25:8: E721 Do not compare types, use `isinstance()`
    |
-20 | assert type(res) == type([])
-21 | #: E721
-22 | assert type(res) == type(())
+23 | assert type(res) == type([])
+24 | #: E721
+25 | assert type(res) == type(())
    |        ^^^^^^^^^^^^^^^^^^^^^ E721
-23 | #: E721
-24 | assert type(res) == type((0,))
+26 | #: E721
+27 | assert type(res) == type((0,))
    |
 
-E721.py:24:8: E721 Do not compare types, use `isinstance()`
+E721.py:27:8: E721 Do not compare types, use `isinstance()`
    |
-22 | assert type(res) == type(())
-23 | #: E721
-24 | assert type(res) == type((0,))
+25 | assert type(res) == type(())
+26 | #: E721
+27 | assert type(res) == type((0,))
    |        ^^^^^^^^^^^^^^^^^^^^^^^ E721
-25 | #: E721
-26 | assert type(res) == type((0))
+28 | #: E721
+29 | assert type(res) == type((0))
    |
 
-E721.py:26:8: E721 Do not compare types, use `isinstance()`
+E721.py:29:8: E721 Do not compare types, use `isinstance()`
    |
-24 | assert type(res) == type((0,))
-25 | #: E721
-26 | assert type(res) == type((0))
+27 | assert type(res) == type((0,))
+28 | #: E721
+29 | assert type(res) == type((0))
    |        ^^^^^^^^^^^^^^^^^^^^^^ E721
-27 | #: E721
-28 | assert type(res) != type((1, ))
+30 | #: E721
+31 | assert type(res) != type((1, ))
    |
 
-E721.py:28:8: E721 Do not compare types, use `isinstance()`
+E721.py:31:8: E721 Do not compare types, use `isinstance()`
    |
-26 | assert type(res) == type((0))
-27 | #: E721
-28 | assert type(res) != type((1, ))
+29 | assert type(res) == type((0))
+30 | #: E721
+31 | assert type(res) != type((1, ))
    |        ^^^^^^^^^^^^^^^^^^^^^^^^ E721
-29 | #: Okay
-30 | assert type(res) is type((1, ))
+32 | #: Okay
+33 | assert type(res) is type((1, ))
    |
 
-E721.py:30:8: E721 Do not compare types, use `isinstance()`
+E721.py:33:8: E721 Do not compare types, use `isinstance()`
    |
-28 | assert type(res) != type((1, ))
-29 | #: Okay
-30 | assert type(res) is type((1, ))
+31 | assert type(res) != type((1, ))
+32 | #: Okay
+33 | assert type(res) is type((1, ))
    |        ^^^^^^^^^^^^^^^^^^^^^^^^ E721
-31 | #: Okay
-32 | assert type(res) is not type((1, ))
+34 | #: Okay
+35 | assert type(res) is not type((1, ))
    |
 
-E721.py:32:8: E721 Do not compare types, use `isinstance()`
+E721.py:35:8: E721 Do not compare types, use `isinstance()`
    |
-30 | assert type(res) is type((1, ))
-31 | #: Okay
-32 | assert type(res) is not type((1, ))
+33 | assert type(res) is type((1, ))
+34 | #: Okay
+35 | assert type(res) is not type((1, ))
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
-33 | #: E211 E721
-34 | assert type(res) == type ([2, ])
+36 | #: E211 E721
+37 | assert type(res) == type ([2, ])
    |
 
-E721.py:34:8: E721 Do not compare types, use `isinstance()`
+E721.py:37:8: E721 Do not compare types, use `isinstance()`
    |
-32 | assert type(res) is not type((1, ))
-33 | #: E211 E721
-34 | assert type(res) == type ([2, ])
+35 | assert type(res) is not type((1, ))
+36 | #: E211 E721
+37 | assert type(res) == type ([2, ])
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ E721
-35 | #: E201 E201 E202 E721
-36 | assert type(res) == type( ( ) )
+38 | #: E201 E201 E202 E721
+39 | assert type(res) == type( ( ) )
    |
 
-E721.py:36:8: E721 Do not compare types, use `isinstance()`
+E721.py:39:8: E721 Do not compare types, use `isinstance()`
    |
-34 | assert type(res) == type ([2, ])
-35 | #: E201 E201 E202 E721
-36 | assert type(res) == type( ( ) )
+37 | assert type(res) == type ([2, ])
+38 | #: E201 E201 E202 E721
+39 | assert type(res) == type( ( ) )
    |        ^^^^^^^^^^^^^^^^^^^^^^^^ E721
-37 | #: E201 E202 E721
-38 | assert type(res) == type( (0, ) )
+40 | #: E201 E202 E721
+41 | assert type(res) == type( (0, ) )
    |
 
-E721.py:38:8: E721 Do not compare types, use `isinstance()`
+E721.py:41:8: E721 Do not compare types, use `isinstance()`
    |
-36 | assert type(res) == type( ( ) )
-37 | #: E201 E202 E721
-38 | assert type(res) == type( (0, ) )
+39 | assert type(res) == type( ( ) )
+40 | #: E201 E202 E721
+41 | assert type(res) == type( (0, ) )
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
-39 | #:
+42 | #:
    |
 
-E721.py:96:12: E721 Do not compare types, use `isinstance()`
-   |
-94 |     def asdf(self, value: str | None):
-95 |         #: E721
-96 |         if type(value) is str:
-   |            ^^^^^^^^^^^^^^^^^^ E721
-97 |             ...
-   |
-
-E721.py:106:12: E721 Do not compare types, use `isinstance()`
+E721.py:101:12: E721 Do not compare types, use `isinstance()`
     |
-104 |     def asdf(self, value: str | None):
-105 |         #: E721
-106 |         if type(value) is str:
+ 99 |     def asdf(self, value: str | None):
+100 |         #: E721
+101 |         if type(value) is str:
     |            ^^^^^^^^^^^^^^^^^^ E721
-107 |             ...
+102 |             ...
+    |
+
+E721.py:111:12: E721 Do not compare types, use `isinstance()`
+    |
+109 |     def asdf(self, value: str | None):
+110 |         #: E721
+111 |         if type(value) is str:
+    |            ^^^^^^^^^^^^^^^^^^ E721
+112 |             ...
     |
 
 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E721_E721.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E721_E721.py.snap
@@ -20,6 +20,16 @@ E721.py:5:4: E721 Do not compare types, use `isinstance()`
 7 | #: E721
   |
 
+E721.py:8:4: E721 Do not compare types, use `isinstance()`
+   |
+ 6 |     pass
+ 7 | #: E721
+ 8 | if type(res) == memoryview:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^ E721
+ 9 |     pass
+10 | #: Okay
+   |
+
 E721.py:18:4: E721 Do not compare types, use `isinstance()`
    |
 16 | import types

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__E721_E721.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__E721_E721.py.snap
@@ -17,96 +17,106 @@ E721.py:5:4: E721 Use `is` and `is not` for type comparisons, or `isinstance()` 
 5 | if type(res) != type(""):
   |    ^^^^^^^^^^^^^^^^^^^^^ E721
 6 |     pass
-7 | #: Okay
+7 | #: E721
   |
 
-E721.py:18:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
+E721.py:8:4: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
-16 |     pass
-17 | #: E721
-18 | assert type(res) == type(False) or type(res) == type(None)
+ 6 |     pass
+ 7 | #: E721
+ 8 | if type(res) == memoryview:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^ E721
+ 9 |     pass
+10 | #: Okay
+   |
+
+E721.py:21:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
+   |
+19 |     pass
+20 | #: E721
+21 | assert type(res) == type(False) or type(res) == type(None)
    |        ^^^^^^^^^^^^^^^^^^^^^^^^ E721
-19 | #: E721
-20 | assert type(res) == type([])
+22 | #: E721
+23 | assert type(res) == type([])
    |
 
-E721.py:20:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
+E721.py:23:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
-18 | assert type(res) == type(False) or type(res) == type(None)
-19 | #: E721
-20 | assert type(res) == type([])
+21 | assert type(res) == type(False) or type(res) == type(None)
+22 | #: E721
+23 | assert type(res) == type([])
    |        ^^^^^^^^^^^^^^^^^^^^^ E721
-21 | #: E721
-22 | assert type(res) == type(())
+24 | #: E721
+25 | assert type(res) == type(())
    |
 
-E721.py:22:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
+E721.py:25:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
-20 | assert type(res) == type([])
-21 | #: E721
-22 | assert type(res) == type(())
+23 | assert type(res) == type([])
+24 | #: E721
+25 | assert type(res) == type(())
    |        ^^^^^^^^^^^^^^^^^^^^^ E721
-23 | #: E721
-24 | assert type(res) == type((0,))
+26 | #: E721
+27 | assert type(res) == type((0,))
    |
 
-E721.py:24:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
+E721.py:27:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
-22 | assert type(res) == type(())
-23 | #: E721
-24 | assert type(res) == type((0,))
+25 | assert type(res) == type(())
+26 | #: E721
+27 | assert type(res) == type((0,))
    |        ^^^^^^^^^^^^^^^^^^^^^^^ E721
-25 | #: E721
-26 | assert type(res) == type((0))
+28 | #: E721
+29 | assert type(res) == type((0))
    |
 
-E721.py:26:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
+E721.py:29:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
-24 | assert type(res) == type((0,))
-25 | #: E721
-26 | assert type(res) == type((0))
+27 | assert type(res) == type((0,))
+28 | #: E721
+29 | assert type(res) == type((0))
    |        ^^^^^^^^^^^^^^^^^^^^^^ E721
-27 | #: E721
-28 | assert type(res) != type((1, ))
+30 | #: E721
+31 | assert type(res) != type((1, ))
    |
 
-E721.py:28:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
+E721.py:31:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
-26 | assert type(res) == type((0))
-27 | #: E721
-28 | assert type(res) != type((1, ))
+29 | assert type(res) == type((0))
+30 | #: E721
+31 | assert type(res) != type((1, ))
    |        ^^^^^^^^^^^^^^^^^^^^^^^^ E721
-29 | #: Okay
-30 | assert type(res) is type((1, ))
+32 | #: Okay
+33 | assert type(res) is type((1, ))
    |
 
-E721.py:34:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
+E721.py:37:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
-32 | assert type(res) is not type((1, ))
-33 | #: E211 E721
-34 | assert type(res) == type ([2, ])
+35 | assert type(res) is not type((1, ))
+36 | #: E211 E721
+37 | assert type(res) == type ([2, ])
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ E721
-35 | #: E201 E201 E202 E721
-36 | assert type(res) == type( ( ) )
+38 | #: E201 E201 E202 E721
+39 | assert type(res) == type( ( ) )
    |
 
-E721.py:36:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
+E721.py:39:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
-34 | assert type(res) == type ([2, ])
-35 | #: E201 E201 E202 E721
-36 | assert type(res) == type( ( ) )
+37 | assert type(res) == type ([2, ])
+38 | #: E201 E201 E202 E721
+39 | assert type(res) == type( ( ) )
    |        ^^^^^^^^^^^^^^^^^^^^^^^^ E721
-37 | #: E201 E202 E721
-38 | assert type(res) == type( (0, ) )
+40 | #: E201 E202 E721
+41 | assert type(res) == type( (0, ) )
    |
 
-E721.py:38:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
+E721.py:41:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
-36 | assert type(res) == type( ( ) )
-37 | #: E201 E202 E721
-38 | assert type(res) == type( (0, ) )
+39 | assert type(res) == type( ( ) )
+40 | #: E201 E202 E721
+41 | assert type(res) == type( (0, ) )
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
-39 | #:
+42 | #:
    |
 
 


### PR DESCRIPTION
## Summary

Adds `memoryview` to the list of typeclasses that `fn is_type()` uses for type comparison checks so that it raises a violation if `is`, `is not` or `isinstance()` are not used. 

## Test Plan

Added examples to existing fixture

## Issue Link

Closes: https://github.com/astral-sh/ruff/issues/8483