### PR TITLE
Ignore `@overload` and `@override` methods for too-many-arguments checks

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/too_many_arguments.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/too_many_arguments.py
@@ -32,3 +32,16 @@ def f(x, y, z, *, u, v, w):  # Too many arguments (6/5)
 
 def f(x, y, z, a, b, c, *, u, v, w):  # Too many arguments (9/5)
     pass
+
+
+from typing import override, overload
+
+
+@override
+def f(x, y, z, a, b, c, *, u, v, w):  # OK
+    pass
+
+
+@overload
+def f(x, y, z, a, b, c, *, u, v, w):  # OK
+    pass

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -248,7 +248,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 pylint::rules::property_with_parameters(checker, stmt, decorator_list, parameters);
             }
             if checker.enabled(Rule::TooManyArguments) {
-                pylint::rules::too_many_arguments(checker, parameters, stmt);
+                pylint::rules::too_many_arguments(checker, function_def);
             }
             if checker.enabled(Rule::TooManyReturnStatements) {
                 if let Some(diagnostic) = pylint::rules::too_many_return_statements(

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_arguments.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_arguments.rs
@@ -1,8 +1,8 @@
-use ruff_python_ast::{Parameters, Stmt};
-
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast as ast;
 use ruff_python_ast::identifier::Identifier;
+use ruff_python_semantic::analyze::visibility;
 
 use crate::checkers::ast::Checker;
 
@@ -58,12 +58,13 @@ impl Violation for TooManyArguments {
 }
 
 /// PLR0913
-pub(crate) fn too_many_arguments(checker: &mut Checker, parameters: &Parameters, stmt: &Stmt) {
-    let num_arguments = parameters
+pub(crate) fn too_many_arguments(checker: &mut Checker, function_def: &ast::StmtFunctionDef) {
+    let num_arguments = function_def
+        .parameters
         .args
         .iter()
-        .chain(&parameters.kwonlyargs)
-        .chain(&parameters.posonlyargs)
+        .chain(&function_def.parameters.kwonlyargs)
+        .chain(&function_def.parameters.posonlyargs)
         .filter(|arg| {
             !checker
                 .settings
@@ -71,13 +72,22 @@ pub(crate) fn too_many_arguments(checker: &mut Checker, parameters: &Parameters,
                 .is_match(&arg.parameter.name)
         })
         .count();
+
     if num_arguments > checker.settings.pylint.max_args {
+        // Allow excessive arguments in `@override` or `@overload` methods, since they're required
+        // to adhere to the parent signature.
+        if visibility::is_override(&function_def.decorator_list, checker.semantic())
+            || visibility::is_overload(&function_def.decorator_list, checker.semantic())
+        {
+            return;
+        }
+
         checker.diagnostics.push(Diagnostic::new(
             TooManyArguments {
                 c_args: num_arguments,
                 max_args: checker.settings.pylint.max_args,
             },
-            stmt.identifier(),
+            function_def.identifier(),
         ));
     }
 }


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/8945.