### PR TITLE
RFC/idea: import map command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,6 +2098,7 @@ dependencies = [
  "ruff_notebook",
  "ruff_python_ast",
  "ruff_python_formatter",
+ "ruff_python_parser",
  "ruff_python_stdlib",
  "ruff_python_trivia",
  "ruff_source_file",

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -22,6 +22,7 @@ ruff_formatter = { path = "../ruff_formatter" }
 ruff_notebook = { path = "../ruff_notebook" }
 ruff_macros = { path = "../ruff_macros" }
 ruff_python_ast = { path = "../ruff_python_ast" }
+ruff_python_parser = { path = "../ruff_python_parser" }
 ruff_python_formatter = { path = "../ruff_python_formatter" }
 ruff_source_file = { path = "../ruff_source_file" }
 ruff_python_trivia = { path = "../ruff_python_trivia" }

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -76,6 +76,8 @@ pub enum Command {
     GenerateShellCompletion { shell: clap_complete_command::Shell },
     /// Run the Ruff formatter on the given files or directories.
     Format(FormatCommand),
+    /// (Experimental.) Generate a mapping of module imports.
+    ImportMap(ImportMapCommand),
     /// Display Ruff's version
     Version {
         #[arg(long, value_enum, default_value = "text")]
@@ -432,6 +434,19 @@ pub struct FormatCommand {
     preview: bool,
     #[clap(long, overrides_with("preview"), hide = true)]
     no_preview: bool,
+}
+
+#[derive(Clone, Debug, clap::Parser)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct ImportMapCommand {
+    /// List of files or directories to inspect.
+    #[clap(help = "List of files or directories to inspect [default: .]")]
+    pub files: Vec<PathBuf>,
+    /// Path to the `pyproject.toml` or `ruff.toml` file to use for configuration.
+    #[arg(long, conflicts_with = "isolated")]
+    pub config: Option<PathBuf>,
+    #[arg(long, conflicts_with = "config", help_heading = "Miscellaneous")]
+    pub isolated: bool,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]

--- a/crates/ruff_cli/src/commands/import_map.rs
+++ b/crates/ruff_cli/src/commands/import_map.rs
@@ -1,0 +1,133 @@
+use anyhow::Result;
+use log::{error, warn};
+use rustc_hash::FxHashMap;
+
+use ruff_linter::source_kind::SourceKind;
+use ruff_linter::warn_user_once;
+use ruff_python_ast::helpers::to_module_path;
+use ruff_python_ast::imports::{populate_module_imports, ImportMap, ModuleImport};
+use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
+use ruff_python_ast::Stmt;
+use ruff_python_ast::{SourceType, Suite};
+use ruff_python_parser::parse_suite;
+use ruff_workspace::resolver::{python_files_in_path, ResolvedFile};
+
+use crate::args::{CliOverrides, ImportMapCommand};
+use crate::resolve::resolve;
+use crate::{resolve_default_files, ExitStatus};
+
+/// Export imports for the given files.
+pub(crate) fn import_map(cli: ImportMapCommand) -> Result<ExitStatus> {
+    let overrides = CliOverrides::default(); // TODO
+    let pyproject_config = resolve(cli.isolated, cli.config.as_deref(), &overrides, None)?;
+    let files = resolve_default_files(cli.files, false);
+    let (paths, resolver) = python_files_in_path(&files, &pyproject_config, &overrides)?;
+
+    if paths.is_empty() {
+        warn_user_once!("No Python files found under the given path(s)");
+        return Ok(ExitStatus::Success);
+    }
+
+    // Discover the package root for each Python file.
+    let package_roots = resolver.package_roots(
+        &paths
+            .iter()
+            .flatten()
+            .map(ResolvedFile::path)
+            .collect::<Vec<_>>(),
+        &pyproject_config,
+    );
+
+    let mut errors = 0;
+    let mut import_map = ImportMap::new();
+    let mut path_to_module_path = FxHashMap::default();
+
+    // TODO: par_iter() where possible
+    for ent in paths.iter() {
+        match ent {
+            Ok(resolved_file) => {
+                let path = resolved_file.path();
+                let SourceType::Python(source_type) = SourceType::from(&path) else {
+                    continue;
+                };
+                let source_kind = match SourceKind::from_path(path, source_type) {
+                    Ok(Some(source_kind)) => source_kind,
+                    _ => panic!("Failed to read source file"),
+                };
+
+                let package = path
+                    .parent()
+                    .and_then(|parent| package_roots.get(parent).copied())
+                    .flatten();
+
+                let Some(package) = package else {
+                    continue; // TODO: report?
+                };
+                let Some(module_path) = to_module_path(package, path) else {
+                    continue; // TODO: report?
+                };
+
+                let dotted_module_path = module_path.join(".");
+                path_to_module_path.insert(
+                    dotted_module_path.clone(),
+                    path.to_string_lossy().to_string(),
+                );
+
+                match parse_suite(source_kind.source_code(), &path.to_string_lossy()) {
+                    Ok(python_ast) => {
+                        let module_imports = extract_imports(&python_ast, &module_path);
+                        import_map.insert(dotted_module_path, module_imports);
+                    }
+                    Err(parse_error) => {
+                        errors += 1;
+                        error!(
+                            "Failed to parse {path}: {error}",
+                            path = path.display(),
+                            error = parse_error
+                        );
+                    }
+                };
+            }
+            Err(error) => {
+                error!("{error}");
+                errors += 1;
+            }
+        }
+    }
+    // TODO: come up with an actual JSON format
+    println!("{}", serde_json::to_string(&import_map)?);
+    println!("{}", serde_json::to_string(&path_to_module_path)?);
+
+    if errors > 0 {
+        Ok(ExitStatus::Success)
+    } else {
+        Ok(ExitStatus::Error)
+    }
+}
+
+#[derive(Debug, Default)]
+struct ImportStmtFinder<'a> {
+    imports: Vec<&'a Stmt>,
+}
+
+impl<'a, 'b> StatementVisitor<'b> for ImportStmtFinder<'a>
+where
+    'b: 'a,
+{
+    fn visit_stmt(&mut self, stmt: &'b Stmt) {
+        match stmt {
+            Stmt::Import(_) | Stmt::ImportFrom(_) => self.imports.push(stmt),
+            _ => walk_stmt(self, stmt),
+        }
+    }
+}
+
+fn extract_imports(python_ast: &Suite, module_path: &Vec<String>) -> Vec<ModuleImport> {
+    let mut visitor = ImportStmtFinder::default();
+    visitor.visit_body(python_ast);
+    let mut module_imports = Vec::with_capacity(visitor.imports.len());
+    for stmt in visitor.imports {
+        populate_module_imports(&mut module_imports, &module_path, stmt);
+    }
+    module_imports
+}

--- a/crates/ruff_cli/src/commands/mod.rs
+++ b/crates/ruff_cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod clean;
 pub(crate) mod config;
 pub(crate) mod format;
 pub(crate) mod format_stdin;
+pub(crate) mod import_map;
 pub(crate) mod linter;
 pub(crate) mod rule;
 pub(crate) mod show_files;

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -200,6 +200,7 @@ pub fn run(
         }
         Command::Check(args) => check(args, log_level),
         Command::Format(args) => format(args, log_level),
+        Command::ImportMap(args) => commands::import_map::import_map(args),
     }
 }
 

