### PR TITLE
Implement `blank_line_after_nested_stub_class` preview style

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/stub_files/blank_line_after_nested_stub_class.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/stub_files/blank_line_after_nested_stub_class.options.json
@@ -1,0 +1,6 @@
+[
+  {
+    "source_type": "Stub",
+    "preview": "enabled"
+  }
+]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/stub_files/blank_line_after_nested_stub_class.pyi
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/stub_files/blank_line_after_nested_stub_class.pyi
@@ -1,0 +1,183 @@
+class Top1:
+    pass
+class Top2:
+    pass
+
+class Top:
+    class Ellipsis: ...
+    class Ellipsis: ...
+
+class Top:
+    class Ellipsis: ...
+    class Pass:
+        pass
+
+class Top:
+    class Ellipsis: ...
+    class_variable = 1
+
+class Top:
+    class TrailingComment:
+        pass
+    # comment
+    class Other:
+        pass
+
+class Top:
+    class CommentWithEllipsis: ...
+    # comment
+    class Other: ...
+
+class Top:
+    class TrailingCommentWithMultipleBlankLines:
+        pass
+
+
+    # comment
+    class Other:
+        pass
+
+class Top:
+    class Nested:
+        pass
+
+    # comment
+    class LeadingComment:
+        pass
+
+class Top:
+    @decorator
+    class Ellipsis: ...
+    class Ellipsis: ...
+
+class Top:
+    @decorator
+    class Ellipsis: ...
+    @decorator
+    class Ellipsis: ...
+
+class Top:
+    @decorator
+    class Ellipsis: ...
+    @decorator
+    class Pass:
+        pass
+
+class Top:
+    class Foo:
+        pass
+
+
+
+
+    class AfterMultipleEmptyLines:
+        pass
+
+class Top:
+    class Nested11:
+        class Nested12:
+            pass
+    class Nested21:
+        pass
+
+class Top:
+    class Nested11:
+        class Nested12:
+            pass
+        # comment
+    class Nested21:
+        pass
+
+class Top:
+    class Nested11:
+        class Nested12:
+            pass
+    # comment
+    class Nested21:
+        pass
+    # comment
+
+class Top1:
+    class Nested:
+        pass
+class Top2:
+    pass
+
+class Top1:
+    class Nested:
+        pass
+    # comment
+class Top2:
+    pass
+
+class Top1:
+    class Nested:
+        pass
+# comment
+class Top2:
+    pass
+
+if foo:
+    class Nested1:
+        pass
+    class Nested2:
+        pass
+else:
+    pass
+
+if foo:
+    class Nested1:
+        pass
+    class Nested2:
+        pass
+    # comment
+elif bar:
+    class Nested1:
+        pass
+# comment
+else:
+    pass
+
+if top1:
+    class Nested:
+        pass
+if top2:
+    pass
+
+if top1:
+    class Nested:
+        pass
+    # comment
+if top2:
+    pass
+
+if top1:
+    class Nested:
+        pass
+# comment
+if top2:
+    pass
+
+try:
+    class Try:
+        pass
+except:
+    class Except:
+        pass
+foo = 1
+
+match foo:
+    case 1:
+        class Nested:
+            pass
+    case 2:
+        class Nested:
+            pass
+    case _:
+        class Nested:
+            pass
+foo = 1
+
+class Eof:
+    class Nested:
+        pass

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/stub_files/blank_line_after_nested_stub_class_eof.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/stub_files/blank_line_after_nested_stub_class_eof.options.json
@@ -1,0 +1,6 @@
+[
+  {
+    "source_type": "Stub",
+    "preview": "enabled"
+  }
+]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/stub_files/blank_line_after_nested_stub_class_eof.pyi
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/stub_files/blank_line_after_nested_stub_class_eof.pyi
@@ -1,0 +1,17 @@
+# A separate file to test out the behavior when there are a mix of blank lines
+# and comments at EOF just after a nested stub class.
+
+class Top:
+    class Nested1:
+        class Nested12:
+            pass
+        # comment
+    class Nested2:
+        pass
+
+
+
+# comment
+
+
+

