### PR TITLE
improve error message for RUF006

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/asyncio_dangling_task.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/asyncio_dangling_task.rs
@@ -9,7 +9,7 @@ use ruff_text_size::Ranged;
 
 /// ## What it does
 /// Checks for `asyncio.create_task` and `asyncio.ensure_future` calls
-/// that do not store a reference to the returned result.
+/// that do not eventually await the returned task.
 ///
 /// ## Why is this bad?
 /// Per the `asyncio` documentation, the event loop only retains a weak
@@ -59,7 +59,7 @@ impl Violation for AsyncioDanglingTask {
     #[derive_message_formats]
     fn message(&self) -> String {
         let AsyncioDanglingTask { method } = self;
-        format!("Store a reference to the return value of `asyncio.{method}`")
+        format!("Cannot prove result of `asyncio.{method}` is awaited in all program traces.")
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF006_RUF006.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF006_RUF006.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
-RUF006.py:6:5: RUF006 Store a reference to the return value of `asyncio.create_task`
+RUF006.py:6:5: RUF006 Cannot prove result of `asyncio.create_task` is awaited in all program traces.
   |
 4 | # Error
 5 | def f():
@@ -9,7 +9,7 @@ RUF006.py:6:5: RUF006 Store a reference to the return value of `asyncio.create_t
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF006
   |
 
-RUF006.py:11:5: RUF006 Store a reference to the return value of `asyncio.ensure_future`
+RUF006.py:11:5: RUF006 Cannot prove result of `asyncio.ensure_future` is awaited in all program traces.
    |
  9 | # Error
 10 | def f():
@@ -17,7 +17,7 @@ RUF006.py:11:5: RUF006 Store a reference to the return value of `asyncio.ensure_
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF006
    |
 
-RUF006.py:68:12: RUF006 Store a reference to the return value of `asyncio.create_task`
+RUF006.py:68:12: RUF006 Cannot prove result of `asyncio.create_task` is awaited in all program traces.
    |
 66 | # Error
 67 | def f():
@@ -25,7 +25,7 @@ RUF006.py:68:12: RUF006 Store a reference to the return value of `asyncio.create
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF006
    |
 
-RUF006.py:74:26: RUF006 Store a reference to the return value of `asyncio.create_task`
+RUF006.py:74:26: RUF006 Cannot prove result of `asyncio.create_task` is awaited in all program traces.
    |
 72 | def f():
 73 |     loop = asyncio.get_running_loop()
@@ -33,7 +33,7 @@ RUF006.py:74:26: RUF006 Store a reference to the return value of `asyncio.create
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF006
    |
 
-RUF006.py:97:5: RUF006 Store a reference to the return value of `asyncio.create_task`
+RUF006.py:97:5: RUF006 Cannot prove result of `asyncio.create_task` is awaited in all program traces.
    |
 95 | def f():
 96 |     loop = asyncio.get_running_loop()


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #9133

Ruff cannot always prove a task is awaited. The error message should be clear about this possibility.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

The tests were updated with the new error message.

<!-- How was it tested? -->
