### PR TITLE
Allow `sys.path` modifications between imports

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E402.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E402.py
@@ -19,21 +19,26 @@ if x > 0:
 else:
     import e
 
-__some__magic = 1
+import sys
+sys.path.insert(0, "some/path")
 
 import f
 
+__some__magic = 1
+
+import g
+
 
 def foo() -> None:
-    import e
+    import h
 
 
 if __name__ == "__main__":
-    import g
+    import i
 
-import h; import i
+import j; import k
 
 
 if __name__ == "__main__":
-    import j; \
-import k
+    import l; \
+import m

--- a/crates/ruff_linter/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/mod.rs
@@ -65,6 +65,7 @@ mod tests {
     }
 
     #[test_case(Rule::IsLiteral, Path::new("constant_literals.py"))]
+    #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E402.py"))]
     #[test_case(Rule::TypeComparison, Path::new("E721.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/imports.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/imports.rs
@@ -41,6 +41,10 @@ impl Violation for MultipleImportsOnOneLine {
 /// According to [PEP 8], "imports are always put at the top of the file, just after any
 /// module comments and docstrings, and before module globals and constants."
 ///
+/// In [preview], this rule makes an exception for `sys.path` modifications,
+/// allowing for `sys.path.insert`, `sys.path.append`, and similar
+/// modifications between import statements.
+///
 /// ## Example
 /// ```python
 /// "One string"

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__E402_E402.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__E402_E402.py.snap
@@ -1,16 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E402.py:25:1: E402 Module level import not at top of file
-   |
-23 | sys.path.insert(0, "some/path")
-24 | 
-25 | import f
-   | ^^^^^^^^ E402
-26 | 
-27 | __some__magic = 1
-   |
-
 E402.py:29:1: E402 Module level import not at top of file
    |
 27 | __some__magic = 1

--- a/crates/ruff_python_semantic/src/analyze/imports.rs
+++ b/crates/ruff_python_semantic/src/analyze/imports.rs
@@ -1,0 +1,37 @@
+use ruff_python_ast::{self as ast, Expr, Stmt};
+
+use crate::SemanticModel;
+
+/// Returns `true` if a [`Stmt`] is a `sys.path` modification, as in:
+/// ```python
+/// import sys
+///
+/// sys.path.append("../")
+/// ```
+pub fn is_sys_path_modification(stmt: &Stmt, semantic: &SemanticModel) -> bool {
+    let Stmt::Expr(ast::StmtExpr { value, range: _ }) = stmt else {
+        return false;
+    };
+    let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() else {
+        return false;
+    };
+    semantic
+        .resolve_call_path(func.as_ref())
+        .is_some_and(|call_path| {
+            matches!(
+                call_path.as_slice(),
+                [
+                    "sys",
+                    "path",
+                    "append"
+                        | "insert"
+                        | "extend"
+                        | "remove"
+                        | "pop"
+                        | "clear"
+                        | "reverse"
+                        | "sort"
+                ]
+            )
+        })
+}

--- a/crates/ruff_python_semantic/src/analyze/mod.rs
+++ b/crates/ruff_python_semantic/src/analyze/mod.rs
@@ -1,4 +1,5 @@
 pub mod function_type;
+pub mod imports;
 pub mod logging;
 pub mod type_inference;
 pub mod typing;


### PR DESCRIPTION
## Summary

It's common to interleave a `sys.path` modification between imports at the top of a file. This is a frequent cause of `# noqa: E402` false positives, as seen in the ecosystem checks. This PR modifies E402 to omit such modifications when determining the "import boundary".

(We could consider linting against `sys.path` modifications, but that should be a separate rule.)

Closes: https://github.com/astral-sh/ruff/issues/5557.
