### PR TITLE
Fix formatting of a warning box in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -338,7 +338,7 @@ You can also change the default selection using the [`include`](settings.md#incl
 
 !!! warning
     Paths provided to `include` _must_ match files. For example, `include = ["src"]` will fail since it
-matches a directory.
+    matches a directory.
 
 ## Jupyter Notebook discovery
 


### PR DESCRIPTION
## Summary

The last few words of a sentence that should be inside a warning box (in https://docs.astral.sh/ruff/configuration/#default-inclusions) are currently placed just after it because of a mistake in indentation.