### PR TITLE
Enable auto-return-type involving `Optional` and `Union` annotations

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_annotations/auto_return_type.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_annotations/auto_return_type.py
@@ -42,8 +42,24 @@ def func(x: int):
     return {"foo": 1}
 
 
-def func():
+def func(x: int):
     if not x:
         return 1
     else:
         return True
+
+
+def func(x: int):
+    if not x:
+        return 1
+    else:
+        return None
+
+
+def func(x: int):
+    if not x:
+        return 1
+    elif x > 5:
+        return "str"
+    else:
+        return None

--- a/crates/ruff_linter/src/rules/flake8_annotations/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/helpers.rs
@@ -1,12 +1,17 @@
 use itertools::Itertools;
+use ruff_diagnostics::Edit;
+use rustc_hash::FxHashSet;
 
-use ruff_python_ast::helpers::{pep_604_union, ReturnStatementVisitor};
+use crate::importer::{ImportRequest, Importer};
+use ruff_python_ast::helpers::{
+    pep_604_union, typing_optional, typing_union, ReturnStatementVisitor,
+};
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{self as ast, Expr, ExprContext};
 use ruff_python_semantic::analyze::type_inference::{NumberLike, PythonType, ResolvedPythonType};
 use ruff_python_semantic::analyze::visibility;
 use ruff_python_semantic::{Definition, SemanticModel};
-use ruff_text_size::TextRange;
+use ruff_text_size::{TextRange, TextSize};
 
 use crate::settings::types::PythonVersion;
 
@@ -38,10 +43,7 @@ pub(crate) fn is_overload_impl(
 }
 
 /// Given a function, guess its return type.
