### PR TITLE
Update `ruff-dev` to use `SourceKind`

### DIFF
--- a/crates/ruff_dev/src/print_ast.rs
+++ b/crates/ruff_dev/src/print_ast.rs
@@ -1,30 +1,34 @@
 //! Print the AST for a given Python file.
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
-use std::fs;
 use std::path::PathBuf;
 
 use anyhow::Result;
-use ruff_python_parser::{parse, Mode};
+
+use ruff_linter::source_kind::SourceKind;
+use ruff_python_ast::PySourceType;
+use ruff_python_parser::{parse, AsMode};
 
 #[derive(clap::Args)]
 pub(crate) struct Args {
     /// Python file for which to generate the AST.
     #[arg(required = true)]
     file: PathBuf,
-    /// Run in Jupyter mode i.e., allow line magics.
-    #[arg(long)]
-    jupyter: bool,
 }
 
 pub(crate) fn main(args: &Args) -> Result<()> {
-    let contents = fs::read_to_string(&args.file)?;
-    let mode = if args.jupyter {
-        Mode::Ipython
-    } else {
-        Mode::Module
-    };
-    let python_ast = parse(&contents, mode, &args.file.to_string_lossy())?;
+    let source_type = PySourceType::from(&args.file);
+    let source_kind = SourceKind::from_path(&args.file, source_type)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Could not determine source kind for file: {}",
+            args.file.display()
+        )
+    })?;
+    let python_ast = parse(
+        source_kind.source_code(),
+        source_type.as_mode(),
+        &args.file.to_string_lossy(),
+    )?;
     println!("{python_ast:#?}");
     Ok(())
 }

--- a/crates/ruff_dev/src/print_tokens.rs
+++ b/crates/ruff_dev/src/print_tokens.rs
@@ -1,30 +1,30 @@
 //! Print the token stream for a given Python file.
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
-use std::fs;
 use std::path::PathBuf;
 
 use anyhow::Result;
-use ruff_python_parser::{lexer, Mode};
+
+use ruff_linter::source_kind::SourceKind;
+use ruff_python_ast::PySourceType;
+use ruff_python_parser::{lexer, AsMode};
 
 #[derive(clap::Args)]
 pub(crate) struct Args {
     /// Python file for which to generate the AST.
     #[arg(required = true)]
     file: PathBuf,
-    /// Run in Jupyter mode i.e., allow line magics (`%`, `!`, `?`, `/`, `,`, `;`).
-    #[arg(long)]
-    jupyter: bool,
 }
 
 pub(crate) fn main(args: &Args) -> Result<()> {
-    let contents = fs::read_to_string(&args.file)?;
-    let mode = if args.jupyter {
-        Mode::Ipython
-    } else {
-        Mode::Module
-    };
-    for (tok, range) in lexer::lex(&contents, mode).flatten() {
+    let source_type = PySourceType::from(&args.file);
+    let source_kind = SourceKind::from_path(&args.file, source_type)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Could not determine source kind for file: {}",
+            args.file.display()
+        )
+    })?;
+    for (tok, range) in lexer::lex(source_kind.source_code(), source_type.as_mode()).flatten() {
         println!(
             "{start:#?} {tok:#?} {end:#?}",
             start = range.start(),


### PR DESCRIPTION
Just a small quality of life improvement to be able to pass in the Jupyter Notebook to `ruff-dev` CLI.
