### PR TITLE
ruff_python_formatter: light refactoring of code snippet formatting in docstrings

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples.py
@@ -1,3 +1,12 @@
+###############################################################################
+# DOCTEST CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# Python's "doctest" format.
+#
+# See: https://docs.python.org/3/library/doctest.html
+###############################################################################
+
 # The simplest doctest to ensure basic formatting works.
 def doctest_simple():
     """

--- a/crates/ruff_python_formatter/src/expression/string/docstring.rs
+++ b/crates/ruff_python_formatter/src/expression/string/docstring.rs
@@ -276,6 +276,12 @@ impl<'ast, 'buf, 'fmt, 'src> DocstringLinePrinter<'ast, 'buf, 'fmt, 'src> {
         match self.code_example.add(line) {
             CodeExampleAddAction::Print { original } => self.print_one(&original)?,
             CodeExampleAddAction::Kept => {}
+            CodeExampleAddAction::Reset { code, original } => {
+                for codeline in code {
+                    self.print_one(&codeline.original)?;
+                }
+                self.print_one(&original)?;
+            }
             CodeExampleAddAction::Format {
                 kind,
                 code,
@@ -658,6 +664,19 @@ enum CodeExampleAddAction<'src> {
         /// or it is part of another code example and should be treated as a
         /// [`Kept`] action.
         original: Option<DocstringLine<'src>>,
+    },
+    /// This occurs when adding a line to an existing code example
+    /// results in that code example becoming invalid. In this case,
+    /// we don't want to treat it as a code example, but instead write
+    /// back the lines to the docstring unchanged.
+    #[allow(dead_code)] // FIXME: remove when reStructuredText support is added
+    Reset {
+        /// The lines of code that we collected but should be printed back to
+        /// the docstring as-is and not formatted.
+        code: Vec<CodeExampleLine<'src>>,
+        /// The line that was added and triggered this reset to occur. It
+        /// should be written back to the docstring as-is after the code lines.
+        original: DocstringLine<'src>,
     },
 }
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
@@ -4,6 +4,15 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_
 ---
 ## Input
 ```python
+###############################################################################
+# DOCTEST CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# Python's "doctest" format.
+#
+# See: https://docs.python.org/3/library/doctest.html
+###############################################################################
+
 # The simplest doctest to ensure basic formatting works.
 def doctest_simple():
     """
@@ -336,6 +345,15 @@ preview                 = Disabled
 ```
 
 ```python
+###############################################################################
+# DOCTEST CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# Python's "doctest" format.
+#
+# See: https://docs.python.org/3/library/doctest.html
+###############################################################################
+
 # The simplest doctest to ensure basic formatting works.
 def doctest_simple():
     """
@@ -671,6 +689,15 @@ preview                 = Disabled
 ```
 
 ```python
+###############################################################################
+# DOCTEST CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# Python's "doctest" format.
+#
+# See: https://docs.python.org/3/library/doctest.html
+###############################################################################
+
 # The simplest doctest to ensure basic formatting works.
 def doctest_simple():
   """
@@ -1006,6 +1033,15 @@ preview                 = Disabled
 ```
 
 ```python
+###############################################################################
+# DOCTEST CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# Python's "doctest" format.
+#
+# See: https://docs.python.org/3/library/doctest.html
+###############################################################################
+
 # The simplest doctest to ensure basic formatting works.
 def doctest_simple():
 	"""
@@ -1341,6 +1377,15 @@ preview                 = Disabled
 ```
 
 ```python
+###############################################################################
+# DOCTEST CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# Python's "doctest" format.
+#
+# See: https://docs.python.org/3/library/doctest.html
+###############################################################################
+
 # The simplest doctest to ensure basic formatting works.
 def doctest_simple():
 	"""
@@ -1676,6 +1721,15 @@ preview                 = Disabled
 ```
 
 ```python
+###############################################################################
+# DOCTEST CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# Python's "doctest" format.
+#
+# See: https://docs.python.org/3/library/doctest.html
+###############################################################################
+
 # The simplest doctest to ensure basic formatting works.
 def doctest_simple():
     """
@@ -2011,6 +2065,15 @@ preview                 = Disabled
 ```
 
 ```python
+###############################################################################
+# DOCTEST CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# Python's "doctest" format.
+#
+# See: https://docs.python.org/3/library/doctest.html
+###############################################################################
+
 # The simplest doctest to ensure basic formatting works.
 def doctest_simple():
   """
@@ -2346,6 +2409,15 @@ preview                 = Disabled
 ```
 
 ```python
+###############################################################################
+# DOCTEST CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# Python's "doctest" format.
+#
+# See: https://docs.python.org/3/library/doctest.html
+###############################################################################
+
 # The simplest doctest to ensure basic formatting works.
 def doctest_simple():
 	"""
@@ -2681,6 +2753,15 @@ preview                 = Disabled
 ```
 
 ```python
+###############################################################################
+# DOCTEST CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# Python's "doctest" format.
+#
+# See: https://docs.python.org/3/library/doctest.html
+###############################################################################
+
 # The simplest doctest to ensure basic formatting works.
 def doctest_simple():
 	"""


### PR DESCRIPTION
In the source of working on #8859, I made a number of smallish refactors to how code snippet formatting works. Most or all of these were motivated by writing in support for reStructuredText blocks. They have some fundamentally different requirements than doctests, and there are a lot more ways for reStructuredText blocks to become invalid.

(Commit-by-commit review is recommended as the commit messages provide further context on each change. I split this off from ongoing work to make review more manageable.)