### PR TITLE
Fix error in `t-suffixed-type-alias` (`PYI043`) example

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/type_alias_naming.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/type_alias_naming.rs
@@ -46,12 +46,16 @@ impl Violation for SnakeCaseTypeAlias {
 ///
 /// ## Example
 /// ```python
-/// MyTypeT = int
+/// from typing import TypeAlias
+///
+/// _MyTypeT: TypeAlias = int
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// MyType = int
+/// from typing import TypeAlias
+///
+/// _MyType: TypeAlias = int
 /// ```
 #[violation]
 pub struct TSuffixedTypeAlias {


### PR DESCRIPTION
## Summary

For `t-suffixed-type-alias` to trigger, the type alias needs to be marked as such using the `typing.TypeAlias` annotation and the name of the alias must be marked as private using a leading underscore. The documentation example was of an unannotated type alias that was not marked as private, which was misleading.

## Test Plan

The current example doesn't trigger the rule; the example in this merge request does.
