### PR TITLE
Use function range for `no-self-use`

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
@@ -1,12 +1,12 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::{from_qualified_name, CallPath};
+use ruff_python_ast::identifier::Identifier;
 use ruff_python_ast::{self as ast, ParameterWithDefault};
 use ruff_python_semantic::{
     analyze::{function_type, visibility},
     Scope, ScopeId, ScopeKind,
 };
-use ruff_text_size::Ranged;
 
 use crate::{checkers::ast::Checker, rules::flake8_unused_arguments::helpers};
 
@@ -53,16 +53,17 @@ pub(crate) fn no_self_use(
         return;
     };
 
-    let ScopeKind::Function(ast::StmtFunctionDef {
+    let ScopeKind::Function(func) = scope.kind else {
+        return;
+    };
+
+    let ast::StmtFunctionDef {
         name,
         parameters,
         body,
         decorator_list,
         ..
-    }) = scope.kind
-    else {
-        return;
-    };
+    } = func;
 
     if !matches!(
         function_type::classify(
@@ -135,7 +136,7 @@ pub(crate) fn no_self_use(
             NoSelfUse {
                 method_name: name.to_string(),
             },
-            parameter.range(),
+            func.identifier(),
         ));
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR6301_no_self_use.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR6301_no_self_use.py.snap
@@ -1,29 +1,29 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-no_self_use.py:7:28: PLR6301 Method `developer_greeting` could be a function, class method, or static method
+no_self_use.py:7:9: PLR6301 Method `developer_greeting` could be a function, class method, or static method
   |
 6 | class Person:
 7 |     def developer_greeting(self, name):  # [no-self-use]
-  |                            ^^^^ PLR6301
+  |         ^^^^^^^^^^^^^^^^^^ PLR6301
 8 |         print(f"Greetings {name}!")
   |
 
-no_self_use.py:10:20: PLR6301 Method `greeting_1` could be a function, class method, or static method
+no_self_use.py:10:9: PLR6301 Method `greeting_1` could be a function, class method, or static method
    |
  8 |         print(f"Greetings {name}!")
  9 | 
 10 |     def greeting_1(self):  # [no-self-use]
-   |                    ^^^^ PLR6301
+   |         ^^^^^^^^^^ PLR6301
 11 |         print("Hello!")
    |
 
-no_self_use.py:13:20: PLR6301 Method `greeting_2` could be a function, class method, or static method
+no_self_use.py:13:9: PLR6301 Method `greeting_2` could be a function, class method, or static method
    |
 11 |         print("Hello!")
 12 | 
 13 |     def greeting_2(self):  # [no-self-use]
-   |                    ^^^^ PLR6301
+   |         ^^^^^^^^^^ PLR6301
 14 |         print("Hi!")
    |
 


### PR DESCRIPTION
Previously, this rule used the range of the `self` annotation, but it's a lot more natural to use the range of the function name (since it also means the `# noqa` is associated with the method rather than its first argument).

Closes https://github.com/astral-sh/ruff/issues/8635.