### PR TITLE
docs: Apply consistent md code block indentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -326,23 +326,23 @@ If you'd prefer to either only lint or only format Jupyter Notebook files, you c
 section specific `exclude` option to do so. For example, the following would only lint Jupyter
 Notebook files and not format them:
 
-```toml
-[tool.ruff]
-extend-include = ["*.ipynb"]
+    ```toml
+    [tool.ruff]
+    extend-include = ["*.ipynb"]
 
-[tool.ruff.format]
-exclude = ["*.ipynb"]
-```
+    [tool.ruff.format]
+    exclude = ["*.ipynb"]
+    ```
 
 And, conversely, the following would only format Jupyter Notebook files and not lint them:
 
-```toml
-[tool.ruff]
-extend-include = ["*.ipynb"]
+    ```toml
+    [tool.ruff]
+    extend-include = ["*.ipynb"]
 
-[tool.ruff.lint]
-exclude = ["*.ipynb"]
-```
+    [tool.ruff.lint]
+    exclude = ["*.ipynb"]
+    ```
 
 Alternatively, pass the notebook file(s) to `ruff` on the command-line directly. For example,
 `ruff check /path/to/notebook.ipynb` will always lint `notebook.ipynb`. Similarly,
@@ -353,9 +353,9 @@ Alternatively, pass the notebook file(s) to `ruff` on the command-line directly.
 Some configuration options can be provided via the command-line, such as those related to rule
 enablement and disablement, file discovery, logging level, and more:
 
-```shell
-ruff check path/to/code/ --select F401 --select F403 --quiet
-```
+    ```shell
+    ruff check path/to/code/ --select F401 --select F403 --quiet
+    ```
 
 See `ruff help` for more on Ruff's top-level commands:
 
@@ -548,7 +548,7 @@ As an example: to enable autocompletion for Zsh, run
 `ruff generate-shell-completion zsh > ~/.zfunc/_ruff`. Then add the following line to your
 `~/.zshrc` file, if they're not already present:
 
-```zsh
-fpath+=~/.zfunc
-autoload -Uz compinit && compinit
-```
+    ```zsh
+    fpath+=~/.zfunc
+    autoload -Uz compinit && compinit
+    ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -222,9 +222,9 @@ Ruff is installable under any Python version from 3.7 onwards.
 
 Nope! Ruff is available as [`ruff`](https://pypi.org/project/ruff/) on PyPI:
 
-```shell
-pip install ruff
-```
+    ```shell
+    pip install ruff
+    ```
 
 Ruff ships with wheels for all major platforms, which enables `pip` to install Ruff without relying
 on Rust at all.
@@ -245,18 +245,18 @@ isort treat inline comments in some cases (see: [#1381](https://github.com/astra
 
 For example, Ruff tends to group non-aliased imports from the same module:
 
-```py
-from numpy import cos, int8, int16, int32, int64, tan, uint8, uint16, uint32, uint64
-from numpy import sin as np_sin
-```
+    ```py
+    from numpy import cos, int8, int16, int32, int64, tan, uint8, uint16, uint32, uint64
+    from numpy import sin as np_sin
+    ```
 
 Whereas isort splits them into separate import statements at each aliased boundary:
 
-```py
-from numpy import cos, int8, int16, int32, int64
-from numpy import sin as np_sin
-from numpy import tan, uint8, uint16, uint32, uint64
-```
+    ```py
+    from numpy import cos, int8, int16, int32, int64
+    from numpy import sin as np_sin
+    from numpy import tan, uint8, uint16, uint32, uint64
+    ```
 
 Like isort, Ruff's import sorting is compatible with Black.
 
@@ -315,16 +315,16 @@ first-party.
 
 For example, if you have a project with the following structure:
 
-```tree
-my_project
-├── pyproject.toml
-└── src
-    └── foo
-        ├── __init__.py
-        └── bar
+    ```tree
+    my_project
+    ├── pyproject.toml
+    └── src
+        └── foo
             ├── __init__.py
-            └── baz.py
-```
+            └── bar
+                ├── __init__.py
+                └── baz.py
+    ```
 
 When Ruff sees an import like `import foo`, it will then iterate over the `src` directories,
 looking for a corresponding Python module (in reality, a directory named `foo` or a file named
@@ -415,14 +415,14 @@ code formatters over Jupyter Notebooks.
 
 After installing `ruff` and `nbqa`, you can run Ruff over a notebook like so:
 
-```shell
-> nbqa ruff Untitled.ipynb
-Untitled.ipynb:cell_1:2:5: F841 Local variable `x` is assigned to but never used
-Untitled.ipynb:cell_2:1:1: E402 Module level import not at top of file
-Untitled.ipynb:cell_2:1:8: F401 `os` imported but unused
-Found 3 errors.
-1 potentially fixable with the --fix option.
-```
+    ```shell
+    > nbqa ruff Untitled.ipynb
+    Untitled.ipynb:cell_1:2:5: F841 Local variable `x` is assigned to but never used
+    Untitled.ipynb:cell_2:1:1: E402 Module level import not at top of file
+    Untitled.ipynb:cell_2:1:8: F401 `os` imported but unused
+    Found 3 errors.
+    1 potentially fixable with the --fix option.
+    ```
 
 ## Does Ruff support NumPy- or Google-style docstrings?
 
@@ -497,22 +497,22 @@ file can omit the `[tool.ruff]` section header. For example:
 
 === "pyproject.toml"
 
-```toml
-[tool.ruff]
-line-length = 88
+    ```toml
+    [tool.ruff]
+    line-length = 88
 
-[tool.ruff.lint.pydocstyle]
-convention = "google"
-```
+    [tool.ruff.lint.pydocstyle]
+    convention = "google"
+    ```
 
 === "ruff.toml"
 
-```toml
-line-length = 88
+    ```toml
+    line-length = 88
 
-[pydocstyle]
-convention = "google"
-```
+    [pydocstyle]
+    convention = "google"
+    ```
 
 Ruff doesn't currently support INI files, like `setup.cfg` or `tox.ini`.
 

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -8,10 +8,10 @@ The Ruff formatter is an extremely fast Python code formatter designed as a drop
 `ruff format` is the primary entrypoint to the formatter. It accepts a list of files or
 directories, and formats all discovered Python files:
 
-```shell
-ruff format .                 # Format all files in the current directory.
-ruff format /path/to/file.py  # Format a single file.
-```
+    ```shell
+    ruff format .                 # Format all files in the current directory.
+    ruff format /path/to/file.py  # Format a single file.
+    ```
 
 Similar to Black, running `ruff format /path/to/file.py` will format the given file or directory
 in-place, while `ruff format --check /path/to/file.py` will avoid writing any formatted files back,
@@ -38,46 +38,46 @@ Given this focus on Black compatibility, the formatter thus adheres to [Black's 
 which aims for "consistency, generality, readability and reducing git diffs". To give you a sense
 for the enforced code style, here's an example:
 
-```python
-# Input
-def _make_ssl_transport(
-    rawsock, protocol, sslcontext, waiter=None,
-    *, server_side=False, server_hostname=None,
-    extra=None, server=None,
-    ssl_handshake_timeout=None,
-    call_connection_made=True):
-    '''Make an SSL transport.'''
-    if waiter is None:
-      waiter = Future(loop=loop)
+    ```python
+    # Input
+    def _make_ssl_transport(
+        rawsock, protocol, sslcontext, waiter=None,
+        *, server_side=False, server_hostname=None,
+        extra=None, server=None,
+        ssl_handshake_timeout=None,
+        call_connection_made=True):
+        '''Make an SSL transport.'''
+        if waiter is None:
+          waiter = Future(loop=loop)
 
-    if extra is None:
-      extra = {}
+        if extra is None:
+          extra = {}
 
-    ...
+        ...
 
-# Ruff
-def _make_ssl_transport(
-    rawsock,
-    protocol,
-    sslcontext,
-    waiter=None,
-    *,
-    server_side=False,
-    server_hostname=None,
-    extra=None,
-    server=None,
-    ssl_handshake_timeout=None,
-    call_connection_made=True,
-):
-    """Make an SSL transport."""
-    if waiter is None:
-        waiter = Future(loop=loop)
+    # Ruff
+    def _make_ssl_transport(
+        rawsock,
+        protocol,
+        sslcontext,
+        waiter=None,
+        *,
+        server_side=False,
+        server_hostname=None,
+        extra=None,
+        server=None,
+        ssl_handshake_timeout=None,
+        call_connection_made=True,
+    ):
+        """Make an SSL transport."""
+        if waiter is None:
+            waiter = Future(loop=loop)
 
-    if extra is None:
-        extra = {}
+        if extra is None:
+            extra = {}
 
-    ...
-```
+        ...
+    ```
 
 Like Black, the Ruff formatter does _not_ support extensive code style configuration; however,
 unlike Black, it _does_ support configuring the desired quote style, indent style, line endings,
@@ -137,54 +137,54 @@ be used to temporarily disable formatting for a given code block.
 
 `# fmt: on` and `# fmt: off` comments are enforced at the statement level:
 