-pub(crate) fn auto_return_type(
-    function: &ast::StmtFunctionDef,
-    target_version: PythonVersion,
-) -> Option<Expr> {
+pub(crate) fn auto_return_type(function: &ast::StmtFunctionDef) -> Option<AutoPythonType> {
     // Collect all the `return` statements.
     let returns = {
         let mut visitor = ReturnStatementVisitor::default();
@@ -68,21 +70,91 @@ pub(crate) fn auto_return_type(
     }
 
     match return_type {
-        ResolvedPythonType::Atom(python_type) => type_expr(python_type),
-        ResolvedPythonType::Union(python_types) if target_version >= PythonVersion::Py310 => {
-            // Aggregate all the individual types (e.g., `int`, `float`).
-            let names = python_types
-                .iter()
-                .sorted_unstable()
-                .map(|python_type| type_expr(*python_type))
-                .collect::<Option<Vec<_>>>()?;
-
-            // Wrap in a bitwise union (e.g., `int | float`).
-            Some(pep_604_union(&names))
-        }
-        ResolvedPythonType::Union(_) => None,
+        ResolvedPythonType::Atom(python_type) => Some(AutoPythonType::Atom(python_type)),
+        ResolvedPythonType::Union(python_types) => Some(AutoPythonType::Union(python_types)),
         ResolvedPythonType::Unknown => None,
         ResolvedPythonType::TypeError => None,
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum AutoPythonType {
+    Atom(PythonType),
+    Union(FxHashSet<PythonType>),
+}
+
+impl AutoPythonType {
+    /// Convert an [`AutoPythonType`] into an [`Expr`].
+    ///
+    /// If the [`Expr`] relies on importing any external symbols, those imports will be returned as
+    /// additional edits.
+    pub(crate) fn into_expression(
+        self,
+        importer: &Importer,
+        at: TextSize,
+        semantic: &SemanticModel,
+        target_version: PythonVersion,
+    ) -> Option<(Expr, Vec<Edit>)> {
+        match self {
+            AutoPythonType::Atom(python_type) => {
+                let expr = type_expr(python_type)?;
+                Some((expr, vec![]))
+            }
+            AutoPythonType::Union(python_types) => {
+                if target_version >= PythonVersion::Py310 {
+                    // Aggregate all the individual types (e.g., `int`, `float`).
+                    let names = python_types
+                        .iter()
+                        .sorted_unstable()
+                        .map(|python_type| type_expr(*python_type))
+                        .collect::<Option<Vec<_>>>()?;
+
+                    // Wrap in a bitwise union (e.g., `int | float`).
+                    let expr = pep_604_union(&names);
+
+                    Some((expr, vec![]))
+                } else {
+                    let python_types = python_types
+                        .into_iter()
+                        .sorted_unstable()
+                        .collect::<Vec<_>>();
+
+                    match python_types.as_slice() {
+                        [python_type, PythonType::None] | [PythonType::None, python_type] => {
+                            let element = type_expr(*python_type)?;
+
+                            // Ex) `Optional[int]`
+                            let (optional_edit, binding) = importer
+                                .get_or_import_symbol(
+                                    &ImportRequest::import_from("typing", "Optional"),
+                                    at,
+                                    semantic,
+                                )
+                                .ok()?;
+                            let expr = typing_optional(element, binding);
+                            Some((expr, vec![optional_edit]))
+                        }
+                        _ => {
+                            let elements = python_types
+                                .into_iter()
+                                .map(type_expr)
+                                .collect::<Option<Vec<_>>>()?;
+
+                            // Ex) `Union[int, str]`
+                            let (union_edit, binding) = importer
+                                .get_or_import_symbol(
+                                    &ImportRequest::import_from("typing", "Union"),
+                                    at,
+                                    semantic,
+                                )
+                                .ok()?;
+                            let expr = typing_union(&elements, binding);
+                            Some((expr, vec![union_edit]))
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_annotations/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/mod.rs
@@ -11,6 +11,7 @@ mod tests {
 
     use crate::assert_messages;
     use crate::registry::Rule;
+    use crate::settings::types::PythonVersion;
     use crate::settings::LinterSettings;
     use crate::test::test_path;
 
@@ -115,6 +116,25 @@ mod tests {
         let diagnostics = test_path(
             Path::new("flake8_annotations/auto_return_type.py"),
             &LinterSettings {
+                ..LinterSettings::for_rules(vec![
+                    Rule::MissingReturnTypeUndocumentedPublicFunction,
+                    Rule::MissingReturnTypePrivateFunction,
+                    Rule::MissingReturnTypeSpecialMethod,
+                    Rule::MissingReturnTypeStaticMethod,
+                    Rule::MissingReturnTypeClassMethod,
+                ])
+            },
+        )?;
+        assert_messages!(diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn auto_return_type_py38() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("flake8_annotations/auto_return_type.py"),
+            &LinterSettings {
+                target_version: PythonVersion::Py38,
                 ..LinterSettings::for_rules(vec![
                     Rule::MissingReturnTypeUndocumentedPublicFunction,
                     Rule::MissingReturnTypePrivateFunction,

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type_py38.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type_py38.snap
@@ -96,17 +96,22 @@ auto_return_type.py:27:5: ANN201 [*] Missing return type annotation for public f
    |     ^^^^ ANN201
 28 |     return 1 or 2.5 if x > 0 else 1.5 or "str"
    |
-   = help: Add return type annotation: `str | float`
+   = help: Add return type annotation: `Union[str | float]`
 
 ℹ Unsafe fix
-24 24 |         return
-25 25 | 
-26 26 | 
+   1  |+from typing import Union
+1  2  | def func():
+2  3  |     return 1
+3  4  | 
+--------------------------------------------------------------------------------
+24 25 |         return
+25 26 | 
+26 27 | 
 27    |-def func(x: int):
-   27 |+def func(x: int) -> str | float:
-28 28 |     return 1 or 2.5 if x > 0 else 1.5 or "str"
-29 29 | 
-30 30 | 
+   28 |+def func(x: int) -> Union[str | float]:
+28 29 |     return 1 or 2.5 if x > 0 else 1.5 or "str"
+29 30 | 
+30 31 | 
 
 auto_return_type.py:31:5: ANN201 [*] Missing return type annotation for public function `func`
    |
@@ -114,17 +119,22 @@ auto_return_type.py:31:5: ANN201 [*] Missing return type annotation for public f
    |     ^^^^ ANN201
 32 |     return 1 + 2.5 if x > 0 else 1.5 or "str"
    |
-   = help: Add return type annotation: `str | float`
+   = help: Add return type annotation: `Union[str | float]`
 
 ℹ Unsafe fix
-28 28 |     return 1 or 2.5 if x > 0 else 1.5 or "str"
-29 29 | 
-30 30 | 
+   1  |+from typing import Union
+1  2  | def func():
+2  3  |     return 1
+3  4  | 
+--------------------------------------------------------------------------------
+28 29 |     return 1 or 2.5 if x > 0 else 1.5 or "str"
+29 30 | 
+30 31 | 
 31    |-def func(x: int):
-   31 |+def func(x: int) -> str | float:
-32 32 |     return 1 + 2.5 if x > 0 else 1.5 or "str"
-33 33 | 
-34 34 | 
+   32 |+def func(x: int) -> Union[str | float]:
+32 33 |     return 1 + 2.5 if x > 0 else 1.5 or "str"
+33 34 | 
+34 35 | 
 
 auto_return_type.py:35:5: ANN201 Missing return type annotation for public function `func`
    |
@@ -169,17 +179,22 @@ auto_return_type.py:52:5: ANN201 [*] Missing return type annotation for public f
 53 |     if not x:
 54 |         return 1
    |
-   = help: Add return type annotation: `int | None`
+   = help: Add return type annotation: `Optional[int]`
 
 ℹ Unsafe fix
-49 49 |         return True
-50 50 | 
-51 51 | 
+   1  |+from typing import Optional
+1  2  | def func():
+2  3  |     return 1
+3  4  | 
+--------------------------------------------------------------------------------
+49 50 |         return True
+50 51 | 
+51 52 | 
 52    |-def func(x: int):
-   52 |+def func(x: int) -> int | None:
-53 53 |     if not x:
-54 54 |         return 1
-55 55 |     else:
+   53 |+def func(x: int) -> Optional[int]:
+53 54 |     if not x:
+54 55 |         return 1
+55 56 |     else:
 
 auto_return_type.py:59:5: ANN201 [*] Missing return type annotation for public function `func`
    |
@@ -188,16 +203,21 @@ auto_return_type.py:59:5: ANN201 [*] Missing return type annotation for public f
 60 |     if not x:
 61 |         return 1
    |
-   = help: Add return type annotation: `str | int | None`
+   = help: Add return type annotation: `Union[str | int | None]`
 
 ℹ Unsafe fix
-56 56 |         return None
-57 57 | 
-58 58 | 
+   1  |+from typing import Union
+1  2  | def func():
+2  3  |     return 1
+3  4  | 
+--------------------------------------------------------------------------------
+56 57 |         return None
+57 58 | 
+58 59 | 
 59    |-def func(x: int):
-   59 |+def func(x: int) -> str | int | None:
-60 60 |     if not x:
-61 61 |         return 1
-62 62 |     elif x > 5:
+   60 |+def func(x: int) -> Union[str | int | None]:
+60 61 |     if not x:
+61 62 |         return 1
+62 63 |     elif x > 5:
 
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -550,7 +550,7 @@ fn check_duplicates(checker: &mut Checker, values: &Expr) {
                     element.range(),
                 );
                 if let Some(prev) = prev {
-                    let values_end = values.range().end() - TextSize::new(1);
+                    let values_end = values.end() - TextSize::new(1);
                     let previous_end =
                         trailing_comma(prev, checker.locator().contents()).unwrap_or(values_end);
                     let element_end =

--- a/crates/ruff_python_parser/src/python.lalrpop
+++ b/crates/ruff_python_parser/src/python.lalrpop
@@ -399,7 +399,7 @@ IpyHelpEndEscapeCommandStatement: ast::Stmt = {
                 _ => {
                     return Err(LexicalError {
                         error: LexicalErrorType::OtherError("only Name, Subscript and Attribute expressions are allowed in help end escape command".to_string()),
-                        location: expr.range().start(),
+                        location: expr.start(),
                     });
                 }
             }
@@ -1642,12 +1642,12 @@ FStringReplacementField: ast::Expr = {
             } else {
                 format_spec.as_ref().map_or_else(
                     || end_location - "}".text_len(),
-                    |spec| spec.range().start() - ":".text_len(),
+                    |spec| spec.start() - ":".text_len(),
                 )
             };
             ast::DebugText {
-                leading: source_code[TextRange::new(start_offset, value.range().start())].to_string(),
-                trailing: source_code[TextRange::new(value.range().end(), end_offset)].to_string(),
+                leading: source_code[TextRange::new(start_offset, value.start())].to_string(),
+                trailing: source_code[TextRange::new(value.end(), end_offset)].to_string(),
             }
         });
         Ok(

--- a/crates/ruff_python_parser/src/python.rs
+++ b/crates/ruff_python_parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: e78a653b50980f07fcb78bfa43c9f023870e26514f59acdec0bec5bf84c2a133
+// sha3: e999c9c9ca8fe5a29655244aa995b8cf4e639f0bda95099d8f2a395bc06b6408
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
 use crate::{
@@ -33700,7 +33700,7 @@ fn __action76<
                 _ => {
                     return Err(LexicalError {
                         error: LexicalErrorType::OtherError("only Name, Subscript and Attribute expressions are allowed in help end escape command".to_string()),
-                        location: expr.range().start(),
+                        location: expr.start(),
                     });
                 }
             }
@@ -36420,12 +36420,12 @@ fn __action221<
             } else {
                 format_spec.as_ref().map_or_else(
                     || end_location - "}".text_len(),
-                    |spec| spec.range().start() - ":".text_len(),
+                    |spec| spec.start() - ":".text_len(),
                 )
             };
             ast::DebugText {
-                leading: source_code[TextRange::new(start_offset, value.range().start())].to_string(),
-                trailing: source_code[TextRange::new(value.range().end(), end_offset)].to_string(),
+                leading: source_code[TextRange::new(start_offset, value.start())].to_string(),
+                trailing: source_code[TextRange::new(value.end(), end_offset)].to_string(),
             }
         });
         Ok(


### PR DESCRIPTION
## Summary

Previously, this was only supported for Python 3.10 and later, since we always use the PEP 604-style unions.
