### PR TITLE
Redirect from rule codes to rule pages in docs

### DIFF
--- a/docs/requirements-insiders.txt
+++ b/docs/requirements-insiders.txt
@@ -2,3 +2,4 @@ PyYAML==6.0.1
 black==23.10.0
 mkdocs==1.5.0
 git+ssh://git@github.com/astral-sh/mkdocs-material-insiders.git@38c0b8187325c3bab386b666daf3518ac036f2f4
+mkdocs-redirects==1.2.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ PyYAML==6.0.1
 black==23.10.0
 mkdocs==1.5.0
 mkdocs-material==9.1.18
+mkdocs-redirects==1.2.1

--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -1,4 +1,1 @@
 INHERIT: mkdocs.generated.yml
-plugins:
-  - search
-  - typeset

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -60,6 +60,7 @@ markdown_extensions:
       alternate_style: true
 plugins:
   - search
+  - typeset
 extra_css:
   - stylesheets/extra.css
 not_in_nav: |

--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import shutil
 import subprocess
@@ -138,9 +139,37 @@ def main() -> None:
 
             f.write(clean_file_content(file_content, title))
 
-    # Add the nav section to mkdocs.yml.
     with Path("mkdocs.template.yml").open(encoding="utf8") as fp:
         config = yaml.safe_load(fp)
+
+    # Add the redirect section to mkdocs.yml.
+    rules = json.loads(
+        subprocess.check_output(
+            [
+                "cargo",
+                "run",
+                "-p",
+                "ruff_cli",
+                "--",
+                "rule",
+                "--all",
+                "--output-format",
+                "json",
+            ],
+        ),
+    )
+    config["plugins"].append(
+        {
+            "redirects": {
+                "redirect_maps": {
+                    f'rules/{rule["code"]}.md': f'rules/{rule["name"]}.md'
+                    for rule in rules
+                },
+            },
+        },
+    )
+
+    # Add the nav section to mkdocs.yml.
     config["nav"] = [{section.title: section.filename} for section in SECTIONS]
 
     with Path("mkdocs.generated.yml").open("w+") as fp:


### PR DESCRIPTION
## Summary

This adds redirects from, e.g., `https://docs.astral.sh/ruff/rules/F401` to `https://docs.astral.sh/ruff/rules/unused-import`, which are generated automatically when creating the documentation. Though we want to move towards human-readable names eventually, I think this is a nice and user-friendly change (and doesn't require any fancy infrastructure, since the redirects are handled via a plugin and added client-side).

Closes #4710.
