### PR TITLE
Mark `pydantic_settings.BaseSettings` as having default copy semantics

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF012.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF012.py
@@ -48,3 +48,14 @@ class E(Struct):
     without_annotation = []
     class_variable: ClassVar[list[int]] = []
     final_variable: Final[list[int]] = []
+
+
+from pydantic_settings import BaseSettings
+
+
+class F(BaseSettings):
+    mutable_default: list[int] = []
+    immutable_annotation: Sequence[int] = []
+    without_annotation = []
+    class_variable: ClassVar[list[int]] = []
+    final_variable: Final[list[int]] = []

--- a/crates/ruff_linter/src/rules/ruff/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/helpers.rs
@@ -65,7 +65,9 @@ pub(super) fn has_default_copy_semantics(
         semantic.resolve_call_path(expr).is_some_and(|call_path| {
             matches!(
                 call_path.as_slice(),
-                ["pydantic", "BaseModel" | "BaseSettings"] | ["msgspec", "Struct"]
+                ["pydantic", "BaseModel" | "BaseSettings"]
+                    | ["pydantic_settings", "BaseSettings"]
+                    | ["msgspec", "Struct"]
             )
         })
     })


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

In 2.0, Pydantic has moved the `BaseSettings` class to a separate package called `pydantic-settings` (https://docs.pydantic.dev/2.4/migration/#basesettings-has-moved-to-pydantic-settings), which results in a false positive on `RUF012` (`mutable-class-default`). A simple fix for that would be adding `pydantic_settings.BaseSettings` base to the `has_default_copy_semantics` helper, which I've done in this PR.

Related issue: #5308

## Test Plan

`cargo test`