### PR TITLE
Avoid `ANN2xx` autofix for abstract methods with empty body

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_annotations/auto_return_type.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_annotations/auto_return_type.py
@@ -147,3 +147,38 @@ def func(x: int):
     while x > 0:
         break
         return 1
+
+
+import abc
+from abc import abstractmethod
+
+
+class Foo(abc.ABC):
+    @abstractmethod
+    def method(self):
+        pass
+
+    @abc.abstractmethod
+    def method(self):
+        """Docstring."""
+
+    @abc.abstractmethod
+    def method(self):
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def method():
+        pass
+
+    @classmethod
+    @abstractmethod
+    def method(cls):
+        pass
+
+    @abstractmethod
+    def method(self):
+        if self.x > 0:
+            return 1
+        else:
+            return 1.5

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type.snap
@@ -427,4 +427,72 @@ auto_return_type.py:146:5: ANN201 [*] Missing return type annotation for public 
 148 148 |         break
 149 149 |         return 1
 
+auto_return_type.py:158:9: ANN201 Missing return type annotation for public function `method`
+    |
+156 | class Foo(abc.ABC):
+157 |     @abstractmethod
+158 |     def method(self):
+    |         ^^^^^^ ANN201
+159 |         pass
+    |
+    = help: Add return type annotation
+
+auto_return_type.py:162:9: ANN201 Missing return type annotation for public function `method`
+    |
+161 |     @abc.abstractmethod
+162 |     def method(self):
+    |         ^^^^^^ ANN201
+163 |         """Docstring."""
+    |
+    = help: Add return type annotation
+
+auto_return_type.py:166:9: ANN201 Missing return type annotation for public function `method`
+    |
+165 |     @abc.abstractmethod
+166 |     def method(self):
+    |         ^^^^^^ ANN201
+167 |         ...
+    |
+    = help: Add return type annotation
+
+auto_return_type.py:171:9: ANN205 Missing return type annotation for staticmethod `method`
+    |
+169 |     @staticmethod
+170 |     @abstractmethod
+171 |     def method():
+    |         ^^^^^^ ANN205
+172 |         pass
+    |
+    = help: Add return type annotation
+
+auto_return_type.py:176:9: ANN206 Missing return type annotation for classmethod `method`
+    |
+174 |     @classmethod
+175 |     @abstractmethod
+176 |     def method(cls):
+    |         ^^^^^^ ANN206
+177 |         pass
+    |
+    = help: Add return type annotation
+
+auto_return_type.py:180:9: ANN201 [*] Missing return type annotation for public function `method`
+    |
+179 |     @abstractmethod
+180 |     def method(self):
+    |         ^^^^^^ ANN201
+181 |         if self.x > 0:
+182 |             return 1
+    |
+    = help: Add return type annotation: `float`
+
+ℹ Unsafe fix
+177 177 |         pass
+178 178 | 
+179 179 |     @abstractmethod
+180     |-    def method(self):
+    180 |+    def method(self) -> float:
+181 181 |         if self.x > 0:
+182 182 |             return 1
+183 183 |         else:
+
 

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type_py38.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type_py38.snap
@@ -482,4 +482,72 @@ auto_return_type.py:146:5: ANN201 [*] Missing return type annotation for public 
 148 149 |         break
 149 150 |         return 1
 
+auto_return_type.py:158:9: ANN201 Missing return type annotation for public function `method`
+    |
+156 | class Foo(abc.ABC):
+157 |     @abstractmethod
+158 |     def method(self):
+    |         ^^^^^^ ANN201
+159 |         pass
+    |
+    = help: Add return type annotation
+
+auto_return_type.py:162:9: ANN201 Missing return type annotation for public function `method`
+    |
+161 |     @abc.abstractmethod
+162 |     def method(self):
+    |         ^^^^^^ ANN201
+163 |         """Docstring."""
+    |
+    = help: Add return type annotation
+
+auto_return_type.py:166:9: ANN201 Missing return type annotation for public function `method`
+    |
+165 |     @abc.abstractmethod
+166 |     def method(self):
+    |         ^^^^^^ ANN201
+167 |         ...
+    |
+    = help: Add return type annotation
+
+auto_return_type.py:171:9: ANN205 Missing return type annotation for staticmethod `method`
+    |
+169 |     @staticmethod
+170 |     @abstractmethod
+171 |     def method():
+    |         ^^^^^^ ANN205
+172 |         pass
+    |
+    = help: Add return type annotation
+
+auto_return_type.py:176:9: ANN206 Missing return type annotation for classmethod `method`
+    |
+174 |     @classmethod
+175 |     @abstractmethod
+176 |     def method(cls):
+    |         ^^^^^^ ANN206
+177 |         pass
+    |
+    = help: Add return type annotation
+
+auto_return_type.py:180:9: ANN201 [*] Missing return type annotation for public function `method`
+    |
+179 |     @abstractmethod
+180 |     def method(self):
+    |         ^^^^^^ ANN201
+181 |         if self.x > 0:
+182 |             return 1
+    |
+    = help: Add return type annotation: `float`
+
+ℹ Unsafe fix
+177 177 |         pass
+178 178 | 
+179 179 |     @abstractmethod
+180     |-    def method(self):
+    180 |+    def method(self) -> float:
+181 181 |         if self.x > 0:
+182 182 |             return 1
+183 183 |         else:
+
 


### PR DESCRIPTION
## Summary

This PR updates the `ANN201`, `ANN202`, `ANN205`, and `ANN206` rules to not create a fix for the return type when it's an abstract method and the function body is empty i.e., it only contains either a pass statement, docstring or an ellipsis literal.

fixes: #9004

## Test Plan

Add the following test cases:
- Abstract method with pass statement
- Abstract method with docstring
- Abstract method with ellipsis literal
- Abstract method with possible return type
