### PR TITLE
Document link between import sorting and formatter

### DIFF
--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -392,3 +392,15 @@ flag.
 Black promotes some of its preview styling to stable at the end of each year. Ruff will similarly
 implement formatting changes under the [`preview`](https://docs.astral.sh/ruff/settings/#preview)
 flag, promoting them to stable through minor releases, in accordance with our [versioning policy](https://github.com/astral-sh/ruff/discussions/6998#discussioncomment-7016766).
+
+## Sorting imports
+
+Currently, the Ruff formatter does not sort imports. In order to both sort imports and format,
+call the Ruff linter and then the formatter:
+
+```shell
+ruff check --select I --fix .
+ruff format .
+```
+
+A unified command for both linting and formatting is currently [being developed](https://github.com/astral-sh/ruff/issues/8232).

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -403,4 +403,4 @@ ruff check --select I --fix .
 ruff format .
 ```
 
-A unified command for both linting and formatting is currently [being developed](https://github.com/astral-sh/ruff/issues/8232).
+A unified command for both linting and formatting is [planned](https://github.com/astral-sh/ruff/issues/8232).


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

Fixes #8367.

This documents the link between import sorting and the formatter to clear up some existing confusion. This can probably be removed once #8232 gets merged.
