### PR TITLE
Use `indent-width` and `lint.tab-size` when checking indentation in `E` rules

### DIFF
--- a/crates/ruff_linter/src/checkers/logical_lines.rs
+++ b/crates/ruff_linter/src/checkers/logical_lines.rs
@@ -86,7 +86,7 @@ pub(crate) fn check_logical_lines(
 
         let indent_level = expand_indent(locator.slice(range));
 
-        let indent_size = 4;
+        let indent_size = settings.tab_size.as_usize();
 
         for kind in indentation(
             &line,


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/8705

Needs test cases still.
We should consider updating the formatter incompatibility documentation and checks.