### PR TITLE
Avoid unstable formatting in ellipsis-only body with trailing comment

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/ellipsis.pyi
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/ellipsis.pyi
@@ -68,6 +68,10 @@ with True:
 with True:
     ... # comment
 
+with True:
+    ...
+    # comment
+
 match x:
     case 1:
         ...

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -511,7 +511,9 @@ pub(crate) fn contains_only_an_ellipsis(body: &[Stmt], comments: &Comments) -> b
             let [node] = body else {
                 return false;
             };
-            value.is_ellipsis_literal_expr() && !comments.has_leading(node)
+            value.is_ellipsis_literal_expr()
+                && !comments.has_leading(node)
+                && !comments.has_trailing_own_line(node)
         }
         _ => false,
     }

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__ellipsis.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__ellipsis.pyi.snap
@@ -74,6 +74,10 @@ with True:
 with True:
     ... # comment
 
+with True:
+    ...
+    # comment
+
 match x:
     case 1:
         ...
@@ -105,7 +109,8 @@ try:
 except:
     ...  # comment
 finally:
-    ...  # comment```
+    ...  # comment
+```
 
 ## Output
 ```python
@@ -162,6 +167,10 @@ with True:
     ...
 
 with True: ...  # comment
+
+with True:
+    ...
+    # comment
 
 match x:
     case 1: ...


### PR DESCRIPTION
## Summary

We should avoid inlining the ellipsis in:

```python
def h():
    ...
    # bye
```

Just as we omit the ellipsis in:

```python
def h():
    # bye
    ...
```

Closes https://github.com/astral-sh/ruff/issues/8905.