### PR TITLE
add support for formatting reStructuredText code snippets

### DIFF
--- a/crates/ruff_python_formatter/Cargo.toml
+++ b/crates/ruff_python_formatter/Cargo.toml
@@ -28,6 +28,7 @@ countme = "3.0.1"
 itertools = { workspace = true }
 memchr = { workspace = true }
 once_cell = { workspace = true }
+regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples.py
@@ -67,6 +67,27 @@ def doctest_last_line_continued():
     pass
 
 
+# Test that a doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line():
+    """
+    Do cool stuff.
+
+    >>> cool_stuff( x )"""
+    pass
+
+
+# Test that a continued doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line_continued():
+    """
+    Do cool stuff.
+
+    >>> cool_stuff( x )
+    ... more( y )"""
+    pass
+
+
 # Test that a doctest is correctly identified and formatted with a blank
 # continuation line.
 def doctest_blank_continued():

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples.py
@@ -344,3 +344,487 @@ def doctest_invalid_skipped_with_triple_double_in_single_quote_string():
     >>> x        =      '\"\"\"'
     """
     pass
+
+
+###############################################################################
+# reStructuredText CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# reStructuredText formatted code blocks.
+#
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#literal-blocks
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-30
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-38
+###############################################################################
+
+
+def rst_literal_simple():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_literal_simple_continued():
+    """
+    Do cool stuff::
+
+        def cool_stuff( x ):
+            print( f"hi {x}" );
+
+    Done.
+    """
+    pass
+
+
+# Tests that we can end the literal block on the second
+# to last line of the docstring.
+def rst_literal_second_to_last():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )
+    """
+    pass
+
+
+# Tests that we can end the literal block on the actual
+# last line of the docstring.
+def rst_literal_actually_last():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )"""
+    pass
+
+
+def rst_literal_with_blank_lines():
+    """
+    Do cool stuff::
+
+        def cool_stuff( x ):
+            print( f"hi {x}" );
+
+        def other_stuff( y ):
+            print(    y     )
+
+    Done.
+    """
+    pass
+
+
+# Extra blanks should be preserved.
+def rst_literal_extra_blanks():
+    """
+    Do cool stuff::
+
+
+
+        cool_stuff( 1 )
+
+
+
+    Done.
+    """
+    pass
+
+
+# If a literal block is never properly ended (via a non-empty unindented line),
+# then the end of the block should be the last non-empty line. And subsequent
+# empty lines should be preserved as-is.
+def rst_literal_extra_blanks_at_end():
+    """
+    Do cool stuff::
+
+
+        cool_stuff( 1 )
+
+
+
+    """
+    pass
+
+
+# A literal block can contain many empty lines and it should not end the block
+# if it continues.
+def rst_literal_extra_blanks_in_snippet():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )
+
+
+        cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# This tests that a unindented line appearing after an indented line (but where
+# the indent is still beyond the minimum) gets formatted properly.
+def rst_literal_subsequent_line_not_indented():
+    """
+    Do cool stuff::
+
+     if True:
+        cool_stuff( '''
+     hiya''' )
+
+    Done.
+    """
+    pass
+
+
+# This checks that if the first line in a code snippet has been indented with
+# tabs, then so long as its "indentation length" is considered bigger than the
+# line with `::`, it is reformatted as code.
+#
+# (If your tabwidth is set to 4, then it looks like the code snippet
+# isn't indented at all, which is perhaps counter-intuitive. Indeed, reST
+# itself also seems to recognize this as a code block, although it appears
+# under-specified.)
+def rst_literal_first_line_indent_uses_tabs_4spaces():
+    """
+    Do cool stuff::
+
+	cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
+    """
+    Do cool stuff::
+
+	cool_stuff( 1 )
+	cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# Another test with tabs, except in this case, if your tabwidth is less than
+# 8, than the code snippet actually looks like its indent is *less* than the
+# opening line with a `::`. One might presume this means that the code snippet
+# is not treated as a literal block and thus not reformatted, but since we
+# assume all tabs have tabwidth=8 when computing indentation length, the code
+# snippet is actually seen as being more indented than the opening `::` line.
+# As with the above example, reST seems to behave the same way here.
+def rst_literal_first_line_indent_uses_tabs_8spaces():
+        """
+        Do cool stuff::
+
+	 cool_stuff( 1 )
+
+        Done.
+        """
+        pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
+        """
+        Do cool stuff::
+
+	 cool_stuff( 1 )
+	 cool_stuff( 2 )
+
+        Done.
+        """
+        pass
+
+
+# Tests that if two lines in a literal block are indented to the same level
+# but by different means (tabs versus spaces), then we correctly recognize the
+# block and format it.
+def rst_literal_first_line_tab_second_line_spaces():
+    """
+    Do cool stuff::
+
+	cool_stuff( 1 )
+        cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# Tests that when two lines in a code snippet have weird and inconsistent
+# indentation, the code still gets formatted so long as the indent is greater
+# than the indent of the `::` line.
+#
+# In this case, the minimum indent is 5 spaces (from the second line) where as
+# the first line has an indent of 8 spaces via a tab (by assuming tabwidth=8).
+# The minimum indent is stripped from each code line. Since tabs aren't
+# divisible, the entire tab is stripped, which means the first and second lines
+# wind up with the same level of indentation.
+#
+# An alternative behavior here would be that the tab is replaced with 3 spaces
+# instead of being stripped entirely. The code snippet itself would then have
+# inconsistent indentation to the point of being invalid Python, and thus code
+# formatting would be skipped.
+#
+# I decided on the former behavior because it seems a bit easier to implement,
+# but we might want to switch to the alternative if cases like this show up in
+# the real world. ---AG
+def rst_literal_odd_indentation():
+    """
+    Do cool stuff::
+
+	cool_stuff( 1 )
+     cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# Tests that having a line with a lone `::` works as an introduction of a
+# literal block.
+def rst_literal_lone_colon():
+    """
+    Do cool stuff.
+
+    ::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_simple():
+    """
+    .. code-block:: python
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_case_insensitive():
+    """
+    .. cOdE-bLoCk:: python
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_sourcecode():
+    """
+    .. sourcecode:: python
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_options():
+    """
+    .. code-block:: python
+        :linenos:
+        :emphasize-lines: 2,3
+        :name: blah blah
+
+        cool_stuff( 1 )
+        cool_stuff( 2 )
+        cool_stuff( 3 )
+        cool_stuff( 4 )
+
+    Done.
+    """
+    pass
+
+
+# In this case, since `pycon` isn't recognized as a Python code snippet, the
+# docstring reformatter ignores it. But it then picks up the doctest and
+# reformats it.
+def rst_directive_doctest():
+    """
+    .. code-block:: pycon
+
+        >>> cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# This checks that if the first non-empty line after the start of a literal
+# block is not indented more than the line containing the `::`, then it is not
+# treated as a code snippet.
+def rst_literal_skipped_first_line_not_indented():
+    """
+    Do cool stuff::
+
+    cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# Like the test above, but inserts an indented line after the un-indented one.
+# This should not cause the literal block to be resumed.
+def rst_literal_skipped_first_line_not_indented_then_indented():
+    """
+    Do cool stuff::
+
+    cool_stuff( 1 )
+      cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# This also checks that a code snippet is not reformatted when the indentation
+# of the first line is not more than the line with `::`, but this uses tabs to
+# make it a little more confounding. It relies on the fact that indentation
+# length is computed by assuming a tabwidth equal to 8. reST also rejects this
+# and doesn't treat it as a literal block.
+def rst_literal_skipped_first_line_not_indented_tab():
+        """
+        Do cool stuff::
+
+	cool_stuff( 1 )
+
+        Done.
+        """
+        pass
+
+
+# Like the previous test, but adds a second line.
+def rst_literal_skipped_first_line_not_indented_tab_multiple():
+        """
+        Do cool stuff::
+
+	cool_stuff( 1 )
+	cool_stuff( 2 )
+
+        Done.
+        """
+        pass
+
+
+# Tests that a code block with a second line that is not properly indented gets
+# skipped. A valid code block needs to have an empty line separating these.
+#
+# One trick here is that we need to make sure the Python code in the snippet is
+# valid, otherwise it would be skipped because of invalid Python.
+def rst_literal_skipped_subsequent_line_not_indented():
+    """
+    Do cool stuff::
+
+     if True:
+        cool_stuff( '''
+    hiya''' )
+
+    Done.
+    """
+    pass
+
+
+# In this test, we write what looks like a code-block, but it should be treated
+# as invalid due to the missing `language` argument.
+#
+# It does still look like it could be a literal block according to the literal
+# rules, but we currently consider the `.. ` prefix to indicate that it is not
+# a literal block.
+def rst_literal_skipped_not_directive():
+    """
+    .. code-block::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# In this test, we start a line with `.. `, which makes it look like it might
+# be a directive. But instead continue it as if it was just some periods from
+# the previous line, and then try to end it by starting a literal block.
+#
+# But because of the `.. ` in the beginning, we wind up not treating this as a
+# code snippet. The reST render I was using to test things does actually treat
+# this as a code block, so we may be out of conformance here.
+def rst_literal_skipped_possible_false_negative():
+    """
+    This is a test.
+    .. This is a test::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# This tests that a doctest inside of a reST literal block doesn't get
+# reformatted. It's plausible this isn't the right behavior, but it also seems
+# like it might be the right behavior since it is a literal block. (The doctest
+# makes the Python code invalid.)
+def rst_literal_skipped_doctest():
+    """
+    Do cool stuff::
+
+        >>> cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_skipped_not_indented():
+    """
+    .. code-block:: python
+
+    cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_skipped_wrong_language():
+    """
+    .. code-block:: rust
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# This gets skipped for the same reason that the doctest in a literal block
+# gets skipped.
+def rst_directive_skipped_doctest():
+    """
+    .. code-block:: python
+
+        >>> cool_stuff( 1 )
+
+    Done.
+    """
+    pass

--- a/crates/ruff_python_formatter/src/expression/string/docstring.rs
+++ b/crates/ruff_python_formatter/src/expression/string/docstring.rs
@@ -225,6 +225,7 @@ fn contains_unescaped_newline(haystack: &str) -> bool {
 /// An abstraction for printing each line of a docstring.
 struct DocstringLinePrinter<'ast, 'buf, 'fmt, 'src> {
     f: &'fmt mut PyFormatter<'ast, 'buf>,
+
     /// A queue of actions to perform.
     ///
     /// Whenever we process a line, it is possible for it to generate multiple
@@ -236,17 +237,22 @@ struct DocstringLinePrinter<'ast, 'buf, 'fmt, 'src> {
     /// Actions are pushed on to the end of the queue and popped from the
     /// beginning.
     action_queue: VecDeque<CodeExampleAddAction<'src>>,
+
     /// The source offset of the beginning of the line that is currently being
     /// printed.
     offset: TextSize,
+
     /// Indentation alignment based on the least indented line in the
     /// docstring.
     stripped_indentation_length: TextSize,
+
     /// Whether the docstring is overall already considered normalized. When it
     /// is, the formatter can take a fast path.
     already_normalized: bool,
+
     /// The quote style used by the docstring being printed.
     quote_style: QuoteStyle,
+
     /// The current code example detected in the docstring.
     code_example: CodeExample<'src>,
 }
@@ -525,8 +531,10 @@ struct InputDocstringLine<'src> {
     /// unformatted line in a docstring, and owned when it corresponds to a
     /// reformatted line (e.g., from a code snippet) in a docstring.
     line: &'src str,
+
     /// The offset into the source document which this line corresponds to.
     offset: TextSize,
+
     /// For any input line that isn't the last line, this contains a reference
     /// to the line immediately following this one.
     ///
@@ -565,9 +573,11 @@ struct OutputDocstringLine<'src> {
     /// a line from a reformatted code snippet. In other cases, it is borrowed
     /// from the input docstring line as-is.
     line: Cow<'src, str>,
+
     /// The offset into the source document which this line corresponds to.
     /// Currently, this is an estimate.
     offset: TextSize,
+
     /// Whether this is the last line in a docstring or not. This is determined
     /// by whether the last line in the code snippet was also the last line in
     /// the docstring. If it was, then it follows that the last line in the
@@ -730,6 +740,7 @@ impl<'src> CodeExampleKind<'src> {
 struct CodeExampleDoctest<'src> {
     /// The lines that have been seen so far that make up the doctest.
     lines: Vec<CodeExampleLine<'src>>,
+
     /// The indent observed in the first doctest line.
     ///
     /// More precisely, this corresponds to the whitespace observed before
@@ -832,15 +843,19 @@ impl<'src> CodeExampleDoctest<'src> {
 struct CodeExampleRst<'src> {
     /// The lines that have been seen so far that make up the block.
     lines: Vec<CodeExampleLine<'src>>,
-    /// The indent of the line "opening" this block. It can either be the
-    /// indent of a line ending with `::` (for a literal block) or the indent
-    /// of a line starting with `.. ` (a directive).
+
+    /// The indent of the line "opening" this block measured via
+    /// `indentation_length`.
+    ///
+    /// It can either be the indent of a line ending with `::` (for a literal
+    /// block) or the indent of a line starting with `.. ` (a directive).
     ///
     /// The content body of a block needs to be indented more than the line
     /// opening the block, so we use this indentation to look for indentation
     /// that is "more than" it.
     opening_indent: TextSize,
-    /// The minimum indent of the block.
+
+    /// The minimum indent of the block measured via `indentation_length`.
     ///
     /// This is `None` until the first such line is seen. If no such line is
     /// found, then we consider it an invalid block and bail out of trying to
@@ -858,6 +873,7 @@ struct CodeExampleRst<'src> {
     /// reformatted. The minimum indent is stripped from each line when it is
     /// re-built.
     min_indent: Option<TextSize>,
+
     /// Whether this is a directive block or not. When not a directive, this is
     /// a literal block. The main difference between them is that they start
     /// differently. A literal block is started merely by trailing a line with
@@ -1159,6 +1175,7 @@ struct CodeExampleLine<'src> {
     /// example, contain a `>>> ` or `... ` prefix if this code example is a
     /// doctest.
     original: InputDocstringLine<'src>,
+
     /// The code extracted from the line.
     code: &'src str,
 }

--- a/crates/ruff_python_formatter/src/expression/string/docstring.rs
+++ b/crates/ruff_python_formatter/src/expression/string/docstring.rs
@@ -4,9 +4,9 @@
 
 use std::{borrow::Cow, collections::VecDeque};
 
-use ruff_python_trivia::PythonWhitespace;
 use {
     ruff_formatter::{write, IndentStyle, Printed},
+    ruff_python_trivia::{is_python_whitespace, PythonWhitespace},
     ruff_source_file::Locator,
     ruff_text_size::{Ranged, TextLen, TextRange, TextSize},
 };

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
@@ -73,6 +73,27 @@ def doctest_last_line_continued():
     pass
 
 
+# Test that a doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line():
+    """
+    Do cool stuff.
+
+    >>> cool_stuff( x )"""
+    pass
+
+
+# Test that a continued doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line_continued():
+    """
+    Do cool stuff.
+
+    >>> cool_stuff( x )
+    ... more( y )"""
+    pass
+
+
 # Test that a doctest is correctly identified and formatted with a blank
 # continuation line.
 def doctest_blank_continued():
@@ -411,6 +432,27 @@ def doctest_last_line_continued():
     >>> def cool_stuff( x ):
     ...     print( f"hi {x}" );
     """
