### PR TITLE
Fix instability with await fluent style

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/await.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/await.py
@@ -48,3 +48,12 @@ await (
     # comment
     [foo]
 )
+
+# https://github.com/astral-sh/ruff/issues/8644
+test_data = await (
+    Stream.from_async(async_data)
+    .flat_map_async()
+    .map()
+    .filter_async(is_valid_data)
+    .to_list()
+)

--- a/crates/ruff_python_formatter/src/expression/expr_await.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_await.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<ExprAwait> for FormatExprAwait {
             [
                 token("await"),
                 space(),
-                maybe_parenthesize_expression(value, item, Parenthesize::IfRequired)
+                maybe_parenthesize_expression(value, item, Parenthesize::IfBreaks)
             ]
         )
     }

--- a/crates/ruff_python_formatter/src/expression/parentheses.rs
+++ b/crates/ruff_python_formatter/src/expression/parentheses.rs
@@ -14,6 +14,7 @@ use crate::comments::{
 use crate::context::{NodeLevel, WithNodeLevel};
 use crate::prelude::*;
 
+/// From the perspective of the expression, under which circumstances does it need parentheses
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum OptionalParentheses {
     /// Add parentheses if the expression expands over multiple lines
@@ -41,7 +42,8 @@ pub(crate) trait NeedsParentheses {
     ) -> OptionalParentheses;
 }
 
-/// Configures if the expression should be parenthesized.
+/// From the perspective of the parent statement or expression, when should the child expression
+/// get parentheses?
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum Parenthesize {
     /// Parenthesizes the expression if it doesn't fit on a line OR if the expression is parenthesized in the source code.

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__remove_await_parens.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@simple_cases__remove_await_parens.py.snap
@@ -93,13 +93,20 @@ async def main():
 ```diff
 --- Black
 +++ Ruff
-@@ -21,7 +21,9 @@
+@@ -21,11 +21,15 @@
  
  # Check comments
  async def main():
 -    await asyncio.sleep(1)  # Hello
 +    await (  # Hello
 +        asyncio.sleep(1)
++    )
+ 
+ 
+ async def main():
+-    await asyncio.sleep(1)  # Hello
++    await (
++        asyncio.sleep(1)  # Hello
 +    )
  
  
@@ -138,7 +145,9 @@ async def main():
 
 
 async def main():
-    await asyncio.sleep(1)  # Hello
+    await (
+        asyncio.sleep(1)  # Hello
+    )
 
 
 async def main():

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__await.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__await.py.snap
@@ -54,6 +54,15 @@ await (
     # comment
     [foo]
 )
+
+# https://github.com/astral-sh/ruff/issues/8644
+test_data = await (
+    Stream.from_async(async_data)
+    .flat_map_async()
+    .map()
+    .filter_async(is_valid_data)
+    .to_list()
+)
 ```
 
 ## Output
@@ -121,6 +130,15 @@ await (  # comment
 await (
     # comment
     [foo]
+)
+
+# https://github.com/astral-sh/ruff/issues/8644
+test_data = await (
+    Stream.from_async(async_data)
+    .flat_map_async()
+    .map()
+    .filter_async(is_valid_data)
+    .to_list()
 )
 ```
 


### PR DESCRIPTION
Fix an instability where await was followed by a breaking fluent style expression:

```python
test_data = await (
    Stream.from_async(async_data)
    .flat_map_async()
    .map()
    .filter_async(is_valid_data)
    .to_list()
)
```

Note that this technically a minor style change (see ecosystem check)