### PR TITLE
Add autofix for PIE800

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE800.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE800.py
@@ -1,8 +1,20 @@
 {"foo": 1, **{"bar": 1}}  # PIE800
 
+{**{"bar": 10}, "a": "b"}  # PIE800
+
 foo({**foo, **{"bar": True}})  # PIE800
 
 {**foo, **{"bar": 10}}  # PIE800
+
+{ # PIE800
+    "a": "b",
+    # Preserve
+    **{
+        # all
+        "bar": 10,  # the
+        # comments
+    },
+}
 
 {**foo, **buzz, **{bar: 10}}  # PIE800
 

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -936,13 +936,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 flake8_trio::rules::zero_sleep_call(checker, call);
             }
         }
-        Expr::Dict(
-            dict @ ast::ExprDict {
-                keys,
-                values,
-                range: _,
-            },
-        ) => {
+        Expr::Dict(dict) => {
             if checker.any_enabled(&[
                 Rule::MultiValueRepeatedKeyLiteral,
                 Rule::MultiValueRepeatedKeyVariable,
@@ -950,7 +944,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 pyflakes::rules::repeated_keys(checker, dict);
             }
             if checker.enabled(Rule::UnnecessarySpread) {
-                flake8_pie::rules::unnecessary_spread(checker, keys, values);
+                flake8_pie::rules::unnecessary_spread(checker, dict);
             }
         }
         Expr::Set(ast::ExprSet { elts, range: _ }) => {

--- a/crates/ruff_linter/src/rules/flake8_pie/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/mod.rs
@@ -32,6 +32,7 @@ mod tests {
     }
 
     #[test_case(Rule::UnnecessaryPlaceholder, Path::new("PIE790.py"))]
+    #[test_case(Rule::UnnecessarySpread, Path::new("PIE800.py"))]
     #[test_case(Rule::ReimplementedContainerBuiltin, Path::new("PIE807.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_spread.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_spread.rs
@@ -2,6 +2,7 @@ use ruff_python_ast::Expr;
 
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_trivia::{BackwardsTokenizer, SimpleTokenKind};
 use ruff_text_size::{Ranged, TextSize};
 
 use crate::checkers::ast::Checker;
@@ -49,22 +50,56 @@ pub(crate) fn unnecessary_spread(checker: &mut Checker, keys: &[Option<Expr>], v
         if let (None, value) = item {
             // We only care about when the key is None which indicates a spread `**`
             // inside a dict.
-            if let Expr::Dict(_) = value {
+            if let Expr::Dict(dict) = value {
                 let mut diagnostic = Diagnostic::new(UnnecessarySpread, value.range());
                 if checker.settings.preview.is_enabled() {
-                    let range = value.range();
-                    // unwrap -- `item.0 == None` iff this is a spread operator
-                    // which means there *must* be a `**` here
-                    let doublestar = checker.locator().up_to(range.start()).rfind("**").unwrap();
-                    diagnostic.set_fix(Fix::safe_edits(
-                        // delete the `**{`
-                        Edit::deletion(
-                            TextSize::from(doublestar as u32),
-                            range.start() + TextSize::from(1),
-                        ),
-                        // delete the `}`
-                        [Edit::deletion(range.end() - TextSize::from(1), range.end())],
-                    ));
+                    // Delete the `**{`
+                    let tokenizer = BackwardsTokenizer::up_to(
+                        dict.range.start(),
+                        checker.locator().contents(),
+                        &[],
+                    );
+                    let mut start = None;
+                    for tok in tokenizer {
+                        if let SimpleTokenKind::DoubleStar = tok.kind() {
+                            start = Some(tok.range.start());
+                            break;
+                        }
+                    }
+                    // unwrap is ok, b/c item.0 can't be None without a DoubleStar
+                    let first =
+                        Edit::deletion(start.unwrap(), dict.range.start() + TextSize::from(1));
+
+                    // Delete the `}` (and possibly a trailing comma) but preserve comments
+                    let mut edits = Vec::with_capacity(1);
+                    let mut end = dict.range.end();
+
+                    let tokenizer = BackwardsTokenizer::up_to(
+                        dict.range.end() - TextSize::from(1),
+                        checker.locator().contents(),
+                        &[],
+                    );
+                    for tok in tokenizer {
+                        match tok.kind() {
+                            SimpleTokenKind::Comment => {
+                                if tok.range.end() != end {
+                                    edits.push(Edit::deletion(tok.range.end(), end));
+                                }
+                                end = tok.range.start();
+                            }
+                            SimpleTokenKind::Comma
+                            | SimpleTokenKind::Whitespace
+                            | SimpleTokenKind::Newline
+                            | SimpleTokenKind::Continuation => {}
+                            _ => {
+                                if tok.range.end() != end {
+                                    edits.push(Edit::deletion(tok.range.end(), end));
+                                }
+                                break;
+                            }
+                        }
+                    }
+                    diagnostic.set_fix(Fix::safe_edits(first, edits));
                 }
                 checker.diagnostics.push(diagnostic);
             }

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_spread.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_spread.rs
@@ -1,9 +1,8 @@
 use ruff_python_ast::Expr;
 
-use ruff_diagnostics::Diagnostic;
-use ruff_diagnostics::Violation;
+use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_text_size::Ranged;
+use ruff_text_size::{Ranged, TextSize};
 
 use crate::checkers::ast::Checker;
 
@@ -32,9 +31,15 @@ use crate::checkers::ast::Checker;
 pub struct UnnecessarySpread;
 
 impl Violation for UnnecessarySpread {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("Unnecessary spread `**`")
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some(format!("Remove unnecessary dict"))
     }
 }
 
@@ -45,7 +50,22 @@ pub(crate) fn unnecessary_spread(checker: &mut Checker, keys: &[Option<Expr>], v
             // We only care about when the key is None which indicates a spread `**`
             // inside a dict.
             if let Expr::Dict(_) = value {
-                let diagnostic = Diagnostic::new(UnnecessarySpread, value.range());
+                let mut diagnostic = Diagnostic::new(UnnecessarySpread, value.range());
+                if checker.settings.preview.is_enabled() {
+                    let range = value.range();
+                    // unwrap -- `item.0 == None` iff this is a spread operator
+                    // which means there *must* be a `**` here
+                    let doublestar = checker.locator().up_to(range.start()).rfind("**").unwrap();
+                    diagnostic.set_fix(Fix::safe_edits(
+                        // delete the `**{`
+                        Edit::deletion(
+                            TextSize::from(doublestar as u32),
+                            range.start() + TextSize::from(1),
+                        ),
+                        // delete the `}`
+                        [Edit::deletion(range.end() - TextSize::from(1), range.end())],
+                    ));
+                }
                 checker.diagnostics.push(diagnostic);
             }
         }

--- a/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE800_PIE800.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE800_PIE800.py.snap
@@ -6,41 +6,67 @@ PIE800.py:1:14: PIE800 Unnecessary spread `**`
 1 | {"foo": 1, **{"bar": 1}}  # PIE800
   |              ^^^^^^^^^^ PIE800
 2 | 
-3 | foo({**foo, **{"bar": True}})  # PIE800
+3 | {**{"bar": 10}, "a": "b"}  # PIE800
   |
   = help: Remove unnecessary dict
 
-PIE800.py:3:15: PIE800 Unnecessary spread `**`
+PIE800.py:3:4: PIE800 Unnecessary spread `**`
   |
 1 | {"foo": 1, **{"bar": 1}}  # PIE800
 2 | 
-3 | foo({**foo, **{"bar": True}})  # PIE800
+3 | {**{"bar": 10}, "a": "b"}  # PIE800
+  |    ^^^^^^^^^^^ PIE800
+4 | 
+5 | foo({**foo, **{"bar": True}})  # PIE800
+  |
+  = help: Remove unnecessary dict
+
+PIE800.py:5:15: PIE800 Unnecessary spread `**`
+  |
+3 | {**{"bar": 10}, "a": "b"}  # PIE800
+4 | 
+5 | foo({**foo, **{"bar": True}})  # PIE800
   |               ^^^^^^^^^^^^^ PIE800
-4 | 
-5 | {**foo, **{"bar": 10}}  # PIE800
+6 | 
+7 | {**foo, **{"bar": 10}}  # PIE800
   |
   = help: Remove unnecessary dict
 
-PIE800.py:5:11: PIE800 Unnecessary spread `**`
+PIE800.py:7:11: PIE800 Unnecessary spread `**`
   |
-3 | foo({**foo, **{"bar": True}})  # PIE800
-4 | 
-5 | {**foo, **{"bar": 10}}  # PIE800
+5 | foo({**foo, **{"bar": True}})  # PIE800
+6 | 
+7 | {**foo, **{"bar": 10}}  # PIE800
   |           ^^^^^^^^^^^ PIE800
-6 | 
-7 | {**foo, **buzz, **{bar: 10}}  # PIE800
+8 | 
+9 | { # PIE800
   |
   = help: Remove unnecessary dict
 
-PIE800.py:7:19: PIE800 Unnecessary spread `**`
-  |
-5 | {**foo, **{"bar": 10}}  # PIE800
-6 | 
-7 | {**foo, **buzz, **{bar: 10}}  # PIE800
-  |                   ^^^^^^^^^ PIE800
-8 | 
-9 | {**foo,    "bar": True  }  # OK
-  |
-  = help: Remove unnecessary dict
+PIE800.py:12:7: PIE800 Unnecessary spread `**`
+   |
+10 |       "a": "b",
+11 |       # Preserve
+12 |       **{
+   |  _______^
+13 | |         # all
+14 | |         "bar": 10,  # the
+15 | |         # comments
+16 | |     },
+   | |_____^ PIE800
+17 |   }
+   |
+   = help: Remove unnecessary dict
+
+PIE800.py:19:19: PIE800 Unnecessary spread `**`
+   |
+17 | }
+18 | 
+19 | {**foo, **buzz, **{bar: 10}}  # PIE800
+   |                   ^^^^^^^^^ PIE800
+20 | 
+21 | {**foo,    "bar": True  }  # OK
+   |
+   = help: Remove unnecessary dict
 
 

--- a/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE800_PIE800.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE800_PIE800.py.snap
@@ -8,6 +8,7 @@ PIE800.py:1:14: PIE800 Unnecessary spread `**`
 2 | 
 3 | foo({**foo, **{"bar": True}})  # PIE800
   |
+  = help: Remove unnecessary dict
 
 PIE800.py:3:15: PIE800 Unnecessary spread `**`
   |
@@ -18,6 +19,7 @@ PIE800.py:3:15: PIE800 Unnecessary spread `**`
 4 | 
 5 | {**foo, **{"bar": 10}}  # PIE800
   |
+  = help: Remove unnecessary dict
 
 PIE800.py:5:11: PIE800 Unnecessary spread `**`
   |
@@ -28,6 +30,7 @@ PIE800.py:5:11: PIE800 Unnecessary spread `**`
 6 | 
 7 | {**foo, **buzz, **{bar: 10}}  # PIE800
   |
+  = help: Remove unnecessary dict
 
 PIE800.py:7:19: PIE800 Unnecessary spread `**`
   |
@@ -38,5 +41,6 @@ PIE800.py:7:19: PIE800 Unnecessary spread `**`
 8 | 
 9 | {**foo,    "bar": True  }  # OK
   |
+  = help: Remove unnecessary dict
 
 

--- a/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__preview__PIE800_PIE800.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__preview__PIE800_PIE800.py.snap
@@ -1,0 +1,82 @@
+---
+source: crates/ruff_linter/src/rules/flake8_pie/mod.rs
+---
+PIE800.py:1:14: PIE800 [*] Unnecessary spread `**`
+  |
+1 | {"foo": 1, **{"bar": 1}}  # PIE800
+  |              ^^^^^^^^^^ PIE800
+2 | 
+3 | foo({**foo, **{"bar": True}})  # PIE800
+  |
+  = help: Remove unnecessary dict
+
+ℹ Safe fix
+1   |-{"foo": 1, **{"bar": 1}}  # PIE800
+  1 |+{"foo": 1, "bar": 1}  # PIE800
+2 2 | 
+3 3 | foo({**foo, **{"bar": True}})  # PIE800
+4 4 | 
+
+PIE800.py:3:15: PIE800 [*] Unnecessary spread `**`
+  |
+1 | {"foo": 1, **{"bar": 1}}  # PIE800
+2 | 
+3 | foo({**foo, **{"bar": True}})  # PIE800
+  |               ^^^^^^^^^^^^^ PIE800
+4 | 
+5 | {**foo, **{"bar": 10}}  # PIE800
+  |
+  = help: Remove unnecessary dict
+
+ℹ Safe fix
+1 1 | {"foo": 1, **{"bar": 1}}  # PIE800
+2 2 | 
+3   |-foo({**foo, **{"bar": True}})  # PIE800
+  3 |+foo({**foo, "bar": True})  # PIE800
+4 4 | 
+5 5 | {**foo, **{"bar": 10}}  # PIE800
+6 6 | 
+
+PIE800.py:5:11: PIE800 [*] Unnecessary spread `**`
+  |
+3 | foo({**foo, **{"bar": True}})  # PIE800
+4 | 
+5 | {**foo, **{"bar": 10}}  # PIE800
+  |           ^^^^^^^^^^^ PIE800
+6 | 
+7 | {**foo, **buzz, **{bar: 10}}  # PIE800
+  |
+  = help: Remove unnecessary dict
+
+ℹ Safe fix
+2 2 | 
+3 3 | foo({**foo, **{"bar": True}})  # PIE800
+4 4 | 
+5   |-{**foo, **{"bar": 10}}  # PIE800
+  5 |+{**foo, "bar": 10}  # PIE800
+6 6 | 
+7 7 | {**foo, **buzz, **{bar: 10}}  # PIE800
+8 8 | 
+
+PIE800.py:7:19: PIE800 [*] Unnecessary spread `**`
+  |
+5 | {**foo, **{"bar": 10}}  # PIE800
+6 | 
+7 | {**foo, **buzz, **{bar: 10}}  # PIE800
+  |                   ^^^^^^^^^ PIE800
+8 | 
+9 | {**foo,    "bar": True  }  # OK
+  |
+  = help: Remove unnecessary dict
+
+ℹ Safe fix
+4 4 | 
+5 5 | {**foo, **{"bar": 10}}  # PIE800
+6 6 | 
+7   |-{**foo, **buzz, **{bar: 10}}  # PIE800
+  7 |+{**foo, **buzz, bar: 10}  # PIE800
+8 8 | 
+9 9 | {**foo,    "bar": True  }  # OK
+10 10 | 
+
+

--- a/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__preview__PIE800_PIE800.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__preview__PIE800_PIE800.py.snap
@@ -101,13 +101,14 @@ PIE800.py:12:7: PIE800 [*] Unnecessary spread `**`
 12    |-    **{
    12 |+    
 13 13 |         # all
-14 14 |         "bar": 10,  # the
-15    |-        # comments
+14    |-        "bar": 10,  # the
+   14 |+        "bar": 10  # the
+15 15 |         # comments
 16    |-    },
-   15 |+        # comments,
-17 16 | }
-18 17 | 
-19 18 | {**foo, **buzz, **{bar: 10}}  # PIE800
+   16 |+    ,
+17 17 | }
+18 18 | 
+19 19 | {**foo, **buzz, **{bar: 10}}  # PIE800
 
 PIE800.py:19:19: PIE800 [*] Unnecessary spread `**`
    |

--- a/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__preview__PIE800_PIE800.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__preview__PIE800_PIE800.py.snap
@@ -6,7 +6,7 @@ PIE800.py:1:14: PIE800 [*] Unnecessary spread `**`
 1 | {"foo": 1, **{"bar": 1}}  # PIE800
   |              ^^^^^^^^^^ PIE800
 2 | 
-3 | foo({**foo, **{"bar": True}})  # PIE800
+3 | {**{"bar": 10}, "a": "b"}  # PIE800
   |
   = help: Remove unnecessary dict
 
@@ -14,69 +14,120 @@ PIE800.py:1:14: PIE800 [*] Unnecessary spread `**`
 1   |-{"foo": 1, **{"bar": 1}}  # PIE800
   1 |+{"foo": 1, "bar": 1}  # PIE800
 2 2 | 
-3 3 | foo({**foo, **{"bar": True}})  # PIE800
+3 3 | {**{"bar": 10}, "a": "b"}  # PIE800
 4 4 | 
 
-PIE800.py:3:15: PIE800 [*] Unnecessary spread `**`
+PIE800.py:3:4: PIE800 [*] Unnecessary spread `**`
   |
 1 | {"foo": 1, **{"bar": 1}}  # PIE800
 2 | 
-3 | foo({**foo, **{"bar": True}})  # PIE800
-  |               ^^^^^^^^^^^^^ PIE800
+3 | {**{"bar": 10}, "a": "b"}  # PIE800
+  |    ^^^^^^^^^^^ PIE800
 4 | 
-5 | {**foo, **{"bar": 10}}  # PIE800
+5 | foo({**foo, **{"bar": True}})  # PIE800
   |
   = help: Remove unnecessary dict
 
 ℹ Safe fix
 1 1 | {"foo": 1, **{"bar": 1}}  # PIE800
 2 2 | 
-3   |-foo({**foo, **{"bar": True}})  # PIE800
-  3 |+foo({**foo, "bar": True})  # PIE800
+3   |-{**{"bar": 10}, "a": "b"}  # PIE800
+  3 |+{"bar": 10, "a": "b"}  # PIE800
 4 4 | 
-5 5 | {**foo, **{"bar": 10}}  # PIE800
+5 5 | foo({**foo, **{"bar": True}})  # PIE800
 6 6 | 
 
-PIE800.py:5:11: PIE800 [*] Unnecessary spread `**`
+PIE800.py:5:15: PIE800 [*] Unnecessary spread `**`
   |
-3 | foo({**foo, **{"bar": True}})  # PIE800
+3 | {**{"bar": 10}, "a": "b"}  # PIE800
 4 | 
-5 | {**foo, **{"bar": 10}}  # PIE800
-  |           ^^^^^^^^^^^ PIE800
+5 | foo({**foo, **{"bar": True}})  # PIE800
+  |               ^^^^^^^^^^^^^ PIE800
 6 | 
-7 | {**foo, **buzz, **{bar: 10}}  # PIE800
+7 | {**foo, **{"bar": 10}}  # PIE800
   |
   = help: Remove unnecessary dict
 
 ℹ Safe fix
 2 2 | 
-3 3 | foo({**foo, **{"bar": True}})  # PIE800
+3 3 | {**{"bar": 10}, "a": "b"}  # PIE800
 4 4 | 
-5   |-{**foo, **{"bar": 10}}  # PIE800
-  5 |+{**foo, "bar": 10}  # PIE800
+5   |-foo({**foo, **{"bar": True}})  # PIE800
+  5 |+foo({**foo, "bar": True})  # PIE800
 6 6 | 
-7 7 | {**foo, **buzz, **{bar: 10}}  # PIE800
+7 7 | {**foo, **{"bar": 10}}  # PIE800
 8 8 | 
 
-PIE800.py:7:19: PIE800 [*] Unnecessary spread `**`
+PIE800.py:7:11: PIE800 [*] Unnecessary spread `**`
   |
-5 | {**foo, **{"bar": 10}}  # PIE800
+5 | foo({**foo, **{"bar": True}})  # PIE800
 6 | 
-7 | {**foo, **buzz, **{bar: 10}}  # PIE800
-  |                   ^^^^^^^^^ PIE800
+7 | {**foo, **{"bar": 10}}  # PIE800
+  |           ^^^^^^^^^^^ PIE800
 8 | 
-9 | {**foo,    "bar": True  }  # OK
+9 | { # PIE800
   |
   = help: Remove unnecessary dict
 
 ℹ Safe fix
 4 4 | 
-5 5 | {**foo, **{"bar": 10}}  # PIE800
+5 5 | foo({**foo, **{"bar": True}})  # PIE800
 6 6 | 
-7   |-{**foo, **buzz, **{bar: 10}}  # PIE800
-  7 |+{**foo, **buzz, bar: 10}  # PIE800
+7   |-{**foo, **{"bar": 10}}  # PIE800
+  7 |+{**foo, "bar": 10}  # PIE800
 8 8 | 
-9 9 | {**foo,    "bar": True  }  # OK
-10 10 | 
+9 9 | { # PIE800
+10 10 |     "a": "b",
+
+PIE800.py:12:7: PIE800 [*] Unnecessary spread `**`
+   |
+10 |       "a": "b",
+11 |       # Preserve
+12 |       **{
+   |  _______^
+13 | |         # all
+14 | |         "bar": 10,  # the
+15 | |         # comments
+16 | |     },
+   | |_____^ PIE800
+17 |   }
+   |
+   = help: Remove unnecessary dict
+
+ℹ Safe fix
+9  9  | { # PIE800
+10 10 |     "a": "b",
+11 11 |     # Preserve
+12    |-    **{
+   12 |+    
+13 13 |         # all
+14 14 |         "bar": 10,  # the
+15    |-        # comments
+16    |-    },
+   15 |+        # comments,
+17 16 | }
+18 17 | 
+19 18 | {**foo, **buzz, **{bar: 10}}  # PIE800
+
+PIE800.py:19:19: PIE800 [*] Unnecessary spread `**`
+   |
+17 | }
+18 | 
+19 | {**foo, **buzz, **{bar: 10}}  # PIE800
+   |                   ^^^^^^^^^ PIE800
+20 | 
+21 | {**foo,    "bar": True  }  # OK
+   |
+   = help: Remove unnecessary dict
+
+ℹ Safe fix
+16 16 |     },
+17 17 | }
+18 18 | 
+19    |-{**foo, **buzz, **{bar: 10}}  # PIE800
+   19 |+{**foo, **buzz, bar: 10}  # PIE800
+20 20 | 
+21 21 | {**foo,    "bar": True  }  # OK
+22 22 | 
 
 


### PR DESCRIPTION
## Summary

This adds an autofix for PIE800 (unnecessary spread) -- whenever we see a `**{...}` inside another dictionary literal, just delete the `**{` and `}` to inline the key-value pairs. So `{"a": "b", **{"c": "d"}}` becomes just `{"a": "b", "c": "d"}`.

I have enabled this just for preview mode.

## Test Plan

Updated the preview snapshot test.