+    pass
+
+
+# Test that a doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line():
+    """
+    Do cool stuff.
+
+    >>> cool_stuff( x )"""
+    pass
+
+
+# Test that a continued doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line_continued():
+    """
+    Do cool stuff.
+
+    >>> cool_stuff( x )
+    ... more( y )"""
     pass
 
 
@@ -758,6 +800,27 @@ def doctest_last_line_continued():
   pass
 
 
+# Test that a doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line():
+  """
+  Do cool stuff.
+
+  >>> cool_stuff( x )"""
+  pass
+
+
+# Test that a continued doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line_continued():
+  """
+  Do cool stuff.
+
+  >>> cool_stuff( x )
+  ... more( y )"""
+  pass
+
+
 # Test that a doctest is correctly identified and formatted with a blank
 # continuation line.
 def doctest_blank_continued():
@@ -1099,6 +1162,27 @@ def doctest_last_line_continued():
 	>>> def cool_stuff( x ):
 	...     print( f"hi {x}" );
 	"""
+	pass
+
+
+# Test that a doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line():
+	"""
+	Do cool stuff.
+
+	>>> cool_stuff( x )"""
+	pass
+
+
+# Test that a continued doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line_continued():
+	"""
+	Do cool stuff.
+
+	>>> cool_stuff( x )
+	... more( y )"""
 	pass
 
 
@@ -1446,6 +1530,27 @@ def doctest_last_line_continued():
 	pass
 
 
+# Test that a doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line():
+	"""
+	Do cool stuff.
+
+	>>> cool_stuff( x )"""
+	pass
+
+
+# Test that a continued doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line_continued():
+	"""
+	Do cool stuff.
+
+	>>> cool_stuff( x )
+	... more( y )"""
+	pass
+
+
 # Test that a doctest is correctly identified and formatted with a blank
 # continuation line.
 def doctest_blank_continued():
@@ -1787,6 +1892,27 @@ def doctest_last_line_continued():
     >>> def cool_stuff(x):
     ...     print(f"hi {x}")
     """
+    pass
+
+
+# Test that a doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line():
+    """
+    Do cool stuff.
+
+    >>> cool_stuff(x)"""
+    pass
+
+
+# Test that a continued doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line_continued():
+    """
+    Do cool stuff.
+
+    >>> cool_stuff(x)
+    ... more(y)"""
     pass
 
 
@@ -2134,6 +2260,27 @@ def doctest_last_line_continued():
   pass
 
 
+# Test that a doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line():
+  """
+  Do cool stuff.
+
+  >>> cool_stuff(x)"""
+  pass
+
+
+# Test that a continued doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line_continued():
+  """
+  Do cool stuff.
+
+  >>> cool_stuff(x)
+  ... more(y)"""
+  pass
+
+
 # Test that a doctest is correctly identified and formatted with a blank
 # continuation line.
 def doctest_blank_continued():
@@ -2478,6 +2625,27 @@ def doctest_last_line_continued():
 	pass
 
 
+# Test that a doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line():
+	"""
+	Do cool stuff.
+
+	>>> cool_stuff(x)"""
+	pass
+
+
+# Test that a continued doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line_continued():
+	"""
+	Do cool stuff.
+
+	>>> cool_stuff(x)
+	... more(y)"""
+	pass
+
+
 # Test that a doctest is correctly identified and formatted with a blank
 # continuation line.
 def doctest_blank_continued():
@@ -2819,6 +2987,27 @@ def doctest_last_line_continued():
 	>>> def cool_stuff(x):
 	... 	print(f"hi {x}")
 	"""
+	pass
+
+
+# Test that a doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line():
+	"""
+	Do cool stuff.
+
+	>>> cool_stuff(x)"""
+	pass
+
+
+# Test that a continued doctest on the real last line of a docstring reformats
+# correctly.
+def doctest_really_last_line_continued():
+	"""
+	Do cool stuff.
+
+	>>> cool_stuff(x)
+	... more(y)"""
 	pass
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
@@ -2583,7 +2583,7 @@ def doctest_simple_continued():
 	Do cool stuff.
 
 	>>> def cool_stuff(x):
-	... 	print(f"hi {x}")
+	...         print(f"hi {x}")
 	hi 2
 	"""
 	pass
@@ -2620,7 +2620,7 @@ def doctest_last_line_continued():
 	Do cool stuff.
 
 	>>> def cool_stuff(x):
-	... 	print(f"hi {x}")
+	...         print(f"hi {x}")
 	"""
 	pass
 
@@ -2653,9 +2653,9 @@ def doctest_blank_continued():
 	Do cool stuff.
 
 	>>> def cool_stuff(x):
-	... 	print(x)
+	...         print(x)
 	...
-	... 	print(x)
+	...         print(x)
 	"""
 	pass
 
@@ -2668,8 +2668,8 @@ def doctest_blank_end():
 	Do cool stuff.
 
 	>>> def cool_stuff(x):
-	... 	print(x)
-	... 	print(x)
+	...         print(x)
+	...         print(x)
 	"""
 	pass
 
@@ -2681,8 +2681,8 @@ def doctest_blank_end_then_some_text():
 	Do cool stuff.
 
 	>>> def cool_stuff(x):
-	... 	print(x)
-	... 	print(x)
+	...         print(x)
+	...         print(x)
 
 	And say something else.
 	"""
@@ -2754,11 +2754,11 @@ def doctest_nested_doctest_not_formatted():
 	Do cool stuff.
 
 	>>> def nested(x):
-	... 	"""
-	... 	Do nested cool stuff.
-	... 	>>> func_call( 5 )
-	... 	"""
-	... 	pass
+	...         """
+	...         Do nested cool stuff.
+	...         >>> func_call( 5 )
+	...         """
+	...         pass
 	'''
 	pass
 
@@ -2799,7 +2799,7 @@ def doctest_long_lines():
 
 	But this one is long enough to get wrapped.
 	>>> foo, bar, quux = this_is_a_long_line(
-	... 	lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard
+	...         lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard
 	... )
 	"""
 	# This demostrates a normal line that will get wrapped but won't
@@ -2855,7 +2855,7 @@ def doctest_skipped_partial_inconsistent_indent():
 	Do cool stuff.
 
 	 >>> def cool_stuff(x):
-	 ... 	print(x)
+	 ...         print(x)
 	...     print( f"hi {x}" );
 	hi 2
 	"""
@@ -2948,7 +2948,7 @@ def doctest_simple_continued():
 	Do cool stuff.
 
 	>>> def cool_stuff(x):
-	... 	print(f"hi {x}")
+	...     print(f"hi {x}")
 	hi 2
 	"""
 	pass
@@ -2985,7 +2985,7 @@ def doctest_last_line_continued():
 	Do cool stuff.
 
 	>>> def cool_stuff(x):
-	... 	print(f"hi {x}")
+	...     print(f"hi {x}")
 	"""
 	pass
 
@@ -3018,9 +3018,9 @@ def doctest_blank_continued():
 	Do cool stuff.
 
 	>>> def cool_stuff(x):
-	... 	print(x)
+	...     print(x)
 	...
-	... 	print(x)
+	...     print(x)
 	"""
 	pass
 
@@ -3033,8 +3033,8 @@ def doctest_blank_end():
 	Do cool stuff.
 
 	>>> def cool_stuff(x):
-	... 	print(x)
-	... 	print(x)
+	...     print(x)
+	...     print(x)
 	"""
 	pass
 
@@ -3046,8 +3046,8 @@ def doctest_blank_end_then_some_text():
 	Do cool stuff.
 
 	>>> def cool_stuff(x):
-	... 	print(x)
-	... 	print(x)
+	...     print(x)
+	...     print(x)
 
 	And say something else.
 	"""
@@ -3119,11 +3119,11 @@ def doctest_nested_doctest_not_formatted():
 	Do cool stuff.
 
 	>>> def nested(x):
-	... 	"""
-	... 	Do nested cool stuff.
-	... 	>>> func_call( 5 )
-	... 	"""
-	... 	pass
+	...     """
+	...     Do nested cool stuff.
+	...     >>> func_call( 5 )
+	...     """
+	...     pass
 	'''
 	pass
 
