### PR TITLE
Allow `EM` fixes even if `msg` variable is defined

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_errmsg/EM.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_errmsg/EM.py
@@ -27,7 +27,7 @@ def f_ok():
     raise RuntimeError(msg)
 
 
-def f_unfixable():
+def f_msg_defined():
     msg = "hello"
     raise RuntimeError("This is an example exception")
 

--- a/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
@@ -191,15 +191,13 @@ pub(crate) fn string_in_exception(checker: &mut Checker, stmt: &Stmt, exc: &Expr
                             if let Some(indentation) =
                                 whitespace::indentation(checker.locator(), stmt)
                             {
-                                if checker.semantic().is_available("msg") {
-                                    diagnostic.set_fix(generate_fix(
-                                        stmt,
-                                        first,
-                                        indentation,
-                                        checker.stylist(),
-                                        checker.locator(),
-                                    ));
-                                }
+                                diagnostic.set_fix(generate_fix(
+                                    stmt,
+                                    first,
+                                    indentation,
+                                    checker.stylist(),
+                                    checker.locator(),
+                                ));
                             }
                             checker.diagnostics.push(diagnostic);
                         }
@@ -211,15 +209,13 @@ pub(crate) fn string_in_exception(checker: &mut Checker, stmt: &Stmt, exc: &Expr
                         let mut diagnostic = Diagnostic::new(FStringInException, first.range());
                         if let Some(indentation) = whitespace::indentation(checker.locator(), stmt)
                         {
-                            if checker.semantic().is_available("msg") {
-                                diagnostic.set_fix(generate_fix(
-                                    stmt,
-                                    first,
-                                    indentation,
-                                    checker.stylist(),
-                                    checker.locator(),
-                                ));
-                            }
+                            diagnostic.set_fix(generate_fix(
+                                stmt,
+                                first,
+                                indentation,
+                                checker.stylist(),
+                                checker.locator(),
+                            ));
                         }
                         checker.diagnostics.push(diagnostic);
                     }
@@ -236,15 +232,13 @@ pub(crate) fn string_in_exception(checker: &mut Checker, stmt: &Stmt, exc: &Expr
                                 if let Some(indentation) =
                                     whitespace::indentation(checker.locator(), stmt)
                                 {
-                                    if checker.semantic().is_available("msg") {
-                                        diagnostic.set_fix(generate_fix(
-                                            stmt,
-                                            first,
-                                            indentation,
-                                            checker.stylist(),
-                                            checker.locator(),
-                                        ));
-                                    }
+                                    diagnostic.set_fix(generate_fix(
+                                        stmt,
+                                        first,
+                                        indentation,
+                                        checker.stylist(),
+                                        checker.locator(),
+                                    ));
                                 }
                                 checker.diagnostics.push(diagnostic);
                             }

--- a/crates/ruff_linter/src/rules/flake8_errmsg/snapshots/ruff_linter__rules__flake8_errmsg__tests__custom.snap
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/snapshots/ruff_linter__rules__flake8_errmsg__tests__custom.snap
@@ -59,14 +59,25 @@ EM.py:22:24: EM103 [*] Exception must not use a `.format()` string directly, ass
 24 25 | 
 25 26 | def f_ok():
 
-EM.py:32:24: EM101 Exception must not use a string literal, assign to variable first
+EM.py:32:24: EM101 [*] Exception must not use a string literal, assign to variable first
    |
-30 | def f_unfixable():
+30 | def f_msg_defined():
 31 |     msg = "hello"
 32 |     raise RuntimeError("This is an example exception")
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EM101
    |
    = help: Assign to variable; remove string literal
+
+ℹ Unsafe fix
+29 29 | 
+30 30 | def f_msg_defined():
+31 31 |     msg = "hello"
+32    |-    raise RuntimeError("This is an example exception")
+   32 |+    msg = "This is an example exception"
+   33 |+    raise RuntimeError(msg)
+33 34 | 
+34 35 | 
+35 36 | def f_msg_in_nested_scope():
 
 EM.py:39:24: EM101 [*] Exception must not use a string literal, assign to variable first
    |
@@ -88,13 +99,24 @@ EM.py:39:24: EM101 [*] Exception must not use a string literal, assign to variab
 41 42 | 
 42 43 | def f_msg_in_parent_scope():
 
-EM.py:46:28: EM101 Exception must not use a string literal, assign to variable first
+EM.py:46:28: EM101 [*] Exception must not use a string literal, assign to variable first
    |
 45 |     def nested():
 46 |         raise RuntimeError("This is an example exception")
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EM101
    |
    = help: Assign to variable; remove string literal
+
+ℹ Unsafe fix
+43 43 |     msg = "hello"
+44 44 | 
+45 45 |     def nested():
+46    |-        raise RuntimeError("This is an example exception")
+   46 |+        msg = "This is an example exception"
+   47 |+        raise RuntimeError(msg)
+47 48 | 
+48 49 | 
+49 50 | def f_fix_indentation_check(foo):
 
 EM.py:51:28: EM101 [*] Exception must not use a string literal, assign to variable first
    |

--- a/crates/ruff_linter/src/rules/flake8_errmsg/snapshots/ruff_linter__rules__flake8_errmsg__tests__defaults.snap
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/snapshots/ruff_linter__rules__flake8_errmsg__tests__defaults.snap
@@ -97,14 +97,25 @@ EM.py:22:24: EM103 [*] Exception must not use a `.format()` string directly, ass
 24 25 | 
 25 26 | def f_ok():
 
-EM.py:32:24: EM101 Exception must not use a string literal, assign to variable first
+EM.py:32:24: EM101 [*] Exception must not use a string literal, assign to variable first
    |
-30 | def f_unfixable():
+30 | def f_msg_defined():
 31 |     msg = "hello"
 32 |     raise RuntimeError("This is an example exception")
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EM101
    |
    = help: Assign to variable; remove string literal
+
+ℹ Unsafe fix
+29 29 | 
+30 30 | def f_msg_defined():
+31 31 |     msg = "hello"
+32    |-    raise RuntimeError("This is an example exception")
+   32 |+    msg = "This is an example exception"
+   33 |+    raise RuntimeError(msg)
+33 34 | 
+34 35 | 
+35 36 | def f_msg_in_nested_scope():
 
 EM.py:39:24: EM101 [*] Exception must not use a string literal, assign to variable first
    |
@@ -126,13 +137,24 @@ EM.py:39:24: EM101 [*] Exception must not use a string literal, assign to variab
 41 42 | 
 42 43 | def f_msg_in_parent_scope():
 
-EM.py:46:28: EM101 Exception must not use a string literal, assign to variable first
+EM.py:46:28: EM101 [*] Exception must not use a string literal, assign to variable first
    |
 45 |     def nested():
 46 |         raise RuntimeError("This is an example exception")
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EM101
    |
    = help: Assign to variable; remove string literal
+
+ℹ Unsafe fix
+43 43 |     msg = "hello"
+44 44 | 
+45 45 |     def nested():
+46    |-        raise RuntimeError("This is an example exception")
+   46 |+        msg = "This is an example exception"
+   47 |+        raise RuntimeError(msg)
+47 48 | 
+48 49 | 
+49 50 | def f_fix_indentation_check(foo):
 
 EM.py:51:28: EM101 [*] Exception must not use a string literal, assign to variable first
    |


### PR DESCRIPTION
This PR updates the `EM` rules to generate the auto-fix even if the `msg` variable is defined in the current scope.

As discussed in https://github.com/astral-sh/ruff/issues/9052.