### PR TITLE
Avoid trailing comma for single-argument with positional separator

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/function.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/function.py
@@ -410,3 +410,13 @@ def default_arg_comments2(#
         #
 ):
     print(x)
+
+def function_with_one_argument_and_a_positional_separator(
+    argument: str, /
+) -> ReallyReallyReallyReallyReallyReallyReallyReallyLongName:
+    pass
+
+def function_with_one_argument_and_a_keyword_separator(
+    *, argument: str
+) -> ReallyReallyReallyReallyReallyReallyReallyReallyLongName:
+    pass

--- a/crates/ruff_python_formatter/src/other/parameters.rs
+++ b/crates/ruff_python_formatter/src/other/parameters.rs
@@ -252,7 +252,7 @@ impl FormatNodeRule<Parameters> for FormatParameters {
             let mut f = WithNodeLevel::new(NodeLevel::ParenthesizedExpression, f);
             // No parameters, format any dangling comments between `()`
             write!(f, [empty_parenthesized("(", dangling, ")")])
-        } else if num_parameters == 1 {
+        } else if num_parameters == 1 && posonlyargs.is_empty() && kwonlyargs.is_empty() {
             // If we have a single argument, avoid the inner group, to ensure that we insert a
             // trailing comma if the outer group breaks.
             let mut f = WithNodeLevel::new(NodeLevel::ParenthesizedExpression, f);

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
@@ -416,6 +416,16 @@ def default_arg_comments2(#
         #
 ):
     print(x)
+
+def function_with_one_argument_and_a_positional_separator(
+    argument: str, /
+) -> ReallyReallyReallyReallyReallyReallyReallyReallyLongName:
+    pass
+
+def function_with_one_argument_and_a_keyword_separator(
+    *, argument: str
+) -> ReallyReallyReallyReallyReallyReallyReallyReallyLongName:
+    pass
 ```
 
 ## Output
@@ -993,6 +1003,18 @@ def default_arg_comments2(  #
     #
 ):
     print(x)
+
+
+def function_with_one_argument_and_a_positional_separator(
+    argument: str, /
+) -> ReallyReallyReallyReallyReallyReallyReallyReallyLongName:
+    pass
+
+
+def function_with_one_argument_and_a_keyword_separator(
+    *, argument: str
+) -> ReallyReallyReallyReallyReallyReallyReallyReallyLongName:
+    pass
 ```
 
 


### PR DESCRIPTION
## Summary

In https://github.com/astral-sh/ruff/pull/8921, we changed our parameter formatting behavior to add a trailing comma whenever a single-argument function breaks. This introduced a deviation in the case that a function contains a single argument, but _also_ includes a positional-only or keyword-only separator.

Closes https://github.com/astral-sh/ruff/issues/9074.