@@ -3164,7 +3164,7 @@ def doctest_long_lines():
 
 	But this one is long enough to get wrapped.
 	>>> foo, bar, quux = this_is_a_long_line(
-	... 	lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard
+	...     lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard
 	... )
 	"""
 	# This demostrates a normal line that will get wrapped but won't
@@ -3220,7 +3220,7 @@ def doctest_skipped_partial_inconsistent_indent():
 	Do cool stuff.
 
 	 >>> def cool_stuff(x):
-	 ... 	print(x)
+	 ...     print(x)
 	...     print( f"hi {x}" );
 	hi 2
 	"""

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
@@ -350,6 +350,490 @@ def doctest_invalid_skipped_with_triple_double_in_single_quote_string():
     >>> x        =      '\"\"\"'
     """
     pass
+
+
+###############################################################################
+# reStructuredText CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# reStructuredText formatted code blocks.
+#
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#literal-blocks
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-30
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-38
+###############################################################################
+
+
+def rst_literal_simple():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_literal_simple_continued():
+    """
+    Do cool stuff::
+
+        def cool_stuff( x ):
+            print( f"hi {x}" );
+
+    Done.
+    """
+    pass
+
+
+# Tests that we can end the literal block on the second
+# to last line of the docstring.
+def rst_literal_second_to_last():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )
+    """
+    pass
+
+
+# Tests that we can end the literal block on the actual
+# last line of the docstring.
+def rst_literal_actually_last():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )"""
+    pass
+
+
+def rst_literal_with_blank_lines():
+    """
+    Do cool stuff::
+
+        def cool_stuff( x ):
+            print( f"hi {x}" );
+
+        def other_stuff( y ):
+            print(    y     )
+
+    Done.
+    """
+    pass
+
+
+# Extra blanks should be preserved.
+def rst_literal_extra_blanks():
+    """
+    Do cool stuff::
+
+
+
+        cool_stuff( 1 )
+
+
+
+    Done.
+    """
+    pass
+
+
+# If a literal block is never properly ended (via a non-empty unindented line),
+# then the end of the block should be the last non-empty line. And subsequent
+# empty lines should be preserved as-is.
+def rst_literal_extra_blanks_at_end():
+    """
+    Do cool stuff::
+
+
+        cool_stuff( 1 )
+
+
+
+    """
+    pass
+
+
+# A literal block can contain many empty lines and it should not end the block
+# if it continues.
+def rst_literal_extra_blanks_in_snippet():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )
+
+
+        cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# This tests that a unindented line appearing after an indented line (but where
+# the indent is still beyond the minimum) gets formatted properly.
+def rst_literal_subsequent_line_not_indented():
+    """
+    Do cool stuff::
+
+     if True:
+        cool_stuff( '''
+     hiya''' )
+
+    Done.
+    """
+    pass
+
+
+# This checks that if the first line in a code snippet has been indented with
+# tabs, then so long as its "indentation length" is considered bigger than the
+# line with `::`, it is reformatted as code.
+#
+# (If your tabwidth is set to 4, then it looks like the code snippet
+# isn't indented at all, which is perhaps counter-intuitive. Indeed, reST
+# itself also seems to recognize this as a code block, although it appears
+# under-specified.)
+def rst_literal_first_line_indent_uses_tabs_4spaces():
+    """
+    Do cool stuff::
+
+	cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
+    """
+    Do cool stuff::
+
+	cool_stuff( 1 )
+	cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# Another test with tabs, except in this case, if your tabwidth is less than
+# 8, than the code snippet actually looks like its indent is *less* than the
+# opening line with a `::`. One might presume this means that the code snippet
+# is not treated as a literal block and thus not reformatted, but since we
+# assume all tabs have tabwidth=8 when computing indentation length, the code
+# snippet is actually seen as being more indented than the opening `::` line.
+# As with the above example, reST seems to behave the same way here.
+def rst_literal_first_line_indent_uses_tabs_8spaces():
+        """
+        Do cool stuff::
+
+	 cool_stuff( 1 )
+
+        Done.
+        """
+        pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
+        """
+        Do cool stuff::
+
+	 cool_stuff( 1 )
+	 cool_stuff( 2 )
+
+        Done.
+        """
+        pass
+
+
+# Tests that if two lines in a literal block are indented to the same level
+# but by different means (tabs versus spaces), then we correctly recognize the
+# block and format it.
+def rst_literal_first_line_tab_second_line_spaces():
+    """
+    Do cool stuff::
+
+	cool_stuff( 1 )
+        cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# Tests that when two lines in a code snippet have weird and inconsistent
+# indentation, the code still gets formatted so long as the indent is greater
+# than the indent of the `::` line.
+#
+# In this case, the minimum indent is 5 spaces (from the second line) where as
+# the first line has an indent of 8 spaces via a tab (by assuming tabwidth=8).
+# The minimum indent is stripped from each code line. Since tabs aren't
+# divisible, the entire tab is stripped, which means the first and second lines
+# wind up with the same level of indentation.
+#
+# An alternative behavior here would be that the tab is replaced with 3 spaces
+# instead of being stripped entirely. The code snippet itself would then have
+# inconsistent indentation to the point of being invalid Python, and thus code
+# formatting would be skipped.
+#
+# I decided on the former behavior because it seems a bit easier to implement,
+# but we might want to switch to the alternative if cases like this show up in
+# the real world. ---AG
+def rst_literal_odd_indentation():
+    """
+    Do cool stuff::
+
+	cool_stuff( 1 )
+     cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# Tests that having a line with a lone `::` works as an introduction of a
+# literal block.
+def rst_literal_lone_colon():
+    """
+    Do cool stuff.
+
+    ::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_simple():
+    """
+    .. code-block:: python
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_case_insensitive():
+    """
+    .. cOdE-bLoCk:: python
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_sourcecode():
+    """
+    .. sourcecode:: python
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_options():
+    """
+    .. code-block:: python
+        :linenos:
+        :emphasize-lines: 2,3
+        :name: blah blah
+
+        cool_stuff( 1 )
+        cool_stuff( 2 )
+        cool_stuff( 3 )
+        cool_stuff( 4 )
+
+    Done.
+    """
+    pass
+
+
+# In this case, since `pycon` isn't recognized as a Python code snippet, the
+# docstring reformatter ignores it. But it then picks up the doctest and
+# reformats it.
+def rst_directive_doctest():
+    """
+    .. code-block:: pycon
+
+        >>> cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# This checks that if the first non-empty line after the start of a literal
+# block is not indented more than the line containing the `::`, then it is not
+# treated as a code snippet.
+def rst_literal_skipped_first_line_not_indented():
+    """
+    Do cool stuff::
+
+    cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# Like the test above, but inserts an indented line after the un-indented one.
+# This should not cause the literal block to be resumed.
+def rst_literal_skipped_first_line_not_indented_then_indented():
+    """
+    Do cool stuff::
+
+    cool_stuff( 1 )
+      cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# This also checks that a code snippet is not reformatted when the indentation
+# of the first line is not more than the line with `::`, but this uses tabs to
+# make it a little more confounding. It relies on the fact that indentation
+# length is computed by assuming a tabwidth equal to 8. reST also rejects this
+# and doesn't treat it as a literal block.
+def rst_literal_skipped_first_line_not_indented_tab():
+        """
+        Do cool stuff::
+
+	cool_stuff( 1 )
+
+        Done.
+        """
+        pass
+
+
+# Like the previous test, but adds a second line.
+def rst_literal_skipped_first_line_not_indented_tab_multiple():
+        """
+        Do cool stuff::
+
+	cool_stuff( 1 )
+	cool_stuff( 2 )
+
+        Done.
+        """
+        pass
+
+
+# Tests that a code block with a second line that is not properly indented gets
+# skipped. A valid code block needs to have an empty line separating these.
+#
+# One trick here is that we need to make sure the Python code in the snippet is
+# valid, otherwise it would be skipped because of invalid Python.
+def rst_literal_skipped_subsequent_line_not_indented():
+    """
+    Do cool stuff::
+
+     if True:
+        cool_stuff( '''
+    hiya''' )
+
+    Done.
+    """
+    pass
+
+
+# In this test, we write what looks like a code-block, but it should be treated
+# as invalid due to the missing `language` argument.
+#
+# It does still look like it could be a literal block according to the literal
+# rules, but we currently consider the `.. ` prefix to indicate that it is not
+# a literal block.
+def rst_literal_skipped_not_directive():
+    """
+    .. code-block::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# In this test, we start a line with `.. `, which makes it look like it might
+# be a directive. But instead continue it as if it was just some periods from
+# the previous line, and then try to end it by starting a literal block.
+#
+# But because of the `.. ` in the beginning, we wind up not treating this as a
+# code snippet. The reST render I was using to test things does actually treat
+# this as a code block, so we may be out of conformance here.
+def rst_literal_skipped_possible_false_negative():
+    """
+    This is a test.
+    .. This is a test::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# This tests that a doctest inside of a reST literal block doesn't get
+# reformatted. It's plausible this isn't the right behavior, but it also seems
+# like it might be the right behavior since it is a literal block. (The doctest
+# makes the Python code invalid.)
+def rst_literal_skipped_doctest():
+    """
+    Do cool stuff::
+
+        >>> cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_skipped_not_indented():
+    """
+    .. code-block:: python
+
+    cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_skipped_wrong_language():
+    """
+    .. code-block:: rust
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# This gets skipped for the same reason that the doctest in a literal block
+# gets skipped.
+def rst_directive_skipped_doctest():
+    """
+    .. code-block:: python
+
+        >>> cool_stuff( 1 )
+
+    Done.
+    """
+    pass
 ```
 
 ## Outputs
@@ -713,6 +1197,490 @@ def doctest_invalid_skipped_with_triple_double_in_single_quote_string():
     Do cool stuff.
 
     >>> x        =      '\"\"\"'
+    """
+    pass
+
+
+###############################################################################
+# reStructuredText CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# reStructuredText formatted code blocks.
+#
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#literal-blocks
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-30
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-38
+###############################################################################
+
+
+def rst_literal_simple():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_literal_simple_continued():
+    """
+    Do cool stuff::
+
+        def cool_stuff( x ):
+            print( f"hi {x}" );
+
+    Done.
+    """
+    pass
+
+
+# Tests that we can end the literal block on the second
+# to last line of the docstring.
+def rst_literal_second_to_last():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )
+    """
+    pass
+
+
+# Tests that we can end the literal block on the actual
+# last line of the docstring.
+def rst_literal_actually_last():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )"""
+    pass
+
+
+def rst_literal_with_blank_lines():
+    """
+    Do cool stuff::
+
+        def cool_stuff( x ):
+            print( f"hi {x}" );
+
+        def other_stuff( y ):
+            print(    y     )
+
+    Done.
+    """
+    pass
+
+
+# Extra blanks should be preserved.
+def rst_literal_extra_blanks():
+    """
+    Do cool stuff::
+
+
+
+        cool_stuff( 1 )
+
+
+
+    Done.
+    """
+    pass
+
+
+# If a literal block is never properly ended (via a non-empty unindented line),
+# then the end of the block should be the last non-empty line. And subsequent
+# empty lines should be preserved as-is.
+def rst_literal_extra_blanks_at_end():
+    """
+    Do cool stuff::
+
+
+        cool_stuff( 1 )
+
+
+
+    """
+    pass
+
+
+# A literal block can contain many empty lines and it should not end the block
+# if it continues.
+def rst_literal_extra_blanks_in_snippet():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )
+
+
+        cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# This tests that a unindented line appearing after an indented line (but where
+# the indent is still beyond the minimum) gets formatted properly.
+def rst_literal_subsequent_line_not_indented():
+    """
+    Do cool stuff::
+
+     if True:
+        cool_stuff( '''
+     hiya''' )
+
+    Done.
+    """
+    pass
+
+
+# This checks that if the first line in a code snippet has been indented with
+# tabs, then so long as its "indentation length" is considered bigger than the
+# line with `::`, it is reformatted as code.
+#
+# (If your tabwidth is set to 4, then it looks like the code snippet
+# isn't indented at all, which is perhaps counter-intuitive. Indeed, reST
+# itself also seems to recognize this as a code block, although it appears
+# under-specified.)
+def rst_literal_first_line_indent_uses_tabs_4spaces():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )
+        cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# Another test with tabs, except in this case, if your tabwidth is less than
+# 8, than the code snippet actually looks like its indent is *less* than the
+# opening line with a `::`. One might presume this means that the code snippet
+# is not treated as a literal block and thus not reformatted, but since we
+# assume all tabs have tabwidth=8 when computing indentation length, the code
+# snippet is actually seen as being more indented than the opening `::` line.
+# As with the above example, reST seems to behave the same way here.
+def rst_literal_first_line_indent_uses_tabs_8spaces():
+    """
+    Do cool stuff::
+
+     cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
+    """
+    Do cool stuff::
+
+     cool_stuff( 1 )
+     cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# Tests that if two lines in a literal block are indented to the same level
+# but by different means (tabs versus spaces), then we correctly recognize the
+# block and format it.
+def rst_literal_first_line_tab_second_line_spaces():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )
+        cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# Tests that when two lines in a code snippet have weird and inconsistent
+# indentation, the code still gets formatted so long as the indent is greater
+# than the indent of the `::` line.
+#
+# In this case, the minimum indent is 5 spaces (from the second line) where as
+# the first line has an indent of 8 spaces via a tab (by assuming tabwidth=8).
+# The minimum indent is stripped from each code line. Since tabs aren't
+# divisible, the entire tab is stripped, which means the first and second lines
+# wind up with the same level of indentation.
+#
+# An alternative behavior here would be that the tab is replaced with 3 spaces
+# instead of being stripped entirely. The code snippet itself would then have
+# inconsistent indentation to the point of being invalid Python, and thus code
+# formatting would be skipped.
+#
+# I decided on the former behavior because it seems a bit easier to implement,
+# but we might want to switch to the alternative if cases like this show up in
+# the real world. ---AG
+def rst_literal_odd_indentation():
+    """
+    Do cool stuff::
+
+        cool_stuff( 1 )
+     cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# Tests that having a line with a lone `::` works as an introduction of a
+# literal block.
+def rst_literal_lone_colon():
+    """
+    Do cool stuff.
+
+    ::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_simple():
+    """
+    .. code-block:: python
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_case_insensitive():
+    """
+    .. cOdE-bLoCk:: python
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_sourcecode():
+    """
+    .. sourcecode:: python
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_options():
+    """
+    .. code-block:: python
+        :linenos:
+        :emphasize-lines: 2,3
+        :name: blah blah
+
+        cool_stuff( 1 )
+        cool_stuff( 2 )
+        cool_stuff( 3 )
+        cool_stuff( 4 )
+
+    Done.
+    """
+    pass
+
+
+# In this case, since `pycon` isn't recognized as a Python code snippet, the
+# docstring reformatter ignores it. But it then picks up the doctest and
+# reformats it.
+def rst_directive_doctest():
+    """
+    .. code-block:: pycon
+
+        >>> cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# This checks that if the first non-empty line after the start of a literal
+# block is not indented more than the line containing the `::`, then it is not
+# treated as a code snippet.
+def rst_literal_skipped_first_line_not_indented():
+    """
+    Do cool stuff::
+
+    cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# Like the test above, but inserts an indented line after the un-indented one.
+# This should not cause the literal block to be resumed.
+def rst_literal_skipped_first_line_not_indented_then_indented():
+    """
+    Do cool stuff::
+
+    cool_stuff( 1 )
+      cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# This also checks that a code snippet is not reformatted when the indentation
+# of the first line is not more than the line with `::`, but this uses tabs to
+# make it a little more confounding. It relies on the fact that indentation
+# length is computed by assuming a tabwidth equal to 8. reST also rejects this
+# and doesn't treat it as a literal block.
+def rst_literal_skipped_first_line_not_indented_tab():
+    """
+    Do cool stuff::
+
+    cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# Like the previous test, but adds a second line.
+def rst_literal_skipped_first_line_not_indented_tab_multiple():
+    """
+    Do cool stuff::
+
+    cool_stuff( 1 )
+    cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# Tests that a code block with a second line that is not properly indented gets
+# skipped. A valid code block needs to have an empty line separating these.
+#
+# One trick here is that we need to make sure the Python code in the snippet is
+# valid, otherwise it would be skipped because of invalid Python.
+def rst_literal_skipped_subsequent_line_not_indented():
+    """
+    Do cool stuff::
+
+     if True:
+        cool_stuff( '''
+    hiya''' )
+
+    Done.
+    """
+    pass
+
+
+# In this test, we write what looks like a code-block, but it should be treated
+# as invalid due to the missing `language` argument.
+#
+# It does still look like it could be a literal block according to the literal
+# rules, but we currently consider the `.. ` prefix to indicate that it is not
+# a literal block.
+def rst_literal_skipped_not_directive():
+    """
+    .. code-block::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# In this test, we start a line with `.. `, which makes it look like it might
+# be a directive. But instead continue it as if it was just some periods from
+# the previous line, and then try to end it by starting a literal block.
+#
+# But because of the `.. ` in the beginning, we wind up not treating this as a
+# code snippet. The reST render I was using to test things does actually treat
+# this as a code block, so we may be out of conformance here.
+def rst_literal_skipped_possible_false_negative():
+    """
+    This is a test.
+    .. This is a test::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# This tests that a doctest inside of a reST literal block doesn't get
+# reformatted. It's plausible this isn't the right behavior, but it also seems
+# like it might be the right behavior since it is a literal block. (The doctest
+# makes the Python code invalid.)
+def rst_literal_skipped_doctest():
+    """
+    Do cool stuff::
+
+        >>> cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_skipped_not_indented():
+    """
+    .. code-block:: python
+
+    cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_skipped_wrong_language():
+    """
+    .. code-block:: rust
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# This gets skipped for the same reason that the doctest in a literal block
+# gets skipped.
+def rst_directive_skipped_doctest():
+    """
+    .. code-block:: python
+
+        >>> cool_stuff( 1 )
+
+    Done.
     """
     pass
 ```
@@ -1080,6 +2048,490 @@ def doctest_invalid_skipped_with_triple_double_in_single_quote_string():
   >>> x        =      '\"\"\"'
   """
   pass
