### PR TITLE
Auto-generate formatter nodes for string parts

### DIFF
--- a/crates/ruff_python_formatter/src/generated.rs
+++ b/crates/ruff_python_formatter/src/generated.rs
@@ -2978,3 +2978,103 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::TypeParamParamSpec {
         )
     }
 }
+
+impl FormatRule<ast::FString, PyFormatContext<'_>> for crate::other::f_string::FormatFString {
+    #[inline]
+    fn fmt(&self, node: &ast::FString, f: &mut PyFormatter) -> FormatResult<()> {
+        FormatNodeRule::<ast::FString>::fmt(self, node, f)
+    }
+}
+impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::FString {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        ast::FString,
+        crate::other::f_string::FormatFString,
+        PyFormatContext<'ast>,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(self, crate::other::f_string::FormatFString::default())
+    }
+}
+impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::FString {
+    type Format = FormatOwnedWithRule<
+        ast::FString,
+        crate::other::f_string::FormatFString,
+        PyFormatContext<'ast>,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(self, crate::other::f_string::FormatFString::default())
+    }
+}
+
+impl FormatRule<ast::StringLiteral, PyFormatContext<'_>>
+    for crate::other::string_literal::FormatStringLiteral
+{
+    #[inline]
+    fn fmt(&self, node: &ast::StringLiteral, f: &mut PyFormatter) -> FormatResult<()> {
+        FormatNodeRule::<ast::StringLiteral>::fmt(self, node, f)
+    }
+}
+impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StringLiteral {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        ast::StringLiteral,
+        crate::other::string_literal::FormatStringLiteral,
+        PyFormatContext<'ast>,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::other::string_literal::FormatStringLiteral::default(),
+        )
+    }
+}
+impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StringLiteral {
+    type Format = FormatOwnedWithRule<
+        ast::StringLiteral,
+        crate::other::string_literal::FormatStringLiteral,
+        PyFormatContext<'ast>,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::other::string_literal::FormatStringLiteral::default(),
+        )
+    }
+}
+
+impl FormatRule<ast::BytesLiteral, PyFormatContext<'_>>
+    for crate::other::bytes_literal::FormatBytesLiteral
+{
+    #[inline]
+    fn fmt(&self, node: &ast::BytesLiteral, f: &mut PyFormatter) -> FormatResult<()> {
+        FormatNodeRule::<ast::BytesLiteral>::fmt(self, node, f)
+    }
+}
+impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::BytesLiteral {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        ast::BytesLiteral,
+        crate::other::bytes_literal::FormatBytesLiteral,
+        PyFormatContext<'ast>,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::other::bytes_literal::FormatBytesLiteral::default(),
+        )
+    }
+}
+impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::BytesLiteral {
+    type Format = FormatOwnedWithRule<
+        ast::BytesLiteral,
+        crate::other::bytes_literal::FormatBytesLiteral,
+        PyFormatContext<'ast>,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::other::bytes_literal::FormatBytesLiteral::default(),
+        )
+    }
+}

--- a/crates/ruff_python_formatter/src/other/bytes_literal.rs
+++ b/crates/ruff_python_formatter/src/other/bytes_literal.rs
@@ -6,7 +6,7 @@ use crate::prelude::*;
 pub struct FormatBytesLiteral;
 
 impl FormatNodeRule<BytesLiteral> for FormatBytesLiteral {
-    fn fmt_fields(&self, item: &BytesLiteral, f: &mut PyFormatter) -> FormatResult<()> {
+    fn fmt_fields(&self, _item: &BytesLiteral, _f: &mut PyFormatter) -> FormatResult<()> {
         unreachable!("Handled inside of `FormatExprBytesLiteral`");
     }
 }

--- a/crates/ruff_python_formatter/src/other/bytes_literal.rs
+++ b/crates/ruff_python_formatter/src/other/bytes_literal.rs
@@ -1,0 +1,12 @@
+use ruff_python_ast::BytesLiteral;
+
+use crate::prelude::*;
+
+#[derive(Default)]
+pub struct FormatBytesLiteral;
+
+impl FormatNodeRule<BytesLiteral> for FormatBytesLiteral {
+    fn fmt_fields(&self, item: &BytesLiteral, f: &mut PyFormatter) -> FormatResult<()> {
+        unreachable!("Handled inside of `FormatExprBytesLiteral`");
+    }
+}

--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -1,0 +1,12 @@
+use ruff_python_ast::FString;
+
+use crate::prelude::*;
+
+#[derive(Default)]
+pub struct FormatFString;
+
+impl FormatNodeRule<FString> for FormatFString {
+    fn fmt_fields(&self, item: &FString, f: &mut PyFormatter) -> FormatResult<()> {
+        unreachable!("Handled inside of `FormatExprFString`");
+    }
+}

--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -6,7 +6,7 @@ use crate::prelude::*;
 pub struct FormatFString;
 
 impl FormatNodeRule<FString> for FormatFString {
-    fn fmt_fields(&self, item: &FString, f: &mut PyFormatter) -> FormatResult<()> {
+    fn fmt_fields(&self, _item: &FString, _f: &mut PyFormatter) -> FormatResult<()> {
         unreachable!("Handled inside of `FormatExprFString`");
     }
 }

--- a/crates/ruff_python_formatter/src/other/mod.rs
+++ b/crates/ruff_python_formatter/src/other/mod.rs
@@ -1,14 +1,17 @@
 pub(crate) mod alias;
 pub(crate) mod arguments;
+pub(crate) mod bytes_literal;
 pub(crate) mod commas;
 pub(crate) mod comprehension;
 pub(crate) mod decorator;
 pub(crate) mod elif_else_clause;
 pub(crate) mod except_handler_except_handler;
+pub(crate) mod f_string;
 pub(crate) mod identifier;
 pub(crate) mod keyword;
 pub(crate) mod match_case;
 pub(crate) mod parameter;
 pub(crate) mod parameter_with_default;
 pub(crate) mod parameters;
+pub(crate) mod string_literal;
 pub(crate) mod with_item;

--- a/crates/ruff_python_formatter/src/other/string_literal.rs
+++ b/crates/ruff_python_formatter/src/other/string_literal.rs
@@ -1,0 +1,12 @@
+use ruff_python_ast::StringLiteral;
+
+use crate::prelude::*;
+
+#[derive(Default)]
+pub struct FormatStringLiteral;
+
+impl FormatNodeRule<StringLiteral> for FormatStringLiteral {
+    fn fmt_fields(&self, item: &StringLiteral, f: &mut PyFormatter) -> FormatResult<()> {
+        unreachable!("Handled inside of `FormatExprStringLiteral`");
+    }
+}

--- a/crates/ruff_python_formatter/src/other/string_literal.rs
+++ b/crates/ruff_python_formatter/src/other/string_literal.rs
@@ -6,7 +6,7 @@ use crate::prelude::*;
 pub struct FormatStringLiteral;
 
 impl FormatNodeRule<StringLiteral> for FormatStringLiteral {
-    fn fmt_fields(&self, item: &StringLiteral, f: &mut PyFormatter) -> FormatResult<()> {
+    fn fmt_fields(&self, _item: &StringLiteral, _f: &mut PyFormatter) -> FormatResult<()> {
         unreachable!("Handled inside of `FormatExprStringLiteral`");
     }
 }


### PR DESCRIPTION
A follow-up to auto-generate the `FormatNodeRule` implementation for the string part nodes. This is just a dummy implementation that is unreachable because it's handled by the parent nodes.
