### PR TITLE
List all ipython builtins

### DIFF
--- a/crates/ruff_python_stdlib/src/builtins.rs
+++ b/crates/ruff_python_stdlib/src/builtins.rs
@@ -163,8 +163,18 @@ pub const PYTHON_BUILTINS: &[&str] = &[
 
 /// A list of all builtins that are available in IPython.
 ///
+/// How to create this list:
+/// ```python
+/// import json
+/// from subprocess import check_output
+///
+/// builtins_python = json.loads(check_output(["python3", "-c" "import json; print(json.dumps(dir(__builtins__)))"]))
+/// builtins_ipython = json.loads(check_output(["ipython3", "-c" "import json; print(json.dumps(dir(__builtins__)))"]))
+/// print(sorted(set(builtins_ipython) - set(builtins_python)))
+/// ```
+///
 /// Intended to be kept in sync with [`is_ipython_builtin`].
-pub const IPYTHON_BUILTINS: &[&str] = &["display"];
+pub const IPYTHON_BUILTINS: &[&str] = &["__IPYTHON__", "display", "get_ipython"];
 
 /// Globally defined names which are not attributes of the builtins module, or
 /// are only present on some platforms.
@@ -356,5 +366,5 @@ pub fn is_iterator(name: &str) -> bool {
 /// Intended to be kept in sync with [`IPYTHON_BUILTINS`].
 pub fn is_ipython_builtin(name: &str) -> bool {
     // Constructed by converting the `IPYTHON_BUILTINS` slice to a `match` expression.
-    matches!(name, "display")
+    matches!(name, "__IPYTHON__" | "display" | "get_ipython")
 }


### PR DESCRIPTION
I checked for ipython-specific builtins on python 3.11 using
```python
import json
from subprocess import check_output

builtins_python = json.loads(check_output(["python3", "-c" "import json; print(json.dumps(dir(__builtins__)))"]))
builtins_ipython = json.loads(check_output(["ipython3", "-c" "import json; print(json.dumps(dir(__builtins__)))"]))
print(sorted(set(builtins_ipython) - set(builtins_python)))
```
and updated the relevant constant and match. The list changes from

`display`

to

`__IPYTHON__`, `display`, `get_ipython`.

Followup to #8707