### PR TITLE
Rename string AST nodes

### DIFF
--- a/crates/ruff_python_ast/src/expression.rs
+++ b/crates/ruff_python_ast/src/expression.rs
@@ -24,8 +24,8 @@ pub enum ExpressionRef<'a> {
     Compare(&'a ast::ExprCompare),
     Call(&'a ast::ExprCall),
     FString(&'a ast::ExprFString),
-    StringLiteral(&'a ast::ExprStringLiteral),
-    BytesLiteral(&'a ast::ExprBytesLiteral),
+    StringLiteral(&'a ast::ExprString),
+    BytesLiteral(&'a ast::ExprBytes),
     NumberLiteral(&'a ast::ExprNumberLiteral),
     BooleanLiteral(&'a ast::ExprBooleanLiteral),
     NoneLiteral(&'a ast::ExprNoneLiteral),
@@ -67,8 +67,8 @@ impl<'a> From<&'a Expr> for ExpressionRef<'a> {
             Expr::Compare(value) => ExpressionRef::Compare(value),
             Expr::Call(value) => ExpressionRef::Call(value),
             Expr::FString(value) => ExpressionRef::FString(value),
-            Expr::StringLiteral(value) => ExpressionRef::StringLiteral(value),
-            Expr::BytesLiteral(value) => ExpressionRef::BytesLiteral(value),
+            Expr::String(value) => ExpressionRef::StringLiteral(value),
+            Expr::Bytes(value) => ExpressionRef::BytesLiteral(value),
             Expr::NumberLiteral(value) => ExpressionRef::NumberLiteral(value),
             Expr::BooleanLiteral(value) => ExpressionRef::BooleanLiteral(value),
             Expr::NoneLiteral(value) => ExpressionRef::NoneLiteral(value),
@@ -175,13 +175,13 @@ impl<'a> From<&'a ast::ExprFString> for ExpressionRef<'a> {
         Self::FString(value)
     }
 }
-impl<'a> From<&'a ast::ExprStringLiteral> for ExpressionRef<'a> {
-    fn from(value: &'a ast::ExprStringLiteral) -> Self {
+impl<'a> From<&'a ast::ExprString> for ExpressionRef<'a> {
+    fn from(value: &'a ast::ExprString) -> Self {
         Self::StringLiteral(value)
     }
 }
-impl<'a> From<&'a ast::ExprBytesLiteral> for ExpressionRef<'a> {
-    fn from(value: &'a ast::ExprBytesLiteral) -> Self {
+impl<'a> From<&'a ast::ExprBytes> for ExpressionRef<'a> {
+    fn from(value: &'a ast::ExprBytes) -> Self {
         Self::BytesLiteral(value)
     }
 }
@@ -332,8 +332,8 @@ impl Ranged for ExpressionRef<'_> {
 /// reference instead of an owned value.
 #[derive(Copy, Clone, Debug, PartialEq, is_macro::Is)]
 pub enum LiteralExpressionRef<'a> {
-    StringLiteral(&'a ast::ExprStringLiteral),
-    BytesLiteral(&'a ast::ExprBytesLiteral),
+    StringLiteral(&'a ast::ExprString),
+    BytesLiteral(&'a ast::ExprBytes),
     NumberLiteral(&'a ast::ExprNumberLiteral),
     BooleanLiteral(&'a ast::ExprBooleanLiteral),
     NoneLiteral(&'a ast::ExprNoneLiteral),
@@ -399,19 +399,19 @@ impl LiteralExpressionRef<'_> {
 /// f-strings.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum StringLike<'a> {
-    StringLiteral(&'a ast::ExprStringLiteral),
-    BytesLiteral(&'a ast::ExprBytesLiteral),
+    StringLiteral(&'a ast::ExprString),
+    BytesLiteral(&'a ast::ExprBytes),
     FStringLiteral(&'a ast::FStringLiteralElement),
 }
 
-impl<'a> From<&'a ast::ExprStringLiteral> for StringLike<'a> {
-    fn from(value: &'a ast::ExprStringLiteral) -> Self {
+impl<'a> From<&'a ast::ExprString> for StringLike<'a> {
+    fn from(value: &'a ast::ExprString) -> Self {
         StringLike::StringLiteral(value)
     }
 }
 
-impl<'a> From<&'a ast::ExprBytesLiteral> for StringLike<'a> {
-    fn from(value: &'a ast::ExprBytesLiteral) -> Self {
+impl<'a> From<&'a ast::ExprBytes> for StringLike<'a> {
+    fn from(value: &'a ast::ExprBytes) -> Self {
         StringLike::BytesLiteral(value)
     }
 }

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -72,8 +72,8 @@ pub enum AnyNode {
     ExprCompare(ast::ExprCompare),
     ExprCall(ast::ExprCall),
     ExprFString(ast::ExprFString),
-    ExprStringLiteral(ast::ExprStringLiteral),
-    ExprBytesLiteral(ast::ExprBytesLiteral),
+    ExprStringLiteral(ast::ExprString),
+    ExprBytesLiteral(ast::ExprBytes),
     ExprNumberLiteral(ast::ExprNumberLiteral),
     ExprBooleanLiteral(ast::ExprBooleanLiteral),
     ExprNoneLiteral(ast::ExprNoneLiteral),
@@ -238,8 +238,8 @@ impl AnyNode {
             AnyNode::ExprCompare(node) => Some(Expr::Compare(node)),
             AnyNode::ExprCall(node) => Some(Expr::Call(node)),
             AnyNode::ExprFString(node) => Some(Expr::FString(node)),
-            AnyNode::ExprStringLiteral(node) => Some(Expr::StringLiteral(node)),
-            AnyNode::ExprBytesLiteral(node) => Some(Expr::BytesLiteral(node)),
+            AnyNode::ExprStringLiteral(node) => Some(Expr::String(node)),
+            AnyNode::ExprBytesLiteral(node) => Some(Expr::Bytes(node)),
             AnyNode::ExprNumberLiteral(node) => Some(Expr::NumberLiteral(node)),
             AnyNode::ExprBooleanLiteral(node) => Some(Expr::BooleanLiteral(node)),
             AnyNode::ExprNoneLiteral(node) => Some(Expr::NoneLiteral(node)),
@@ -2788,7 +2788,7 @@ impl AstNode for ast::ExprFString {
 
         for f_string_part in value {
             match f_string_part {
-                ast::FStringPart::Literal(string_literal) => {
+                ast::FStringPart::String(string_literal) => {
                     visitor.visit_string_literal(string_literal);
                 }
                 ast::FStringPart::FString(f_string) => {
@@ -2798,7 +2798,7 @@ impl AstNode for ast::ExprFString {
         }
     }
 }
-impl AstNode for ast::ExprStringLiteral {
+impl AstNode for ast::ExprString {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2830,14 +2830,14 @@ impl AstNode for ast::ExprStringLiteral {
     where
         V: PreorderVisitor<'a> + ?Sized,
     {
-        let ast::ExprStringLiteral { value, range: _ } = self;
+        let ast::ExprString { value, range: _ } = self;
 
         for string_literal in value {
             visitor.visit_string_literal(string_literal);
         }
     }
 }
-impl AstNode for ast::ExprBytesLiteral {
+impl AstNode for ast::ExprBytes {
     fn cast(kind: AnyNode) -> Option<Self>
     where
         Self: Sized,
@@ -2869,7 +2869,7 @@ impl AstNode for ast::ExprBytesLiteral {
     where
         V: PreorderVisitor<'a> + ?Sized,
     {
-        let ast::ExprBytesLiteral { value, range: _ } = self;
+        let ast::ExprBytes { value, range: _ } = self;
 
         for bytes_literal in value {
             visitor.visit_bytes_literal(bytes_literal);
@@ -4557,8 +4557,8 @@ impl From<Expr> for AnyNode {
             Expr::Compare(node) => AnyNode::ExprCompare(node),
             Expr::Call(node) => AnyNode::ExprCall(node),
             Expr::FString(node) => AnyNode::ExprFString(node),
-            Expr::StringLiteral(node) => AnyNode::ExprStringLiteral(node),
-            Expr::BytesLiteral(node) => AnyNode::ExprBytesLiteral(node),
+            Expr::String(node) => AnyNode::ExprStringLiteral(node),
+            Expr::Bytes(node) => AnyNode::ExprBytesLiteral(node),
             Expr::NumberLiteral(node) => AnyNode::ExprNumberLiteral(node),
             Expr::BooleanLiteral(node) => AnyNode::ExprBooleanLiteral(node),
             Expr::NoneLiteral(node) => AnyNode::ExprNoneLiteral(node),
@@ -4910,14 +4910,14 @@ impl From<ast::ExprFString> for AnyNode {
     }
 }
 
-impl From<ast::ExprStringLiteral> for AnyNode {
-    fn from(node: ast::ExprStringLiteral) -> Self {
+impl From<ast::ExprString> for AnyNode {
+    fn from(node: ast::ExprString) -> Self {
         AnyNode::ExprStringLiteral(node)
     }
 }
 
-impl From<ast::ExprBytesLiteral> for AnyNode {
-    fn from(node: ast::ExprBytesLiteral) -> Self {
+impl From<ast::ExprBytes> for AnyNode {
+    fn from(node: ast::ExprBytes) -> Self {
         AnyNode::ExprBytesLiteral(node)
     }
 }
@@ -5299,8 +5299,8 @@ pub enum AnyNodeRef<'a> {
     FStringLiteralElement(&'a ast::FStringLiteralElement),
     FStringFormatSpec(&'a ast::FStringFormatSpec),
     ExprFString(&'a ast::ExprFString),
-    ExprStringLiteral(&'a ast::ExprStringLiteral),
-    ExprBytesLiteral(&'a ast::ExprBytesLiteral),
+    ExprStringLiteral(&'a ast::ExprString),
+    ExprBytesLiteral(&'a ast::ExprBytes),
     ExprNumberLiteral(&'a ast::ExprNumberLiteral),
     ExprBooleanLiteral(&'a ast::ExprBooleanLiteral),
     ExprNoneLiteral(&'a ast::ExprNoneLiteral),
@@ -6492,14 +6492,14 @@ impl<'a> From<&'a ast::ExprFString> for AnyNodeRef<'a> {
     }
 }
 
-impl<'a> From<&'a ast::ExprStringLiteral> for AnyNodeRef<'a> {
-    fn from(node: &'a ast::ExprStringLiteral) -> Self {
+impl<'a> From<&'a ast::ExprString> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprString) -> Self {
         AnyNodeRef::ExprStringLiteral(node)
     }
 }
 
-impl<'a> From<&'a ast::ExprBytesLiteral> for AnyNodeRef<'a> {
-    fn from(node: &'a ast::ExprBytesLiteral) -> Self {
+impl<'a> From<&'a ast::ExprBytes> for AnyNodeRef<'a> {
+    fn from(node: &'a ast::ExprBytes) -> Self {
         AnyNodeRef::ExprBytesLiteral(node)
     }
 }
@@ -6742,8 +6742,8 @@ impl<'a> From<&'a Expr> for AnyNodeRef<'a> {
             Expr::Compare(node) => AnyNodeRef::ExprCompare(node),
             Expr::Call(node) => AnyNodeRef::ExprCall(node),
             Expr::FString(node) => AnyNodeRef::ExprFString(node),
-            Expr::StringLiteral(node) => AnyNodeRef::ExprStringLiteral(node),
-            Expr::BytesLiteral(node) => AnyNodeRef::ExprBytesLiteral(node),
+            Expr::String(node) => AnyNodeRef::ExprStringLiteral(node),
+            Expr::Bytes(node) => AnyNodeRef::ExprBytesLiteral(node),
             Expr::NumberLiteral(node) => AnyNodeRef::ExprNumberLiteral(node),
             Expr::BooleanLiteral(node) => AnyNodeRef::ExprBooleanLiteral(node),
             Expr::NoneLiteral(node) => AnyNodeRef::ExprNoneLiteral(node),


### PR DESCRIPTION
Rename the string nodes for better understanding between the types. The following renames are performed:

**Enum variants:**
- `Expr::StringLiteral`-> `Expr::String`
- `Expr::BytesLiteral` -> `Expr::Bytes`
- `FStringPart::Literal` -> `FStringPart::String` - This includes the string literal part of an implictly concatenated f-string (e.g. `"foo" f"bar {x}"`)
    - `FStringExprValue::literals` -> `FStringExprValue::strings`

**AST nodes:**
- `ExprStringLiteral` -> `ExprString`
- `ExprBytesLiteral` -> `ExprBytes`

To better reflect that the following are expressions:
- `StringValue` -> `StringExprValue`
- `BytesValue` -> `BytesExprValue`
- `FStringValue` -> `FStringExprValue`


### Open ended renames

- `LiteralExpressionRef::StringLiteral` -> `LiteralExpressionRef::String` (enum variant)
- `LiteralExpressionRef::BytesLiteral` -> `LiteralExpressionRef::Bytes` (enum variant)
- `StringLike::StringLiteral` -> `StringLike::String` (enum variant)
- `StringLike::BytesLiteral` -> `StringLike::Bytes` (enum variant)
- `FStringElement` / `FStringPart` -> `FStringComponent` (enum type)
- Expand `FString` to `FormattedString` everywhere (struct, enum)

**LibCST f-string names:** https://github.com/Instagram/LibCST/blob/52bbff6dfc2dd7b3086710bc64896ccfaaed1a3d/native/libcst/src/nodes/expression.rs#L2430-L2443
- `FormattedString`
- `FormattedStringContent` (aka `FStringElement`)
- `FormattedStringText` (aka `FStringLiteralElement`)
- `FormattedStringExpression` (aka `FStringExpressionElement`)

I like the rename of `FStringElement` to `FStringContent` as "content" better describes the value between the quotes or a "string content".

Reference:
- https://github.com/astral-sh/ruff/pull/8835#discussion_r1414759829
- https://github.com/astral-sh/ruff/pull/9058#pullrequestreview-1778954720
