### PR TITLE
Avoid off-by-one error in with-item named expressions

### DIFF
--- a/crates/ruff_python_parser/src/python.lalrpop
+++ b/crates/ruff_python_parser/src/python.lalrpop
@@ -1026,7 +1026,7 @@ WithItems: Vec<ast::WithItem> = {
         // ```
         // In this case, the `(` and `)` are part of the `with` statement.
         // The same applies to `yield` and `yield from`.
-        let item = if matches!(item.context_expr, ast::Expr::NamedExpr(_) | ast::Expr::Yield(_) | ast::Expr::YieldFrom(_)) {
+        let item = if item.optional_vars.is_none() && matches!(item.context_expr, ast::Expr::NamedExpr(_) | ast::Expr::Yield(_) | ast::Expr::YieldFrom(_)) {
             ast::WithItem {
                 range: item.range().add_start(TextSize::new(1)).sub_end(TextSize::new(1)),
                 context_expr: item.context_expr,

--- a/crates/ruff_python_parser/src/python.rs
+++ b/crates/ruff_python_parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: e999c9c9ca8fe5a29655244aa995b8cf4e639f0bda95099d8f2a395bc06b6408
+// sha3: c7c0b9368fa05f7d2fc1d06a665ff4232555f276a1d9569afdbc86d0905b3a2a
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
 use crate::{
@@ -35374,7 +35374,7 @@ fn __action159<
         // ```
         // In this case, the `(` and `)` are part of the `with` statement.
         // The same applies to `yield` and `yield from`.
-        let item = if matches!(item.context_expr, ast::Expr::NamedExpr(_) | ast::Expr::Yield(_) | ast::Expr::YieldFrom(_)) {
+        let item = if item.optional_vars.is_none() && matches!(item.context_expr, ast::Expr::NamedExpr(_) | ast::Expr::Yield(_) | ast::Expr::YieldFrom(_)) {
             ast::WithItem {
                 range: item.range().add_start(TextSize::new(1)).sub_end(TextSize::new(1)),
                 context_expr: item.context_expr,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parenthesized_with_statement.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__parenthesized_with_statement.snap
@@ -347,7 +347,7 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
             is_async: false,
             items: [
                 WithItem {
-                    range: 184..195,
+                    range: 183..196,
                     context_expr: NamedExpr(
                         ExprNamedExpr {
                             range: 184..190,

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__with_statement.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__parser__tests__with_statement.snap
@@ -782,7 +782,7 @@ expression: "parse_suite(source, \"<test>\").unwrap()"
             is_async: false,
             items: [
                 WithItem {
-                    range: 382..393,
+                    range: 381..394,
                     context_expr: NamedExpr(
                         ExprNamedExpr {
                             range: 382..388,


### PR DESCRIPTION
## Summary

Given `with (a := b): pass`, we truncate the `WithItem` range by one on both sides such that the parentheses are part of the statement, rather than the item. However, for `with (a := b) as x: pass`, we want to avoid this trick.

Closes https://github.com/astral-sh/ruff/issues/8913.
