### PR TITLE
Added the command to run ruff using pkgx to the installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ brew install ruff
 For **pkgx** users, Ruff is also available as [`ruff`](https://pkgx.dev/pkgs/github.com/charliermarsh/ruff/)
 
 ```shell
-pkgx ruff
+pkgx install ruff # or run directly using pkgx ruff
 ```
 
 For **Conda** users, Ruff is also available as [`ruff`](https://anaconda.org/conda-forge/ruff) on

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,17 +20,18 @@ on Homebrew:
 brew install ruff
 ```
 
-For **pkgx** users, Ruff is also available as [`ruff`](https://pkgx.dev/pkgs/github.com/charliermarsh/ruff/)
-
-```shell
-pkgx install ruff # or run directly using pkgx ruff
-```
-
 For **Conda** users, Ruff is also available as [`ruff`](https://anaconda.org/conda-forge/ruff) on
 `conda-forge`:
 
 ```shell
 conda install -c conda-forge ruff
+```
+
+For **pkgx** users, Ruff is also available as [`ruff`](https://pkgx.dev/pkgs/github.com/charliermarsh/ruff/)
+on the `pkgx` registry:
+
+```shell
+pkgx install ruff
 ```
 
 For **Arch Linux** users, Ruff is also available as [`ruff`](https://archlinux.org/packages/extra/x86_64/ruff/)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,6 +20,12 @@ on Homebrew:
 brew install ruff
 ```
 
+For **pkgx** users, Ruff is also available as [`ruff`](https://pkgx.dev/pkgs/github.com/charliermarsh/ruff/)
+
+```shell
+pkgx ruff
+```
+
 For **Conda** users, Ruff is also available as [`ruff`](https://anaconda.org/conda-forge/ruff) on
 `conda-forge`:
 


### PR DESCRIPTION
## Summary

This PR adds the command to run ruff using [pkgx](https://pkgx.sh).

<!-- What's the purpose of the change? What does it do, and why? -->

It's just showing that ruff is supported in one more package manager.

## Test Plan

You can run `pkgx ruff` if you have pkgx installed or run `sh <(curl https://pkgx.sh) +github.com/charliermarsh/ruff sh
`
