### PR TITLE
Improve detail link contrast in dark mode

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -36,7 +36,7 @@
   --md-default-fg-color--lighter: var(--white);
   --md-primary-fg-color: var(--space);
   --md-primary-bg-color: var(--white);
-  --md-accent-fg-color: var(--radiate);
+  --md-accent-fg-color: var(--cosmic);
 
   --md-typeset-color: var(--white);
   --md-typeset-a-color: var(--radiate);
@@ -91,4 +91,9 @@
 }
 .md-typeset table:not([class]) {
   display: table;
+}
+
+/* See: https://github.com/astral-sh/ruff/issues/8519 */
+[data-md-color-scheme="astral-dark"] details summary a {
+  color: var(--flare);
 }


### PR DESCRIPTION
Use our light-mode styling for links in that context.

<img width="627" alt="Screen Shot 2023-11-07 at 4 34 48 PM" src="https://github.com/astral-sh/ruff/assets/1309177/1e30c3ac-18e2-4663-876c-75c6f8b67d53">

Closes https://github.com/astral-sh/ruff/issues/8519.