-```python
-# fmt: off
-not_formatted=3
-also_not_formatted=4
-# fmt: on
-```
+    ```python
+    # fmt: off
+    not_formatted=3
+    also_not_formatted=4
+    # fmt: on
+    ```
 
 As such, adding `# fmt: on` and `# fmt: off` comments within expressions will have no effect. In
 the following example, both list entries will be formatted, despite the `# fmt: off`:
 
-```python
-[
-    # fmt: off
-    '1',
-    # fmt: on
-    '2',
-]
-```
+    ```python
+    [
+        # fmt: off
+        '1',
+        # fmt: on
+        '2',
+    ]
+    ```
 
 Instead, apply the `# fmt: off` comment to the entire statement:
 
-```python
-# fmt: off
-[
-    '1',
-    '2',
-]
-# fmt: on
-```
+    ```python
+    # fmt: off
+    [
+        '1',
+        '2',
+    ]
+    # fmt: on
+    ```
 
 `# fmt: skip` comments suppress formatting for a preceding statement, case header, decorator,
 function definition, or class definition:
 
-```python
-if True:
-    pass
-elif False: # fmt: skip
-    pass
+    ```python
+    if True:
+        pass
+    elif False: # fmt: skip
+        pass
 
-@Test
-@Test2 # fmt: skip
-def test(): ...
+    @Test
+    @Test2 # fmt: skip
+    def test(): ...
 
-a = [1, 2, 3, 4, 5] # fmt: skip
+    a = [1, 2, 3, 4, 5] # fmt: skip
 
