### PR TITLE
Fix typo in SemanticModel.parent_expression docstring

### DIFF
--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -993,7 +993,7 @@ impl<'a> SemanticModel<'a> {
         &self.nodes[node_id]
     }
 
-    /// Given a [`Expr`], return its parent, if any.
+    /// Given a [`NodeId`], return its parent, if any.
     #[inline]
     pub fn parent_expression(&self, node_id: NodeId) -> Option<&'a Expr> {
         self.nodes


### PR DESCRIPTION
Self-explanatory and self-contained! :)