### PR TITLE
Ignore underscore references in type annotations

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
@@ -66,6 +66,10 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
         return;
     };
 
+    if checker.semantic().in_annotation() {
+        return;
+    }
+
     if (attr.starts_with("__") && !attr.ends_with("__"))
         || (attr.starts_with('_') && !attr.starts_with("__"))
     {


### PR DESCRIPTION
## Summary

Occasionally, valid code needs to use `argparse._SubParsersAction` in a type annotation. This isn't great, but it's indicative of the fact that public interfaces can return private types. If you accessed that private type via a private interface, then we should be flagging the call site, rather than the annotation.

Closes https://github.com/astral-sh/ruff/issues/9013.