-def test(a, b, c, d, e, f) -> int: # fmt: skip
-    pass
-```
+    def test(a, b, c, d, e, f) -> int: # fmt: skip
+        pass
+    ```
 
 Like Black, Ruff will _also_ recognize [YAPF](https://github.com/google/yapf)'s `# yapf: disable` and `# yapf: enable` pragma
 comments, which are treated equivalently to `# fmt: off` and `# fmt: on`, respectively.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,43 +2,43 @@
 
 Ruff is available as [`ruff`](https://pypi.org/project/ruff/) on PyPI:
 
-```shell
-pip install ruff
-```
+    ```shell
+    pip install ruff
+    ```
 
 Once installed, you can run Ruff from the command line:
 
-```shell
-ruff check .   # Lint all files in the current directory.
-ruff format .  # Format all files in the current directory.
-```
+    ```shell
+    ruff check .   # Lint all files in the current directory.
+    ruff format .  # Format all files in the current directory.
+    ```
 
 For **macOS Homebrew** and **Linuxbrew** users, Ruff is also available as [`ruff`](https://formulae.brew.sh/formula/ruff)
 on Homebrew:
 
-```shell
-brew install ruff
-```
+    ```shell
+    brew install ruff
+    ```
 
 For **Conda** users, Ruff is also available as [`ruff`](https://anaconda.org/conda-forge/ruff) on
 `conda-forge`:
 
-```shell
-conda install -c conda-forge ruff
-```
+    ```shell
+    conda install -c conda-forge ruff
+    ```
 
 For **Arch Linux** users, Ruff is also available as [`ruff`](https://archlinux.org/packages/community/x86_64/ruff/)
 on the official repositories:
 
-```shell
-pacman -S ruff
-```
+    ```shell
+    pacman -S ruff
+    ```
 
 For **Alpine** users, Ruff is also available as [`ruff`](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/ruff)
 on the testing repositories:
 
-```shell
-apk add ruff
-```
+    ```shell
+    apk add ruff
+    ```
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/ruff-python-linter.svg?exclude_unsupported=1)](https://repology.org/project/ruff-python-linter/versions)

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -11,44 +11,44 @@ which supports fix actions, import sorting, and more.
 
 Ruff can be used as a [pre-commit](https://pre-commit.com) hook via [`ruff-pre-commit`](https://github.com/astral-sh/ruff-pre-commit):
 
-```yaml
-# Run the Ruff linter.
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.0.291
-  hooks:
-    - id: ruff
-# Run the Ruff formatter.
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.0.291
-  hooks:
-    - id: ruff-format
-```
+    ```yaml
+    # Run the Ruff linter.
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      # Ruff version.
+      rev: v0.0.291
+      hooks:
+        - id: ruff
+    # Run the Ruff formatter.
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      # Ruff version.
+      rev: v0.0.291
+      hooks:
+        - id: ruff-format
+    ```
 
 To enable fixes, add the `--fix` argument to the linter:
 
-```yaml
-# Run the Ruff linter.
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.0.291
-  hooks:
-    - id: ruff
-      args: [ --fix, --exit-non-zero-on-fix ]
-```
+    ```yaml
+    # Run the Ruff linter.
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      # Ruff version.
+      rev: v0.0.291
+      hooks:
+        - id: ruff
+          args: [ --fix, --exit-non-zero-on-fix ]
+    ```
 
 To run the hooks over Jupyter Notebooks too, add `jupyter` to the list of allowed filetypes:
 
-```yaml
-# Run the Ruff linter.
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.0.291
-  hooks:
-    - id: ruff
-      types_or: [ python, pyi, jupyter ]
-```
+    ```yaml
+    # Run the Ruff linter.
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      # Ruff version.
+      rev: v0.0.291
+      hooks:
+        - id: ruff
+          types_or: [ python, pyi, jupyter ]
+    ```
 
 Ruff's lint hook should be placed after other formatting tools, such as Ruff's format hook, Black,
 or isort, _unless_ you enable autofix, in which case, Ruff's pre-commit hook should run _before_
@@ -73,60 +73,60 @@ For example, to use `ruff-lsp` with Neovim, install `ruff-lsp` from PyPI along w
 [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig). Then, add something like the following
 to your `init.lua`:
 
-```lua
--- See: https://github.com/neovim/nvim-lspconfig/tree/54eb2a070a4f389b1be0f98070f81d23e2b1a715#suggested-configuration
-local opts = { noremap=true, silent=true }
-vim.keymap.set('n', '<space>e', vim.diagnostic.open_float, opts)
-vim.keymap.set('n', '[d', vim.diagnostic.goto_prev, opts)
-vim.keymap.set('n', ']d', vim.diagnostic.goto_next, opts)
-vim.keymap.set('n', '<space>q', vim.diagnostic.setloclist, opts)
+    ```lua
+    -- See: https://github.com/neovim/nvim-lspconfig/tree/54eb2a070a4f389b1be0f98070f81d23e2b1a715#suggested-configuration
+    local opts = { noremap=true, silent=true }
+    vim.keymap.set('n', '<space>e', vim.diagnostic.open_float, opts)
+    vim.keymap.set('n', '[d', vim.diagnostic.goto_prev, opts)
+    vim.keymap.set('n', ']d', vim.diagnostic.goto_next, opts)
+    vim.keymap.set('n', '<space>q', vim.diagnostic.setloclist, opts)
 
--- Use an on_attach function to only map the following keys
--- after the language server attaches to the current buffer
-local on_attach = function(client, bufnr)
-  -- Enable completion triggered by <c-x><c-o>
-  vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
+    -- Use an on_attach function to only map the following keys
+    -- after the language server attaches to the current buffer
+    local on_attach = function(client, bufnr)
+      -- Enable completion triggered by <c-x><c-o>
+      vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
 
-  -- Mappings.
-  -- See `:help vim.lsp.*` for documentation on any of the below functions
-  local bufopts = { noremap=true, silent=true, buffer=bufnr }
-  vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, bufopts)
-  vim.keymap.set('n', 'gd', vim.lsp.buf.definition, bufopts)
-  vim.keymap.set('n', 'K', vim.lsp.buf.hover, bufopts)
-  vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, bufopts)
-  vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, bufopts)
-  vim.keymap.set('n', '<space>wa', vim.lsp.buf.add_workspace_folder, bufopts)
-  vim.keymap.set('n', '<space>wr', vim.lsp.buf.remove_workspace_folder, bufopts)
-  vim.keymap.set('n', '<space>wl', function()
-    print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
-  end, bufopts)
-  vim.keymap.set('n', '<space>D', vim.lsp.buf.type_definition, bufopts)
-  vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, bufopts)
-  vim.keymap.set('n', '<space>ca', vim.lsp.buf.code_action, bufopts)
-  vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
-  vim.keymap.set('n', '<space>f', function() vim.lsp.buf.format { async = true } end, bufopts)
-end
+      -- Mappings.
+      -- See `:help vim.lsp.*` for documentation on any of the below functions
+      local bufopts = { noremap=true, silent=true, buffer=bufnr }
+      vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, bufopts)
+      vim.keymap.set('n', 'gd', vim.lsp.buf.definition, bufopts)
+      vim.keymap.set('n', 'K', vim.lsp.buf.hover, bufopts)
+      vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, bufopts)
+      vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, bufopts)
+      vim.keymap.set('n', '<space>wa', vim.lsp.buf.add_workspace_folder, bufopts)
+      vim.keymap.set('n', '<space>wr', vim.lsp.buf.remove_workspace_folder, bufopts)
+      vim.keymap.set('n', '<space>wl', function()
+        print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
+      end, bufopts)
+      vim.keymap.set('n', '<space>D', vim.lsp.buf.type_definition, bufopts)
+      vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, bufopts)
+      vim.keymap.set('n', '<space>ca', vim.lsp.buf.code_action, bufopts)
+      vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
+      vim.keymap.set('n', '<space>f', function() vim.lsp.buf.format { async = true } end, bufopts)
+    end
 
