### PR TITLE
Fix handling of trailing target comment

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/assign.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/assign.py
@@ -67,3 +67,12 @@ def main() -> None:
                 db_request.POST["name"]
             )
         )[0]
+
+
+c = b[dddddd, aaaaaa] =  (
+    a[
+        aaaaaaa,
+        bbbbbbbbbbbbbbbbbbb
+    ]
+    # comment
+) = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/crates/ruff_python_formatter/src/statement/stmt_assign.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_assign.rs
@@ -69,7 +69,7 @@ impl Format<PyFormatContext<'_>> for FormatTargets<'_> {
         if let Some((first, rest)) = self.targets.split_first() {
             let comments = f.context().comments();
 
-            let parenthesize = if comments.has_leading(first) {
+            let parenthesize = if comments.has_leading(first) || comments.has_trailing(first) {
                 ParenthesizeTarget::Always
             } else if has_own_parentheses(first, f.context()).is_some() {
                 ParenthesizeTarget::Never

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__assign.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__assign.py.snap
@@ -73,6 +73,15 @@ def main() -> None:
                 db_request.POST["name"]
             )
         )[0]
+
+
+c = b[dddddd, aaaaaa] =  (
+    a[
+        aaaaaaa,
+        bbbbbbbbbbbbbbbbbbb
+    ]
+    # comment
+) = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 ## Output
@@ -151,6 +160,12 @@ def main() -> None:
                 db_request.POST["name"]
             )
         )[0]
+
+
+c = b[dddddd, aaaaaa] = (
+    a[aaaaaaa, bbbbbbbbbbbbbbbbbbb]
+    # comment
+) = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where Ruff moved a trailing target comment past the statement end

```python
c = b[dddddd, aaaaaa] =  (
    a[
        aaaaaaa,
        bbbbbbbbbbbbbbbbbbb
    ] 
    # comment 2
) = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

Before

```python
c = b[dddddd, aaaaaa] = a[
    aaaaaaa, bbbbbbbbbbbbbbbbbbb
] = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
# comment 2
```

Now

```python
c = b[dddddd, aaaaaa] = (
    a[aaaaaaa, bbbbbbbbbbbbbbbbbbb]
    # comment 2
) = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

Which matches black's formatting

## Test Plan

Added test