+
+
+###############################################################################
+# reStructuredText CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# reStructuredText formatted code blocks.
+#
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#literal-blocks
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-30
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-38
+###############################################################################
+
+
+def rst_literal_simple():
+  """
+  Do cool stuff::
+
+      cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+def rst_literal_simple_continued():
+  """
+  Do cool stuff::
+
+      def cool_stuff( x ):
+          print( f"hi {x}" );
+
+  Done.
+  """
+  pass
+
+
+# Tests that we can end the literal block on the second
+# to last line of the docstring.
+def rst_literal_second_to_last():
+  """
+  Do cool stuff::
+
+      cool_stuff( 1 )
+  """
+  pass
+
+
+# Tests that we can end the literal block on the actual
+# last line of the docstring.
+def rst_literal_actually_last():
+  """
+  Do cool stuff::
+
+      cool_stuff( 1 )"""
+  pass
+
+
+def rst_literal_with_blank_lines():
+  """
+  Do cool stuff::
+
+      def cool_stuff( x ):
+          print( f"hi {x}" );
+
+      def other_stuff( y ):
+          print(    y     )
+
+  Done.
+  """
+  pass
+
+
+# Extra blanks should be preserved.
+def rst_literal_extra_blanks():
+  """
+  Do cool stuff::
+
+
+
+      cool_stuff( 1 )
+
+
+
+  Done.
+  """
+  pass
+
+
+# If a literal block is never properly ended (via a non-empty unindented line),
+# then the end of the block should be the last non-empty line. And subsequent
+# empty lines should be preserved as-is.
+def rst_literal_extra_blanks_at_end():
+  """
+  Do cool stuff::
+
+
+      cool_stuff( 1 )
+
+
+
+  """
+  pass
+
+
+# A literal block can contain many empty lines and it should not end the block
+# if it continues.
+def rst_literal_extra_blanks_in_snippet():
+  """
+  Do cool stuff::
+
+      cool_stuff( 1 )
+
+
+      cool_stuff( 2 )
+
+  Done.
+  """
+  pass
+
+
+# This tests that a unindented line appearing after an indented line (but where
+# the indent is still beyond the minimum) gets formatted properly.
+def rst_literal_subsequent_line_not_indented():
+  """
+  Do cool stuff::
+
+   if True:
+      cool_stuff( '''
+   hiya''' )
+
+  Done.
+  """
+  pass
+
+
+# This checks that if the first line in a code snippet has been indented with
+# tabs, then so long as its "indentation length" is considered bigger than the
+# line with `::`, it is reformatted as code.
+#
+# (If your tabwidth is set to 4, then it looks like the code snippet
+# isn't indented at all, which is perhaps counter-intuitive. Indeed, reST
+# itself also seems to recognize this as a code block, although it appears
+# under-specified.)
+def rst_literal_first_line_indent_uses_tabs_4spaces():
+  """
+  Do cool stuff::
+
+      cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
+  """
+  Do cool stuff::
+
+      cool_stuff( 1 )
+      cool_stuff( 2 )
+
+  Done.
+  """
+  pass
+
+
+# Another test with tabs, except in this case, if your tabwidth is less than
+# 8, than the code snippet actually looks like its indent is *less* than the
+# opening line with a `::`. One might presume this means that the code snippet
+# is not treated as a literal block and thus not reformatted, but since we
+# assume all tabs have tabwidth=8 when computing indentation length, the code
+# snippet is actually seen as being more indented than the opening `::` line.
+# As with the above example, reST seems to behave the same way here.
+def rst_literal_first_line_indent_uses_tabs_8spaces():
+  """
+  Do cool stuff::
+
+   cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
+  """
+  Do cool stuff::
+
+   cool_stuff( 1 )
+   cool_stuff( 2 )
+
+  Done.
+  """
+  pass
+
+
+# Tests that if two lines in a literal block are indented to the same level
+# but by different means (tabs versus spaces), then we correctly recognize the
+# block and format it.
+def rst_literal_first_line_tab_second_line_spaces():
+  """
+  Do cool stuff::
+
+      cool_stuff( 1 )
+      cool_stuff( 2 )
+
+  Done.
+  """
+  pass
+
+
+# Tests that when two lines in a code snippet have weird and inconsistent
+# indentation, the code still gets formatted so long as the indent is greater
+# than the indent of the `::` line.
+#
+# In this case, the minimum indent is 5 spaces (from the second line) where as
+# the first line has an indent of 8 spaces via a tab (by assuming tabwidth=8).
+# The minimum indent is stripped from each code line. Since tabs aren't
+# divisible, the entire tab is stripped, which means the first and second lines
+# wind up with the same level of indentation.
+#
+# An alternative behavior here would be that the tab is replaced with 3 spaces
+# instead of being stripped entirely. The code snippet itself would then have
+# inconsistent indentation to the point of being invalid Python, and thus code
+# formatting would be skipped.
+#
+# I decided on the former behavior because it seems a bit easier to implement,
+# but we might want to switch to the alternative if cases like this show up in
+# the real world. ---AG
+def rst_literal_odd_indentation():
+  """
+  Do cool stuff::
+
+      cool_stuff( 1 )
+   cool_stuff( 2 )
+
+  Done.
+  """
+  pass
+
+
+# Tests that having a line with a lone `::` works as an introduction of a
+# literal block.
+def rst_literal_lone_colon():
+  """
+  Do cool stuff.
+
+  ::
+
+      cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+def rst_directive_simple():
+  """
+  .. code-block:: python
+
+      cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+def rst_directive_case_insensitive():
+  """
+  .. cOdE-bLoCk:: python
+
+      cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+def rst_directive_sourcecode():
+  """
+  .. sourcecode:: python
+
+      cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+def rst_directive_options():
+  """
+  .. code-block:: python
+      :linenos:
+      :emphasize-lines: 2,3
+      :name: blah blah
+
+      cool_stuff( 1 )
+      cool_stuff( 2 )
+      cool_stuff( 3 )
+      cool_stuff( 4 )
+
+  Done.
+  """
+  pass
+
+
+# In this case, since `pycon` isn't recognized as a Python code snippet, the
+# docstring reformatter ignores it. But it then picks up the doctest and
+# reformats it.
+def rst_directive_doctest():
+  """
+  .. code-block:: pycon
+
+      >>> cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+# This checks that if the first non-empty line after the start of a literal
+# block is not indented more than the line containing the `::`, then it is not
+# treated as a code snippet.
+def rst_literal_skipped_first_line_not_indented():
+  """
+  Do cool stuff::
+
+  cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+# Like the test above, but inserts an indented line after the un-indented one.
+# This should not cause the literal block to be resumed.
+def rst_literal_skipped_first_line_not_indented_then_indented():
+  """
+  Do cool stuff::
+
+  cool_stuff( 1 )
+    cool_stuff( 2 )
+
+  Done.
+  """
+  pass
+
+
+# This also checks that a code snippet is not reformatted when the indentation
+# of the first line is not more than the line with `::`, but this uses tabs to
+# make it a little more confounding. It relies on the fact that indentation
+# length is computed by assuming a tabwidth equal to 8. reST also rejects this
+# and doesn't treat it as a literal block.
+def rst_literal_skipped_first_line_not_indented_tab():
+  """
+  Do cool stuff::
+
+  cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+# Like the previous test, but adds a second line.
+def rst_literal_skipped_first_line_not_indented_tab_multiple():
+  """
+  Do cool stuff::
+
+  cool_stuff( 1 )
+  cool_stuff( 2 )
+
+  Done.
+  """
+  pass
+
+
+# Tests that a code block with a second line that is not properly indented gets
+# skipped. A valid code block needs to have an empty line separating these.
+#
+# One trick here is that we need to make sure the Python code in the snippet is
+# valid, otherwise it would be skipped because of invalid Python.
+def rst_literal_skipped_subsequent_line_not_indented():
+  """
+  Do cool stuff::
+
+   if True:
+      cool_stuff( '''
+  hiya''' )
+
+  Done.
+  """
+  pass
+
+
+# In this test, we write what looks like a code-block, but it should be treated
+# as invalid due to the missing `language` argument.
+#
+# It does still look like it could be a literal block according to the literal
+# rules, but we currently consider the `.. ` prefix to indicate that it is not
+# a literal block.
+def rst_literal_skipped_not_directive():
+  """
+  .. code-block::
+
+      cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+# In this test, we start a line with `.. `, which makes it look like it might
+# be a directive. But instead continue it as if it was just some periods from
+# the previous line, and then try to end it by starting a literal block.
+#
+# But because of the `.. ` in the beginning, we wind up not treating this as a
+# code snippet. The reST render I was using to test things does actually treat
+# this as a code block, so we may be out of conformance here.
+def rst_literal_skipped_possible_false_negative():
+  """
+  This is a test.
+  .. This is a test::
+
+      cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+# This tests that a doctest inside of a reST literal block doesn't get
+# reformatted. It's plausible this isn't the right behavior, but it also seems
+# like it might be the right behavior since it is a literal block. (The doctest
+# makes the Python code invalid.)
+def rst_literal_skipped_doctest():
+  """
+  Do cool stuff::
+
+      >>> cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+def rst_directive_skipped_not_indented():
+  """
+  .. code-block:: python
+
+  cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+def rst_directive_skipped_wrong_language():
+  """
+  .. code-block:: rust
+
+      cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+# This gets skipped for the same reason that the doctest in a literal block
+# gets skipped.
+def rst_directive_skipped_doctest():
+  """
+  .. code-block:: python
+
+      >>> cool_stuff( 1 )
+
+  Done.
+  """
+  pass
 ```
 
 
@@ -1443,6 +2895,490 @@ def doctest_invalid_skipped_with_triple_double_in_single_quote_string():
 	Do cool stuff.
 
 	>>> x        =      '\"\"\"'
+	"""
+	pass
+
+
+###############################################################################
+# reStructuredText CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# reStructuredText formatted code blocks.
+#
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#literal-blocks
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-30
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-38
+###############################################################################
+
+
+def rst_literal_simple():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_literal_simple_continued():
+	"""
+	Do cool stuff::
+
+	    def cool_stuff( x ):
+	        print( f"hi {x}" );
+
+	Done.
+	"""
+	pass
+
+
+# Tests that we can end the literal block on the second
+# to last line of the docstring.
+def rst_literal_second_to_last():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )
+	"""
+	pass
+
+
+# Tests that we can end the literal block on the actual
+# last line of the docstring.
+def rst_literal_actually_last():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )"""
+	pass
+
+
+def rst_literal_with_blank_lines():
+	"""
+	Do cool stuff::
+
+	    def cool_stuff( x ):
+	        print( f"hi {x}" );
+
+	    def other_stuff( y ):
+	        print(    y     )
+
+	Done.
+	"""
+	pass
+
+
+# Extra blanks should be preserved.
+def rst_literal_extra_blanks():
+	"""
+	Do cool stuff::
+
+
+
+	    cool_stuff( 1 )
+
+
+
+	Done.
+	"""
+	pass
+
+
+# If a literal block is never properly ended (via a non-empty unindented line),
+# then the end of the block should be the last non-empty line. And subsequent
+# empty lines should be preserved as-is.
+def rst_literal_extra_blanks_at_end():
+	"""
+	Do cool stuff::
+
+
+	    cool_stuff( 1 )
+
+
+
+	"""
+	pass
+
+
+# A literal block can contain many empty lines and it should not end the block
+# if it continues.
+def rst_literal_extra_blanks_in_snippet():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )
+
+
+	    cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# This tests that a unindented line appearing after an indented line (but where
+# the indent is still beyond the minimum) gets formatted properly.
+def rst_literal_subsequent_line_not_indented():
+	"""
+	Do cool stuff::
+
+	 if True:
+	    cool_stuff( '''
+	 hiya''' )
+
+	Done.
+	"""
+	pass
+
+
+# This checks that if the first line in a code snippet has been indented with
+# tabs, then so long as its "indentation length" is considered bigger than the
+# line with `::`, it is reformatted as code.
+#
+# (If your tabwidth is set to 4, then it looks like the code snippet
+# isn't indented at all, which is perhaps counter-intuitive. Indeed, reST
+# itself also seems to recognize this as a code block, although it appears
+# under-specified.)
+def rst_literal_first_line_indent_uses_tabs_4spaces():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )
+	    cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# Another test with tabs, except in this case, if your tabwidth is less than
+# 8, than the code snippet actually looks like its indent is *less* than the
+# opening line with a `::`. One might presume this means that the code snippet
+# is not treated as a literal block and thus not reformatted, but since we
+# assume all tabs have tabwidth=8 when computing indentation length, the code
+# snippet is actually seen as being more indented than the opening `::` line.
+# As with the above example, reST seems to behave the same way here.
+def rst_literal_first_line_indent_uses_tabs_8spaces():
+	"""
+	Do cool stuff::
+
+	 cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
+	"""
+	Do cool stuff::
+
+	 cool_stuff( 1 )
+	 cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# Tests that if two lines in a literal block are indented to the same level
+# but by different means (tabs versus spaces), then we correctly recognize the
+# block and format it.
+def rst_literal_first_line_tab_second_line_spaces():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )
+	    cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# Tests that when two lines in a code snippet have weird and inconsistent
+# indentation, the code still gets formatted so long as the indent is greater
+# than the indent of the `::` line.
+#
+# In this case, the minimum indent is 5 spaces (from the second line) where as
+# the first line has an indent of 8 spaces via a tab (by assuming tabwidth=8).
+# The minimum indent is stripped from each code line. Since tabs aren't
+# divisible, the entire tab is stripped, which means the first and second lines
+# wind up with the same level of indentation.
+#
+# An alternative behavior here would be that the tab is replaced with 3 spaces
+# instead of being stripped entirely. The code snippet itself would then have
+# inconsistent indentation to the point of being invalid Python, and thus code
+# formatting would be skipped.
+#
+# I decided on the former behavior because it seems a bit easier to implement,
+# but we might want to switch to the alternative if cases like this show up in
+# the real world. ---AG
+def rst_literal_odd_indentation():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )
+	 cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# Tests that having a line with a lone `::` works as an introduction of a
+# literal block.
+def rst_literal_lone_colon():
+	"""
+	Do cool stuff.
+
+	::
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_simple():
+	"""
+	.. code-block:: python
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_case_insensitive():
+	"""
+	.. cOdE-bLoCk:: python
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_sourcecode():
+	"""
+	.. sourcecode:: python
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_options():
+	"""
+	.. code-block:: python
+	    :linenos:
+	    :emphasize-lines: 2,3
+	    :name: blah blah
+
+	    cool_stuff( 1 )
+	    cool_stuff( 2 )
+	    cool_stuff( 3 )
+	    cool_stuff( 4 )
+
+	Done.
+	"""
+	pass
+
+
+# In this case, since `pycon` isn't recognized as a Python code snippet, the
+# docstring reformatter ignores it. But it then picks up the doctest and
+# reformats it.
+def rst_directive_doctest():
+	"""
+	.. code-block:: pycon
+
+	    >>> cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# This checks that if the first non-empty line after the start of a literal
+# block is not indented more than the line containing the `::`, then it is not
+# treated as a code snippet.
+def rst_literal_skipped_first_line_not_indented():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# Like the test above, but inserts an indented line after the un-indented one.
+# This should not cause the literal block to be resumed.
+def rst_literal_skipped_first_line_not_indented_then_indented():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+	  cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# This also checks that a code snippet is not reformatted when the indentation
+# of the first line is not more than the line with `::`, but this uses tabs to
+# make it a little more confounding. It relies on the fact that indentation
+# length is computed by assuming a tabwidth equal to 8. reST also rejects this
+# and doesn't treat it as a literal block.
+def rst_literal_skipped_first_line_not_indented_tab():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# Like the previous test, but adds a second line.
+def rst_literal_skipped_first_line_not_indented_tab_multiple():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+	cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# Tests that a code block with a second line that is not properly indented gets
+# skipped. A valid code block needs to have an empty line separating these.
+#
+# One trick here is that we need to make sure the Python code in the snippet is
+# valid, otherwise it would be skipped because of invalid Python.
+def rst_literal_skipped_subsequent_line_not_indented():
+	"""
+	Do cool stuff::
+
+	 if True:
+	    cool_stuff( '''
+	hiya''' )
+
+	Done.
+	"""
+	pass
+
+
+# In this test, we write what looks like a code-block, but it should be treated
+# as invalid due to the missing `language` argument.
+#
+# It does still look like it could be a literal block according to the literal
+# rules, but we currently consider the `.. ` prefix to indicate that it is not
+# a literal block.
+def rst_literal_skipped_not_directive():
+	"""
+	.. code-block::
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# In this test, we start a line with `.. `, which makes it look like it might
+# be a directive. But instead continue it as if it was just some periods from
+# the previous line, and then try to end it by starting a literal block.
+#
+# But because of the `.. ` in the beginning, we wind up not treating this as a
+# code snippet. The reST render I was using to test things does actually treat
+# this as a code block, so we may be out of conformance here.
+def rst_literal_skipped_possible_false_negative():
+	"""
+	This is a test.
+	.. This is a test::
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# This tests that a doctest inside of a reST literal block doesn't get
+# reformatted. It's plausible this isn't the right behavior, but it also seems
+# like it might be the right behavior since it is a literal block. (The doctest
+# makes the Python code invalid.)
+def rst_literal_skipped_doctest():
+	"""
+	Do cool stuff::
+
+	    >>> cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_skipped_not_indented():
+	"""
+	.. code-block:: python
+
+	cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_skipped_wrong_language():
+	"""
+	.. code-block:: rust
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# This gets skipped for the same reason that the doctest in a literal block
+# gets skipped.
+def rst_directive_skipped_doctest():
+	"""
+	.. code-block:: python
+
+	    >>> cool_stuff( 1 )
+
+	Done.
 	"""
 	pass
 ```
@@ -1810,6 +3746,490 @@ def doctest_invalid_skipped_with_triple_double_in_single_quote_string():
 	>>> x        =      '\"\"\"'
 	"""
 	pass
+
+
+###############################################################################
+# reStructuredText CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# reStructuredText formatted code blocks.
+#
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#literal-blocks
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-30
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-38
+###############################################################################
+
+
+def rst_literal_simple():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_literal_simple_continued():
+	"""
+	Do cool stuff::
+
+	    def cool_stuff( x ):
+	        print( f"hi {x}" );
+
+	Done.
+	"""
+	pass
+
+
+# Tests that we can end the literal block on the second
+# to last line of the docstring.
+def rst_literal_second_to_last():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )
+	"""
+	pass
+
+
+# Tests that we can end the literal block on the actual
+# last line of the docstring.
+def rst_literal_actually_last():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )"""
+	pass
+
+
+def rst_literal_with_blank_lines():
+	"""
+	Do cool stuff::
+
+	    def cool_stuff( x ):
+	        print( f"hi {x}" );
+
+	    def other_stuff( y ):
+	        print(    y     )
+
+	Done.
+	"""
+	pass
+
+
+# Extra blanks should be preserved.
+def rst_literal_extra_blanks():
+	"""
+	Do cool stuff::
+
+
+
+	    cool_stuff( 1 )
+
+
+
+	Done.
+	"""
+	pass
+
+
+# If a literal block is never properly ended (via a non-empty unindented line),
+# then the end of the block should be the last non-empty line. And subsequent
+# empty lines should be preserved as-is.
+def rst_literal_extra_blanks_at_end():
+	"""
+	Do cool stuff::
+
+
+	    cool_stuff( 1 )
+
+
+
+	"""
+	pass
+
+
+# A literal block can contain many empty lines and it should not end the block
+# if it continues.
+def rst_literal_extra_blanks_in_snippet():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )
+
+
+	    cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# This tests that a unindented line appearing after an indented line (but where
+# the indent is still beyond the minimum) gets formatted properly.
+def rst_literal_subsequent_line_not_indented():
+	"""
+	Do cool stuff::
+
+	 if True:
+	    cool_stuff( '''
+	 hiya''' )
+
+	Done.
+	"""
+	pass
+
+
+# This checks that if the first line in a code snippet has been indented with
+# tabs, then so long as its "indentation length" is considered bigger than the
+# line with `::`, it is reformatted as code.
+#
+# (If your tabwidth is set to 4, then it looks like the code snippet
+# isn't indented at all, which is perhaps counter-intuitive. Indeed, reST
+# itself also seems to recognize this as a code block, although it appears
+# under-specified.)
+def rst_literal_first_line_indent_uses_tabs_4spaces():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )
+	    cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# Another test with tabs, except in this case, if your tabwidth is less than
+# 8, than the code snippet actually looks like its indent is *less* than the
+# opening line with a `::`. One might presume this means that the code snippet
+# is not treated as a literal block and thus not reformatted, but since we
+# assume all tabs have tabwidth=8 when computing indentation length, the code
+# snippet is actually seen as being more indented than the opening `::` line.
+# As with the above example, reST seems to behave the same way here.
+def rst_literal_first_line_indent_uses_tabs_8spaces():
+	"""
+	Do cool stuff::
+
+	 cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
+	"""
+	Do cool stuff::
+
+	 cool_stuff( 1 )
+	 cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# Tests that if two lines in a literal block are indented to the same level
+# but by different means (tabs versus spaces), then we correctly recognize the
+# block and format it.
+def rst_literal_first_line_tab_second_line_spaces():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )
+	    cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# Tests that when two lines in a code snippet have weird and inconsistent
+# indentation, the code still gets formatted so long as the indent is greater
+# than the indent of the `::` line.
+#
+# In this case, the minimum indent is 5 spaces (from the second line) where as
+# the first line has an indent of 8 spaces via a tab (by assuming tabwidth=8).
+# The minimum indent is stripped from each code line. Since tabs aren't
+# divisible, the entire tab is stripped, which means the first and second lines
+# wind up with the same level of indentation.
+#
+# An alternative behavior here would be that the tab is replaced with 3 spaces
+# instead of being stripped entirely. The code snippet itself would then have
+# inconsistent indentation to the point of being invalid Python, and thus code
+# formatting would be skipped.
+#
+# I decided on the former behavior because it seems a bit easier to implement,
+# but we might want to switch to the alternative if cases like this show up in
+# the real world. ---AG
+def rst_literal_odd_indentation():
+	"""
+	Do cool stuff::
+
+	    cool_stuff( 1 )
+	 cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# Tests that having a line with a lone `::` works as an introduction of a
+# literal block.
+def rst_literal_lone_colon():
+	"""
+	Do cool stuff.
+
+	::
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_simple():
+	"""
+	.. code-block:: python
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_case_insensitive():
+	"""
+	.. cOdE-bLoCk:: python
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_sourcecode():
+	"""
+	.. sourcecode:: python
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_options():
+	"""
+	.. code-block:: python
+	    :linenos:
+	    :emphasize-lines: 2,3
+	    :name: blah blah
+
+	    cool_stuff( 1 )
+	    cool_stuff( 2 )
+	    cool_stuff( 3 )
+	    cool_stuff( 4 )
+
+	Done.
+	"""
+	pass
+
+
+# In this case, since `pycon` isn't recognized as a Python code snippet, the
+# docstring reformatter ignores it. But it then picks up the doctest and
+# reformats it.
+def rst_directive_doctest():
+	"""
+	.. code-block:: pycon
+
+	    >>> cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# This checks that if the first non-empty line after the start of a literal
+# block is not indented more than the line containing the `::`, then it is not
+# treated as a code snippet.
+def rst_literal_skipped_first_line_not_indented():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# Like the test above, but inserts an indented line after the un-indented one.
+# This should not cause the literal block to be resumed.
+def rst_literal_skipped_first_line_not_indented_then_indented():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+	  cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# This also checks that a code snippet is not reformatted when the indentation
+# of the first line is not more than the line with `::`, but this uses tabs to
+# make it a little more confounding. It relies on the fact that indentation
+# length is computed by assuming a tabwidth equal to 8. reST also rejects this
+# and doesn't treat it as a literal block.
+def rst_literal_skipped_first_line_not_indented_tab():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# Like the previous test, but adds a second line.
+def rst_literal_skipped_first_line_not_indented_tab_multiple():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+	cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# Tests that a code block with a second line that is not properly indented gets
+# skipped. A valid code block needs to have an empty line separating these.
+#
+# One trick here is that we need to make sure the Python code in the snippet is
+# valid, otherwise it would be skipped because of invalid Python.
+def rst_literal_skipped_subsequent_line_not_indented():
+	"""
+	Do cool stuff::
+
+	 if True:
+	    cool_stuff( '''
+	hiya''' )
+
+	Done.
+	"""
+	pass
+
+
+# In this test, we write what looks like a code-block, but it should be treated
+# as invalid due to the missing `language` argument.
+#
+# It does still look like it could be a literal block according to the literal
+# rules, but we currently consider the `.. ` prefix to indicate that it is not
+# a literal block.
+def rst_literal_skipped_not_directive():
+	"""
+	.. code-block::
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# In this test, we start a line with `.. `, which makes it look like it might
+# be a directive. But instead continue it as if it was just some periods from
+# the previous line, and then try to end it by starting a literal block.
+#
+# But because of the `.. ` in the beginning, we wind up not treating this as a
+# code snippet. The reST render I was using to test things does actually treat
+# this as a code block, so we may be out of conformance here.
+def rst_literal_skipped_possible_false_negative():
+	"""
+	This is a test.
+	.. This is a test::
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# This tests that a doctest inside of a reST literal block doesn't get
+# reformatted. It's plausible this isn't the right behavior, but it also seems
+# like it might be the right behavior since it is a literal block. (The doctest
+# makes the Python code invalid.)
+def rst_literal_skipped_doctest():
+	"""
+	Do cool stuff::
+
+	    >>> cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_skipped_not_indented():
+	"""
+	.. code-block:: python
+
+	cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_skipped_wrong_language():
+	"""
+	.. code-block:: rust
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# This gets skipped for the same reason that the doctest in a literal block
+# gets skipped.
+def rst_directive_skipped_doctest():
+	"""
+	.. code-block:: python
+
+	    >>> cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
 ```
 
 
