### PR TITLE
Respect local subclasses in `flake8-type-checking`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/runtime_evaluated_base_classes_5.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/runtime_evaluated_base_classes_5.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Sequence  # TCH003
+from pandas import DataFrame
+from pydantic import BaseModel
 
 
-class MyBaseClass:
-    pass
+class Parent(BaseModel):
+    ...
 
 
-class Foo(MyBaseClass):
-    foo: Sequence
+class Child(Parent):
+    baz: DataFrame

--- a/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
@@ -1,6 +1,8 @@
 use ruff_python_ast::call_path::from_qualified_name;
 use ruff_python_ast::helpers::{map_callable, map_subscript};
-use ruff_python_semantic::{Binding, BindingKind, ScopeKind, SemanticModel};
+use ruff_python_ast::{self as ast};
+use ruff_python_semantic::{Binding, BindingId, BindingKind, ScopeKind, SemanticModel};
+use rustc_hash::FxHashSet;
 
 pub(crate) fn is_valid_runtime_import(binding: &Binding, semantic: &SemanticModel) -> bool {
     if matches!(
@@ -35,19 +37,54 @@ pub(crate) fn runtime_evaluated(
 }
 
 fn runtime_evaluated_base_class(base_classes: &[String], semantic: &SemanticModel) -> bool {
-    let ScopeKind::Class(class_def) = &semantic.current_scope().kind else {
-        return false;
-    };
+    fn inner(
+        class_def: &ast::StmtClassDef,
+        base_classes: &[String],
+        semantic: &SemanticModel,
+        seen: &mut FxHashSet<BindingId>,
+    ) -> bool {
+        class_def.bases().iter().any(|expr| {
+            // If the base class is itself runtime-evaluated, then this is too.
+            // Ex) `class Foo(BaseModel): ...`
+            if semantic
+                .resolve_call_path(map_subscript(expr))
+                .is_some_and(|call_path| {
+                    base_classes
+                        .iter()
+                        .any(|base_class| from_qualified_name(base_class) == call_path)
+                })
+            {
+                return true;
+            }
 
-    class_def.bases().iter().any(|base| {
-        semantic
-            .resolve_call_path(map_subscript(base))
-            .is_some_and(|call_path| {
-                base_classes
-                    .iter()
-                    .any(|base_class| from_qualified_name(base_class) == call_path)
-            })
-    })
+            // If the base class extends a runtime-evaluated class, then this does too.
+            // Ex) `class Bar(BaseModel): ...; class Foo(Bar): ...`
+            if let Some(id) = semantic.lookup_attribute(map_subscript(expr)) {
+                if seen.insert(id) {
+                    let binding = semantic.binding(id);
+                    if let Some(base_class) = binding
+                        .kind
+                        .as_class_definition()
+                        .map(|id| &semantic.scopes[*id])
+                        .and_then(|scope| scope.kind.as_class())
+                    {
+                        if inner(base_class, base_classes, semantic, seen) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            false
+        })
+    }
+
+    semantic
+        .current_scope()
+        .kind
+        .as_class()
+        .is_some_and(|class_def| {
+            inner(class_def, base_classes, semantic, &mut FxHashSet::default())
+        })
 }
 
 fn runtime_evaluated_decorators(decorators: &[String], semantic: &SemanticModel) -> bool {

--- a/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
@@ -98,6 +98,10 @@ mod tests {
         Rule::TypingOnlyStandardLibraryImport,
         Path::new("runtime_evaluated_base_classes_4.py")
     )]
+    #[test_case(
+        Rule::TypingOnlyThirdPartyImport,
+        Path::new("runtime_evaluated_base_classes_5.py")
+    )]
     fn runtime_evaluated_base_classes(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_runtime_evaluated_base_classes_5.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_runtime_evaluated_base_classes_5.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
+---
+


### PR DESCRIPTION
If you define a subclass of `pydantic.BaseModel`, and then a subclass of _that_ class in the same file, we'll now correctly treat it as runtime-evaluated.

Closes https://github.com/astral-sh/ruff/issues/7893.