### PR TITLE
Retain extra ellipses in protocols and abstract methods

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE790.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE790.py
@@ -177,3 +177,33 @@ for i in range(10):
 for i in range(10):
     ...
     pass
+
+from typing import Protocol
+
+
+class Repro(Protocol):
+    def func(self) -> str:
+        """Docstring"""
+        ...
+
+    def impl(self) -> str:
+        """Docstring"""
+        return self.func()
+
+
+import abc
+
+
+class Repro:
+    @abc.abstractmethod
+    def func(self) -> str:
+        """Docstring"""
+        ...
+
+    def impl(self) -> str:
+        """Docstring"""
+        return self.func()
+
+    def stub(self) -> str:
+        """Docstring"""
+        ...

--- a/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE790_PIE790.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE790_PIE790.py.snap
@@ -473,6 +473,8 @@ PIE790.py:179:5: PIE790 [*] Unnecessary `pass` statement
 178 |     ...
 179 |     pass
     |     ^^^^ PIE790
+180 | 
+181 | from typing import Protocol
     |
     = help: Remove unnecessary `pass`
 
@@ -481,5 +483,8 @@ PIE790.py:179:5: PIE790 [*] Unnecessary `pass` statement
 177 177 | for i in range(10):
 178 178 |     ...
 179     |-    pass
+180 179 | 
+181 180 | from typing import Protocol
+182 181 | 
 
 

--- a/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__preview__PIE790_PIE790.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__preview__PIE790_PIE790.py.snap
@@ -634,6 +634,8 @@ PIE790.py:178:5: PIE790 [*] Unnecessary `...` literal
 177 177 | for i in range(10):
 178     |-    ...
 179 178 |     pass
+180 179 | 
+181 180 | from typing import Protocol
 
 PIE790.py:179:5: PIE790 [*] Unnecessary `pass` statement
     |
@@ -641,6 +643,8 @@ PIE790.py:179:5: PIE790 [*] Unnecessary `pass` statement
 178 |     ...
 179 |     pass
     |     ^^^^ PIE790
+180 | 
+181 | from typing import Protocol
     |
     = help: Remove unnecessary `pass`
 
@@ -649,5 +653,23 @@ PIE790.py:179:5: PIE790 [*] Unnecessary `pass` statement
 177 177 | for i in range(10):
 178 178 |     ...
 179     |-    pass
+180 179 | 
+181 180 | from typing import Protocol
+182 181 | 
+
+PIE790.py:209:9: PIE790 [*] Unnecessary `...` literal
+    |
+207 |     def stub(self) -> str:
+208 |         """Docstring"""
+209 |         ...
+    |         ^^^ PIE790
+    |
+    = help: Remove unnecessary `...`
+
+ℹ Safe fix
+206 206 | 
+207 207 |     def stub(self) -> str:
+208 208 |         """Docstring"""
+209     |-        ...
 
 


### PR DESCRIPTION
## Summary

It turns out that some type checkers rely on the presence of ellipses in `Protocol` interfaces and abstract methods, in order to differentiate between default implementations and stubs. This PR modifies the preview behavior of `PIE790` to avoid flagging "unnecessary" ellipses in such cases.

Closes https://github.com/astral-sh/ruff/issues/8756.

## Test Plan

`cargo test`
