### PR TITLE
New AST nodes for f-string elements

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S104.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S104.py
@@ -8,6 +8,7 @@ def func(address):
 # Error
 "0.0.0.0"
 '0.0.0.0'
+f"0.0.0.0"
 
 
 # Error

--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S108.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S108.py
@@ -5,6 +5,9 @@ with open("/abc/tmp", "w") as f:
 with open("/tmp/abc", "w") as f:
     f.write("def")
 
+with open(f"/tmp/abc", "w") as f:
+    f.write("def")
+
 with open("/var/tmp/123", "w") as f:
     f.write("def")
 

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI053.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI053.py
@@ -32,6 +32,7 @@ def f8(x: bytes = b"50 character byte stringgggggggggggggggggggggggggg\xff") -> 
 
 foo: str = "50 character stringggggggggggggggggggggggggggggggg"
 bar: str = "51 character stringgggggggggggggggggggggggggggggggg"
+baz: str = f"51 character stringgggggggggggggggggggggggggggggggg"
 
 baz: bytes = b"50 character byte stringgggggggggggggggggggggggggg"
 

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI053.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI053.pyi
@@ -29,6 +29,10 @@ baz: bytes = b"50 character byte stringgggggggggggggggggggggggggg"  # OK
 
 qux: bytes = b"51 character byte stringggggggggggggggggggggggggggg\xff"  # Error: PYI053
 
+ffoo: str = f"50 character stringggggggggggggggggggggggggggggggg"  # OK
+
+fbar: str = f"51 character stringgggggggggggggggggggggggggggggggg"  # Error: PYI053
+
 class Demo:
     """Docstrings are excluded from this rule. Some padding."""  # OK
 

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -4,6 +4,7 @@ use ruff_python_literal::cformat::{CFormatError, CFormatErrorType};
 use ruff_diagnostics::Diagnostic;
 
 use ruff_python_ast::types::Node;
+use ruff_python_ast::AstNode;
 use ruff_python_semantic::analyze::typing;
 use ruff_python_semantic::ScopeKind;
 use ruff_text_size::Ranged;
@@ -1006,6 +1007,30 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                     pyupgrade::rules::unicode_kind_prefix(checker, string_literal);
                 }
             }
+            for literal in value.elements().filter_map(|element| element.as_literal()) {
+                if checker.enabled(Rule::HardcodedBindAllInterfaces) {
+                    flake8_bandit::rules::hardcoded_bind_all_interfaces(
+                        checker,
+                        &literal.value,
+                        literal.range,
+                    );
+                }
+                if checker.enabled(Rule::HardcodedTempFile) {
+                    flake8_bandit::rules::hardcoded_tmp_directory(
+                        checker,
+                        &literal.value,
+                        literal.range,
+                    );
+                }
+                if checker.source_type.is_stub() {
+                    if checker.enabled(Rule::StringOrBytesTooLong) {
+                        flake8_pyi::rules::string_or_bytes_too_long(
+                            checker,
+                            literal.as_any_node_ref(),
+                        );
+                    }
+                }
+            }
         }
         Expr::BinOp(ast::ExprBinOp {
             left,
@@ -1270,30 +1295,36 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 refurb::rules::math_constant(checker, number_literal);
             }
         }
