### PR TITLE
Split string formatting to individual nodes

### DIFF
--- a/crates/ruff_python_formatter/generate.py
+++ b/crates/ruff_python_formatter/generate.py
@@ -33,9 +33,9 @@ node_lines = (
 nodes = []
 for node_line in node_lines:
     node = node_line.split("(")[1].split(")")[0].split("::")[-1].split("<")[0]
-    # These nodes aren't used in the formatter as the formatting of them is handled
-    # in one of the other nodes containing them.
-    if node in ("FStringLiteralElement", "FStringExpressionElement"):
+    # `FString` has a custom implementation while the formatting for `FStringLiteralElement`
+    # and `FStringExpressionElement` are handled by the `FString` implementation.
+    if node in ("FString", "FStringLiteralElement", "FStringExpressionElement"):
         continue
     nodes.append(node)
 print(nodes)

--- a/crates/ruff_python_formatter/generate.py
+++ b/crates/ruff_python_formatter/generate.py
@@ -33,9 +33,15 @@ node_lines = (
 nodes = []
 for node_line in node_lines:
     node = node_line.split("(")[1].split(")")[0].split("::")[-1].split("<")[0]
-    # `FString` has a custom implementation while the formatting for `FStringLiteralElement`
-    # and `FStringExpressionElement` are handled by the `FString` implementation.
-    if node in ("FString", "FStringLiteralElement", "FStringExpressionElement"):
+    # `FString` and `StringLiteral` has a custom implementation while the formatting for
+    # `FStringLiteralElement` and `FStringExpressionElement` are handled by the `FString`
+    # implementation.
+    if node in (
+        "FString",
+        "StringLiteral",
+        "FStringLiteralElement",
+        "FStringExpressionElement",
+    ):
         continue
     nodes.append(node)
 print(nodes)

--- a/crates/ruff_python_formatter/src/context.rs
+++ b/crates/ruff_python_formatter/src/context.rs
@@ -1,5 +1,5 @@
 use crate::comments::Comments;
-use crate::expression::string::QuoteChar;
+use crate::string::QuoteChar;
 use crate::PyFormatOptions;
 use ruff_formatter::{Buffer, FormatContext, GroupId, IndentWidth, SourceCode};
 use ruff_source_file::Locator;

--- a/crates/ruff_python_formatter/src/expression/binary_like.rs
+++ b/crates/ruff_python_formatter/src/expression/binary_like.rs
@@ -395,8 +395,9 @@ impl Format<PyFormatContext<'_>> for BinaryLike<'_> {
                             [
                                 operand.leading_binary_comments().map(leading_comments),
                                 leading_comments(comments.leading(&string_constant)),
-                                // Format it without the enclosing group because the group is
-                                // added by the binary like formatting.
+                                // Call `FormatStringContinuation` directly to avoid formatting
+                                // the implicitly concatenated string with the enclosing group
+                                // because the group is added by the binary like formatting.
                                 FormatStringContinuation::new(&string_constant),
                                 trailing_comments(comments.trailing(&string_constant)),
                                 operand.trailing_binary_comments().map(trailing_comments),
@@ -413,8 +414,9 @@ impl Format<PyFormatContext<'_>> for BinaryLike<'_> {
                             f,
                             [
                                 leading_comments(comments.leading(&string_constant)),
-                                // Format it without the enclosing group because the group is
-                                // added by the binary like formatting.
+                                // Call `FormatStringContinuation` directly to avoid formatting
+                                // the implicitly concatenated string with the enclosing group
+                                // because the group is added by the binary like formatting.
                                 FormatStringContinuation::new(&string_constant),
                                 trailing_comments(comments.trailing(&string_constant)),
                             ]

--- a/crates/ruff_python_formatter/src/expression/binary_like.rs
+++ b/crates/ruff_python_formatter/src/expression/binary_like.rs
@@ -18,10 +18,10 @@ use crate::expression::parentheses::{
     is_expression_parenthesized, write_in_parentheses_only_group_end_tag,
     write_in_parentheses_only_group_start_tag, Parentheses,
 };
-use crate::expression::string::{AnyString, FormatString, StringLayout};
 use crate::expression::OperatorPrecedence;
 use crate::prelude::*;
 use crate::preview::is_fix_power_op_line_length_enabled;
+use crate::string::{AnyString, FormatStringContinuation};
 
 #[derive(Copy, Clone, Debug)]
 pub(super) enum BinaryLike<'a> {
@@ -395,9 +395,9 @@ impl Format<PyFormatContext<'_>> for BinaryLike<'_> {
                             [
                                 operand.leading_binary_comments().map(leading_comments),
                                 leading_comments(comments.leading(&string_constant)),
-                                FormatString::new(&string_constant).with_layout(
-                                    StringLayout::ImplicitConcatenatedStringInBinaryLike,
-                                ),
+                                // Format it without the enclosing group because the group is
+                                // added by the binary like formatting.
+                                FormatStringContinuation::new(&string_constant),
                                 trailing_comments(comments.trailing(&string_constant)),
                                 operand.trailing_binary_comments().map(trailing_comments),
                                 line_suffix_boundary(),
@@ -413,9 +413,9 @@ impl Format<PyFormatContext<'_>> for BinaryLike<'_> {
                             f,
                             [
                                 leading_comments(comments.leading(&string_constant)),
-                                FormatString::new(&string_constant).with_layout(
-                                    StringLayout::ImplicitConcatenatedStringInBinaryLike
-                                ),
+                                // Format it without the enclosing group because the group is
+                                // added by the binary like formatting.
+                                FormatStringContinuation::new(&string_constant),
                                 trailing_comments(comments.trailing(&string_constant)),
                             ]
                         )?;

--- a/crates/ruff_python_formatter/src/expression/expr_f_string.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_f_string.rs
@@ -1,6 +1,5 @@
 use memchr::memchr2;
 
-use ruff_formatter::{FormatResult, FormatRuleWithOptions};
 use ruff_python_ast::{AnyNodeRef, ExprFString};
 use ruff_source_file::Locator;
 use ruff_text_size::Ranged;
@@ -10,32 +9,20 @@ use crate::expression::parentheses::{
     in_parentheses_only_group, NeedsParentheses, OptionalParentheses,
 };
 use crate::prelude::*;
-use crate::string::{AnyString, FormatStringContinuation, Quoting, StringContext};
+use crate::string::{AnyString, FormatStringContinuation, Quoting, StringOptions};
 
 #[derive(Default)]
-pub struct FormatExprFString {
-    context: StringContext,
-}
-
-impl FormatRuleWithOptions<ExprFString, PyFormatContext<'_>> for FormatExprFString {
-    type Options = StringContext;
-
-    fn with_options(mut self, options: Self::Options) -> Self {
-        self.context = options;
-        self
-    }
-}
+pub struct FormatExprFString;
 
 impl FormatNodeRule<ExprFString> for FormatExprFString {
     fn fmt_fields(&self, item: &ExprFString, f: &mut PyFormatter) -> FormatResult<()> {
-        let context = self
-            .context
-            .with_quoting(f_string_quoting(item, &f.context().locator()));
+        let options =
+            StringOptions::default().with_quoting(f_string_quoting(item, &f.context().locator()));
 
         match item.value.as_slice() {
-            [f_string_part] => f_string_part.format().with_options(context).fmt(f),
+            [f_string_part] => f_string_part.format().with_options(options).fmt(f),
             _ => in_parentheses_only_group(
-                &FormatStringContinuation::new(&AnyString::FString(item)).with_context(context),
+                &FormatStringContinuation::new(&AnyString::FString(item)).with_options(options),
             )
             .fmt(f),
         }

--- a/crates/ruff_python_formatter/src/expression/expr_f_string.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_f_string.rs
@@ -1,21 +1,44 @@
 use memchr::memchr2;
 
+use ruff_formatter::{FormatResult, FormatRuleWithOptions};
+use ruff_python_ast::{AnyNodeRef, ExprFString};
+use ruff_source_file::Locator;
+use ruff_text_size::Ranged;
+
 use crate::comments::SourceComment;
-use ruff_formatter::FormatResult;
-use ruff_python_ast::AnyNodeRef;
-use ruff_python_ast::ExprFString;
-
-use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
+use crate::expression::parentheses::{
+    in_parentheses_only_group, NeedsParentheses, OptionalParentheses,
+};
 use crate::prelude::*;
-
-use super::string::{AnyString, FormatString};
+use crate::string::{AnyString, FormatStringContinuation, Quoting, StringContext};
 
 #[derive(Default)]
-pub struct FormatExprFString;
+pub struct FormatExprFString {
+    context: StringContext,
+}
+
+impl FormatRuleWithOptions<ExprFString, PyFormatContext<'_>> for FormatExprFString {
+    type Options = StringContext;
+
+    fn with_options(mut self, options: Self::Options) -> Self {
+        self.context = options;
+        self
+    }
+}
 
 impl FormatNodeRule<ExprFString> for FormatExprFString {
     fn fmt_fields(&self, item: &ExprFString, f: &mut PyFormatter) -> FormatResult<()> {
-        FormatString::new(&AnyString::FString(item)).fmt(f)
+        let context = self
+            .context
+            .with_quoting(f_string_quoting(item, &f.context().locator()));
+
+        match item.value.as_slice() {
+            [f_string_part] => f_string_part.format().with_options(context).fmt(f),
+            _ => in_parentheses_only_group(
+                &FormatStringContinuation::new(&AnyString::FString(item)).with_context(context),
+            )
+            .fmt(f),
+        }
     }
 
     fn fmt_dangling_comments(
@@ -41,5 +64,30 @@ impl NeedsParentheses for ExprFString {
         } else {
             OptionalParentheses::Never
         }
+    }
+}
+
+fn f_string_quoting(f_string: &ExprFString, locator: &Locator) -> Quoting {
+    let unprefixed = locator
+        .slice(f_string.range())
+        .trim_start_matches(|c| c != '"' && c != '\'');
+    let triple_quoted = unprefixed.starts_with(r#"""""#) || unprefixed.starts_with(r"'''");
+
+    if f_string
+        .value
+        .elements()
+        .filter_map(|element| element.as_expression())
+        .any(|expression| {
+            let string_content = locator.slice(expression.range());
+            if triple_quoted {
+                string_content.contains(r#"""""#) || string_content.contains("'''")
+            } else {
+                string_content.contains(['"', '\''])
+            }
+        })
+    {
+        Quoting::Preserve
+    } else {
+        Quoting::CanChange
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_string_literal.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_string_literal.rs
@@ -6,21 +6,40 @@ use crate::comments::SourceComment;
 use crate::expression::parentheses::{
     in_parentheses_only_group, NeedsParentheses, OptionalParentheses,
 };
+use crate::other::string_literal::{FormatStringLiteral, StringLiteralKind};
 use crate::prelude::*;
-use crate::string::{
-    AnyString, FormatStringContinuation, StringOptions, StringPrefix, StringQuotes,
-};
+use crate::string::{AnyString, FormatStringContinuation, StringPrefix, StringQuotes};
 
 #[derive(Default)]
 pub struct FormatExprStringLiteral {
-    options: StringOptions,
+    kind: ExprStringLiteralKind,
+}
+
+#[derive(Default, Copy, Clone, Debug)]
+pub enum ExprStringLiteralKind {
+    #[default]
+    String,
+    Docstring,
+}
+
+impl ExprStringLiteralKind {
+    const fn string_literal_kind(self) -> StringLiteralKind {
+        match self {
+            ExprStringLiteralKind::String => StringLiteralKind::String,
+            ExprStringLiteralKind::Docstring => StringLiteralKind::Docstring,
+        }
+    }
+
+    const fn is_docstring(self) -> bool {
+        matches!(self, ExprStringLiteralKind::Docstring)
+    }
 }
 
 impl FormatRuleWithOptions<ExprStringLiteral, PyFormatContext<'_>> for FormatExprStringLiteral {
-    type Options = StringOptions;
+    type Options = ExprStringLiteralKind;
 
     fn with_options(mut self, options: Self::Options) -> Self {
-        self.options = options;
+        self.kind = options;
         self
     }
 }
@@ -30,10 +49,16 @@ impl FormatNodeRule<ExprStringLiteral> for FormatExprStringLiteral {
         let ExprStringLiteral { value, .. } = item;
 
         match value.as_slice() {
-            [string_literal] => string_literal.format().with_options(self.options).fmt(f),
-            _ => in_parentheses_only_group(
-                &FormatStringContinuation::new(&AnyString::String(item)).with_options(self.options),
-            )
+            [string_literal] => {
+                FormatStringLiteral::new(string_literal, self.kind.string_literal_kind()).fmt(f)
+            }
+            _ => {
+                // This is just a sanity check because [`DocstringStmt::try_from_statement`]
+                // ensures that the docstring is a *single* string literal.
+                assert!(!self.kind.is_docstring());
+
+                in_parentheses_only_group(&FormatStringContinuation::new(&AnyString::String(item)))
+            }
             .fmt(f),
         }
     }

--- a/crates/ruff_python_formatter/src/expression/expr_string_literal.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_string_literal.rs
@@ -1,6 +1,5 @@
 use ruff_formatter::FormatRuleWithOptions;
-use ruff_python_ast::AnyNodeRef;
-use ruff_python_ast::ExprStringLiteral;
+use ruff_python_ast::{AnyNodeRef, ExprStringLiteral};
 use ruff_text_size::{Ranged, TextLen, TextRange};
 
 use crate::comments::SourceComment;
@@ -8,19 +7,20 @@ use crate::expression::parentheses::{
     in_parentheses_only_group, NeedsParentheses, OptionalParentheses,
 };
 use crate::prelude::*;
-use crate::string::StringContext;
-use crate::string::{AnyString, FormatStringContinuation, StringPrefix, StringQuotes};
+use crate::string::{
+    AnyString, FormatStringContinuation, StringOptions, StringPrefix, StringQuotes,
+};
 
 #[derive(Default)]
 pub struct FormatExprStringLiteral {
-    context: StringContext,
+    options: StringOptions,
 }
 
 impl FormatRuleWithOptions<ExprStringLiteral, PyFormatContext<'_>> for FormatExprStringLiteral {
-    type Options = StringContext;
+    type Options = StringOptions;
 
     fn with_options(mut self, options: Self::Options) -> Self {
-        self.context = options;
+        self.options = options;
         self
     }
 }
@@ -30,9 +30,9 @@ impl FormatNodeRule<ExprStringLiteral> for FormatExprStringLiteral {
         let ExprStringLiteral { value, .. } = item;
 
         match value.as_slice() {
-            [string_literal] => string_literal.format().with_options(self.context).fmt(f),
+            [string_literal] => string_literal.format().with_options(self.options).fmt(f),
             _ => in_parentheses_only_group(
-                &FormatStringContinuation::new(&AnyString::String(item)).with_context(self.context),
+                &FormatStringContinuation::new(&AnyString::String(item)).with_options(self.options),
             )
             .fmt(f),
         }

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -58,7 +58,6 @@ pub(crate) mod expr_yield;
 pub(crate) mod expr_yield_from;
 mod operator;
 pub(crate) mod parentheses;
-pub(crate) mod string;
 
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
 pub struct FormatExpr {

--- a/crates/ruff_python_formatter/src/generated.rs
+++ b/crates/ruff_python_formatter/src/generated.rs
@@ -2943,34 +2943,6 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::TypeParamParamSpec {
     }
 }
 
-impl FormatRule<ast::FString, PyFormatContext<'_>> for crate::other::f_string::FormatFString {
-    #[inline]
-    fn fmt(&self, node: &ast::FString, f: &mut PyFormatter) -> FormatResult<()> {
-        FormatNodeRule::<ast::FString>::fmt(self, node, f)
-    }
-}
-impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::FString {
-    type Format<'a> = FormatRefWithRule<
-        'a,
-        ast::FString,
-        crate::other::f_string::FormatFString,
-        PyFormatContext<'ast>,
-    >;
-    fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, crate::other::f_string::FormatFString::default())
-    }
-}
-impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::FString {
-    type Format = FormatOwnedWithRule<
-        ast::FString,
-        crate::other::f_string::FormatFString,
-        PyFormatContext<'ast>,
-    >;
-    fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, crate::other::f_string::FormatFString::default())
-    }
-}
-
 impl FormatRule<ast::StringLiteral, PyFormatContext<'_>>
     for crate::other::string_literal::FormatStringLiteral
 {

--- a/crates/ruff_python_formatter/src/generated.rs
+++ b/crates/ruff_python_formatter/src/generated.rs
@@ -2943,42 +2943,6 @@ impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::TypeParamParamSpec {
     }
 }
 
-impl FormatRule<ast::StringLiteral, PyFormatContext<'_>>
-    for crate::other::string_literal::FormatStringLiteral
-{
-    #[inline]
-    fn fmt(&self, node: &ast::StringLiteral, f: &mut PyFormatter) -> FormatResult<()> {
-        FormatNodeRule::<ast::StringLiteral>::fmt(self, node, f)
-    }
-}
-impl<'ast> AsFormat<PyFormatContext<'ast>> for ast::StringLiteral {
-    type Format<'a> = FormatRefWithRule<
-        'a,
-        ast::StringLiteral,
-        crate::other::string_literal::FormatStringLiteral,
-        PyFormatContext<'ast>,
-    >;
-    fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::other::string_literal::FormatStringLiteral::default(),
-        )
-    }
-}
-impl<'ast> IntoFormat<PyFormatContext<'ast>> for ast::StringLiteral {
-    type Format = FormatOwnedWithRule<
-        ast::StringLiteral,
-        crate::other::string_literal::FormatStringLiteral,
-        PyFormatContext<'ast>,
-    >;
-    fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::other::string_literal::FormatStringLiteral::default(),
-        )
-    }
-}
-
 impl FormatRule<ast::BytesLiteral, PyFormatContext<'_>>
     for crate::other::bytes_literal::FormatBytesLiteral
 {

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -36,6 +36,7 @@ mod prelude;
 mod preview;
 mod shared_traits;
 pub(crate) mod statement;
+pub(crate) mod string;
 pub(crate) mod type_param;
 mod verbatim;
 

--- a/crates/ruff_python_formatter/src/other/bytes_literal.rs
+++ b/crates/ruff_python_formatter/src/other/bytes_literal.rs
@@ -1,12 +1,24 @@
 use ruff_python_ast::BytesLiteral;
+use ruff_text_size::Ranged;
 
 use crate::prelude::*;
+use crate::string::{Quoting, StringPart};
 
 #[derive(Default)]
 pub struct FormatBytesLiteral;
 
 impl FormatNodeRule<BytesLiteral> for FormatBytesLiteral {
-    fn fmt_fields(&self, _item: &BytesLiteral, _f: &mut PyFormatter) -> FormatResult<()> {
-        unreachable!("Handled inside of `FormatExprBytesLiteral`");
+    fn fmt_fields(&self, item: &BytesLiteral, f: &mut PyFormatter) -> FormatResult<()> {
+        let locator = f.context().locator();
+        let parent_docstring_quote_style = f.context().docstring();
+
+        StringPart::from_source(item.range(), &locator)
+            .normalize(
+                Quoting::CanChange,
+                &locator,
+                f.options().quote_style(),
+                parent_docstring_quote_style,
+            )
+            .fmt(f)
     }
 }

--- a/crates/ruff_python_formatter/src/other/bytes_literal.rs
+++ b/crates/ruff_python_formatter/src/other/bytes_literal.rs
@@ -10,14 +10,13 @@ pub struct FormatBytesLiteral;
 impl FormatNodeRule<BytesLiteral> for FormatBytesLiteral {
     fn fmt_fields(&self, item: &BytesLiteral, f: &mut PyFormatter) -> FormatResult<()> {
         let locator = f.context().locator();
-        let parent_docstring_quote_style = f.context().docstring();
 
         StringPart::from_source(item.range(), &locator)
             .normalize(
                 Quoting::CanChange,
                 &locator,
                 f.options().quote_style(),
-                parent_docstring_quote_style,
+                f.context().docstring(),
             )
             .fmt(f)
     }

--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -4,8 +4,14 @@ use ruff_text_size::Ranged;
 use crate::prelude::*;
 use crate::string::{Quoting, StringPart};
 
+/// Formats an f-string which is part of a larger f-string expression.
+///
+/// For example, this would be used to format the f-string part in `"foo" f"bar {x}"`
+/// or the standalone f-string in `f"foo {x} bar"`.
 pub(crate) struct FormatFString<'a> {
     value: &'a FString,
+    /// The quoting of an f-string. This is determined by the parent node
+    /// (f-string expression) and is required to format an f-string correctly.
     quoting: Quoting,
 }
 

--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -1,12 +1,48 @@
+use ruff_formatter::FormatRuleWithOptions;
 use ruff_python_ast::FString;
+use ruff_text_size::Ranged;
 
 use crate::prelude::*;
+use crate::string::{StringContext, StringPart};
 
 #[derive(Default)]
-pub struct FormatFString;
+pub struct FormatFString {
+    context: StringContext,
+}
+
+impl FormatRuleWithOptions<FString, PyFormatContext<'_>> for FormatFString {
+    type Options = StringContext;
+
+    fn with_options(mut self, options: Self::Options) -> Self {
+        self.context = options;
+        self
+    }
+}
 
 impl FormatNodeRule<FString> for FormatFString {
-    fn fmt_fields(&self, _item: &FString, _f: &mut PyFormatter) -> FormatResult<()> {
-        unreachable!("Handled inside of `FormatExprFString`");
+    fn fmt_fields(&self, item: &FString, f: &mut PyFormatter) -> FormatResult<()> {
+        let locator = f.context().locator();
+        let parent_docstring_quote_style = f.context().docstring();
+
+        let result = StringPart::from_source(item.range(), &locator)
+            .normalize(
+                self.context.quoting(),
+                &locator,
+                f.options().quote_style(),
+                parent_docstring_quote_style,
+            )
+            .fmt(f);
+
+        // TODO(dhruvmanila): With PEP 701, comments can be inside f-strings.
+        // This is to mark all of those comments as formatted but we need to
+        // figure out how to handle them. Note that this needs to be done only
+        // after the f-string is formatted, so only for all the non-formatted
+        // comments.
+        let comments = f.context().comments();
+        item.elements.iter().for_each(|value| {
+            comments.mark_verbatim_node_comments_formatted(value.into());
+        });
+
+        result
     }
 }

--- a/crates/ruff_python_formatter/src/other/f_string_part.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_part.rs
@@ -1,19 +1,20 @@
 use ruff_formatter::{FormatOwnedWithRule, FormatRefWithRule, FormatRuleWithOptions};
 use ruff_python_ast::FStringPart;
 
+use crate::other::f_string::FormatFString;
 use crate::prelude::*;
-use crate::string::StringContext;
+use crate::string::StringOptions;
 
 #[derive(Default)]
 pub struct FormatFStringPart {
-    context: StringContext,
+    options: StringOptions,
 }
 
 impl FormatRuleWithOptions<FStringPart, PyFormatContext<'_>> for FormatFStringPart {
-    type Options = StringContext;
+    type Options = StringOptions;
 
     fn with_options(mut self, options: Self::Options) -> Self {
-        self.context = options;
+        self.options = options;
         self
     }
 }
@@ -22,9 +23,11 @@ impl FormatRule<FStringPart, PyFormatContext<'_>> for FormatFStringPart {
     fn fmt(&self, item: &FStringPart, f: &mut PyFormatter) -> FormatResult<()> {
         match item {
             FStringPart::Literal(string_literal) => {
-                string_literal.format().with_options(self.context).fmt(f)
+                string_literal.format().with_options(self.options).fmt(f)
             }
-            FStringPart::FString(f_string) => f_string.format().with_options(self.context).fmt(f),
+            FStringPart::FString(f_string) => {
+                FormatFString::new(f_string, self.options.quoting()).fmt(f)
+            }
         }
     }
 }

--- a/crates/ruff_python_formatter/src/other/f_string_part.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_part.rs
@@ -1,0 +1,46 @@
+use ruff_formatter::{FormatOwnedWithRule, FormatRefWithRule, FormatRuleWithOptions};
+use ruff_python_ast::FStringPart;
+
+use crate::prelude::*;
+use crate::string::StringContext;
+
+#[derive(Default)]
+pub struct FormatFStringPart {
+    context: StringContext,
+}
+
+impl FormatRuleWithOptions<FStringPart, PyFormatContext<'_>> for FormatFStringPart {
+    type Options = StringContext;
+
+    fn with_options(mut self, options: Self::Options) -> Self {
+        self.context = options;
+        self
+    }
+}
+
+impl FormatRule<FStringPart, PyFormatContext<'_>> for FormatFStringPart {
+    fn fmt(&self, item: &FStringPart, f: &mut PyFormatter) -> FormatResult<()> {
+        match item {
+            FStringPart::Literal(string_literal) => {
+                string_literal.format().with_options(self.context).fmt(f)
+            }
+            FStringPart::FString(f_string) => f_string.format().with_options(self.context).fmt(f),
+        }
+    }
+}
+
+impl<'ast> AsFormat<PyFormatContext<'ast>> for FStringPart {
+    type Format<'a> = FormatRefWithRule<'a, FStringPart, FormatFStringPart, PyFormatContext<'ast>>;
+
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(self, FormatFStringPart::default())
+    }
+}
+
+impl<'ast> IntoFormat<PyFormatContext<'ast>> for FStringPart {
+    type Format = FormatOwnedWithRule<FStringPart, FormatFStringPart, PyFormatContext<'ast>>;
+
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(self, FormatFStringPart::default())
+    }
+}

