### PR TITLE
Revert "Avoid inserting trailing commas within f-strings"

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_commas/COM81.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_commas/COM81.py
@@ -42,7 +42,7 @@ foo = (
 4,
 )
 
-foo = 3,
+foo = 3, 
 
 class A(object):
  foo = 3
@@ -639,10 +639,3 @@ foo = namedtuple(
         :20
     ],
 )
-
-# Make sure we don't insert commas within f-strings.
-f"""This is a test. {
-    "Another sentence."
-    if True else
-    "Alternative route!"
-}"""

--- a/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
+++ b/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
@@ -223,24 +223,11 @@ pub(crate) fn trailing_commas(
     tokens: &[LexResult],
     locator: &Locator,
 ) {
-    let mut fstrings = 0u32;
     let tokens = tokens
         .iter()
         .flatten()
-        .filter(|(tok, _)| match tok {
-            // Completely ignore comments -- they just interfere with the logic.
-            Tok::Comment(_) => false,
-            // Ignore content within f-strings.
-            Tok::FStringStart => {
-                fstrings = fstrings.saturating_add(1);
-                false
-            }
-            Tok::FStringEnd => {
-                fstrings = fstrings.saturating_sub(1);
-                false
-            }
-            _ => fstrings == 0,
-        })
+        // Completely ignore comments -- they just interfere with the logic.
+        .filter(|&r| !matches!(r, (Tok::Comment(_), _)))
         .map(Token::from_spanned);
     let tokens = [Token::irrelevant(), Token::irrelevant()]
         .into_iter()

--- a/crates/ruff_linter/src/rules/flake8_commas/snapshots/ruff_linter__rules__flake8_commas__tests__COM81.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_commas/snapshots/ruff_linter__rules__flake8_commas__tests__COM81.py.snap
@@ -106,7 +106,7 @@ COM81.py:45:8: COM818 Trailing comma on bare tuple prohibited
    |
 43 | )
 44 | 
-45 | foo = 3,
+45 | foo = 3, 
    |        ^ COM818
 46 | 
 47 | class A(object):


### PR DESCRIPTION
Reverts astral-sh/ruff#8574. This caused a bunch of ecosystem changes -- needs more work.