### PR TITLE
E274: allow tab indentation before keyword

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E27.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E27.py
@@ -60,3 +60,6 @@ def f():
 if (a and
     b):
     pass
+#: Okay
+def f():
+	return 1

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/mod.rs
@@ -381,20 +381,16 @@ impl Whitespace {
             }
         }
 
-        if has_tabs {
+        if len == content.text_len() {
+            // All whitespace up to the start of the line -> Indent
+            (Self::None, TextSize::default())
+        } else if has_tabs {
             (Self::Tab, len)
         } else {
             match count {
                 0 => (Self::None, TextSize::default()),
                 1 => (Self::Single, len),
-                _ => {
-                    if len == content.text_len() {
-                        // All whitespace up to the start of the line -> Indent
-                        (Self::None, TextSize::default())
-                    } else {
-                        (Self::Many, len)
-                    }
-                }
+                _ => (Self::Many, len),
             }
         }
     }


### PR DESCRIPTION
## Summary

E274 currently flags any keyword at the start of a line indented with tabs. This turns out to be due to a bug in `Whitespace::trailing` that never considers any whitespace containing a tab as indentation.

## Test Plan

Added a simple test case.