### PR TITLE
Avoid raising `TRIO115` violations for `trio.sleep(...)` calls with non-number values

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_trio/TRIO115.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_trio/TRIO115.py
@@ -17,6 +17,9 @@ async def func():
 
     sleep(0)  # TRIO115
 
+    bar = "bar"
+    trio.sleep(bar)
+
 
 trio.sleep(0)  # TRIO115
 

--- a/crates/ruff_linter/src/rules/flake8_trio/rules/zero_sleep_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_trio/rules/zero_sleep_call.rs
@@ -77,14 +77,14 @@ pub(crate) fn zero_sleep_call(checker: &mut Checker, call: &ExprCall) {
                         })
                         | Stmt::AugAssign(ast::StmtAugAssign { value, .. }) = parent
                         {
-                            if let Expr::NumberLiteral(ast::ExprNumberLiteral {
-                                value: num, ..
-                            }) = value.as_ref()
-                            {
-                                let Some(int) = num.as_int() else { return };
-                                if *int != Int::ZERO {
-                                    return;
-                                }
+                            let Expr::NumberLiteral(ast::ExprNumberLiteral { value: num, .. }) =
+                                value.as_ref()
+                            else {
+                                return;
+                            };
+                            let Some(int) = num.as_int() else { return };
+                            if *int != Int::ZERO {
+                                return;
                             }
                         }
                     }

--- a/crates/ruff_linter/src/rules/flake8_trio/snapshots/ruff_linter__rules__flake8_trio__tests__TRIO115_TRIO115.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_trio/snapshots/ruff_linter__rules__flake8_trio__tests__TRIO115_TRIO115.py.snap
@@ -69,6 +69,8 @@ TRIO115.py:18:5: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.s
 17 | 
 18 |     sleep(0)  # TRIO115
    |     ^^^^^^^^ TRIO115
+19 | 
+20 |     bar = "bar"
    |
    = help: Replace with `trio.lowlevel.checkpoint()`
 
@@ -79,39 +81,39 @@ TRIO115.py:18:5: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.s
 18    |-    sleep(0)  # TRIO115
    18 |+    trio.lowlevel.checkpoint  # TRIO115
 19 19 | 
-20 20 | 
-21 21 | trio.sleep(0)  # TRIO115
+20 20 |     bar = "bar"
+21 21 |     trio.sleep(bar)
 
-TRIO115.py:21:1: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
+TRIO115.py:24:1: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
    |
-21 | trio.sleep(0)  # TRIO115
+24 | trio.sleep(0)  # TRIO115
    | ^^^^^^^^^^^^^ TRIO115
    |
    = help: Replace with `trio.lowlevel.checkpoint()`
 
 ℹ Fix
-18 18 |     sleep(0)  # TRIO115
-19 19 | 
-20 20 | 
-21    |-trio.sleep(0)  # TRIO115
-   21 |+trio.lowlevel.checkpoint  # TRIO115
+21 21 |     trio.sleep(bar)
 22 22 | 
 23 23 | 
-24 24 | def func():
+24    |-trio.sleep(0)  # TRIO115
+   24 |+trio.lowlevel.checkpoint  # TRIO115
+25 25 | 
+26 26 | 
+27 27 | def func():
 
-TRIO115.py:25:14: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
+TRIO115.py:28:14: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
    |
-24 | def func():
-25 |     trio.run(trio.sleep(0))  # TRIO115
+27 | def func():
+28 |     trio.run(trio.sleep(0))  # TRIO115
    |              ^^^^^^^^^^^^^ TRIO115
    |
    = help: Replace with `trio.lowlevel.checkpoint()`
 
 ℹ Fix
-22 22 | 
-23 23 | 
-24 24 | def func():
-25    |-    trio.run(trio.sleep(0))  # TRIO115
-   25 |+    trio.run(trio.lowlevel.checkpoint)  # TRIO115
+25 25 | 
+26 26 | 
+27 27 | def func():
+28    |-    trio.run(trio.sleep(0))  # TRIO115
+   28 |+    trio.run(trio.lowlevel.checkpoint)  # TRIO115
 
 


### PR DESCRIPTION
## Summary

Fixes bug in `TRIO115` where it would not `return` for values that were not a `NumberLiteral` so 
```python
x = "bla"
trio.sleep(x)
```
would set off a false positive

## Test Plan

Added test case to fixture
