### PR TITLE
Avoid `FURB113` autofix if comments are present

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB113.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB113.py
@@ -123,6 +123,15 @@ def yes_six(x: list):
     x.append(2)
 
 
+if True:
+    # FURB113
+    nums.append(1)
+    # comment
+    nums.append(2)
+    # comment
+    nums.append(3)
+
+
 # Non-errors.
 
 nums.append(1)

--- a/crates/ruff_linter/src/rules/refurb/rules/repeated_append.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/repeated_append.rs
@@ -106,7 +106,16 @@ pub(crate) fn repeated_append(checker: &mut Checker, stmt: &Stmt) {
 
             // We only suggest a fix when all appends in a group are clumped together. If they're
             // non-consecutive, fixing them is much more difficult.
-            if group.is_consecutive {
+            //
+            // Avoid fixing if there are comments in between the appends:
+            //
+            // ```python
+            // a.append(1)
+            // # comment
+            // a.append(2)
+            // ```
+            if group.is_consecutive && !checker.indexer().comment_ranges().intersects(group.range())
+            {
                 diagnostic.set_fix(Fix::unsafe_edit(Edit::replacement(
                     replacement,
                     group.start(),

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB113_FURB113.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB113_FURB113.py.snap
@@ -330,6 +330,20 @@ FURB113.py:122:5: FURB113 [*] Use `x.extend((1, 2))` instead of repeatedly calli
     122 |+    x.extend((1, 2))
 124 123 | 
 125 124 | 
-126 125 | # Non-errors.
+126 125 | if True:
+
+FURB113.py:128:5: FURB113 Use `nums.extend((1, 2, 3))` instead of repeatedly calling `nums.append()`
+    |
+126 |   if True:
+127 |       # FURB113
+128 |       nums.append(1)
+    |  _____^
+129 | |     # comment
+130 | |     nums.append(2)
+131 | |     # comment
+132 | |     nums.append(3)
+    | |__________________^ FURB113
+    |
+    = help: Replace with `nums.extend((1, 2, 3))`
 
 


### PR DESCRIPTION
This PR avoids creating the fix for `FURB113` if there are comments in between the `append` calls.

fixes: #8105