### PR TITLE
Doc: Fix link to isort `known-first-party`

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -262,7 +262,7 @@ Like isort, Ruff's import sorting is compatible with Black.
 
 Ruff does not yet support all of isort's configuration options, though it does support many of
 them. You can find the supported settings in the [API reference](settings.md#isort).
-For example, you can set [`known-first-party`](settings.md#known-first-party--isort-known-first-party-)
+For example, you can set [`known-first-party`](settings.md#isort-known-first-party)
 like so:
 
 === "pyproject.toml"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Fix link in the documentation to isort's `known-first-party`.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

None
<!-- How was it tested? -->
