### PR TITLE
Fix `can_omit_optional_parentheses` for expressions with a right most fstring

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/binary.py
@@ -319,6 +319,18 @@ expected_content = (
     )
 )
 
+# Skip FString content when determining whether to omit optional parentheses or not.0
+# The below expression should be parenthesized because it ends with an fstring and starts with a name.
+# (Call expressions at the beginning don't count as parenthesized because they don't start with parens).
+assert (
+    format.format_event(spec)
+    == f'Event("_remove_cookie", {{key:`testkey`,options:{json.dumps(options)}}})'
+)
+# Avoid parentheses for this example because it starts with a tuple expression.
+assert (
+    (spec, format)
+    == f'Event("_remove_cookie", {{key:`testkey`,options:{json.dumps(options)}}})'
+)
 
 rowuses = [(1 << j) |                  # column ordinal
            (1 << (n + i-j + n-1)) |    # NW-SE ordinal

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__binary.py.snap
@@ -325,6 +325,18 @@ expected_content = (
     )
 )
 
+# Skip FString content when determining whether to omit optional parentheses or not.0
+# The below expression should be parenthesized because it ends with an fstring and starts with a name.
+# (Call expressions at the beginning don't count as parenthesized because they don't start with parens).
+assert (
+    format.format_event(spec)
+    == f'Event("_remove_cookie", {{key:`testkey`,options:{json.dumps(options)}}})'
+)
+# Avoid parentheses for this example because it starts with a tuple expression.
+assert (
+    (spec, format)
+    == f'Event("_remove_cookie", {{key:`testkey`,options:{json.dumps(options)}}})'
+)
 
 rowuses = [(1 << j) |                  # column ordinal
            (1 << (n + i-j + n-1)) |    # NW-SE ordinal
@@ -790,6 +802,18 @@ expected_content = (
     )
 )
 
+# Skip FString content when determining whether to omit optional parentheses or not.0
+# The below expression should be parenthesized because it ends with an fstring and starts with a name.
+# (Call expressions at the beginning don't count as parenthesized because they don't start with parens).
+assert (
+    format.format_event(spec)
+    == f'Event("_remove_cookie", {{key:`testkey`,options:{json.dumps(options)}}})'
+)
+# Avoid parentheses for this example because it starts with a tuple expression.
+assert (
+    spec,
+    format,
+) == f'Event("_remove_cookie", {{key:`testkey`,options:{json.dumps(options)}}})'
 
 rowuses = [
     (1 << j)  # column ordinal


### PR DESCRIPTION
## Summary

This PR fixes an issue in our `can_omit_optional_parentheses` implementation. 

The goal of `can_omit_optional_parentheses` is to return true when the expression starts or ends with a parenthesized expression.

```python
if a + [
	parentheses,
	are,
	not,
	required,
	here
]: pass
```

However, our implementation incorrectly traversed into fstrings and other expressions that end with a token. We should skip these 
(similar to other parenthesized expressions) because they're not at the end of the expression (they're wrapped). 

A silly example, but it should do it for illustrating what it is about

```python
if a + f"parentheses are required because the list isn't at the very end, the closing quote is {[1, 2]}": 
	pass

``` 

## Test Plan

Added test. The similarity for our old compatibility check remains unchanged. The ecosystem only shows one intentional change.
