### PR TITLE
[isort] Simplify code structure for ordering imports

### DIFF
--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -2,8 +2,6 @@
 
 use std::path::{Path, PathBuf};
 
-use itertools::Itertools;
-
 use annotate::annotate_imports;
 use block::{Block, Trailer};
 pub(crate) use categorize::categorize;
@@ -16,9 +14,8 @@ use ruff_python_ast::PySourceType;
 use ruff_python_codegen::Stylist;
 use ruff_source_file::Locator;
 use settings::Settings;
-use sorting::ModuleKey;
 use types::EitherImport::{Import, ImportFrom};
-use types::{AliasData, EitherImport, ImportBlock, TrailingComma};
+use types::{AliasData, ImportBlock, TrailingComma};
 
 use crate::line_width::{LineLength, LineWidthBuilder};
 use crate::settings::types::PythonVersion;
@@ -174,30 +171,6 @@ fn format_import_block(
         };
 
         let imports = order_imports(import_block, settings);
-
-        let imports = imports
-            .import
-            .into_iter()
-            .map(Import)
-            .chain(imports.import_from.into_iter().map(ImportFrom));
-        let imports: Vec<EitherImport> = if settings.force_sort_within_sections {
-            imports
-                .sorted_by_cached_key(|import| match import {
-                    Import((alias, _)) => {
-                        ModuleKey::from_module(Some(alias.name), alias.asname, None, None, settings)
-                    }
-                    ImportFrom((import_from, _, _, aliases)) => ModuleKey::from_module(
-                        import_from.module,
-                        None,
-                        import_from.level,
-                        aliases.first().map(|(alias, _)| (alias.name, alias.asname)),
-                        settings,
-                    ),
-                })
-                .collect()
-        } else {
-            imports.collect()
-        };
 
         // Add a blank line between every section.
         if is_first_block {

--- a/crates/ruff_linter/src/rules/isort/types.rs
+++ b/crates/ruff_linter/src/rules/isort/types.rs
@@ -94,9 +94,3 @@ pub(crate) enum EitherImport<'a> {
     Import(Import<'a>),
     ImportFrom(ImportFrom<'a>),
 }
-
-#[derive(Debug, Default)]
-pub(crate) struct OrderedImportBlock<'a> {
-    pub(crate) import: Vec<Import<'a>>,
-    pub(crate) import_from: Vec<ImportFrom<'a>>,
-}


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

While fixing #8661 I noticed that the code structure for sorting imports could be simplified.

## Summary

- Move the logic for `force_sort_within_sections` from `isort/mod.rs` to `isort/ordering.rs` => now there is just one line in `isort/mod.rs`: `let imports = order_imports(import_block, settings);` which yields the sorted imports
- Change the function signature of `order_imports` to directly return a `Vec<EitherImport<'a>>`  => no need for `OrderedImportBlock`

I think this is a bit of an improvement because the code is simpler and there should be a bit of a speedup when setting `force-sort-within-sections` to true. Indeed, when it's set to true we're now directly ordering all the imports, whereas before we would first order the straight imports, then the from imports, combine them and finally sort the combination a second time (this is probably not noticeable in practice though).
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

No tests added, this is a simple refactor.
<!-- How was it tested? -->
