### PR TITLE
Extend `dict-get-with-none-default` (`SIM910`) to non-literals

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM910.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM910.py
@@ -25,3 +25,11 @@ a = {}.get(key, None)
 
 # SIM910
 ({}).get(key, None)
+
+# SIM910
+ages = {"Tom": 23, "Maria": 23, "Dog": 11}
+age = ages.get("Cat", None)
+
+# OK
+ages = ["Tom", "Maria", "Dog"]
+age = ages.get("Cat", None)

--- a/crates/ruff_linter/src/rules/flake8_simplify/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/mod.rs
@@ -57,6 +57,7 @@ mod tests {
 
     #[test_case(Rule::InDictKeys, Path::new("SIM118.py"))]
     #[test_case(Rule::IfElseBlockInsteadOfDictGet, Path::new("SIM401.py"))]
+    #[test_case(Rule::DictGetWithNoneDefault, Path::new("SIM910.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(
             "preview__{}_{}",

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__preview__SIM910_SIM910.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__preview__SIM910_SIM910.py.snap
@@ -98,4 +98,25 @@ SIM910.py:27:1: SIM910 [*] Use `({}).get(key)` instead of `({}).get(key, None)`
 29 29 | # SIM910
 30 30 | ages = {"Tom": 23, "Maria": 23, "Dog": 11}
 
+SIM910.py:31:7: SIM910 [*] Use `ages.get("Cat")` instead of `ages.get("Cat", None)`
+   |
+29 | # SIM910
+30 | ages = {"Tom": 23, "Maria": 23, "Dog": 11}
+31 | age = ages.get("Cat", None)
+   |       ^^^^^^^^^^^^^^^^^^^^^ SIM910
+32 | 
+33 | # OK
+   |
+   = help: Replace `ages.get("Cat", None)` with `ages.get("Cat")`
+
+ℹ Safe fix
+28 28 | 
+29 29 | # SIM910
+30 30 | ages = {"Tom": 23, "Maria": 23, "Dog": 11}
+31    |-age = ages.get("Cat", None)
+   31 |+age = ages.get("Cat")
+32 32 | 
+33 33 | # OK
+34 34 | ages = ["Tom", "Maria", "Dog"]
+
 


### PR DESCRIPTION
## Summary

Ensures that we can catch cases like:

```python
ages = {"Tom": 23, "Maria": 23, "Dog": 11}
age = ages.get("Cat", None)
```

Previously, the rule was somewhat useless, as it only checked for literal accesses.

Closes https://github.com/astral-sh/ruff/issues/8760.
