### PR TITLE
Update ecosystem check headers to show unchanged project count

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/check.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/check.py
@@ -52,6 +52,8 @@ def markdown_check_result(result: Result) -> str:
     """
     Render a `ruff check` ecosystem check result as markdown.
     """
+    projects_with_changes = 0
+
     # Calculate the total number of rule changes
     all_rule_changes = RuleChanges()
     project_diffs = {
@@ -62,6 +64,9 @@ def markdown_check_result(result: Result) -> str:
     for project, diff in project_diffs.items():
         project_rule_changes[project] = changes = RuleChanges.from_diff(diff)
         all_rule_changes.update(changes)
+
+        if diff:
+            projects_with_changes += 1
 
     lines: list[str] = []
     total_removed = all_rule_changes.total_removed_violations()
@@ -88,11 +93,17 @@ def markdown_check_result(result: Result) -> str:
         change_summary = (
             f"{markdown_plus_minus(total_added, total_removed)} violations, "
             f"{markdown_plus_minus(total_added_fixes, total_removed_fixes)} fixes "
-            f"in {len(result.completed)} projects"
+            f"in {projects_with_changes} projects"
         )
         if error_count:
             s = "s" if error_count != 1 else ""
             change_summary += f"; {error_count} project error{s}"
+
+        unchanged_projects = len(result.completed) - projects_with_changes
+        if unchanged_projects:
+            s = "s" if unchanged_projects != 1 else ""
+            change_summary += f"; {unchanged_projects} project{s} unchanged"
+
         lines.append(
             f"\u2139\ufe0f ecosystem check **detected linter changes**. ({change_summary})"
         )

--- a/python/ruff-ecosystem/ruff_ecosystem/format.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/format.py
@@ -28,6 +28,7 @@ def markdown_format_result(result: Result) -> str:
     lines: list[str] = []
     total_lines_removed = total_lines_added = 0
     total_files_modified = 0
+    projects_with_changes = 0
     error_count = len(result.errored)
     patch_sets: list[PatchSet] = []
 
@@ -38,6 +39,9 @@ def markdown_format_result(result: Result) -> str:
         patch_set = PatchSet("\n".join(comparison.diff.lines))
         patch_sets.append(patch_set)
         total_files_modified += len(patch_set.modified_files)
+
+        if comparison.diff:
+            projects_with_changes += 1
 
     if total_lines_removed == 0 and total_lines_added == 0 and error_count == 0:
         return "\u2705 ecosystem check detected no format changes."
@@ -51,10 +55,20 @@ def markdown_format_result(result: Result) -> str:
         )
     else:
         s = "s" if total_files_modified != 1 else ""
-        changes = f"+{total_lines_added} -{total_lines_removed} lines in {total_files_modified} file{s} in {len(result.completed)} projects"
+        changes = (
+            f"+{total_lines_added} -{total_lines_removed} lines "
+            f"in {total_files_modified} file{s} in "
+            f"{projects_with_changes} projects"
+        )
+
         if error_count:
             s = "s" if error_count != 1 else ""
             changes += f"; {error_count} project error{s}"
+
+        unchanged_projects = len(result.completed) - projects_with_changes
+        if unchanged_projects:
+            s = "s" if unchanged_projects != 1 else ""
+            changes += f"; {unchanged_projects} project{s} unchanged"
 
         lines.append(
             f"\u2139\ufe0f ecosystem check **detected format changes**. ({changes})"


### PR DESCRIPTION
Instead of displaying the total completed project count in the "changed" section of a header, we now separately calculated the changed and unchanged count to make the header message nice and clear.

e.g.

> ℹ️ ecosystem check **detected format changes**. (+1772 -1859 lines in 239 files in 26 projects; 6 project errors; 9 projects unchanged)

and

> ℹ️ ecosystem check **detected linter changes**. (+4598 -5023 violations, +0 -40 fixes in 13 projects; 4 project errors; 24 projects unchanged)


Previously, it would have included the unchanged count in the first project count.