### PR TITLE
Allow transparent cell magics

### DIFF
--- a/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__ipy_escape_command.snap
+++ b/crates/ruff_linter/src/snapshots/ruff_linter__linter__tests__ipy_escape_command.snap
@@ -19,5 +19,20 @@ ipy_escape_command.ipynb:cell 1:5:8: F401 [*] `os` imported but unused
 5   |-import os
 6 5 | 
 7 6 | _ = math.pi
+8 7 | %%timeit
+
+ipy_escape_command.ipynb:cell 2:2:8: F401 [*] `sys` imported but unused
+  |
+1 | %%timeit
+2 | import sys
+  |        ^^^ F401
+  |
+  = help: Remove unused import: `sys`
+
+ℹ Safe fix
+6 6 | 
+7 7 | _ = math.pi
+8 8 | %%timeit
+9   |-import sys
 
 

--- a/crates/ruff_notebook/resources/test/fixtures/jupyter/cell/valid_cell_magic.json
+++ b/crates/ruff_notebook/resources/test/fixtures/jupyter/cell/valid_cell_magic.json
@@ -5,9 +5,7 @@
   "metadata": {},
   "outputs": [],
   "source": [
-    "%%script bash\n",
-    "for i in 1 2 3; do\n",
-    "  echo $i\n",
-    "done"
+    "%%timeit\n",
+    "print('hello world')"
   ]
 }

--- a/crates/ruff_notebook/resources/test/fixtures/jupyter/ipy_escape_command.ipynb
+++ b/crates/ruff_notebook/resources/test/fixtures/jupyter/ipy_escape_command.ipynb
@@ -26,6 +26,18 @@
     "%%timeit\n",
     "import sys"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36dedfd1-6c03-4894-bea6-6c1687b82b3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%random\n",
+    "# This cell is ignored\n",
+    "import pathlib"
+   ]
   }
  ],
  "metadata": {

--- a/crates/ruff_notebook/resources/test/fixtures/jupyter/ipy_escape_command_expected.ipynb
+++ b/crates/ruff_notebook/resources/test/fixtures/jupyter/ipy_escape_command_expected.ipynb
@@ -22,8 +22,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%timeit\n",
-    "import sys"
+    "%%timeit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b6d7faa-72b3-4087-8670-fe6d35e41fb6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%random\n",
+    "# This cell is ignored\n",
+    "import pathlib"
    ]
   }
  ],

--- a/crates/ruff_notebook/src/notebook.rs
+++ b/crates/ruff_notebook/src/notebook.rs
@@ -426,6 +426,7 @@ mod tests {
     #[test_case(Path::new("code_and_magic.json"), true; "code_and_magic")]
     #[test_case(Path::new("only_code.json"), true; "only_code")]
     #[test_case(Path::new("cell_magic.json"), false; "cell_magic")]
+    #[test_case(Path::new("valid_cell_magic.json"), true; "valid_cell_magic")]
     #[test_case(Path::new("automagic.json"), false; "automagic")]
     #[test_case(Path::new("automagics.json"), false; "automagics")]
     #[test_case(Path::new("automagic_before_code.json"), false; "automagic_before_code")]


### PR DESCRIPTION
## Summary

This PR updates the logic for `is_magic_cell` to include certain cell magics. These cell magics would contain Python code following the line defining the command. The code could define a variable which can then be referenced in other cells. Currently, we would ignore the cell completely leading to undefined-name violation.

As discussed in https://github.com/astral-sh/ruff/issues/8354#issuecomment-1832221009

## Test Plan

Add new test case to validate this scenario.
