### PR TITLE
Fix ecosystem format line changed counts

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/types.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/types.py
@@ -32,11 +32,15 @@ class Diff(Serializable):
             line[2:]
             for line in self.lines
             if line.startswith("+" + " " * leading_spaces)
+            # Do not include patch headers
+            and not line.startswith("+++")
         )
         self.removed = list(
             line[2:]
             for line in self.lines
             if line.startswith("-" + " " * leading_spaces)
+            # Do not include patch headers
+            and not line.startswith("---")
         )
 
     def __bool__(self) -> bool:


### PR DESCRIPTION
We were erroneously including patch headers so for each _file_ changed we could include an extra added and removed line e.g. we counted the diff in the following as +4 -4 instead of +3 -3.

```diff
diff --git a/tests/test_param_include_in_schema.py b/tests/test_param_include_in_schema.py
index 26201e9..f461947 100644
--- a/tests/test_param_include_in_schema.py
+++ b/tests/test_param_include_in_schema.py
@@ -9,14 +9,14 @@ app = FastAPI()
 
 @app.get("/hidden_cookie")
 async def hidden_cookie(
-    hidden_cookie: Optional[str] = Cookie(default=None, include_in_schema=False)
+    hidden_cookie: Optional[str] = Cookie(default=None, include_in_schema=False),
 ):
     return {"hidden_cookie": hidden_cookie}
 
 
 @app.get("/hidden_header")
 async def hidden_header(
-    hidden_header: Optional[str] = Header(default=None, include_in_schema=False)
+    hidden_header: Optional[str] = Header(default=None, include_in_schema=False),
 ):
     return {"hidden_header": hidden_header}
 
@@ -28,7 +28,7 @@ async def hidden_path(hidden_path: str = Path(include_in_schema=False)):
 
 @app.get("/hidden_query")
 async def hidden_query(
-    hidden_query: Optional[str] = Query(default=None, include_in_schema=False)
+    hidden_query: Optional[str] = Query(default=None, include_in_schema=False),
 ):
     return {"hidden_query": hidden_query}
 
```

Tested with a single project locally e.g.

> ℹ️ ecosystem check **detected format changes**. (+65 -65 lines in 39 files in 1 projects)
> 
> <details><summary><a href="https://github.com/tiangolo/fastapi">tiangolo/fastapi</a> (+65 -65 lines across 39 files)

instead of

> ℹ️ ecosystem check **detected format changes**. (+104 -104 lines in 39 files in 1 projects)
>
> <details><summary><a href="https://github.com/tiangolo/fastapi">tiangolo/fastapi</a> (+104 -104 lines across 39 files)
