### PR TITLE
Add advice for fixing RUF008 when mutability is not desired

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/mutable_class_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/mutable_class_default.rs
@@ -20,13 +20,15 @@ use crate::rules::ruff::rules::helpers::{
 /// changed in one instance, as those changes will unexpectedly affect all
 /// other instances.
 ///
-/// When mutable value are intended, they should be annotated with
-/// `typing.ClassVar`.
+/// When mutable values are intended, they should be annotated with
+/// `typing.ClassVar`. When mutability is not required, values should be
+/// immutable types, like `tuple` or `frozenset`.
 ///
 /// ## Examples
 /// ```python
 /// class A:
 ///     mutable_default: list[int] = []
+///     immutable_default: list[int] = []
 /// ```
 ///
 /// Use instead:
@@ -36,6 +38,7 @@ use crate::rules::ruff::rules::helpers::{
 ///
 /// class A:
 ///     mutable_default: ClassVar[list[int]] = []
+///     immutable_default: tuple[int, ...] = ()
 /// ```
 #[violation]
 pub struct MutableClassDefault;


### PR DESCRIPTION
## Summary

A common mistake in Python code is creating global mutable state by assigning class attributes that are mutable (e.g. a list or dictionary). `RUF012` helpfully catches this mistake and can be used to prevent inadvertent global state form being created.

The description of that rule helpfully provides advice for adjusting code to stop beigng reported as an error *if the attribute should be mutable*, but does not say how the error can be avoided when mutability is not the goal.

This change adds that advice, so that both possibilities are accounted for.

## Test Plan

Docs built and inspected visually:

![Screenshot 2023-11-27 at 14 30 02](https://github.com/astral-sh/ruff/assets/7549858/5bcf2f06-38ed-43e5-adab-bf8fc5992c3d)
