### PR TITLE
F-strings doesn't contain bytes literal for `PLW0129`

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/assert_on_string_literal.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/assert_on_string_literal.rs
@@ -76,15 +76,11 @@ pub(crate) fn assert_on_string_literal(checker: &mut Checker, test: &Expr) {
                         Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => {
                             value.is_empty()
                         }
-                        Expr::BytesLiteral(ast::ExprBytesLiteral { value, .. }) => value.is_empty(),
                         _ => false,
                     }) {
                         Kind::Empty
                     } else if values.iter().any(|value| match value {
                         Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => {
-                            !value.is_empty()
-                        }
-                        Expr::BytesLiteral(ast::ExprBytesLiteral { value, .. }) => {
                             !value.is_empty()
                         }
                         _ => false,


### PR DESCRIPTION
For the `PLW0129` rule, the f-string case shouldn't match against bytes literal as f-strings cannot contain them. F-strings are made up of either string literals or formatted expressions.