### PR TITLE
Enable annotation quoting for multi-line expressions

### DIFF
--- a/crates/ruff_diagnostics/src/edit.rs
+++ b/crates/ruff_diagnostics/src/edit.rs
@@ -7,7 +7,7 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 
 /// A text edit to be applied to a source file. Inserts, deletes, or replaces
 /// content at a given location.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Edit {
     /// The start location of the edit.

--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/quote.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/quote.py
@@ -72,3 +72,18 @@ def f():
 
     def baz() -> DataFrame | Series:
         ...
+
+
+def f():
+    from pandas import DataFrame, Series
+
+    def baz() -> (
+        DataFrame |
+        Series
+    ):
+        ...
+
+    class C:
+        x: DataFrame[
+            int
+        ] = 1

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -274,6 +274,7 @@ fn quote_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) 
                         checker.semantic(),
                         checker.locator(),
                         checker.stylist(),
+                        checker.generator(),
                     ))
                 } else {
                     None
@@ -282,7 +283,7 @@ fn quote_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) 
         })
         .collect::<Result<Vec<_>>>()?;
 
-    let mut rest = quote_reference_edits.into_iter().dedup();
+    let mut rest = quote_reference_edits.into_iter().unique();
     let head = rest.next().expect("Expected at least one reference");
     Ok(Fix::unsafe_edits(head, rest).isolate(Checker::isolation(
         checker.semantic().parent_statement_id(node_id),

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -494,6 +494,7 @@ fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) ->
                         checker.semantic(),
                         checker.locator(),
                         checker.stylist(),
+                        checker.generator(),
                     ))
                 } else {
                     None
@@ -507,7 +508,7 @@ fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) ->
         add_import_edit
             .into_edits()
             .into_iter()
-            .chain(quote_reference_edits.into_iter().dedup()),
+            .chain(quote_reference_edits.into_iter().unique()),
     )
     .isolate(Checker::isolation(
         checker.semantic().parent_statement_id(node_id),

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__quote_typing-only-third-party-import_quote.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__quote_typing-only-third-party-import_quote.py.snap
@@ -223,6 +223,8 @@ quote.py:71:24: TCH002 [*] Move third-party import `pandas.DataFrame` into a typ
 73    |-    def baz() -> DataFrame | Series:
    76 |+    def baz() -> "DataFrame | Series":
 74 77 |         ...
+75 78 | 
+76 79 | 
 
 quote.py:71:35: TCH002 [*] Move third-party import `pandas.Series` into a type-checking block
    |
@@ -251,5 +253,81 @@ quote.py:71:35: TCH002 [*] Move third-party import `pandas.Series` into a type-c
 73    |-    def baz() -> DataFrame | Series:
    76 |+    def baz() -> "DataFrame | Series":
 74 77 |         ...
+75 78 | 
+76 79 | 
+
+quote.py:78:24: TCH002 [*] Move third-party import `pandas.DataFrame` into a type-checking block
+   |
+77 | def f():
+78 |     from pandas import DataFrame, Series
+   |                        ^^^^^^^^^ TCH002
+79 | 
+80 |     def baz() -> (
+   |
+   = help: Move into type-checking block
+
+ℹ Unsafe fix
+   1  |+from typing import TYPE_CHECKING
+   2  |+
+   3  |+if TYPE_CHECKING:
+   4  |+    from pandas import DataFrame, Series
+1  5  | def f():
+2  6  |     from pandas import DataFrame
+3  7  | 
+--------------------------------------------------------------------------------
+75 79 | 
+76 80 | 
+77 81 | def f():
+78    |-    from pandas import DataFrame, Series
+79 82 | 
+80 83 |     def baz() -> (
+81    |-        DataFrame |
+82    |-        Series
+   84 |+        "DataFrame | Series"
+83 85 |     ):
+84 86 |         ...
+85 87 | 
+86 88 |     class C:
+87    |-        x: DataFrame[
+88    |-            int
+89    |-        ] = 1
+   89 |+        x: "DataFrame[int]" = 1
+
+quote.py:78:35: TCH002 [*] Move third-party import `pandas.Series` into a type-checking block
+   |
+77 | def f():
+78 |     from pandas import DataFrame, Series
+   |                                   ^^^^^^ TCH002
+79 | 
+80 |     def baz() -> (
+   |
+   = help: Move into type-checking block
+
+ℹ Unsafe fix
+   1  |+from typing import TYPE_CHECKING
+   2  |+
+   3  |+if TYPE_CHECKING:
+   4  |+    from pandas import DataFrame, Series
+1  5  | def f():
+2  6  |     from pandas import DataFrame
+3  7  | 
+--------------------------------------------------------------------------------
+75 79 | 
+76 80 | 
+77 81 | def f():
+78    |-    from pandas import DataFrame, Series
+79 82 | 
+80 83 |     def baz() -> (
+81    |-        DataFrame |
+82    |-        Series
+   84 |+        "DataFrame | Series"
+83 85 |     ):
+84 86 |         ...
+85 87 | 
+86 88 |     class C:
+87    |-        x: DataFrame[
+88    |-            int
+89    |-        ] = 1
+   89 |+        x: "DataFrame[int]" = 1
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,3 @@ version_files = [
   "crates/ruff_shrinking/Cargo.toml",
   "scripts/benchmarks/pyproject.toml",
 ]
-
-[tool.ruff.flake8-type-checking]
-quote-annotations = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,3 +99,6 @@ version_files = [
   "crates/ruff_shrinking/Cargo.toml",
   "scripts/benchmarks/pyproject.toml",
 ]
+
+[tool.ruff.flake8-type-checking]
+quote-annotations = true


### PR DESCRIPTION
Given:

```python
x: DataFrame[
    int
] = 1
```

We currently wrap the annotation in single quotes, which leads to a syntax error:

```python
x: "DataFrame[
    int
]" = 1
```

There are a few options for what to suggest for users here... Use triple quotes:

```python
x: """DataFrame[
    int
]""" = 1
```

Or, use an implicit string concatenation (which may require parentheses):

```python
x: ("DataFrame["
    "int"
"]") = 1
```

The solution I settled on here is to use the `Generator`, which effectively means we write it out on a single line, like:

```python
x: "DataFrame[int]" = 1
```

It's kind of the "least opinionated" solution, but it does mean we'll expand to a very long line in some cases.

Closes https://github.com/astral-sh/ruff/issues/9136.