### PR TITLE
Fix false positive for `S608` where SQL-like expression follows other text

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S608.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S608.py
@@ -101,4 +101,5 @@ query = "INSERT table VALUES (%s)" % (var,)
 query = "REPLACE INTO table VALUES (%s)" % (var,)
 query = "REPLACE table VALUES (%s)" % (var,)
 
-query = "Deselect something that is not SQL even though it has a ' from ' somewhere in %s." % "there"
+not_a_query = "Deselect something that is not SQL even though it has a ' from ' somewhere in %s." % "there"
+not_a_query = f"Please select a value from the list of possible variants: {variants}."

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S608_S608.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S608_S608.py.snap
@@ -476,7 +476,7 @@ S608.py:102:9: S608 Possible SQL injection vector through string-based query con
 102 | query = "REPLACE table VALUES (%s)" % (var,)
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S608
 103 | 
-104 | query = "Deselect something that is not SQL even though it has a ' from ' somewhere in %s." % "there"
+104 | not_a_query = "Deselect something that is not SQL even though it has a ' from ' somewhere in %s." % "there"
     |
 
 


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/8717

Updates the regex to enforce that the SQL keywords are at the start of the string. Unfortunately we are passing "generated expression strings" to the regular expression instead of the inner contents of a string, so I need to allow for all sorts of cruft in front e.g. `f"`, `f'`, `'`, `"`, `\n` (literal), and whitespace.