### PR TITLE
Avoid `D100` for Jupyter Notebooks

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydocstyle/D100.ipynb
+++ b/crates/ruff_linter/resources/test/fixtures/pydocstyle/D100.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "33faf7ad-a3fd-4ac4-a0c3-52e507ed49df",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello world!\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Hello world!\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (ruff-playground)",
+   "language": "python",
+   "name": "ruff-playground"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/crates/ruff_linter/src/rules/pydocstyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/mod.rs
@@ -62,6 +62,7 @@ mod tests {
     #[test_case(Rule::UndocumentedPublicMethod, Path::new("D.py"))]
     #[test_case(Rule::UndocumentedPublicMethod, Path::new("setter.py"))]
     #[test_case(Rule::UndocumentedPublicModule, Path::new("D.py"))]
+    #[test_case(Rule::UndocumentedPublicModule, Path::new("D100.ipynb"))]
     #[test_case(
         Rule::UndocumentedPublicModule,
         Path::new("_unrelated/pkg/D100_pub.py")

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/not_missing.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/not_missing.rs
@@ -534,6 +534,9 @@ pub(crate) fn not_missing(
             kind: ModuleKind::Module,
             ..
         }) => {
+            if checker.source_type.is_ipynb() {
+                return true;
+            }
             if checker.enabled(Rule::UndocumentedPublicModule) {
                 checker.diagnostics.push(Diagnostic::new(
                     UndocumentedPublicModule,

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D100_D100.ipynb.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D100_D100.ipynb.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pydocstyle/mod.rs
+---
+


### PR DESCRIPTION
This PR avoids triggering `D100` for Jupyter Notebooks.

Part of #8669
