### PR TITLE
Support local and dynamic class- and static-method decorators

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N805.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N805.py
@@ -63,3 +63,33 @@ class PosOnlyClass:
 
     def bad_method_pos_only(this, blah, /, self, something: str):
         pass
+
+
+class ModelClass:
+    @hybrid_property
+    def bad(cls):
+        pass
+
+    @bad.expression
+    def bad(self):
+        pass
+
+    @bad.wtf
+    def bad(cls):
+        pass
+
+    @hybrid_property
+    def good(self):
+        pass
+
+    @good.expression
+    def good(cls):
+        pass
+
+    @good.wtf
+    def good(self):
+        pass
+
+    @foobar.thisisstatic
+    def badstatic(foo):
+        pass

--- a/crates/ruff_linter/src/rules/pep8_naming/mod.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/mod.rs
@@ -96,6 +96,26 @@ mod tests {
                     classmethod_decorators: vec![
                         "classmethod".to_string(),
                         "pydantic.validator".to_string(),
+                        "expression".to_string(),
+                    ],
+                    ..Default::default()
+                },
+                ..settings::LinterSettings::for_rule(Rule::InvalidFirstArgumentNameForMethod)
+            },
+        )?;
+        assert_messages!(diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn staticmethod_decorators() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("pep8_naming").join("N805.py").as_path(),
+            &settings::LinterSettings {
+                pep8_naming: pep8_naming::settings::Settings {
+                    staticmethod_decorators: vec![
+                        "staticmethod".to_string(),
+                        "thisisstatic".to_string(),
                     ],
                     ..Default::default()
                 },

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__classmethod_decorators.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__classmethod_decorators.snap
@@ -27,4 +27,29 @@ N805.py:64:29: N805 First argument of a method should be named `self`
 65 |         pass
    |
 
+N805.py:70:13: N805 First argument of a method should be named `self`
+   |
+68 | class ModelClass:
+69 |     @hybrid_property
+70 |     def bad(cls):
+   |             ^^^ N805
+71 |         pass
+   |
+
+N805.py:78:13: N805 First argument of a method should be named `self`
+   |
+77 |     @bad.wtf
+78 |     def bad(cls):
+   |             ^^^ N805
+79 |         pass
+   |
+
+N805.py:94:19: N805 First argument of a method should be named `self`
+   |
+93 |     @foobar.thisisstatic
+94 |     def badstatic(foo):
+   |                   ^^^ N805
+95 |         pass
+   |
+
 

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__staticmethod_decorators.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__staticmethod_decorators.snap
@@ -68,12 +68,4 @@ N805.py:86:14: N805 First argument of a method should be named `self`
 87 |         pass
    |
 
-N805.py:94:19: N805 First argument of a method should be named `self`
-   |
-93 |     @foobar.thisisstatic
-94 |     def badstatic(foo):
-   |                   ^^^ N805
-95 |         pass
-   |
-
 

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2248,8 +2248,14 @@ pub struct Pep8NamingOptions {
         default = r#"[]"#,
         value_type = "list[str]",
         example = r#"
-            # Allow Pydantic's `@validator` decorator to trigger class method treatment.
-            classmethod-decorators = ["pydantic.validator"]
+            classmethod-decorators = [
+                # Allow Pydantic's `@validator` decorator to trigger class method treatment.
+                "pydantic.validator",
+                # Allow SQLAlchemy's dynamic decorators, like `@field.expression`, to trigger class method treatment.
+                "declared_attr",
+                "expression",
+                "comparator",
+            ]
         "#
     )]
     pub classmethod_decorators: Option<Vec<String>>,

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2242,7 +2242,8 @@ pub struct Pep8NamingOptions {
     /// in this list takes a `cls` argument as its first argument.
     ///
     /// Expects to receive a list of fully-qualified names (e.g., `pydantic.validator`,
-    /// rather than `validator`).
+    /// rather than `validator`) or alternatively a plain name which is then matched against
+    /// the last segment in case the decorator itself consists of a dotted name.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",
@@ -2261,7 +2262,8 @@ pub struct Pep8NamingOptions {
     /// in this list has no `self` or `cls` argument.
     ///
     /// Expects to receive a list of fully-qualified names (e.g., `belay.Device.teardown`,
-    /// rather than `teardown`).
+    /// rather than `teardown`) or alternatively a plain name which is then matched against
+    /// the last segment in case the decorator itself consists of a dotted name.
     #[option(
         default = r#"[]"#,
         value_type = "list[str]",

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -2147,7 +2147,7 @@
       "type": "object",
       "properties": {
         "classmethod-decorators": {
-          "description": "A list of decorators that, when applied to a method, indicate that the method should be treated as a class method (in addition to the builtin `@classmethod`).\n\nFor example, Ruff will expect that any method decorated by a decorator in this list takes a `cls` argument as its first argument.\n\nExpects to receive a list of fully-qualified names (e.g., `pydantic.validator`, rather than `validator`).",
+          "description": "A list of decorators that, when applied to a method, indicate that the method should be treated as a class method (in addition to the builtin `@classmethod`).\n\nFor example, Ruff will expect that any method decorated by a decorator in this list takes a `cls` argument as its first argument.\n\nExpects to receive a list of fully-qualified names (e.g., `pydantic.validator`, rather than `validator`) or alternatively a plain name which is then matched against the last segment in case the decorator itself consists of a dotted name.",
           "type": [
             "array",
             "null"
@@ -2177,7 +2177,7 @@
           }
         },
         "staticmethod-decorators": {
-          "description": "A list of decorators that, when applied to a method, indicate that the method should be treated as a static method (in addition to the builtin `@staticmethod`).\n\nFor example, Ruff will expect that any method decorated by a decorator in this list has no `self` or `cls` argument.\n\nExpects to receive a list of fully-qualified names (e.g., `belay.Device.teardown`, rather than `teardown`).",
+          "description": "A list of decorators that, when applied to a method, indicate that the method should be treated as a static method (in addition to the builtin `@staticmethod`).\n\nFor example, Ruff will expect that any method decorated by a decorator in this list has no `self` or `cls` argument.\n\nExpects to receive a list of fully-qualified names (e.g., `belay.Device.teardown`, rather than `teardown`) or alternatively a plain name which is then matched against the last segment in case the decorator itself consists of a dotted name.",
           "type": [
             "array",
             "null"


### PR DESCRIPTION
## Summary

This brings ruff's behavior in line with what `pep8-naming` already does and thus closes #8397.

I had initially implemented this to look at the last segment of a dotted path only when the entry in the `*-decorators` setting started with a `.`, but in the end I thought it's better to remain consistent w/ `pep8-naming` and doing a match against the last segment of the decorator name in any case.

If you prefer to diverge from this in favor of less ambiguity in the configuration let me know and I'll change it so you would need to put e.g. `.expression` in the `classmethod-decorators` list.

## Test Plan

Tested against the file in the issue linked below, plus the new testcase added in this PR.
