### PR TITLE
Fix typo in documentation

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/delete_full_slice.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/delete_full_slice.rs
@@ -14,7 +14,7 @@ use crate::rules::refurb::helpers::generate_method_call;
 /// dictionary.
 ///
 /// ## Why is this bad?
-/// It's is faster and more succinct to remove all items via the `clear()`
+/// It is faster and more succinct to remove all items via the `clear()`
 /// method.
 ///
 /// ## Known problems

--- a/crates/ruff_python_formatter/CONTRIBUTING.md
+++ b/crates/ruff_python_formatter/CONTRIBUTING.md
@@ -218,7 +218,7 @@ call, for single items `.format().fmt(f)` or `.fmt(f)` is sufficient.
 impl FormatNodeRule<StmtReturn> for FormatStmtReturn {
     fn fmt_fields(&self, item: &StmtReturn, f: &mut PyFormatter) -> FormatResult<()> {
         // Here we destructure item and make sure each field is listed.
-        // We generally don't need range is it's underscore-ignored
+        // We generally don't need range if it's underscore-ignored
         let StmtReturn { range: _, value } = item;
         // Implement some formatting logic, in this case no space (and no value) after a return with
         // no value


### PR DESCRIPTION
## Summary

Fix a couple typos:
- I'm certain about `It's is` → `It is`.
- Not sure about `is it's` → `if it's` because I don't understand the sentence.

## Test Plan

No tests.
