### PR TITLE
Rename semantic model flag `LITERAL` to `TYPING_LITERAL`

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -816,7 +816,7 @@ where
     fn visit_expr(&mut self, expr: &'b Expr) {
         // Step 0: Pre-processing
         if !self.semantic.in_f_string()
-            && !self.semantic.in_literal()
+            && !self.semantic.in_typing_literal()
             && !self.semantic.in_deferred_type_definition()
             && self.semantic.in_type_definition()
             && self.semantic.future_annotations()
@@ -1198,7 +1198,7 @@ where
                     ) {
                         // Ex) Literal["Class"]
                         Some(typing::SubscriptKind::Literal) => {
-                            self.semantic.flags |= SemanticModelFlags::LITERAL;
+                            self.semantic.flags |= SemanticModelFlags::TYPING_LITERAL;
 
                             self.visit_expr(slice);
                             self.visit_expr_context(ctx);
@@ -1239,7 +1239,7 @@ where
             }
             Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => {
                 if self.semantic.in_type_definition()
-                    && !self.semantic.in_literal()
+                    && !self.semantic.in_typing_literal()
                     && !self.semantic.in_f_string()
                 {
                     self.deferred.string_type_definitions.push((

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -1359,8 +1359,8 @@ impl<'a> SemanticModel<'a> {
     }
 
     /// Return `true` if the model is in a `typing::Literal` annotation.
-    pub const fn in_literal(&self) -> bool {
-        self.flags.intersects(SemanticModelFlags::LITERAL)
+    pub const fn in_typing_literal(&self) -> bool {
+        self.flags.intersects(SemanticModelFlags::TYPING_LITERAL)
     }
 
     /// Return `true` if the model is in a subscript expression.
@@ -1576,7 +1576,7 @@ bitflags! {
         /// def f(x: Literal["A", "B", "C"]):
         ///     ...
         /// ```
-        const LITERAL = 1 << 9;
+        const TYPING_LITERAL = 1 << 9;
 
         /// The model is in a subscript expression.
         ///


### PR DESCRIPTION
This PR renames the semantic model flag `LITERAL` to `TYPING_LITERAL` to better reflect its purpose. The main motivation behind this change is to avoid any confusion with the "literal" terminology used in the AST for literal nodes like string, bytes, numbers, etc.