@@ -2173,6 +4593,493 @@ def doctest_invalid_skipped_with_triple_double_in_single_quote_string():
     Do cool stuff.
 
     >>> x        =      '\"\"\"'
+    """
+    pass
+
+
+###############################################################################
+# reStructuredText CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# reStructuredText formatted code blocks.
+#
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#literal-blocks
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-30
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-38
+###############################################################################
+
+
+def rst_literal_simple():
+    """
+    Do cool stuff::
+
+        cool_stuff(1)
+
+    Done.
+    """
+    pass
+
+
+def rst_literal_simple_continued():
+    """
+    Do cool stuff::
+
+        def cool_stuff(x):
+            print(f"hi {x}")
+
+    Done.
+    """
+    pass
+
+
+# Tests that we can end the literal block on the second
+# to last line of the docstring.
+def rst_literal_second_to_last():
+    """
+    Do cool stuff::
+
+        cool_stuff(1)
+    """
+    pass
+
+
+# Tests that we can end the literal block on the actual
+# last line of the docstring.
+def rst_literal_actually_last():
+    """
+    Do cool stuff::
+
+        cool_stuff(1)"""
+    pass
+
+
+def rst_literal_with_blank_lines():
+    """
+    Do cool stuff::
+
+        def cool_stuff(x):
+            print(f"hi {x}")
+
+
+        def other_stuff(y):
+            print(y)
+
+    Done.
+    """
+    pass
+
+
+# Extra blanks should be preserved.
+def rst_literal_extra_blanks():
+    """
+    Do cool stuff::
+
+
+
+        cool_stuff(1)
+
+
+
+    Done.
+    """
+    pass
+
+
+# If a literal block is never properly ended (via a non-empty unindented line),
+# then the end of the block should be the last non-empty line. And subsequent
+# empty lines should be preserved as-is.
+def rst_literal_extra_blanks_at_end():
+    """
+    Do cool stuff::
+
+
+        cool_stuff(1)
+
+
+
+    """
+    pass
+
+
+# A literal block can contain many empty lines and it should not end the block
+# if it continues.
+def rst_literal_extra_blanks_in_snippet():
+    """
+    Do cool stuff::
+
+        cool_stuff(1)
+
+
+        cool_stuff(2)
+
+    Done.
+    """
+    pass
+
+
+# This tests that a unindented line appearing after an indented line (but where
+# the indent is still beyond the minimum) gets formatted properly.
+def rst_literal_subsequent_line_not_indented():
+    """
+    Do cool stuff::
+
+     if True:
+         cool_stuff(
+             '''
+     hiya'''
+         )
+
+    Done.
+    """
+    pass
+
+
+# This checks that if the first line in a code snippet has been indented with
+# tabs, then so long as its "indentation length" is considered bigger than the
+# line with `::`, it is reformatted as code.
+#
+# (If your tabwidth is set to 4, then it looks like the code snippet
+# isn't indented at all, which is perhaps counter-intuitive. Indeed, reST
+# itself also seems to recognize this as a code block, although it appears
+# under-specified.)
+def rst_literal_first_line_indent_uses_tabs_4spaces():
+    """
+    Do cool stuff::
+
+        cool_stuff(1)
+
+    Done.
+    """
+    pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
+    """
+    Do cool stuff::
+
+        cool_stuff(1)
+        cool_stuff(2)
+
+    Done.
+    """
+    pass
+
+
+# Another test with tabs, except in this case, if your tabwidth is less than
+# 8, than the code snippet actually looks like its indent is *less* than the
+# opening line with a `::`. One might presume this means that the code snippet
+# is not treated as a literal block and thus not reformatted, but since we
+# assume all tabs have tabwidth=8 when computing indentation length, the code
+# snippet is actually seen as being more indented than the opening `::` line.
+# As with the above example, reST seems to behave the same way here.
+def rst_literal_first_line_indent_uses_tabs_8spaces():
+    """
+    Do cool stuff::
+
+     cool_stuff(1)
+
+    Done.
+    """
+    pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
+    """
+    Do cool stuff::
+
+     cool_stuff(1)
+     cool_stuff(2)
+
+    Done.
+    """
+    pass
+
+
+# Tests that if two lines in a literal block are indented to the same level
+# but by different means (tabs versus spaces), then we correctly recognize the
+# block and format it.
+def rst_literal_first_line_tab_second_line_spaces():
+    """
+    Do cool stuff::
+
+        cool_stuff(1)
+        cool_stuff(2)
+
+    Done.
+    """
+    pass
+
+
+# Tests that when two lines in a code snippet have weird and inconsistent
+# indentation, the code still gets formatted so long as the indent is greater
+# than the indent of the `::` line.
+#
+# In this case, the minimum indent is 5 spaces (from the second line) where as
+# the first line has an indent of 8 spaces via a tab (by assuming tabwidth=8).
+# The minimum indent is stripped from each code line. Since tabs aren't
+# divisible, the entire tab is stripped, which means the first and second lines
+# wind up with the same level of indentation.
+#
+# An alternative behavior here would be that the tab is replaced with 3 spaces
+# instead of being stripped entirely. The code snippet itself would then have
+# inconsistent indentation to the point of being invalid Python, and thus code
+# formatting would be skipped.
+#
+# I decided on the former behavior because it seems a bit easier to implement,
+# but we might want to switch to the alternative if cases like this show up in
+# the real world. ---AG
+def rst_literal_odd_indentation():
+    """
+    Do cool stuff::
+
+     cool_stuff(1)
+     cool_stuff(2)
+
+    Done.
+    """
+    pass
+
+
+# Tests that having a line with a lone `::` works as an introduction of a
+# literal block.
+def rst_literal_lone_colon():
+    """
+    Do cool stuff.
+
+    ::
+
+        cool_stuff(1)
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_simple():
+    """
+    .. code-block:: python
+
+        cool_stuff(1)
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_case_insensitive():
+    """
+    .. cOdE-bLoCk:: python
+
+        cool_stuff(1)
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_sourcecode():
+    """
+    .. sourcecode:: python
+
+        cool_stuff(1)
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_options():
+    """
+    .. code-block:: python
+        :linenos:
+        :emphasize-lines: 2,3
+        :name: blah blah
+
+        cool_stuff(1)
+        cool_stuff(2)
+        cool_stuff(3)
+        cool_stuff(4)
+
+    Done.
+    """
+    pass
+
+
+# In this case, since `pycon` isn't recognized as a Python code snippet, the
+# docstring reformatter ignores it. But it then picks up the doctest and
+# reformats it.
+def rst_directive_doctest():
+    """
+    .. code-block:: pycon
+
+        >>> cool_stuff(1)
+
+    Done.
+    """
+    pass
+
+
+# This checks that if the first non-empty line after the start of a literal
+# block is not indented more than the line containing the `::`, then it is not
+# treated as a code snippet.
+def rst_literal_skipped_first_line_not_indented():
+    """
+    Do cool stuff::
+
+    cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# Like the test above, but inserts an indented line after the un-indented one.
+# This should not cause the literal block to be resumed.
+def rst_literal_skipped_first_line_not_indented_then_indented():
+    """
+    Do cool stuff::
+
+    cool_stuff( 1 )
+      cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# This also checks that a code snippet is not reformatted when the indentation
+# of the first line is not more than the line with `::`, but this uses tabs to
+# make it a little more confounding. It relies on the fact that indentation
+# length is computed by assuming a tabwidth equal to 8. reST also rejects this
+# and doesn't treat it as a literal block.
+def rst_literal_skipped_first_line_not_indented_tab():
+    """
+    Do cool stuff::
+
+    cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# Like the previous test, but adds a second line.
+def rst_literal_skipped_first_line_not_indented_tab_multiple():
+    """
+    Do cool stuff::
+
+    cool_stuff( 1 )
+    cool_stuff( 2 )
+
+    Done.
+    """
+    pass
+
+
+# Tests that a code block with a second line that is not properly indented gets
+# skipped. A valid code block needs to have an empty line separating these.
+#
+# One trick here is that we need to make sure the Python code in the snippet is
+# valid, otherwise it would be skipped because of invalid Python.
+def rst_literal_skipped_subsequent_line_not_indented():
+    """
+    Do cool stuff::
+
+     if True:
+        cool_stuff( '''
+    hiya''' )
+
+    Done.
+    """
+    pass
+
+
+# In this test, we write what looks like a code-block, but it should be treated
+# as invalid due to the missing `language` argument.
+#
+# It does still look like it could be a literal block according to the literal
+# rules, but we currently consider the `.. ` prefix to indicate that it is not
+# a literal block.
+def rst_literal_skipped_not_directive():
+    """
+    .. code-block::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# In this test, we start a line with `.. `, which makes it look like it might
+# be a directive. But instead continue it as if it was just some periods from
+# the previous line, and then try to end it by starting a literal block.
+#
+# But because of the `.. ` in the beginning, we wind up not treating this as a
+# code snippet. The reST render I was using to test things does actually treat
+# this as a code block, so we may be out of conformance here.
+def rst_literal_skipped_possible_false_negative():
+    """
+    This is a test.
+    .. This is a test::
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# This tests that a doctest inside of a reST literal block doesn't get
+# reformatted. It's plausible this isn't the right behavior, but it also seems
+# like it might be the right behavior since it is a literal block. (The doctest
+# makes the Python code invalid.)
+def rst_literal_skipped_doctest():
+    """
+    Do cool stuff::
+
+        >>> cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_skipped_not_indented():
+    """
+    .. code-block:: python
+
+    cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+def rst_directive_skipped_wrong_language():
+    """
+    .. code-block:: rust
+
+        cool_stuff( 1 )
+
+    Done.
+    """
+    pass
+
+
+# This gets skipped for the same reason that the doctest in a literal block
+# gets skipped.
+def rst_directive_skipped_doctest():
+    """
+    .. code-block:: python
+
+        >>> cool_stuff( 1 )
+
+    Done.
     """
     pass
 ```
@@ -2540,6 +5447,493 @@ def doctest_invalid_skipped_with_triple_double_in_single_quote_string():
   >>> x        =      '\"\"\"'
   """
   pass
+
+
+###############################################################################
+# reStructuredText CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# reStructuredText formatted code blocks.
+#
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#literal-blocks
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-30
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-38
+###############################################################################
+
+
+def rst_literal_simple():
+  """
+  Do cool stuff::
+
+      cool_stuff(1)
+
+  Done.
+  """
+  pass
+
+
+def rst_literal_simple_continued():
+  """
+  Do cool stuff::
+
+      def cool_stuff(x):
+        print(f"hi {x}")
+
+  Done.
+  """
+  pass
+
+
+# Tests that we can end the literal block on the second
+# to last line of the docstring.
+def rst_literal_second_to_last():
+  """
+  Do cool stuff::
+
+      cool_stuff(1)
+  """
+  pass
+
+
+# Tests that we can end the literal block on the actual
+# last line of the docstring.
+def rst_literal_actually_last():
+  """
+  Do cool stuff::
+
+      cool_stuff(1)"""
+  pass
+
+
+def rst_literal_with_blank_lines():
+  """
+  Do cool stuff::
+
+      def cool_stuff(x):
+        print(f"hi {x}")
+
+
+      def other_stuff(y):
+        print(y)
+
+  Done.
+  """
+  pass
+
+
+# Extra blanks should be preserved.
+def rst_literal_extra_blanks():
+  """
+  Do cool stuff::
+
+
+
+      cool_stuff(1)
+
+
+
+  Done.
+  """
+  pass
+
+
+# If a literal block is never properly ended (via a non-empty unindented line),
+# then the end of the block should be the last non-empty line. And subsequent
+# empty lines should be preserved as-is.
+def rst_literal_extra_blanks_at_end():
+  """
+  Do cool stuff::
+
+
+      cool_stuff(1)
+
+
+
+  """
+  pass
+
+
+# A literal block can contain many empty lines and it should not end the block
+# if it continues.
+def rst_literal_extra_blanks_in_snippet():
+  """
+  Do cool stuff::
+
+      cool_stuff(1)
+
+
+      cool_stuff(2)
+
+  Done.
+  """
+  pass
+
+
+# This tests that a unindented line appearing after an indented line (but where
+# the indent is still beyond the minimum) gets formatted properly.
+def rst_literal_subsequent_line_not_indented():
+  """
+  Do cool stuff::
+
+   if True:
+     cool_stuff(
+       '''
+   hiya'''
+     )
+
+  Done.
+  """
+  pass
+
+
+# This checks that if the first line in a code snippet has been indented with
+# tabs, then so long as its "indentation length" is considered bigger than the
+# line with `::`, it is reformatted as code.
+#
+# (If your tabwidth is set to 4, then it looks like the code snippet
+# isn't indented at all, which is perhaps counter-intuitive. Indeed, reST
+# itself also seems to recognize this as a code block, although it appears
+# under-specified.)
+def rst_literal_first_line_indent_uses_tabs_4spaces():
+  """
+  Do cool stuff::
+
+      cool_stuff(1)
+
+  Done.
+  """
+  pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
+  """
+  Do cool stuff::
+
+      cool_stuff(1)
+      cool_stuff(2)
+
+  Done.
+  """
+  pass
+
+
+# Another test with tabs, except in this case, if your tabwidth is less than
+# 8, than the code snippet actually looks like its indent is *less* than the
+# opening line with a `::`. One might presume this means that the code snippet
+# is not treated as a literal block and thus not reformatted, but since we
+# assume all tabs have tabwidth=8 when computing indentation length, the code
+# snippet is actually seen as being more indented than the opening `::` line.
+# As with the above example, reST seems to behave the same way here.
+def rst_literal_first_line_indent_uses_tabs_8spaces():
+  """
+  Do cool stuff::
+
+   cool_stuff(1)
+
+  Done.
+  """
+  pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
+  """
+  Do cool stuff::
+
+   cool_stuff(1)
+   cool_stuff(2)
+
+  Done.
+  """
+  pass
+
+
+# Tests that if two lines in a literal block are indented to the same level
+# but by different means (tabs versus spaces), then we correctly recognize the
+# block and format it.
+def rst_literal_first_line_tab_second_line_spaces():
+  """
+  Do cool stuff::
+
+      cool_stuff(1)
+      cool_stuff(2)
+
+  Done.
+  """
+  pass
+
+
+# Tests that when two lines in a code snippet have weird and inconsistent
+# indentation, the code still gets formatted so long as the indent is greater
+# than the indent of the `::` line.
+#
+# In this case, the minimum indent is 5 spaces (from the second line) where as
+# the first line has an indent of 8 spaces via a tab (by assuming tabwidth=8).
+# The minimum indent is stripped from each code line. Since tabs aren't
+# divisible, the entire tab is stripped, which means the first and second lines
+# wind up with the same level of indentation.
+#
+# An alternative behavior here would be that the tab is replaced with 3 spaces
+# instead of being stripped entirely. The code snippet itself would then have
+# inconsistent indentation to the point of being invalid Python, and thus code
+# formatting would be skipped.
+#
+# I decided on the former behavior because it seems a bit easier to implement,
+# but we might want to switch to the alternative if cases like this show up in
+# the real world. ---AG
+def rst_literal_odd_indentation():
+  """
+  Do cool stuff::
+
+   cool_stuff(1)
+   cool_stuff(2)
+
+  Done.
+  """
+  pass
+
+
+# Tests that having a line with a lone `::` works as an introduction of a
+# literal block.
+def rst_literal_lone_colon():
+  """
+  Do cool stuff.
+
+  ::
+
+      cool_stuff(1)
+
+  Done.
+  """
+  pass
+
+
+def rst_directive_simple():
+  """
+  .. code-block:: python
+
+      cool_stuff(1)
+
+  Done.
+  """
+  pass
+
+
+def rst_directive_case_insensitive():
+  """
+  .. cOdE-bLoCk:: python
+
+      cool_stuff(1)
+
+  Done.
+  """
+  pass
+
+
+def rst_directive_sourcecode():
+  """
+  .. sourcecode:: python
+
+      cool_stuff(1)
+
+  Done.
+  """
+  pass
+
+
+def rst_directive_options():
+  """
+  .. code-block:: python
+      :linenos:
+      :emphasize-lines: 2,3
+      :name: blah blah
+
+      cool_stuff(1)
+      cool_stuff(2)
+      cool_stuff(3)
+      cool_stuff(4)
+
+  Done.
+  """
+  pass
+
+
+# In this case, since `pycon` isn't recognized as a Python code snippet, the
+# docstring reformatter ignores it. But it then picks up the doctest and
+# reformats it.
+def rst_directive_doctest():
+  """
+  .. code-block:: pycon
+
+      >>> cool_stuff(1)
+
+  Done.
+  """
+  pass
+
+
+# This checks that if the first non-empty line after the start of a literal
+# block is not indented more than the line containing the `::`, then it is not
+# treated as a code snippet.
+def rst_literal_skipped_first_line_not_indented():
+  """
+  Do cool stuff::
+
+  cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+# Like the test above, but inserts an indented line after the un-indented one.
+# This should not cause the literal block to be resumed.
+def rst_literal_skipped_first_line_not_indented_then_indented():
+  """
+  Do cool stuff::
+
+  cool_stuff( 1 )
+    cool_stuff( 2 )
+
+  Done.
+  """
+  pass
+
+
+# This also checks that a code snippet is not reformatted when the indentation
+# of the first line is not more than the line with `::`, but this uses tabs to
+# make it a little more confounding. It relies on the fact that indentation
+# length is computed by assuming a tabwidth equal to 8. reST also rejects this
+# and doesn't treat it as a literal block.
+def rst_literal_skipped_first_line_not_indented_tab():
+  """
+  Do cool stuff::
+
+  cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+# Like the previous test, but adds a second line.
+def rst_literal_skipped_first_line_not_indented_tab_multiple():
+  """
+  Do cool stuff::
+
+  cool_stuff( 1 )
+  cool_stuff( 2 )
+
+  Done.
+  """
+  pass
+
+
+# Tests that a code block with a second line that is not properly indented gets
+# skipped. A valid code block needs to have an empty line separating these.
+#
+# One trick here is that we need to make sure the Python code in the snippet is
+# valid, otherwise it would be skipped because of invalid Python.
+def rst_literal_skipped_subsequent_line_not_indented():
+  """
+  Do cool stuff::
+
+   if True:
+      cool_stuff( '''
+  hiya''' )
+
+  Done.
+  """
+  pass
+
+
+# In this test, we write what looks like a code-block, but it should be treated
+# as invalid due to the missing `language` argument.
+#
+# It does still look like it could be a literal block according to the literal
+# rules, but we currently consider the `.. ` prefix to indicate that it is not
+# a literal block.
+def rst_literal_skipped_not_directive():
+  """
+  .. code-block::
+
+      cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+# In this test, we start a line with `.. `, which makes it look like it might
+# be a directive. But instead continue it as if it was just some periods from
+# the previous line, and then try to end it by starting a literal block.
+#
+# But because of the `.. ` in the beginning, we wind up not treating this as a
+# code snippet. The reST render I was using to test things does actually treat
+# this as a code block, so we may be out of conformance here.
+def rst_literal_skipped_possible_false_negative():
+  """
+  This is a test.
+  .. This is a test::
+
+      cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+# This tests that a doctest inside of a reST literal block doesn't get
+# reformatted. It's plausible this isn't the right behavior, but it also seems
+# like it might be the right behavior since it is a literal block. (The doctest
+# makes the Python code invalid.)
+def rst_literal_skipped_doctest():
+  """
+  Do cool stuff::
+
+      >>> cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+def rst_directive_skipped_not_indented():
+  """
+  .. code-block:: python
+
+  cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+def rst_directive_skipped_wrong_language():
+  """
+  .. code-block:: rust
+
+      cool_stuff( 1 )
+
+  Done.
+  """
+  pass
+
+
+# This gets skipped for the same reason that the doctest in a literal block
+# gets skipped.
+def rst_directive_skipped_doctest():
+  """
+  .. code-block:: python
+
+      >>> cool_stuff( 1 )
+
+  Done.
+  """
+  pass
 ```
 
 
