### PR TITLE
Mark wildcard imports as unused when all references are resolved

### DIFF
--- a/crates/ruff_cli/tests/snapshots/integration_test__explain_status_codes_f401.snap
+++ b/crates/ruff_cli/tests/snapshots/integration_test__explain_status_codes_f401.snap
@@ -25,6 +25,9 @@ import cycles. They also increase the cognitive load of reading the code.
 If an import statement is used to check for the availability or existence
 of a module, consider using `importlib.util.find_spec` instead.
 
+In [preview], this rule will also mark wildcard imports as unused if there
+are no unresolved references in the importing module.
+
 ## Example
 ```python
 import numpy as np  # unused import
@@ -56,6 +59,8 @@ else:
 ## References
 - [Python documentation: `import`](https://docs.python.org/3/reference/simple_stmts.html#the-import-statement)
 - [Python documentation: `importlib.util.find_spec`](https://docs.python.org/3/library/importlib.html#importlib.util.find_spec)
+
+[preview]: https://docs.astral.sh/ruff/preview/
 
 ----- stderr -----
 

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_20.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_20.py
@@ -1,0 +1,11 @@
+"""Test that wildcard imports are flagged when there are no unresolved references.
+
+Only applies to preview mode.
+"""
+
+from . import *
+from foo import *
+from .foo import *
+
+x = 1
+print(x + 1)

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -374,7 +374,7 @@ where
                 names,
                 module,
                 level,
-                range: _,
+                range,
             }) => {
                 let module = module.as_deref();
                 let level = *level;
@@ -388,9 +388,16 @@ where
                             BindingFlags::empty(),
                         );
                     } else if &alias.name == "*" {
-                        self.semantic
-                            .current_scope_mut()
-                            .add_star_import(StarImport { level, module });
+                        if let Some(node_id) = self.semantic.current_statement_id() {
+                            self.semantic
+                                .current_scope_mut()
+                                .add_star_import(StarImport {
+                                    level,
+                                    module,
+                                    node_id,
+                                    range: *range,
+                                });
+                        }
                     } else {
                         let mut flags = BindingFlags::EXTERNAL;
                         if alias.asname.is_some() {

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -52,6 +52,7 @@ mod tests {
     #[test_case(Rule::UnusedImport, Path::new("F401_17.py"))]
     #[test_case(Rule::UnusedImport, Path::new("F401_18.py"))]
     #[test_case(Rule::UnusedImport, Path::new("F401_19.py"))]
+    #[test_case(Rule::UnusedImport, Path::new("F401_20.py"))]
     #[test_case(Rule::ImportShadowedByLoopVar, Path::new("F402.py"))]
     #[test_case(Rule::UndefinedLocalWithImportStar, Path::new("F403.py"))]
     #[test_case(Rule::LateFutureImport, Path::new("F404.py"))]
@@ -162,6 +163,7 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Rule::UnusedImport, Path::new("F401_20.py"))]
     #[test_case(Rule::UnusedVariable, Path::new("F841_4.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_F401_20.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_F401_20.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_20.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__preview__F401_F401_20.py.snap
@@ -1,0 +1,62 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+F401_20.py:6:1: F401 [*] `from . import *` imported but unused
+  |
+4 | """
+5 | 
+6 | from . import *
+  | ^^^^^^^^^^^^^^^ F401
+7 | from foo import *
+8 | from .foo import *
+  |
+  = help: Remove unused import: `from . import *`
+
+ℹ Safe fix
+3 3 | Only applies to preview mode.
+4 4 | """
+5 5 | 
+6   |-from . import *
+7 6 | from foo import *
+8 7 | from .foo import *
+9 8 | 
+
+F401_20.py:7:1: F401 [*] `foo.*` imported but unused
+  |
+6 | from . import *
+7 | from foo import *
+  | ^^^^^^^^^^^^^^^^^ F401
+8 | from .foo import *
+  |
+  = help: Remove unused import: `foo.*`
+
+ℹ Safe fix
+4 4 | """
+5 5 | 
+6 6 | from . import *
+7   |-from foo import *
+8 7 | from .foo import *
+9 8 | 
+10 9 | x = 1
+
+F401_20.py:8:1: F401 [*] `.foo.*` imported but unused
+   |
+ 6 | from . import *
+ 7 | from foo import *
+ 8 | from .foo import *
+   | ^^^^^^^^^^^^^^^^^^ F401
+ 9 | 
+10 | x = 1
+   |
+   = help: Remove unused import: `.foo.*`
+
+ℹ Safe fix
+5 5 | 
+6 6 | from . import *
+7 7 | from foo import *
+8   |-from .foo import *
+9 8 | 
+10 9 | x = 1
+11 10 | print(x + 1)
+
+

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -714,7 +714,9 @@ where
 /// assert_eq!(format_import_from(Some(1), Some("foo")), ".foo".to_string());
 /// ```
 pub fn format_import_from(level: Option<u32>, module: Option<&str>) -> String {
-    let mut module_name = String::with_capacity(16);
+    let mut module_name = String::with_capacity(
+        (level.unwrap_or(0) as usize) + module.as_ref().map_or(0, |module| module.len()),
+    );
     if let Some(level) = level {
         for _ in 0..level {
             module_name.push('.');

--- a/crates/ruff_python_semantic/src/star_import.rs
+++ b/crates/ruff_python_semantic/src/star_import.rs
@@ -1,7 +1,57 @@
+use ruff_text_size::{Ranged, TextRange};
+
+use crate::NodeId;
+
 #[derive(Debug, Clone)]
 pub struct StarImport<'a> {
     /// The level of the import. `None` or `Some(0)` indicate an absolute import.
     pub level: Option<u32>,
     /// The module being imported. `None` indicates a wildcard import.
     pub module: Option<&'a str>,
+    /// The node ID of the import statement.
+    pub node_id: NodeId,
+    /// The range of the import statement.
+    pub range: TextRange,
+}
+
+impl StarImport<'_> {
+    /// Returns the fully-qualified name of the imported symbol.
+    pub fn qualified_name(&self) -> String {
+        if let Some(module) = self.module {
+            // Ex) `from foo import *` -> `foo.*`
+            let mut module_name =
+                String::with_capacity((self.level.unwrap_or(0) as usize) + module.len() + 1 + 1);
+            if let Some(level) = self.level {
+                for _ in 0..level {
+                    module_name.push('.');
+                }
+            }
+            module_name.push_str(module);
+            module_name.push_str(".*");
+            module_name
+        } else if let Some(level) = self.level {
+            // Ex) `from . import *` -> `from . import *`
+            let mut module_name = String::with_capacity(
+                "from".len() + 1 + (level as usize) + 1 + "import".len() + 1 + 1,
+            );
+            module_name.push_str("from");
+            module_name.push(' ');
+            for _ in 0..level {
+                module_name.push('.');
+            }
+            module_name.push(' ');
+            module_name.push_str("import");
+            module_name.push(' ');
+            module_name.push('*');
+            module_name
+        } else {
+            "*".to_string()
+        }
+    }
+}
+
+impl Ranged for StarImport<'_> {
+    fn range(&self) -> TextRange {
+        self.range
+    }
 }


### PR DESCRIPTION
## Summary

If a file contains, e.g., `from foo import *`, but all references are resolved, we should mark the import as unused (similar to Flake8).

This change is gated behind preview for now.

Closes https://github.com/astral-sh/ruff/issues/9028.