### PR TITLE
Recommend `project.requires-python` over `target-version`

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -298,17 +298,18 @@ pub struct Options {
     /// For example, to represent supporting Python >=3.10 or ==3.10
     /// specify `target-version = "py310"`.
     ///
-    /// If you are already using a `pyproject.toml` file, we recommend using
-    /// `project.requires-python` instead, e.g. the following has the same effect
-    /// as `target-version = "py38"`:
+    /// If you're already using a `pyproject.toml` file, we recommend
+    /// `project.requires-python` instead, as it's based on Python packaging
+    /// standards, and will be respected by other tools. For example, Ruff
+    /// treats the following as identical to `target-version = "py38"`:
     ///
     /// ```toml
     /// [project]
-    /// # ...
     /// requires-python = ">=3.8"
     /// ```
     ///
-    /// `target-version` takes precedence over `requires-python`.
+    /// If both are specified, `target-version` takes precedence over
+    /// `requires-python`.
     #[option(
         default = r#""py38""#,
         value_type = r#""py37" | "py38" | "py39" | "py310" | "py311" | "py312""#,

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -298,10 +298,17 @@ pub struct Options {
     /// For example, to represent supporting Python >=3.10 or ==3.10
     /// specify `target-version = "py310"`.
     ///
-    /// If omitted, and Ruff is configured via a `pyproject.toml` file, the
-    /// target version will be inferred from its `project.requires-python`
-    /// field (e.g., `requires-python = ">=3.8"`). If Ruff is configured via
-    /// `ruff.toml` or `.ruff.toml`, no such inference will be performed.
+    /// If you are already using a `pyproject.toml` file, we recommend using
+    /// `project.requires-python` instead, e.g. the following has the same effect
+    /// as `target-version = "py38"`:
+    ///
+    /// ```toml
+    /// [project]
+    /// # ...
+    /// requires-python = ">=3.8"
+    /// ```
+    ///
+    /// `target-version` takes precedence over `requires-python`.
     #[option(
         default = r#""py38""#,
         value_type = r#""py37" | "py38" | "py39" | "py310" | "py311" | "py312""#,

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -649,7 +649,7 @@
       ]
     },
     "target-version": {
-      "description": "The minimum Python version to target, e.g., when considering automatic code upgrades, like rewriting type annotations. Ruff will not propose changes using features that are not available in the given version.\n\nFor example, to represent supporting Python >=3.10 or ==3.10 specify `target-version = \"py310\"`.\n\nIf you are already using a `pyproject.toml` file, we recommend using `project.requires-python` instead, e.g. the following has the same effect as `target-version = \"py38\"`:\n\n```toml [project] # ... requires-python = \">=3.8\" ```\n\n`target-version` takes precedence over `requires-python`.",
+      "description": "The minimum Python version to target, e.g., when considering automatic code upgrades, like rewriting type annotations. Ruff will not propose changes using features that are not available in the given version.\n\nFor example, to represent supporting Python >=3.10 or ==3.10 specify `target-version = \"py310\"`.\n\nIf you're already using a `pyproject.toml` file, we recommend `project.requires-python` instead, as it's based on Python packaging standards, and will be respected by other tools. For example, Ruff treats the following as identical to `target-version = \"py38\"`:\n\n```toml [project] requires-python = \">=3.8\" ```\n\nIf both are specified, `target-version` takes precedence over `requires-python`.",
       "anyOf": [
         {
           "$ref": "#/definitions/PythonVersion"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -649,7 +649,7 @@
       ]
     },
     "target-version": {
-      "description": "The minimum Python version to target, e.g., when considering automatic code upgrades, like rewriting type annotations. Ruff will not propose changes using features that are not available in the given version.\n\nFor example, to represent supporting Python >=3.10 or ==3.10 specify `target-version = \"py310\"`.\n\nIf omitted, and Ruff is configured via a `pyproject.toml` file, the target version will be inferred from its `project.requires-python` field (e.g., `requires-python = \">=3.8\"`). If Ruff is configured via `ruff.toml` or `.ruff.toml`, no such inference will be performed.",
+      "description": "The minimum Python version to target, e.g., when considering automatic code upgrades, like rewriting type annotations. Ruff will not propose changes using features that are not available in the given version.\n\nFor example, to represent supporting Python >=3.10 or ==3.10 specify `target-version = \"py310\"`.\n\nIf you are already using a `pyproject.toml` file, we recommend using `project.requires-python` instead, e.g. the following has the same effect as `target-version = \"py38\"`:\n\n```toml [project] # ... requires-python = \">=3.8\" ```\n\n`target-version` takes precedence over `requires-python`.",
       "anyOf": [
         {
           "$ref": "#/definitions/PythonVersion"


### PR DESCRIPTION
**Summary** Recommend the standardized, shared `project.requires-python` over ruff's custom `target-version`. See https://mastodon.social/deck/@davidism@mas.to/111347072204727710

**Test Plan** Docs only change
