### PR TITLE
[`pylint`] Add `allow-dunder-method-names` setting for `bad-dunder-method-name` (`PLW3201`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
@@ -83,7 +83,7 @@ class Apples:
     def _(self):
         pass
 
-    # Allow custom dunder names (via setting)
+    # Allow custom dunder names (via setting).
     def __special_custom_magic__(self):
         pass
 

--- a/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
@@ -50,7 +50,7 @@ class Apples:
         return "Docstring"
 
     # Added in Python 3.12
-    def __buffer__(self):  
+    def __buffer__(self):
         return memoryview(b'')
 
     def __release_buffer__(self, buf):
@@ -81,6 +81,10 @@ class Apples:
 
     # Allow anonymous functions.
     def _(self):
+        pass
+
+    # Allow custom dunder names (via setting)
+    def __special_custom_magic__(self):
         pass
 
 

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -9,6 +9,7 @@ mod tests {
 
     use anyhow::Result;
     use regex::Regex;
+    use rustc_hash::FxHashSet;
     use test_case::test_case;
 
     use crate::assert_messages;
@@ -157,7 +158,15 @@ mod tests {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("pylint").join(path).as_path(),
-            &LinterSettings::for_rule(rule_code),
+            &LinterSettings {
+                pylint: pylint::settings::Settings {
+                    custom_dunder_method_names: FxHashSet::from_iter([
+                        "__special_custom_magic__".to_string()
+                    ]),
+                    ..pylint::settings::Settings::default()
+                },
+                ..LinterSettings::for_rule(rule_code)
+            },
         )?;
         assert_messages!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -160,7 +160,7 @@ mod tests {
             Path::new("pylint").join(path).as_path(),
             &LinterSettings {
                 pylint: pylint::settings::Settings {
-                    custom_dunder_method_names: FxHashSet::from_iter([
+                    allow_dunder_method_names: FxHashSet::from_iter([
                         "__special_custom_magic__".to_string()
                     ]),
                     ..pylint::settings::Settings::default()

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_dunder_method_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_dunder_method_name.rs
@@ -18,13 +18,12 @@ use crate::checkers::ast::Checker;
 /// that diverges from standard Python dunder methods could potentially
 /// confuse someone reading the code.
 ///
-/// Non-standard dunder methods that are required by some library you're
-/// using can be defined using the [`pylint.custom-dunder-method-names`]
-/// configuration option.
-///
 /// This rule will detect all methods starting and ending with at least
 /// one underscore (e.g., `_str_`), but ignores known dunder methods (like
 /// `__init__`), as well as methods that are marked with `@override`.
+///
+/// Additional dunder methods names can be allowed via the
+/// [`pylint.allow-dunder-method-names`] setting.
 ///
 /// ## Example
 /// ```python
@@ -41,7 +40,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## Options
-/// - `pylint.custom-dunder-method-names`
+/// - `pylint.allow-dunder-method-names`
 #[violation]
 pub struct BadDunderMethodName {
     name: String,
@@ -65,7 +64,7 @@ pub(crate) fn bad_dunder_method_name(checker: &mut Checker, class_body: &[Stmt])
                 || checker
                     .settings
                     .pylint
-                    .custom_dunder_method_names
+                    .allow_dunder_method_names
                     .contains(method.name.as_str())
                 || matches!(method.name.as_str(), "_")
             {

--- a/crates/ruff_linter/src/rules/pylint/settings.rs
+++ b/crates/ruff_linter/src/rules/pylint/settings.rs
@@ -37,7 +37,7 @@ impl ConstantType {
 #[derive(Debug, CacheKey)]
 pub struct Settings {
     pub allow_magic_value_types: Vec<ConstantType>,
-    pub custom_dunder_method_names: FxHashSet<String>,
+    pub allow_dunder_method_names: FxHashSet<String>,
     pub max_args: usize,
     pub max_returns: usize,
     pub max_bool_expr: usize,
@@ -50,7 +50,7 @@ impl Default for Settings {
     fn default() -> Self {
         Self {
             allow_magic_value_types: vec![ConstantType::Str, ConstantType::Bytes],
-            custom_dunder_method_names: FxHashSet::default(),
+            allow_dunder_method_names: FxHashSet::default(),
             max_args: 5,
             max_returns: 6,
             max_bool_expr: 5,

--- a/crates/ruff_linter/src/rules/pylint/settings.rs
+++ b/crates/ruff_linter/src/rules/pylint/settings.rs
@@ -1,5 +1,6 @@
 //! Settings for the `pylint` plugin.
 
+use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 
 use ruff_macros::CacheKey;
@@ -36,6 +37,7 @@ impl ConstantType {
 #[derive(Debug, CacheKey)]
 pub struct Settings {
     pub allow_magic_value_types: Vec<ConstantType>,
+    pub custom_dunder_method_names: FxHashSet<String>,
     pub max_args: usize,
     pub max_returns: usize,
     pub max_bool_expr: usize,
@@ -48,6 +50,7 @@ impl Default for Settings {
     fn default() -> Self {
         Self {
             allow_magic_value_types: vec![ConstantType::Str, ConstantType::Bytes],
+            custom_dunder_method_names: FxHashSet::default(),
             max_args: 5,
             max_returns: 6,
             max_bool_expr: 5,

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2545,6 +2545,16 @@ pub struct PylintOptions {
     )]
     pub allow_magic_value_types: Option<Vec<ConstantType>>,
 
+    /// Custom names to allow for dunder methods (see: `PLW3201`).
+    #[option(
+        default = r#"[]"#,
+        value_type = r#"list[str]"#,
+        example = r#"
+            custom-dunder-method-names = ["__tablename__", "__table_args__"]
+        "#
+    )]
+    pub custom_dunder_method_names: Option<FxHashSet<String>>,
+
     /// Maximum number of branches allowed for a function or method body (see:
     /// `PLR0912`).
     #[option(default = r"12", value_type = "int", example = r"max-branches = 12")]
@@ -2586,6 +2596,7 @@ impl PylintOptions {
             allow_magic_value_types: self
                 .allow_magic_value_types
                 .unwrap_or(defaults.allow_magic_value_types),
+            custom_dunder_method_names: self.custom_dunder_method_names.unwrap_or_default(),
             max_args: self.max_args.unwrap_or(defaults.max_args),
             max_bool_expr: self.max_bool_expr.unwrap_or(defaults.max_bool_expr),
             max_returns: self.max_returns.unwrap_or(defaults.max_returns),

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2545,15 +2545,16 @@ pub struct PylintOptions {
     )]
     pub allow_magic_value_types: Option<Vec<ConstantType>>,
 
-    /// Custom names to allow for dunder methods (see: `PLW3201`).
+    /// Dunder methods name to allow, in addition to the default set from the
+    /// Python standard library (see: `PLW3201`).
     #[option(
         default = r#"[]"#,
         value_type = r#"list[str]"#,
         example = r#"
-            custom-dunder-method-names = ["__tablename__", "__table_args__"]
+            allow-dunder-method-names = ["__tablename__", "__table_args__"]
         "#
     )]
-    pub custom_dunder_method_names: Option<FxHashSet<String>>,
+    pub allow_dunder_method_names: Option<FxHashSet<String>>,
 
     /// Maximum number of branches allowed for a function or method body (see:
     /// `PLR0912`).
@@ -2596,7 +2597,7 @@ impl PylintOptions {
             allow_magic_value_types: self
                 .allow_magic_value_types
                 .unwrap_or(defaults.allow_magic_value_types),
-            custom_dunder_method_names: self.custom_dunder_method_names.unwrap_or_default(),
+            allow_dunder_method_names: self.allow_dunder_method_names.unwrap_or_default(),
             max_args: self.max_args.unwrap_or(defaults.max_args),
             max_bool_expr: self.max_bool_expr.unwrap_or(defaults.max_bool_expr),
             max_returns: self.max_returns.unwrap_or(defaults.max_returns),

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -2310,6 +2310,17 @@
             "$ref": "#/definitions/ConstantType"
           }
         },
+        "custom-dunder-method-names": {
+          "description": "Custom names to allow for dunder methods (see: `PLW3201`).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
         "max-args": {
           "description": "Maximum number of arguments allowed for a function or method definition (see: `PLR0913`).",
           "type": [

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -2300,6 +2300,17 @@
     "PylintOptions": {
       "type": "object",
       "properties": {
+        "allow-dunder-method-names": {
+          "description": "Dunder methods name to allow, in addition to the default set from the Python standard library (see: `PLW3201`).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
         "allow-magic-value-types": {
           "description": "Constant types to ignore when used as \"magic values\" (see: `PLR2004`).",
           "type": [
@@ -2309,17 +2320,6 @@
           "items": {
             "$ref": "#/definitions/ConstantType"
           }
-        },
-        "custom-dunder-method-names": {
-          "description": "Custom names to allow for dunder methods (see: `PLW3201`).",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
         },
         "max-args": {
           "description": "Maximum number of arguments allowed for a function or method definition (see: `PLR0913`).",


### PR DESCRIPTION
closes #8732

I noticed that the reference to the setting in the rule docs doesn't work, but there seem to be something wrong with pylint settings in general in the docs - the "For related settings, see ...." is also missing there.