### PR TITLE
[`pep8-naming`] Avoid `N806` errors for type alias statements

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N806.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N806.py
@@ -25,6 +25,8 @@ def assign():
 
     IntOrStr: TypeAlias = int | str
 
+    type MyInt = int
+
 
 def aug_assign(rank, world_size):
     global CURRENT_PORT

--- a/crates/ruff_linter/src/rules/pep8_naming/helpers.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/helpers.rs
@@ -63,10 +63,13 @@ pub(super) fn is_type_var_assignment(stmt: &Stmt, semantic: &SemanticModel) -> b
 
 /// Returns `true` if the statement is an assignment to a `TypeAlias`.
 pub(super) fn is_type_alias_assignment(stmt: &Stmt, semantic: &SemanticModel) -> bool {
-    let Stmt::AnnAssign(ast::StmtAnnAssign { annotation, .. }) = stmt else {
-        return false;
-    };
-    semantic.match_typing_expr(annotation, "TypeAlias")
+    match stmt {
+        Stmt::AnnAssign(ast::StmtAnnAssign { annotation, .. }) => {
+            semantic.match_typing_expr(annotation, "TypeAlias")
+        }
+        Stmt::TypeAlias(_) => true,
+        _ => false,
+    }
 }
 
 pub(super) fn is_typed_dict_class(arguments: Option<&Arguments>, semantic: &SemanticModel) -> bool {


### PR DESCRIPTION
Allow, e.g.:

```python
def func():
    type MyInt = int
```

(We already allowed `MyInt: TypeAlias = int`.)

Closes https://github.com/astral-sh/ruff/issues/8773.