--- Configure `ruff-lsp`.
-local configs = require 'lspconfig.configs'
-if not configs.ruff_lsp then
-  configs.ruff_lsp = {
-    default_config = {
-      cmd = { 'ruff-lsp' },
-      filetypes = { 'python' },
-      root_dir = require('lspconfig').util.find_git_ancestor,
-      init_options = {
-        settings = {
-          args = {}
+    -- Configure `ruff-lsp`.
+    local configs = require 'lspconfig.configs'
+    if not configs.ruff_lsp then
+      configs.ruff_lsp = {
+        default_config = {
+          cmd = { 'ruff-lsp' },
+          filetypes = { 'python' },
+          root_dir = require('lspconfig').util.find_git_ancestor,
+          init_options = {
+            settings = {
+              args = {}
+            }
+          }
         }
       }
+    end
+    require('lspconfig').ruff_lsp.setup {
+      on_attach = on_attach,
     }
-  }
-end
-require('lspconfig').ruff_lsp.setup {
-  on_attach = on_attach,
-}
-```
+    ```
 
 Upon successful installation, you should see Ruff's diagnostics surfaced directly in your editor:
 
@@ -140,37 +140,37 @@ Ruff is also available as the [`python-lsp-ruff`](https://github.com/python-lsp/
 plugin for [`python-lsp-server`](https://github.com/python-lsp/python-lsp-ruff), both of which are
 installable from PyPI:
 
-```shell
-pip install python-lsp-server python-lsp-ruff
-```
+    ```shell
+    pip install python-lsp-server python-lsp-ruff
+    ```
 
 The LSP server can then be used with any editor that supports the Language Server Protocol.
 
 For example, to use `python-lsp-ruff` with Neovim, add something like the following to your
 `init.lua`:
 
-```lua
-require'lspconfig'.pylsp.setup {
-  settings = {
-    pylsp = {
-      plugins = {
-        ruff = {
-          enabled = true
-        },
-        pycodestyle = {
-          enabled = false
-        },
-        pyflakes = {
-          enabled = false
-        },
-        mccabe = {
-          enabled = false
+    ```lua
+    require'lspconfig'.pylsp.setup {
+      settings = {
+        pylsp = {
+          plugins = {
+            ruff = {
+              enabled = true
+            },
+            pycodestyle = {
+              enabled = false
+            },
+            pyflakes = {
+              enabled = false
+            },
+            mccabe = {
+              enabled = false
+            }
+          }
         }
-      }
+      },
     }
-  },
-}
-```
+    ```
 
 ## Vim & Neovim
 
@@ -182,53 +182,53 @@ officially supported LSP server for Ruff. To use `ruff-lsp` with Neovim, install
 PyPI along with [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig). Then, add something
 like the following to your `init.lua`:
 
-```lua
--- See: https://github.com/neovim/nvim-lspconfig/tree/54eb2a070a4f389b1be0f98070f81d23e2b1a715#suggested-configuration
-local opts = { noremap=true, silent=true }
-vim.keymap.set('n', '<space>e', vim.diagnostic.open_float, opts)
-vim.keymap.set('n', '[d', vim.diagnostic.goto_prev, opts)
-vim.keymap.set('n', ']d', vim.diagnostic.goto_next, opts)
-vim.keymap.set('n', '<space>q', vim.diagnostic.setloclist, opts)
+    ```lua
+    -- See: https://github.com/neovim/nvim-lspconfig/tree/54eb2a070a4f389b1be0f98070f81d23e2b1a715#suggested-configuration
+    local opts = { noremap=true, silent=true }
+    vim.keymap.set('n', '<space>e', vim.diagnostic.open_float, opts)
+    vim.keymap.set('n', '[d', vim.diagnostic.goto_prev, opts)
+    vim.keymap.set('n', ']d', vim.diagnostic.goto_next, opts)
+    vim.keymap.set('n', '<space>q', vim.diagnostic.setloclist, opts)
 
--- Use an on_attach function to only map the following keys
--- after the language server attaches to the current buffer
-local on_attach = function(client, bufnr)
-  -- Enable completion triggered by <c-x><c-o>
-  vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
+    -- Use an on_attach function to only map the following keys
+    -- after the language server attaches to the current buffer
+    local on_attach = function(client, bufnr)
+      -- Enable completion triggered by <c-x><c-o>
+      vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
 
-  -- Mappings.
-  -- See `:help vim.lsp.*` for documentation on any of the below functions
-  local bufopts = { noremap=true, silent=true, buffer=bufnr }
-  vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, bufopts)
-  vim.keymap.set('n', 'gd', vim.lsp.buf.definition, bufopts)
-  vim.keymap.set('n', 'K', vim.lsp.buf.hover, bufopts)
-  vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, bufopts)
-  vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, bufopts)
-  vim.keymap.set('n', '<space>wa', vim.lsp.buf.add_workspace_folder, bufopts)
-  vim.keymap.set('n', '<space>wr', vim.lsp.buf.remove_workspace_folder, bufopts)
-  vim.keymap.set('n', '<space>wl', function()
-    print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
-  end, bufopts)
-  vim.keymap.set('n', '<space>D', vim.lsp.buf.type_definition, bufopts)
-  vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, bufopts)
-  vim.keymap.set('n', '<space>ca', vim.lsp.buf.code_action, bufopts)
-  vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
-  vim.keymap.set('n', '<space>f', function() vim.lsp.buf.format { async = true } end, bufopts)
-end
+      -- Mappings.
+      -- See `:help vim.lsp.*` for documentation on any of the below functions
+      local bufopts = { noremap=true, silent=true, buffer=bufnr }
+      vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, bufopts)
+      vim.keymap.set('n', 'gd', vim.lsp.buf.definition, bufopts)
+      vim.keymap.set('n', 'K', vim.lsp.buf.hover, bufopts)
+      vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, bufopts)
+      vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, bufopts)
+      vim.keymap.set('n', '<space>wa', vim.lsp.buf.add_workspace_folder, bufopts)
+      vim.keymap.set('n', '<space>wr', vim.lsp.buf.remove_workspace_folder, bufopts)
+      vim.keymap.set('n', '<space>wl', function()
+        print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
+      end, bufopts)
+      vim.keymap.set('n', '<space>D', vim.lsp.buf.type_definition, bufopts)
+      vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, bufopts)
+      vim.keymap.set('n', '<space>ca', vim.lsp.buf.code_action, bufopts)
+      vim.keymap.set('n', 'gr', vim.lsp.buf.references, bufopts)
+      vim.keymap.set('n', '<space>f', function() vim.lsp.buf.format { async = true } end, bufopts)
+    end
 