--- a/crates/ruff_python_formatter/src/other/f_string_part.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_part.rs
@@ -1,49 +1,39 @@
-use ruff_formatter::{FormatOwnedWithRule, FormatRefWithRule, FormatRuleWithOptions};
 use ruff_python_ast::FStringPart;
 
 use crate::other::f_string::FormatFString;
+use crate::other::string_literal::{FormatStringLiteral, StringLiteralKind};
 use crate::prelude::*;
-use crate::string::StringOptions;
+use crate::string::Quoting;
 
-#[derive(Default)]
-pub struct FormatFStringPart {
-    options: StringOptions,
+/// Formats an f-string part which is either a string literal or an f-string.
+///
+/// This delegates the actual formatting to the appropriate formatter.
+pub(crate) struct FormatFStringPart<'a> {
+    part: &'a FStringPart,
+    /// The quoting to be used for all the f-string parts. This is determined by
+    /// the parent node (f-string expression) and is required to format all parts
+    /// correctly.
+    quoting: Quoting,
 }
 
-impl FormatRuleWithOptions<FStringPart, PyFormatContext<'_>> for FormatFStringPart {
-    type Options = StringOptions;
-
-    fn with_options(mut self, options: Self::Options) -> Self {
-        self.options = options;
-        self
+impl<'a> FormatFStringPart<'a> {
+    pub(crate) fn new(part: &'a FStringPart, quoting: Quoting) -> Self {
+        Self { part, quoting }
     }
 }
 
-impl FormatRule<FStringPart, PyFormatContext<'_>> for FormatFStringPart {
-    fn fmt(&self, item: &FStringPart, f: &mut PyFormatter) -> FormatResult<()> {
-        match item {
-            FStringPart::Literal(string_literal) => {
-                string_literal.format().with_options(self.options).fmt(f)
-            }
-            FStringPart::FString(f_string) => {
-                FormatFString::new(f_string, self.options.quoting()).fmt(f)
-            }
+impl Format<PyFormatContext<'_>> for FormatFStringPart<'_> {
+    fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
+        match self.part {
+            FStringPart::Literal(string_literal) => FormatStringLiteral::new(
+                string_literal,
+                // If an f-string part is a string literal, the f-string is always
+                // implicitly concatenated e.g., `"foo" f"bar {x}"`. A standalone
+                // string literal would be a string expression, not an f-string.
+                StringLiteralKind::InImplicitlyConcatenatedFString(self.quoting),
+            )
+            .fmt(f),
+            FStringPart::FString(f_string) => FormatFString::new(f_string, self.quoting).fmt(f),
         }
-    }
-}
-
-impl<'ast> AsFormat<PyFormatContext<'ast>> for FStringPart {
-    type Format<'a> = FormatRefWithRule<'a, FStringPart, FormatFStringPart, PyFormatContext<'ast>>;
-
-    fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(self, FormatFStringPart::default())
-    }
-}
-
-impl<'ast> IntoFormat<PyFormatContext<'ast>> for FStringPart {
-    type Format = FormatOwnedWithRule<FStringPart, FormatFStringPart, PyFormatContext<'ast>>;
-
-    fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(self, FormatFStringPart::default())
     }
 }