@@ -2905,6 +6299,493 @@ def doctest_invalid_skipped_with_triple_double_in_single_quote_string():
 	>>> x        =      '\"\"\"'
 	"""
 	pass
+
+
+###############################################################################
+# reStructuredText CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# reStructuredText formatted code blocks.
+#
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#literal-blocks
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-30
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-38
+###############################################################################
+
+
+def rst_literal_simple():
+	"""
+	Do cool stuff::
+
+	    cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+def rst_literal_simple_continued():
+	"""
+	Do cool stuff::
+
+	    def cool_stuff(x):
+	            print(f"hi {x}")
+
+	Done.
+	"""
+	pass
+
+
+# Tests that we can end the literal block on the second
+# to last line of the docstring.
+def rst_literal_second_to_last():
+	"""
+	Do cool stuff::
+
+	    cool_stuff(1)
+	"""
+	pass
+
+
+# Tests that we can end the literal block on the actual
+# last line of the docstring.
+def rst_literal_actually_last():
+	"""
+	Do cool stuff::
+
+	    cool_stuff(1)"""
+	pass
+
+
+def rst_literal_with_blank_lines():
+	"""
+	Do cool stuff::
+
+	    def cool_stuff(x):
+	            print(f"hi {x}")
+
+
+	    def other_stuff(y):
+	            print(y)
+
+	Done.
+	"""
+	pass
+
+
+# Extra blanks should be preserved.
+def rst_literal_extra_blanks():
+	"""
+	Do cool stuff::
+
+
+
+	    cool_stuff(1)
+
+
+
+	Done.
+	"""
+	pass
+
+
+# If a literal block is never properly ended (via a non-empty unindented line),
+# then the end of the block should be the last non-empty line. And subsequent
+# empty lines should be preserved as-is.
+def rst_literal_extra_blanks_at_end():
+	"""
+	Do cool stuff::
+
+
+	    cool_stuff(1)
+
+
+
+	"""
+	pass
+
+
+# A literal block can contain many empty lines and it should not end the block
+# if it continues.
+def rst_literal_extra_blanks_in_snippet():
+	"""
+	Do cool stuff::
+
+	    cool_stuff(1)
+
+
+	    cool_stuff(2)
+
+	Done.
+	"""
+	pass
+
+
+# This tests that a unindented line appearing after an indented line (but where
+# the indent is still beyond the minimum) gets formatted properly.
+def rst_literal_subsequent_line_not_indented():
+	"""
+	Do cool stuff::
+
+	 if True:
+	         cool_stuff(
+	                 '''
+	 hiya'''
+	         )
+
+	Done.
+	"""
+	pass
+
+
+# This checks that if the first line in a code snippet has been indented with
+# tabs, then so long as its "indentation length" is considered bigger than the
+# line with `::`, it is reformatted as code.
+#
+# (If your tabwidth is set to 4, then it looks like the code snippet
+# isn't indented at all, which is perhaps counter-intuitive. Indeed, reST
+# itself also seems to recognize this as a code block, although it appears
+# under-specified.)
+def rst_literal_first_line_indent_uses_tabs_4spaces():
+	"""
+	Do cool stuff::
+
+	    cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
+	"""
+	Do cool stuff::
+
+	    cool_stuff(1)
+	    cool_stuff(2)
+
+	Done.
+	"""
+	pass
+
+
+# Another test with tabs, except in this case, if your tabwidth is less than
+# 8, than the code snippet actually looks like its indent is *less* than the
+# opening line with a `::`. One might presume this means that the code snippet
+# is not treated as a literal block and thus not reformatted, but since we
+# assume all tabs have tabwidth=8 when computing indentation length, the code
+# snippet is actually seen as being more indented than the opening `::` line.
+# As with the above example, reST seems to behave the same way here.
+def rst_literal_first_line_indent_uses_tabs_8spaces():
+	"""
+	Do cool stuff::
+
+	 cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
+	"""
+	Do cool stuff::
+
+	 cool_stuff(1)
+	 cool_stuff(2)
+
+	Done.
+	"""
+	pass
+
+
+# Tests that if two lines in a literal block are indented to the same level
+# but by different means (tabs versus spaces), then we correctly recognize the
+# block and format it.
+def rst_literal_first_line_tab_second_line_spaces():
+	"""
+	Do cool stuff::
+
+	    cool_stuff(1)
+	    cool_stuff(2)
+
+	Done.
+	"""
+	pass
+
+
+# Tests that when two lines in a code snippet have weird and inconsistent
+# indentation, the code still gets formatted so long as the indent is greater
+# than the indent of the `::` line.
+#
+# In this case, the minimum indent is 5 spaces (from the second line) where as
+# the first line has an indent of 8 spaces via a tab (by assuming tabwidth=8).
+# The minimum indent is stripped from each code line. Since tabs aren't
+# divisible, the entire tab is stripped, which means the first and second lines
+# wind up with the same level of indentation.
+#
+# An alternative behavior here would be that the tab is replaced with 3 spaces
+# instead of being stripped entirely. The code snippet itself would then have
+# inconsistent indentation to the point of being invalid Python, and thus code
+# formatting would be skipped.
+#
+# I decided on the former behavior because it seems a bit easier to implement,
+# but we might want to switch to the alternative if cases like this show up in
+# the real world. ---AG
+def rst_literal_odd_indentation():
+	"""
+	Do cool stuff::
+
+	 cool_stuff(1)
+	 cool_stuff(2)
+
+	Done.
+	"""
+	pass
+
+
+# Tests that having a line with a lone `::` works as an introduction of a
+# literal block.
+def rst_literal_lone_colon():
+	"""
+	Do cool stuff.
+
+	::
+
+	    cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_simple():
+	"""
+	.. code-block:: python
+
+	    cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_case_insensitive():
+	"""
+	.. cOdE-bLoCk:: python
+
+	    cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_sourcecode():
+	"""
+	.. sourcecode:: python
+
+	    cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_options():
+	"""
+	.. code-block:: python
+	    :linenos:
+	    :emphasize-lines: 2,3
+	    :name: blah blah
+
+	    cool_stuff(1)
+	    cool_stuff(2)
+	    cool_stuff(3)
+	    cool_stuff(4)
+
+	Done.
+	"""
+	pass
+
+
+# In this case, since `pycon` isn't recognized as a Python code snippet, the
+# docstring reformatter ignores it. But it then picks up the doctest and
+# reformats it.
+def rst_directive_doctest():
+	"""
+	.. code-block:: pycon
+
+	    >>> cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+# This checks that if the first non-empty line after the start of a literal
+# block is not indented more than the line containing the `::`, then it is not
+# treated as a code snippet.
+def rst_literal_skipped_first_line_not_indented():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# Like the test above, but inserts an indented line after the un-indented one.
+# This should not cause the literal block to be resumed.
+def rst_literal_skipped_first_line_not_indented_then_indented():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+	  cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# This also checks that a code snippet is not reformatted when the indentation
+# of the first line is not more than the line with `::`, but this uses tabs to
+# make it a little more confounding. It relies on the fact that indentation
+# length is computed by assuming a tabwidth equal to 8. reST also rejects this
+# and doesn't treat it as a literal block.
+def rst_literal_skipped_first_line_not_indented_tab():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# Like the previous test, but adds a second line.
+def rst_literal_skipped_first_line_not_indented_tab_multiple():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+	cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# Tests that a code block with a second line that is not properly indented gets
+# skipped. A valid code block needs to have an empty line separating these.
+#
+# One trick here is that we need to make sure the Python code in the snippet is
+# valid, otherwise it would be skipped because of invalid Python.
+def rst_literal_skipped_subsequent_line_not_indented():
+	"""
+	Do cool stuff::
+
+	 if True:
+	    cool_stuff( '''
+	hiya''' )
+
+	Done.
+	"""
+	pass
+
+
+# In this test, we write what looks like a code-block, but it should be treated
+# as invalid due to the missing `language` argument.
+#
+# It does still look like it could be a literal block according to the literal
+# rules, but we currently consider the `.. ` prefix to indicate that it is not
+# a literal block.
+def rst_literal_skipped_not_directive():
+	"""
+	.. code-block::
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# In this test, we start a line with `.. `, which makes it look like it might
+# be a directive. But instead continue it as if it was just some periods from
+# the previous line, and then try to end it by starting a literal block.
+#
+# But because of the `.. ` in the beginning, we wind up not treating this as a
+# code snippet. The reST render I was using to test things does actually treat
+# this as a code block, so we may be out of conformance here.
+def rst_literal_skipped_possible_false_negative():
+	"""
+	This is a test.
+	.. This is a test::
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# This tests that a doctest inside of a reST literal block doesn't get
+# reformatted. It's plausible this isn't the right behavior, but it also seems
+# like it might be the right behavior since it is a literal block. (The doctest
+# makes the Python code invalid.)
+def rst_literal_skipped_doctest():
+	"""
+	Do cool stuff::
+
+	    >>> cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_skipped_not_indented():
+	"""
+	.. code-block:: python
+
+	cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_skipped_wrong_language():
+	"""
+	.. code-block:: rust
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# This gets skipped for the same reason that the doctest in a literal block
+# gets skipped.
+def rst_directive_skipped_doctest():
+	"""
+	.. code-block:: python
+
+	    >>> cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
 ```
 
 
@@ -3268,6 +7149,493 @@ def doctest_invalid_skipped_with_triple_double_in_single_quote_string():
 	Do cool stuff.
 
 	>>> x        =      '\"\"\"'
+	"""
+	pass
+
+
+###############################################################################
+# reStructuredText CODE EXAMPLES
+#
+# This section shows examples of docstrings that contain code snippets in
+# reStructuredText formatted code blocks.
+#
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks
+# See: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#literal-blocks
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-30
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-38
+###############################################################################
+
+
+def rst_literal_simple():
+	"""
+	Do cool stuff::
+
+	    cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+def rst_literal_simple_continued():
+	"""
+	Do cool stuff::
+
+	    def cool_stuff(x):
+	        print(f"hi {x}")
+
+	Done.
+	"""
+	pass
+
+
+# Tests that we can end the literal block on the second
+# to last line of the docstring.
+def rst_literal_second_to_last():
+	"""
+	Do cool stuff::
+
+	    cool_stuff(1)
+	"""
+	pass
+
+
+# Tests that we can end the literal block on the actual
+# last line of the docstring.
+def rst_literal_actually_last():
+	"""
+	Do cool stuff::
+
+	    cool_stuff(1)"""
+	pass
+
+
+def rst_literal_with_blank_lines():
+	"""
+	Do cool stuff::
+
+	    def cool_stuff(x):
+	        print(f"hi {x}")
+
+
+	    def other_stuff(y):
+	        print(y)
+
+	Done.
+	"""
+	pass
+
+
+# Extra blanks should be preserved.
+def rst_literal_extra_blanks():
+	"""
+	Do cool stuff::
+
+
+
+	    cool_stuff(1)
+
+
+
+	Done.
+	"""
+	pass
+
+
+# If a literal block is never properly ended (via a non-empty unindented line),
+# then the end of the block should be the last non-empty line. And subsequent
+# empty lines should be preserved as-is.
+def rst_literal_extra_blanks_at_end():
+	"""
+	Do cool stuff::
+
+
+	    cool_stuff(1)
+
+
+
+	"""
+	pass
+
+
+# A literal block can contain many empty lines and it should not end the block
+# if it continues.
+def rst_literal_extra_blanks_in_snippet():
+	"""
+	Do cool stuff::
+
+	    cool_stuff(1)
+
+
+	    cool_stuff(2)
+
+	Done.
+	"""
+	pass
+
+
+# This tests that a unindented line appearing after an indented line (but where
+# the indent is still beyond the minimum) gets formatted properly.
+def rst_literal_subsequent_line_not_indented():
+	"""
+	Do cool stuff::
+
+	 if True:
+	     cool_stuff(
+	         '''
+	 hiya'''
+	     )
+
+	Done.
+	"""
+	pass
+
+
+# This checks that if the first line in a code snippet has been indented with
+# tabs, then so long as its "indentation length" is considered bigger than the
+# line with `::`, it is reformatted as code.
+#
+# (If your tabwidth is set to 4, then it looks like the code snippet
+# isn't indented at all, which is perhaps counter-intuitive. Indeed, reST
+# itself also seems to recognize this as a code block, although it appears
+# under-specified.)
+def rst_literal_first_line_indent_uses_tabs_4spaces():
+	"""
+	Do cool stuff::
+
+	    cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
+	"""
+	Do cool stuff::
+
+	    cool_stuff(1)
+	    cool_stuff(2)
+
+	Done.
+	"""
+	pass
+
+
+# Another test with tabs, except in this case, if your tabwidth is less than
+# 8, than the code snippet actually looks like its indent is *less* than the
+# opening line with a `::`. One might presume this means that the code snippet
+# is not treated as a literal block and thus not reformatted, but since we
+# assume all tabs have tabwidth=8 when computing indentation length, the code
+# snippet is actually seen as being more indented than the opening `::` line.
+# As with the above example, reST seems to behave the same way here.
+def rst_literal_first_line_indent_uses_tabs_8spaces():
+	"""
+	Do cool stuff::
+
+	 cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+# Like the test above, but with multiple lines.
+def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
+	"""
+	Do cool stuff::
+
+	 cool_stuff(1)
+	 cool_stuff(2)
+
+	Done.
+	"""
+	pass
+
+
+# Tests that if two lines in a literal block are indented to the same level
+# but by different means (tabs versus spaces), then we correctly recognize the
+# block and format it.
+def rst_literal_first_line_tab_second_line_spaces():
+	"""
+	Do cool stuff::
+
+	    cool_stuff(1)
+	    cool_stuff(2)
+
+	Done.
+	"""
+	pass
+
+
+# Tests that when two lines in a code snippet have weird and inconsistent
+# indentation, the code still gets formatted so long as the indent is greater
+# than the indent of the `::` line.
+#
+# In this case, the minimum indent is 5 spaces (from the second line) where as
+# the first line has an indent of 8 spaces via a tab (by assuming tabwidth=8).
+# The minimum indent is stripped from each code line. Since tabs aren't
+# divisible, the entire tab is stripped, which means the first and second lines
+# wind up with the same level of indentation.
+#
+# An alternative behavior here would be that the tab is replaced with 3 spaces
+# instead of being stripped entirely. The code snippet itself would then have
+# inconsistent indentation to the point of being invalid Python, and thus code
+# formatting would be skipped.
+#
+# I decided on the former behavior because it seems a bit easier to implement,
+# but we might want to switch to the alternative if cases like this show up in
+# the real world. ---AG
+def rst_literal_odd_indentation():
+	"""
+	Do cool stuff::
+
+	 cool_stuff(1)
+	 cool_stuff(2)
+
+	Done.
+	"""
+	pass
+
+
+# Tests that having a line with a lone `::` works as an introduction of a
+# literal block.
+def rst_literal_lone_colon():
+	"""
+	Do cool stuff.
+
+	::
+
+	    cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_simple():
+	"""
+	.. code-block:: python
+
+	    cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_case_insensitive():
+	"""
+	.. cOdE-bLoCk:: python
+
+	    cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_sourcecode():
+	"""
+	.. sourcecode:: python
+
+	    cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_options():
+	"""
+	.. code-block:: python
+	    :linenos:
+	    :emphasize-lines: 2,3
+	    :name: blah blah
+
+	    cool_stuff(1)
+	    cool_stuff(2)
+	    cool_stuff(3)
+	    cool_stuff(4)
+
+	Done.
+	"""
+	pass
+
+
+# In this case, since `pycon` isn't recognized as a Python code snippet, the
+# docstring reformatter ignores it. But it then picks up the doctest and
+# reformats it.
+def rst_directive_doctest():
+	"""
+	.. code-block:: pycon
+
+	    >>> cool_stuff(1)
+
+	Done.
+	"""
+	pass
+
+
+# This checks that if the first non-empty line after the start of a literal
+# block is not indented more than the line containing the `::`, then it is not
+# treated as a code snippet.
+def rst_literal_skipped_first_line_not_indented():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# Like the test above, but inserts an indented line after the un-indented one.
+# This should not cause the literal block to be resumed.
+def rst_literal_skipped_first_line_not_indented_then_indented():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+	  cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# This also checks that a code snippet is not reformatted when the indentation
+# of the first line is not more than the line with `::`, but this uses tabs to
+# make it a little more confounding. It relies on the fact that indentation
+# length is computed by assuming a tabwidth equal to 8. reST also rejects this
+# and doesn't treat it as a literal block.
+def rst_literal_skipped_first_line_not_indented_tab():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# Like the previous test, but adds a second line.
+def rst_literal_skipped_first_line_not_indented_tab_multiple():
+	"""
+	Do cool stuff::
+
+	cool_stuff( 1 )
+	cool_stuff( 2 )
+
+	Done.
+	"""
+	pass
+
+
+# Tests that a code block with a second line that is not properly indented gets
+# skipped. A valid code block needs to have an empty line separating these.
+#
+# One trick here is that we need to make sure the Python code in the snippet is
+# valid, otherwise it would be skipped because of invalid Python.
+def rst_literal_skipped_subsequent_line_not_indented():
+	"""
+	Do cool stuff::
+
+	 if True:
+	    cool_stuff( '''
+	hiya''' )
+
+	Done.
+	"""
+	pass
+
+
+# In this test, we write what looks like a code-block, but it should be treated
+# as invalid due to the missing `language` argument.
+#
+# It does still look like it could be a literal block according to the literal
+# rules, but we currently consider the `.. ` prefix to indicate that it is not
+# a literal block.
+def rst_literal_skipped_not_directive():
+	"""
+	.. code-block::
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# In this test, we start a line with `.. `, which makes it look like it might
+# be a directive. But instead continue it as if it was just some periods from
+# the previous line, and then try to end it by starting a literal block.
+#
+# But because of the `.. ` in the beginning, we wind up not treating this as a
+# code snippet. The reST render I was using to test things does actually treat
+# this as a code block, so we may be out of conformance here.
+def rst_literal_skipped_possible_false_negative():
+	"""
+	This is a test.
+	.. This is a test::
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# This tests that a doctest inside of a reST literal block doesn't get
+# reformatted. It's plausible this isn't the right behavior, but it also seems
+# like it might be the right behavior since it is a literal block. (The doctest
+# makes the Python code invalid.)
+def rst_literal_skipped_doctest():
+	"""
+	Do cool stuff::
+
+	    >>> cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_skipped_not_indented():
+	"""
+	.. code-block:: python
+
+	cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+def rst_directive_skipped_wrong_language():
+	"""
+	.. code-block:: rust
+
+	    cool_stuff( 1 )
+
+	Done.
+	"""
+	pass
+
+
+# This gets skipped for the same reason that the doctest in a literal block
+# gets skipped.
+def rst_directive_skipped_doctest():
+	"""
+	.. code-block:: python
+
+	    >>> cool_stuff( 1 )
+
+	Done.
 	"""
 	pass
 ```


### PR DESCRIPTION
(This is not possible to actually use until https://github.com/astral-sh/ruff/pull/8854 is merged.)

ruff_python_formatter: add reStructuredText docstring formatting support

This commit makes use of the refactoring done in prior commits to slot
in reStructuredText support. Essentially, we add a new type of code
example and look for *both* literal blocks and code block directives.
Literal blocks are treated as Python by default because it seems to be a
[common practice](https://github.com/adamchainz/blacken-docs/issues/195).

That is, literal blocks like this:

```
def example():
    """
    Here's an example::

        foo( 1 )

    All done.
    """
    pass
```

Will get reformatted. And code blocks (via reStructuredText directives)
will also get reformatted:


```
def example():
    """
    Here's an example:

    .. code-block:: python

        foo( 1 )

    All done.
    """
    pass
```

When looking for a code block, it is possible for it to become invalid.
In which case, we back out of looking for a code example and print the
lines out as they are. As with doctest formatting, if reformatting the
code would result in invalid Python or if the code collected from the
block is invalid, then formatting is also skipped.

A number of tests have been added to check both the formatting and
resetting behavior. Mixed indentation is also tested a fair bit, since
one of my initial attempts at dealing with mixed indentation ended up
not working.

I recommend working through this PR commit-by-commit. There is in
particular a somewhat gnarly refactoring before reST support is added.

Closes #8859
