### PR TITLE
Ensure that from-style imports are always ordered first in `__future__`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/isort/force_sort_within_sections_future.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/force_sort_within_sections_future.py
@@ -1,0 +1,2 @@
+import __future__
+from __future__ import annotations

--- a/crates/ruff_linter/resources/test/fixtures/isort/future_from.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/future_from.py
@@ -1,0 +1,2 @@
+import __future__
+from __future__ import annotations

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -180,7 +180,7 @@ fn format_import_block(
             continue;
         };
 
-        let imports = order_imports(import_block, settings);
+        let imports = order_imports(import_block, import_section, settings);
 
         // Add a blank line between every section.
         if is_first_block {
@@ -291,6 +291,7 @@ mod tests {
     #[test_case(Path::new("force_sort_within_sections.py"))]
     #[test_case(Path::new("force_to_top.py"))]
     #[test_case(Path::new("force_wrap_aliases.py"))]
+    #[test_case(Path::new("future_from.py"))]
     #[test_case(Path::new("if_elif_else.py"))]
     #[test_case(Path::new("import_from_after_import.py"))]
     #[test_case(Path::new("inline_comments.py"))]
@@ -701,6 +702,7 @@ mod tests {
 
     #[test_case(Path::new("force_sort_within_sections.py"))]
     #[test_case(Path::new("force_sort_within_sections_with_as_names.py"))]
+    #[test_case(Path::new("force_sort_within_sections_future.py"))]
     fn force_sort_within_sections(path: &Path) -> Result<()> {
         let snapshot = format!("force_sort_within_sections_{}", path.to_string_lossy());
         let mut diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__force_sort_within_sections_force_sort_within_sections_future.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__force_sort_within_sections_force_sort_within_sections_future.py.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+force_sort_within_sections_future.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+  |
+1 | / import __future__
+2 | | from __future__ import annotations
+  |
+  = help: Organize imports
+
+ℹ Safe fix
+  1 |+from __future__ import annotations
+1 2 | import __future__
+2   |-from __future__ import annotations
+
+

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__future_from.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__future_from.py.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+future_from.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+  |
+1 | / import __future__
+2 | | from __future__ import annotations
+  |
+  = help: Organize imports
+
+ℹ Safe fix
+  1 |+from __future__ import annotations
+1 2 | import __future__
+2   |-from __future__ import annotations
+
+


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/8823.