--- Configure `ruff-lsp`.
--- See: https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruff_lsp
--- For the default config, along with instructions on how to customize the settings
-require('lspconfig').ruff_lsp.setup {
-  on_attach = on_attach,
-  init_options = {
-    settings = {
-      -- Any extra CLI arguments for `ruff` go here.
-      args = {},
+    -- Configure `ruff-lsp`.
+    -- See: https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruff_lsp
+    -- For the default config, along with instructions on how to customize the settings
+    require('lspconfig').ruff_lsp.setup {
+      on_attach = on_attach,
+      init_options = {
+        settings = {
+          -- Any extra CLI arguments for `ruff` go here.
+          args = {},
+        }
+      }
     }
-  }
-}
-```
+    ```
 
 Ruff is also available as part of the [coc-pyright](https://github.com/fannheyward/coc-pyright)
 extension for `coc.nvim`.
@@ -236,12 +236,12 @@ extension for `coc.nvim`.
 <details>
 <summary>With the <a href="https://github.com/dense-analysis/ale">ALE</a> plugin for (Neo)Vim.</summary>
 
-```vim
-let g:ale_linters = { "python": ["ruff"] }
-let g:ale_fixers = {
-\       "python": ["black", "ruff"],
-\}
-```
+    ```vim
+    let g:ale_linters = { "python": ["ruff"] }
+    let g:ale_fixers = {
+    \       "python": ["black", "ruff"],
+    \}
+    ```
 
 </details>
 
@@ -258,16 +258,16 @@ in just a
 </summary>
 <br>
 
-```yaml
-tools:
-  python-ruff: &python-ruff
-    lint-command: "ruff check --config ~/myconfigs/linters/ruff.toml --quiet ${INPUT}"
-    lint-stdin: true
-    lint-formats:
-      - "%f:%l:%c: %m"
-    format-command: "ruff check --stdin-filename ${INPUT} --config ~/myconfigs/linters/ruff.toml --fix --exit-zero --quiet -"
-    format-stdin: true
-```
+    ```yaml
+    tools:
+      python-ruff: &python-ruff
+        lint-command: "ruff check --config ~/myconfigs/linters/ruff.toml --quiet ${INPUT}"
+        lint-stdin: true
+        lint-formats:
+          - "%f:%l:%c: %m"
+        format-command: "ruff check --stdin-filename ${INPUT} --config ~/myconfigs/linters/ruff.toml --fix --exit-zero --quiet -"
+        format-stdin: true
+    ```
 
 </details>
 
@@ -277,18 +277,18 @@ With the <a href="https://github.com/stevearc/conform.nvim"><code>conform.nvim</
 </summary>
 <br>
 
-```lua
-require("conform").setup({
-    formatters_by_ft = {
-        python = {
-          -- To fix lint errors.
-          "ruff_fix",
-          -- To run the Ruff formatter.
-          "ruff_format",
+    ```lua
+    require("conform").setup({
+        formatters_by_ft = {
+            python = {
+              -- To fix lint errors.
+              "ruff_fix",
+              -- To run the Ruff formatter.
+              "ruff_format",
+            },
         },
-    },
-})
-```
+    })
+    ```
 
 </details>
 
@@ -297,11 +297,11 @@ require("conform").setup({
 With the <a href="https://github.com/mfussenegger/nvim-lint"><code>nvim-lint</code></a> plugin for Neovim.
 </summary>
 
-```lua
-require("lint").linters_by_ft = {
-  python = { "ruff" },
-}
-```
+    ```lua
+    require("lint").linters_by_ft = {
+      python = { "ruff" },
+    }
+    ```
 
 </details>
 
@@ -326,17 +326,17 @@ IntelliJ Marketplace (maintained by @koxudaxi).
 
 Ruff is available as [`flymake-ruff`](https://melpa.org/#/flymake-ruff) on MELPA:
 
-```elisp
-(require 'flymake-ruff)
-(add-hook 'python-mode-hook #'flymake-ruff-load)
-```
+    ```elisp
+    (require 'flymake-ruff)
+    (add-hook 'python-mode-hook #'flymake-ruff-load)
+    ```
 
 Ruff can be used as a formatter in Emacs using the [Apheleia](https://github.com/radian-software/apheleia) formatter library, by setting this configuration:
 
-```emacs-lisp
-(add-to-list 'apheleia-mode-alist '(python-mode . ruff))
-(add-to-list 'apheleia-mode-alist '(python-ts-mode . ruff))
-```
+    ```emacs-lisp
+    (add-to-list 'apheleia-mode-alist '(python-mode . ruff))
+    (add-to-list 'apheleia-mode-alist '(python-ts-mode . ruff))
+    ```
 
 ## TextMate (Unofficial)
 
@@ -347,26 +347,26 @@ bundle for TextMate.
 
 GitHub Actions has everything you need to run Ruff out-of-the-box:
 
-```yaml
-name: CI
-on: push
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ruff
-      # Update output format to enable automatic inline annotations.
-      - name: Run Ruff
-        run: ruff check --output-format=github .
-```
+    ```yaml
+    name: CI
+    on: push
+    jobs:
+      build:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v3
+          - name: Install Python
+            uses: actions/setup-python@v4
+            with:
+              python-version: "3.11"
+          - name: Install dependencies
+            run: |
+              python -m pip install --upgrade pip
+              pip install ruff
+          # Update output format to enable automatic inline annotations.
+          - name: Run Ruff
+            run: ruff check --output-format=github .
+    ```
 
 Ruff can also be used as a GitHub Action via [`ruff-action`](https://github.com/chartboost/ruff-action).
 
@@ -381,22 +381,22 @@ execute any supported `ruff` command (e.g., `ruff check --fix`).
 To use `ruff-action`, create a file (e.g., `.github/workflows/ruff.yml`) inside your repository
 with:
 
-```yaml
-name: Ruff
-on: [ push, pull_request ]
-jobs:
-  ruff:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: chartboost/ruff-action@v1
-```
+    ```yaml
+    name: Ruff
+    on: [ push, pull_request ]
+    jobs:
+      ruff:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v3
+          - uses: chartboost/ruff-action@v1
+    ```
 
 Alternatively, you can include `ruff-action` as a step in any other workflow file:
 
-```yaml
-      - uses: chartboost/ruff-action@v1
-```
+    ```yaml
+          - uses: chartboost/ruff-action@v1
+    ```
 
 `ruff-action` accepts optional configuration parameters via `with:`, including:
 
@@ -406,10 +406,10 @@ Alternatively, you can include `ruff-action` as a step in any other workflow fil
 
 For example, to run `ruff check --select B ./src` using Ruff version `0.0.259`:
 
-```yaml
-- uses: chartboost/ruff-action@v1
-  with:
-    src: "./src"
-    version: 0.0.259
-    args: --select B
-```
+    ```yaml
+    - uses: chartboost/ruff-action@v1
+      with:
+        src: "./src"
+        version: 0.0.259
+        args: --select B
+    ```

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -10,11 +10,11 @@ and more.
 `ruff check` is the primary entrypoint to the Ruff linter. It accepts a list of files or
 directories, and lints all discovered Python files, optionally fixing any fixable errors:
 
-```shell
-ruff check .          # Lint all files in the current directory.
-ruff check . --fix    # Lint all files in the current directory, and fix any fixable errors.
-ruff check . --watch  # Lint all files in the current directory, and re-lint on change.
-```
+    ```shell
+    ruff check .          # Lint all files in the current directory.
+    ruff check . --fix    # Lint all files in the current directory, and fix any fixable errors.
+    ruff check . --watch  # Lint all files in the current directory, and re-lint on change.
+    ```
 
 For the full list of supported options, run `ruff check --help`.
 
@@ -145,9 +145,9 @@ imports, reformat docstrings, rewrite type annotations to use newer Python synta
 
 To enable fixes, pass the `--fix` flag to `ruff check`:
 
-```shell
-ruff check . --fix
-```
+    ```shell
+    ruff check . --fix
+    ```
 
 By default, Ruff will fix all violations for which safe fixes are available; to determine
 whether a rule supports fixing, see [_Rules_](rules.md).
@@ -161,43 +161,43 @@ For example, [`unnecessary-iterable-allocation-for-first-element`](rules/unneces
 (`RUF015`) is a rule which checks for potentially unperformant use of `list(...)[0]`. The fix
 replaces this pattern with `next(iter(...))` which can result in a drastic speedup:
 
-```shell
-$ python -m timeit "head = list(range(99999999))[0]"
-1 loop, best of 5: 1.69 sec per loop
-```
+    ```shell
+    $ python -m timeit "head = list(range(99999999))[0]"
+    1 loop, best of 5: 1.69 sec per loop
+    ```
 
-```shell
-$ python -m timeit "head = next(iter(range(99999999)))"
-5000000 loops, best of 5: 70.8 nsec per loop
-```
+    ```shell
+    $ python -m timeit "head = next(iter(range(99999999)))"
+    5000000 loops, best of 5: 70.8 nsec per loop
+    ```
 
 However, when the collection is empty, this changes the raised exception from an `IndexError` to `StopIteration`:
 
-```shell
-$ python -c 'list(range(0))[0]'
-Traceback (most recent call last):
-  File "<string>", line 1, in <module>
-IndexError: list index out of range
-```
+    ```shell
+    $ python -c 'list(range(0))[0]'
+    Traceback (most recent call last):
+      File "<string>", line 1, in <module>
+    IndexError: list index out of range
+    ```
 
-```shell
-$ python -c 'next(iter(range(0)))[0]'
-Traceback (most recent call last):
-  File "<string>", line 1, in <module>
-StopIteration
-```
+    ```shell
+    $ python -c 'next(iter(range(0)))[0]'
+    Traceback (most recent call last):
+      File "<string>", line 1, in <module>
+    StopIteration
+    ```
 
 Since this could break error handling, this fix is categorized as unsafe.
 
 Ruff only enables safe fixes by default. Unsafe fixes can be enabled by settings [`unsafe-fixes`](settings.md#unsafe-fixes) in your configuration file or passing the `--unsafe-fixes` flag to `ruff check`:
 
-```shell
-# Show unsafe fixes
-ruff check . --unsafe-fixes
+    ```shell
+    # Show unsafe fixes
+    ruff check . --unsafe-fixes
 
-# Apply unsafe fixes
-ruff check . --fix --unsafe-fixes
-```
+    # Apply unsafe fixes
+    ruff check . --fix --unsafe-fixes
+    ```
 
 The safety of fixes can be adjusted per rule using the [`extend-safe-fixes`](settings.md#extend-safe-fixes) and [`extend-unsafe-fixes`](settings.md#extend-unsafe-fixes) settings.
 
@@ -276,40 +276,40 @@ setting, either on the command-line or in your `pyproject.toml` or `ruff.toml` f
 To suppress a violation inline, Ruff uses a `noqa` system similar to [Flake8](https://flake8.pycqa.org/en/3.1.1/user/ignoring-errors.html).
 To ignore an individual violation, add `# noqa: {code}` to the end of the line, like so:
 
-```python
-# Ignore F841.
-x = 1  # noqa: F841
+    ```python
+    # Ignore F841.
+    x = 1  # noqa: F841
 
-# Ignore E741 and F841.
-i = 1  # noqa: E741, F841
+    # Ignore E741 and F841.
+    i = 1  # noqa: E741, F841
 
-# Ignore _all_ violations.
-x = 1  # noqa
-```
+    # Ignore _all_ violations.
+    x = 1  # noqa
+    ```
 
 For multi-line strings (like docstrings), the `noqa` directive should come at the end of the string
 (after the closing triple quote), and will apply to the entire string, like so:
 
-```python
-"""Lorem ipsum dolor sit amet.
+    ```python
+    """Lorem ipsum dolor sit amet.
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.
-"""  # noqa: E501
-```
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.
+    """  # noqa: E501
+    ```
 
 To ignore all violations across an entire file, add the line `# ruff: noqa` anywhere in the file,
 preferably towards the top, like so:
 
-```python
-# ruff: noqa
-```
+    ```python
+    # ruff: noqa
+    ```
 
 To ignore a specific rule across an entire file, add the line `# ruff: noqa: {code}` anywhere in the
 file, preferably towards the top, like so:
 
-```python
-# ruff: noqa: F841
-```
+    ```python
+    # ruff: noqa: F841
+    ```
 
 Or see the [`per-file-ignores`](settings.md#per-file-ignores) setting, which enables the same
 functionality from within your `pyproject.toml` or `ruff.toml` file.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -7,93 +7,93 @@ your project. For a more detailed overview, see [_Configuring Ruff_](configurati
 
 To start, we'll install Ruff through PyPI (or with your [preferred package manager](installation.md)):
 
-```shell
-pip install ruff
-```
+    ```shell
+    pip install ruff
+    ```
 
 Let's then assume that our project structure looks like:
 
-```text
-numbers
-  ├── __init__.py
-  └── numbers.py
-```
+    ```text
+    numbers
+      ├── __init__.py
+      └── numbers.py
+    ```
 
 ...where `numbers.py` contains the following code:
 
-```py
-from typing import Iterable
+    ```py
+    from typing import Iterable
 
-import os
+    import os
 
 
-def sum_even_numbers(numbers: Iterable[int]) -> int:
-    """Given an iterable of integers, return the sum of all even numbers in the iterable."""
-    return sum(
-        num for num in numbers
-        if num % 2 == 0
-    )
-```
+    def sum_even_numbers(numbers: Iterable[int]) -> int:
+        """Given an iterable of integers, return the sum of all even numbers in the iterable."""
+        return sum(
+            num for num in numbers
+            if num % 2 == 0
+        )
+    ```
 
 We can run the Ruff linter over our project via `ruff check`:
 
-```shell
-❯ ruff check .
-numbers/numbers.py:3:8: F401 [*] `os` imported but unused
-Found 1 error.
-[*] 1 fixable with the `--fix` option.
-```
+    ```shell
+    ❯ ruff check .
+    numbers/numbers.py:3:8: F401 [*] `os` imported but unused
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+    ```
 
 Ruff identified an unused import, which is a common error in Python code. Ruff considers this a
 "fixable" error, so we can resolve the issue automatically by running `ruff check --fix`:
 
-```shell
-❯ ruff check --fix .
-Found 1 error (1 fixed, 0 remaining).
-```
+    ```shell
+    ❯ ruff check --fix .
+    Found 1 error (1 fixed, 0 remaining).
+    ```
 
 Running `git diff` shows the following:
 
-```diff
---- a/numbers/numbers.py
-+++ b/numbers/numbers.py
-@@ -1,7 +1,5 @@
- from typing import Iterable
+    ```diff
+    --- a/numbers/numbers.py
+    +++ b/numbers/numbers.py
+    @@ -1,7 +1,5 @@
+     from typing import Iterable
 
--import os
--
+    -import os
+    -
 
-def sum_even_numbers(numbers: Iterable[int]) -> int:
-    """Given an iterable of integers, return the sum of all even numbers in the iterable."""
-    return sum(
-        num for num in numbers
-        if num % 2 == 0
-    )
-```
+    def sum_even_numbers(numbers: Iterable[int]) -> int:
+        """Given an iterable of integers, return the sum of all even numbers in the iterable."""
+        return sum(
+            num for num in numbers
+            if num % 2 == 0
+        )
+    ```
 
 Now that our project is passing `ruff check`, we can run the Ruff formatter via `ruff format`:
 
-```shell
-❯ ruff format .
-1 file reformatted
-```
+    ```shell
+    ❯ ruff format .
+    1 file reformatted
+    ```
 
 Running `git diff` shows that the `sum` call was reformatted to fit within the default 88-character
 line length limit:
 
-```diff
---- a/numbers.py
-+++ b/numbers.py
-@@ -3,7 +3,4 @@ from typing import Iterable
+    ```diff
+    --- a/numbers.py
+    +++ b/numbers.py
+    @@ -3,7 +3,4 @@ from typing import Iterable
 
- def sum_even_numbers(numbers: Iterable[int]) -> int:
-     """Given an iterable of integers, return the sum of all even numbers in the iterable."""
--    return sum(
--        num for num in numbers
--        if num % 2 == 0
--    )
-+    return sum(num for num in numbers if num % 2 == 0)
-```
+     def sum_even_numbers(numbers: Iterable[int]) -> int:
+         """Given an iterable of integers, return the sum of all even numbers in the iterable."""
+    -    return sum(
+    -        num for num in numbers
+    -        if num % 2 == 0
+    -    )
+    +    return sum(num for num in numbers if num % 2 == 0)
+    ```
 
 Thus far, we've been using Ruff's default configuration. Let's take a look at how we can customize
 Ruff's behavior.
@@ -134,11 +134,11 @@ To configure Ruff, let's create a configuration file in our project's root direc
 
 Running Ruff again, we see that it now enforces a maximum line width, with a limit of 79:
 
-```shell
-❯ ruff check .
-numbers/numbers.py:5:80: E501 Line too long (90 > 79)
-Found 1 error.
-```
+    ```shell
+    ❯ ruff check .
+    numbers/numbers.py:5:80: E501 Line too long (90 > 79)
+    Found 1 error.
+    ```
 
 For a full enumeration of the supported settings, see [_Settings_](settings.md). For our project
 specifically, we'll want to make note of the minimum supported Python version:
@@ -216,12 +216,12 @@ rules, we can set our configuration file to the following:
 If we run Ruff again, we'll see that it now enforces the pyupgrade rules. In particular, Ruff flags
 the use of the deprecated `typing.Iterable` instead of `collections.abc.Iterable`:
 
-```shell
-❯ ruff check .
-numbers/numbers.py:1:1: UP035 [*] Import from `collections.abc` instead: `Iterable`
-Found 1 error.
-[*] 1 fixable with the `--fix` option.
-```
+    ```shell
+    ❯ ruff check .
+    numbers/numbers.py:1:1: UP035 [*] Import from `collections.abc` instead: `Iterable`
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+    ```
 
 Over time, we may choose to enforce additional rules. For example, we may want to enforce that
 all functions have docstrings:
@@ -259,50 +259,50 @@ all functions have docstrings:
 
 If we run Ruff again, we'll see that it now enforces the pydocstyle rules:
 
-```shell
-❯ ruff check .
-numbers/__init__.py:1:1: D104 Missing docstring in public package
-numbers/numbers.py:1:1: UP035 [*] Import from `collections.abc` instead: `Iterable`
-numbers/numbers.py:1:1: D100 Missing docstring in public module
-Found 3 errors.
-[*] 1 fixable with the `--fix` option.
-```
+    ```shell
+    ❯ ruff check .
+    numbers/__init__.py:1:1: D104 Missing docstring in public package
+    numbers/numbers.py:1:1: UP035 [*] Import from `collections.abc` instead: `Iterable`
+    numbers/numbers.py:1:1: D100 Missing docstring in public module
+    Found 3 errors.
+    [*] 1 fixable with the `--fix` option.
+    ```
 
 ### Ignoring Errors
 
 Any lint rule can be ignored by adding a `# noqa` comment to the line in question. For example,
 let's ignore the `UP035` rule for the `Iterable` import:
 
-```py
-from typing import Iterable  # noqa: UP035
+    ```py
+    from typing import Iterable  # noqa: UP035
 
 
-def sum_even_numbers(numbers: Iterable[int]) -> int:
-    """Given an iterable of integers, return the sum of all even numbers in the iterable."""
-    return sum(num for num in numbers if num % 2 == 0)
-```
+    def sum_even_numbers(numbers: Iterable[int]) -> int:
+        """Given an iterable of integers, return the sum of all even numbers in the iterable."""
+        return sum(num for num in numbers if num % 2 == 0)
+    ```
 
 Running `ruff check` again, we'll see that it no longer flags the `Iterable` import:
 
-```shell
-❯ ruff check .
-numbers/__init__.py:1:1: D104 Missing docstring in public package
-numbers/numbers.py:1:1: D100 Missing docstring in public module
-Found 3 errors.
-```
+    ```shell
+    ❯ ruff check .
+    numbers/__init__.py:1:1: D104 Missing docstring in public package
+    numbers/numbers.py:1:1: D100 Missing docstring in public module
+    Found 3 errors.
+    ```
 
 If we want to ignore a rule for an entire file, we can add the line `# ruff: noqa: {code}` anywhere
 in the file, preferably towards the top, like so:
 
-```py
-# ruff: noqa: UP035
-from typing import Iterable
+    ```py
+    # ruff: noqa: UP035
+    from typing import Iterable
 
 
-def sum_even_numbers(numbers: Iterable[int]) -> int:
-    """Given an iterable of integers, return the sum of all even numbers in the iterable."""
-    return sum(num for num in numbers if num % 2 == 0)
-```
+    def sum_even_numbers(numbers: Iterable[int]) -> int:
+        """Given an iterable of integers, return the sum of all even numbers in the iterable."""
+        return sum(num for num in numbers if num % 2 == 0)
+    ```
 
 For more in-depth instructions on ignoring errors, please see [_Error suppression_](linter.md#error-suppression).
 
@@ -315,45 +315,45 @@ Ruff enables this workflow via the `--add-noqa` flag, which will add a `# noqa` 
 line based on its existing violations. We can combine `--add-noqa` with the `--select` command-line
 flag to add `# noqa` directives to all existing `UP035` violations:
 
-```shell
-❯ ruff check --select UP035 --add-noqa .
-Added 1 noqa directive.
-```
+    ```shell
+    ❯ ruff check --select UP035 --add-noqa .
+    Added 1 noqa directive.
+    ```
 
 Running `git diff` shows the following:
 
-```diff
-diff --git a/tutorial/src/main.py b/tutorial/src/main.py
-index b9291c5ca..b9f15b8c1 100644
---- a/numbers/numbers.py
-+++ b/numbers/numbers.py
-@@ -1,4 +1,4 @@
--from typing import Iterable
-+from typing import Iterable  # noqa: UP035
+    ```diff
+    diff --git a/tutorial/src/main.py b/tutorial/src/main.py
+    index b9291c5ca..b9f15b8c1 100644
+    --- a/numbers/numbers.py
+    +++ b/numbers/numbers.py
+    @@ -1,4 +1,4 @@
+    -from typing import Iterable
+    +from typing import Iterable  # noqa: UP035
 
 
- def sum_even_numbers(numbers: Iterable[int]) -> int:
-```
+     def sum_even_numbers(numbers: Iterable[int]) -> int:
+    ```
 
 ## Integrations
 
 This tutorial has focused on Ruff's command-line interface, but Ruff can also be used as a
 [pre-commit](https://pre-commit.com) hook via [`ruff-pre-commit`](https://github.com/astral-sh/ruff-pre-commit):
 
-```yaml
-# Run the Ruff linter.
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.1.4
-  hooks:
-    - id: ruff
-# Run the Ruff formatter.
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.1.4
-  hooks:
-    - id: ruff-format
-```
+    ```yaml
+    # Run the Ruff linter.
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      # Ruff version.
+      rev: v0.1.4
+      hooks:
+        - id: ruff
+    # Run the Ruff formatter.
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      # Ruff version.
+      rev: v0.1.4
+      hooks:
+        - id: ruff-format
+    ```
 
 Ruff can also be used as a [VS Code extension](https://github.com/astral-sh/ruff-vscode) or
 alongside any other editor through the [Ruff LSP](https://github.com/astral-sh/ruff-lsp).


### PR DESCRIPTION
Note, I did not adjust the auto-generated text code blocks in configuration.md as I presumed any changes would be overwritten. To apply the same style for those blocks I presume it would have to be applied from where those blocks are generated. But I was unsure where that was.
