### PR TITLE
Enable Preview mode for formatter benchmarks

### DIFF
--- a/crates/ruff_benchmark/benches/formatter.rs
+++ b/crates/ruff_benchmark/benches/formatter.rs
@@ -4,7 +4,7 @@ use ruff_benchmark::criterion::{
     criterion_group, criterion_main, BenchmarkId, Criterion, Throughput,
 };
 use ruff_benchmark::{TestCase, TestFile, TestFileDownloadError};
-use ruff_python_formatter::{format_module_ast, PyFormatOptions};
+use ruff_python_formatter::{format_module_ast, PreviewMode, PyFormatOptions};
 use ruff_python_index::CommentRangesBuilder;
 use ruff_python_parser::lexer::lex;
 use ruff_python_parser::{parse_tokens, Mode};
@@ -69,7 +69,8 @@ fn benchmark_formatter(criterion: &mut Criterion) {
                     .expect("Input to be a valid python program");
 
                 b.iter(|| {
-                    let options = PyFormatOptions::from_extension(Path::new(case.name()));
+                    let options = PyFormatOptions::from_extension(Path::new(case.name()))
+                        .with_preview(PreviewMode::Enabled);
                     let formatted =
                         format_module_ast(&module, &comment_ranges, case.code(), options)
                             .expect("Formatting to succeed");


### PR DESCRIPTION
## Summary

This PR enables preview mode for the formatter benchmark.

The reasoning for enabling preview mode is that most (significant) changes to the formatter are made to preview mode. 
The "stable" style may get smaller bugfixes or we introduce new branching for preview styles. However, neither of these should have a significant impact on performance (a bug fix might, but I consider it less likely). 
That's why benchmarking with preview style helps us catch significant regressions before shortly before a release when we promote a style to stable. 

## Test Plan

Codspeed
