### PR TITLE
Allow RUFF_NO_CACHE environment variable (like RUFF_CACHE_DIR)

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -278,7 +278,7 @@ pub struct CheckCommand {
     #[arg(long, help_heading = "Rule configuration", hide = true)]
     pub dummy_variable_rgx: Option<Regex>,
     /// Disable cache reads.
-    #[arg(short, long, help_heading = "Miscellaneous")]
+    #[arg(short, long, env = "RUFF_NO_CACHE", help_heading = "Miscellaneous")]
     pub no_cache: bool,
     /// Ignore all configuration files.
     #[arg(long, conflicts_with = "config", help_heading = "Miscellaneous")]
@@ -374,7 +374,7 @@ pub struct FormatCommand {
     pub config: Option<PathBuf>,
 
     /// Disable cache reads.
-    #[arg(short, long, help_heading = "Miscellaneous")]
+    #[arg(short, long, env = "RUFF_NO_CACHE", help_heading = "Miscellaneous")]
     pub no_cache: bool,
     /// Path to the cache directory.
     #[arg(long, env = "RUFF_CACHE_DIR", help_heading = "Miscellaneous")]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -466,7 +466,7 @@ File selection:
 
 Miscellaneous:
   -n, --no-cache
-          Disable cache reads
+          Disable cache reads [env: RUFF_NO_CACHE=]
       --isolated
           Ignore all configuration files
       --cache-dir <CACHE_DIR>
@@ -513,7 +513,7 @@ Options:
           Print help
 
 Miscellaneous:
-  -n, --no-cache                         Disable cache reads
+  -n, --no-cache                         Disable cache reads [env: RUFF_NO_CACHE=]
       --cache-dir <CACHE_DIR>            Path to the cache directory [env: RUFF_CACHE_DIR=]
       --isolated                         Ignore all configuration files
       --stdin-filename <STDIN_FILENAME>  The name of the file when passing it through stdin


### PR DESCRIPTION
## Summary

Being able to set `--no-cache` without touching the command line makes comparing formatter speed with e.g. Hyperfine a lot easier; Black allows one to set `BLACK_CACHE_DIR=/dev/null`, but setting `RUFF_CACHE_DIR=/dev/null` has Ruff choke:

```
error: Failed to initialize cache at /dev/null: Not a directory (os error 20)
error: Failed to initialize cache at /dev/null: Not a directory (os error 20)
warning: Failed to open cache file '/dev/null/0.1.4/18160934645386409287': Not a directory (os error 20)
```

Alternately, we could make a `/dev/null` (or `nul` on Windows) cache directory imply `--no-cache`?

## Test Plan

None yet.