### PR TITLE
Remove unecessary commentary in PD901 message

### DIFF
--- a/crates/ruff_linter/src/rules/pandas_vet/rules/assignment_to_df.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/assignment_to_df.rs
@@ -33,7 +33,7 @@ pub struct PandasDfVariableName;
 impl Violation for PandasDfVariableName {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`df` is a bad variable name. Be kinder to your future self.")
+        format!("`df` is a bad variable name.")
     }
 }
 

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/assignment_to_df.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/assignment_to_df.rs
@@ -33,7 +33,7 @@ pub struct PandasDfVariableName;
 impl Violation for PandasDfVariableName {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("`df` is a bad variable name.")
+        format!("Avoid using the generic variable name `df` for DataFrames")
     }
 }
 

--- a/crates/ruff_linter/src/rules/pandas_vet/snapshots/ruff_linter__rules__pandas_vet__tests__PD901_fail_df_var.snap
+++ b/crates/ruff_linter/src/rules/pandas_vet/snapshots/ruff_linter__rules__pandas_vet__tests__PD901_fail_df_var.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pandas_vet/mod.rs
 ---
-<filename>:3:1: PD901 `df` is a bad variable name. Be kinder to your future self.
+<filename>:3:1: PD901 `df` is a bad variable name.
   |
 2 | import pandas as pd
 3 | df = pd.DataFrame()

--- a/crates/ruff_linter/src/rules/pandas_vet/snapshots/ruff_linter__rules__pandas_vet__tests__PD901_fail_df_var.snap
+++ b/crates/ruff_linter/src/rules/pandas_vet/snapshots/ruff_linter__rules__pandas_vet__tests__PD901_fail_df_var.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pandas_vet/mod.rs
 ---
-<filename>:3:1: PD901 `df` is a bad variable name.
+<filename>:3:1: PD901 Avoid using the generic variable name `df` for DataFrames
   |
 2 | import pandas as pd
 3 | df = pd.DataFrame()


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Removes unnecessary commentary from the PD901 message. This does make it different from pandas-vet, but it improves consistency with the rest of messages.

Current Message:

> `df` is a bad variable name. Be kinder to your future self.


New Message

> `df` is a bad variable name.


## Test Plan

The relevant snapshot has been updated with the new message.


