### PR TITLE
Rename `as_str` to `to_str`

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -380,13 +380,13 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                                 flynt::rules::static_join_to_fstring(
                                     checker,
                                     expr,
-                                    string_value.as_str(),
+                                    string_value.to_str(),
                                 );
                             }
                         } else if attr == "format" {
                             // "...".format(...) call
                             let location = expr.range();
-                            match pyflakes::format::FormatSummary::try_from(string_value.as_str()) {
+                            match pyflakes::format::FormatSummary::try_from(string_value.to_str()) {
                                 Err(e) => {
                                     if checker.enabled(Rule::StringDotFormatInvalidFormat) {
                                         checker.diagnostics.push(Diagnostic::new(
@@ -432,7 +432,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                             if checker.enabled(Rule::BadStringFormatCharacter) {
                                 pylint::rules::bad_string_format_character::call(
                                     checker,
-                                    string_value.as_str(),
+                                    string_value.to_str(),
                                     location,
                                 );
                             }
@@ -1045,7 +1045,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                     Rule::PercentFormatUnsupportedFormatCharacter,
                 ]) {
                     let location = expr.range();
-                    match pyflakes::cformat::CFormatSummary::try_from(value.as_str()) {
+                    match pyflakes::cformat::CFormatSummary::try_from(value.to_str()) {
                         Err(CFormatError {
                             typ: CFormatErrorType::UnsupportedFormatChar(c),
                             ..

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -799,7 +799,7 @@ where
             if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = expr {
                 self.deferred.string_type_definitions.push((
                     expr.range(),
-                    value.as_str(),
+                    value.to_str(),
                     self.semantic.snapshot(),
                 ));
             } else {
@@ -1219,7 +1219,7 @@ where
                 {
                     self.deferred.string_type_definitions.push((
                         expr.range(),
-                        value.as_str(),
+                        value.to_str(),
                         self.semantic.snapshot(),
                     ));
                 }

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -508,7 +508,7 @@ fn check_dynamically_typed<F>(
     if let Expr::StringLiteral(ast::ExprStringLiteral { range, value }) = annotation {
         // Quoted annotations
         if let Ok((parsed_annotation, _)) =
-            parse_type_annotation(value.as_str(), *range, checker.locator().contents())
+            parse_type_annotation(value.to_str(), *range, checker.locator().contents())
         {
             if type_hint_resolves_to_any(
                 &parsed_annotation,

--- a/crates/ruff_linter/src/rules/flake8_bandit/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/helpers.rs
@@ -10,7 +10,7 @@ static PASSWORD_CANDIDATE_REGEX: Lazy<Regex> = Lazy::new(|| {
 
 pub(super) fn string_literal(expr: &Expr) -> Option<&str> {
     match expr {
-        Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => Some(value.as_str()),
+        Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => Some(value.to_str()),
         _ => None,
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
@@ -35,7 +35,7 @@ impl Violation for HardcodedBindAllInterfaces {
 
 /// S104
 pub(crate) fn hardcoded_bind_all_interfaces(string: &ExprStringLiteral) -> Option<Diagnostic> {
-    if string.value.as_str() == "0.0.0.0" {
+    if string.value.to_str() == "0.0.0.0" {
         Some(Diagnostic::new(HardcodedBindAllInterfaces, string.range))
     } else {
         None

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
@@ -55,7 +55,7 @@ fn password_target(target: &Expr) -> Option<&str> {
         Expr::Name(ast::ExprName { id, .. }) => id.as_str(),
         // d["password"] = "s3cr3t"
         Expr::Subscript(ast::ExprSubscript { slice, .. }) => match slice.as_ref() {
-            Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => value.as_str(),
+            Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => value.to_str(),
             _ => return None,
         },
         // obj.password = "s3cr3t"

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
@@ -93,7 +93,7 @@ pub(crate) fn hardcoded_sql_expression(checker: &mut Checker, expr: &Expr) {
             let Some(string) = left.as_string_literal_expr() else {
                 return;
             };
-            string.value.as_str().escape_default().to_string()
+            string.value.to_str().escape_default().to_string()
         }
         Expr::Call(ast::ExprCall { func, .. }) => {
             let Expr::Attribute(ast::ExprAttribute { attr, value, .. }) = func.as_ref() else {
@@ -106,7 +106,7 @@ pub(crate) fn hardcoded_sql_expression(checker: &mut Checker, expr: &Expr) {
             let Some(string) = value.as_string_literal_expr() else {
                 return;
             };
-            string.value.as_str().escape_default().to_string()
+            string.value.to_str().escape_default().to_string()
         }
         // f"select * from table where val = {val}"
         Expr::FString(f_string) => concatenated_f_string(f_string, checker.locator()),

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
@@ -57,7 +57,7 @@ pub(crate) fn hardcoded_tmp_directory(checker: &mut Checker, string: &ast::ExprS
         .flake8_bandit
         .hardcoded_tmp_directory
         .iter()
-        .any(|prefix| string.value.as_str().starts_with(prefix))
+        .any(|prefix| string.value.to_str().starts_with(prefix))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
@@ -855,7 +855,7 @@ pub(crate) fn suspicious_function_call(checker: &mut Checker, call: &ExprCall) {
                 // If the `url` argument is a string literal, allow `http` and `https` schemes.
                 if call.arguments.args.iter().all(|arg| !arg.is_starred_expr()) && call.arguments.keywords.iter().all(|keyword| keyword.arg.is_some()) {
                     if let Some(Expr::StringLiteral(ast::ExprStringLiteral { value, .. })) = &call.arguments.find_argument("url", 0) {
-                        let url = value.as_str().trim_start();
+                        let url = value.to_str().trim_start();
                         if url.starts_with("http://") || url.starts_with("https://") {
                             return None;
                         }

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/tarfile_unsafe_members.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/tarfile_unsafe_members.rs
@@ -60,7 +60,7 @@ pub(crate) fn tarfile_unsafe_members(checker: &mut Checker, call: &ast::ExprCall
         .arguments
         .find_keyword("filter")
         .and_then(|keyword| keyword.value.as_string_literal_expr())
-        .is_some_and(|value| matches!(value.value.as_str(), "data" | "tar"))
+        .is_some_and(|value| matches!(value.value.to_str(), "data" | "tar"))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -69,10 +69,10 @@ pub(crate) fn getattr_with_constant(
     let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = arg else {
         return;
     };
-    if !is_identifier(value.as_str()) {
+    if !is_identifier(value.to_str()) {
         return;
     }
-    if is_mangled_private(value.as_str()) {
+    if is_mangled_private(value.to_str()) {
         return;
     }
     if !checker.semantic().is_builtin("getattr") {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -83,10 +83,10 @@ pub(crate) fn setattr_with_constant(
     let Expr::StringLiteral(ast::ExprStringLiteral { value: name, .. }) = name else {
         return;
     };
-    if !is_identifier(name.as_str()) {
+    if !is_identifier(name.to_str()) {
         return;
     }
-    if is_mangled_private(name.as_str()) {
+    if is_mangled_private(name.to_str()) {
         return;
     }
     if !checker.semantic().is_builtin("setattr") {
@@ -104,7 +104,7 @@ pub(crate) fn setattr_with_constant(
         if expr == child.as_ref() {
             let mut diagnostic = Diagnostic::new(SetAttrWithConstant, expr.range());
             diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
-                assignment(obj, name.as_str(), value, checker.generator()),
+                assignment(obj, name.to_str(), value, checker.generator()),
                 expr.range(),
             )));
             checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
@@ -78,7 +78,7 @@ pub(crate) fn call_datetime_strptime_without_zone(checker: &mut Checker, call: &
     if let Some(Expr::StringLiteral(ast::ExprStringLiteral { value: format, .. })) =
         call.arguments.args.get(1).as_ref()
     {
-        if format.as_str().contains("%z") {
+        if format.to_str().contains("%z") {
             return;
         }
     };

--- a/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -93,7 +93,7 @@ fn check_log_record_attr_clash(checker: &mut Checker, extra: &Keyword) {
             for key in keys {
                 if let Some(key) = &key {
                     if let Expr::StringLiteral(ast::ExprStringLiteral { value: attr, .. }) = key {
-                        if is_reserved_attr(attr.as_str()) {
+                        if is_reserved_attr(attr.to_str()) {
                             checker.diagnostics.push(Diagnostic::new(
                                 LoggingExtraAttrClash(attr.to_string()),
                                 key.range(),

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_dict_kwargs.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_dict_kwargs.rs
@@ -110,8 +110,8 @@ pub(crate) fn unnecessary_dict_kwargs(checker: &mut Checker, expr: &Expr, kwargs
 /// Return `Some` if a key is a valid keyword argument name, or `None` otherwise.
 fn as_kwarg(key: &Expr) -> Option<&str> {
     if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = key {
-        if is_identifier(value.as_str()) {
-            return Some(value.as_str());
+        if is_identifier(value.to_str()) {
+            return Some(value.to_str());
         }
     }
     None

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -127,7 +127,7 @@ pub(crate) fn unrecognized_platform(checker: &mut Checker, test: &Expr) {
         // Other values are possible but we don't need them right now.
         // This protects against typos.
         if checker.enabled(Rule::UnrecognizedPlatformName) {
-            if !matches!(value.as_str(), "linux" | "win32" | "cygwin" | "darwin") {
+            if !matches!(value.to_str(), "linux" | "win32" | "cygwin" | "darwin") {
                 checker.diagnostics.push(Diagnostic::new(
                     UnrecognizedPlatformName {
                         platform: value.to_string(),

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -258,7 +258,7 @@ fn elts_to_csv(elts: &[Expr], generator: Generator) -> Option<String> {
                 if !acc.is_empty() {
                     acc.push(',');
                 }
-                acc.push_str(value.as_str());
+                acc.push_str(value.to_str());
             }
             acc
         }),
@@ -301,7 +301,7 @@ fn check_names(checker: &mut Checker, decorator: &Decorator, expr: &Expr) {
 
     match expr {
         Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => {
-            let names = split_names(value.as_str());
+            let names = split_names(value.to_str());
             if names.len() > 1 {
                 match names_type {
                     types::ParametrizeNameType::Tuple => {
@@ -476,7 +476,7 @@ fn check_values(checker: &mut Checker, names: &Expr, values: &Expr) {
         .parametrize_values_row_type;
 
     let is_multi_named = if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = &names {
-        split_names(value.as_str()).len() > 1
+        split_names(value.to_str()).len() > 1
     } else {
         true
     };

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -161,12 +161,12 @@ pub(crate) fn use_capital_environment_variables(checker: &mut Checker, expr: &Ex
         return;
     }
 
-    if is_lowercase_allowed(env_var.as_str()) {
+    if is_lowercase_allowed(env_var.to_str()) {
         return;
     }
 
-    let capital_env_var = env_var.as_str().to_ascii_uppercase();
-    if capital_env_var == env_var.as_str() {
+    let capital_env_var = env_var.to_str().to_ascii_uppercase();
+    if capital_env_var == env_var.to_str() {
         return;
     }
 
@@ -201,12 +201,12 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
         return;
     };
 
-    if is_lowercase_allowed(env_var.as_str()) {
+    if is_lowercase_allowed(env_var.to_str()) {
         return;
     }
 
-    let capital_env_var = env_var.as_str().to_ascii_uppercase();
-    if capital_env_var == env_var.as_str() {
+    let capital_env_var = env_var.to_str().to_ascii_uppercase();
+    if capital_env_var == env_var.to_str() {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
@@ -69,7 +69,7 @@ pub(crate) fn path_constructor_current_directory(checker: &mut Checker, expr: &E
         return;
     };
 
-    if matches!(value.as_str(), "" | ".") {
+    if matches!(value.to_str(), "" | ".") {
         let mut diagnostic = Diagnostic::new(PathConstructorCurrentDirectory, *range);
         diagnostic.set_fix(Fix::safe_edit(Edit::range_deletion(*range)));
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -67,7 +67,7 @@ fn build_fstring(joiner: &str, joinees: &[Expr]) -> Option<Expr> {
                 .iter()
                 .filter_map(|expr| {
                     if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = expr {
-                        Some(value.as_str())
+                        Some(value.to_str())
                     } else {
                         None
                     }

--- a/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
@@ -583,10 +583,10 @@ pub(crate) fn percent_format_extra_named_arguments(
         .enumerate()
         .filter_map(|(index, key)| match key {
             Some(Expr::StringLiteral(ast::ExprStringLiteral { value, .. })) => {
-                if summary.keywords.contains(value.as_str()) {
+                if summary.keywords.contains(value.to_str()) {
                     None
                 } else {
-                    Some((index, value.as_str()))
+                    Some((index, value.to_str()))
                 }
             }
             _ => None,
@@ -641,7 +641,7 @@ pub(crate) fn percent_format_missing_arguments(
     for key in keys.iter().flatten() {
         match key {
             Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => {
-                keywords.insert(value.as_str());
+                keywords.insert(value.to_str());
             }
             _ => {
                 return; // Dynamic keys present

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -12,7 +12,7 @@ pub(super) fn type_param_name(arguments: &Arguments) -> Option<&str> {
     // Handle both `TypeVar("T")` and `TypeVar(name="T")`.
     let name_param = arguments.find_argument("name", 0)?;
     if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = &name_param {
-        Some(value.as_str())
+        Some(value.to_str())
     } else {
         None
     }

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_type.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_type.rs
@@ -201,7 +201,7 @@ fn is_valid_dict(
             value: mapping_key, ..
         }) = key
         {
-            let Some(format) = formats_hash.get(mapping_key.as_str()) else {
+            let Some(format) = formats_hash.get(mapping_key.to_str()) else {
                 return true;
             };
             if !equivalent(format, value) {

--- a/crates/ruff_linter/src/rules/pylint/rules/logging.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/logging.rs
@@ -134,7 +134,7 @@ pub(crate) fn logging_call(checker: &mut Checker, call: &ast::ExprCall) {
         return;
     };
 
-    let Ok(summary) = CFormatSummary::try_from(value.as_str()) else {
+    let Ok(summary) = CFormatSummary::try_from(value.to_str()) else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/magic_value_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/magic_value_comparison.rs
@@ -83,7 +83,7 @@ fn is_magic_value(literal_expr: LiteralExpressionRef, allowed_types: &[ConstantT
         | LiteralExpressionRef::EllipsisLiteral(_) => false,
         // Special-case some common string and integer types.
         LiteralExpressionRef::StringLiteral(ast::ExprStringLiteral { value, .. }) => {
-            !matches!(value.as_str(), "" | "__main__")
+            !matches!(value.to_str(), "" | "__main__")
         }
         LiteralExpressionRef::NumberLiteral(ast::ExprNumberLiteral { value, .. }) => match value {
             ast::Number::Int(value) => !matches!(*value, Int::ZERO | Int::ONE),

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_keyword_argument.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_keyword_argument.rs
@@ -60,7 +60,7 @@ pub(crate) fn repeated_keyword_argument(checker: &mut Checker, call: &ExprCall) 
             // Ex) `func(**{"a": 1, "a": 2})`
             for key in keys.iter().flatten() {
                 if let Expr::StringLiteral(ExprStringLiteral { value, .. }) = key {
-                    if !seen.insert(value.as_str()) {
+                    if !seen.insert(value.to_str()) {
                         checker.diagnostics.push(Diagnostic::new(
                             RepeatedKeywordArgument {
                                 duplicate_keyword: value.to_string(),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -185,13 +185,13 @@ fn create_fields_from_fields_arg(fields: &Expr) -> Option<Vec<Stmt>> {
                     return None;
                 }
                 let ast::ExprStringLiteral { value: field, .. } = field.as_string_literal_expr()?;
-                if !is_identifier(field.as_str()) {
+                if !is_identifier(field.to_str()) {
                     return None;
                 }
-                if is_dunder(field.as_str()) {
+                if is_dunder(field.to_str()) {
                     return None;
                 }
-                Some(create_field_assignment_stmt(field.as_str(), annotation))
+                Some(create_field_assignment_stmt(field.to_str(), annotation))
             })
             .collect()
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -174,13 +174,13 @@ fn fields_from_dict_literal(keys: &[Option<Expr>], values: &[Expr]) -> Option<Ve
             .zip(values.iter())
             .map(|(key, value)| match key {
                 Some(Expr::StringLiteral(ast::ExprStringLiteral { value: field, .. })) => {
-                    if !is_identifier(field.as_str()) {
+                    if !is_identifier(field.to_str()) {
                         return None;
                     }
-                    if is_dunder(field.as_str()) {
+                    if is_dunder(field.to_str()) {
                         return None;
                     }
-                    Some(create_field_assignment_stmt(field.as_str(), value))
+                    Some(create_field_assignment_stmt(field.to_str(), value))
                 }
                 _ => None,
             })

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -228,14 +228,14 @@ fn clean_params_dictionary(right: &Expr, locator: &Locator, stylist: &Stylist) -
                     }) = key
                     {
                         // If the dictionary key is not a valid variable name, abort.
-                        if !is_identifier(key_string.as_str()) {
+                        if !is_identifier(key_string.to_str()) {
                             return None;
                         }
                         // If there are multiple entries of the same key, abort.
-                        if seen.contains(&key_string.as_str()) {
+                        if seen.contains(&key_string.to_str()) {
                             return None;
                         }
-                        seen.push(key_string.as_str());
+                        seen.push(key_string.to_str());
                         if is_multi_line {
                             if indent.is_none() {
                                 indent = indentation(locator, key);

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -76,7 +76,7 @@ pub(crate) fn redundant_open_modes(checker: &mut Checker, call: &ast::ExprCall) 
                         ..
                     }) = &keyword.value
                     {
-                        if let Ok(mode) = OpenMode::from_str(mode_param_value.as_str()) {
+                        if let Ok(mode) = OpenMode::from_str(mode_param_value.to_str()) {
                             checker.diagnostics.push(create_check(
                                 call,
                                 &keyword.value,
@@ -91,7 +91,7 @@ pub(crate) fn redundant_open_modes(checker: &mut Checker, call: &ast::ExprCall) 
         }
         Some(mode_param) => {
             if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = &mode_param {
-                if let Ok(mode) = OpenMode::from_str(value.as_str()) {
+                if let Ok(mode) = OpenMode::from_str(value.to_str()) {
                     checker.diagnostics.push(create_check(
                         call,
                         mode_param,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -74,7 +74,7 @@ fn match_encoded_variable(func: &Expr) -> Option<&Expr> {
 
 fn is_utf8_encoding_arg(arg: &Expr) -> bool {
     if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = &arg {
-        UTF8_LITERALS.contains(&value.as_str().to_lowercase().as_str())
+        UTF8_LITERALS.contains(&value.to_str().to_lowercase().as_str())
     } else {
         false
     }
@@ -161,7 +161,7 @@ pub(crate) fn unnecessary_encode_utf8(checker: &mut Checker, call: &ast::ExprCal
         Expr::StringLiteral(ast::ExprStringLiteral { value: literal, .. }) => {
             // Ex) `"str".encode()`, `"str".encode("utf-8")`
             if let Some(encoding_arg) = match_encoding_arg(&call.arguments) {
-                if literal.as_str().is_ascii() {
+                if literal.to_str().is_ascii() {
                     // Ex) Convert `"foo".encode()` to `b"foo"`.
                     let mut diagnostic = Diagnostic::new(
                         UnnecessaryEncodeUTF8 {

--- a/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
@@ -66,7 +66,7 @@ pub(crate) fn no_implicit_cwd(checker: &mut Checker, call: &ExprCall) {
             let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = arg else {
                 return;
             };
-            if !matches!(value.as_str(), "" | ".") {
+            if !matches!(value.to_str(), "" | ".") {
                 return;
             }
         }

--- a/crates/ruff_linter/src/rules/refurb/rules/read_whole_file.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/read_whole_file.rs
@@ -248,7 +248,7 @@ fn match_open_mode(mode: &Expr) -> Option<ReadMode> {
     if value.is_implicit_concatenated() {
         return None;
     }
-    match value.as_str() {
+    match value.to_str() {
         "r" => Some(ReadMode::Text),
         "rb" => Some(ReadMode::Bytes),
         _ => None,

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -184,7 +184,7 @@ pub(crate) fn implicit_optional(checker: &mut Checker, parameters: &Parameters) 
         if let Expr::StringLiteral(ast::ExprStringLiteral { range, value }) = annotation.as_ref() {
             // Quoted annotation.
             if let Ok((annotation, kind)) =
-                parse_type_annotation(value.as_str(), *range, checker.locator().contents())
+                parse_type_annotation(value.to_str(), *range, checker.locator().contents())
             {
                 let Some(expr) = type_hint_explicitly_allows_none(
                     &annotation,

--- a/crates/ruff_linter/src/rules/ruff/typing.rs
+++ b/crates/ruff_linter/src/rules/ruff/typing.rs
@@ -109,7 +109,7 @@ impl<'a> TypingTarget<'a> {
             }) => Some(TypingTarget::PEP604Union(left, right)),
             Expr::NoneLiteral(_) => Some(TypingTarget::None),
             Expr::StringLiteral(ast::ExprStringLiteral { value, range }) => {
-                parse_type_annotation(value.as_str(), *range, locator.contents())
+                parse_type_annotation(value.to_str(), *range, locator.contents())
                     .map_or(None, |(expr, _)| Some(TypingTarget::ForwardReference(expr)))
             }
             _ => semantic.resolve_call_path(expr).map_or(

--- a/crates/ruff_python_ast/src/all.rs
+++ b/crates/ruff_python_ast/src/all.rs
@@ -24,7 +24,7 @@ where
     fn add_to_names<'a>(elts: &'a [Expr], names: &mut Vec<&'a str>, flags: &mut DunderAllFlags) {
         for elt in elts {
             if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = elt {
-                names.push(value.as_str());
+                names.push(value.to_str());
             } else {
                 *flags |= DunderAllFlags::INVALID_OBJECT;
             }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1233,10 +1233,10 @@ impl StringLiteralValue {
     ///
     /// Note that this will perform an allocation on the first invocation if the
     /// string value is implicitly concatenated.
-    pub fn as_str(&self) -> &str {
+    pub fn to_str(&self) -> &str {
         match &self.inner {
             StringLiteralValueInner::Single(value) => value.as_str(),
-            StringLiteralValueInner::Concatenated(value) => value.as_str(),
+            StringLiteralValueInner::Concatenated(value) => value.to_str(),
         }
     }
 }
@@ -1259,7 +1259,7 @@ impl PartialEq<String> for StringLiteralValue {
 
 impl fmt::Display for StringLiteralValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
+        f.write_str(self.to_str())
     }
 }
 
@@ -1331,7 +1331,7 @@ struct ConcatenatedStringLiteral {
 
 impl ConcatenatedStringLiteral {
     /// Extracts a string slice containing the entire concatenated string.
-    fn as_str(&self) -> &str {
+    fn to_str(&self) -> &str {
         self.value
             .get_or_init(|| self.strings.iter().map(StringLiteral::as_str).collect())
     }
@@ -1354,7 +1354,7 @@ impl Debug for ConcatenatedStringLiteral {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ConcatenatedStringLiteral")
             .field("strings", &self.strings)
-            .field("value", &self.as_str())
+            .field("value", &self.to_str())
             .finish()
     }
 }

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1356,7 +1356,7 @@ impl<'a> Generator<'a> {
     fn unparse_f_string_elem(&mut self, expr: &Expr, is_spec: bool) {
         match expr {
             Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => {
-                self.unparse_f_string_literal(value.as_str());
+                self.unparse_f_string_literal(value.to_str());
             }
             Expr::FString(ast::ExprFString { value, .. }) => {
                 self.unparse_f_string_value(value, is_spec);


### PR DESCRIPTION
This PR renames the method on `StringLiteralValue` from `as_str` to `to_str`. The main motivation is to follow the naming convention as described in the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv). This method can perform a string allocation in case the string is implicitly concatenated.
