### PR TITLE
Add support for `@functools.singledispatch`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/singledispatch.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/singledispatch.py
@@ -1,0 +1,34 @@
+"""Test module."""
+from __future__ import annotations
+
+from functools import singledispatch
+from typing import TYPE_CHECKING
+
+from numpy import asarray
+from numpy.typing import ArrayLike
+from scipy.sparse import spmatrix
+from pandas import DataFrame
+
+if TYPE_CHECKING:
+    from numpy import ndarray
+
+
+@singledispatch
+def to_array_or_mat(a: ArrayLike | spmatrix) -> ndarray | spmatrix:
+    """Convert arg to array or leaves it as sparse matrix."""
+    msg = f"Unhandled type {type(a)}"
+    raise NotImplementedError(msg)
+
+
+@to_array_or_mat.register
+def _(a: ArrayLike) -> ndarray:
+    return asarray(a)
+
+
+@to_array_or_mat.register
+def _(a: spmatrix) -> spmatrix:
+    return a
+
+
+def _(a: DataFrame) -> DataFrame:
+    return a

--- a/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
@@ -37,6 +37,7 @@ mod tests {
     #[test_case(Rule::TypingOnlyStandardLibraryImport, Path::new("TCH003.py"))]
     #[test_case(Rule::TypingOnlyStandardLibraryImport, Path::new("snapshot.py"))]
     #[test_case(Rule::TypingOnlyThirdPartyImport, Path::new("TCH002.py"))]
+    #[test_case(Rule::TypingOnlyThirdPartyImport, Path::new("singledispatch.py"))]
     #[test_case(Rule::TypingOnlyThirdPartyImport, Path::new("strict.py"))]
     #[test_case(Rule::TypingOnlyThirdPartyImport, Path::new("typing_modules_1.py"))]
     #[test_case(Rule::TypingOnlyThirdPartyImport, Path::new("typing_modules_2.py"))]

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_singledispatch.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__typing-only-third-party-import_singledispatch.py.snap
@@ -1,0 +1,27 @@
+---
+source: crates/ruff_linter/src/rules/flake8_type_checking/mod.rs
+---
+singledispatch.py:10:20: TCH002 [*] Move third-party import `pandas.DataFrame` into a type-checking block
+   |
+ 8 | from numpy.typing import ArrayLike
+ 9 | from scipy.sparse import spmatrix
+10 | from pandas import DataFrame
+   |                    ^^^^^^^^^ TCH002
+11 | 
+12 | if TYPE_CHECKING:
+   |
+   = help: Move into type-checking block
+
+ℹ Unsafe fix
+7  7  | from numpy import asarray
+8  8  | from numpy.typing import ArrayLike
+9  9  | from scipy.sparse import spmatrix
+10    |-from pandas import DataFrame
+11 10 | 
+12 11 | if TYPE_CHECKING:
+   12 |+    from pandas import DataFrame
+13 13 |     from numpy import ndarray
+14 14 | 
+15 15 | 
+
+


### PR DESCRIPTION
## Summary

When a function uses `@functools.singledispatch`, we need to treat the first argument of any implementations as runtime-required.

Closes https://github.com/astral-sh/ruff/issues/6849.