### PR TITLE
[`flake8-pyi`] Check PEP 695 type aliases for `snake-case-type-alias` and `t-suffixed-type-alias`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI042.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI042.py
@@ -22,3 +22,7 @@ Snake_case_alias: TypeAlias = int | float  # PYI042, since not camel case
 
 # check that this edge case doesn't crash
 _: TypeAlias = str | int
+
+# PEP 695
+type foo_bar = int | str
+type FooBar = int | str

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI042.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI042.pyi
@@ -22,3 +22,7 @@ Snake_case_alias: TypeAlias = int | float  # PYI042, since not camel case
 
 # check that this edge case doesn't crash
 _: TypeAlias = str | int
+
+# PEP 695
+type foo_bar = int | str
+type FooBar = int | str

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI043.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI043.py
@@ -21,3 +21,7 @@ _PrivateAliasS2: TypeAlias = Annotated[str, "also okay"]
 
 # check that this edge case doesn't crash
 _: TypeAlias = str | int
+
+# PEP 695
+type _FooT = str | int
+type Foo = str | int

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI043.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI043.pyi
@@ -21,3 +21,7 @@ _PrivateAliasS2: TypeAlias = Annotated[str, "also okay"]
 
 # check that this edge case doesn't crash
 _: TypeAlias = str | int
+
+# PEP 695
+type _FooT = str | int
+type Foo = str | int

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -1534,6 +1534,14 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 }
             }
         }
+        Stmt::TypeAlias(ast::StmtTypeAlias { name, .. }) => {
+            if checker.enabled(Rule::SnakeCaseTypeAlias) {
+                flake8_pyi::rules::snake_case_type_alias(checker, name);
+            }
+            if checker.enabled(Rule::TSuffixedTypeAlias) {
+                flake8_pyi::rules::t_suffixed_type_alias(checker, name);
+            }
+        }
         Stmt::Delete(delete @ ast::StmtDelete { targets, range: _ }) => {
             if checker.enabled(Rule::GlobalStatement) {
                 for target in targets {

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI042_PYI042.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI042_PYI042.py.snap
@@ -29,4 +29,12 @@ PYI042.py:20:1: PYI042 Type alias `_snake_case_alias2` should be CamelCase
 21 | Snake_case_alias: TypeAlias = int | float  # PYI042, since not camel case
    |
 
+PYI042.py:27:6: PYI042 Type alias `foo_bar` should be CamelCase
+   |
+26 | # PEP 695
+27 | type foo_bar = int | str
+   |      ^^^^^^^ PYI042
+28 | type FooBar = int | str
+   |
+
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI042_PYI042.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI042_PYI042.pyi.snap
@@ -29,4 +29,12 @@ PYI042.pyi:20:1: PYI042 Type alias `_snake_case_alias2` should be CamelCase
 21 | Snake_case_alias: TypeAlias = int | float  # PYI042, since not camel case
    |
 
+PYI042.pyi:27:6: PYI042 Type alias `foo_bar` should be CamelCase
+   |
+26 | # PEP 695
+27 | type foo_bar = int | str
+   |      ^^^^^^^ PYI042
+28 | type FooBar = int | str
+   |
+
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI043_PYI043.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI043_PYI043.py.snap
@@ -30,4 +30,12 @@ PYI043.py:12:1: PYI043 Private type alias `_PrivateAliasT3` should not be suffix
 14 | ]  # PYI043, since this ends in a T
    |
 
+PYI043.py:26:6: PYI043 Private type alias `_FooT` should not be suffixed with `T` (the `T` suffix implies that an object is a `TypeVar`)
+   |
+25 | # PEP 695
+26 | type _FooT = str | int
+   |      ^^^^^ PYI043
+27 | type Foo = str | int
+   |
+
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI043_PYI043.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI043_PYI043.pyi.snap
@@ -30,4 +30,12 @@ PYI043.pyi:12:1: PYI043 Private type alias `_PrivateAliasT3` should not be suffi
 14 | ]  # PYI043, since this ends in a T
    |
 
+PYI043.pyi:26:6: PYI043 Private type alias `_FooT` should not be suffixed with `T` (the `T` suffix implies that an object is a `TypeVar`)
+   |
+25 | # PEP 695
+26 | type _FooT = str | int
+   |      ^^^^^ PYI043
+27 | type Foo = str | int
+   |
+
 


### PR DESCRIPTION
## Summary

Check PEP 695 type alias definitions for `snake-case-type-alias` (`PYI042`) and `t-suffixed-type-alias` (`PYI043`)

Related to #8771.

## Test Plan

`cargo test`