--- a/crates/ruff_python_formatter/src/other/mod.rs
+++ b/crates/ruff_python_formatter/src/other/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod decorator;
 pub(crate) mod elif_else_clause;
 pub(crate) mod except_handler_except_handler;
 pub(crate) mod f_string;
+pub(crate) mod f_string_part;
 pub(crate) mod identifier;
 pub(crate) mod keyword;
 pub(crate) mod match_case;

--- a/crates/ruff_python_formatter/src/other/string_literal.rs
+++ b/crates/ruff_python_formatter/src/other/string_literal.rs
@@ -3,19 +3,19 @@ use ruff_python_ast::StringLiteral;
 use ruff_text_size::Ranged;
 
 use crate::prelude::*;
-use crate::string::{docstring, StringContext, StringPart};
+use crate::string::{docstring, StringOptions, StringPart};
 use crate::QuoteStyle;
 
 #[derive(Default)]
 pub struct FormatStringLiteral {
-    context: StringContext,
+    options: StringOptions,
 }
 
 impl FormatRuleWithOptions<StringLiteral, PyFormatContext<'_>> for FormatStringLiteral {
-    type Options = StringContext;
+    type Options = StringOptions;
 
     fn with_options(mut self, options: Self::Options) -> Self {
-        self.context = options;
+        self.options = options;
         self
     }
 }
