### PR TITLE
Add a `Fix` constructor that takes `Applicability` as an argument

### DIFF
--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -107,6 +107,30 @@ impl Fix {
         }
     }
 
+    /// Create a new [`Fix`] with the specified [`Applicability`] to apply an [`Edit`] element.
+    pub fn applicable_edit(edit: Edit, applicability: Applicability) -> Self {
+        Self {
+            edits: vec![edit],
+            applicability,
+            isolation_level: IsolationLevel::default(),
+        }
+    }
+
+    /// Create a new [`Fix`] with the specified [`Applicability`] to apply multiple [`Edit`] elements.
+    pub fn applicable_edits(
+        edit: Edit,
+        rest: impl IntoIterator<Item = Edit>,
+        applicability: Applicability,
+    ) -> Self {
+        let mut edits: Vec<Edit> = std::iter::once(edit).chain(rest).collect();
+        edits.sort_by_key(|edit| (edit.start(), edit.end()));
+        Self {
+            edits,
+            applicability,
+            isolation_level: IsolationLevel::default(),
+        }
+    }
+
     /// Return the [`TextSize`] of the first [`Edit`] in the [`Fix`].
     pub fn min_start(&self) -> Option<TextSize> {
         self.edits.first().map(Edit::start)

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysFixableViolation, Applicability, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::{self as ast, Expr};
 use ruff_text_size::Ranged;
@@ -83,13 +83,14 @@ pub(crate) fn unnecessary_call_around_sorted(
         expr.range(),
     );
     diagnostic.try_set_fix(|| {
-        let edit =
-            fixes::fix_unnecessary_call_around_sorted(expr, checker.locator(), checker.stylist())?;
-        if outer.id == "reversed" {
-            Ok(Fix::unsafe_edit(edit))
-        } else {
-            Ok(Fix::safe_edit(edit))
-        }
+        Ok(Fix::applicable_edit(
+            fixes::fix_unnecessary_call_around_sorted(expr, checker.locator(), checker.stylist())?,
+            if outer.id == "reversed" {
+                Applicability::Unsafe
+            } else {
+                Applicability::Safe
+            },
+        ))
     });
     checker.diagnostics.push(diagnostic);
 }


### PR DESCRIPTION
## Summary

If you want to create an edit with dynamic applicability, you have to branch and repeat the edit entirely between the two branches. If you further need the edit itself to be dynamic (e.g., perhaps you have a single edit in one case, vs. multiple in another), you suddenly have four branches. This PR just adds an alternate constructor that takes applicability as an argument, as an escape hatch.