### PR TITLE
ruff_python_formatter: add test for extraneous info string text

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples.py
@@ -1195,6 +1195,20 @@ def markdown_over_indented():
     pass
 
 
+# This tests that we can have additional text after the language specifier.
+def markdown_additional_info_string():
+    """
+    Do cool stuff.
+
+    ```python tab="plugin.py"
+    cool_stuff( 1 )
+    ```
+
+    Done.
+    """
+    pass
+
+
 # Tests that an unclosed block gobbles up everything remaining in the
 # docstring, even if it isn't valid Python. Since it isn't valid Python,
 # reformatting fails and the entire thing is skipped.

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
@@ -1201,6 +1201,20 @@ def markdown_over_indented():
     pass
 
 
+# This tests that we can have additional text after the language specifier.
+def markdown_additional_info_string():
+    """
+    Do cool stuff.
+
+    ```python tab="plugin.py"
+    cool_stuff( 1 )
+    ```
+
+    Done.
+    """
+    pass
+
+
 # Tests that an unclosed block gobbles up everything remaining in the
 # docstring, even if it isn't valid Python. Since it isn't valid Python,
 # reformatting fails and the entire thing is skipped.
@@ -2552,6 +2566,20 @@ def markdown_over_indented():
         ```python
         print( 5 )
         ```
+    """
+    pass
+
+
+# This tests that we can have additional text after the language specifier.
+def markdown_additional_info_string():
+    """
+    Do cool stuff.
+
+    ```python tab="plugin.py"
+    cool_stuff( 1 )
+    ```
+
+    Done.
     """
     pass
 
@@ -3911,6 +3939,20 @@ def markdown_over_indented():
   pass
 
 
+# This tests that we can have additional text after the language specifier.
+def markdown_additional_info_string():
+  """
+  Do cool stuff.
+
+  ```python tab="plugin.py"
+  cool_stuff( 1 )
+  ```
+
+  Done.
+  """
+  pass
+
+
 # Tests that an unclosed block gobbles up everything remaining in the
 # docstring, even if it isn't valid Python. Since it isn't valid Python,
 # reformatting fails and the entire thing is skipped.
@@ -5262,6 +5304,20 @@ def markdown_over_indented():
 	    ```python
 	    print( 5 )
 	    ```
+	"""
+	pass
+
+
+# This tests that we can have additional text after the language specifier.
+def markdown_additional_info_string():
+	"""
+	Do cool stuff.
+
+	```python tab="plugin.py"
+	cool_stuff( 1 )
+	```
+
+	Done.
 	"""
 	pass
 
@@ -6621,6 +6677,20 @@ def markdown_over_indented():
 	pass
 
 
+# This tests that we can have additional text after the language specifier.
+def markdown_additional_info_string():
+	"""
+	Do cool stuff.
+
+	```python tab="plugin.py"
+	cool_stuff( 1 )
+	```
+
+	Done.
+	"""
+	pass
+
+
 # Tests that an unclosed block gobbles up everything remaining in the
 # docstring, even if it isn't valid Python. Since it isn't valid Python,
 # reformatting fails and the entire thing is skipped.
@@ -7967,6 +8037,20 @@ def markdown_over_indented():
         ```python
         print(5)
         ```
+    """
+    pass
+
+
+# This tests that we can have additional text after the language specifier.
+def markdown_additional_info_string():
+    """
+    Do cool stuff.
+
+    ```python tab="plugin.py"
+    cool_stuff(1)
+    ```
+
+    Done.
     """
     pass
 
@@ -9321,6 +9405,20 @@ def markdown_over_indented():
   pass
 
 
+# This tests that we can have additional text after the language specifier.
+def markdown_additional_info_string():
+  """
+  Do cool stuff.
+
+  ```python tab="plugin.py"
+  cool_stuff(1)
+  ```
+
+  Done.
+  """
+  pass
+
+
 # Tests that an unclosed block gobbles up everything remaining in the
 # docstring, even if it isn't valid Python. Since it isn't valid Python,
 # reformatting fails and the entire thing is skipped.
@@ -10671,6 +10769,20 @@ def markdown_over_indented():
 	pass
 
 
+# This tests that we can have additional text after the language specifier.
+def markdown_additional_info_string():
+	"""
+	Do cool stuff.
+
+	```python tab="plugin.py"
+	cool_stuff(1)
+	```
+
+	Done.
+	"""
+	pass
+
+
 # Tests that an unclosed block gobbles up everything remaining in the
 # docstring, even if it isn't valid Python. Since it isn't valid Python,
 # reformatting fails and the entire thing is skipped.
@@ -12017,6 +12129,20 @@ def markdown_over_indented():
 	    ```python
 	    print(5)
 	    ```
+	"""
+	pass
+
+
+# This tests that we can have additional text after the language specifier.
+def markdown_additional_info_string():
+	"""
+	Do cool stuff.
+
+	```python tab="plugin.py"
+	cool_stuff(1)
+	```
+
+	Done.
 	"""
 	pass
 


### PR DESCRIPTION
@ofek asked [about this][ref]. I did specifically add support for it, but neglected to add a test. This PR adds a test.

[ref]: https://github.com/astral-sh/ruff/pull/9030#issuecomment-1846054764