-        Expr::BytesLiteral(_) => {
+        Expr::BytesLiteral(bytes_literal) => {
             if checker.source_type.is_stub() && checker.enabled(Rule::StringOrBytesTooLong) {
-                flake8_pyi::rules::string_or_bytes_too_long(checker, expr);
+                flake8_pyi::rules::string_or_bytes_too_long(
+                    checker,
+                    bytes_literal.as_any_node_ref(),
+                );
             }
         }
-        Expr::StringLiteral(string) => {
+        Expr::StringLiteral(string_literal @ ast::ExprStringLiteral { value, range }) => {
             if checker.enabled(Rule::HardcodedBindAllInterfaces) {
-                if let Some(diagnostic) =
-                    flake8_bandit::rules::hardcoded_bind_all_interfaces(string)
-                {
-                    checker.diagnostics.push(diagnostic);
-                }
+                flake8_bandit::rules::hardcoded_bind_all_interfaces(
+                    checker,
+                    value.to_str(),
+                    *range,
+                );
             }
             if checker.enabled(Rule::HardcodedTempFile) {
-                flake8_bandit::rules::hardcoded_tmp_directory(checker, string);
+                flake8_bandit::rules::hardcoded_tmp_directory(checker, value.to_str(), *range);
             }
             if checker.enabled(Rule::UnicodeKindPrefix) {
-                for string_part in string.value.parts() {
+                for string_part in value.parts() {
                     pyupgrade::rules::unicode_kind_prefix(checker, string_part);
                 }
             }
             if checker.source_type.is_stub() {
                 if checker.enabled(Rule::StringOrBytesTooLong) {
-                    flake8_pyi::rules::string_or_bytes_too_long(checker, expr);
+                    flake8_pyi::rules::string_or_bytes_too_long(
+                        checker,
+                        string_literal.as_any_node_ref(),
+                    );
                 }
             }
         }

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -815,8 +815,7 @@ where
 
     fn visit_expr(&mut self, expr: &'b Expr) {
         // Step 0: Pre-processing
-        if !self.semantic.in_f_string()
-            && !self.semantic.in_typing_literal()
+        if !self.semantic.in_typing_literal()
             && !self.semantic.in_deferred_type_definition()
             && self.semantic.in_type_definition()
             && self.semantic.future_annotations()
@@ -1238,10 +1237,7 @@ where
                 }
             }
             Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => {
-                if self.semantic.in_type_definition()
-                    && !self.semantic.in_typing_literal()
-                    && !self.semantic.in_f_string()
-                {
+                if self.semantic.in_type_definition() && !self.semantic.in_typing_literal() {
                     self.deferred.string_type_definitions.push((
                         expr.range(),
                         value.to_str(),
@@ -1324,17 +1320,6 @@ where
         analyze::except_handler(except_handler, self);
 
         self.semantic.flags = flags_snapshot;
-    }
-
-    fn visit_format_spec(&mut self, format_spec: &'b Expr) {
-        match format_spec {
-            Expr::FString(ast::ExprFString { value, .. }) => {
-                for expr in value.elements() {
-                    self.visit_expr(expr);
-                }
-            }
-            _ => unreachable!("Unexpected expression for format_spec"),
-        }
     }
 
     fn visit_parameters(&mut self, parameters: &'b Parameters) {

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
@@ -1,6 +1,8 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::ExprStringLiteral;
+use ruff_text_size::TextRange;
+
+use crate::checkers::ast::Checker;
 
 /// ## What it does
 /// Checks for hardcoded bindings to all network interfaces (`0.0.0.0`).
@@ -34,10 +36,10 @@ impl Violation for HardcodedBindAllInterfaces {
 }
 
 /// S104
-pub(crate) fn hardcoded_bind_all_interfaces(string: &ExprStringLiteral) -> Option<Diagnostic> {
-    if string.value.to_str() == "0.0.0.0" {
-        Some(Diagnostic::new(HardcodedBindAllInterfaces, string.range))
-    } else {
-        None
+pub(crate) fn hardcoded_bind_all_interfaces(checker: &mut Checker, value: &str, range: TextRange) {
+    if value == "0.0.0.0" {
+        checker
+            .diagnostics
+            .push(Diagnostic::new(HardcodedBindAllInterfaces, range));
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
@@ -1,4 +1,5 @@
 use ruff_python_ast::{self as ast, Expr};
+use ruff_text_size::TextRange;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -51,13 +52,13 @@ impl Violation for HardcodedTempFile {
 }
 
 /// S108
-pub(crate) fn hardcoded_tmp_directory(checker: &mut Checker, string: &ast::ExprStringLiteral) {
+pub(crate) fn hardcoded_tmp_directory(checker: &mut Checker, value: &str, range: TextRange) {
     if !checker
         .settings
         .flake8_bandit
         .hardcoded_tmp_directory
         .iter()
-        .any(|prefix| string.value.to_str().starts_with(prefix))
+        .any(|prefix| value.starts_with(prefix))
     {
         return;
     }
@@ -76,8 +77,8 @@ pub(crate) fn hardcoded_tmp_directory(checker: &mut Checker, string: &ast::ExprS
 
     checker.diagnostics.push(Diagnostic::new(
         HardcodedTempFile {
-            string: string.value.to_string(),
+            string: value.to_string(),
         },
-        string.range,
+        range,
     ));
 }

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S104_S104.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S104_S104.py.snap
@@ -7,6 +7,7 @@ S104.py:9:1: S104 Possible binding to all interfaces
  9 | "0.0.0.0"
    | ^^^^^^^^^ S104
 10 | '0.0.0.0'
+11 | f"0.0.0.0"
    |
 
 S104.py:10:1: S104 Possible binding to all interfaces
@@ -15,21 +16,30 @@ S104.py:10:1: S104 Possible binding to all interfaces
  9 | "0.0.0.0"
 10 | '0.0.0.0'
    | ^^^^^^^^^ S104
+11 | f"0.0.0.0"
    |
 
-S104.py:14:6: S104 Possible binding to all interfaces
+S104.py:11:3: S104 Possible binding to all interfaces
    |
-13 | # Error
-14 | func("0.0.0.0")
+ 9 | "0.0.0.0"
+10 | '0.0.0.0'
+11 | f"0.0.0.0"
+   |   ^^^^^^^ S104
+   |
+
+S104.py:15:6: S104 Possible binding to all interfaces
+   |
+14 | # Error
+15 | func("0.0.0.0")
    |      ^^^^^^^^^ S104
    |
 
-S104.py:18:9: S104 Possible binding to all interfaces
+S104.py:19:9: S104 Possible binding to all interfaces
    |
-17 | def my_func():
-18 |     x = "0.0.0.0"
+18 | def my_func():
+19 |     x = "0.0.0.0"
    |         ^^^^^^^^^ S104
-19 |     print(x)
+20 |     print(x)
    |
 
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S108_S108.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S108_S108.py.snap
@@ -10,22 +10,31 @@ S108.py:5:11: S108 Probable insecure usage of temporary file or directory: "/tmp
 6 |     f.write("def")
   |
 
-S108.py:8:11: S108 Probable insecure usage of temporary file or directory: "/var/tmp/123"
+S108.py:8:13: S108 Probable insecure usage of temporary file or directory: "/tmp/abc"
   |
 6 |     f.write("def")
 7 | 
-8 | with open("/var/tmp/123", "w") as f:
-  |           ^^^^^^^^^^^^^^ S108
+8 | with open(f"/tmp/abc", "w") as f:
+  |             ^^^^^^^^ S108
 9 |     f.write("def")
   |
 
-S108.py:11:11: S108 Probable insecure usage of temporary file or directory: "/dev/shm/unit/test"
+S108.py:11:11: S108 Probable insecure usage of temporary file or directory: "/var/tmp/123"
    |
  9 |     f.write("def")
 10 | 
-11 | with open("/dev/shm/unit/test", "w") as f:
-   |           ^^^^^^^^^^^^^^^^^^^^ S108
+11 | with open("/var/tmp/123", "w") as f:
+   |           ^^^^^^^^^^^^^^ S108
 12 |     f.write("def")
+   |
+
+S108.py:14:11: S108 Probable insecure usage of temporary file or directory: "/dev/shm/unit/test"
+   |
+12 |     f.write("def")
+13 | 
+14 | with open("/dev/shm/unit/test", "w") as f:
+   |           ^^^^^^^^^^^^^^^^^^^^ S108
+15 |     f.write("def")
    |
 
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S108_extend.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S108_extend.snap
@@ -10,30 +10,39 @@ S108.py:5:11: S108 Probable insecure usage of temporary file or directory: "/tmp
 6 |     f.write("def")
   |
 
-S108.py:8:11: S108 Probable insecure usage of temporary file or directory: "/var/tmp/123"
+S108.py:8:13: S108 Probable insecure usage of temporary file or directory: "/tmp/abc"
   |
 6 |     f.write("def")
 7 | 
-8 | with open("/var/tmp/123", "w") as f:
-  |           ^^^^^^^^^^^^^^ S108
+8 | with open(f"/tmp/abc", "w") as f:
+  |             ^^^^^^^^ S108
 9 |     f.write("def")
   |
 
-S108.py:11:11: S108 Probable insecure usage of temporary file or directory: "/dev/shm/unit/test"
+S108.py:11:11: S108 Probable insecure usage of temporary file or directory: "/var/tmp/123"
    |
  9 |     f.write("def")
 10 | 
-11 | with open("/dev/shm/unit/test", "w") as f:
-   |           ^^^^^^^^^^^^^^^^^^^^ S108
+11 | with open("/var/tmp/123", "w") as f:
+   |           ^^^^^^^^^^^^^^ S108
 12 |     f.write("def")
    |
 
-S108.py:15:11: S108 Probable insecure usage of temporary file or directory: "/foo/bar"
+S108.py:14:11: S108 Probable insecure usage of temporary file or directory: "/dev/shm/unit/test"
    |
-14 | # not ok by config
-15 | with open("/foo/bar", "w") as f:
+12 |     f.write("def")
+13 | 
+14 | with open("/dev/shm/unit/test", "w") as f:
+   |           ^^^^^^^^^^^^^^^^^^^^ S108
+15 |     f.write("def")
+   |
+
+S108.py:18:11: S108 Probable insecure usage of temporary file or directory: "/foo/bar"
+   |
+17 | # not ok by config
+18 | with open("/foo/bar", "w") as f:
    |           ^^^^^^^^^^ S108
-16 |     f.write("def")
+19 |     f.write("def")
    |
 
 

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
@@ -1083,7 +1083,7 @@ pub(crate) fn fix_unnecessary_map(
     // If the expression is embedded in an f-string, surround it with spaces to avoid
     // syntax errors.
     if matches!(object_type, ObjectType::Set | ObjectType::Dict) {
-        if parent.is_some_and(Expr::is_formatted_value_expr) {
+        if parent.is_some_and(Expr::is_f_string_expr) {
             content = format!(" {content} ");
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
@@ -1,8 +1,7 @@
-use ruff_python_ast::{self as ast, Expr};
-
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::is_docstring_stmt;
+use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -44,25 +43,30 @@ impl AlwaysFixableViolation for StringOrBytesTooLong {
 }
 
 /// PYI053
-pub(crate) fn string_or_bytes_too_long(checker: &mut Checker, expr: &Expr) {
+pub(crate) fn string_or_bytes_too_long(checker: &mut Checker, node: AnyNodeRef) {
     // Ignore docstrings.
     if is_docstring_stmt(checker.semantic().current_statement()) {
         return;
     }
 
-    let length = match expr {
-        Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => value.chars().count(),
-        Expr::BytesLiteral(ast::ExprBytesLiteral { value, .. }) => value.len(),
+    let length = match node {
+        AnyNodeRef::ExprStringLiteral(ast::ExprStringLiteral { value, .. }) => {
+            value.chars().count()
+        }
+        AnyNodeRef::ExprBytesLiteral(ast::ExprBytesLiteral { value, .. }) => value.len(),
+        AnyNodeRef::FStringLiteralElement(ast::FStringLiteralElement { value, .. }) => {
+            value.chars().count()
+        }
         _ => return,
     };
     if length <= 50 {
         return;
     }
 
-    let mut diagnostic = Diagnostic::new(StringOrBytesTooLong, expr.range());
+    let mut diagnostic = Diagnostic::new(StringOrBytesTooLong, node.range());
     diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
         "...".to_string(),
-        expr.range(),
+        node.range(),
     )));
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI053_PYI053.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI053_PYI053.pyi.snap
@@ -90,7 +90,7 @@ PYI053.pyi:30:14: PYI053 [*] String and bytes literals longer than 50 characters
 30 | qux: bytes = b"51 character byte stringggggggggggggggggggggggggggg\xff"  # Error: PYI053
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI053
 31 | 
-32 | class Demo:
+32 | ffoo: str = f"50 character stringggggggggggggggggggggggggggggggg"  # OK
    |
    = help: Replace with `...`
 
@@ -101,7 +101,28 @@ PYI053.pyi:30:14: PYI053 [*] String and bytes literals longer than 50 characters
 30    |-qux: bytes = b"51 character byte stringggggggggggggggggggggggggggg\xff"  # Error: PYI053
    30 |+qux: bytes = ...  # Error: PYI053
 31 31 | 
-32 32 | class Demo:
-33 33 |     """Docstrings are excluded from this rule. Some padding."""  # OK
+32 32 | ffoo: str = f"50 character stringggggggggggggggggggggggggggggggg"  # OK
+33 33 | 
+
+PYI053.pyi:34:15: PYI053 [*] String and bytes literals longer than 50 characters are not permitted
+   |
+32 | ffoo: str = f"50 character stringggggggggggggggggggggggggggggggg"  # OK
+33 | 
+34 | fbar: str = f"51 character stringgggggggggggggggggggggggggggggggg"  # Error: PYI053
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PYI053
+35 | 
+36 | class Demo:
+   |
+   = help: Replace with `...`
+
+ℹ Safe fix
+31 31 | 
+32 32 | ffoo: str = f"50 character stringggggggggggggggggggggggggggggggg"  # OK
+33 33 | 
+34    |-fbar: str = f"51 character stringgggggggggggggggggggggggggggggggg"  # Error: PYI053
+   34 |+fbar: str = f"..."  # Error: PYI053
+35 35 | 
+36 36 | class Demo:
+37 37 |     """Docstrings are excluded from this rule. Some padding."""  # OK
 
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -58,12 +58,22 @@ pub(super) fn is_empty_or_null_string(expr: &Expr) -> bool {
         Expr::FString(ast::ExprFString { value, .. }) => {
             value.parts().all(|f_string_part| match f_string_part {
                 ast::FStringPart::Literal(literal) => literal.is_empty(),
-                ast::FStringPart::FString(f_string) => {
-                    f_string.values.iter().all(is_empty_or_null_string)
-                }
+                ast::FStringPart::FString(f_string) => f_string
+                    .elements
+                    .iter()
+                    .all(is_empty_or_null_fstring_element),
             })
         }
         _ => false,
+    }
+}
+
+fn is_empty_or_null_fstring_element(element: &ast::FStringElement) -> bool {
+    match element {
+        ast::FStringElement::Literal(ast::FStringLiteralElement { value, .. }) => value.is_empty(),
+        ast::FStringElement::Expression(ast::FStringExpressionElement { expression, .. }) => {
+            is_empty_or_null_string(expression)
+        }
     }
 }
 

--- a/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -78,7 +78,7 @@ fn build_fstring(joiner: &str, joinees: &[Expr]) -> Option<Expr> {
         return Some(node.into());
     }
 
-    let mut fstring_elems = Vec::with_capacity(joinees.len() * 2);
+    let mut f_string_elements = Vec::with_capacity(joinees.len() * 2);
     let mut first = true;
 
     for expr in joinees {
@@ -88,13 +88,13 @@ fn build_fstring(joiner: &str, joinees: &[Expr]) -> Option<Expr> {
             return None;
         }
         if !std::mem::take(&mut first) {
-            fstring_elems.push(helpers::to_constant_string(joiner));
+            f_string_elements.push(helpers::to_f_string_literal_element(joiner));
         }
-        fstring_elems.push(helpers::to_f_string_element(expr)?);
+        f_string_elements.push(helpers::to_f_string_element(expr)?);
     }
 
     let node = ast::FString {
-        values: fstring_elems,
+        elements: f_string_elements,
         range: TextRange::default(),
     };
     Some(node.into())
@@ -127,7 +127,7 @@ pub(crate) fn static_join_to_fstring(checker: &mut Checker, expr: &Expr, joiner:
     };
 
     // Try to build the fstring (internally checks whether e.g. the elements are
-    // convertible to f-string parts).
+    // convertible to f-string elements).
     let Some(new_expr) = build_fstring(joiner, joinees) else {
         return;
     };

--- a/crates/ruff_linter/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{self as ast, Expr};
+use ruff_python_ast as ast;
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
@@ -47,11 +47,12 @@ impl AlwaysFixableViolation for FStringMissingPlaceholders {
 
 /// F541
 pub(crate) fn f_string_missing_placeholders(checker: &mut Checker, expr: &ast::ExprFString) {
-    if expr
-        .value
-        .f_strings()
-        .any(|f_string| f_string.values.iter().any(Expr::is_formatted_value_expr))
-    {
+    if expr.value.f_strings().any(|f_string| {
+        f_string
+            .elements
+            .iter()
+            .any(ast::FStringElement::is_expression)
+    }) {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/assert_on_string_literal.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/assert_on_string_literal.rs
@@ -72,24 +72,26 @@ pub(crate) fn assert_on_string_literal(checker: &mut Checker, test: &Expr) {
         Expr::FString(ast::ExprFString { value, .. }) => {
             let kind = if value.parts().all(|f_string_part| match f_string_part {
                 ast::FStringPart::Literal(literal) => literal.is_empty(),
-                ast::FStringPart::FString(f_string) => f_string.values.iter().all(|value| {
-                    if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = value {
-                        value.is_empty()
-                    } else {
-                        false
-                    }
-                }),
+                ast::FStringPart::FString(f_string) => {
+                    f_string.elements.iter().all(|element| match element {
+                        ast::FStringElement::Literal(ast::FStringLiteralElement {
+                            value, ..
+                        }) => value.is_empty(),
+                        ast::FStringElement::Expression(_) => false,
+                    })
+                }
             }) {
                 Kind::Empty
             } else if value.parts().any(|f_string_part| match f_string_part {
                 ast::FStringPart::Literal(literal) => !literal.is_empty(),
-                ast::FStringPart::FString(f_string) => f_string.values.iter().any(|value| {
-                    if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = value {
-                        !value.is_empty()
-                    } else {
-                        false
-                    }
-                }),
+                ast::FStringPart::FString(f_string) => {
+                    f_string.elements.iter().any(|element| match element {
+                        ast::FStringElement::Literal(ast::FStringLiteralElement {
+                            value, ..
+                        }) => !value.is_empty(),
+                        ast::FStringElement::Expression(_) => false,
+                    })
+                }
             }) {
                 Kind::NonEmpty
             } else {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -180,7 +180,6 @@ fn is_allowed_value(expr: &Expr) -> bool {
         | Expr::GeneratorExp(_)
         | Expr::Compare(_)
         | Expr::Call(_)
-        | Expr::FormattedValue(_)
         | Expr::FString(_)
         | Expr::StringLiteral(_)
         | Expr::BytesLiteral(_)

--- a/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -53,10 +53,12 @@ impl AlwaysFixableViolation for ExplicitFStringTypeConversion {
 
 /// RUF010
 pub(crate) fn explicit_f_string_type_conversion(checker: &mut Checker, f_string: &ast::FString) {
-    for (index, expr) in f_string.values.iter().enumerate() {
-        let Some(ast::ExprFormattedValue {
-            value, conversion, ..
-        }) = expr.as_formatted_value_expr()
+    for (index, element) in f_string.elements.iter().enumerate() {
+        let Some(ast::FStringExpressionElement {
+            expression,
+            conversion,
+            ..
+        }) = element.as_expression()
         else {
             continue;
         };
@@ -75,7 +77,7 @@ pub(crate) fn explicit_f_string_type_conversion(checker: &mut Checker, f_string:
                     range: _,
                 },
             ..
-        }) = value.as_ref()
+        }) = expression.as_ref()
         else {
             continue;
         };
@@ -110,7 +112,7 @@ pub(crate) fn explicit_f_string_type_conversion(checker: &mut Checker, f_string:
             continue;
         }
 
-        let mut diagnostic = Diagnostic::new(ExplicitFStringTypeConversion, value.range());
+        let mut diagnostic = Diagnostic::new(ExplicitFStringTypeConversion, expression.range());
         diagnostic.try_set_fix(|| {
             convert_call_to_conversion_flag(f_string, index, checker.locator(), checker.stylist())
         });

--- a/crates/ruff_linter/src/rules/ruff/rules/unreachable.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unreachable.rs
@@ -635,7 +635,6 @@ impl<'stmt> BasicBlocksBuilder<'stmt> {
                         | Expr::Set(_)
                         | Expr::Compare(_)
                         | Expr::Call(_)
-                        | Expr::FormattedValue(_)
                         | Expr::FString(_)
                         | Expr::StringLiteral(_)
                         | Expr::BytesLiteral(_)

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
@@ -98,8 +98,12 @@ fn contains_message(expr: &Expr) -> bool {
                         }
                     }
                     ast::FStringPart::FString(f_string) => {
-                        for value in &f_string.values {
-                            if contains_message(value) {
+                        for literal in f_string
+                            .elements
+                            .iter()
+                            .filter_map(|element| element.as_literal())
+                        {
+                            if literal.chars().any(char::is_whitespace) {
                                 return true;
                             }
                         }

--- a/crates/ruff_python_ast/src/expression.rs
+++ b/crates/ruff_python_ast/src/expression.rs
@@ -23,7 +23,6 @@ pub enum ExpressionRef<'a> {
     YieldFrom(&'a ast::ExprYieldFrom),
     Compare(&'a ast::ExprCompare),
     Call(&'a ast::ExprCall),
-    FormattedValue(&'a ast::ExprFormattedValue),
     FString(&'a ast::ExprFString),
     StringLiteral(&'a ast::ExprStringLiteral),
     BytesLiteral(&'a ast::ExprBytesLiteral),
@@ -67,7 +66,6 @@ impl<'a> From<&'a Expr> for ExpressionRef<'a> {
             Expr::YieldFrom(value) => ExpressionRef::YieldFrom(value),
             Expr::Compare(value) => ExpressionRef::Compare(value),
             Expr::Call(value) => ExpressionRef::Call(value),
-            Expr::FormattedValue(value) => ExpressionRef::FormattedValue(value),
             Expr::FString(value) => ExpressionRef::FString(value),
             Expr::StringLiteral(value) => ExpressionRef::StringLiteral(value),
             Expr::BytesLiteral(value) => ExpressionRef::BytesLiteral(value),
@@ -172,11 +170,6 @@ impl<'a> From<&'a ast::ExprCall> for ExpressionRef<'a> {
         Self::Call(value)
     }
 }
-impl<'a> From<&'a ast::ExprFormattedValue> for ExpressionRef<'a> {
-    fn from(value: &'a ast::ExprFormattedValue) -> Self {
-        Self::FormattedValue(value)
-    }
-}
 impl<'a> From<&'a ast::ExprFString> for ExpressionRef<'a> {
     fn from(value: &'a ast::ExprFString) -> Self {
         Self::FString(value)
@@ -273,7 +266,6 @@ impl<'a> From<ExpressionRef<'a>> for AnyNodeRef<'a> {
             ExpressionRef::YieldFrom(expression) => AnyNodeRef::ExprYieldFrom(expression),
             ExpressionRef::Compare(expression) => AnyNodeRef::ExprCompare(expression),
             ExpressionRef::Call(expression) => AnyNodeRef::ExprCall(expression),
-            ExpressionRef::FormattedValue(expression) => AnyNodeRef::ExprFormattedValue(expression),
             ExpressionRef::FString(expression) => AnyNodeRef::ExprFString(expression),
             ExpressionRef::StringLiteral(expression) => AnyNodeRef::ExprStringLiteral(expression),
             ExpressionRef::BytesLiteral(expression) => AnyNodeRef::ExprBytesLiteral(expression),
@@ -317,7 +309,6 @@ impl Ranged for ExpressionRef<'_> {
             ExpressionRef::YieldFrom(expression) => expression.range(),
             ExpressionRef::Compare(expression) => expression.range(),
             ExpressionRef::Call(expression) => expression.range(),
-            ExpressionRef::FormattedValue(expression) => expression.range(),
             ExpressionRef::FString(expression) => expression.range(),
             ExpressionRef::StringLiteral(expression) => expression.range(),
             ExpressionRef::BytesLiteral(expression) => expression.range(),

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -1,7 +1,7 @@
 use crate::visitor::preorder::PreorderVisitor;
 use crate::{
     self as ast, Alias, ArgOrKeyword, Arguments, Comprehension, Decorator, ExceptHandler, Expr,
-    Keyword, MatchCase, Mod, Parameter, ParameterWithDefault, Parameters, Pattern,
+    FStringElement, Keyword, MatchCase, Mod, Parameter, ParameterWithDefault, Parameters, Pattern,
     PatternArguments, PatternKeyword, Stmt, TypeParam, TypeParamParamSpec, TypeParamTypeVar,
     TypeParamTypeVarTuple, TypeParams, WithItem,
 };
@@ -71,7 +71,6 @@ pub enum AnyNode {
     ExprYieldFrom(ast::ExprYieldFrom),
     ExprCompare(ast::ExprCompare),
     ExprCall(ast::ExprCall),
-    ExprFormattedValue(ast::ExprFormattedValue),
     ExprFString(ast::ExprFString),
     ExprStringLiteral(ast::ExprStringLiteral),
     ExprBytesLiteral(ast::ExprBytesLiteral),
@@ -88,6 +87,8 @@ pub enum AnyNode {
     ExprSlice(ast::ExprSlice),
     ExprIpyEscapeCommand(ast::ExprIpyEscapeCommand),
     ExceptHandlerExceptHandler(ast::ExceptHandlerExceptHandler),
+    FStringExpressionElement(ast::FStringExpressionElement),
+    FStringLiteralElement(ast::FStringLiteralElement),
     PatternMatchValue(ast::PatternMatchValue),
     PatternMatchSingleton(ast::PatternMatchSingleton),
     PatternMatchSequence(ast::PatternMatchSequence),
@@ -166,7 +167,8 @@ impl AnyNode {
             | AnyNode::ExprYieldFrom(_)
             | AnyNode::ExprCompare(_)
             | AnyNode::ExprCall(_)
-            | AnyNode::ExprFormattedValue(_)
+            | AnyNode::FStringExpressionElement(_)
+            | AnyNode::FStringLiteralElement(_)
             | AnyNode::ExprFString(_)
             | AnyNode::ExprStringLiteral(_)
             | AnyNode::ExprBytesLiteral(_)
@@ -233,7 +235,6 @@ impl AnyNode {
             AnyNode::ExprYieldFrom(node) => Some(Expr::YieldFrom(node)),
             AnyNode::ExprCompare(node) => Some(Expr::Compare(node)),
             AnyNode::ExprCall(node) => Some(Expr::Call(node)),
-            AnyNode::ExprFormattedValue(node) => Some(Expr::FormattedValue(node)),
             AnyNode::ExprFString(node) => Some(Expr::FString(node)),
             AnyNode::ExprStringLiteral(node) => Some(Expr::StringLiteral(node)),
             AnyNode::ExprBytesLiteral(node) => Some(Expr::BytesLiteral(node)),
@@ -278,6 +279,8 @@ impl AnyNode {
             | AnyNode::StmtContinue(_)
             | AnyNode::StmtIpyEscapeCommand(_)
             | AnyNode::ExceptHandlerExceptHandler(_)
+            | AnyNode::FStringExpressionElement(_)
+            | AnyNode::FStringLiteralElement(_)
             | AnyNode::PatternMatchValue(_)
             | AnyNode::PatternMatchSingleton(_)
             | AnyNode::PatternMatchSequence(_)
@@ -356,7 +359,8 @@ impl AnyNode {
             | AnyNode::ExprYieldFrom(_)
             | AnyNode::ExprCompare(_)
             | AnyNode::ExprCall(_)
-            | AnyNode::ExprFormattedValue(_)
+            | AnyNode::FStringExpressionElement(_)
+            | AnyNode::FStringLiteralElement(_)
             | AnyNode::ExprFString(_)
             | AnyNode::ExprStringLiteral(_)
             | AnyNode::ExprBytesLiteral(_)
@@ -459,7 +463,8 @@ impl AnyNode {
             | AnyNode::ExprYieldFrom(_)
             | AnyNode::ExprCompare(_)
             | AnyNode::ExprCall(_)
-            | AnyNode::ExprFormattedValue(_)
+            | AnyNode::FStringExpressionElement(_)
+            | AnyNode::FStringLiteralElement(_)
             | AnyNode::ExprFString(_)
             | AnyNode::ExprStringLiteral(_)
             | AnyNode::ExprBytesLiteral(_)
@@ -547,7 +552,8 @@ impl AnyNode {
             | AnyNode::ExprYieldFrom(_)
             | AnyNode::ExprCompare(_)
             | AnyNode::ExprCall(_)
-            | AnyNode::ExprFormattedValue(_)
+            | AnyNode::FStringExpressionElement(_)
+            | AnyNode::FStringLiteralElement(_)
             | AnyNode::ExprFString(_)
             | AnyNode::ExprStringLiteral(_)
             | AnyNode::ExprBytesLiteral(_)
@@ -660,7 +666,8 @@ impl AnyNode {
             Self::ExprYieldFrom(node) => AnyNodeRef::ExprYieldFrom(node),
             Self::ExprCompare(node) => AnyNodeRef::ExprCompare(node),
             Self::ExprCall(node) => AnyNodeRef::ExprCall(node),
-            Self::ExprFormattedValue(node) => AnyNodeRef::ExprFormattedValue(node),
+            Self::FStringExpressionElement(node) => AnyNodeRef::FStringExpressionElement(node),
+            Self::FStringLiteralElement(node) => AnyNodeRef::FStringLiteralElement(node),
             Self::ExprFString(node) => AnyNodeRef::ExprFString(node),
             Self::ExprStringLiteral(node) => AnyNodeRef::ExprStringLiteral(node),
             Self::ExprBytesLiteral(node) => AnyNodeRef::ExprBytesLiteral(node),
@@ -2621,12 +2628,12 @@ impl AstNode for ast::ExprCall {
         visitor.visit_arguments(arguments);
     }
 }
-impl AstNode for ast::ExprFormattedValue {
+impl AstNode for ast::FStringExpressionElement {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
     {
-        if let AnyNode::ExprFormattedValue(node) = kind {
+        if let AnyNode::FStringExpressionElement(node) = kind {
             Some(node)
         } else {
             None
@@ -2634,7 +2641,7 @@ impl AstNode for ast::ExprFormattedValue {
     }
 
     fn cast_ref(kind: AnyNodeRef) -> Option<&Self> {
-        if let AnyNodeRef::ExprFormattedValue(node) = kind {
+        if let AnyNodeRef::FStringExpressionElement(node) = kind {
             Some(node)
         } else {
             None
@@ -2653,14 +2660,52 @@ impl AstNode for ast::ExprFormattedValue {
     where
         V: PreorderVisitor<'a> + ?Sized,
     {
-        let ast::ExprFormattedValue {
-            value, format_spec, ..
+        let ast::FStringExpressionElement {
+            expression,
+            format_spec,
+            ..
         } = self;
-        visitor.visit_expr(value);
+        visitor.visit_expr(expression);
 
-        if let Some(expr) = format_spec {
-            visitor.visit_format_spec(expr);
+        if let Some(format_spec) = format_spec {
+            for spec_part in &format_spec.elements {
+                visitor.visit_f_string_element(spec_part);
+            }
         }
+    }
+}
+impl AstNode for ast::FStringLiteralElement {
+    fn cast(kind: AnyNode) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if let AnyNode::FStringLiteralElement(node) = kind {
+            Some(node)
+        } else {
+            None
+        }
+    }
+
+    fn cast_ref(kind: AnyNodeRef) -> Option<&Self> {
+        if let AnyNodeRef::FStringLiteralElement(node) = kind {
+            Some(node)
+        } else {
+            None
+        }
+    }
+
+    fn as_any_node_ref(&self) -> AnyNodeRef {
+        AnyNodeRef::from(self)
+    }
+
+    fn into_any_node(self) -> AnyNode {
+        AnyNode::from(self)
+    }
+
+    fn visit_preorder<'a, V>(&'a self, _visitor: &mut V)
+    where
+        V: PreorderVisitor<'a> + ?Sized,
+    {
     }
 }
 impl AstNode for ast::ExprFString {
@@ -4339,10 +4384,10 @@ impl AstNode for ast::FString {
     where
         V: PreorderVisitor<'a> + ?Sized,
     {
-        let ast::FString { values, range: _ } = self;
+        let ast::FString { elements, range: _ } = self;
 
-        for expr in values {
-            visitor.visit_expr(expr);
+        for fstring_element in elements {
+            visitor.visit_f_string_element(fstring_element);
         }
     }
 }
@@ -4467,7 +4512,6 @@ impl From<Expr> for AnyNode {
             Expr::YieldFrom(node) => AnyNode::ExprYieldFrom(node),
             Expr::Compare(node) => AnyNode::ExprCompare(node),
             Expr::Call(node) => AnyNode::ExprCall(node),
-            Expr::FormattedValue(node) => AnyNode::ExprFormattedValue(node),
             Expr::FString(node) => AnyNode::ExprFString(node),
             Expr::StringLiteral(node) => AnyNode::ExprStringLiteral(node),
             Expr::BytesLiteral(node) => AnyNode::ExprBytesLiteral(node),
@@ -4492,6 +4536,15 @@ impl From<Mod> for AnyNode {
         match module {
             Mod::Module(node) => AnyNode::ModModule(node),
             Mod::Expression(node) => AnyNode::ModExpression(node),
+        }
+    }
+}
+
+impl From<FStringElement> for AnyNode {
+    fn from(element: FStringElement) -> Self {
+        match element {
+            FStringElement::Literal(node) => AnyNode::FStringLiteralElement(node),
+            FStringElement::Expression(node) => AnyNode::FStringExpressionElement(node),
         }
     }
 }
@@ -4789,9 +4842,15 @@ impl From<ast::ExprCall> for AnyNode {
     }
 }
 
-impl From<ast::ExprFormattedValue> for AnyNode {
-    fn from(node: ast::ExprFormattedValue) -> Self {
-        AnyNode::ExprFormattedValue(node)
+impl From<ast::FStringExpressionElement> for AnyNode {
+    fn from(node: ast::FStringExpressionElement) -> Self {
+        AnyNode::FStringExpressionElement(node)
+    }
+}
+
+impl From<ast::FStringLiteralElement> for AnyNode {
+    fn from(node: ast::FStringLiteralElement) -> Self {
+        AnyNode::FStringLiteralElement(node)
     }
 }
 
@@ -5089,7 +5148,8 @@ impl Ranged for AnyNode {
             AnyNode::ExprYieldFrom(node) => node.range(),
             AnyNode::ExprCompare(node) => node.range(),
             AnyNode::ExprCall(node) => node.range(),
-            AnyNode::ExprFormattedValue(node) => node.range(),
+            AnyNode::FStringExpressionElement(node) => node.range(),
+            AnyNode::FStringLiteralElement(node) => node.range(),
             AnyNode::ExprFString(node) => node.range(),
             AnyNode::ExprStringLiteral(node) => node.range(),
             AnyNode::ExprBytesLiteral(node) => node.range(),
@@ -5184,7 +5244,8 @@ pub enum AnyNodeRef<'a> {
     ExprYieldFrom(&'a ast::ExprYieldFrom),
     ExprCompare(&'a ast::ExprCompare),
     ExprCall(&'a ast::ExprCall),
-    ExprFormattedValue(&'a ast::ExprFormattedValue),
+    FStringExpressionElement(&'a ast::FStringExpressionElement),
+    FStringLiteralElement(&'a ast::FStringLiteralElement),
     ExprFString(&'a ast::ExprFString),
     ExprStringLiteral(&'a ast::ExprStringLiteral),
     ExprBytesLiteral(&'a ast::ExprBytesLiteral),
@@ -5278,7 +5339,8 @@ impl<'a> AnyNodeRef<'a> {
             AnyNodeRef::ExprYieldFrom(node) => NonNull::from(*node).cast(),
             AnyNodeRef::ExprCompare(node) => NonNull::from(*node).cast(),
             AnyNodeRef::ExprCall(node) => NonNull::from(*node).cast(),
-            AnyNodeRef::ExprFormattedValue(node) => NonNull::from(*node).cast(),
+            AnyNodeRef::FStringExpressionElement(node) => NonNull::from(*node).cast(),
+            AnyNodeRef::FStringLiteralElement(node) => NonNull::from(*node).cast(),
             AnyNodeRef::ExprFString(node) => NonNull::from(*node).cast(),
             AnyNodeRef::ExprStringLiteral(node) => NonNull::from(*node).cast(),
             AnyNodeRef::ExprBytesLiteral(node) => NonNull::from(*node).cast(),
@@ -5378,7 +5440,8 @@ impl<'a> AnyNodeRef<'a> {
             AnyNodeRef::ExprYieldFrom(_) => NodeKind::ExprYieldFrom,
             AnyNodeRef::ExprCompare(_) => NodeKind::ExprCompare,
             AnyNodeRef::ExprCall(_) => NodeKind::ExprCall,
-            AnyNodeRef::ExprFormattedValue(_) => NodeKind::ExprFormattedValue,
+            AnyNodeRef::FStringExpressionElement(_) => NodeKind::FStringExpressionElement,
+            AnyNodeRef::FStringLiteralElement(_) => NodeKind::FStringLiteralElement,
             AnyNodeRef::ExprFString(_) => NodeKind::ExprFString,
             AnyNodeRef::ExprStringLiteral(_) => NodeKind::ExprStringLiteral,
             AnyNodeRef::ExprBytesLiteral(_) => NodeKind::ExprBytesLiteral,
@@ -5473,7 +5536,8 @@ impl<'a> AnyNodeRef<'a> {
             | AnyNodeRef::ExprYieldFrom(_)
             | AnyNodeRef::ExprCompare(_)
             | AnyNodeRef::ExprCall(_)
-            | AnyNodeRef::ExprFormattedValue(_)
+            | AnyNodeRef::FStringExpressionElement(_)
+            | AnyNodeRef::FStringLiteralElement(_)
             | AnyNodeRef::ExprFString(_)
             | AnyNodeRef::ExprStringLiteral(_)
             | AnyNodeRef::ExprBytesLiteral(_)
@@ -5540,7 +5604,6 @@ impl<'a> AnyNodeRef<'a> {
             | AnyNodeRef::ExprYieldFrom(_)
             | AnyNodeRef::ExprCompare(_)
             | AnyNodeRef::ExprCall(_)
-            | AnyNodeRef::ExprFormattedValue(_)
             | AnyNodeRef::ExprFString(_)
             | AnyNodeRef::ExprStringLiteral(_)
             | AnyNodeRef::ExprBytesLiteral(_)
@@ -5585,6 +5648,8 @@ impl<'a> AnyNodeRef<'a> {
             | AnyNodeRef::StmtContinue(_)
             | AnyNodeRef::StmtIpyEscapeCommand(_)
             | AnyNodeRef::ExceptHandlerExceptHandler(_)
+            | AnyNodeRef::FStringExpressionElement(_)
+            | AnyNodeRef::FStringLiteralElement(_)
             | AnyNodeRef::PatternMatchValue(_)
             | AnyNodeRef::PatternMatchSingleton(_)
             | AnyNodeRef::PatternMatchSequence(_)
@@ -5662,7 +5727,8 @@ impl<'a> AnyNodeRef<'a> {
             | AnyNodeRef::ExprYieldFrom(_)
             | AnyNodeRef::ExprCompare(_)
             | AnyNodeRef::ExprCall(_)
-            | AnyNodeRef::ExprFormattedValue(_)
+            | AnyNodeRef::FStringExpressionElement(_)
+            | AnyNodeRef::FStringLiteralElement(_)
             | AnyNodeRef::ExprFString(_)
             | AnyNodeRef::ExprStringLiteral(_)
             | AnyNodeRef::ExprBytesLiteral(_)
@@ -5765,7 +5831,8 @@ impl<'a> AnyNodeRef<'a> {
             | AnyNodeRef::ExprYieldFrom(_)
             | AnyNodeRef::ExprCompare(_)
             | AnyNodeRef::ExprCall(_)
-            | AnyNodeRef::ExprFormattedValue(_)
+            | AnyNodeRef::FStringExpressionElement(_)
+            | AnyNodeRef::FStringLiteralElement(_)
             | AnyNodeRef::ExprFString(_)
             | AnyNodeRef::ExprStringLiteral(_)
             | AnyNodeRef::ExprBytesLiteral(_)
@@ -5853,7 +5920,8 @@ impl<'a> AnyNodeRef<'a> {
             | AnyNodeRef::ExprYieldFrom(_)
             | AnyNodeRef::ExprCompare(_)
             | AnyNodeRef::ExprCall(_)
-            | AnyNodeRef::ExprFormattedValue(_)
+            | AnyNodeRef::FStringExpressionElement(_)
+            | AnyNodeRef::FStringLiteralElement(_)
             | AnyNodeRef::ExprFString(_)
             | AnyNodeRef::ExprStringLiteral(_)
             | AnyNodeRef::ExprBytesLiteral(_)
@@ -5975,7 +6043,8 @@ impl<'a> AnyNodeRef<'a> {
             AnyNodeRef::ExprYieldFrom(node) => node.visit_preorder(visitor),
             AnyNodeRef::ExprCompare(node) => node.visit_preorder(visitor),
             AnyNodeRef::ExprCall(node) => node.visit_preorder(visitor),
-            AnyNodeRef::ExprFormattedValue(node) => node.visit_preorder(visitor),
+            AnyNodeRef::FStringExpressionElement(node) => node.visit_preorder(visitor),
+            AnyNodeRef::FStringLiteralElement(node) => node.visit_preorder(visitor),
             AnyNodeRef::ExprFString(node) => node.visit_preorder(visitor),
             AnyNodeRef::ExprStringLiteral(node) => node.visit_preorder(visitor),
             AnyNodeRef::ExprBytesLiteral(node) => node.visit_preorder(visitor),
@@ -6354,9 +6423,15 @@ impl<'a> From<&'a ast::ExprCall> for AnyNodeRef<'a> {
     }
 }
 
-impl<'a> From<&'a ast::ExprFormattedValue> for AnyNodeRef<'a> {
-    fn from(node: &'a ast::ExprFormattedValue) -> Self {
-        AnyNodeRef::ExprFormattedValue(node)
+impl<'a> From<&'a ast::FStringExpressionElement> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::FStringExpressionElement) -> Self {
+        AnyNodeRef::FStringExpressionElement(node)
+    }
+}
+
+impl<'a> From<&'a ast::FStringLiteralElement> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::FStringLiteralElement) -> Self {
+        AnyNodeRef::FStringLiteralElement(node)
     }
 }
 
@@ -6615,7 +6690,6 @@ impl<'a> From<&'a Expr> for AnyNodeRef<'a> {
             Expr::YieldFrom(node) => AnyNodeRef::ExprYieldFrom(node),
             Expr::Compare(node) => AnyNodeRef::ExprCompare(node),
             Expr::Call(node) => AnyNodeRef::ExprCall(node),
-            Expr::FormattedValue(node) => AnyNodeRef::ExprFormattedValue(node),
             Expr::FString(node) => AnyNodeRef::ExprFString(node),
             Expr::StringLiteral(node) => AnyNodeRef::ExprStringLiteral(node),
             Expr::BytesLiteral(node) => AnyNodeRef::ExprBytesLiteral(node),
@@ -6640,6 +6714,15 @@ impl<'a> From<&'a Mod> for AnyNodeRef<'a> {
         match module {
             Mod::Module(node) => AnyNodeRef::ModModule(node),
             Mod::Expression(node) => AnyNodeRef::ModExpression(node),
+        }
+    }
+}
+
+impl<'a> From<&'a FStringElement> for AnyNodeRef<'a> {
+    fn from(element: &'a FStringElement) -> Self {
+        match element {
+            FStringElement::Expression(node) => AnyNodeRef::FStringExpressionElement(node),
+            FStringElement::Literal(node) => AnyNodeRef::FStringLiteralElement(node),
         }
     }
 }
@@ -6772,7 +6855,8 @@ impl Ranged for AnyNodeRef<'_> {
             AnyNodeRef::ExprYieldFrom(node) => node.range(),
             AnyNodeRef::ExprCompare(node) => node.range(),
             AnyNodeRef::ExprCall(node) => node.range(),
-            AnyNodeRef::ExprFormattedValue(node) => node.range(),
+            AnyNodeRef::FStringExpressionElement(node) => node.range(),
+            AnyNodeRef::FStringLiteralElement(node) => node.range(),
             AnyNodeRef::ExprFString(node) => node.range(),
             AnyNodeRef::ExprStringLiteral(node) => node.range(),
             AnyNodeRef::ExprBytesLiteral(node) => node.range(),
@@ -6869,7 +6953,8 @@ pub enum NodeKind {
     ExprYieldFrom,
     ExprCompare,
     ExprCall,
-    ExprFormattedValue,
+    FStringExpressionElement,
+    FStringLiteralElement,
     ExprFString,
     ExprStringLiteral,
     ExprBytesLiteral,

--- a/crates/ruff_python_ast/src/relocate.rs
+++ b/crates/ruff_python_ast/src/relocate.rs
@@ -68,9 +68,6 @@ impl Transformer for Relocator {
             Expr::Call(nodes::ExprCall { range, .. }) => {
                 *range = self.range;
             }
-            Expr::FormattedValue(nodes::ExprFormattedValue { range, .. }) => {
-                *range = self.range;
-            }
             Expr::FString(nodes::ExprFString { range, .. }) => {
                 *range = self.range;
             }

--- a/crates/ruff_python_ast/tests/snapshots/preorder__f_strings.snap
+++ b/crates/ruff_python_ast/tests/snapshots/preorder__f_strings.snap
@@ -7,19 +7,12 @@ expression: trace
     - ExprFString
       - StringLiteral
       - FString
-        - ExprStringLiteral
-          - StringLiteral
-        - ExprFormattedValue
+        - FStringLiteralElement
+        - FStringExpressionElement
           - ExprName
-          - ExprFString
-            - ExprFString
-              - FString
-                - ExprStringLiteral
-                  - StringLiteral
-                - ExprFormattedValue
-                  - ExprName
-                - ExprStringLiteral
-                  - StringLiteral
-        - ExprStringLiteral
-          - StringLiteral
+          - FStringLiteralElement
+          - FStringExpressionElement
+            - ExprName
+          - FStringLiteralElement
+        - FStringLiteralElement
 

--- a/crates/ruff_python_ast/tests/snapshots/visitor__f_strings.snap
+++ b/crates/ruff_python_ast/tests/snapshots/visitor__f_strings.snap
@@ -5,17 +5,13 @@ expression: trace
 - StmtExpr
   - ExprFString
     - StringLiteral
-    - ExprStringLiteral
-      - StringLiteral
-    - ExprFormattedValue
-      - ExprName
-      - ExprFString
-        - ExprStringLiteral
-          - StringLiteral
-        - ExprFormattedValue
+    - FString
+      - FStringLiteralElement
+      - FStringExpressionElement
+        - ExprName
+        - FStringLiteralElement
+        - FStringExpressionElement
           - ExprName
-        - ExprStringLiteral
-          - StringLiteral
-    - ExprStringLiteral
-      - StringLiteral
+        - FStringLiteralElement
+      - FStringLiteralElement
 

--- a/crates/ruff_python_ast/tests/visitor.rs
+++ b/crates/ruff_python_ast/tests/visitor.rs
@@ -7,13 +7,15 @@ use ruff_python_parser::{parse_tokens, Mode};
 
 use ruff_python_ast::visitor::{
     walk_alias, walk_bytes_literal, walk_comprehension, walk_except_handler, walk_expr,
-    walk_keyword, walk_match_case, walk_parameter, walk_parameters, walk_pattern, walk_stmt,
-    walk_string_literal, walk_type_param, walk_with_item, Visitor,
+    walk_f_string, walk_f_string_element, walk_keyword, walk_match_case, walk_parameter,
+    walk_parameters, walk_pattern, walk_stmt, walk_string_literal, walk_type_param, walk_with_item,
+    Visitor,
 };
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::{
-    Alias, BoolOp, BytesLiteral, CmpOp, Comprehension, ExceptHandler, Expr, Keyword, MatchCase,
-    Operator, Parameter, Parameters, Pattern, Stmt, StringLiteral, TypeParam, UnaryOp, WithItem,
+    Alias, BoolOp, BytesLiteral, CmpOp, Comprehension, ExceptHandler, Expr, FString,
+    FStringElement, Keyword, MatchCase, Operator, Parameter, Parameters, Pattern, Stmt,
+    StringLiteral, TypeParam, UnaryOp, WithItem,
 };
 
 #[test]
@@ -255,12 +257,6 @@ impl Visitor<'_> for RecordVisitor {
         self.exit_node();
     }
 
-    fn visit_format_spec(&mut self, format_spec: &Expr) {
-        self.enter_node(format_spec);
-        walk_expr(self, format_spec);
-        self.exit_node();
-    }
-
     fn visit_parameters(&mut self, parameters: &Parameters) {
         self.enter_node(parameters);
         walk_parameters(self, parameters);
@@ -318,6 +314,18 @@ impl Visitor<'_> for RecordVisitor {
     fn visit_bytes_literal(&mut self, bytes_literal: &BytesLiteral) {
         self.enter_node(bytes_literal);
         walk_bytes_literal(self, bytes_literal);
+        self.exit_node();
+    }
+
+    fn visit_f_string(&mut self, f_string: &FString) {
+        self.enter_node(f_string);
+        walk_f_string(self, f_string);
+        self.exit_node();
+    }
+
+    fn visit_f_string_element(&mut self, f_string_element: &FStringElement) {
+        self.enter_node(f_string_element);
+        walk_f_string_element(self, f_string_element);
         self.exit_node();
     }
 }

--- a/crates/ruff_python_formatter/generate.py
+++ b/crates/ruff_python_formatter/generate.py
@@ -30,10 +30,14 @@ nodes_file = (
 node_lines = (
     nodes_file.split("pub enum AnyNode {")[1].split("}")[0].strip().splitlines()
 )
-nodes = [
-    node_line.split("(")[1].split(")")[0].split("::")[-1].split("<")[0]
-    for node_line in node_lines
-]
+nodes = []
+for node_line in node_lines:
+    node = node_line.split("(")[1].split(")")[0].split("::")[-1].split("<")[0]
+    # These nodes aren't used in the formatter as the formatting of them is handled
+    # in one of the other nodes containing them.
+    if node in ("FStringLiteralElement", "FStringExpressionElement"):
+        continue
+    nodes.append(node)
 print(nodes)
 
 # %%

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -36,7 +36,6 @@ pub(crate) mod expr_dict;
 pub(crate) mod expr_dict_comp;
 pub(crate) mod expr_ellipsis_literal;
 pub(crate) mod expr_f_string;
-pub(crate) mod expr_formatted_value;
 pub(crate) mod expr_generator_exp;
 pub(crate) mod expr_if_exp;
 pub(crate) mod expr_ipy_escape_command;
@@ -97,7 +96,6 @@ impl FormatRule<Expr, PyFormatContext<'_>> for FormatExpr {
             Expr::YieldFrom(expr) => expr.format().fmt(f),
             Expr::Compare(expr) => expr.format().fmt(f),
             Expr::Call(expr) => expr.format().fmt(f),
-            Expr::FormattedValue(expr) => expr.format().fmt(f),
             Expr::FString(expr) => expr.format().fmt(f),
             Expr::StringLiteral(expr) => expr.format().fmt(f),
             Expr::BytesLiteral(expr) => expr.format().fmt(f),
@@ -286,7 +284,6 @@ fn format_with_parentheses_comments(
         Expr::YieldFrom(expr) => FormatNodeRule::fmt_fields(expr.format().rule(), expr, f),
         Expr::Compare(expr) => FormatNodeRule::fmt_fields(expr.format().rule(), expr, f),
         Expr::Call(expr) => FormatNodeRule::fmt_fields(expr.format().rule(), expr, f),
-        Expr::FormattedValue(expr) => FormatNodeRule::fmt_fields(expr.format().rule(), expr, f),
         Expr::FString(expr) => FormatNodeRule::fmt_fields(expr.format().rule(), expr, f),
         Expr::StringLiteral(expr) => FormatNodeRule::fmt_fields(expr.format().rule(), expr, f),
         Expr::BytesLiteral(expr) => FormatNodeRule::fmt_fields(expr.format().rule(), expr, f),
@@ -488,7 +485,6 @@ impl NeedsParentheses for Expr {
             Expr::YieldFrom(expr) => expr.needs_parentheses(parent, context),
             Expr::Compare(expr) => expr.needs_parentheses(parent, context),
             Expr::Call(expr) => expr.needs_parentheses(parent, context),
-            Expr::FormattedValue(expr) => expr.needs_parentheses(parent, context),
             Expr::FString(expr) => expr.needs_parentheses(parent, context),
             Expr::StringLiteral(expr) => expr.needs_parentheses(parent, context),
             Expr::BytesLiteral(expr) => expr.needs_parentheses(parent, context),
@@ -746,7 +742,6 @@ impl<'input> CanOmitOptionalParenthesesVisitor<'input> {
             Expr::Tuple(_)
             | Expr::NamedExpr(_)
             | Expr::GeneratorExp(_)
-            | Expr::FormattedValue(_)
             | Expr::FString(_)
             | Expr::StringLiteral(_)
             | Expr::BytesLiteral(_)
@@ -1098,7 +1093,6 @@ pub(crate) fn is_expression_huggable(expr: &Expr, context: &PyFormatContext) -> 
         | Expr::YieldFrom(_)
         | Expr::Compare(_)
         | Expr::Call(_)
-        | Expr::FormattedValue(_)
         | Expr::FString(_)
         | Expr::Attribute(_)
         | Expr::Subscript(_)

--- a/crates/ruff_python_formatter/src/expression/string/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/string/mod.rs
@@ -52,8 +52,11 @@ impl<'a> AnyString<'a> {
                     .trim_start_matches(|c| c != '"' && c != '\'');
                 let triple_quoted =
                     unprefixed.starts_with(r#"""""#) || unprefixed.starts_with(r"'''");
-                if f_string.value.elements().any(|value| match value {
-                    Expr::FormattedValue(ast::ExprFormattedValue { range, .. }) => {
+                if f_string.value.elements().any(|element| match element {
+                    ast::FStringElement::Expression(ast::FStringExpressionElement {
+                        range,
+                        ..
+                    }) => {
                         let string_content = locator.slice(*range);
                         if triple_quoted {
                             string_content.contains(r#"""""#) || string_content.contains("'''")
@@ -61,7 +64,7 @@ impl<'a> AnyString<'a> {
                             string_content.contains(['"', '\''])
                         }
                     }
-                    _ => false,
+                    ast::FStringElement::Literal(_) => false,
                 }) {
                     Quoting::Preserve
                 } else {

--- a/crates/ruff_python_formatter/src/generated.rs
+++ b/crates/ruff_python_formatter/src/generated.rs
@@ -1534,42 +1534,6 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprCall {
     }
 }
 
-impl FormatRule<ast::ExprFormattedValue, PyFormatContext<'_>>
-    for crate::expression::expr_formatted_value::FormatExprFormattedValue
-{
-    #[inline]
-    fn fmt(&self, node: &ast::ExprFormattedValue, f: &mut PyFormatter) -> FormatResult<()> {
-        FormatNodeRule::<ast::ExprFormattedValue>::fmt(self, node, f)
-    }
-}
-impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::ExprFormattedValue {
-    type Format<'a> = FormatRefWithRule<
-        'a,
-        ast::ExprFormattedValue,
-        crate::expression::expr_formatted_value::FormatExprFormattedValue,
-        PyFormatContext<'ast>,
-    >;
-    fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::expression::expr_formatted_value::FormatExprFormattedValue::default(),
-        )
-    }
-}
-impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::ExprFormattedValue {
-    type Format = FormatOwnedWithRule<
-        ast::ExprFormattedValue,
-        crate::expression::expr_formatted_value::FormatExprFormattedValue,
-        PyFormatContext<'ast>,
-    >;
-    fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::expression::expr_formatted_value::FormatExprFormattedValue::default(),
-        )
-    }
-}
-
 impl FormatRule<ast::ExprFString, PyFormatContext<'_>>
     for crate::expression::expr_f_string::FormatExprFString
 {

--- a/crates/ruff_python_parser/src/invalid.rs
+++ b/crates/ruff_python_parser/src/invalid.rs
@@ -59,7 +59,6 @@ pub(crate) fn assignment_target(target: &Expr) -> Result<(), LexicalError> {
         YieldFrom(ref e) => Err(err(e.range.start())),
         Compare(ref e) => Err(err(e.range.start())),
         Call(ref e) => Err(err(e.range.start())),
-        FormattedValue(ref e) => Err(err(e.range.start())),
         // FString is recursive, but all its forms are invalid as an
         // assignment target, so we can reject it without exploring it.
         FString(ref e) => Err(err(e.range.start())),

--- a/crates/ruff_python_parser/src/python.lalrpop
+++ b/crates/ruff_python_parser/src/python.lalrpop
@@ -11,7 +11,7 @@ use crate::{
     lexer::{LexicalError, LexicalErrorType},
     function::{ArgumentList, parse_arguments, validate_pos_params, validate_arguments},
     context::set_context,
-    string::{StringType, concatenated_strings, parse_fstring_middle, parse_string_literal},
+    string::{StringType, concatenated_strings, parse_fstring_literal_element, parse_string_literal},
     token::{self, StringKind},
     invalid,
 };
@@ -1611,23 +1611,23 @@ StringLiteral: StringType = {
 };
 
 FStringExpr: StringType = {
-    <location:@L> FStringStart <values:FStringMiddlePattern*> FStringEnd <end_location:@R> => {
+    <location:@L> FStringStart <elements:FStringMiddlePattern*> FStringEnd <end_location:@R> => {
         StringType::FString(ast::FString {
-            values,
+            elements,
             range: (location..end_location).into()
         })
     }
 };
 
-FStringMiddlePattern: ast::Expr = {
+FStringMiddlePattern: ast::FStringElement = {
     FStringReplacementField,
     <location:@L> <fstring_middle:fstring_middle> <end_location:@R> =>? {
         let (source, is_raw) = fstring_middle;
-        Ok(parse_fstring_middle(&source, is_raw, (location..end_location).into())?)
+        Ok(parse_fstring_literal_element(&source, is_raw, (location..end_location).into())?)
     }
 };
 
-FStringReplacementField: ast::Expr = {
+FStringReplacementField: ast::FStringElement = {
     <location:@L> "{" <value:TestListOrYieldExpr> <debug:"="?> <conversion:FStringConversion?> <format_spec:FStringFormatSpecSuffix?> "}" <end_location:@R> =>? {
         if value.expr.is_lambda_expr() && !value.is_parenthesized() {
             return Err(LexicalError {
@@ -1651,30 +1651,27 @@ FStringReplacementField: ast::Expr = {
             }
         });
         Ok(
-            ast::ExprFormattedValue {
-                value: Box::new(value.into()),
+            ast::FStringElement::Expression(ast::FStringExpressionElement {
+                expression: Box::new(value.into()),
                 debug_text,
                 conversion: conversion.map_or(ast::ConversionFlag::None, |(_, conversion_flag)| {
                     conversion_flag
                 }),
                 format_spec: format_spec.map(Box::new),
                 range: (location..end_location).into(),
-            }
-            .into()
+            })
         )
     }
 };
 
-FStringFormatSpecSuffix: ast::Expr = {
+FStringFormatSpecSuffix: ast::FStringFormatSpec = {
     ":" <format_spec:FStringFormatSpec> => format_spec
 };
 
-FStringFormatSpec: ast::Expr = {
-    <location:@L> <values:FStringMiddlePattern*> <end_location:@R> => {
-        ast::FString {
-            values,
-            range: (location..end_location).into()
-        }.into()
+FStringFormatSpec: ast::FStringFormatSpec = {
+    <location:@L> <elements:FStringMiddlePattern*> <end_location:@R> => ast::FStringFormatSpec {
+        elements,
+        range: (location..end_location).into(),
     },
 };
 

--- a/crates/ruff_python_parser/src/python.rs
+++ b/crates/ruff_python_parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: bf21214efe22cee1db2a8fe27c1793b02afee5017a8474a3543f4d8526c1c0ec
+// sha3: 031689e389556292d9dbd8a1b1ff8ca29bac76d83f1b345630481d620b89e1c2
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
 use crate::{
@@ -8,7 +8,7 @@ use crate::{
     lexer::{LexicalError, LexicalErrorType},
     function::{ArgumentList, parse_arguments, validate_pos_params, validate_arguments},
     context::set_context,
-    string::{StringType, concatenated_strings, parse_fstring_middle, parse_string_literal},
+    string::{StringType, concatenated_strings, parse_fstring_literal_element, parse_string_literal},
     token::{self, StringKind},
     invalid,
 };
@@ -32,7 +32,7 @@ mod __parse__Top {
     lexer::{LexicalError, LexicalErrorType},
     function::{ArgumentList, parse_arguments, validate_pos_params, validate_arguments},
     context::set_context,
-    string::{StringType, concatenated_strings, parse_fstring_middle, parse_string_literal},
+    string::{StringType, concatenated_strings, parse_fstring_literal_element, parse_string_literal},
     token::{self, StringKind},
     invalid,
 };
@@ -117,38 +117,41 @@ mod __parse__Top {
         Variant67((TextSize, ast::ConversionFlag)),
         Variant68(core::option::Option<(TextSize, ast::ConversionFlag)>),
         Variant69(StringType),
-        Variant70(alloc::vec::Vec<ast::Expr>),
-        Variant71(core::option::Option<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>),
-        Variant72(ast::Alias),
-        Variant73(Vec<ast::Alias>),
-        Variant74(u32),
-        Variant75(alloc::vec::Vec<u32>),
-        Variant76((Option<u32>, Option<ast::Identifier>)),
-        Variant77(ast::MatchCase),
-        Variant78(alloc::vec::Vec<ast::MatchCase>),
-        Variant79(ast::PatternKeyword),
-        Variant80((ast::Expr, ast::Pattern)),
-        Variant81(ast::Number),
-        Variant82(Vec<ast::Identifier>),
-        Variant83(Vec<ast::PatternKeyword>),
-        Variant84(Vec<(ast::Expr, ast::Pattern)>),
-        Variant85(Vec<ast::ParameterWithDefault>),
-        Variant86(Vec<ast::TypeParam>),
-        Variant87((Vec<ast::ParameterWithDefault>, Vec<ast::ParameterWithDefault>)),
-        Variant88(core::option::Option<ast::Pattern>),
-        Variant89(ast::PatternArguments),
-        Variant90(ast::Comprehension),
-        Variant91(alloc::vec::Vec<ast::Comprehension>),
-        Variant92(Option<crate::parser::ParenthesizedExpr>),
-        Variant93(core::option::Option<Option<crate::parser::ParenthesizedExpr>>),
-        Variant94(Vec<ast::Stmt>),
-        Variant95(ast::Mod),
-        Variant96(Vec<StringType>),
-        Variant97(ast::TypeParam),
-        Variant98(ast::TypeParams),
-        Variant99(core::option::Option<ast::TypeParams>),
-        Variant100(ast::UnaryOp),
-        Variant101(core::option::Option<(String, bool)>),
+        Variant70(ast::FStringFormatSpec),
+        Variant71(core::option::Option<ast::FStringFormatSpec>),
+        Variant72(ast::FStringElement),
+        Variant73(alloc::vec::Vec<ast::FStringElement>),
+        Variant74(core::option::Option<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>),
+        Variant75(ast::Alias),
+        Variant76(Vec<ast::Alias>),
+        Variant77(u32),
+        Variant78(alloc::vec::Vec<u32>),
+        Variant79((Option<u32>, Option<ast::Identifier>)),
+        Variant80(ast::MatchCase),
+        Variant81(alloc::vec::Vec<ast::MatchCase>),
+        Variant82(ast::PatternKeyword),
+        Variant83((ast::Expr, ast::Pattern)),
+        Variant84(ast::Number),
+        Variant85(Vec<ast::Identifier>),
+        Variant86(Vec<ast::PatternKeyword>),
+        Variant87(Vec<(ast::Expr, ast::Pattern)>),
+        Variant88(Vec<ast::ParameterWithDefault>),
+        Variant89(Vec<ast::TypeParam>),
+        Variant90((Vec<ast::ParameterWithDefault>, Vec<ast::ParameterWithDefault>)),
+        Variant91(core::option::Option<ast::Pattern>),
+        Variant92(ast::PatternArguments),
+        Variant93(ast::Comprehension),
+        Variant94(alloc::vec::Vec<ast::Comprehension>),
+        Variant95(Option<crate::parser::ParenthesizedExpr>),
+        Variant96(core::option::Option<Option<crate::parser::ParenthesizedExpr>>),
+        Variant97(Vec<ast::Stmt>),
+        Variant98(ast::Mod),
+        Variant99(Vec<StringType>),
+        Variant100(ast::TypeParam),
+        Variant101(ast::TypeParams),
+        Variant102(core::option::Option<ast::TypeParams>),
+        Variant103(ast::UnaryOp),
+        Variant104(core::option::Option<(String, bool)>),
     }
     const __ACTION: &[i16] = &[
         // State 0
@@ -13866,7 +13869,7 @@ mod __parse__Top {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
-                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+                __symbols.push((__start, __Symbol::Variant72(__nt), __end));
                 (1, 144)
             }
             374 => {
@@ -13885,7 +13888,7 @@ mod __parse__Top {
                 // FStringReplacementField = "{", TestListOrYieldExpr, "=", FStringConversion, FStringFormatSpecSuffix, "}" => ActionFn(1581);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
-                let __sym4 = __pop_Variant44(__symbols);
+                let __sym4 = __pop_Variant70(__symbols);
                 let __sym3 = __pop_Variant67(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant15(__symbols);
@@ -13896,7 +13899,7 @@ mod __parse__Top {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
-                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+                __symbols.push((__start, __Symbol::Variant72(__nt), __end));
                 (6, 147)
             }
             379 => {
@@ -13913,14 +13916,14 @@ mod __parse__Top {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
-                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+                __symbols.push((__start, __Symbol::Variant72(__nt), __end));
                 (5, 147)
             }
             380 => {
                 // FStringReplacementField = "{", TestListOrYieldExpr, "=", FStringFormatSpecSuffix, "}" => ActionFn(1583);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
-                let __sym3 = __pop_Variant44(__symbols);
+                let __sym3 = __pop_Variant70(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant15(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
@@ -13930,7 +13933,7 @@ mod __parse__Top {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
-                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+                __symbols.push((__start, __Symbol::Variant72(__nt), __end));
                 (5, 147)
             }
             381 => {
@@ -13946,14 +13949,14 @@ mod __parse__Top {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
-                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+                __symbols.push((__start, __Symbol::Variant72(__nt), __end));
                 (4, 147)
             }
             382 => {
                 // FStringReplacementField = "{", TestListOrYieldExpr, FStringConversion, FStringFormatSpecSuffix, "}" => ActionFn(1585);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
-                let __sym3 = __pop_Variant44(__symbols);
+                let __sym3 = __pop_Variant70(__symbols);
                 let __sym2 = __pop_Variant67(__symbols);
                 let __sym1 = __pop_Variant15(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
@@ -13963,7 +13966,7 @@ mod __parse__Top {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
-                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+                __symbols.push((__start, __Symbol::Variant72(__nt), __end));
                 (5, 147)
             }
             383 => {
@@ -13979,14 +13982,14 @@ mod __parse__Top {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
-                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+                __symbols.push((__start, __Symbol::Variant72(__nt), __end));
                 (4, 147)
             }
             384 => {
                 // FStringReplacementField = "{", TestListOrYieldExpr, FStringFormatSpecSuffix, "}" => ActionFn(1587);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant44(__symbols);
+                let __sym2 = __pop_Variant70(__symbols);
                 let __sym1 = __pop_Variant15(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -13995,7 +13998,7 @@ mod __parse__Top {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
-                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+                __symbols.push((__start, __Symbol::Variant72(__nt), __end));
                 (4, 147)
             }
             385 => {
@@ -14010,7 +14013,7 @@ mod __parse__Top {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
-                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+                __symbols.push((__start, __Symbol::Variant72(__nt), __end));
                 (3, 147)
             }
             386 => {
@@ -14360,7 +14363,7 @@ mod __parse__Top {
             }
             474 => {
                 // LiteralPattern = TwoOrMore<StringLiteral> => ActionFn(1354);
-                let __sym0 = __pop_Variant96(__symbols);
+                let __sym0 = __pop_Variant99(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
                 let __nt = match super::__action1354::<>(source_code, mode, __sym0) {
@@ -14670,7 +14673,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1607::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -14691,7 +14694,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
                 let __nt = match super::__action1608::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
@@ -14713,7 +14716,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
                 let __nt = match super::__action1609::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
@@ -14731,7 +14734,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1610::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -14751,7 +14754,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1611::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -14772,7 +14775,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
                 let __nt = match super::__action1612::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
@@ -14792,7 +14795,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1613::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -14814,7 +14817,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
                 let __nt = match super::__action1614::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
@@ -14837,7 +14840,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym10.2;
                 let __nt = match super::__action1615::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9, __sym10) {
@@ -14856,7 +14859,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1616::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -14877,7 +14880,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
                 let __nt = match super::__action1617::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
@@ -14899,7 +14902,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
                 let __nt = match super::__action1618::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
@@ -14916,7 +14919,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
                 let __nt = match super::__action1619::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
@@ -14935,7 +14938,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1620::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -14955,7 +14958,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1621::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -14971,7 +14974,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
                 let __nt = match super::__action1622::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
@@ -14989,7 +14992,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1623::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -15008,7 +15011,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1624::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -15026,7 +15029,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1625::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -15046,7 +15049,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1626::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -15067,7 +15070,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
                 let __nt = match super::__action1627::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
@@ -15084,7 +15087,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
                 let __nt = match super::__action1628::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
@@ -15103,7 +15106,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1629::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -15123,7 +15126,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1630::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -15137,7 +15140,7 @@ mod __parse__Top {
                 // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, "," => ActionFn(1631);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
                 let __nt = match super::__action1631::<>(source_code, mode, __sym0, __sym1) {
@@ -15153,7 +15156,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
                 let __nt = match super::__action1632::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
@@ -15170,7 +15173,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
                 let __nt = match super::__action1633::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
@@ -15188,7 +15191,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1634::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -15208,7 +15211,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1635::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -15229,7 +15232,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
                 let __nt = match super::__action1636::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
@@ -15246,7 +15249,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
                 let __nt = match super::__action1637::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
@@ -15265,7 +15268,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1638::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -15285,7 +15288,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1639::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -15304,7 +15307,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1640::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -15325,7 +15328,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
                 let __nt = match super::__action1641::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
@@ -15347,7 +15350,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
                 let __nt = match super::__action1642::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
@@ -15365,7 +15368,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1643::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -15385,7 +15388,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1644::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -15406,7 +15409,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
                 let __nt = match super::__action1645::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
@@ -15422,7 +15425,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
                 let __nt = match super::__action1646::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
@@ -15440,7 +15443,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1647::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -15459,7 +15462,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1648::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -15474,7 +15477,7 @@ mod __parse__Top {
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
                 let __nt = match super::__action1649::<>(source_code, mode, __sym0, __sym1, __sym2) {
@@ -15491,7 +15494,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
                 let __nt = match super::__action1650::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
@@ -15509,7 +15512,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1651::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -15526,7 +15529,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
                 let __nt = match super::__action1652::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
@@ -15545,7 +15548,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1653::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -15565,7 +15568,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1654::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -15581,7 +15584,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
                 let __nt = match super::__action1655::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
@@ -15599,7 +15602,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1656::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -15618,7 +15621,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1657::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -15630,7 +15633,7 @@ mod __parse__Top {
             }
             623 => {
                 // ParameterList<TypedParameter, StarTypedParameter, DoubleStarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>> => ActionFn(1658);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
                 let __nt = match super::__action1658::<>(source_code, mode, __sym0) {
@@ -15645,7 +15648,7 @@ mod __parse__Top {
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
                 let __nt = match super::__action1659::<>(source_code, mode, __sym0, __sym1, __sym2) {
@@ -15661,7 +15664,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
                 let __nt = match super::__action1660::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
@@ -15677,7 +15680,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant9(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
                 let __nt = match super::__action1661::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
@@ -15695,7 +15698,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1662::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -15714,7 +15717,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1663::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -15729,7 +15732,7 @@ mod __parse__Top {
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant9(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
                 let __nt = match super::__action1664::<>(source_code, mode, __sym0, __sym1, __sym2) {
@@ -15746,7 +15749,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
                 let __nt = match super::__action1665::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
@@ -15764,7 +15767,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1666::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -16036,7 +16039,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1667::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -16057,7 +16060,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
                 let __nt = match super::__action1668::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
@@ -16079,7 +16082,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
                 let __nt = match super::__action1669::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
@@ -16097,7 +16100,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1670::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -16117,7 +16120,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1671::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -16138,7 +16141,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
                 let __nt = match super::__action1672::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
@@ -16158,7 +16161,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1673::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -16180,7 +16183,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
                 let __nt = match super::__action1674::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
@@ -16203,7 +16206,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym10.2;
                 let __nt = match super::__action1675::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9, __sym10) {
@@ -16222,7 +16225,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1676::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -16243,7 +16246,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
                 let __nt = match super::__action1677::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
@@ -16265,7 +16268,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
                 let __nt = match super::__action1678::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
@@ -16282,7 +16285,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
                 let __nt = match super::__action1679::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
@@ -16301,7 +16304,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1680::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -16321,7 +16324,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1681::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -16337,7 +16340,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
                 let __nt = match super::__action1682::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
@@ -16355,7 +16358,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1683::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -16374,7 +16377,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1684::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -16392,7 +16395,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1685::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -16412,7 +16415,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1686::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -16433,7 +16436,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
                 let __nt = match super::__action1687::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
@@ -16450,7 +16453,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
                 let __nt = match super::__action1688::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
@@ -16469,7 +16472,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1689::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -16489,7 +16492,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1690::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -16503,7 +16506,7 @@ mod __parse__Top {
                 // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, "," => ActionFn(1691);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
                 let __nt = match super::__action1691::<>(source_code, mode, __sym0, __sym1) {
@@ -16519,7 +16522,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
                 let __nt = match super::__action1692::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
@@ -16536,7 +16539,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
                 let __nt = match super::__action1693::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
@@ -16554,7 +16557,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1694::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -16574,7 +16577,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1695::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -16595,7 +16598,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
                 let __nt = match super::__action1696::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
@@ -16612,7 +16615,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
                 let __nt = match super::__action1697::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
@@ -16631,7 +16634,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1698::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -16651,7 +16654,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1699::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -16670,7 +16673,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1700::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -16691,7 +16694,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
                 let __nt = match super::__action1701::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
@@ -16713,7 +16716,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
                 let __nt = match super::__action1702::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
@@ -16731,7 +16734,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1703::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -16751,7 +16754,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1704::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -16772,7 +16775,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
                 let __nt = match super::__action1705::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
@@ -16788,7 +16791,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
                 let __nt = match super::__action1706::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
@@ -16806,7 +16809,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1707::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -16825,7 +16828,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1708::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -16840,7 +16843,7 @@ mod __parse__Top {
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
                 let __nt = match super::__action1709::<>(source_code, mode, __sym0, __sym1, __sym2) {
@@ -16857,7 +16860,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
                 let __nt = match super::__action1710::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
@@ -16875,7 +16878,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1711::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -16892,7 +16895,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant63(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
                 let __nt = match super::__action1712::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
@@ -16911,7 +16914,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1713::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -16931,7 +16934,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
                 let __nt = match super::__action1714::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
@@ -16947,7 +16950,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
                 let __nt = match super::__action1715::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
@@ -16965,7 +16968,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1716::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -16984,7 +16987,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1717::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -16996,7 +16999,7 @@ mod __parse__Top {
             }
             701 => {
                 // ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>> => ActionFn(1718);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
                 let __nt = match super::__action1718::<>(source_code, mode, __sym0) {
@@ -17011,7 +17014,7 @@ mod __parse__Top {
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
                 let __nt = match super::__action1719::<>(source_code, mode, __sym0, __sym1, __sym2) {
@@ -17027,7 +17030,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
                 let __nt = match super::__action1720::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
@@ -17043,7 +17046,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant9(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
                 let __nt = match super::__action1721::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3) {
@@ -17061,7 +17064,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1722::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -17080,7 +17083,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
                 let __nt = match super::__action1723::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
@@ -17095,7 +17098,7 @@ mod __parse__Top {
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant9(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
                 let __nt = match super::__action1724::<>(source_code, mode, __sym0, __sym1, __sym2) {
@@ -17112,7 +17115,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
                 let __nt = match super::__action1725::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4) {
@@ -17130,7 +17133,7 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant85(__symbols);
+                let __sym0 = __pop_Variant88(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
                 let __nt = match super::__action1726::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
@@ -17932,7 +17935,7 @@ mod __parse__Top {
             }
             836 => {
                 // String = TwoOrMore<StringLiteralOrFString> => ActionFn(1493);
-                let __sym0 = __pop_Variant96(__symbols);
+                let __sym0 = __pop_Variant99(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
                 let __nt = match super::__action1493::<>(source_code, mode, __sym0) {
@@ -18295,7 +18298,7 @@ mod __parse__Top {
             }
             951 => {
                 // __Top = Top => ActionFn(0);
-                let __sym0 = __pop_Variant95(__symbols);
+                let __sym0 = __pop_Variant98(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
                 let __nt = super::__action0::<>(source_code, mode, __sym0);
@@ -18360,13 +18363,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant76<
+    fn __pop_Variant79<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, (Option<u32>, Option<ast::Identifier>), TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant76(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant79(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -18420,13 +18423,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant87<
+    fn __pop_Variant90<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, (Vec<ast::ParameterWithDefault>, Vec<ast::ParameterWithDefault>), TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant87(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant90(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -18440,13 +18443,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant80<
+    fn __pop_Variant83<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, (ast::Expr, ast::Pattern), TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant80(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant83(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -18510,13 +18513,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant92<
+    fn __pop_Variant95<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, Option<crate::parser::ParenthesizedExpr>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant92(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant95(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -18570,33 +18573,33 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant84<
+    fn __pop_Variant87<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, Vec<(ast::Expr, ast::Pattern)>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant84(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant87(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant96<
+    fn __pop_Variant99<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, Vec<StringType>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant96(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant99(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant73<
+    fn __pop_Variant76<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, Vec<ast::Alias>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant73(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant76(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -18610,23 +18613,23 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant82<
+    fn __pop_Variant85<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, Vec<ast::Identifier>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant82(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant85(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant85<
+    fn __pop_Variant88<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, Vec<ast::ParameterWithDefault>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant85(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant88(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -18640,33 +18643,33 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant83<
+    fn __pop_Variant86<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, Vec<ast::PatternKeyword>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant83(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant86(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant94<
+    fn __pop_Variant97<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, Vec<ast::Stmt>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant94(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant97(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant86<
+    fn __pop_Variant89<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, Vec<ast::TypeParam>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant86(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant89(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -18730,13 +18733,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant91<
+    fn __pop_Variant94<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, alloc::vec::Vec<ast::Comprehension>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant91(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant94(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -18760,23 +18763,23 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant70<
+    fn __pop_Variant73<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
-    ) -> (TextSize, alloc::vec::Vec<ast::Expr>, TextSize)
+    ) -> (TextSize, alloc::vec::Vec<ast::FStringElement>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant70(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant73(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant78<
+    fn __pop_Variant81<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant78(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant81(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -18840,23 +18843,23 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant75<
+    fn __pop_Variant78<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, alloc::vec::Vec<u32>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant75(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant78(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant72<
+    fn __pop_Variant75<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::Alias, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant72(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant75(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -18880,13 +18883,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant90<
+    fn __pop_Variant93<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::Comprehension, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant90(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant93(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -18920,6 +18923,26 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
+    fn __pop_Variant72<
+    >(
+        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
+    ) -> (TextSize, ast::FStringElement, TextSize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant72(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant70<
+    >(
+        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
+    ) -> (TextSize, ast::FStringFormatSpec, TextSize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant70(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
     fn __pop_Variant23<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
@@ -18930,33 +18953,33 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant77<
+    fn __pop_Variant80<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::MatchCase, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant77(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant80(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant95<
+    fn __pop_Variant98<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::Mod, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant95(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant98(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant81<
+    fn __pop_Variant84<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::Number, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant81(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant84(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -19010,23 +19033,23 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant89<
+    fn __pop_Variant92<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::PatternArguments, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant89(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant92(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant79<
+    fn __pop_Variant82<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::PatternKeyword, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant79(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant82(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -19050,33 +19073,33 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant97<
+    fn __pop_Variant100<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::TypeParam, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant97(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant100(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant98<
+    fn __pop_Variant101<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::TypeParams, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant98(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant101(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant100<
+    fn __pop_Variant103<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::UnaryOp, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant100(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant103(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -19090,13 +19113,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant71<
+    fn __pop_Variant74<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, core::option::Option<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant71(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant74(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -19110,13 +19133,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant101<
+    fn __pop_Variant104<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, core::option::Option<(String, bool)>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant101(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant104(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -19150,13 +19173,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant93<
+    fn __pop_Variant96<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, core::option::Option<Option<crate::parser::ParenthesizedExpr>>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant93(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant96(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -19220,6 +19243,16 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
+    fn __pop_Variant71<
+    >(
+        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
+    ) -> (TextSize, core::option::Option<ast::FStringFormatSpec>, TextSize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant71(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
     fn __pop_Variant24<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
@@ -19250,13 +19283,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant88<
+    fn __pop_Variant91<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, core::option::Option<ast::Pattern>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant88(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant91(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -19270,13 +19303,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant99<
+    fn __pop_Variant102<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, core::option::Option<ast::TypeParams>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant99(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant102(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -19330,13 +19363,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant74<
+    fn __pop_Variant77<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, u32, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant74(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant77(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -21983,7 +22016,7 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // Atom<"all"> = Number => ActionFn(1239);
-        let __sym0 = __pop_Variant81(__symbols);
+        let __sym0 = __pop_Variant84(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action1239::<>(source_code, mode, __sym0);
@@ -22364,7 +22397,7 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // Atom<"no-withitems"> = Number => ActionFn(1265);
-        let __sym0 = __pop_Variant81(__symbols);
+        let __sym0 = __pop_Variant84(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action1265::<>(source_code, mode, __sym0);
@@ -23155,7 +23188,7 @@ mod __parse__Top {
         let __sym5 = __pop_Variant25(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant50(__symbols);
-        let __sym2 = __pop_Variant98(__symbols);
+        let __sym2 = __pop_Variant101(__symbols);
         let __sym1 = __pop_Variant23(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
@@ -23200,7 +23233,7 @@ mod __parse__Top {
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant50(__symbols);
-        let __sym3 = __pop_Variant98(__symbols);
+        let __sym3 = __pop_Variant101(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant58(__symbols);
@@ -23246,7 +23279,7 @@ mod __parse__Top {
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant25(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant98(__symbols);
+        let __sym2 = __pop_Variant101(__symbols);
         let __sym1 = __pop_Variant23(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
@@ -23289,7 +23322,7 @@ mod __parse__Top {
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant25(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant98(__symbols);
+        let __sym3 = __pop_Variant101(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant58(__symbols);
@@ -23332,7 +23365,7 @@ mod __parse__Top {
     {
         // ClassPattern = MatchName, PatternArguments => ActionFn(1298);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant89(__symbols);
+        let __sym1 = __pop_Variant92(__symbols);
         let __sym0 = __pop_Variant44(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
@@ -23351,7 +23384,7 @@ mod __parse__Top {
     {
         // ClassPattern = MatchNameOrAttr, PatternArguments => ActionFn(1299);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant89(__symbols);
+        let __sym1 = __pop_Variant92(__symbols);
         let __sym0 = __pop_Variant44(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
@@ -23626,7 +23659,7 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // CompFor = SingleForComprehension+ => ActionFn(237);
-        let __sym0 = __pop_Variant91(__symbols);
+        let __sym0 = __pop_Variant94(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action237::<>(source_code, mode, __sym0);
@@ -24899,7 +24932,7 @@ mod __parse__Top {
         // FStringExpr = FStringStart, FStringMiddlePattern+, FStringEnd => ActionFn(1590);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant70(__symbols);
+        let __sym1 = __pop_Variant73(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
@@ -24920,7 +24953,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action1591::<>(source_code, mode, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant70(__nt), __end));
         (0, 141)
     }
     pub(crate) fn __reduce368<
@@ -24933,11 +24966,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // FStringFormatSpec = FStringMiddlePattern+ => ActionFn(1592);
-        let __sym0 = __pop_Variant70(__symbols);
+        let __sym0 = __pop_Variant73(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action1592::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant70(__nt), __end));
         (1, 141)
     }
     pub(crate) fn __reduce369<
@@ -24951,12 +24984,12 @@ mod __parse__Top {
     {
         // FStringFormatSpecSuffix = ":", FStringFormatSpec => ActionFn(222);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant44(__symbols);
+        let __sym1 = __pop_Variant70(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action222::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant70(__nt), __end));
         (2, 142)
     }
     pub(crate) fn __reduce370<
@@ -24969,11 +25002,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // FStringFormatSpecSuffix? = FStringFormatSpecSuffix => ActionFn(267);
-        let __sym0 = __pop_Variant44(__symbols);
+        let __sym0 = __pop_Variant70(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action267::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant45(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant71(__nt), __end));
         (1, 143)
     }
     pub(crate) fn __reduce371<
@@ -24989,7 +25022,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action268::<>(source_code, mode, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant45(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant71(__nt), __end));
         (0, 143)
     }
     pub(crate) fn __reduce372<
@@ -25002,11 +25035,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // FStringMiddlePattern = FStringReplacementField => ActionFn(219);
-        let __sym0 = __pop_Variant44(__symbols);
+        let __sym0 = __pop_Variant72(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action219::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant72(__nt), __end));
         (1, 144)
     }
     pub(crate) fn __reduce374<
@@ -25022,7 +25055,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action273::<>(source_code, mode, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant70(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
         (0, 145)
     }
     pub(crate) fn __reduce375<
@@ -25035,11 +25068,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // FStringMiddlePattern* = FStringMiddlePattern+ => ActionFn(274);
-        let __sym0 = __pop_Variant70(__symbols);
+        let __sym0 = __pop_Variant73(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action274::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant70(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
         (1, 145)
     }
     pub(crate) fn __reduce376<
@@ -25052,11 +25085,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // FStringMiddlePattern+ = FStringMiddlePattern => ActionFn(456);
-        let __sym0 = __pop_Variant44(__symbols);
+        let __sym0 = __pop_Variant72(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action456::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant70(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
         (1, 146)
     }
     pub(crate) fn __reduce377<
@@ -25070,12 +25103,12 @@ mod __parse__Top {
     {
         // FStringMiddlePattern+ = FStringMiddlePattern+, FStringMiddlePattern => ActionFn(457);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant44(__symbols);
-        let __sym0 = __pop_Variant70(__symbols);
+        let __sym1 = __pop_Variant72(__symbols);
+        let __sym0 = __pop_Variant73(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action457::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant70(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
         (2, 146)
     }
     pub(crate) fn __reduce386<
@@ -25090,7 +25123,7 @@ mod __parse__Top {
         // Factor<"all"> = UnaryOp, Factor<"all"> => ActionFn(1318);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
-        let __sym0 = __pop_Variant100(__symbols);
+        let __sym0 = __pop_Variant103(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action1318::<>(source_code, mode, __sym0, __sym1);
@@ -25126,7 +25159,7 @@ mod __parse__Top {
         // Factor<"no-withitems"> = UnaryOp, Factor<"all"> => ActionFn(1319);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
-        let __sym0 = __pop_Variant100(__symbols);
+        let __sym0 = __pop_Variant103(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action1319::<>(source_code, mode, __sym0, __sym1);
@@ -25370,7 +25403,7 @@ mod __parse__Top {
         let __sym6 = __pop_Variant15(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant46(__symbols);
-        let __sym3 = __pop_Variant98(__symbols);
+        let __sym3 = __pop_Variant101(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
@@ -25421,7 +25454,7 @@ mod __parse__Top {
         let __sym7 = __pop_Variant15(__symbols);
         let __sym6 = __pop_Variant0(__symbols);
         let __sym5 = __pop_Variant46(__symbols);
-        let __sym4 = __pop_Variant98(__symbols);
+        let __sym4 = __pop_Variant101(__symbols);
         let __sym3 = __pop_Variant23(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
@@ -25472,7 +25505,7 @@ mod __parse__Top {
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant46(__symbols);
-        let __sym3 = __pop_Variant98(__symbols);
+        let __sym3 = __pop_Variant101(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
@@ -25519,7 +25552,7 @@ mod __parse__Top {
         let __sym7 = __pop_Variant25(__symbols);
         let __sym6 = __pop_Variant0(__symbols);
         let __sym5 = __pop_Variant46(__symbols);
-        let __sym4 = __pop_Variant98(__symbols);
+        let __sym4 = __pop_Variant101(__symbols);
         let __sym3 = __pop_Variant23(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
@@ -25570,7 +25603,7 @@ mod __parse__Top {
         let __sym5 = __pop_Variant15(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant46(__symbols);
-        let __sym2 = __pop_Variant98(__symbols);
+        let __sym2 = __pop_Variant101(__symbols);
         let __sym1 = __pop_Variant23(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
@@ -25619,7 +25652,7 @@ mod __parse__Top {
         let __sym6 = __pop_Variant15(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant46(__symbols);
-        let __sym3 = __pop_Variant98(__symbols);
+        let __sym3 = __pop_Variant101(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant58(__symbols);
@@ -25668,7 +25701,7 @@ mod __parse__Top {
         let __sym5 = __pop_Variant25(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant46(__symbols);
-        let __sym2 = __pop_Variant98(__symbols);
+        let __sym2 = __pop_Variant101(__symbols);
         let __sym1 = __pop_Variant23(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
@@ -25713,7 +25746,7 @@ mod __parse__Top {
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant46(__symbols);
-        let __sym3 = __pop_Variant98(__symbols);
+        let __sym3 = __pop_Variant101(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant58(__symbols);
@@ -25854,7 +25887,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action467::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant71(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant74(__nt), __end));
         (1, 154)
     }
     pub(crate) fn __reduce422<
@@ -25870,7 +25903,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action468::<>(source_code, mode, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant71(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant74(__nt), __end));
         (0, 154)
     }
     pub(crate) fn __reduce423<
@@ -25956,7 +25989,7 @@ mod __parse__Top {
     {
         // GlobalStatement = "global", OneOrMore<Identifier> => ActionFn(1332);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant82(__symbols);
+        let __sym1 = __pop_Variant85(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
@@ -26109,7 +26142,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1334::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant72(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
         (3, 161)
     }
     pub(crate) fn __reduce435<
@@ -26126,7 +26159,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action1335::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant72(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
         (1, 161)
     }
     pub(crate) fn __reduce436<
@@ -26146,7 +26179,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1336::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant72(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
         (3, 162)
     }
     pub(crate) fn __reduce437<
@@ -26163,7 +26196,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action1337::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant72(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
         (1, 162)
     }
     pub(crate) fn __reduce438<
@@ -26176,11 +26209,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ImportAsNames = OneOrMore<ImportAsAlias<Identifier>> => ActionFn(1338);
-        let __sym0 = __pop_Variant73(__symbols);
+        let __sym0 = __pop_Variant76(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action1338::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (1, 163)
     }
     pub(crate) fn __reduce439<
@@ -26196,12 +26229,12 @@ mod __parse__Top {
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant73(__symbols);
+        let __sym1 = __pop_Variant76(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action1339::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (4, 163)
     }
     pub(crate) fn __reduce440<
@@ -26216,12 +26249,12 @@ mod __parse__Top {
         // ImportAsNames = "(", OneOrMore<ImportAsAlias<Identifier>>, ")" => ActionFn(1340);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant73(__symbols);
+        let __sym1 = __pop_Variant76(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1340::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (3, 163)
     }
     pub(crate) fn __reduce441<
@@ -26238,7 +26271,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action1341::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (1, 163)
     }
     pub(crate) fn __reduce442<
@@ -26255,7 +26288,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action64::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant74(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant77(__nt), __end));
         (1, 164)
     }
     pub(crate) fn __reduce443<
@@ -26272,7 +26305,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action65::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant74(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant77(__nt), __end));
         (1, 164)
     }
     pub(crate) fn __reduce444<
@@ -26288,7 +26321,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action391::<>(source_code, mode, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant78(__nt), __end));
         (0, 165)
     }
     pub(crate) fn __reduce445<
@@ -26301,11 +26334,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ImportDots* = ImportDots+ => ActionFn(392);
-        let __sym0 = __pop_Variant75(__symbols);
+        let __sym0 = __pop_Variant78(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action392::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant78(__nt), __end));
         (1, 165)
     }
     pub(crate) fn __reduce446<
@@ -26318,11 +26351,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ImportDots+ = ImportDots => ActionFn(389);
-        let __sym0 = __pop_Variant74(__symbols);
+        let __sym0 = __pop_Variant77(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action389::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant78(__nt), __end));
         (1, 166)
     }
     pub(crate) fn __reduce447<
@@ -26336,12 +26369,12 @@ mod __parse__Top {
     {
         // ImportDots+ = ImportDots+, ImportDots => ActionFn(390);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant74(__symbols);
-        let __sym0 = __pop_Variant75(__symbols);
+        let __sym1 = __pop_Variant77(__symbols);
+        let __sym0 = __pop_Variant78(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action390::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant78(__nt), __end));
         (2, 166)
     }
     pub(crate) fn __reduce448<
@@ -26358,7 +26391,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action1601::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant79(__nt), __end));
         (1, 167)
     }
     pub(crate) fn __reduce449<
@@ -26373,11 +26406,11 @@ mod __parse__Top {
         // ImportFromLocation = ImportDots+, DottedName => ActionFn(1602);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant23(__symbols);
-        let __sym0 = __pop_Variant75(__symbols);
+        let __sym0 = __pop_Variant78(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action1602::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant79(__nt), __end));
         (2, 167)
     }
     pub(crate) fn __reduce450<
@@ -26390,11 +26423,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ImportFromLocation = ImportDots+ => ActionFn(63);
-        let __sym0 = __pop_Variant75(__symbols);
+        let __sym0 = __pop_Variant78(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action63::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant79(__nt), __end));
         (1, 167)
     }
     pub(crate) fn __reduce451<
@@ -26408,7 +26441,7 @@ mod __parse__Top {
     {
         // ImportStatement = "import", OneOrMore<ImportAsAlias<DottedName>> => ActionFn(1342);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant73(__symbols);
+        let __sym1 = __pop_Variant76(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
@@ -26427,9 +26460,9 @@ mod __parse__Top {
     {
         // ImportStatement = "from", ImportFromLocation, "import", ImportAsNames => ActionFn(1343);
         assert!(__symbols.len() >= 4);
-        let __sym3 = __pop_Variant73(__symbols);
+        let __sym3 = __pop_Variant76(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant76(__symbols);
+        let __sym1 = __pop_Variant79(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
@@ -26831,7 +26864,7 @@ mod __parse__Top {
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant84(__symbols);
+        let __sym1 = __pop_Variant87(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
@@ -26851,7 +26884,7 @@ mod __parse__Top {
         // MappingPattern = "{", OneOrMore<MatchMappingEntry>, "}" => ActionFn(1360);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant84(__symbols);
+        let __sym1 = __pop_Variant87(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
@@ -26918,7 +26951,7 @@ mod __parse__Top {
         let __sym4 = __pop_Variant23(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant84(__symbols);
+        let __sym1 = __pop_Variant87(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
@@ -26941,7 +26974,7 @@ mod __parse__Top {
         let __sym4 = __pop_Variant23(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant84(__symbols);
+        let __sym1 = __pop_Variant87(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
@@ -26968,7 +27001,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym4.2;
         let __nt = super::__action1223::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant77(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant80(__nt), __end));
         (5, 180)
     }
     pub(crate) fn __reduce490<
@@ -26989,7 +27022,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action1224::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant77(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant80(__nt), __end));
         (4, 180)
     }
     pub(crate) fn __reduce491<
@@ -27002,11 +27035,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // MatchCase+ = MatchCase => ActionFn(369);
-        let __sym0 = __pop_Variant77(__symbols);
+        let __sym0 = __pop_Variant80(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action369::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant78(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant81(__nt), __end));
         (1, 181)
     }
     pub(crate) fn __reduce492<
@@ -27020,12 +27053,12 @@ mod __parse__Top {
     {
         // MatchCase+ = MatchCase+, MatchCase => ActionFn(370);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant77(__symbols);
-        let __sym0 = __pop_Variant78(__symbols);
+        let __sym1 = __pop_Variant80(__symbols);
+        let __sym0 = __pop_Variant81(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action370::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant78(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant81(__nt), __end));
         (2, 181)
     }
     pub(crate) fn __reduce493<
@@ -27045,7 +27078,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1365::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant79(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant82(__nt), __end));
         (3, 182)
     }
     pub(crate) fn __reduce494<
@@ -27065,7 +27098,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action134::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant80(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
         (3, 183)
     }
     pub(crate) fn __reduce495<
@@ -27137,7 +27170,7 @@ mod __parse__Top {
         // MatchStatement = "match", TestOrStarNamedExpr, ":", "\n", Indent, MatchCase+, Dedent => ActionFn(862);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant0(__symbols);
-        let __sym5 = __pop_Variant78(__symbols);
+        let __sym5 = __pop_Variant81(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -27161,7 +27194,7 @@ mod __parse__Top {
         // MatchStatement = "match", TestOrStarNamedExpr, ",", ":", "\n", Indent, MatchCase+, Dedent => ActionFn(1369);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
-        let __sym6 = __pop_Variant78(__symbols);
+        let __sym6 = __pop_Variant81(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -27186,7 +27219,7 @@ mod __parse__Top {
         // MatchStatement = "match", TwoOrMoreSep<TestOrStarNamedExpr, ",">, ",", ":", "\n", Indent, MatchCase+, Dedent => ActionFn(1370);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
-        let __sym6 = __pop_Variant78(__symbols);
+        let __sym6 = __pop_Variant81(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -27211,7 +27244,7 @@ mod __parse__Top {
         // MatchStatement = "match", TwoOrMoreSep<TestOrStarNamedExpr, ",">, ":", "\n", Indent, MatchCase+, Dedent => ActionFn(1371);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant0(__symbols);
-        let __sym5 = __pop_Variant78(__symbols);
+        let __sym5 = __pop_Variant81(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -27424,7 +27457,7 @@ mod __parse__Top {
     {
         // NonlocalStatement = "nonlocal", OneOrMore<Identifier> => ActionFn(1374);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant82(__symbols);
+        let __sym1 = __pop_Variant85(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
@@ -27518,7 +27551,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action246::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant81(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
         (1, 195)
     }
     pub(crate) fn __reduce519<
@@ -27535,7 +27568,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action247::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant81(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
         (1, 195)
     }
     pub(crate) fn __reduce520<
@@ -27552,7 +27585,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action248::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant81(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
         (1, 195)
     }
     pub(crate) fn __reduce521<
@@ -27565,7 +27598,7 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // NumberAtom = Number => ActionFn(1377);
-        let __sym0 = __pop_Variant81(__symbols);
+        let __sym0 = __pop_Variant84(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action1377::<>(source_code, mode, __sym0);
@@ -27696,7 +27729,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action379::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant82(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
         (1, 200)
     }
     pub(crate) fn __reduce529<
@@ -27712,11 +27745,11 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant82(__symbols);
+        let __sym0 = __pop_Variant85(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action380::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant82(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
         (3, 200)
     }
     pub(crate) fn __reduce530<
@@ -27736,7 +27769,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1593::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (3, 201)
     }
     pub(crate) fn __reduce531<
@@ -27753,7 +27786,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action1594::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (1, 201)
     }
     pub(crate) fn __reduce532<
@@ -27771,11 +27804,11 @@ mod __parse__Top {
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant73(__symbols);
+        let __sym0 = __pop_Variant76(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
         let __nt = super::__action1595::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (5, 201)
     }
     pub(crate) fn __reduce533<
@@ -27791,11 +27824,11 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant73(__symbols);
+        let __sym0 = __pop_Variant76(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1596::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (3, 201)
     }
     pub(crate) fn __reduce534<
@@ -27815,7 +27848,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1597::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (3, 202)
     }
     pub(crate) fn __reduce535<
@@ -27832,7 +27865,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action1598::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (1, 202)
     }
     pub(crate) fn __reduce536<
@@ -27850,11 +27883,11 @@ mod __parse__Top {
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant73(__symbols);
+        let __sym0 = __pop_Variant76(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
         let __nt = super::__action1599::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (5, 202)
     }
     pub(crate) fn __reduce537<
@@ -27870,11 +27903,11 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant73(__symbols);
+        let __sym0 = __pop_Variant76(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1600::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (3, 202)
     }
     pub(crate) fn __reduce538<
@@ -27887,11 +27920,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // OneOrMore<MatchKeywordEntry> = MatchKeywordEntry => ActionFn(348);
-        let __sym0 = __pop_Variant79(__symbols);
+        let __sym0 = __pop_Variant82(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action348::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant86(__nt), __end));
         (1, 203)
     }
     pub(crate) fn __reduce539<
@@ -27905,13 +27938,13 @@ mod __parse__Top {
     {
         // OneOrMore<MatchKeywordEntry> = OneOrMore<MatchKeywordEntry>, ",", MatchKeywordEntry => ActionFn(349);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant79(__symbols);
+        let __sym2 = __pop_Variant82(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant83(__symbols);
+        let __sym0 = __pop_Variant86(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action349::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant86(__nt), __end));
         (3, 203)
     }
     pub(crate) fn __reduce540<
@@ -27924,11 +27957,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // OneOrMore<MatchMappingEntry> = MatchMappingEntry => ActionFn(352);
-        let __sym0 = __pop_Variant80(__symbols);
+        let __sym0 = __pop_Variant83(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action352::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant87(__nt), __end));
         (1, 204)
     }
     pub(crate) fn __reduce541<
@@ -27942,13 +27975,13 @@ mod __parse__Top {
     {
         // OneOrMore<MatchMappingEntry> = OneOrMore<MatchMappingEntry>, ",", MatchMappingEntry => ActionFn(353);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant80(__symbols);
+        let __sym2 = __pop_Variant83(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant84(__symbols);
+        let __sym0 = __pop_Variant87(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action353::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant87(__nt), __end));
         (3, 204)
     }
     pub(crate) fn __reduce542<
@@ -27965,7 +27998,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action490::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant88(__nt), __end));
         (1, 205)
     }
     pub(crate) fn __reduce543<
@@ -27981,11 +28014,11 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant85(__symbols);
+        let __sym0 = __pop_Variant88(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action491::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant88(__nt), __end));
         (3, 205)
     }
     pub(crate) fn __reduce544<
@@ -28002,7 +28035,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action479::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant88(__nt), __end));
         (1, 206)
     }
     pub(crate) fn __reduce545<
@@ -28018,11 +28051,11 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant85(__symbols);
+        let __sym0 = __pop_Variant88(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action480::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant88(__nt), __end));
         (3, 206)
     }
     pub(crate) fn __reduce546<
@@ -28183,11 +28216,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // OneOrMore<TypeParam> = TypeParam => ActionFn(289);
-        let __sym0 = __pop_Variant97(__symbols);
+        let __sym0 = __pop_Variant100(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action289::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant86(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant89(__nt), __end));
         (1, 211)
     }
     pub(crate) fn __reduce555<
@@ -28201,13 +28234,13 @@ mod __parse__Top {
     {
         // OneOrMore<TypeParam> = OneOrMore<TypeParam>, ",", TypeParam => ActionFn(290);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant97(__symbols);
+        let __sym2 = __pop_Variant100(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant86(__symbols);
+        let __sym0 = __pop_Variant89(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action290::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant86(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant89(__nt), __end));
         (3, 211)
     }
     pub(crate) fn __reduce556<
@@ -28400,11 +28433,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ParameterDefs<TypedParameter> = OneOrMore<ParameterDef<TypedParameter>> => ActionFn(446);
-        let __sym0 = __pop_Variant85(__symbols);
+        let __sym0 = __pop_Variant88(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action446::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant87(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant90(__nt), __end));
         (1, 217)
     }
     pub(crate) fn __reduce567<
@@ -28420,11 +28453,11 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant85(__symbols);
+        let __sym0 = __pop_Variant88(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action701::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant87(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant90(__nt), __end));
         (3, 217)
     }
     pub(crate) fn __reduce568<
@@ -28441,11 +28474,11 @@ mod __parse__Top {
         let __sym3 = __pop_Variant12(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant85(__symbols);
+        let __sym0 = __pop_Variant88(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action702::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant87(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant90(__nt), __end));
         (4, 217)
     }
     pub(crate) fn __reduce569<
@@ -28458,11 +28491,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ParameterDefs<UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>> => ActionFn(454);
-        let __sym0 = __pop_Variant85(__symbols);
+        let __sym0 = __pop_Variant88(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action454::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant87(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant90(__nt), __end));
         (1, 218)
     }
     pub(crate) fn __reduce570<
@@ -28478,11 +28511,11 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant85(__symbols);
+        let __sym0 = __pop_Variant88(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action709::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant87(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant90(__nt), __end));
         (3, 218)
     }
     pub(crate) fn __reduce571<
@@ -28499,11 +28532,11 @@ mod __parse__Top {
         let __sym3 = __pop_Variant12(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant85(__symbols);
+        let __sym0 = __pop_Variant88(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action710::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant87(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant90(__nt), __end));
         (4, 218)
     }
     pub(crate) fn __reduce648<
@@ -28676,7 +28709,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action429::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant88(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant91(__nt), __end));
         (1, 227)
     }
     pub(crate) fn __reduce752<
@@ -28692,7 +28725,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action430::<>(source_code, mode, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant88(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant91(__nt), __end));
         (0, 227)
     }
     pub(crate) fn __reduce753<
@@ -28708,14 +28741,14 @@ mod __parse__Top {
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant83(__symbols);
+        let __sym3 = __pop_Variant86(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant53(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
         let __nt = super::__action1463::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
-        __symbols.push((__start, __Symbol::Variant89(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant92(__nt), __end));
         (6, 228)
     }
     pub(crate) fn __reduce754<
@@ -28730,14 +28763,14 @@ mod __parse__Top {
         // PatternArguments = "(", OneOrMore<Pattern>, ",", OneOrMore<MatchKeywordEntry>, ")" => ActionFn(1464);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant83(__symbols);
+        let __sym3 = __pop_Variant86(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant53(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
         let __nt = super::__action1464::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant89(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant92(__nt), __end));
         (5, 228)
     }
     pub(crate) fn __reduce755<
@@ -28758,7 +28791,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action1465::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant89(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant92(__nt), __end));
         (4, 228)
     }
     pub(crate) fn __reduce756<
@@ -28778,7 +28811,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1466::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant89(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant92(__nt), __end));
         (3, 228)
     }
     pub(crate) fn __reduce757<
@@ -28794,12 +28827,12 @@ mod __parse__Top {
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant83(__symbols);
+        let __sym1 = __pop_Variant86(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action1467::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant89(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant92(__nt), __end));
         (4, 228)
     }
     pub(crate) fn __reduce758<
@@ -28814,12 +28847,12 @@ mod __parse__Top {
         // PatternArguments = "(", OneOrMore<MatchKeywordEntry>, ")" => ActionFn(1468);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant83(__symbols);
+        let __sym1 = __pop_Variant86(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1468::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant89(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant92(__nt), __end));
         (3, 228)
     }
     pub(crate) fn __reduce759<
@@ -28838,7 +28871,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action1469::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant89(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant92(__nt), __end));
         (2, 228)
     }
     pub(crate) fn __reduce760<
@@ -29528,7 +29561,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym4.2;
         let __nt = super::__action1555::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant90(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant93(__nt), __end));
         (5, 239)
     }
     pub(crate) fn __reduce796<
@@ -29551,7 +29584,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym5.2;
         let __nt = super::__action1556::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
-        __symbols.push((__start, __Symbol::Variant90(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant93(__nt), __end));
         (6, 239)
     }
     pub(crate) fn __reduce797<
@@ -29572,7 +29605,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action1557::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant90(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant93(__nt), __end));
         (4, 239)
     }
     pub(crate) fn __reduce798<
@@ -29594,7 +29627,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym4.2;
         let __nt = super::__action1558::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant90(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant93(__nt), __end));
         (5, 239)
     }
     pub(crate) fn __reduce799<
@@ -29607,11 +29640,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // SingleForComprehension+ = SingleForComprehension => ActionFn(257);
-        let __sym0 = __pop_Variant90(__symbols);
+        let __sym0 = __pop_Variant93(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action257::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant91(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant94(__nt), __end));
         (1, 240)
     }
     pub(crate) fn __reduce800<
@@ -29625,12 +29658,12 @@ mod __parse__Top {
     {
         // SingleForComprehension+ = SingleForComprehension+, SingleForComprehension => ActionFn(258);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant90(__symbols);
-        let __sym0 = __pop_Variant91(__symbols);
+        let __sym1 = __pop_Variant93(__symbols);
+        let __sym0 = __pop_Variant94(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action258::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant91(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant94(__nt), __end));
         (2, 240)
     }
     pub(crate) fn __reduce801<
@@ -29649,7 +29682,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action1733::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant92(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant95(__nt), __end));
         (2, 241)
     }
     pub(crate) fn __reduce802<
@@ -29666,7 +29699,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action1734::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant92(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant95(__nt), __end));
         (1, 241)
     }
     pub(crate) fn __reduce803<
@@ -29679,11 +29712,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // SliceOp? = SliceOp => ActionFn(277);
-        let __sym0 = __pop_Variant92(__symbols);
+        let __sym0 = __pop_Variant95(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action277::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant93(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant96(__nt), __end));
         (1, 242)
     }
     pub(crate) fn __reduce804<
@@ -29699,7 +29732,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action278::<>(source_code, mode, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant93(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant96(__nt), __end));
         (0, 242)
     }
     pub(crate) fn __reduce805<
@@ -30064,7 +30097,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1194::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant94(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant97(__nt), __end));
         (3, 250)
     }
     pub(crate) fn __reduce826<
@@ -30085,7 +30118,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action1195::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant94(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant97(__nt), __end));
         (4, 250)
     }
     pub(crate) fn __reduce827<
@@ -30104,7 +30137,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action1196::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant94(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant97(__nt), __end));
         (2, 250)
     }
     pub(crate) fn __reduce828<
@@ -30124,7 +30157,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1197::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant94(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant97(__nt), __end));
         (3, 250)
     }
     pub(crate) fn __reduce829<
@@ -30141,7 +30174,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action10::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant94(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant97(__nt), __end));
         (1, 250)
     }
     pub(crate) fn __reduce830<
@@ -30156,11 +30189,11 @@ mod __parse__Top {
         // Statements = Statements, CompoundStatement => ActionFn(11);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant37(__symbols);
-        let __sym0 = __pop_Variant94(__symbols);
+        let __sym0 = __pop_Variant97(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action11::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant94(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant97(__nt), __end));
         (2, 250)
     }
     pub(crate) fn __reduce831<
@@ -30177,11 +30210,11 @@ mod __parse__Top {
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant37(__symbols);
-        let __sym0 = __pop_Variant94(__symbols);
+        let __sym0 = __pop_Variant97(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action1198::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant94(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant97(__nt), __end));
         (4, 250)
     }
     pub(crate) fn __reduce832<
@@ -30199,11 +30232,11 @@ mod __parse__Top {
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant37(__symbols);
         let __sym1 = __pop_Variant38(__symbols);
-        let __sym0 = __pop_Variant94(__symbols);
+        let __sym0 = __pop_Variant97(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
         let __nt = super::__action1199::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant94(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant97(__nt), __end));
         (5, 250)
     }
     pub(crate) fn __reduce833<
@@ -30219,11 +30252,11 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant37(__symbols);
-        let __sym0 = __pop_Variant94(__symbols);
+        let __sym0 = __pop_Variant97(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1200::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant94(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant97(__nt), __end));
         (3, 250)
     }
     pub(crate) fn __reduce834<
@@ -30240,11 +30273,11 @@ mod __parse__Top {
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant37(__symbols);
         let __sym1 = __pop_Variant38(__symbols);
-        let __sym0 = __pop_Variant94(__symbols);
+        let __sym0 = __pop_Variant97(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action1201::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant94(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant97(__nt), __end));
         (4, 250)
     }
     pub(crate) fn __reduce835<
@@ -30326,7 +30359,7 @@ mod __parse__Top {
     {
         // Subscript = Test<"all">, ":", Test<"all">, SliceOp => ActionFn(1735);
         assert!(__symbols.len() >= 4);
-        let __sym3 = __pop_Variant92(__symbols);
+        let __sym3 = __pop_Variant95(__symbols);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
@@ -30347,7 +30380,7 @@ mod __parse__Top {
     {
         // Subscript = Test<"all">, ":", SliceOp => ActionFn(1736);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant92(__symbols);
+        let __sym2 = __pop_Variant95(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
@@ -30367,7 +30400,7 @@ mod __parse__Top {
     {
         // Subscript = ":", Test<"all">, SliceOp => ActionFn(1737);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant92(__symbols);
+        let __sym2 = __pop_Variant95(__symbols);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
@@ -30387,7 +30420,7 @@ mod __parse__Top {
     {
         // Subscript = ":", SliceOp => ActionFn(1738);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant92(__symbols);
+        let __sym1 = __pop_Variant95(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
@@ -30634,7 +30667,7 @@ mod __parse__Top {
         // Suite = "\n", Indent, Statements, Dedent => ActionFn(8);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant94(__symbols);
+        let __sym2 = __pop_Variant97(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
@@ -31047,7 +31080,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action1503::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant95(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant98(__nt), __end));
         (2, 268)
     }
     pub(crate) fn __reduce881<
@@ -31066,7 +31099,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action1750::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant95(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant98(__nt), __end));
         (2, 268)
     }
     pub(crate) fn __reduce882<
@@ -31086,7 +31119,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1751::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant95(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant98(__nt), __end));
         (3, 268)
     }
     pub(crate) fn __reduce883<
@@ -31320,7 +31353,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action354::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant96(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant99(__nt), __end));
         (2, 270)
     }
     pub(crate) fn __reduce893<
@@ -31335,11 +31368,11 @@ mod __parse__Top {
         // TwoOrMore<StringLiteral> = TwoOrMore<StringLiteral>, StringLiteral => ActionFn(355);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant69(__symbols);
-        let __sym0 = __pop_Variant96(__symbols);
+        let __sym0 = __pop_Variant99(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action355::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant96(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant99(__nt), __end));
         (2, 270)
     }
     pub(crate) fn __reduce894<
@@ -31358,7 +31391,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action275::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant96(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant99(__nt), __end));
         (2, 271)
     }
     pub(crate) fn __reduce895<
@@ -31373,11 +31406,11 @@ mod __parse__Top {
         // TwoOrMore<StringLiteralOrFString> = TwoOrMore<StringLiteralOrFString>, StringLiteralOrFString => ActionFn(276);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant69(__symbols);
-        let __sym0 = __pop_Variant96(__symbols);
+        let __sym0 = __pop_Variant99(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action276::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant96(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant99(__nt), __end));
         (2, 271)
     }
     pub(crate) fn __reduce896<
@@ -31570,7 +31603,7 @@ mod __parse__Top {
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant15(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant98(__symbols);
+        let __sym2 = __pop_Variant101(__symbols);
         let __sym1 = __pop_Variant44(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
@@ -31617,7 +31650,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1516::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant97(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant100(__nt), __end));
         (3, 278)
     }
     pub(crate) fn __reduce908<
@@ -31634,7 +31667,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action1517::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant97(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant100(__nt), __end));
         (1, 278)
     }
     pub(crate) fn __reduce909<
@@ -31653,7 +31686,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action1518::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant97(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant100(__nt), __end));
         (2, 278)
     }
     pub(crate) fn __reduce910<
@@ -31672,7 +31705,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action1519::<>(source_code, mode, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant97(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant100(__nt), __end));
         (2, 278)
     }
     pub(crate) fn __reduce911<
@@ -31688,12 +31721,12 @@ mod __parse__Top {
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant86(__symbols);
+        let __sym1 = __pop_Variant89(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action1520::<>(source_code, mode, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant98(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant101(__nt), __end));
         (4, 279)
     }
     pub(crate) fn __reduce912<
@@ -31708,12 +31741,12 @@ mod __parse__Top {
         // TypeParams = "[", OneOrMore<TypeParam>, "]" => ActionFn(1521);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant86(__symbols);
+        let __sym1 = __pop_Variant89(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1521::<>(source_code, mode, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant98(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant101(__nt), __end));
         (3, 279)
     }
     pub(crate) fn __reduce913<
@@ -31726,11 +31759,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // TypeParams? = TypeParams => ActionFn(309);
-        let __sym0 = __pop_Variant98(__symbols);
+        let __sym0 = __pop_Variant101(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action309::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant99(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant102(__nt), __end));
         (1, 280)
     }
     pub(crate) fn __reduce914<
@@ -31746,7 +31779,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action310::<>(source_code, mode, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant99(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant102(__nt), __end));
         (0, 280)
     }
     pub(crate) fn __reduce915<
@@ -31800,7 +31833,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action204::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant100(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant103(__nt), __end));
         (1, 282)
     }
     pub(crate) fn __reduce918<
@@ -31817,7 +31850,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action205::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant100(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant103(__nt), __end));
         (1, 282)
     }
     pub(crate) fn __reduce919<
@@ -31834,7 +31867,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action206::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant100(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant103(__nt), __end));
         (1, 282)
     }
     pub(crate) fn __reduce920<
@@ -32461,7 +32494,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action281::<>(source_code, mode, __sym0);
-        __symbols.push((__start, __Symbol::Variant101(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant104(__nt), __end));
         (1, 296)
     }
     pub(crate) fn __reduce953<
@@ -32477,7 +32510,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action282::<>(source_code, mode, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant101(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant104(__nt), __end));
         (0, 296)
     }
 }
@@ -36348,14 +36381,14 @@ fn __action218<
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
-    (_, values, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    (_, elements, _): (TextSize, alloc::vec::Vec<ast::FStringElement>, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> StringType
 {
     {
         StringType::FString(ast::FString {
-            values,
+            elements,
             range: (location..end_location).into()
         })
     }
@@ -36367,8 +36400,8 @@ fn __action219<
 >(
     source_code: &str,
     mode: Mode,
-    (_, __0, _): (TextSize, ast::Expr, TextSize),
-) -> ast::Expr
+    (_, __0, _): (TextSize, ast::FStringElement, TextSize),
+) -> ast::FStringElement
 {
     __0
 }
@@ -36382,11 +36415,11 @@ fn __action220<
     (_, location, _): (TextSize, TextSize, TextSize),
     (_, fstring_middle, _): (TextSize, (String, bool), TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     {
         let (source, is_raw) = fstring_middle;
-        Ok(parse_fstring_middle(&source, is_raw, (location..end_location).into())?)
+        Ok(parse_fstring_literal_element(&source, is_raw, (location..end_location).into())?)
     }
 }
 
@@ -36401,10 +36434,10 @@ fn __action221<
     (_, value, _): (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     (_, debug, _): (TextSize, core::option::Option<token::Tok>, TextSize),
     (_, conversion, _): (TextSize, core::option::Option<(TextSize, ast::ConversionFlag)>, TextSize),
-    (_, format_spec, _): (TextSize, core::option::Option<ast::Expr>, TextSize),
+    (_, format_spec, _): (TextSize, core::option::Option<ast::FStringFormatSpec>, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     {
         if value.expr.is_lambda_expr() && !value.is_parenthesized() {
@@ -36429,16 +36462,15 @@ fn __action221<
             }
         });
         Ok(
-            ast::ExprFormattedValue {
-                value: Box::new(value.into()),
+            ast::FStringElement::Expression(ast::FStringExpressionElement {
+                expression: Box::new(value.into()),
                 debug_text,
                 conversion: conversion.map_or(ast::ConversionFlag::None, |(_, conversion_flag)| {
                     conversion_flag
                 }),
                 format_spec: format_spec.map(Box::new),
                 range: (location..end_location).into(),
-            }
-            .into()
+            })
         )
     }
 }
@@ -36450,8 +36482,8 @@ fn __action222<
     source_code: &str,
     mode: Mode,
     (_, _, _): (TextSize, token::Tok, TextSize),
-    (_, format_spec, _): (TextSize, ast::Expr, TextSize),
-) -> ast::Expr
+    (_, format_spec, _): (TextSize, ast::FStringFormatSpec, TextSize),
+) -> ast::FStringFormatSpec
 {
     format_spec
 }
@@ -36463,15 +36495,13 @@ fn __action223<
     source_code: &str,
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, values, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    (_, elements, _): (TextSize, alloc::vec::Vec<ast::FStringElement>, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
-) -> ast::Expr
+) -> ast::FStringFormatSpec
 {
-    {
-        ast::FString {
-            values,
-            range: (location..end_location).into()
-        }.into()
+    ast::FStringFormatSpec {
+        elements,
+        range: (location..end_location).into(),
     }
 }
 
@@ -37142,8 +37172,8 @@ fn __action267<
 >(
     source_code: &str,
     mode: Mode,
-    (_, __0, _): (TextSize, ast::Expr, TextSize),
-) -> core::option::Option<ast::Expr>
+    (_, __0, _): (TextSize, ast::FStringFormatSpec, TextSize),
+) -> core::option::Option<ast::FStringFormatSpec>
 {
     Some(__0)
 }
@@ -37156,7 +37186,7 @@ fn __action268<
     mode: Mode,
     __lookbehind: &TextSize,
     __lookahead: &TextSize,
-) -> core::option::Option<ast::Expr>
+) -> core::option::Option<ast::FStringFormatSpec>
 {
     None
 }
@@ -37219,7 +37249,7 @@ fn __action273<
     mode: Mode,
     __lookbehind: &TextSize,
     __lookahead: &TextSize,
-) -> alloc::vec::Vec<ast::Expr>
+) -> alloc::vec::Vec<ast::FStringElement>
 {
     alloc::vec![]
 }
@@ -37230,8 +37260,8 @@ fn __action274<
 >(
     source_code: &str,
     mode: Mode,
-    (_, v, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
-) -> alloc::vec::Vec<ast::Expr>
+    (_, v, _): (TextSize, alloc::vec::Vec<ast::FStringElement>, TextSize),
+) -> alloc::vec::Vec<ast::FStringElement>
 {
     v
 }
@@ -39813,8 +39843,8 @@ fn __action456<
 >(
     source_code: &str,
     mode: Mode,
-    (_, __0, _): (TextSize, ast::Expr, TextSize),
-) -> alloc::vec::Vec<ast::Expr>
+    (_, __0, _): (TextSize, ast::FStringElement, TextSize),
+) -> alloc::vec::Vec<ast::FStringElement>
 {
     alloc::vec![__0]
 }
@@ -39825,9 +39855,9 @@ fn __action457<
 >(
     source_code: &str,
     mode: Mode,
-    (_, v, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
-    (_, e, _): (TextSize, ast::Expr, TextSize),
-) -> alloc::vec::Vec<ast::Expr>
+    (_, v, _): (TextSize, alloc::vec::Vec<ast::FStringElement>, TextSize),
+    (_, e, _): (TextSize, ast::FStringElement, TextSize),
+) -> alloc::vec::Vec<ast::FStringElement>
 {
     { let mut v = v; v.push(e); v }
 }
@@ -44486,10 +44516,10 @@ fn __action679<
     __2: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __3: (TextSize, token::Tok, TextSize),
     __4: (TextSize, core::option::Option<(TextSize, ast::ConversionFlag)>, TextSize),
-    __5: (TextSize, core::option::Option<ast::Expr>, TextSize),
+    __5: (TextSize, core::option::Option<ast::FStringFormatSpec>, TextSize),
     __6: (TextSize, token::Tok, TextSize),
     __7: (TextSize, TextSize, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __3.0;
     let __end0 = __3.2;
@@ -44523,10 +44553,10 @@ fn __action680<
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __3: (TextSize, core::option::Option<(TextSize, ast::ConversionFlag)>, TextSize),
-    __4: (TextSize, core::option::Option<ast::Expr>, TextSize),
+    __4: (TextSize, core::option::Option<ast::FStringFormatSpec>, TextSize),
     __5: (TextSize, token::Tok, TextSize),
     __6: (TextSize, TextSize, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __2.2;
     let __end0 = __3.0;
@@ -48416,7 +48446,7 @@ fn __action802<
     source_code: &str,
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::FStringElement>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, TextSize, TextSize),
 ) -> StringType
@@ -48447,9 +48477,9 @@ fn __action803<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::FStringElement>, TextSize),
     __1: (TextSize, TextSize, TextSize),
-) -> ast::Expr
+) -> ast::FStringFormatSpec
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -48477,7 +48507,7 @@ fn __action804<
     mode: Mode,
     __0: (TextSize, (String, bool), TextSize),
     __1: (TextSize, TextSize, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -48507,10 +48537,10 @@ fn __action805<
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, core::option::Option<(TextSize, ast::ConversionFlag)>, TextSize),
-    __4: (TextSize, core::option::Option<ast::Expr>, TextSize),
+    __4: (TextSize, core::option::Option<ast::FStringFormatSpec>, TextSize),
     __5: (TextSize, token::Tok, TextSize),
     __6: (TextSize, TextSize, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -48544,10 +48574,10 @@ fn __action806<
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __2: (TextSize, core::option::Option<(TextSize, ast::ConversionFlag)>, TextSize),
-    __3: (TextSize, core::option::Option<ast::Expr>, TextSize),
+    __3: (TextSize, core::option::Option<ast::FStringFormatSpec>, TextSize),
     __4: (TextSize, token::Tok, TextSize),
     __5: (TextSize, TextSize, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -64442,7 +64472,7 @@ fn __action1313<
     source_code: &str,
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::FStringElement>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
 ) -> StringType
 {
@@ -64471,8 +64501,8 @@ fn __action1314<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
-) -> ast::Expr
+    __0: (TextSize, alloc::vec::Vec<ast::FStringElement>, TextSize),
+) -> ast::FStringFormatSpec
 {
     let __start0 = __0.2;
     let __end0 = __0.2;
@@ -64498,7 +64528,7 @@ fn __action1315<
     source_code: &str,
     mode: Mode,
     __0: (TextSize, (String, bool), TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.2;
     let __end0 = __0.2;
@@ -64527,9 +64557,9 @@ fn __action1316<
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, core::option::Option<(TextSize, ast::ConversionFlag)>, TextSize),
-    __4: (TextSize, core::option::Option<ast::Expr>, TextSize),
+    __4: (TextSize, core::option::Option<ast::FStringFormatSpec>, TextSize),
     __5: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __5.2;
     let __end0 = __5.2;
@@ -64562,9 +64592,9 @@ fn __action1317<
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __2: (TextSize, core::option::Option<(TextSize, ast::ConversionFlag)>, TextSize),
-    __3: (TextSize, core::option::Option<ast::Expr>, TextSize),
+    __3: (TextSize, core::option::Option<ast::FStringFormatSpec>, TextSize),
     __4: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __4.2;
     let __end0 = __4.2;
@@ -72535,9 +72565,9 @@ fn __action1577<
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, (TextSize, ast::ConversionFlag), TextSize),
-    __4: (TextSize, core::option::Option<ast::Expr>, TextSize),
+    __4: (TextSize, core::option::Option<ast::FStringFormatSpec>, TextSize),
     __5: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __3.0;
     let __end0 = __3.2;
@@ -72568,9 +72598,9 @@ fn __action1578<
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __2: (TextSize, token::Tok, TextSize),
-    __3: (TextSize, core::option::Option<ast::Expr>, TextSize),
+    __3: (TextSize, core::option::Option<ast::FStringFormatSpec>, TextSize),
     __4: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __2.2;
     let __end0 = __3.0;
@@ -72602,9 +72632,9 @@ fn __action1579<
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __2: (TextSize, (TextSize, ast::ConversionFlag), TextSize),
-    __3: (TextSize, core::option::Option<ast::Expr>, TextSize),
+    __3: (TextSize, core::option::Option<ast::FStringFormatSpec>, TextSize),
     __4: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __2.0;
     let __end0 = __2.2;
@@ -72633,9 +72663,9 @@ fn __action1580<
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
-    __2: (TextSize, core::option::Option<ast::Expr>, TextSize),
+    __2: (TextSize, core::option::Option<ast::FStringFormatSpec>, TextSize),
     __3: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __1.2;
     let __end0 = __2.0;
@@ -72667,9 +72697,9 @@ fn __action1581<
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, (TextSize, ast::ConversionFlag), TextSize),
-    __4: (TextSize, ast::Expr, TextSize),
+    __4: (TextSize, ast::FStringFormatSpec, TextSize),
     __5: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __4.0;
     let __end0 = __4.2;
@@ -72702,7 +72732,7 @@ fn __action1582<
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, (TextSize, ast::ConversionFlag), TextSize),
     __4: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __3.2;
     let __end0 = __4.0;
@@ -72734,9 +72764,9 @@ fn __action1583<
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __2: (TextSize, token::Tok, TextSize),
-    __3: (TextSize, ast::Expr, TextSize),
+    __3: (TextSize, ast::FStringFormatSpec, TextSize),
     __4: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __3.0;
     let __end0 = __3.2;
@@ -72767,7 +72797,7 @@ fn __action1584<
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __2.2;
     let __end0 = __3.0;
@@ -72798,9 +72828,9 @@ fn __action1585<
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __2: (TextSize, (TextSize, ast::ConversionFlag), TextSize),
-    __3: (TextSize, ast::Expr, TextSize),
+    __3: (TextSize, ast::FStringFormatSpec, TextSize),
     __4: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __3.0;
     let __end0 = __3.2;
@@ -72831,7 +72861,7 @@ fn __action1586<
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __2: (TextSize, (TextSize, ast::ConversionFlag), TextSize),
     __3: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __2.2;
     let __end0 = __3.0;
@@ -72861,9 +72891,9 @@ fn __action1587<
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
-    __2: (TextSize, ast::Expr, TextSize),
+    __2: (TextSize, ast::FStringFormatSpec, TextSize),
     __3: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __2.0;
     let __end0 = __2.2;
@@ -72892,7 +72922,7 @@ fn __action1588<
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, crate::parser::ParenthesizedExpr, TextSize),
     __2: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+) -> Result<ast::FStringElement,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __1.2;
     let __end0 = __2.0;
@@ -72948,7 +72978,7 @@ fn __action1590<
     source_code: &str,
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::FStringElement>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
 ) -> StringType
 {
@@ -72977,7 +73007,7 @@ fn __action1591<
     mode: Mode,
     __lookbehind: &TextSize,
     __lookahead: &TextSize,
-) -> ast::Expr
+) -> ast::FStringFormatSpec
 {
     let __start0 = *__lookbehind;
     let __end0 = *__lookahead;
@@ -73001,8 +73031,8 @@ fn __action1592<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
-) -> ast::Expr
+    __0: (TextSize, alloc::vec::Vec<ast::FStringElement>, TextSize),
+) -> ast::FStringFormatSpec
 {
     let __start0 = __0.0;
     let __end0 = __0.2;

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__fstrings.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__fstrings.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..9,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 2..8,
-                                                value: StringLiteral(
+                                                expression: StringLiteral(
                                                     ExprStringLiteral {
                                                         range: 3..7,
                                                         value: StringLiteralValue {
@@ -57,11 +57,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 10..20,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 12..19,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 13..16,
                                                         id: "foo",
@@ -93,11 +93,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 21..28,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 23..27,
-                                                value: Tuple(
+                                                expression: Tuple(
                                                     ExprTuple {
                                                         range: 24..26,
                                                         elts: [
@@ -138,11 +138,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 29..39,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 31..38,
-                                                value: Compare(
+                                                expression: Compare(
                                                     ExprCompare {
                                                         range: 32..36,
                                                         left: NumberLiteral(
@@ -171,21 +171,10 @@ expression: parse_ast
                                                 debug_text: None,
                                                 conversion: None,
                                                 format_spec: Some(
-                                                    FString(
-                                                        ExprFString {
-                                                            range: 37..37,
-                                                            value: FStringValue {
-                                                                inner: Single(
-                                                                    FString(
-                                                                        FString {
-                                                                            range: 37..37,
-                                                                            values: [],
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
+                                                    FStringFormatSpec {
+                                                        range: 37..37,
+                                                        elements: [],
+                                                    },
                                                 ),
                                             },
                                         ),
@@ -209,11 +198,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 40..55,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 42..54,
-                                                value: NumberLiteral(
+                                                expression: NumberLiteral(
                                                     ExprNumberLiteral {
                                                         range: 43..44,
                                                         value: Int(
@@ -224,58 +213,39 @@ expression: parse_ast
                                                 debug_text: None,
                                                 conversion: None,
                                                 format_spec: Some(
-                                                    FString(
-                                                        ExprFString {
-                                                            range: 45..53,
-                                                            value: FStringValue {
-                                                                inner: Single(
-                                                                    FString(
-                                                                        FString {
-                                                                            range: 45..53,
-                                                                            values: [
-                                                                                FormattedValue(
-                                                                                    ExprFormattedValue {
-                                                                                        range: 45..50,
-                                                                                        value: StringLiteral(
-                                                                                            ExprStringLiteral {
-                                                                                                range: 46..49,
-                                                                                                value: StringLiteralValue {
-                                                                                                    inner: Single(
-                                                                                                        StringLiteral {
-                                                                                                            range: 46..49,
-                                                                                                            value: "}",
-                                                                                                            unicode: false,
-                                                                                                        },
-                                                                                                    ),
-                                                                                                },
-                                                                                            },
-                                                                                        ),
-                                                                                        debug_text: None,
-                                                                                        conversion: None,
-                                                                                        format_spec: None,
+                                                    FStringFormatSpec {
+                                                        range: 45..53,
+                                                        elements: [
+                                                            Expression(
+                                                                FStringExpressionElement {
+                                                                    range: 45..50,
+                                                                    expression: StringLiteral(
+                                                                        ExprStringLiteral {
+                                                                            range: 46..49,
+                                                                            value: StringLiteralValue {
+                                                                                inner: Single(
+                                                                                    StringLiteral {
+                                                                                        range: 46..49,
+                                                                                        value: "}",
+                                                                                        unicode: false,
                                                                                     },
                                                                                 ),
-                                                                                StringLiteral(
-                                                                                    ExprStringLiteral {
-                                                                                        range: 50..53,
-                                                                                        value: StringLiteralValue {
-                                                                                            inner: Single(
-                                                                                                StringLiteral {
-                                                                                                    range: 50..53,
-                                                                                                    value: ">10",
-                                                                                                    unicode: false,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
-                                                                                    },
-                                                                                ),
-                                                                            ],
+                                                                            },
                                                                         },
                                                                     ),
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
+                                                                    debug_text: None,
+                                                                    conversion: None,
+                                                                    format_spec: None,
+                                                                },
+                                                            ),
+                                                            Literal(
+                                                                FStringLiteralElement {
+                                                                    range: 50..53,
+                                                                    value: ">10",
+                                                                },
+                                                            ),
+                                                        ],
+                                                    },
                                                 ),
                                             },
                                         ),
@@ -299,11 +269,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 56..71,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 58..70,
-                                                value: NumberLiteral(
+                                                expression: NumberLiteral(
                                                     ExprNumberLiteral {
                                                         range: 59..60,
                                                         value: Int(
@@ -314,58 +284,39 @@ expression: parse_ast
                                                 debug_text: None,
                                                 conversion: None,
                                                 format_spec: Some(
-                                                    FString(
-                                                        ExprFString {
-                                                            range: 61..69,
-                                                            value: FStringValue {
-                                                                inner: Single(
-                                                                    FString(
-                                                                        FString {
-                                                                            range: 61..69,
-                                                                            values: [
-                                                                                FormattedValue(
-                                                                                    ExprFormattedValue {
-                                                                                        range: 61..66,
-                                                                                        value: StringLiteral(
-                                                                                            ExprStringLiteral {
-                                                                                                range: 62..65,
-                                                                                                value: StringLiteralValue {
-                                                                                                    inner: Single(
-                                                                                                        StringLiteral {
-                                                                                                            range: 62..65,
-                                                                                                            value: "{",
-                                                                                                            unicode: false,
-                                                                                                        },
-                                                                                                    ),
-                                                                                                },
-                                                                                            },
-                                                                                        ),
-                                                                                        debug_text: None,
-                                                                                        conversion: None,
-                                                                                        format_spec: None,
+                                                    FStringFormatSpec {
+                                                        range: 61..69,
+                                                        elements: [
+                                                            Expression(
+                                                                FStringExpressionElement {
+                                                                    range: 61..66,
+                                                                    expression: StringLiteral(
+                                                                        ExprStringLiteral {
+                                                                            range: 62..65,
+                                                                            value: StringLiteralValue {
+                                                                                inner: Single(
+                                                                                    StringLiteral {
+                                                                                        range: 62..65,
+                                                                                        value: "{",
+                                                                                        unicode: false,
                                                                                     },
                                                                                 ),
-                                                                                StringLiteral(
-                                                                                    ExprStringLiteral {
-                                                                                        range: 66..69,
-                                                                                        value: StringLiteralValue {
-                                                                                            inner: Single(
-                                                                                                StringLiteral {
-                                                                                                    range: 66..69,
-                                                                                                    value: ">10",
-                                                                                                    unicode: false,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
-                                                                                    },
-                                                                                ),
-                                                                            ],
+                                                                            },
                                                                         },
                                                                     ),
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
+                                                                    debug_text: None,
+                                                                    conversion: None,
+                                                                    format_spec: None,
+                                                                },
+                                                            ),
+                                                            Literal(
+                                                                FStringLiteralElement {
+                                                                    range: 66..69,
+                                                                    value: ">10",
+                                                                },
+                                                            ),
+                                                        ],
+                                                    },
                                                 ),
                                             },
                                         ),
@@ -389,11 +340,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 72..86,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 74..85,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 77..80,
                                                         id: "foo",
@@ -430,11 +381,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 87..107,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 89..106,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 92..95,
                                                         id: "foo",
@@ -449,36 +400,17 @@ expression: parse_ast
                                                 ),
                                                 conversion: None,
                                                 format_spec: Some(
-                                                    FString(
-                                                        ExprFString {
-                                                            range: 100..105,
-                                                            value: FStringValue {
-                                                                inner: Single(
-                                                                    FString(
-                                                                        FString {
-                                                                            range: 100..105,
-                                                                            values: [
-                                                                                StringLiteral(
-                                                                                    ExprStringLiteral {
-                                                                                        range: 100..105,
-                                                                                        value: StringLiteralValue {
-                                                                                            inner: Single(
-                                                                                                StringLiteral {
-                                                                                                    range: 100..105,
-                                                                                                    value: ".3f  ",
-                                                                                                    unicode: false,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
-                                                                                    },
-                                                                                ),
-                                                                            ],
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
+                                                    FStringFormatSpec {
+                                                        range: 100..105,
+                                                        elements: [
+                                                            Literal(
+                                                                FStringLiteralElement {
+                                                                    range: 100..105,
+                                                                    value: ".3f  ",
+                                                                },
+                                                            ),
+                                                        ],
+                                                    },
                                                 ),
                                             },
                                         ),
@@ -502,11 +434,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 108..126,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 110..125,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 113..116,
                                                         id: "foo",
@@ -543,11 +475,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 127..143,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 129..142,
-                                                value: Tuple(
+                                                expression: Tuple(
                                                     ExprTuple {
                                                         range: 132..136,
                                                         elts: [
@@ -601,11 +533,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 144..170,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 146..169,
-                                                value: FString(
+                                                expression: FString(
                                                     ExprFString {
                                                         range: 147..163,
                                                         value: FStringValue {
@@ -613,11 +545,11 @@ expression: parse_ast
                                                                 FString(
                                                                     FString {
                                                                         range: 147..163,
-                                                                        values: [
-                                                                            FormattedValue(
-                                                                                ExprFormattedValue {
+                                                                        elements: [
+                                                                            Expression(
+                                                                                FStringExpressionElement {
                                                                                     range: 149..162,
-                                                                                    value: NumberLiteral(
+                                                                                    expression: NumberLiteral(
                                                                                         ExprNumberLiteral {
                                                                                             range: 150..156,
                                                                                             value: Float(
@@ -633,36 +565,17 @@ expression: parse_ast
                                                                                     ),
                                                                                     conversion: None,
                                                                                     format_spec: Some(
-                                                                                        FString(
-                                                                                            ExprFString {
-                                                                                                range: 158..161,
-                                                                                                value: FStringValue {
-                                                                                                    inner: Single(
-                                                                                                        FString(
-                                                                                                            FString {
-                                                                                                                range: 158..161,
-                                                                                                                values: [
-                                                                                                                    StringLiteral(
-                                                                                                                        ExprStringLiteral {
-                                                                                                                            range: 158..161,
-                                                                                                                            value: StringLiteralValue {
-                                                                                                                                inner: Single(
-                                                                                                                                    StringLiteral {
-                                                                                                                                        range: 158..161,
-                                                                                                                                        value: ".1f",
-                                                                                                                                        unicode: false,
-                                                                                                                                    },
-                                                                                                                                ),
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                    ),
-                                                                                                                ],
-                                                                                                            },
-                                                                                                        ),
-                                                                                                    ),
-                                                                                                },
-                                                                                            },
-                                                                                        ),
+                                                                                        FStringFormatSpec {
+                                                                                            range: 158..161,
+                                                                                            elements: [
+                                                                                                Literal(
+                                                                                                    FStringLiteralElement {
+                                                                                                        range: 158..161,
+                                                                                                        value: ".1f",
+                                                                                                    },
+                                                                                                ),
+                                                                                            ],
+                                                                                        },
                                                                                     ),
                                                                                 },
                                                                             ),
@@ -676,36 +589,17 @@ expression: parse_ast
                                                 debug_text: None,
                                                 conversion: None,
                                                 format_spec: Some(
-                                                    FString(
-                                                        ExprFString {
-                                                            range: 164..168,
-                                                            value: FStringValue {
-                                                                inner: Single(
-                                                                    FString(
-                                                                        FString {
-                                                                            range: 164..168,
-                                                                            values: [
-                                                                                StringLiteral(
-                                                                                    ExprStringLiteral {
-                                                                                        range: 164..168,
-                                                                                        value: StringLiteralValue {
-                                                                                            inner: Single(
-                                                                                                StringLiteral {
-                                                                                                    range: 164..168,
-                                                                                                    value: "*^20",
-                                                                                                    unicode: false,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
-                                                                                    },
-                                                                                ),
-                                                                            ],
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
+                                                    FStringFormatSpec {
+                                                        range: 164..168,
+                                                        elements: [
+                                                            Literal(
+                                                                FStringLiteralElement {
+                                                                    range: 164..168,
+                                                                    value: "*^20",
+                                                                },
+                                                            ),
+                                                        ],
+                                                    },
                                                 ),
                                             },
                                         ),
@@ -742,25 +636,17 @@ expression: parse_ast
                                                 FString(
                                                     FString {
                                                         range: 180..195,
-                                                        values: [
-                                                            StringLiteral(
-                                                                ExprStringLiteral {
+                                                        elements: [
+                                                            Literal(
+                                                                FStringLiteralElement {
                                                                     range: 182..186,
-                                                                    value: StringLiteralValue {
-                                                                        inner: Single(
-                                                                            StringLiteral {
-                                                                                range: 182..186,
-                                                                                value: "bar ",
-                                                                                unicode: false,
-                                                                            },
-                                                                        ),
-                                                                    },
+                                                                    value: "bar ",
                                                                 },
                                                             ),
-                                                            FormattedValue(
-                                                                ExprFormattedValue {
+                                                            Expression(
+                                                                FStringExpressionElement {
                                                                     range: 186..193,
-                                                                    value: BinOp(
+                                                                    expression: BinOp(
                                                                         ExprBinOp {
                                                                             range: 187..192,
                                                                             left: Name(
@@ -785,18 +671,10 @@ expression: parse_ast
                                                                     format_spec: None,
                                                                 },
                                                             ),
-                                                            StringLiteral(
-                                                                ExprStringLiteral {
+                                                            Literal(
+                                                                FStringLiteralElement {
                                                                     range: 193..194,
-                                                                    value: StringLiteralValue {
-                                                                        inner: Single(
-                                                                            StringLiteral {
-                                                                                range: 193..194,
-                                                                                value: " ",
-                                                                                unicode: false,
-                                                                            },
-                                                                        ),
-                                                                    },
+                                                                    value: " ",
                                                                 },
                                                             ),
                                                         ],
@@ -925,25 +803,17 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 300..317,
-                                    values: [
-                                        StringLiteral(
-                                            ExprStringLiteral {
+                                    elements: [
+                                        Literal(
+                                            FStringLiteralElement {
                                                 range: 302..303,
-                                                value: StringLiteralValue {
-                                                    inner: Single(
-                                                        StringLiteral {
-                                                            range: 302..303,
-                                                            value: "\\",
-                                                            unicode: false,
-                                                        },
-                                                    ),
-                                                },
+                                                value: "\\",
                                             },
                                         ),
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 303..308,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 304..307,
                                                         id: "foo",
@@ -955,24 +825,16 @@ expression: parse_ast
                                                 format_spec: None,
                                             },
                                         ),
-                                        StringLiteral(
-                                            ExprStringLiteral {
+                                        Literal(
+                                            FStringLiteralElement {
                                                 range: 308..309,
-                                                value: StringLiteralValue {
-                                                    inner: Single(
-                                                        StringLiteral {
-                                                            range: 308..309,
-                                                            value: "\\",
-                                                            unicode: false,
-                                                        },
-                                                    ),
-                                                },
+                                                value: "\\",
                                             },
                                         ),
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 309..316,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 310..313,
                                                         id: "bar",
@@ -982,36 +844,17 @@ expression: parse_ast
                                                 debug_text: None,
                                                 conversion: None,
                                                 format_spec: Some(
-                                                    FString(
-                                                        ExprFString {
-                                                            range: 314..315,
-                                                            value: FStringValue {
-                                                                inner: Single(
-                                                                    FString(
-                                                                        FString {
-                                                                            range: 314..315,
-                                                                            values: [
-                                                                                StringLiteral(
-                                                                                    ExprStringLiteral {
-                                                                                        range: 314..315,
-                                                                                        value: StringLiteralValue {
-                                                                                            inner: Single(
-                                                                                                StringLiteral {
-                                                                                                    range: 314..315,
-                                                                                                    value: "\\",
-                                                                                                    unicode: false,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
-                                                                                    },
-                                                                                ),
-                                                                            ],
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
+                                                    FStringFormatSpec {
+                                                        range: 314..315,
+                                                        elements: [
+                                                            Literal(
+                                                                FStringLiteralElement {
+                                                                    range: 314..315,
+                                                                    value: "\\",
+                                                                },
+                                                            ),
+                                                        ],
+                                                    },
                                                 ),
                                             },
                                         ),
@@ -1035,19 +878,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 318..332,
-                                    values: [
-                                        StringLiteral(
-                                            ExprStringLiteral {
+                                    elements: [
+                                        Literal(
+                                            FStringLiteralElement {
                                                 range: 320..331,
-                                                value: StringLiteralValue {
-                                                    inner: Single(
-                                                        StringLiteral {
-                                                            range: 320..331,
-                                                            value: "\\{foo\\}",
-                                                            unicode: false,
-                                                        },
-                                                    ),
-                                                },
+                                                value: "\\{foo\\}",
                                             },
                                         ),
                                     ],
@@ -1070,11 +905,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 333..373,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 337..370,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 343..346,
                                                         id: "foo",
@@ -1084,36 +919,17 @@ expression: parse_ast
                                                 debug_text: None,
                                                 conversion: None,
                                                 format_spec: Some(
-                                                    FString(
-                                                        ExprFString {
-                                                            range: 347..369,
-                                                            value: FStringValue {
-                                                                inner: Single(
-                                                                    FString(
-                                                                        FString {
-                                                                            range: 347..369,
-                                                                            values: [
-                                                                                StringLiteral(
-                                                                                    ExprStringLiteral {
-                                                                                        range: 347..369,
-                                                                                        value: StringLiteralValue {
-                                                                                            inner: Single(
-                                                                                                StringLiteral {
-                                                                                                    range: 347..369,
-                                                                                                    value: "x\n        y\n        z\n",
-                                                                                                    unicode: false,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
-                                                                                    },
-                                                                                ),
-                                                                            ],
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
+                                                    FStringFormatSpec {
+                                                        range: 347..369,
+                                                        elements: [
+                                                            Literal(
+                                                                FStringLiteralElement {
+                                                                    range: 347..369,
+                                                                    value: "x\n        y\n        z\n",
+                                                                },
+                                                            ),
+                                                        ],
+                                                    },
                                                 ),
                                             },
                                         ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__fstrings_with_unicode.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__fstrings_with_unicode.snap
@@ -22,11 +22,11 @@ expression: parse_ast
                                 FString(
                                     FString {
                                         range: 7..15,
-                                        values: [
-                                            FormattedValue(
-                                                ExprFormattedValue {
+                                        elements: [
+                                            Expression(
+                                                FStringExpressionElement {
                                                     range: 9..14,
-                                                    value: Name(
+                                                    expression: Name(
                                                         ExprName {
                                                             range: 10..13,
                                                             id: "bar",
@@ -81,11 +81,11 @@ expression: parse_ast
                                 FString(
                                     FString {
                                         range: 36..44,
-                                        values: [
-                                            FormattedValue(
-                                                ExprFormattedValue {
+                                        elements: [
+                                            Expression(
+                                                FStringExpressionElement {
                                                     range: 38..43,
-                                                    value: Name(
+                                                    expression: Name(
                                                         ExprName {
                                                             range: 39..42,
                                                             id: "bar",
@@ -140,11 +140,11 @@ expression: parse_ast
                                 FString(
                                     FString {
                                         range: 66..74,
-                                        values: [
-                                            FormattedValue(
-                                                ExprFormattedValue {
+                                        elements: [
+                                            Expression(
+                                                FStringExpressionElement {
                                                     range: 68..73,
-                                                    value: Name(
+                                                    expression: Name(
                                                         ExprName {
                                                             range: 69..72,
                                                             id: "bar",
@@ -199,25 +199,17 @@ expression: parse_ast
                                 FString(
                                     FString {
                                         range: 97..116,
-                                        values: [
-                                            StringLiteral(
-                                                ExprStringLiteral {
+                                        elements: [
+                                            Literal(
+                                                FStringLiteralElement {
                                                     range: 99..103,
-                                                    value: StringLiteralValue {
-                                                        inner: Single(
-                                                            StringLiteral {
-                                                                range: 99..103,
-                                                                value: "bar ",
-                                                                unicode: false,
-                                                            },
-                                                        ),
-                                                    },
+                                                    value: "bar ",
                                                 },
                                             ),
-                                            FormattedValue(
-                                                ExprFormattedValue {
+                                            Expression(
+                                                FStringExpressionElement {
                                                     range: 103..108,
-                                                    value: Name(
+                                                    expression: Name(
                                                         ExprName {
                                                             range: 104..107,
                                                             id: "baz",
@@ -229,18 +221,10 @@ expression: parse_ast
                                                     format_spec: None,
                                                 },
                                             ),
-                                            StringLiteral(
-                                                ExprStringLiteral {
+                                            Literal(
+                                                FStringLiteralElement {
                                                     range: 108..115,
-                                                    value: StringLiteralValue {
-                                                        inner: Single(
-                                                            StringLiteral {
-                                                                range: 108..115,
-                                                                value: " really",
-                                                                unicode: false,
-                                                            },
-                                                        ),
-                                                    },
+                                                    value: " really",
                                                 },
                                             ),
                                         ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_f_string.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parse_f_string.snap
@@ -14,19 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..14,
-                                    values: [
-                                        StringLiteral(
-                                            ExprStringLiteral {
+                                    elements: [
+                                        Literal(
+                                            FStringLiteralElement {
                                                 range: 2..13,
-                                                value: StringLiteralValue {
-                                                    inner: Single(
-                                                        StringLiteral {
-                                                            range: 2..13,
-                                                            value: "Hello world",
-                                                            unicode: false,
-                                                        },
-                                                    ),
-                                                },
+                                                value: "Hello world",
                                             },
                                         ),
                                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__try.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__try.snap
@@ -86,25 +86,17 @@ expression: parse_ast
                                                                     FString(
                                                                         FString {
                                                                             range: 62..81,
-                                                                            values: [
-                                                                                StringLiteral(
-                                                                                    ExprStringLiteral {
+                                                                            elements: [
+                                                                                Literal(
+                                                                                    FStringLiteralElement {
                                                                                         range: 64..71,
-                                                                                        value: StringLiteralValue {
-                                                                                            inner: Single(
-                                                                                                StringLiteral {
-                                                                                                    range: 64..71,
-                                                                                                    value: "caught ",
-                                                                                                    unicode: false,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
+                                                                                        value: "caught ",
                                                                                     },
                                                                                 ),
-                                                                                FormattedValue(
-                                                                                    ExprFormattedValue {
+                                                                                Expression(
+                                                                                    FStringExpressionElement {
                                                                                         range: 71..80,
-                                                                                        value: Call(
+                                                                                        expression: Call(
                                                                                             ExprCall {
                                                                                                 range: 72..79,
                                                                                                 func: Name(
@@ -194,25 +186,17 @@ expression: parse_ast
                                                                     FString(
                                                                         FString {
                                                                             range: 114..133,
-                                                                            values: [
-                                                                                StringLiteral(
-                                                                                    ExprStringLiteral {
+                                                                            elements: [
+                                                                                Literal(
+                                                                                    FStringLiteralElement {
                                                                                         range: 116..123,
-                                                                                        value: StringLiteralValue {
-                                                                                            inner: Single(
-                                                                                                StringLiteral {
-                                                                                                    range: 116..123,
-                                                                                                    value: "caught ",
-                                                                                                    unicode: false,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
+                                                                                        value: "caught ",
                                                                                     },
                                                                                 ),
-                                                                                FormattedValue(
-                                                                                    ExprFormattedValue {
+                                                                                Expression(
+                                                                                    FStringExpressionElement {
                                                                                         range: 123..132,
-                                                                                        value: Call(
+                                                                                        expression: Call(
                                                                                             ExprCall {
                                                                                                 range: 124..131,
                                                                                                 func: Name(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__try_star.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__try_star.snap
@@ -204,25 +204,17 @@ expression: parse_ast
                                                                     FString(
                                                                         FString {
                                                                             range: 133..179,
-                                                                            values: [
-                                                                                StringLiteral(
-                                                                                    ExprStringLiteral {
+                                                                            elements: [
+                                                                                Literal(
+                                                                                    FStringLiteralElement {
                                                                                         range: 135..142,
-                                                                                        value: StringLiteralValue {
-                                                                                            inner: Single(
-                                                                                                StringLiteral {
-                                                                                                    range: 135..142,
-                                                                                                    value: "caught ",
-                                                                                                    unicode: false,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
+                                                                                        value: "caught ",
                                                                                     },
                                                                                 ),
-                                                                                FormattedValue(
-                                                                                    ExprFormattedValue {
+                                                                                Expression(
+                                                                                    FStringExpressionElement {
                                                                                         range: 142..151,
-                                                                                        value: Call(
+                                                                                        expression: Call(
                                                                                             ExprCall {
                                                                                                 range: 143..150,
                                                                                                 func: Name(
@@ -252,24 +244,16 @@ expression: parse_ast
                                                                                         format_spec: None,
                                                                                     },
                                                                                 ),
-                                                                                StringLiteral(
-                                                                                    ExprStringLiteral {
+                                                                                Literal(
+                                                                                    FStringLiteralElement {
                                                                                         range: 151..164,
-                                                                                        value: StringLiteralValue {
-                                                                                            inner: Single(
-                                                                                                StringLiteral {
-                                                                                                    range: 151..164,
-                                                                                                    value: " with nested ",
-                                                                                                    unicode: false,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
+                                                                                        value: " with nested ",
                                                                                     },
                                                                                 ),
-                                                                                FormattedValue(
-                                                                                    ExprFormattedValue {
+                                                                                Expression(
+                                                                                    FStringExpressionElement {
                                                                                         range: 164..178,
-                                                                                        value: Attribute(
+                                                                                        expression: Attribute(
                                                                                             ExprAttribute {
                                                                                                 range: 165..177,
                                                                                                 value: Name(
@@ -351,25 +335,17 @@ expression: parse_ast
                                                                     FString(
                                                                         FString {
                                                                             range: 213..259,
-                                                                            values: [
-                                                                                StringLiteral(
-                                                                                    ExprStringLiteral {
+                                                                            elements: [
+                                                                                Literal(
+                                                                                    FStringLiteralElement {
                                                                                         range: 215..222,
-                                                                                        value: StringLiteralValue {
-                                                                                            inner: Single(
-                                                                                                StringLiteral {
-                                                                                                    range: 215..222,
-                                                                                                    value: "caught ",
-                                                                                                    unicode: false,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
+                                                                                        value: "caught ",
                                                                                     },
                                                                                 ),
-                                                                                FormattedValue(
-                                                                                    ExprFormattedValue {
+                                                                                Expression(
+                                                                                    FStringExpressionElement {
                                                                                         range: 222..231,
-                                                                                        value: Call(
+                                                                                        expression: Call(
                                                                                             ExprCall {
                                                                                                 range: 223..230,
                                                                                                 func: Name(
@@ -399,24 +375,16 @@ expression: parse_ast
                                                                                         format_spec: None,
                                                                                     },
                                                                                 ),
-                                                                                StringLiteral(
-                                                                                    ExprStringLiteral {
+                                                                                Literal(
+                                                                                    FStringLiteralElement {
                                                                                         range: 231..244,
-                                                                                        value: StringLiteralValue {
-                                                                                            inner: Single(
-                                                                                                StringLiteral {
-                                                                                                    range: 231..244,
-                                                                                                    value: " with nested ",
-                                                                                                    unicode: false,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
+                                                                                        value: " with nested ",
                                                                                     },
                                                                                 ),
-                                                                                FormattedValue(
-                                                                                    ExprFormattedValue {
+                                                                                Expression(
+                                                                                    FStringExpressionElement {
                                                                                         range: 244..258,
-                                                                                        value: Attribute(
+                                                                                        expression: Attribute(
                                                                                             ExprAttribute {
                                                                                                 range: 245..257,
                                                                                                 value: Name(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_constant_range.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_constant_range.snap
@@ -14,25 +14,17 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..22,
-                                    values: [
-                                        StringLiteral(
-                                            ExprStringLiteral {
+                                    elements: [
+                                        Literal(
+                                            FStringLiteralElement {
                                                 range: 2..5,
-                                                value: StringLiteralValue {
-                                                    inner: Single(
-                                                        StringLiteral {
-                                                            range: 2..5,
-                                                            value: "aaa",
-                                                            unicode: false,
-                                                        },
-                                                    ),
-                                                },
+                                                value: "aaa",
                                             },
                                         ),
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 5..10,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 6..9,
                                                         id: "bbb",
@@ -44,24 +36,16 @@ expression: parse_ast
                                                 format_spec: None,
                                             },
                                         ),
-                                        StringLiteral(
-                                            ExprStringLiteral {
+                                        Literal(
+                                            FStringLiteralElement {
                                                 range: 10..13,
-                                                value: StringLiteralValue {
-                                                    inner: Single(
-                                                        StringLiteral {
-                                                            range: 10..13,
-                                                            value: "ccc",
-                                                            unicode: false,
-                                                        },
-                                                    ),
-                                                },
+                                                value: "ccc",
                                             },
                                         ),
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 13..18,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 14..17,
                                                         id: "ddd",
@@ -73,18 +57,10 @@ expression: parse_ast
                                                 format_spec: None,
                                             },
                                         ),
-                                        StringLiteral(
-                                            ExprStringLiteral {
+                                        Literal(
+                                            FStringLiteralElement {
                                                 range: 18..21,
-                                                value: StringLiteralValue {
-                                                    inner: Single(
-                                                        StringLiteral {
-                                                            range: 18..21,
-                                                            value: "eee",
-                                                            unicode: false,
-                                                        },
-                                                    ),
-                                                },
+                                                value: "eee",
                                             },
                                         ),
                                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_character.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_character.snap
@@ -14,25 +14,17 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..8,
-                                    values: [
-                                        StringLiteral(
-                                            ExprStringLiteral {
+                                    elements: [
+                                        Literal(
+                                            FStringLiteralElement {
                                                 range: 2..4,
-                                                value: StringLiteralValue {
-                                                    inner: Single(
-                                                        StringLiteral {
-                                                            range: 2..4,
-                                                            value: "\\",
-                                                            unicode: false,
-                                                        },
-                                                    ),
-                                                },
+                                                value: "\\",
                                             },
                                         ),
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 4..7,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 5..6,
                                                         id: "x",

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_newline.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_newline.snap
@@ -14,25 +14,17 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..8,
-                                    values: [
-                                        StringLiteral(
-                                            ExprStringLiteral {
+                                    elements: [
+                                        Literal(
+                                            FStringLiteralElement {
                                                 range: 2..4,
-                                                value: StringLiteralValue {
-                                                    inner: Single(
-                                                        StringLiteral {
-                                                            range: 2..4,
-                                                            value: "\n",
-                                                            unicode: false,
-                                                        },
-                                                    ),
-                                                },
+                                                value: "\n",
                                             },
                                         ),
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 4..7,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 5..6,
                                                         id: "x",

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_line_continuation.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_line_continuation.snap
@@ -14,25 +14,17 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..9,
-                                    values: [
-                                        StringLiteral(
-                                            ExprStringLiteral {
+                                    elements: [
+                                        Literal(
+                                            FStringLiteralElement {
                                                 range: 3..5,
-                                                value: StringLiteralValue {
-                                                    inner: Single(
-                                                        StringLiteral {
-                                                            range: 3..5,
-                                                            value: "\\\n",
-                                                            unicode: false,
-                                                        },
-                                                    ),
-                                                },
+                                                value: "\\\n",
                                             },
                                         ),
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 5..8,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 6..7,
                                                         id: "x",

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_base.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_base.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..10,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 2..9,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 3..7,
                                                         id: "user",

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_base_more.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_base_more.snap
@@ -14,25 +14,17 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..38,
-                                    values: [
-                                        StringLiteral(
-                                            ExprStringLiteral {
+                                    elements: [
+                                        Literal(
+                                            FStringLiteralElement {
                                                 range: 2..6,
-                                                value: StringLiteralValue {
-                                                    inner: Single(
-                                                        StringLiteral {
-                                                            range: 2..6,
-                                                            value: "mix ",
-                                                            unicode: false,
-                                                        },
-                                                    ),
-                                                },
+                                                value: "mix ",
                                             },
                                         ),
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 6..13,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 7..11,
                                                         id: "user",
@@ -49,24 +41,16 @@ expression: parse_ast
                                                 format_spec: None,
                                             },
                                         ),
-                                        StringLiteral(
-                                            ExprStringLiteral {
+                                        Literal(
+                                            FStringLiteralElement {
                                                 range: 13..28,
-                                                value: StringLiteralValue {
-                                                    inner: Single(
-                                                        StringLiteral {
-                                                            range: 13..28,
-                                                            value: " with text and ",
-                                                            unicode: false,
-                                                        },
-                                                    ),
-                                                },
+                                                value: " with text and ",
                                             },
                                         ),
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 28..37,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 29..35,
                                                         id: "second",

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_format.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_format.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..14,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 2..13,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 3..7,
                                                         id: "user",
@@ -33,36 +33,17 @@ expression: parse_ast
                                                 ),
                                                 conversion: None,
                                                 format_spec: Some(
-                                                    FString(
-                                                        ExprFString {
-                                                            range: 9..12,
-                                                            value: FStringValue {
-                                                                inner: Single(
-                                                                    FString(
-                                                                        FString {
-                                                                            range: 9..12,
-                                                                            values: [
-                                                                                StringLiteral(
-                                                                                    ExprStringLiteral {
-                                                                                        range: 9..12,
-                                                                                        value: StringLiteralValue {
-                                                                                            inner: Single(
-                                                                                                StringLiteral {
-                                                                                                    range: 9..12,
-                                                                                                    value: ">10",
-                                                                                                    unicode: false,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
-                                                                                    },
-                                                                                ),
-                                                                            ],
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
+                                                    FStringFormatSpec {
+                                                        range: 9..12,
+                                                        elements: [
+                                                            Literal(
+                                                                FStringLiteralElement {
+                                                                    range: 9..12,
+                                                                    value: ">10",
+                                                                },
+                                                            ),
+                                                        ],
+                                                    },
                                                 ),
                                             },
                                         ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_unescaped_newline.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_unescaped_newline.snap
@@ -14,25 +14,17 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..11,
-                                    values: [
-                                        StringLiteral(
-                                            ExprStringLiteral {
+                                    elements: [
+                                        Literal(
+                                            FStringLiteralElement {
                                                 range: 4..5,
-                                                value: StringLiteralValue {
-                                                    inner: Single(
-                                                        StringLiteral {
-                                                            range: 4..5,
-                                                            value: "\n",
-                                                            unicode: false,
-                                                        },
-                                                    ),
-                                                },
+                                                value: "\n",
                                             },
                                         ),
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 5..8,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 6..7,
                                                         id: "x",

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_empty_fstring.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_empty_fstring.snap
@@ -14,7 +14,7 @@ expression: "parse_suite(r#\"f\"\"\"#, \"<test>\").unwrap()"
                             FString(
                                 FString {
                                     range: 0..3,
-                                    values: [],
+                                    elements: [],
                                 },
                             ),
                         ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_1.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_1.snap
@@ -22,19 +22,11 @@ expression: parse_ast
                                 FString(
                                     FString {
                                         range: 9..17,
-                                        values: [
-                                            StringLiteral(
-                                                ExprStringLiteral {
+                                        elements: [
+                                            Literal(
+                                                FStringLiteralElement {
                                                     range: 11..16,
-                                                    value: StringLiteralValue {
-                                                        inner: Single(
-                                                            StringLiteral {
-                                                                range: 11..16,
-                                                                value: "world",
-                                                                unicode: false,
-                                                            },
-                                                        ),
-                                                    },
+                                                    value: "world",
                                                 },
                                             ),
                                         ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_2.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_2.snap
@@ -22,19 +22,11 @@ expression: parse_ast
                                 FString(
                                     FString {
                                         range: 9..17,
-                                        values: [
-                                            StringLiteral(
-                                                ExprStringLiteral {
+                                        elements: [
+                                            Literal(
+                                                FStringLiteralElement {
                                                     range: 11..16,
-                                                    value: StringLiteralValue {
-                                                        inner: Single(
-                                                            StringLiteral {
-                                                                range: 11..16,
-                                                                value: "world",
-                                                                unicode: false,
-                                                            },
-                                                        ),
-                                                    },
+                                                    value: "world",
                                                 },
                                             ),
                                         ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_3.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_3.snap
@@ -22,25 +22,17 @@ expression: parse_ast
                                 FString(
                                     FString {
                                         range: 9..22,
-                                        values: [
-                                            StringLiteral(
-                                                ExprStringLiteral {
+                                        elements: [
+                                            Literal(
+                                                FStringLiteralElement {
                                                     range: 11..16,
-                                                    value: StringLiteralValue {
-                                                        inner: Single(
-                                                            StringLiteral {
-                                                                range: 11..16,
-                                                                value: "world",
-                                                                unicode: false,
-                                                            },
-                                                        ),
-                                                    },
+                                                    value: "world",
                                                 },
                                             ),
-                                            FormattedValue(
-                                                ExprFormattedValue {
+                                            Expression(
+                                                FStringExpressionElement {
                                                     range: 16..21,
-                                                    value: StringLiteral(
+                                                    expression: StringLiteral(
                                                         ExprStringLiteral {
                                                             range: 17..20,
                                                             value: StringLiteralValue {

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_4.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_string_concat_4.snap
@@ -22,25 +22,17 @@ expression: parse_ast
                                 FString(
                                     FString {
                                         range: 9..22,
-                                        values: [
-                                            StringLiteral(
-                                                ExprStringLiteral {
+                                        elements: [
+                                            Literal(
+                                                FStringLiteralElement {
                                                     range: 11..16,
-                                                    value: StringLiteralValue {
-                                                        inner: Single(
-                                                            StringLiteral {
-                                                                range: 11..16,
-                                                                value: "world",
-                                                                unicode: false,
-                                                            },
-                                                        ),
-                                                    },
+                                                    value: "world",
                                                 },
                                             ),
-                                            FormattedValue(
-                                                ExprFormattedValue {
+                                            Expression(
+                                                FStringExpressionElement {
                                                     range: 16..21,
-                                                    value: StringLiteral(
+                                                    expression: StringLiteral(
                                                         ExprStringLiteral {
                                                             range: 17..20,
                                                             value: StringLiteralValue {

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..18,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 2..5,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 3..4,
                                                         id: "a",
@@ -30,10 +30,10 @@ expression: parse_ast
                                                 format_spec: None,
                                             },
                                         ),
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 5..10,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 7..8,
                                                         id: "b",
@@ -45,18 +45,10 @@ expression: parse_ast
                                                 format_spec: None,
                                             },
                                         ),
-                                        StringLiteral(
-                                            ExprStringLiteral {
+                                        Literal(
+                                            FStringLiteralElement {
                                                 range: 10..17,
-                                                value: StringLiteralValue {
-                                                    inner: Single(
-                                                        StringLiteral {
-                                                            range: 10..17,
-                                                            value: "{foo}",
-                                                            unicode: false,
-                                                        },
-                                                    ),
-                                                },
+                                                value: "{foo}",
                                             },
                                         ),
                                     ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_equals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_equals.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..13,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 2..12,
-                                                value: Compare(
+                                                expression: Compare(
                                                     ExprCompare {
                                                         range: 3..11,
                                                         left: NumberLiteral(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_concatenation_string_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_concatenation_string_spec.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..16,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 2..15,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 3..6,
                                                         id: "foo",
@@ -28,54 +28,43 @@ expression: parse_ast
                                                 debug_text: None,
                                                 conversion: None,
                                                 format_spec: Some(
-                                                    FString(
-                                                        ExprFString {
-                                                            range: 7..14,
-                                                            value: FStringValue {
-                                                                inner: Single(
-                                                                    FString(
-                                                                        FString {
-                                                                            range: 7..14,
-                                                                            values: [
-                                                                                FormattedValue(
-                                                                                    ExprFormattedValue {
-                                                                                        range: 7..14,
-                                                                                        value: StringLiteral(
-                                                                                            ExprStringLiteral {
-                                                                                                range: 8..13,
-                                                                                                value: StringLiteralValue {
-                                                                                                    inner: Concatenated(
-                                                                                                        ConcatenatedStringLiteral {
-                                                                                                            strings: [
-                                                                                                                StringLiteral {
-                                                                                                                    range: 8..10,
-                                                                                                                    value: "",
-                                                                                                                    unicode: false,
-                                                                                                                },
-                                                                                                                StringLiteral {
-                                                                                                                    range: 11..13,
-                                                                                                                    value: "",
-                                                                                                                    unicode: false,
-                                                                                                                },
-                                                                                                            ],
-                                                                                                            value: "",
-                                                                                                        },
-                                                                                                    ),
-                                                                                                },
+                                                    FStringFormatSpec {
+                                                        range: 7..14,
+                                                        elements: [
+                                                            Expression(
+                                                                FStringExpressionElement {
+                                                                    range: 7..14,
+                                                                    expression: StringLiteral(
+                                                                        ExprStringLiteral {
+                                                                            range: 8..13,
+                                                                            value: StringLiteralValue {
+                                                                                inner: Concatenated(
+                                                                                    ConcatenatedStringLiteral {
+                                                                                        strings: [
+                                                                                            StringLiteral {
+                                                                                                range: 8..10,
+                                                                                                value: "",
+                                                                                                unicode: false,
                                                                                             },
-                                                                                        ),
-                                                                                        debug_text: None,
-                                                                                        conversion: None,
-                                                                                        format_spec: None,
+                                                                                            StringLiteral {
+                                                                                                range: 11..13,
+                                                                                                value: "",
+                                                                                                unicode: false,
+                                                                                            },
+                                                                                        ],
+                                                                                        value: "",
                                                                                     },
                                                                                 ),
-                                                                            ],
+                                                                            },
                                                                         },
                                                                     ),
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
+                                                                    debug_text: None,
+                                                                    conversion: None,
+                                                                    format_spec: None,
+                                                                },
+                                                            ),
+                                                        ],
+                                                    },
                                                 ),
                                             },
                                         ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_spec.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..15,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 2..14,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 3..6,
                                                         id: "foo",
@@ -28,37 +28,26 @@ expression: parse_ast
                                                 debug_text: None,
                                                 conversion: None,
                                                 format_spec: Some(
-                                                    FString(
-                                                        ExprFString {
-                                                            range: 7..13,
-                                                            value: FStringValue {
-                                                                inner: Single(
-                                                                    FString(
-                                                                        FString {
-                                                                            range: 7..13,
-                                                                            values: [
-                                                                                FormattedValue(
-                                                                                    ExprFormattedValue {
-                                                                                        range: 7..13,
-                                                                                        value: Name(
-                                                                                            ExprName {
-                                                                                                range: 8..12,
-                                                                                                id: "spec",
-                                                                                                ctx: Load,
-                                                                                            },
-                                                                                        ),
-                                                                                        debug_text: None,
-                                                                                        conversion: None,
-                                                                                        format_spec: None,
-                                                                                    },
-                                                                                ),
-                                                                            ],
+                                                    FStringFormatSpec {
+                                                        range: 7..13,
+                                                        elements: [
+                                                            Expression(
+                                                                FStringExpressionElement {
+                                                                    range: 7..13,
+                                                                    expression: Name(
+                                                                        ExprName {
+                                                                            range: 8..12,
+                                                                            id: "spec",
+                                                                            ctx: Load,
                                                                         },
                                                                     ),
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
+                                                                    debug_text: None,
+                                                                    conversion: None,
+                                                                    format_spec: None,
+                                                                },
+                                                            ),
+                                                        ],
+                                                    },
                                                 ),
                                             },
                                         ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_string_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_string_spec.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..13,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 2..12,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 3..6,
                                                         id: "foo",
@@ -28,44 +28,33 @@ expression: parse_ast
                                                 debug_text: None,
                                                 conversion: None,
                                                 format_spec: Some(
-                                                    FString(
-                                                        ExprFString {
-                                                            range: 7..11,
-                                                            value: FStringValue {
-                                                                inner: Single(
-                                                                    FString(
-                                                                        FString {
-                                                                            range: 7..11,
-                                                                            values: [
-                                                                                FormattedValue(
-                                                                                    ExprFormattedValue {
-                                                                                        range: 7..11,
-                                                                                        value: StringLiteral(
-                                                                                            ExprStringLiteral {
-                                                                                                range: 8..10,
-                                                                                                value: StringLiteralValue {
-                                                                                                    inner: Single(
-                                                                                                        StringLiteral {
-                                                                                                            range: 8..10,
-                                                                                                            value: "",
-                                                                                                            unicode: false,
-                                                                                                        },
-                                                                                                    ),
-                                                                                                },
-                                                                                            },
-                                                                                        ),
-                                                                                        debug_text: None,
-                                                                                        conversion: None,
-                                                                                        format_spec: None,
+                                                    FStringFormatSpec {
+                                                        range: 7..11,
+                                                        elements: [
+                                                            Expression(
+                                                                FStringExpressionElement {
+                                                                    range: 7..11,
+                                                                    expression: StringLiteral(
+                                                                        ExprStringLiteral {
+                                                                            range: 8..10,
+                                                                            value: StringLiteralValue {
+                                                                                inner: Single(
+                                                                                    StringLiteral {
+                                                                                        range: 8..10,
+                                                                                        value: "",
+                                                                                        unicode: false,
                                                                                     },
                                                                                 ),
-                                                                            ],
+                                                                            },
                                                                         },
                                                                     ),
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
+                                                                    debug_text: None,
+                                                                    conversion: None,
+                                                                    format_spec: None,
+                                                                },
+                                                            ),
+                                                        ],
+                                                    },
                                                 ),
                                             },
                                         ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_equals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_equals.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..11,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 2..10,
-                                                value: Compare(
+                                                expression: Compare(
                                                     ExprCompare {
                                                         range: 3..9,
                                                         left: NumberLiteral(

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_nested_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_nested_spec.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..13,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 2..12,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 3..6,
                                                         id: "foo",
@@ -28,36 +28,17 @@ expression: parse_ast
                                                 debug_text: None,
                                                 conversion: None,
                                                 format_spec: Some(
-                                                    FString(
-                                                        ExprFString {
-                                                            range: 7..11,
-                                                            value: FStringValue {
-                                                                inner: Single(
-                                                                    FString(
-                                                                        FString {
-                                                                            range: 7..11,
-                                                                            values: [
-                                                                                StringLiteral(
-                                                                                    ExprStringLiteral {
-                                                                                        range: 7..11,
-                                                                                        value: StringLiteralValue {
-                                                                                            inner: Single(
-                                                                                                StringLiteral {
-                                                                                                    range: 7..11,
-                                                                                                    value: "spec",
-                                                                                                    unicode: false,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
-                                                                                    },
-                                                                                ),
-                                                                            ],
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
+                                                    FStringFormatSpec {
+                                                        range: 7..11,
+                                                        elements: [
+                                                            Literal(
+                                                                FStringLiteralElement {
+                                                                    range: 7..11,
+                                                                    value: "spec",
+                                                                },
+                                                            ),
+                                                        ],
+                                                    },
                                                 ),
                                             },
                                         ),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_self_doc_prec_space.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_self_doc_prec_space.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..10,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 2..9,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 3..4,
                                                         id: "x",

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_self_doc_trailing_space.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_self_doc_trailing_space.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..10,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 2..9,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 3..4,
                                                         id: "x",

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_yield_expr.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_yield_expr.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..10,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 2..9,
-                                                value: Yield(
+                                                expression: Yield(
                                                     ExprYield {
                                                         range: 3..8,
                                                         value: None,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_f_string_concat_1.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_f_string_concat_1.snap
@@ -22,19 +22,11 @@ expression: parse_ast
                                 FString(
                                     FString {
                                         range: 10..18,
-                                        values: [
-                                            StringLiteral(
-                                                ExprStringLiteral {
+                                        elements: [
+                                            Literal(
+                                                FStringLiteralElement {
                                                     range: 12..17,
-                                                    value: StringLiteralValue {
-                                                        inner: Single(
-                                                            StringLiteral {
-                                                                range: 12..17,
-                                                                value: "world",
-                                                                unicode: false,
-                                                            },
-                                                        ),
-                                                    },
+                                                    value: "world",
                                                 },
                                             ),
                                         ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_f_string_concat_2.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_f_string_concat_2.snap
@@ -22,19 +22,11 @@ expression: parse_ast
                                 FString(
                                     FString {
                                         range: 10..18,
-                                        values: [
-                                            StringLiteral(
-                                                ExprStringLiteral {
+                                        elements: [
+                                            Literal(
+                                                FStringLiteralElement {
                                                     range: 12..17,
-                                                    value: StringLiteralValue {
-                                                        inner: Single(
-                                                            StringLiteral {
-                                                                range: 12..17,
-                                                                value: "world",
-                                                                unicode: false,
-                                                            },
-                                                        ),
-                                                    },
+                                                    value: "world",
                                                 },
                                             ),
                                         ],

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__raw_fstring.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__raw_fstring.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..7,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 3..6,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 4..5,
                                                         id: "x",

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__triple_quoted_raw_fstring.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__triple_quoted_raw_fstring.snap
@@ -14,11 +14,11 @@ expression: parse_ast
                             FString(
                                 FString {
                                     range: 0..11,
-                                    values: [
-                                        FormattedValue(
-                                            ExprFormattedValue {
+                                    elements: [
+                                        Expression(
+                                            FStringExpressionElement {
                                                 range: 5..8,
-                                                value: Name(
+                                                expression: Name(
                                                     ExprName {
                                                         range: 6..7,
                                                         id: "x",

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -202,7 +202,7 @@ impl<'a> StringParser<'a> {
         Ok(())
     }
 
-    fn parse_fstring_middle(&mut self) -> Result<Expr, LexicalError> {
+    fn parse_fstring_middle(&mut self) -> Result<ast::FStringElement, LexicalError> {
         let mut value = String::new();
         while let Some(ch) = self.next_char() {
             match ch {
@@ -239,9 +239,8 @@ impl<'a> StringParser<'a> {
                 ch => value.push(ch),
             }
         }
-        Ok(Expr::from(ast::StringLiteral {
+        Ok(ast::FStringElement::Literal(ast::FStringLiteralElement {
             value,
-            unicode: false,
             range: self.range,
         }))
     }
@@ -324,11 +323,11 @@ pub(crate) fn parse_string_literal(
     StringParser::new(source, kind, start_location, range).parse()
 }
 
-pub(crate) fn parse_fstring_middle(
+pub(crate) fn parse_fstring_literal_element(
     source: &str,
     is_raw: bool,
     range: TextRange,
-) -> Result<Expr, LexicalError> {
+) -> Result<ast::FStringElement, LexicalError> {
     let kind = if is_raw {
         StringKind::RawString
     } else {

--- a/crates/ruff_python_semantic/src/analyze/type_inference.rs
+++ b/crates/ruff_python_semantic/src/analyze/type_inference.rs
@@ -323,7 +323,6 @@ impl From<&Expr> for ResolvedPythonType {
             | Expr::YieldFrom(_)
             | Expr::Compare(_)
             | Expr::Call(_)
-            | Expr::FormattedValue(_)
             | Expr::Attribute(_)
             | Expr::Subscript(_)
             | Expr::Starred(_)


### PR DESCRIPTION
Rebase of #6365 authored by @davidszotten.

## Summary

This PR updates the AST structure for an f-string elements.

The main **motivation** behind this change is to have a dedicated node for the string part of an f-string. Previously, the existing `ExprStringLiteral` node was used for this purpose which isn't exactly correct. The `ExprStringLiteral` node should include the quotes as well in the range but the f-string literal element doesn't include the quote as it's a specific part within an f-string. For example,

```python
f"foo {x}"
# ^^^^
# This is the literal part of an f-string
```

The introduction of `FStringElement` enum is helpful which represent either the literal part or the expression part of an f-string.

### Rule Updates

This means that there'll be two nodes representing a string depending on the context. One for a normal string literal while the other is a string literal within an f-string. The AST checker is updated to accommodate this change. The rules which work on string literal are updated to check on the literal part of f-string as well.

#### Notes

1. The `Expr::is_literal_expr` method would check for `ExprStringLiteral` and return true if so. But now that we don't represent the literal part of an f-string using that node, this improves the method's behavior and confines to the actual expression. We do have the `FStringElement::is_literal` method.
2. We avoid checking if we're in a f-string context before adding to `string_type_definitions` because the f-string literal is now a dedicated node and not part of `Expr`.
3. Annotations cannot use f-string so we avoid changing any rules which work on annotation and checks for `ExprStringLiteral`.

## Test Plan

- All references of `Expr::StringLiteral` were checked to see if any of the rules require updating to account for the f-string literal element node.
- New test cases are added for rules which check against the literal part of an f-string.
- Check the ecosystem results and ensure it remains unchanged.

## Performance

There's a performance penalty in the parser. The reason for this remains unknown as it seems that the generated assembly code is now different for the `__reduce154` function. The reduce function body is just popping the `ParenthesizedExpr` on top of the stack and pushing it with the new location.

- The size of `FStringElement` enum is the same as `Expr` which is what it replaces in `FString::format_spec`
- The size of `FStringExpressionElement` is the same as `ExprFormattedValue` which is what it replaces

I tried reducing the `Expr` enum from 80 bytes to 72 bytes but it hardly resulted in any performance gain. The difference can be seen here:
- Original profile: https://share.firefox.dev/3Taa7ES
- Profile after boxing some node fields: https://share.firefox.dev/3GsNXpD

### Backtracking

I tried backtracking the changes to see if any of the isolated change produced this regression. The problem here is that the overall change is so small that there's only a single checkpoint where I can backtrack and that checkpoint results in the same regression. This checkpoint is to revert using `Expr` to the `FString::format_spec` field. After this point, the change would revert back to the original implementation.

## Review process

The review process is similar to #7927. The first set of commits update the node structure, parser, and related AST files. Then, further commits update the linter and formatter part to account for the AST change.