### PR TITLE
Improve debug printing for resolving origin of config settings

### DIFF
--- a/crates/ruff_cli/src/resolve.rs
+++ b/crates/ruff_cli/src/resolve.rs
@@ -43,7 +43,7 @@ pub fn resolve(
     {
         let settings = resolve_root_settings(&pyproject, Relativity::Cwd, overrides)?;
         debug!(
-            "Using user specified pyproject.toml at {}",
+            "Using user specified toml config at {}",
             pyproject.display()
         );
         return Ok(PyprojectConfig::new(
@@ -63,7 +63,7 @@ pub fn resolve(
             .as_ref()
             .unwrap_or(&path_dedot::CWD.as_path()),
     )? {
-        debug!("Using pyproject.toml (parent) at {}", pyproject.display());
+        debug!("Using toml config (parent) at {}", pyproject.display());
         let settings = resolve_root_settings(&pyproject, Relativity::Parent, overrides)?;
         return Ok(PyprojectConfig::new(
             PyprojectDiscoveryStrategy::Hierarchical,
@@ -77,7 +77,7 @@ pub fn resolve(
     // end up the "closest" `pyproject.toml` file for every Python file later on, so
     // these act as the "default" settings.)
     if let Some(pyproject) = pyproject::find_user_settings_toml() {
-        debug!("Using pyproject.toml (cwd) at {}", pyproject.display());
+        debug!("Using toml config (cwd) at {}", pyproject.display());
         let settings = resolve_root_settings(&pyproject, Relativity::Cwd, overrides)?;
         return Ok(PyprojectConfig::new(
             PyprojectDiscoveryStrategy::Hierarchical,

--- a/crates/ruff_cli/src/resolve.rs
+++ b/crates/ruff_cli/src/resolve.rs
@@ -43,7 +43,7 @@ pub fn resolve(
     {
         let settings = resolve_root_settings(&pyproject, Relativity::Cwd, overrides)?;
         debug!(
-            "Using user specified toml config at {}",
+            "Using user-specified configuration file at: {}",
             pyproject.display()
         );
         return Ok(PyprojectConfig::new(
@@ -63,7 +63,10 @@ pub fn resolve(
             .as_ref()
             .unwrap_or(&path_dedot::CWD.as_path()),
     )? {
-        debug!("Using toml config (parent) at {}", pyproject.display());
+        debug!(
+            "Using configuration file (via parent) at: {}",
+            pyproject.display()
+        );
         let settings = resolve_root_settings(&pyproject, Relativity::Parent, overrides)?;
         return Ok(PyprojectConfig::new(
             PyprojectDiscoveryStrategy::Hierarchical,
@@ -77,7 +80,10 @@ pub fn resolve(
     // end up the "closest" `pyproject.toml` file for every Python file later on, so
     // these act as the "default" settings.)
     if let Some(pyproject) = pyproject::find_user_settings_toml() {
-        debug!("Using toml config (cwd) at {}", pyproject.display());
+        debug!(
+            "Using configuration file (via cwd) at: {}",
+            pyproject.display()
+        );
         let settings = resolve_root_settings(&pyproject, Relativity::Cwd, overrides)?;
         return Ok(PyprojectConfig::new(
             PyprojectDiscoveryStrategy::Hierarchical,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

When running ruff in verbose mode with `-v`, the first debug logs show where the config settings are taken from. For example:
```
❯ ruff check ./some_file.py -v
[2023-11-17][00:16:25][ruff_cli::resolve][DEBUG] Using pyproject.toml (parent) at /Users/vince/demo/ruff.toml
```

This threw me off for a second because I knew I had no python project there, and therefore no `pyproject.toml` file. Then I realised it was actually reading a `ruff.toml` file (obvious when you read the whole print I suppose) and that the pyproject.toml is a hardcoded string in the debug log.

I think it would be nice to tweak the wording slightly so it is clear that the settings don't neccessarily have to come from a `pyproject.toml` file.

## Test Plan

<!-- How was it tested? -->
