### PR TITLE
Add River in "Who's Using Ruff?" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Ruff is used by a number of major open-source projects and companies, including:
 - [Pydantic](https://github.com/pydantic/pydantic)
 - [Pylint](https://github.com/PyCQA/pylint)
 - [Reflex](https://github.com/reflex-dev/reflex)
+- [River](https://github.com/online-ml/river)
 - [Rippling](https://rippling.com)
 - [Robyn](https://github.com/sansyrox/robyn)
 - [Saleor](https://github.com/saleor/saleor)


### PR DESCRIPTION

## Summary

I added [`River`](https://github.com/online-ml/river) in "Who's Using Ruff?" section. River is an online machine learning library, with 4.5k stars and 460k downloads, since few months we used [`Ruff`](https://github.com/online-ml/river/blob/3758eb1e0ae7042cd648f352ed1c16fac51b55db/pyproject.toml#L31) as linter.


