### PR TITLE
Make `SIM118` fix as safe when the expression is a known dictionary 

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM118.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM118.py
@@ -1,3 +1,5 @@
+obj = {}
+
 key in obj.keys()  # SIM118
 
 key not in obj.keys()  # SIM118

--- a/crates/ruff_linter/src/rules/flake8_simplify/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/mod.rs
@@ -55,6 +55,7 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Rule::InDictKeys, Path::new("SIM118.py"))]
     #[test_case(Rule::IfElseBlockInsteadOfDictGet, Path::new("SIM401.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__preview__SIM118_SIM118.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__preview__SIM118_SIM118.py.snap
@@ -12,7 +12,7 @@ SIM118.py:3:1: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
   |
   = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | obj = {}
 2 2 | 
 3   |-key in obj.keys()  # SIM118
@@ -32,7 +32,7 @@ SIM118.py:5:1: SIM118 [*] Use `key not in dict` instead of `key not in dict.keys
   |
   = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 2 2 | 
 3 3 | key in obj.keys()  # SIM118
 4 4 | 
@@ -53,7 +53,7 @@ SIM118.py:7:1: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
   |
   = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 4 4 | 
 5 5 | key not in obj.keys()  # SIM118
 6 6 | 
@@ -74,7 +74,7 @@ SIM118.py:9:1: SIM118 [*] Use `key not in dict` instead of `key not in dict.keys
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 6  6  | 
 7  7  | foo["bar"] in obj.keys()  # SIM118
 8  8  | 
@@ -95,7 +95,7 @@ SIM118.py:11:1: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 8  8  | 
 9  9  | foo["bar"] not in obj.keys()  # SIM118
 10 10 | 
@@ -116,7 +116,7 @@ SIM118.py:13:1: SIM118 [*] Use `key not in dict` instead of `key not in dict.key
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 10 10 | 
 11 11 | foo['bar'] in obj.keys()  # SIM118
 12 12 | 
@@ -137,7 +137,7 @@ SIM118.py:15:1: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 12 12 | 
 13 13 | foo['bar'] not in obj.keys()  # SIM118
 14 14 | 
@@ -158,7 +158,7 @@ SIM118.py:17:1: SIM118 [*] Use `key not in dict` instead of `key not in dict.key
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 14 14 | 
 15 15 | foo() in obj.keys()  # SIM118
 16 16 | 
@@ -178,7 +178,7 @@ SIM118.py:19:5: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 16 16 | 
 17 17 | foo() not in obj.keys()  # SIM118
 18 18 | 
@@ -199,7 +199,7 @@ SIM118.py:26:8: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 23 23 |     if some_property(key):
 24 24 |         del obj[key]
 25 25 | 
@@ -220,7 +220,7 @@ SIM118.py:28:8: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 25 25 | 
 26 26 | [k for k in obj.keys()]  # SIM118
 27 27 | 
@@ -241,7 +241,7 @@ SIM118.py:30:11: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 27 27 | 
 28 28 | {k for k in obj.keys()}  # SIM118
 29 29 | 
@@ -262,7 +262,7 @@ SIM118.py:32:8: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 29 29 | 
 30 30 | {k: k for k in obj.keys()}  # SIM118
 31 31 | 
@@ -324,7 +324,7 @@ SIM118.py:50:1: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 47 47 | 
 48 48 | 
 49 49 | # Regression test for: https://github.com/astral-sh/ruff/issues/7124
@@ -344,7 +344,7 @@ SIM118.py:51:2: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 48 48 | 
 49 49 | # Regression test for: https://github.com/astral-sh/ruff/issues/7124
 50 50 | key in obj.keys()and foo
@@ -365,7 +365,7 @@ SIM118.py:52:1: SIM118 [*] Use `key in dict` instead of `key in dict.keys()`
    |
    = help: Remove `.keys()`
 
-ℹ Suggested fix
+ℹ Fix
 49 49 | # Regression test for: https://github.com/astral-sh/ruff/issues/7124
 50 50 | key in obj.keys()and foo
 51 51 | (key in obj.keys())and foo


### PR DESCRIPTION
## Summary

Given `key in obj.keys()`, `obj` _could_ be a dictionary, or it could be another type that defines
a `.keys()` method. In the latter case, removing the `.keys()` attribute
could lead to a runtime error.

Previously, we marked all `SIM118` fixes as unsafe for this reason; however, in preview, we now mark them as safe if we can
infer that the expression is a dictionary.

## Test Plan

Added a preview fixture.
