### PR TITLE
Allow class names when `apps.get_model` is a non-string

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pep8_naming/N806.py
+++ b/crates/ruff_linter/resources/test/fixtures/pep8_naming/N806.py
@@ -55,3 +55,6 @@ def model_assign() -> None:
 
     Bad = apps.get_model()  # N806
     Bad = apps.get_model(model_name="Stream")  # N806
+
+    Address: Type = apps.get_model("zerver", variable)  # OK
+    ValidationError = import_string(variable)  # N806

--- a/crates/ruff_linter/src/rules/pep8_naming/helpers.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/helpers.rs
@@ -112,7 +112,11 @@ pub(super) fn is_django_model_import(name: &str, stmt: &Stmt, semantic: &Semanti
                     arguments.find_argument("model_name", arguments.args.len().saturating_sub(1))
                 {
                     if let Some(string_literal) = argument.as_string_literal_expr() {
-                        return string_literal.value.to_str() == name;
+                        if string_literal.value.to_str() == name {
+                            return true;
+                        }
+                    } else {
+                        return true;
                     }
                 }
             }
@@ -127,7 +131,9 @@ pub(super) fn is_django_model_import(name: &str, stmt: &Stmt, semantic: &Semanti
                 if let Some(argument) = arguments.find_argument("dotted_path", 0) {
                     if let Some(string_literal) = argument.as_string_literal_expr() {
                         if let Some((.., model)) = string_literal.value.to_str().rsplit_once('.') {
-                            return model == name;
+                            if model == name {
+                                return true;
+                            }
                         }
                     }
                 }

--- a/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N806_N806.py.snap
+++ b/crates/ruff_linter/src/rules/pep8_naming/snapshots/ruff_linter__rules__pep8_naming__tests__N806_N806.py.snap
@@ -52,6 +52,15 @@ N806.py:57:5: N806 Variable `Bad` in function should be lowercase
 56 |     Bad = apps.get_model()  # N806
 57 |     Bad = apps.get_model(model_name="Stream")  # N806
    |     ^^^ N806
+58 | 
+59 |     Address: Type = apps.get_model("zerver", variable)  # OK
+   |
+
+N806.py:60:5: N806 Variable `ValidationError` in function should be lowercase
+   |
+59 |     Address: Type = apps.get_model("zerver", variable)  # OK
+60 |     ValidationError = import_string(variable)  # N806
+   |     ^^^^^^^^^^^^^^^ N806
    |
 
 


### PR DESCRIPTION
See: https://github.com/astral-sh/ruff/issues/7675#issuecomment-1848206022