### PR TITLE
remove several uses of `unsafe`

### DIFF
--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -2555,17 +2555,17 @@ pub struct BestFitting<'a, Context> {
 }
 
 impl<'a, Context> BestFitting<'a, Context> {
-    /// Creates a new best fitting IR with the given variants. The method itself isn't unsafe
-    /// but it is to discourage people from using it because the printer will panic if
-    /// the slice doesn't contain at least the least and most expanded variants.
+    /// Creates a new best fitting IR with the given variants.
+    ///
+    /// Callers are required to ensure that the number of variants given
+    /// is at least 2.
     ///
     /// You're looking for a way to create a `BestFitting` object, use the `best_fitting![least_expanded, most_expanded]` macro.
     ///
-    /// ## Safety
-
-    /// The slice must contain at least two variants.
-    #[allow(unsafe_code)]
-    pub unsafe fn from_arguments_unchecked(variants: Arguments<'a, Context>) -> Self {
+    /// # Panics
+    ///
+    /// When the slice contains less than two variants.
+    pub fn from_arguments_unchecked(variants: Arguments<'a, Context>) -> Self {
         assert!(
             variants.0.len() >= 2,
             "Requires at least the least expanded and most expanded variants"
@@ -2696,14 +2696,12 @@ impl<Context> Format<Context> for BestFitting<'_, Context> {
             buffer.write_element(FormatElement::Tag(EndBestFittingEntry));
         }
 
-        // SAFETY: The constructor guarantees that there are always at least two variants. It's, therefore,
-        // safe to call into the unsafe `from_vec_unchecked` function
-        #[allow(unsafe_code)]
-        let element = unsafe {
-            FormatElement::BestFitting {
-                variants: BestFittingVariants::from_vec_unchecked(buffer.into_vec()),
-                mode: self.mode,
-            }
+        // OK because the constructor guarantees that there are always at
+        // least two variants.
+        let variants = BestFittingVariants::from_vec_unchecked(buffer.into_vec());
+        let element = FormatElement::BestFitting {
+            variants,
+            mode: self.mode,
         };
 
         f.write_element(element);

--- a/crates/ruff_formatter/src/macros.rs
+++ b/crates/ruff_formatter/src/macros.rs
@@ -329,10 +329,8 @@ macro_rules! format {
 #[macro_export]
 macro_rules! best_fitting {
     ($least_expanded:expr, $($tail:expr),+ $(,)?) => {{
-        #[allow(unsafe_code)]
-        unsafe {
-            $crate::BestFitting::from_arguments_unchecked($crate::format_args!($least_expanded, $($tail),+))
-        }
+        // OK because the macro syntax requires at least two variants.
+        $crate::BestFitting::from_arguments_unchecked($crate::format_args!($least_expanded, $($tail),+))
     }}
 }
 

--- a/crates/ruff_macros/src/newtype_index.rs
+++ b/crates/ruff_macros/src/newtype_index.rs
@@ -45,6 +45,9 @@ pub(super) fn generate_newtype_index(item: ItemStruct) -> syn::Result<proc_macro
                 // SAFETY:
                 // * The `value < u32::MAX` guarantees that the add doesn't overflow.
                 // * The `+ 1` guarantees that the index is not zero
+                //
+                // N.B. We have to use the unchecked variant here because we're
+                // in a const context and Option::unwrap isn't const yet.
                 #[allow(unsafe_code)]
                 Self(unsafe { std::num::NonZeroU32::new_unchecked((value as u32) + 1) })
             }
@@ -55,6 +58,9 @@ pub(super) fn generate_newtype_index(item: ItemStruct) -> syn::Result<proc_macro
                 // SAFETY:
                 // * The `value < u32::MAX` guarantees that the add doesn't overflow.
                 // * The `+ 1` guarantees that the index is larger than zero.
+                //
+                // N.B. We have to use the unchecked variant here because we're
+                // in a const context and Option::unwrap isn't const yet.
                 #[allow(unsafe_code)]
                 Self(unsafe { std::num::NonZeroU32::new_unchecked(value + 1) })
             }

--- a/crates/ruff_python_formatter/src/comments/map.rs
+++ b/crates/ruff_python_formatter/src/comments/map.rs
@@ -539,11 +539,11 @@ struct PartIndex(NonZeroU32);
 impl PartIndex {
     fn from_len(value: usize) -> Self {
         assert!(value < u32::MAX as usize);
-        // SAFETY:
+        // OK because:
         // * The `value < u32::MAX` guarantees that the add doesn't overflow.
         // * The `+ 1` guarantees that the index is not zero
-        #[allow(unsafe_code, clippy::cast_possible_truncation)]
-        Self(unsafe { std::num::NonZeroU32::new_unchecked((value as u32) + 1) })
+        #[allow(clippy::cast_possible_truncation)]
+        Self(std::num::NonZeroU32::new((value as u32) + 1).expect("valid value"))
     }
 
     fn value(self) -> usize {

--- a/crates/ruff_python_formatter/src/expression/binary_like.rs
+++ b/crates/ruff_python_formatter/src/expression/binary_like.rs
@@ -1105,9 +1105,8 @@ impl OperatorIndex {
     fn new(index: usize) -> Self {
         assert_eq!(index % 2, 1, "Operator indices must be odd positions");
 
-        // SAFETY A value with a module 0 is guaranteed to never equal 0
-        #[allow(unsafe_code)]
-        Self(unsafe { NonZeroUsize::new_unchecked(index) })
+        // OK because a value with a modulo 1 is guaranteed to never equal 0
+        Self(NonZeroUsize::new(index).expect("valid index"))
     }
 
     const fn value(self) -> usize {

--- a/crates/ruff_python_literal/src/escape.rs
+++ b/crates/ruff_python_literal/src/escape.rs
@@ -415,12 +415,10 @@ impl<'a> Escape for AsciiEscape<'a> {
     fn layout(&self) -> &EscapeLayout {
         &self.layout
     }
-    #[allow(unsafe_code)]
     fn write_source(&self, formatter: &mut impl std::fmt::Write) -> std::fmt::Result {
-        formatter.write_str(unsafe {
-            // SAFETY: this function must be called only when source is printable ascii characters
-            std::str::from_utf8_unchecked(self.source)
-        })
+        // OK because function must be called only when source is printable ascii characters.
+        let string = std::str::from_utf8(self.source).expect("ASCII bytes");
+        formatter.write_str(string)
     }
 
     #[cold]

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -120,10 +120,8 @@ impl<'a> StringParser<'a> {
             len += 1;
         }
 
-        // SAFETY: radix_bytes is always going to be in the ASCII range.
-        #[allow(unsafe_code)]
-        let radix_str = unsafe { std::str::from_utf8_unchecked(&radix_bytes[..len]) };
-
+        // OK because radix_bytes is always going to be in the ASCII range.
+        let radix_str = std::str::from_utf8(&radix_bytes[..len]).expect("ASCII bytes");
         let value = u32::from_str_radix(radix_str, 8).unwrap();
         char::from_u32(value).unwrap()
     }

--- a/crates/ruff_source_file/src/newlines.rs
+++ b/crates/ruff_source_file/src/newlines.rs
@@ -58,11 +58,7 @@ impl<'a> UniversalNewlineIterator<'a> {
 pub fn find_newline(text: &str) -> Option<(usize, LineEnding)> {
     let bytes = text.as_bytes();
     if let Some(position) = memchr2(b'\n', b'\r', bytes) {
-        // SAFETY: memchr guarantees to return valid positions
-        #[allow(unsafe_code)]
-        let newline_character = unsafe { *bytes.get_unchecked(position) };
-
-        let line_ending = match newline_character {
+        let line_ending = match bytes[position] {
             // Explicit branch for `\n` as this is the most likely path
             b'\n' => LineEnding::Lf,
             // '\r\n'


### PR DESCRIPTION
This PR removes several uses of `unsafe`. I generally limited myself to low hanging fruit that I could see. There are still a few remaining uses of `unsafe` that looked a bit more difficult to remove (if possible at all). But this gets rid of a good chunk of them.

I put each `unsafe` removal into its own commit with a justification for why I did it. So I would encourage reviewing this PR commit-by-commit. That way, we can legislate them independently. It's no problem to drop a commit if we feel the `unsafe` should stay in that case.