### PR TITLE
Add new `with` and `match` sequence test cases

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
@@ -578,3 +578,8 @@ match n % 3, n % 5:
         print("Buzz")
     case _:
         print(n)
+
+# Unparenthesized tuples
+match x:
+    case Child(aaaaaaaaa, bbbbbbbbbbbbbbb, cccccc), Doc(aaaaa, bbbbbbbbbb, ddddddddddddd):
+        pass

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
@@ -303,3 +303,7 @@ if True:
 if True:
     with anyio.CancelScope(shield=True) if get_running_loop() else contextlib.nullcontext():
         pass
+
+
+with Child(aaaaaaaaa, bbbbbbbbbbbbbbb, cccccc), Document(aaaaa, bbbbbbbbbb, ddddddddddddd):
+    pass

--- a/crates/ruff_python_formatter/src/statement/stmt_with.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_with.rs
@@ -6,9 +6,7 @@ use ruff_text_size::{Ranged, TextRange};
 
 use crate::builders::parenthesize_if_expands;
 use crate::comments::SourceComment;
-use crate::expression::parentheses::{
-    in_parentheses_only_soft_line_break_or_space, optional_parentheses, parenthesized,
-};
+use crate::expression::parentheses::parenthesized;
 use crate::other::commas;
 use crate::prelude::*;
 use crate::statement::clause::{clause_body, clause_header, ClauseHeader};
@@ -77,7 +75,7 @@ impl FormatNodeRule<StmtWith> for FormatStmtWith {
                                     joiner.entry_with_line_separator(
                                         item,
                                         &item.format(),
-                                        in_parentheses_only_soft_line_break_or_space(),
+                                        soft_line_break_or_space(),
                                     );
                                 }
                                 joiner.finish()
@@ -87,7 +85,7 @@ impl FormatNodeRule<StmtWith> for FormatStmtWith {
                             // This is similar to `maybe_parenthesize_expression`, but we're not
                             // dealing with an expression here, it's a `WithItem`.
                             if comments.has_leading(item) || comments.has_trailing(item) {
-                                optional_parentheses(&item.format()).fmt(f)?;
+                                parenthesized("(", &item.format(), ")").fmt(f)?;
                             } else {
                                 item.format().fmt(f)?;
                             }

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -584,6 +584,11 @@ match n % 3, n % 5:
         print("Buzz")
     case _:
         print(n)
+
+# Unparenthesized tuples
+match x:
+    case Child(aaaaaaaaa, bbbbbbbbbbbbbbb, cccccc), Doc(aaaaa, bbbbbbbbbb, ddddddddddddd):
+        pass
 ```
 
 ## Output
@@ -1210,6 +1215,13 @@ match n % 3, n % 5:
         print("Buzz")
     case _:
         print(n)
+
+# Unparenthesized tuples
+match x:
+    case Child(aaaaaaaaa, bbbbbbbbbbbbbbb, cccccc), Doc(
+        aaaaa, bbbbbbbbbb, ddddddddddddd
+    ):
+        pass
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
@@ -309,6 +309,10 @@ if True:
 if True:
     with anyio.CancelScope(shield=True) if get_running_loop() else contextlib.nullcontext():
         pass
+
+
+with Child(aaaaaaaaa, bbbbbbbbbbbbbbb, cccccc), Document(aaaaa, bbbbbbbbbb, ddddddddddddd):
+    pass
 ```
 
 ## Output
@@ -640,6 +644,12 @@ if True:
         shield=True
     ) if get_running_loop() else contextlib.nullcontext():
         pass
+
+
+with Child(aaaaaaaaa, bbbbbbbbbbbbbbb, cccccc), Document(
+    aaaaa, bbbbbbbbbb, ddddddddddddd
+):
+    pass
 ```
 
 


### PR DESCRIPTION
## Summary

Add new test cases for `with_item` and `match` sequence that demonstrate how long headers break. 

Removes one use of `optional_parentheses` in a position where it is know that the parentheses always need to be added.

## Test Plan

cargo test
