### PR TITLE
Avoid filtering out un-representable types in return annotation

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_annotations/auto_return_type.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_annotations/auto_return_type.py
@@ -30,3 +30,20 @@ def func(x: int):
 
 def func(x: int):
     return 1 + 2.5 if x > 0 else 1.5 or "str"
+
+
+def func(x: int):
+    if not x:
+        return None
+    return {"foo": 1}
+
+
+def func(x: int):
+    return {"foo": 1}
+
+
+def func():
+    if not x:
+        return 1
+    else:
+        return True

--- a/crates/ruff_linter/src/rules/flake8_annotations/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/helpers.rs
@@ -74,8 +74,8 @@ pub(crate) fn auto_return_type(
             let names = python_types
                 .iter()
                 .sorted_unstable()
-                .filter_map(|python_type| type_expr(*python_type))
-                .collect::<Vec<_>>();
+                .map(|python_type| type_expr(*python_type))
+                .collect::<Option<Vec<_>>>()?;
 
             // Wrap in a bitwise union (e.g., `int | float`).
             Some(pep_604_union(&names))

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type.snap
@@ -123,5 +123,43 @@ auto_return_type.py:31:5: ANN201 [*] Missing return type annotation for public f
 31    |-def func(x: int):
    31 |+def func(x: int) -> str | float:
 32 32 |     return 1 + 2.5 if x > 0 else 1.5 or "str"
+33 33 | 
+34 34 | 
+
+auto_return_type.py:35:5: ANN201 Missing return type annotation for public function `func`
+   |
+35 | def func(x: int):
+   |     ^^^^ ANN201
+36 |     if not x:
+37 |         return None
+   |
+   = help: Add return type annotation
+
+auto_return_type.py:41:5: ANN201 Missing return type annotation for public function `func`
+   |
+41 | def func(x: int):
+   |     ^^^^ ANN201
+42 |     return {"foo": 1}
+   |
+   = help: Add return type annotation
+
+auto_return_type.py:45:5: ANN201 [*] Missing return type annotation for public function `func`
+   |
+45 | def func():
+   |     ^^^^ ANN201
+46 |     if not x:
+47 |         return 1
+   |
+   = help: Add return type annotation: `int`
+
+ℹ Unsafe fix
+42 42 |     return {"foo": 1}
+43 43 | 
+44 44 | 
+45    |-def func():
+   45 |+def func() -> int:
+46 46 |     if not x:
+47 47 |         return 1
+48 48 |     else:
 
 


### PR DESCRIPTION
## Summary

Given `Union[Dict, None]` (in our internal representation), we were filtering out `Dict` since we treat it as un-representable (i.e., we can't convert it to an expression), returning just `None` as the type annotation. We should require that all members of the union are representable.

Closes https://github.com/astral-sh/ruff/issues/8879.