@@ -25,7 +25,7 @@ impl FormatNodeRule<StringLiteral> for FormatStringLiteral {
         let locator = f.context().locator();
         let parent_docstring_quote_style = f.context().docstring();
 
-        let quote_style = if self.context.is_docstring() {
+        let quote_style = if self.options.is_docstring() {
             // Per PEP 8 and PEP 257, always prefer double quotes for docstrings
             QuoteStyle::Double
         } else {
@@ -33,13 +33,13 @@ impl FormatNodeRule<StringLiteral> for FormatStringLiteral {
         };
 
         let normalized = StringPart::from_source(item.range(), &locator).normalize(
-            self.context.quoting(),
+            self.options.quoting(),
             &locator,
             quote_style,
             parent_docstring_quote_style,
         );
 
-        if self.context.is_docstring() {
+        if self.options.is_docstring() {
             docstring::format(&normalized, f)
         } else {
             normalized.fmt(f)

--- a/crates/ruff_python_formatter/src/other/string_literal.rs
+++ b/crates/ruff_python_formatter/src/other/string_literal.rs
@@ -1,45 +1,69 @@
-use ruff_formatter::FormatRuleWithOptions;
 use ruff_python_ast::StringLiteral;
 use ruff_text_size::Ranged;
 
 use crate::prelude::*;
-use crate::string::{docstring, StringOptions, StringPart};
+use crate::string::{docstring, Quoting, StringPart};
 use crate::QuoteStyle;
 
-#[derive(Default)]
-pub struct FormatStringLiteral {
-    options: StringOptions,
+pub(crate) struct FormatStringLiteral<'a> {
+    value: &'a StringLiteral,
+    layout: StringLiteralKind,
 }
 
-impl FormatRuleWithOptions<StringLiteral, PyFormatContext<'_>> for FormatStringLiteral {
-    type Options = StringOptions;
-
-    fn with_options(mut self, options: Self::Options) -> Self {
-        self.options = options;
-        self
+impl<'a> FormatStringLiteral<'a> {
+    pub(crate) fn new(value: &'a StringLiteral, layout: StringLiteralKind) -> Self {
+        Self { value, layout }
     }
 }
 
-impl FormatNodeRule<StringLiteral> for FormatStringLiteral {
-    fn fmt_fields(&self, item: &StringLiteral, f: &mut PyFormatter) -> FormatResult<()> {
-        let locator = f.context().locator();
-        let parent_docstring_quote_style = f.context().docstring();
+/// The kind of a string literal.
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) enum StringLiteralKind {
+    /// A normal string literal e.g., `"foo"`.
+    #[default]
+    String,
+    /// A string literal used as a docstring.
+    Docstring,
+    /// A string literal that is implicitly concatenated with an f-string. This
+    /// makes the overall expression an f-string whose quoting detection comes
+    /// from the parent node (f-string expression).
+    InImplicitlyConcatenatedFString(Quoting),
+}
 
-        let quote_style = if self.options.is_docstring() {
+impl StringLiteralKind {
+    /// Checks if this string literal is a docstring.
+    pub(crate) const fn is_docstring(self) -> bool {
+        matches!(self, StringLiteralKind::Docstring)
+    }
+
+    /// Returns the quoting to be used for this string literal.
+    fn quoting(self) -> Quoting {
+        match self {
+            StringLiteralKind::String | StringLiteralKind::Docstring => Quoting::CanChange,
+            StringLiteralKind::InImplicitlyConcatenatedFString(quoting) => quoting,
+        }
+    }
+}
+
+impl Format<PyFormatContext<'_>> for FormatStringLiteral<'_> {
+    fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
+        let locator = f.context().locator();
+
+        let quote_style = if self.layout.is_docstring() {
             // Per PEP 8 and PEP 257, always prefer double quotes for docstrings
             QuoteStyle::Double
         } else {
             f.options().quote_style()
         };
 
-        let normalized = StringPart::from_source(item.range(), &locator).normalize(
-            self.options.quoting(),
+        let normalized = StringPart::from_source(self.value.range(), &locator).normalize(
+            self.layout.quoting(),
             &locator,
             quote_style,
-            parent_docstring_quote_style,
+            f.context().docstring(),
         );
 
-        if self.options.is_docstring() {
+        if self.layout.is_docstring() {
             docstring::format(&normalized, f)
         } else {
             normalized.fmt(f)

--- a/crates/ruff_python_formatter/src/other/string_literal.rs
+++ b/crates/ruff_python_formatter/src/other/string_literal.rs
@@ -1,12 +1,48 @@
+use ruff_formatter::FormatRuleWithOptions;
 use ruff_python_ast::StringLiteral;
+use ruff_text_size::Ranged;
 
 use crate::prelude::*;
+use crate::string::{docstring, StringContext, StringPart};
+use crate::QuoteStyle;
 
 #[derive(Default)]
-pub struct FormatStringLiteral;
+pub struct FormatStringLiteral {
+    context: StringContext,
+}
+
+impl FormatRuleWithOptions<StringLiteral, PyFormatContext<'_>> for FormatStringLiteral {
+    type Options = StringContext;
+
+    fn with_options(mut self, options: Self::Options) -> Self {
+        self.context = options;
+        self
+    }
+}
 
 impl FormatNodeRule<StringLiteral> for FormatStringLiteral {
-    fn fmt_fields(&self, _item: &StringLiteral, _f: &mut PyFormatter) -> FormatResult<()> {
-        unreachable!("Handled inside of `FormatExprStringLiteral`");
+    fn fmt_fields(&self, item: &StringLiteral, f: &mut PyFormatter) -> FormatResult<()> {
+        let locator = f.context().locator();
+        let parent_docstring_quote_style = f.context().docstring();
+
+        let quote_style = if self.context.is_docstring() {
+            // Per PEP 8 and PEP 257, always prefer double quotes for docstrings
+            QuoteStyle::Double
+        } else {
+            f.options().quote_style()
+        };
+
+        let normalized = StringPart::from_source(item.range(), &locator).normalize(
+            self.context.quoting(),
+            &locator,
+            quote_style,
+            parent_docstring_quote_style,
+        );
+
+        if self.context.is_docstring() {
+            docstring::format(&normalized, f)
+        } else {
+            normalized.fmt(f)
+        }
     }
 }

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -11,7 +11,7 @@ use crate::comments::{
 use crate::context::{NodeLevel, TopLevelStatementPosition, WithIndentLevel, WithNodeLevel};
 use crate::prelude::*;
 use crate::statement::stmt_expr::FormatStmtExpr;
-use crate::string::StringContext;
+use crate::string::StringOptions;
 use crate::verbatim::{
     suppressed_node, write_suppressed_statements_starting_with_leading_comment,
     write_suppressed_statements_starting_with_trailing_comment,
@@ -609,7 +609,7 @@ impl Format<PyFormatContext<'_>> for DocstringStmt<'_> {
                     leading_comments(node_comments.leading),
                     string_literal
                         .format()
-                        .with_options(StringContext::docstring()),
+                        .with_options(StringOptions::docstring()),
                 ]
             )?;
 

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -9,9 +9,9 @@ use crate::comments::{
     leading_comments, trailing_comments, Comments, LeadingDanglingTrailingComments,
 };
 use crate::context::{NodeLevel, TopLevelStatementPosition, WithIndentLevel, WithNodeLevel};
-use crate::expression::string::StringLayout;
 use crate::prelude::*;
 use crate::statement::stmt_expr::FormatStmtExpr;
+use crate::string::StringContext;
 use crate::verbatim::{
     suppressed_node, write_suppressed_statements_starting_with_leading_comment,
     write_suppressed_statements_starting_with_trailing_comment,
@@ -609,7 +609,7 @@ impl Format<PyFormatContext<'_>> for DocstringStmt<'_> {
                     leading_comments(node_comments.leading),
                     string_literal
                         .format()
-                        .with_options(StringLayout::DocString),
+                        .with_options(StringContext::docstring()),
                 ]
             )?;
 

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -9,9 +9,9 @@ use crate::comments::{
     leading_comments, trailing_comments, Comments, LeadingDanglingTrailingComments,
 };
 use crate::context::{NodeLevel, TopLevelStatementPosition, WithIndentLevel, WithNodeLevel};
+use crate::expression::expr_string_literal::ExprStringLiteralKind;
 use crate::prelude::*;
 use crate::statement::stmt_expr::FormatStmtExpr;
-use crate::string::StringOptions;
 use crate::verbatim::{
     suppressed_node, write_suppressed_statements_starting_with_leading_comment,
     write_suppressed_statements_starting_with_trailing_comment,
@@ -609,7 +609,7 @@ impl Format<PyFormatContext<'_>> for DocstringStmt<'_> {
                     leading_comments(node_comments.leading),
                     string_literal
                         .format()
-                        .with_options(StringOptions::docstring()),
+                        .with_options(ExprStringLiteralKind::Docstring),
                 ]
             )?;
 

--- a/crates/ruff_python_formatter/src/string/docstring.rs
+++ b/crates/ruff_python_formatter/src/string/docstring.rs
@@ -102,7 +102,7 @@ use super::{NormalizedString, QuoteChar};
 ///         line c
 ///    """
 /// ```
-pub(super) fn format(normalized: &NormalizedString, f: &mut PyFormatter) -> FormatResult<()> {
+pub(crate) fn format(normalized: &NormalizedString, f: &mut PyFormatter) -> FormatResult<()> {
     let docstring = &normalized.text;
 
     // Black doesn't change the indentation of docstrings that contain an escaped newline


### PR DESCRIPTION
This PR splits the string formatting code in the formatter to be handled by the respective nodes.

Previously, the string formatting was done through a single `FormatString` interface. Now, the nodes themselves are responsible for formatting.

The following changes were made:
1. Remove `StringLayout::ImplicitStringConcatenationInBinaryLike` and inline the call to `FormatStringContinuation`. After the refactor, the binary like formatting would delegate to `FormatString` which would then delegate to `FormatStringContinuation`. This removes the intermediary steps.
2. Add formatter implementation for `FStringPart` which delegates it to the respective string literal or f-string node.
3. Add `ExprStringLiteralKind` which is either `String` or `Docstring`. If it's a docstring variant, then the string expression would not be implicitly concatenated. This is guaranteed by the `DocstringStmt::try_from_expression` constructor.
4. Add `StringLiteralKind` which is either a `String`, `Docstring` or `InImplicitlyConcatenatedFString`. The last variant is for when the string literal is  implicitly concatenated with an f-string (`"foo" f"bar {x}"`).
5. Remove `FormatString`.
6. Extract the f-string quote detection as a standalone function which is public to the crate. This is used to detect the quote to be used for an f-string at the expression level (`ExprFString` or `FormatStringContinuation`).


### Formatter ecosystem result

**This PR**

| project        | similarity index  | total files       | changed files     |
|----------------|------------------:|------------------:|------------------:|
| cpython        |           0.75804 |              1799 |              1648 |
| django         |           0.99984 |              2772 |                34 |
| home-assistant |           0.99955 |             10596 |               214 |
| poetry         |           0.99905 |               321 |                15 |
| transformers   |           0.99967 |              2657 |               324 |
| twine          |           1.00000 |                33 |                 0 |
| typeshed       |           0.99980 |              3669 |                18 |
| warehouse      |           0.99976 |               654 |                14 |
| zulip          |           0.99958 |              1459 |                36 |

**main**

| project        | similarity index  | total files       | changed files     |
|----------------|------------------:|------------------:|------------------:|
| cpython        |           0.75804 |              1799 |              1648 |
| django         |           0.99984 |              2772 |                34 |
| home-assistant |           0.99955 |             10596 |               214 |
| poetry         |           0.99905 |               321 |                15 |
| transformers   |           0.99967 |              2657 |               324 |
| twine          |           1.00000 |                33 |                 0 |
| typeshed       |           0.99980 |              3669 |                18 |
| warehouse      |           0.99976 |               654 |                14 |
| zulip          |           0.99958 |              1459 |                36 |