### PR TITLE
Avoid `D301` autofix for `u` prefixed strings

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydocstyle/D301.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydocstyle/D301.py
@@ -31,3 +31,7 @@ def make_unique_pod_id(pod_id: str) -> str | None:
     :param pod_id: requested pod name
     :return: ``str`` valid Pod name of appropriate length
     """
+
+
+def shouldnt_add_raw_here2():
+    u"Sum\\mary."

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D301_D301.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D301_D301.py.snap
@@ -17,4 +17,12 @@ D301.py:2:5: D301 [*] Use `r"""` if any backslashes in a docstring
 4 4 | 
 5 5 | def double_quotes_backslash_raw():
 
+D301.py:37:5: D301 Use `r"""` if any backslashes in a docstring
+   |
+36 | def shouldnt_add_raw_here2():
+37 |     u"Sum\\mary."
+   |     ^^^^^^^^^^^^^ D301
+   |
+   = help: Add `r` prefix
+
 


### PR DESCRIPTION
This PR avoids creating the fix for `D301` if the string is prefixed with `u` i.e., it's a unicode string. The reason being that `u` and `r` cannot be used together as it's a syntax error.

Refer: https://github.com/astral-sh/ruff/issues/8402#issuecomment-1788783287