### PR TITLE
Add `as_slice` method for all string nodes

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -1277,7 +1277,7 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
         }
         Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => {
             if checker.enabled(Rule::UnicodeKindPrefix) {
-                for string_part in value.parts() {
+                for string_part in value {
                     pyupgrade::rules::unicode_kind_prefix(checker, string_part);
                 }
             }

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
@@ -57,7 +57,7 @@ impl Violation for HardcodedSQLExpression {
 /// becomes `foobar {x}baz`.
 fn concatenated_f_string(expr: &ast::ExprFString, locator: &Locator) -> String {
     expr.value
-        .parts()
+        .iter()
         .filter_map(|part| {
             raw_contents(locator.slice(part)).map(|s| s.escape_default().to_string())
         })

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -56,7 +56,7 @@ pub(super) fn is_empty_or_null_string(expr: &Expr) -> bool {
         Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => value.is_empty(),
         Expr::NoneLiteral(_) => true,
         Expr::FString(ast::ExprFString { value, .. }) => {
-            value.parts().all(|f_string_part| match f_string_part {
+            value.iter().all(|f_string_part| match f_string_part {
                 ast::FStringPart::Literal(literal) => literal.is_empty(),
                 ast::FStringPart::FString(f_string) => f_string
                     .elements

--- a/crates/ruff_linter/src/rules/pylint/rules/assert_on_string_literal.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/assert_on_string_literal.rs
@@ -70,7 +70,7 @@ pub(crate) fn assert_on_string_literal(checker: &mut Checker, test: &Expr) {
             ));
         }
         Expr::FString(ast::ExprFString { value, .. }) => {
-            let kind = if value.parts().all(|f_string_part| match f_string_part {
+            let kind = if value.iter().all(|f_string_part| match f_string_part {
                 ast::FStringPart::Literal(literal) => literal.is_empty(),
                 ast::FStringPart::FString(f_string) => {
                     f_string.elements.iter().all(|element| match element {
@@ -82,7 +82,7 @@ pub(crate) fn assert_on_string_literal(checker: &mut Checker, test: &Expr) {
                 }
             }) {
                 Kind::Empty
-            } else if value.parts().any(|f_string_part| match f_string_part {
+            } else if value.iter().any(|f_string_part| match f_string_part {
                 ast::FStringPart::Literal(literal) => !literal.is_empty(),
                 ast::FStringPart::FString(f_string) => {
                     f_string.elements.iter().any(|element| match element {

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
@@ -90,7 +90,7 @@ pub(crate) fn raise_vanilla_args(checker: &mut Checker, expr: &Expr) {
 fn contains_message(expr: &Expr) -> bool {
     match expr {
         Expr::FString(ast::ExprFString { value, .. }) => {
-            for f_string_part in value.parts() {
+            for f_string_part in value {
                 match f_string_part {
                     ast::FStringPart::Literal(literal) => {
                         if literal.chars().any(char::is_whitespace) {

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -583,10 +583,10 @@ impl<'a> From<ast::LiteralExpressionRef<'a>> for ComparableLiteral<'a> {
                 value, ..
             }) => Self::Bool(value),
             ast::LiteralExpressionRef::StringLiteral(ast::ExprStringLiteral { value, .. }) => {
-                Self::Str(value.parts().map(Into::into).collect())
+                Self::Str(value.iter().map(Into::into).collect())
             }
             ast::LiteralExpressionRef::BytesLiteral(ast::ExprBytesLiteral { value, .. }) => {
-                Self::Bytes(value.parts().map(Into::into).collect())
+                Self::Bytes(value.iter().map(Into::into).collect())
             }
             ast::LiteralExpressionRef::NumberLiteral(ast::ExprNumberLiteral { value, .. }) => {
                 Self::Number(value.into())
@@ -1012,17 +1012,17 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
             }),
             ast::Expr::FString(ast::ExprFString { value, range: _ }) => {
                 Self::FString(ExprFString {
-                    parts: value.parts().map(Into::into).collect(),
+                    parts: value.iter().map(Into::into).collect(),
                 })
             }
             ast::Expr::StringLiteral(ast::ExprStringLiteral { value, range: _ }) => {
                 Self::StringLiteral(ExprStringLiteral {
-                    parts: value.parts().map(Into::into).collect(),
+                    parts: value.iter().map(Into::into).collect(),
                 })
             }
             ast::Expr::BytesLiteral(ast::ExprBytesLiteral { value, range: _ }) => {
                 Self::BytesLiteral(ExprBytesLiteral {
-                    parts: value.parts().map(Into::into).collect(),
+                    parts: value.iter().map(Into::into).collect(),
                 })
             }
             ast::Expr::NumberLiteral(ast::ExprNumberLiteral { value, range: _ }) => {

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1326,7 +1326,7 @@ impl Truthiness {
             Expr::NoneLiteral(_) => Self::Falsey,
             Expr::EllipsisLiteral(_) => Self::Truthy,
             Expr::FString(ast::ExprFString { value, .. }) => {
-                if value.parts().all(|part| match part {
+                if value.iter().all(|part| match part {
                     ast::FStringPart::Literal(string_literal) => string_literal.is_empty(),
                     ast::FStringPart::FString(f_string) => f_string.elements.is_empty(),
                 }) {

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -2742,7 +2742,7 @@ impl AstNode for ast::ExprFString {
     {
         let ast::ExprFString { value, range: _ } = self;
 
-        for f_string_part in value.parts() {
+        for f_string_part in value {
             match f_string_part {
                 ast::FStringPart::Literal(string_literal) => {
                     visitor.visit_string_literal(string_literal);
@@ -2788,7 +2788,7 @@ impl AstNode for ast::ExprStringLiteral {
     {
         let ast::ExprStringLiteral { value, range: _ } = self;
 
-        for string_literal in value.parts() {
+        for string_literal in value {
             visitor.visit_string_literal(string_literal);
         }
     }
@@ -2827,7 +2827,7 @@ impl AstNode for ast::ExprBytesLiteral {
     {
         let ast::ExprBytesLiteral { value, range: _ } = self;
 
-        for bytes_literal in value.parts() {
+        for bytes_literal in value {
             visitor.visit_bytes_literal(bytes_literal);
         }
     }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1051,6 +1051,14 @@ impl FStringValue {
         matches!(self.inner, FStringValueInner::Concatenated(_))
     }
 
+    /// Returns a slice of all the [`FStringPart`]s contained in this value.
+    pub fn as_slice(&self) -> &[FStringPart] {
+        match &self.inner {
+            FStringValueInner::Single(part) => std::slice::from_ref(part),
+            FStringValueInner::Concatenated(parts) => parts,
+        }
+    }
+
     /// Returns an iterator over all the [`FStringPart`]s contained in this value.
     pub fn parts(&self) -> impl Iterator<Item = &FStringPart> {
         match &self.inner {
@@ -1239,6 +1247,14 @@ impl StringLiteralValue {
     /// string literal is a unicode string.
     pub fn is_unicode(&self) -> bool {
         self.parts().next().map_or(false, |part| part.unicode)
+    }
+
+    /// Returns a slice of all the [`StringLiteral`] parts contained in this value.
+    pub fn as_slice(&self) -> &[StringLiteral] {
+        match &self.inner {
+            StringLiteralValueInner::Single(value) => std::slice::from_ref(value),
+            StringLiteralValueInner::Concatenated(value) => value.strings.as_slice(),
+        }
     }
 
     /// Returns an iterator over all the [`StringLiteral`] parts contained in this value.
@@ -1455,6 +1471,14 @@ impl BytesLiteralValue {
     /// Returns `true` if the bytes literal is implicitly concatenated.
     pub const fn is_implicit_concatenated(&self) -> bool {
         matches!(self.inner, BytesLiteralValueInner::Concatenated(_))
+    }
+
+    /// Returns a slice of all the [`BytesLiteral`] parts contained in this value.
+    pub fn as_slice(&self) -> &[BytesLiteral] {
+        match &self.inner {
+            BytesLiteralValueInner::Single(value) => std::slice::from_ref(value),
+            BytesLiteralValueInner::Concatenated(value) => value.as_slice(),
+        }
     }
 
     /// Returns an iterator over all the [`BytesLiteral`] parts contained in this value.

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -477,7 +477,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
             visitor.visit_arguments(arguments);
         }
         Expr::FString(ast::ExprFString { value, .. }) => {
-            for part in value.parts() {
+            for part in value {
                 match part {
                     FStringPart::Literal(string_literal) => {
                         visitor.visit_string_literal(string_literal);
@@ -487,12 +487,12 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
             }
         }
         Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => {
-            for string_literal in value.parts() {
+            for string_literal in value {
                 visitor.visit_string_literal(string_literal);
             }
         }
         Expr::BytesLiteral(ast::ExprBytesLiteral { value, .. }) => {
-            for bytes_literal in value.parts() {
+            for bytes_literal in value {
                 visitor.visit_bytes_literal(bytes_literal);
             }
         }

--- a/crates/ruff_python_ast/src/visitor/transformer.rs
+++ b/crates/ruff_python_ast/src/visitor/transformer.rs
@@ -464,7 +464,7 @@ pub fn walk_expr<V: Transformer + ?Sized>(visitor: &V, expr: &mut Expr) {
             visitor.visit_arguments(arguments);
         }
         Expr::FString(ast::ExprFString { value, .. }) => {
-            for f_string_part in value.parts_mut() {
+            for f_string_part in value.iter_mut() {
                 match f_string_part {
                     ast::FStringPart::Literal(string_literal) => {
                         visitor.visit_string_literal(string_literal);
@@ -476,12 +476,12 @@ pub fn walk_expr<V: Transformer + ?Sized>(visitor: &V, expr: &mut Expr) {
             }
         }
         Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => {
-            for string_literal in value.parts_mut() {
+            for string_literal in value.iter_mut() {
                 visitor.visit_string_literal(string_literal);
             }
         }
         Expr::BytesLiteral(ast::ExprBytesLiteral { value, .. }) => {
-            for bytes_literal in value.parts_mut() {
+            for bytes_literal in value.iter_mut() {
                 visitor.visit_bytes_literal(bytes_literal);
             }
         }

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1077,7 +1077,7 @@ impl<'a> Generator<'a> {
             }
             Expr::BytesLiteral(ast::ExprBytesLiteral { value, .. }) => {
                 let mut first = true;
-                for bytes_literal in value.parts() {
+                for bytes_literal in value {
                     self.p_delim(&mut first, " ");
                     self.p_bytes_repr(&bytes_literal.value);
                 }
@@ -1273,7 +1273,7 @@ impl<'a> Generator<'a> {
 
     fn unparse_string_literal_value(&mut self, value: &ast::StringLiteralValue) {
         let mut first = true;
-        for string_literal in value.parts() {
+        for string_literal in value {
             self.p_delim(&mut first, " ");
             self.unparse_string_literal(string_literal);
         }
@@ -1281,7 +1281,7 @@ impl<'a> Generator<'a> {
 
     fn unparse_f_string_value(&mut self, value: &ast::FStringValue, is_spec: bool) {
         let mut first = true;
-        for f_string_part in value.parts() {
+        for f_string_part in value {
             self.p_delim(&mut first, " ");
             match f_string_part {
                 ast::FStringPart::Literal(string_literal) => {

--- a/crates/ruff_python_formatter/src/expression/string/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/string/mod.rs
@@ -86,13 +86,13 @@ impl<'a> AnyString<'a> {
     fn parts(&self) -> Vec<AnyStringPart<'a>> {
         match self {
             Self::String(ExprStringLiteral { value, .. }) => {
-                value.parts().map(AnyStringPart::String).collect()
+                value.iter().map(AnyStringPart::String).collect()
             }
             Self::Bytes(ExprBytesLiteral { value, .. }) => {
-                value.parts().map(AnyStringPart::Bytes).collect()
+                value.iter().map(AnyStringPart::Bytes).collect()
             }
             Self::FString(ExprFString { value, .. }) => value
-                .parts()
+                .iter()
                 .map(|f_string_part| match f_string_part {
                     ast::FStringPart::Literal(string_literal) => {
                         AnyStringPart::String(string_literal)


### PR DESCRIPTION
This PR adds a `as_slice` method to all the string nodes which returns all the parts of the nodes as a slice. This will be useful in the next PR to split the string formatting to use this method to extract the _single node_ or _implicitly concanated nodes_.