--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -86,21 +86,9 @@ pub(crate) struct FormatLeadingAlternateBranchComments<'a> {
 
 impl Format<PyFormatContext<'_>> for FormatLeadingAlternateBranchComments<'_> {
     fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
-        let require_empty_line = if is_blank_line_after_nested_stub_class_enabled(f.context())
-            && f.options().source_type().is_stub()
-        {
-            self.last_node.map_or(false, |preceding| {
-                should_insert_blank_line_after_class_in_stub_file(
-                    preceding,
-                    None,
-                    f.context().comments(),
-                )
-            })
-        } else {
-            false
-        };
-
-        if require_empty_line {
+        if self.last_node.map_or(false, |preceding| {
+            should_insert_blank_line_after_class_in_stub_file(preceding, None, f.context())
+        }) {
             write!(f, [empty_line(), leading_comments(self.comments)])?;
         } else if let Some(first_leading) = self.comments.first() {
             // Leading comments only preserves the lines after the comment but not before.

--- a/crates/ruff_python_formatter/src/preview.rs
+++ b/crates/ruff_python_formatter/src/preview.rs
@@ -48,6 +48,13 @@ pub(crate) const fn is_wrap_multiple_context_managers_in_parens_enabled(
     context.is_preview()
 }
 
+/// Returns `true` if the [`blank_line_after_nested_stub_class`](https://github.com/astral-sh/ruff/issues/8891) preview style is enabled.
+pub(crate) const fn is_blank_line_after_nested_stub_class_enabled(
+    context: &PyFormatContext,
+) -> bool {
+    context.is_preview()
+}
+
 /// Returns `true` if the [`module_docstring_newlines`](https://github.com/astral-sh/ruff/issues/7995) preview style is enabled.
 pub(crate) const fn is_module_docstring_newlines_enabled(context: &PyFormatContext) -> bool {
     context.is_preview()

--- a/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
@@ -1,5 +1,5 @@
 use ruff_formatter::write;
-use ruff_python_ast::{Decorator, StmtClassDef};
+use ruff_python_ast::{Decorator, NodeKind, StmtClassDef};
 use ruff_python_trivia::lines_after_ignoring_end_of_line_trivia;
 use ruff_text_size::Ranged;
 
@@ -152,7 +152,10 @@ impl FormatNodeRule<StmtClassDef> for FormatStmtClassDef {
         //
         // # comment
         // ```
-        empty_lines_before_trailing_comments(f, comments.trailing(item)).fmt(f)
+        empty_lines_before_trailing_comments(f, comments.trailing(item), NodeKind::StmtClassDef)
+            .fmt(f)?;
+
+        Ok(())
     }
 
     fn fmt_dangling_comments(

--- a/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
@@ -1,5 +1,5 @@
 use ruff_formatter::write;
-use ruff_python_ast::StmtFunctionDef;
+use ruff_python_ast::{NodeKind, StmtFunctionDef};
 
 use crate::comments::format::{
     empty_lines_after_leading_comments, empty_lines_before_trailing_comments,
@@ -87,7 +87,8 @@ impl FormatNodeRule<StmtFunctionDef> for FormatStmtFunctionDef {
         //
         // # comment
         // ```
-        empty_lines_before_trailing_comments(f, comments.trailing(item)).fmt(f)
+        empty_lines_before_trailing_comments(f, comments.trailing(item), NodeKind::StmtFunctionDef)
+            .fmt(f)
     }
 
     fn fmt_dangling_comments(

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__nested_stub.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__nested_stub.pyi.snap
@@ -42,17 +42,15 @@ class TopLevel:
 ```diff
 --- Black
 +++ Ruff
-@@ -3,33 +3,27 @@
+@@ -3,7 +3,6 @@
  class Outer:
      class InnerStub: ...
      outer_attr_after_inner_stub: int
 -
      class Inner:
          inner_attr: int
--
-     outer_attr: int
  
- if sys.version_info > (3, 7):
+@@ -13,12 +12,10 @@
      if sys.platform == "win32":
          assignment = 1
          def function_definition(self): ...
@@ -65,17 +63,6 @@ class TopLevel:
      def f2(self) -> str: ...
  
  class TopLevel:
-     class Nested1:
-         foo: int
-         def bar(self): ...
--
-     field = 1
- 
-     class Nested2:
-         def bar(self): ...
-         foo: int
--
-     field = 1
 ```
 
 ## Ruff Output
@@ -88,6 +75,7 @@ class Outer:
     outer_attr_after_inner_stub: int
     class Inner:
         inner_attr: int
+
     outer_attr: int
 
 if sys.version_info > (3, 7):
@@ -104,11 +92,13 @@ class TopLevel:
     class Nested1:
         foo: int
         def bar(self): ...
+
     field = 1
 
     class Nested2:
         def bar(self): ...
         foo: int
+
     field = 1
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class.pyi.snap
@@ -202,6 +202,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = Py38
+source_type                = Stub
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class.pyi.snap
@@ -1,0 +1,418 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/stub_files/blank_line_after_nested_stub_class.pyi
+---
+## Input
+```python
+class Top1:
+    pass
+class Top2:
+    pass
+
+class Top:
+    class Ellipsis: ...
+    class Ellipsis: ...
+
+class Top:
+    class Ellipsis: ...
+    class Pass:
+        pass
+
+class Top:
+    class Ellipsis: ...
+    class_variable = 1
+
+class Top:
+    class TrailingComment:
+        pass
+    # comment
+    class Other:
+        pass
+
+class Top:
+    class CommentWithEllipsis: ...
+    # comment
+    class Other: ...
+
+class Top:
+    class TrailingCommentWithMultipleBlankLines:
+        pass
+
+
+    # comment
+    class Other:
+        pass
+
+class Top:
+    class Nested:
+        pass
+
+    # comment
+    class LeadingComment:
+        pass
+
+class Top:
+    @decorator
+    class Ellipsis: ...
+    class Ellipsis: ...
+
+class Top:
+    @decorator
+    class Ellipsis: ...
+    @decorator
+    class Ellipsis: ...
+
+class Top:
+    @decorator
+    class Ellipsis: ...
+    @decorator
+    class Pass:
+        pass
+
+class Top:
+    class Foo:
+        pass
+
+
+
+
+    class AfterMultipleEmptyLines:
+        pass
+
+class Top:
+    class Nested11:
+        class Nested12:
+            pass
+    class Nested21:
+        pass
+
+class Top:
+    class Nested11:
+        class Nested12:
+            pass
+        # comment
+    class Nested21:
+        pass
+
+class Top:
+    class Nested11:
+        class Nested12:
+            pass
+    # comment
+    class Nested21:
+        pass
+    # comment
+
+class Top1:
+    class Nested:
+        pass
+class Top2:
+    pass
+
+class Top1:
+    class Nested:
+        pass
+    # comment
+class Top2:
+    pass
+
+class Top1:
+    class Nested:
+        pass
+# comment
+class Top2:
+    pass
+
+if foo:
+    class Nested1:
+        pass
+    class Nested2:
+        pass
+else:
+    pass
+
+if foo:
+    class Nested1:
+        pass
+    class Nested2:
+        pass
+    # comment
+elif bar:
+    class Nested1:
+        pass
+# comment
+else:
+    pass
+
+if top1:
+    class Nested:
+        pass
+if top2:
+    pass
+
+if top1:
+    class Nested:
+        pass
+    # comment
+if top2:
+    pass
+
+if top1:
+    class Nested:
+        pass
+# comment
+if top2:
+    pass
+
+try:
+    class Try:
+        pass
+except:
+    class Except:
+        pass
+foo = 1
+
+match foo:
+    case 1:
+        class Nested:
+            pass
+    case 2:
+        class Nested:
+            pass
+    case _:
+        class Nested:
+            pass
+foo = 1
+
+class Eof:
+    class Nested:
+        pass
+```
+
+## Outputs
+### Output 1
+```
+indent-style               = space
+line-width                 = 88
+indent-width               = 4
+quote-style                = Double
+line-ending                = LineFeed
+magic-trailing-comma       = Respect
+docstring-code             = Disabled
+docstring-code-line-width  = "dynamic"
+preview                    = Enabled
+target_version             = Py38
+```
+
+```python
+class Top1:
+    pass
+
+class Top2:
+    pass
+
+class Top:
+    class Ellipsis: ...
+    class Ellipsis: ...
+
+class Top:
+    class Ellipsis: ...
+
+    class Pass:
+        pass
+
+class Top:
+    class Ellipsis: ...
+    class_variable = 1
+
+class Top:
+    class TrailingComment:
+        pass
+
+    # comment
+    class Other:
+        pass
+
+class Top:
+    class CommentWithEllipsis: ...
+    # comment
+    class Other: ...
+
+class Top:
+    class TrailingCommentWithMultipleBlankLines:
+        pass
+
+    # comment
+    class Other:
+        pass
+
+class Top:
+    class Nested:
+        pass
+
+    # comment
+    class LeadingComment:
+        pass
+
+class Top:
+    @decorator
+    class Ellipsis: ...
+
+    class Ellipsis: ...
+
+class Top:
+    @decorator
+    class Ellipsis: ...
+
+    @decorator
+    class Ellipsis: ...
+
+class Top:
+    @decorator
+    class Ellipsis: ...
+
+    @decorator
+    class Pass:
+        pass
+
+class Top:
+    class Foo:
+        pass
+
+    class AfterMultipleEmptyLines:
+        pass
+
+class Top:
+    class Nested11:
+        class Nested12:
+            pass
+
+    class Nested21:
+        pass
+
+class Top:
+    class Nested11:
+        class Nested12:
+            pass
+
+        # comment
+
+    class Nested21:
+        pass
+
+class Top:
+    class Nested11:
+        class Nested12:
+            pass
+
+    # comment
+    class Nested21:
+        pass
+
+    # comment
+
+class Top1:
+    class Nested:
+        pass
+
+class Top2:
+    pass
+
+class Top1:
+    class Nested:
+        pass
+
+    # comment
+
+class Top2:
+    pass
+
+class Top1:
+    class Nested:
+        pass
+
+# comment
+class Top2:
+    pass
+
+if foo:
+    class Nested1:
+        pass
+
+    class Nested2:
+        pass
+
+else:
+    pass
+
+if foo:
+    class Nested1:
+        pass
+
+    class Nested2:
+        pass
+
+    # comment
+elif bar:
+    class Nested1:
+        pass
+
+# comment
+else:
+    pass
+
+if top1:
+    class Nested:
+        pass
+
+if top2:
+    pass
+
+if top1:
+    class Nested:
+        pass
+
+    # comment
+if top2:
+    pass
+
+if top1:
+    class Nested:
+        pass
+
+# comment
+if top2:
+    pass
+
+try:
+    class Try:
+        pass
+
+except:
+    class Except:
+        pass
+
+foo = 1
+
+match foo:
+    case 1:
+        class Nested:
+            pass
+
+    case 2:
+        class Nested:
+            pass
+
+    case _:
+        class Nested:
+            pass
+
+foo = 1
+
+class Eof:
+    class Nested:
+        pass
+```
+
+
+

--- a/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class_eof.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class_eof.pyi.snap
@@ -36,6 +36,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = Py38
+source_type                = Stub
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class_eof.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@stub_files__blank_line_after_nested_stub_class_eof.pyi.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/stub_files/blank_line_after_nested_stub_class_eof.pyi
+---
+## Input
+```python
+# A separate file to test out the behavior when there are a mix of blank lines
+# and comments at EOF just after a nested stub class.
+
+class Top:
+    class Nested1:
+        class Nested12:
+            pass
+        # comment
+    class Nested2:
+        pass
+
+
+
+# comment
+
+
+
+```
+
+## Outputs
+### Output 1
+```
+indent-style               = space
+line-width                 = 88
+indent-width               = 4
+quote-style                = Double
+line-ending                = LineFeed
+magic-trailing-comma       = Respect
+docstring-code             = Disabled
+docstring-code-line-width  = "dynamic"
+preview                    = Enabled
+target_version             = Py38
+```
+
+```python
+# A separate file to test out the behavior when there are a mix of blank lines
+# and comments at EOF just after a nested stub class.
+
+class Top:
+    class Nested1:
+        class Nested12:
+            pass
+
+        # comment
+
+    class Nested2:
+        pass
+
+# comment
+```
+
+
+

--- a/crates/ruff_python_formatter/tests/snapshots/format@stub_files__suite.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@stub_files__suite.pyi.snap
@@ -309,4 +309,27 @@ class ComplexStatements:
 ```
 
 
+## Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -110,6 +110,7 @@
+ 
+     class InnerClass5:
+         def a(self): ...
++
+     field1 = 1
+ 
+     class InnerClass6:
+@@ -119,6 +120,7 @@
+ 
+     class InnerClass7:
+         def a(self): ...
++
+     print("hi")
+ 
+     class InnerClass8:
+```
+
+
 


### PR DESCRIPTION
## Summary

This PR implements the `blank_line_after_nested_stub_class` preview style in the formatter.

The logic is divided into 3 parts:
1. In between preceding and following nodes at top level and nested suite
2. When there's a trailing comment after the class
3. When there is no following node from (1) which is the case when it's the last or the only node in a suite

We handle (3) with `FormatLeadingAlternateBranchComments`.

## Test Plan

- Add new test cases and update existing snapshots
- Checked the `typeshed` diff

fixes: #8891
