### PR TITLE
Ruff ecosystem: pass no-preview cli arg by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
               - "!crates/ruff_shrinking/**"
               - scripts/*
               - .github/workflows/ci.yaml
+              - python/**
 
             formatter:
               - Cargo.toml
@@ -58,6 +59,7 @@ jobs:
               - crates/ruff_python_parser/**
               - crates/ruff_dev/**
               - scripts/*
+              - python/**
               - .github/workflows/ci.yaml
 
   cargo-fmt:

--- a/python/ruff-ecosystem/ruff_ecosystem/projects.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/projects.py
@@ -75,7 +75,7 @@ class CheckOptions(CommandOptions):
             "check",
             "--no-cache",
             "--exit-zero",
-            f"--{'' if self.preview else "no-"}preview"
+            f"--{'' if self.preview else "no-"}preview",
         ]
         if self.select:
             args.extend(["--select", self.select])

--- a/python/ruff-ecosystem/ruff_ecosystem/projects.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/projects.py
@@ -71,7 +71,12 @@ class CheckOptions(CommandOptions):
     max_lines_per_rule: int | None = 50
 
     def to_ruff_args(self) -> list[str]:
-        args = ["check", "--no-cache", "--exit-zero"]
+        args = [
+            "check",
+            "--no-cache",
+            "--exit-zero",
+            f"--{'' if self.preview else "no-"}preview"
+        ]
         if self.select:
             args.extend(["--select", self.select])
         if self.ignore:
@@ -80,8 +85,6 @@ class CheckOptions(CommandOptions):
             args.extend(["--exclude", self.exclude])
         if self.show_fixes:
             args.extend(["--show-fixes", "--ecosystem-ci"])
-        if self.preview:
-            args.append("--preview")
         return args
 
 

--- a/python/ruff-ecosystem/ruff_ecosystem/projects.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/projects.py
@@ -24,8 +24,8 @@ class Project(Serializable):
     """
 
     repo: Repository
-    check_options: CheckOptions = field(default_factory=lambda: CheckOptions())
-    format_options: FormatOptions = field(default_factory=lambda: FormatOptions())
+    check_options: CheckOptions = field(default_factory=CheckOptions)
+    format_options: FormatOptions = field(default_factory=FormatOptions)
 
     def with_preview_enabled(self: Self) -> Self:
         return type(self)(
@@ -46,7 +46,7 @@ class CommandOptions(Serializable, abc.ABC):
         """
         Return a copy of self with the given options set.
         """
-        return type(self)(**{**dataclasses.asdict(self), **kwargs})
+        return type(self)(**dataclasses.asdict(self), **kwargs)
 
     @abc.abstractmethod
     def to_ruff_args(self) -> list[str]:
@@ -98,11 +98,9 @@ class FormatOptions(CommandOptions):
     exclude: str = ""
 
     def to_ruff_args(self) -> list[str]:
-        args = ["format"]
+        args = ["format", f"--{'' if self.preview else 'no-'}preview"]
         if self.exclude:
             args.extend(["--exclude", self.exclude])
-        if self.preview:
-            args.append("--preview")
         return args
 
     def to_black_args(self) -> list[str]:

--- a/python/ruff-ecosystem/ruff_ecosystem/projects.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/projects.py
@@ -46,7 +46,7 @@ class CommandOptions(Serializable, abc.ABC):
         """
         Return a copy of self with the given options set.
         """
-        return type(self)(**dataclasses.asdict(self), **kwargs)
+        return type(self)(**{**dataclasses.asdict(self), **kwargs})
 
     @abc.abstractmethod
     def to_ruff_args(self) -> list[str]:

--- a/python/ruff-ecosystem/ruff_ecosystem/projects.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/projects.py
@@ -24,8 +24,8 @@ class Project(Serializable):
     """
 
     repo: Repository
-    check_options: CheckOptions = field(default_factory=CheckOptions)
-    format_options: FormatOptions = field(default_factory=FormatOptions)
+    check_options: CheckOptions = field(default_factory=lambda: CheckOptions())
+    format_options: FormatOptions = field(default_factory=lambda: FormatOptions())
 
     def with_preview_enabled(self: Self) -> Self:
         return type(self)(

--- a/python/ruff-ecosystem/ruff_ecosystem/projects.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/projects.py
@@ -75,7 +75,7 @@ class CheckOptions(CommandOptions):
             "check",
             "--no-cache",
             "--exit-zero",
-            f"--{'' if self.preview else "no-"}preview",
+            f"--{'' if self.preview else 'no-'}preview",
         ]
         if self.select:
             args.extend(["--select", self.select])


### PR DESCRIPTION
Addresses https://github.com/astral-sh/ruff/pull/8489#issuecomment-1793513411
That issues still exist on formatter, but since `black` doesn't support `no-preview` cli arg, I didn't include it in this PR.
