### PR TITLE
Allow `matplotlib.use` calls to intersperse imports

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E402.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E402.py
@@ -24,21 +24,27 @@ sys.path.insert(0, "some/path")
 
 import f
 
-__some__magic = 1
+import matplotlib
+
+matplotlib.use("Agg")
 
 import g
 
+__some__magic = 1
+
+import h
+
 
 def foo() -> None:
-    import h
-
-
-if __name__ == "__main__":
     import i
 
-import j; import k
+
+if __name__ == "__main__":
+    import j
+
+import k; import l
 
 
 if __name__ == "__main__":
-    import l; \
-import m
+    import m; \
+import n

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -306,6 +306,7 @@ where
                 if !(self.semantic.seen_import_boundary()
                     || helpers::is_assignment_to_a_dunder(stmt)
                     || helpers::in_nested_block(self.semantic.current_statements())
+                    || imports::is_matplotlib_activation(stmt, self.semantic())
                     || self.settings.preview.is_enabled()
                         && imports::is_sys_path_modification(stmt, self.semantic()))
                 {

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E402_E402.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E402_E402.py.snap
@@ -8,30 +8,50 @@ E402.py:25:1: E402 Module level import not at top of file
 25 | import f
    | ^^^^^^^^ E402
 26 | 
-27 | __some__magic = 1
+27 | import matplotlib
    |
 
-E402.py:29:1: E402 Module level import not at top of file
+E402.py:27:1: E402 Module level import not at top of file
    |
-27 | __some__magic = 1
+25 | import f
+26 | 
+27 | import matplotlib
+   | ^^^^^^^^^^^^^^^^^ E402
 28 | 
-29 | import g
+29 | matplotlib.use("Agg")
+   |
+
+E402.py:31:1: E402 Module level import not at top of file
+   |
+29 | matplotlib.use("Agg")
+30 | 
+31 | import g
+   | ^^^^^^^^ E402
+32 | 
+33 | __some__magic = 1
+   |
+
+E402.py:35:1: E402 Module level import not at top of file
+   |
+33 | __some__magic = 1
+34 | 
+35 | import h
    | ^^^^^^^^ E402
    |
 
-E402.py:39:1: E402 Module level import not at top of file
+E402.py:45:1: E402 Module level import not at top of file
    |
-37 |     import i
-38 | 
-39 | import j; import k
+43 |     import j
+44 | 
+45 | import k; import l
    | ^^^^^^^^ E402
    |
 
-E402.py:39:11: E402 Module level import not at top of file
+E402.py:45:11: E402 Module level import not at top of file
    |
-37 |     import i
-38 | 
-39 | import j; import k
+43 |     import j
+44 | 
+45 | import k; import l
    |           ^^^^^^^^ E402
    |
 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__E402_E402.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__E402_E402.py.snap
@@ -1,27 +1,27 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E402.py:29:1: E402 Module level import not at top of file
+E402.py:35:1: E402 Module level import not at top of file
    |
-27 | __some__magic = 1
-28 | 
-29 | import g
+33 | __some__magic = 1
+34 | 
+35 | import h
    | ^^^^^^^^ E402
    |
 
-E402.py:39:1: E402 Module level import not at top of file
+E402.py:45:1: E402 Module level import not at top of file
    |
-37 |     import i
-38 | 
-39 | import j; import k
+43 |     import j
+44 | 
+45 | import k; import l
    | ^^^^^^^^ E402
    |
 
-E402.py:39:11: E402 Module level import not at top of file
+E402.py:45:11: E402 Module level import not at top of file
    |
-37 |     import i
-38 | 
-39 | import j; import k
+43 |     import j
+44 | 
+45 | import k; import l
    |           ^^^^^^^^ E402
    |
 

--- a/crates/ruff_python_semantic/src/analyze/imports.rs
+++ b/crates/ruff_python_semantic/src/analyze/imports.rs
@@ -35,3 +35,21 @@ pub fn is_sys_path_modification(stmt: &Stmt, semantic: &SemanticModel) -> bool {
             )
         })
 }
+
+/// Returns `true` if a [`Stmt`] is a `matplotlib.use` activation, as in:
+/// ```python
+/// import matplotlib
+///
+/// matplotlib.use("Agg")
+/// ```
+pub fn is_matplotlib_activation(stmt: &Stmt, semantic: &SemanticModel) -> bool {
+    let Stmt::Expr(ast::StmtExpr { value, range: _ }) = stmt else {
+        return false;
+    };
+    let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() else {
+        return false;
+    };
+    semantic
+        .resolve_call_path(func.as_ref())
+        .is_some_and(|call_path| matches!(call_path.as_slice(), ["matplotlib", "use"]))
+}


### PR DESCRIPTION
This PR allows `matplotlib.use` calls to intersperse imports without triggering `E402`. This is a pragmatic choice as it's common to require `matplotlib.use` calls prior to importing from within `matplotlib` itself.

Closes https://github.com/astral-sh/ruff/issues/9091.