### PR TITLE
Support floating-point base in FURB163

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB163.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB163.py
@@ -16,6 +16,8 @@ special_log(1, 2)
 special_log(1, 10)
 special_log(1, math.e)
 special_log(1, special_e)
+math.log(1, 2.0)
+math.log(1, 10.0)
 
 # Ok.
 math.log2(1)
@@ -45,3 +47,6 @@ def log(*args):
 log(1, 2)
 log(1, 10)
 log(1, math.e)
+
+math.log(1, 2.0001)
+math.log(1, 10.0001)

--- a/crates/ruff_linter/src/rules/refurb/rules/redundant_log_base.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/redundant_log_base.rs
@@ -130,6 +130,8 @@ fn is_number_literal(expr: &Expr, value: i8) -> bool {
     if let Expr::NumberLiteral(number_literal) = expr {
         if let Number::Int(number) = &number_literal.value {
             return number.as_i8().is_some_and(|number| number == value);
+        } else if let Number::Float(number) = number_literal.value {
+            return number == f64::from(value);
         }
     }
     false

--- a/crates/ruff_linter/src/rules/refurb/rules/redundant_log_base.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/redundant_log_base.rs
@@ -131,6 +131,7 @@ fn is_number_literal(expr: &Expr, value: i8) -> bool {
         if let Number::Int(number) = &number_literal.value {
             return number.as_i8().is_some_and(|number| number == value);
         } else if let Number::Float(number) = number_literal.value {
+            #[allow(clippy::float_cmp)]
             return number == f64::from(value);
         }
     }

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB163_FURB163.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB163_FURB163.py.snap
@@ -187,7 +187,7 @@ FURB163.py:16:1: FURB163 [*] Prefer `math.log10(1)` over `math.log` with a redun
    16 |+math.log10(1)
 17 17 | special_log(1, math.e)
 18 18 | special_log(1, special_e)
-19 19 | 
+19 19 | math.log(1, 2.0)
 
 FURB163.py:17:1: FURB163 [*] Prefer `math.log(1)` over `math.log` with a redundant base
    |
@@ -196,6 +196,7 @@ FURB163.py:17:1: FURB163 [*] Prefer `math.log(1)` over `math.log` with a redunda
 17 | special_log(1, math.e)
    | ^^^^^^^^^^^^^^^^^^^^^^ FURB163
 18 | special_log(1, special_e)
+19 | math.log(1, 2.0)
    |
    = help: Replace with `math.log(1)`
 
@@ -206,8 +207,8 @@ FURB163.py:17:1: FURB163 [*] Prefer `math.log(1)` over `math.log` with a redunda
 17    |-special_log(1, math.e)
    17 |+math.log(1)
 18 18 | special_log(1, special_e)
-19 19 | 
-20 20 | # Ok.
+19 19 | math.log(1, 2.0)
+20 20 | math.log(1, 10.0)
 
 FURB163.py:18:1: FURB163 [*] Prefer `math.log(1)` over `math.log` with a redundant base
    |
@@ -215,8 +216,8 @@ FURB163.py:18:1: FURB163 [*] Prefer `math.log(1)` over `math.log` with a redunda
 17 | special_log(1, math.e)
 18 | special_log(1, special_e)
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ FURB163
-19 | 
-20 | # Ok.
+19 | math.log(1, 2.0)
+20 | math.log(1, 10.0)
    |
    = help: Replace with `math.log(1)`
 
@@ -226,8 +227,49 @@ FURB163.py:18:1: FURB163 [*] Prefer `math.log(1)` over `math.log` with a redunda
 17 17 | special_log(1, math.e)
 18    |-special_log(1, special_e)
    18 |+math.log(1)
-19 19 | 
-20 20 | # Ok.
-21 21 | math.log2(1)
+19 19 | math.log(1, 2.0)
+20 20 | math.log(1, 10.0)
+21 21 | 
+
+FURB163.py:19:1: FURB163 [*] Prefer `math.log2(1)` over `math.log` with a redundant base
+   |
+17 | special_log(1, math.e)
+18 | special_log(1, special_e)
+19 | math.log(1, 2.0)
+   | ^^^^^^^^^^^^^^^^ FURB163
+20 | math.log(1, 10.0)
+   |
+   = help: Replace with `math.log2(1)`
+
+ℹ Safe fix
+16 16 | special_log(1, 10)
+17 17 | special_log(1, math.e)
+18 18 | special_log(1, special_e)
+19    |-math.log(1, 2.0)
+   19 |+math.log2(1)
+20 20 | math.log(1, 10.0)
+21 21 | 
+22 22 | # Ok.
+
+FURB163.py:20:1: FURB163 [*] Prefer `math.log10(1)` over `math.log` with a redundant base
+   |
+18 | special_log(1, special_e)
+19 | math.log(1, 2.0)
+20 | math.log(1, 10.0)
+   | ^^^^^^^^^^^^^^^^^ FURB163
+21 | 
+22 | # Ok.
+   |
+   = help: Replace with `math.log10(1)`
+
+ℹ Safe fix
+17 17 | special_log(1, math.e)
+18 18 | special_log(1, special_e)
+19 19 | math.log(1, 2.0)
+20    |-math.log(1, 10.0)
+   20 |+math.log10(1)
+21 21 | 
+22 22 | # Ok.
+23 23 | math.log2(1)
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Check floating-point numbers similarly to integers in FURB163. For example, both `math.log(x, 10)` and `math.log(x, 10.0)` should be changed to `math.log10(x)`.

## Test Plan

<!-- How was it tested? -->

Added couple of test cases.