--- a/crates/ruff_linter/src/checkers/imports.rs
+++ b/crates/ruff_linter/src/checkers/imports.rs
@@ -1,17 +1,15 @@
 //! Lint rules based on import analysis.
-use std::borrow::Cow;
 use std::path::Path;
 
 use ruff_diagnostics::Diagnostic;
 use ruff_notebook::CellOffsets;
 use ruff_python_ast::helpers::to_module_path;
-use ruff_python_ast::imports::{ImportMap, ModuleImport};
+use ruff_python_ast::imports::{populate_module_imports, ImportMap};
 use ruff_python_ast::statement_visitor::StatementVisitor;
-use ruff_python_ast::{self as ast, PySourceType, Stmt, Suite};
+use ruff_python_ast::{PySourceType, Suite};
 use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;
 use ruff_source_file::Locator;
-use ruff_text_size::Ranged;
 
 use crate::directives::IsortDirectives;
 use crate::registry::Rule;
@@ -30,44 +28,7 @@ fn extract_import_map(path: &Path, package: Option<&Path>, blocks: &[&Block]) ->
     let num_imports = blocks.iter().map(|block| block.imports.len()).sum();
     let mut module_imports = Vec::with_capacity(num_imports);
     for stmt in blocks.iter().flat_map(|block| &block.imports) {
-        match stmt {
-            Stmt::Import(ast::StmtImport { names, range: _ }) => {
-                module_imports.extend(
-                    names
-                        .iter()
-                        .map(|name| ModuleImport::new(name.name.to_string(), stmt.range())),
-                );
-            }
-            Stmt::ImportFrom(ast::StmtImportFrom {
-                module,
-                names,
-                level,
-                range: _,
-            }) => {
-                let level = level.unwrap_or_default() as usize;
-                let module = if let Some(module) = module {
-                    let module: &String = module.as_ref();
-                    if level == 0 {
-                        Cow::Borrowed(module)
-                    } else {
-                        if module_path.len() <= level {
-                            continue;
-                        }
-                        let prefix = module_path[..module_path.len() - level].join(".");
-                        Cow::Owned(format!("{prefix}.{module}"))
-                    }
-                } else {
-                    if module_path.len() <= level {
-                        continue;
-                    }
-                    Cow::Owned(module_path[..module_path.len() - level].join("."))
-                };
-                module_imports.extend(names.iter().map(|name| {
-                    ModuleImport::new(format!("{}.{}", module, name.name), name.range())
-                }));
-            }
-            _ => panic!("Expected Stmt::Import | Stmt::ImportFrom"),
-        }
+        populate_module_imports(&mut module_imports, &module_path, stmt);
     }
 
     let mut import_map = ImportMap::default();


### PR DESCRIPTION
## Summary

This PR experiments with a new top-level command `ruff import-map` (nomenclature subject to change and discussion).

Since Ruff is pretty fast at parsing Python and it already needs to figure out import maps internally (the type being aptly named `ImportMap`), I think it would be useful to be able to export those in a machine-readable format too, for instance to act as a backend for something like [`pydeps`](https://github.com/thebjorn/pydeps) – or in my case, I'd like to find names in a codebase that aren't being imported by anything else. (I tried `pydeps` and ran out of patience.)

As you can see, 
* there's a whole bunch of TODOs
* documentation is lacking
* the output stage just YOLO dumps serde_json
* the code is copy-paste-cannibalized from `format.rs` and `checkers/imports.rs`
* I'm honestly not sure I'm using the correct abstraction level of APIs for reading the files (is there a "just give me an AST" API?)
* probably other things

but I figured I'd preferably get some code out there rather than just discussion 😁 

WDYT, should I continue with this, would it be accepted in some form?

## Test Plan

No good test plan yet other than trying out e.g.

```
cargo run --bin=ruff -- import-map ../home-assistant-core
```
to see that it doesn't explode. (It doesn't, and the current non-cached, non-parallel implementation takes about 8 seconds to suss out and JSON dump exports from about 11,000 Python files there.)