### PR TITLE
[`pydocstyle`] Avoid non-character breaks in `over-indentation` (`D208`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydocstyle/D208.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydocstyle/D208.py
@@ -1,0 +1,5 @@
+class Platform:
+    """ Remove sampler
+            Args:
+            Returns:
+            """

--- a/crates/ruff_linter/src/rules/pydocstyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/mod.rs
@@ -46,6 +46,7 @@ mod tests {
     #[test_case(Rule::NoBlankLineBeforeFunction, Path::new("D.py"))]
     #[test_case(Rule::BlankLinesBetweenHeaderAndContent, Path::new("sections.py"))]
     #[test_case(Rule::OverIndentation, Path::new("D.py"))]
+    #[test_case(Rule::OverIndentation, Path::new("D208.py"))]
     #[test_case(Rule::NoSignature, Path::new("D.py"))]
     #[test_case(Rule::SurroundingWhitespace, Path::new("D.py"))]
     #[test_case(Rule::DocstringStartsWithThis, Path::new("D.py"))]

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D208_D208.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D208_D208.py.snap
@@ -1,0 +1,57 @@
+---
+source: crates/ruff_linter/src/rules/pydocstyle/mod.rs
+---
+D208.py:3:1: D208 [*] Docstring is over-indented
+  |
+1 | class Platform:
+2 |     """ Remove sampler
+3 |             Args:
+  |  D208
+4 |             Returns:
+5 |             """
+  |
+  = help: Remove over-indentation
+
+ℹ Safe fix
+1 1 | class Platform:
+2 2 |     """ Remove sampler
+3   |-            Args:
+  3 |+    Args:
+4 4 |             Returns:
+5 5 |             """
+
+D208.py:4:1: D208 [*] Docstring is over-indented
+  |
+2 |     """ Remove sampler
+3 |             Args:
+4 |             Returns:
+  |  D208
+5 |             """
+  |
+  = help: Remove over-indentation
+
+ℹ Safe fix
+1 1 | class Platform:
+2 2 |     """ Remove sampler
+3 3 |             Args:
+4   |-            Returns:
+  4 |+    Returns:
+5 5 |             """
+
+D208.py:5:1: D208 [*] Docstring is over-indented
+  |
+3 |             Args:
+4 |             Returns:
+5 |             """
+  |  D208
+  |
+  = help: Remove over-indentation
+
+ℹ Safe fix
+2 2 |     """ Remove sampler
+3 3 |             Args:
+4 4 |             Returns:
+5   |-            """
+  5 |+    """
+
+


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/8844.