### PR TITLE
Hide unsafe fix suggestions when explicitly disabled

### DIFF
--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -125,15 +125,7 @@ impl Printer {
                 if let Some(fixables) = fixables {
                     let fix_prefix = format!("[{}]", "*".cyan());
 
-                    if self.unsafe_fixes.is_enabled() {
-                        if fixables.applicable > 0 {
-                            writeln!(
-                                writer,
-                                "{fix_prefix} {} fixable with the --fix option.",
-                                fixables.applicable
-                            )?;
-                        }
-                    } else {
+                    if self.unsafe_fixes.is_hint() {
                         if fixables.applicable > 0 && fixables.unapplicable_unsafe > 0 {
                             let es = if fixables.unapplicable_unsafe == 1 {
                                 ""
@@ -161,6 +153,14 @@ impl Printer {
                             writeln!(writer,
                                 "No fixes available ({} hidden fix{es} can be enabled with the `--unsafe-fixes` option).",
                                 fixables.unapplicable_unsafe
+                            )?;
+                        }
+                    } else {
+                        if fixables.applicable > 0 {
+                            writeln!(
+                                writer,
+                                "{fix_prefix} {} fixable with the --fix option.",
+                                fixables.applicable
                             )?;
                         }
                     }

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -1159,6 +1159,44 @@ fn check_hints_hidden_unsafe_fixes_with_no_safe_fixes() {
 }
 
 #[test]
+fn check_no_hint_for_hidden_unsafe_fixes_when_disabled() {
+    let mut cmd = RuffCheck::default()
+        .args(["--select", "F601,UP034", "--no-unsafe-fixes"])
+        .build();
+    assert_cmd_snapshot!(cmd
+        .pass_stdin("x = {'a': 1, 'a': 1}\nprint(('foo'))\n"),
+        @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:14: F601 Dictionary key literal `'a'` repeated
+    -:2:7: UP034 [*] Avoid extraneous parentheses
+    Found 2 errors.
+    [*] 1 fixable with the --fix option.
+
+    ----- stderr -----
+    "###);
+}
+
+#[test]
+fn check_no_hint_for_hidden_unsafe_fixes_with_no_safe_fixes_when_disabled() {
+    let mut cmd = RuffCheck::default()
+        .args(["--select", "F601", "--no-unsafe-fixes"])
+        .build();
+    assert_cmd_snapshot!(cmd
+        .pass_stdin("x = {'a': 1, 'a': 1}\n"),
+        @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:14: F601 Dictionary key literal `'a'` repeated
+    Found 1 error.
+
+    ----- stderr -----
+    "###);
+}
+
+#[test]
 fn check_shows_unsafe_fixes_with_opt_in() {
     let mut cmd = RuffCheck::default()
         .args(["--select", "F601,UP034", "--unsafe-fixes"])

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -119,16 +119,21 @@ impl From<bool> for PreviewMode {
     }
 }
 
+/// Toggle for unsafe fixes.
+/// `Hint` will not apply unsafe fixes but a message will be shown when they are available.
+/// `Disabled` will not apply unsafe fixes or show a message.
+/// `Enabled` will apply unsafe fixes.
 #[derive(Debug, Copy, Clone, CacheKey, Default, PartialEq, Eq, is_macro::Is)]
 pub enum UnsafeFixes {
     #[default]
+    Hint,
     Disabled,
     Enabled,
 }
 
 impl From<bool> for UnsafeFixes {
-    fn from(version: bool) -> Self {
-        if version {
+    fn from(value: bool) -> Self {
+        if value {
             UnsafeFixes::Enabled
         } else {
             UnsafeFixes::Disabled
@@ -140,7 +145,7 @@ impl UnsafeFixes {
     pub fn required_applicability(&self) -> Applicability {
         match self {
             Self::Enabled => Applicability::Unsafe,
-            Self::Disabled => Applicability::Safe,
+            Self::Disabled | Self::Hint => Applicability::Safe,
         }
     }
 }

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -93,8 +93,10 @@ pub struct Options {
     pub fix: Option<bool>,
 
     /// Enable application of unsafe fixes.
+    /// If excluded, a hint will be displayed when unsafe fixes are available.
+    /// If set to false, the hint will be hidden.
     #[option(
-        default = "false",
+        default = r#"null"#,
         value_type = "bool",
         example = "unsafe-fixes = true"
     )]

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -203,6 +203,9 @@ ruff check . --unsafe-fixes
 ruff check . --fix --unsafe-fixes
 ```
 
+By default, Ruff will display a hint when unsafe fixes are available but not enabled. The suggestion can be silenced
+by setting the [`unsafe-fixes`](settings.md#unsafe-fixes) setting to `false` or using the `--no-unsafe-fixes` flag.
+
 The safety of fixes can be adjusted per rule using the [`extend-safe-fixes`](settings.md#extend-safe-fixes) and [`extend-unsafe-fixes`](settings.md#extend-unsafe-fixes) settings.
 
 For example, the following configuration would promote unsafe fixes for `F601` to safe fixes and demote safe fixes for `UP034` to unsafe fixes:

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -690,7 +690,7 @@
       }
     },
     "unsafe-fixes": {
-      "description": "Enable application of unsafe fixes.",
+      "description": "Enable application of unsafe fixes. If excluded, a hint will be displayed when unsafe fixes are available. If set to false, the hint will be hidden.",
       "type": [
         "boolean",
         "null"


### PR DESCRIPTION
Hides hints about unsafe fixes when they are disabled e.g. with `--no-unsafe-fixes` or `unsafe-fixes = false`. By default, unsafe fix hints are still displayed. This seems like a nice way to remove the nag for users who have chosen not to apply unsafe fixes.

Inspired by comment at https://github.com/astral-sh/ruff/issues/9063#issuecomment-1850289675