### PR TITLE
Fix docs typo for `ruff format` preview configuration

### DIFF
--- a/docs/preview.md
+++ b/docs/preview.md
@@ -32,14 +32,14 @@ To enable preview style formatting without enabling any preview lint rules:
 === "pyproject.toml"
 
     ```toml
-    [tool.ruff.preview]
+    [tool.ruff.format]
     preview = true
     ```
 
 === "ruff.toml"
 
     ```toml
-    [preview]
+    [format]
     preview = true
     ```
 


### PR DESCRIPTION
## Summary

The ruff configuration section is called "format", rather than "preview". Using the configuration as it was written in the docs gives an error:

```
$ ruff format --check .
ruff failed
  Cause: TOML parse error at line 143, column 1
    |
143 | [tool.ruff.preview]
    | ^^^^^^^^^^^^^^^^^^^
invalid type: map, expected a boolean
```

## Test Plan

Tested running `ruff format` with the following in my `pyproject.toml`:

```toml
[tool.ruff.format]
preview = true
```

and it worked properly (using preview rules for formatting).