### PR TITLE
[formatter] Indent docstrings using configured indent_style

### DIFF
--- a/crates/ruff_python_formatter/src/string/docstring.rs
+++ b/crates/ruff_python_formatter/src/string/docstring.rs
@@ -15,6 +15,8 @@ use {
     ruff_text_size::{Ranged, TextLen, TextRange, TextSize},
 };
 
+use ruff_formatter::IndentWidth;
+
 use crate::{prelude::*, DocstringCodeLineWidth, FormatModuleError};
 
 use super::{NormalizedString, QuoteChar};
@@ -180,7 +182,7 @@ pub(crate) fn format(normalized: &NormalizedString, f: &mut PyFormatter) -> Form
         .clone()
         // We don't want to count whitespace-only lines as miss-indented
         .filter(|line| !line.trim().is_empty())
-        .map(indentation_length)
+        .map(|line| indentation_length(line, f.options().indent_width()))
         .min()
         .unwrap_or_default();
 
@@ -270,6 +272,7 @@ impl<'ast, 'buf, 'fmt, 'src> DocstringLinePrinter<'ast, 'buf, 'fmt, 'src> {
                 line,
                 offset: self.offset,
                 next: lines.peek().copied(),
+                indent_width: self.f.options().indent_width(),
             };
             // We know that the normalized string has \n line endings.
             self.offset += line.line.text_len() + "\n".text_len();
@@ -392,7 +395,10 @@ impl<'ast, 'buf, 'fmt, 'src> DocstringLinePrinter<'ast, 'buf, 'fmt, 'src> {
             .take_while(|c| c.is_whitespace())
             .any(|c| c != ' ');
 
-        if tab_or_non_ascii_space {
+        let indent_style = self.f.options().indent_style();
+        let indent_width = self.f.options().indent_width();
+
+        if tab_or_non_ascii_space || indent_style == IndentStyle::Tab {
             // We strip the indentation that is shared with the docstring
             // statement, unless a line was indented less than the docstring
             // statement, in which case we strip only this much indentation to
@@ -400,8 +406,16 @@ impl<'ast, 'buf, 'fmt, 'src> DocstringLinePrinter<'ast, 'buf, 'fmt, 'src> {
             // overindented, in which case we strip the additional whitespace
             // (see example in [`format_docstring`] doc comment). We then
             // prepend the in-docstring indentation to the string.
-            let indent_len = indentation_length(trim_end) - self.stripped_indentation_length;
-            let in_docstring_indent = " ".repeat(usize::from(indent_len)) + trim_end.trim_start();
+            let indent_len =
+                indentation_length(trim_end, indent_width) - self.stripped_indentation_length;
+            let in_docstring_indent = if indent_style == IndentStyle::Tab {
+                // When using tabs, replace indent_width spaces with tabs. This
+                // may caused mixed indentation, but that should be uncommon.
+                "\t".repeat(usize::from(indent_len) / indent_width.value() as usize)
+                    + &" ".repeat(usize::from(indent_len) % indent_width.value() as usize)
+            } else {
+                " ".repeat(usize::from(indent_len))
+            } + trim_end.trim_start();
             text(&in_docstring_indent).fmt(self.f)?;
         } else {
             // Take the string with the trailing whitespace removed, then also
@@ -559,6 +573,9 @@ struct InputDocstringLine<'src> {
     ///
     /// This is `None` if and only if this is the last line in the docstring.
     next: Option<&'src str>,
+
+    /// The indentation width to use when expanding tabs in this line.
+    indent_width: IndentWidth,
 }
 
 impl<'src> InputDocstringLine<'src> {
@@ -972,7 +989,7 @@ impl<'src> CodeExampleRst<'src> {
         }
         Some(CodeExampleRst {
             lines: vec![],
-            opening_indent: indentation_length(opening_indent),
+            opening_indent: indentation_length(opening_indent, original.indent_width),
             min_indent: None,
             is_directive: false,
         })
@@ -1010,7 +1027,7 @@ impl<'src> CodeExampleRst<'src> {
         }
         Some(CodeExampleRst {
             lines: vec![],
-            opening_indent: indentation_length(original.line),
+            opening_indent: indentation_length(original.line, original.indent_width),
             min_indent: None,
             is_directive: true,
         })
@@ -1030,7 +1047,7 @@ impl<'src> CodeExampleRst<'src> {
             line.code = if line.original.line.trim().is_empty() {
                 ""
             } else {
-                indentation_trim(min_indent, line.original.line)
+                indentation_trim(min_indent, line.original.line, line.original.indent_width)
             };
         }
         &self.lines
@@ -1067,7 +1084,9 @@ impl<'src> CodeExampleRst<'src> {
             // an empty line followed by an unindented non-empty line.
             if let Some(next) = original.next {
                 let (next_indent, next_rest) = indent_with_suffix(next);
-                if !next_rest.is_empty() && indentation_length(next_indent) <= self.opening_indent {
+                if !next_rest.is_empty()
+                    && indentation_length(next_indent, original.indent_width) <= self.opening_indent
+                {
                     self.push_format_action(queue);
                     return None;
                 }
@@ -1079,7 +1098,7 @@ impl<'src> CodeExampleRst<'src> {
             queue.push_back(CodeExampleAddAction::Kept);
             return Some(self);
         }
-        let indent_len = indentation_length(indent);
+        let indent_len = indentation_length(indent, original.indent_width);
         if indent_len <= self.opening_indent {
             // If we find an unindented non-empty line at the same (or less)
             // indentation of the opening line at this point, then we know it
@@ -1141,7 +1160,7 @@ impl<'src> CodeExampleRst<'src> {
             queue.push_back(CodeExampleAddAction::Print { original });
             return Some(self);
         }
-        let min_indent = indentation_length(indent);
+        let min_indent = indentation_length(indent, original.indent_width);
         // At this point, we found a non-empty line. The only thing we require
         // is that its indentation is strictly greater than the indentation of
         // the line containing the `::`. Otherwise, we treat this as an invalid
@@ -1289,7 +1308,7 @@ impl<'src> CodeExampleMarkdown<'src> {
         };
         Some(CodeExampleMarkdown {
             lines: vec![],
-            opening_fence_indent: indentation_length(opening_fence_indent),
+            opening_fence_indent: indentation_length(opening_fence_indent, original.indent_width),
             fence_kind,
             fence_len,
         })
@@ -1322,7 +1341,7 @@ impl<'src> CodeExampleMarkdown<'src> {
         // its indent normalized. And, at the time of writing, a subsequent
         // formatting run undoes this indentation, thus violating idempotency.
         if !original.line.trim_whitespace().is_empty()
-            && indentation_length(original.line) < self.opening_fence_indent
+            && indentation_length(original.line, original.indent_width) < self.opening_fence_indent
         {
             queue.push_back(self.into_reset_action());
             queue.push_back(CodeExampleAddAction::Print { original });
@@ -1368,7 +1387,11 @@ impl<'src> CodeExampleMarkdown<'src> {
         // Unlike reStructuredText blocks, for Markdown fenced code blocks, the
         // indentation that we want to strip from each line is known when the
         // block is opened. So we can strip it as we collect lines.
-        let code = indentation_trim(self.opening_fence_indent, original.line);
+        let code = indentation_trim(
+            self.opening_fence_indent,
+            original.line,
+            original.indent_width,
+        );
         self.lines.push(CodeExampleLine { original, code });
     }
 
@@ -1538,12 +1561,13 @@ fn needs_chaperone_space(normalized: &NormalizedString, trim_end: &str) -> bool 
 /// to the next multiple of 8. This is effectively a port of
 /// [`str.expandtabs`](https://docs.python.org/3/library/stdtypes.html#str.expandtabs),
 /// which black [calls with the default tab width of 8](https://github.com/psf/black/blob/c36e468794f9256d5e922c399240d49782ba04f1/src/black/strings.py#L61).
-fn indentation_length(line: &str) -> TextSize {
+/// Our version uses the configured indent width for tabs instead.
+fn indentation_length(line: &str, indent_width: IndentWidth) -> TextSize {
     let mut indentation = 0u32;
     for char in line.chars() {
         if char == '\t' {
             // Pad to the next multiple of tab_width
-            indentation += 8 - (indentation.rem_euclid(8));
+            indentation += indent_width.value() - (indentation.rem_euclid(indent_width.value()));
         } else if char.is_whitespace() {
             indentation += u32::from(char.text_len());
         } else {
@@ -1560,7 +1584,7 @@ fn indentation_length(line: &str) -> TextSize {
 /// `indentation_length`. This is useful when one needs to trim some minimum
 /// level of indentation from a code snippet collected from a docstring before
 /// attempting to reformat it.
-fn indentation_trim(indent_len: TextSize, line: &str) -> &str {
+fn indentation_trim(indent_len: TextSize, line: &str, indent_width: IndentWidth) -> &str {
     let mut seen_indent_len = 0u32;
     let mut trimmed = line;
     for char in line.chars() {
@@ -1569,7 +1593,8 @@ fn indentation_trim(indent_len: TextSize, line: &str) -> &str {
         }
         if char == '\t' {
             // Pad to the next multiple of tab_width
-            seen_indent_len += 8 - (seen_indent_len.rem_euclid(8));
+            seen_indent_len +=
+                indent_width.value() - (seen_indent_len.rem_euclid(indent_width.value()));
             trimmed = &trimmed[1..];
         } else if char.is_whitespace() {
             seen_indent_len += u32::from(char.text_len());
@@ -1608,15 +1633,17 @@ fn is_rst_option(line: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use ruff_formatter::IndentWidth;
     use ruff_text_size::TextSize;
 
     use super::indentation_length;
 
     #[test]
     fn test_indentation_like_black() {
-        assert_eq!(indentation_length("\t \t  \t"), TextSize::new(24));
-        assert_eq!(indentation_length("\t        \t"), TextSize::new(24));
-        assert_eq!(indentation_length("\t\t\t"), TextSize::new(24));
-        assert_eq!(indentation_length("    "), TextSize::new(4));
+        let w: IndentWidth = 8.try_into().unwrap();
+        assert_eq!(indentation_length("\t \t  \t", w), TextSize::new(24));
+        assert_eq!(indentation_length("\t        \t", w), TextSize::new(24));
+        assert_eq!(indentation_length("\t\t\t", w), TextSize::new(24));
+        assert_eq!(indentation_length("    ", w), TextSize::new(4));
     }
 }

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__docstring.py.snap
@@ -1,0 +1,731 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/docstring.py
+---
+## Input
+
+```python
+class MyClass:
+  """ Multiline
+  class docstring
+  """
+
+  def method(self):
+    """Multiline
+    method docstring
+    """
+    pass
+
+
+def foo():
+  """This is a docstring with             
+  some lines of text here
+  """
+  return
+
+
+def bar():
+  '''This is another docstring
+  with more lines of text
+  '''
+  return
+
+
+def baz():
+  '''"This" is a string with some
+  embedded "quotes"'''
+  return
+
+
+def troz():
+	'''Indentation with tabs
+	is just as OK
+	'''
+	return
+
+
+def zort():
+        """Another
+        multiline
+        docstring
+        """
+        pass
+
+def poit():
+  """
+  Lorem ipsum dolor sit amet.       
+
+  Consectetur adipiscing elit:
+   - sed do eiusmod tempor incididunt ut labore
+   - dolore magna aliqua
+     - enim ad minim veniam
+     - quis nostrud exercitation ullamco laboris nisi
+   - aliquip ex ea commodo consequat
+  """
+  pass
+
+
+def under_indent():
+  """
+  These lines are indented in a way that does not
+make sense.
+  """
+  pass
+
+
+def over_indent():
+  """
+  This has a shallow indent
+    - But some lines are deeper
+    - And the closing quote is too deep
+    """
+  pass
+
+
+def single_line():
+    """But with a newline after it!
+
+    """
+    pass
+
+
+def this():
+    r"""
+    'hey ho'
+    """
+
+
+def that():
+  """ "hey yah" """
+
+
+def and_that():
+  """
+  "hey yah" """
+
+
+def and_this():
+  ''' 
+  "hey yah"'''
+
+
+def multiline_whitespace():
+    '''
+    
+    
+    
+    
+    '''
+
+
+def oneline_whitespace():
+    '''      '''
+
+
+def empty():
+    """"""
+
+
+def single_quotes():
+    'testing'
+
+
+def believe_it_or_not_this_is_in_the_py_stdlib(): ''' 
+"hey yah"'''
+
+
+def ignored_docstring():
+    """a => \
+b"""  
+
+def single_line_docstring_with_whitespace():
+    """   This should be stripped """
+
+def docstring_with_inline_tabs_and_space_indentation():
+    """hey
+
+    tab	separated	value
+    	tab at start of line and then a tab	separated	value
+    				multiple tabs at the beginning	and	inline
+    	 	  	mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+    			 	  		
+    line ends with some tabs		
+    """
+
+
+def docstring_with_inline_tabs_and_tab_indentation():
+	"""hey
+
+	tab	separated	value
+		tab at start of line and then a tab	separated	value
+					multiple tabs at the beginning	and	inline
+		 	  	mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+				 	  		
+	line ends with some tabs		
+	"""
+	pass
+
+
+def backslash_space():
+    """\ """
+
+
+def multiline_backslash_1():
+  '''
+  hey\there\
+  \ '''
+
+
+def multiline_backslash_2():
+  '''
+  hey there \ '''
+
+# Regression test for #3425
+def multiline_backslash_really_long_dont_crash():
+    """
+    hey there hello guten tag hi hoow are you ola zdravstvuyte ciao como estas ca va \ """
+
+
+def multiline_backslash_3():
+  '''
+  already escaped \\ '''
+
+
+def my_god_its_full_of_stars_1():
+    "I'm sorry Dave\u2001"
+
+
+# the space below is actually a \u2001, removed in output
+def my_god_its_full_of_stars_2():
+    "I'm sorry Dave "
+
+
+def docstring_almost_at_line_limit():
+    """long docstring................................................................."""
+
+
+def docstring_almost_at_line_limit2():
+    """long docstring.................................................................
+
+    ..................................................................................
+    """
+
+
+def docstring_at_line_limit():
+    """long docstring................................................................"""
+
+
+def multiline_docstring_at_line_limit():
+    """first line-----------------------------------------------------------------------
+
+    second line----------------------------------------------------------------------"""
+
+
+def stable_quote_normalization_with_immediate_inner_single_quote(self):
+    ''''<text here>
+
+    <text here, since without another non-empty line black is stable>
+    '''
+
+
+def foo():
+    """
+    Docstring with a backslash followed by a space\ 
+    and then another line
+    """
+```
+
+## Black Differences
+
+```diff
+--- Black
++++ Ruff
+@@ -136,8 +136,8 @@
+ 
+     tab	separated	value
+         tab at start of line and then a tab	separated	value
+-                                multiple tabs at the beginning	and	inline
+-                        mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
++                    multiple tabs at the beginning	and	inline
++                mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+ 
+     line ends with some tabs
+     """
+@@ -147,9 +147,9 @@
+     """hey
+ 
+     tab	separated	value
+-            tab at start of line and then a tab	separated	value
+-                                    multiple tabs at the beginning	and	inline
+-                            mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
++        tab at start of line and then a tab	separated	value
++                    multiple tabs at the beginning	and	inline
++                mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+ 
+     line ends with some tabs
+     """
+```
+
+## Ruff Output
+
+```python
+class MyClass:
+    """Multiline
+    class docstring
+    """
+
+    def method(self):
+        """Multiline
+        method docstring
+        """
+        pass
+
+
+def foo():
+    """This is a docstring with
+    some lines of text here
+    """
+    return
+
+
+def bar():
+    """This is another docstring
+    with more lines of text
+    """
+    return
+
+
+def baz():
+    '''"This" is a string with some
+    embedded "quotes"'''
+    return
+
+
+def troz():
+    """Indentation with tabs
+    is just as OK
+    """
+    return
+
+
+def zort():
+    """Another
+    multiline
+    docstring
+    """
+    pass
+
+
+def poit():
+    """
+    Lorem ipsum dolor sit amet.
+
+    Consectetur adipiscing elit:
+     - sed do eiusmod tempor incididunt ut labore
+     - dolore magna aliqua
+       - enim ad minim veniam
+       - quis nostrud exercitation ullamco laboris nisi
+     - aliquip ex ea commodo consequat
+    """
+    pass
+
+
+def under_indent():
+    """
+      These lines are indented in a way that does not
+    make sense.
+    """
+    pass
+
+
+def over_indent():
+    """
+    This has a shallow indent
+      - But some lines are deeper
+      - And the closing quote is too deep
+    """
+    pass
+
+
+def single_line():
+    """But with a newline after it!"""
+    pass
+
+
+def this():
+    r"""
+    'hey ho'
+    """
+
+
+def that():
+    """ "hey yah" """
+
+
+def and_that():
+    """
+    "hey yah" """
+
+
+def and_this():
+    '''
+    "hey yah"'''
+
+
+def multiline_whitespace():
+    """ """
+
+
+def oneline_whitespace():
+    """ """
+
+
+def empty():
+    """"""
+
+
+def single_quotes():
+    "testing"
+
+
+def believe_it_or_not_this_is_in_the_py_stdlib():
+    '''
+    "hey yah"'''
+
+
+def ignored_docstring():
+    """a => \
+b"""
+
+
+def single_line_docstring_with_whitespace():
+    """This should be stripped"""
+
+
+def docstring_with_inline_tabs_and_space_indentation():
+    """hey
+
+    tab	separated	value
+        tab at start of line and then a tab	separated	value
+                    multiple tabs at the beginning	and	inline
+                mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+
+    line ends with some tabs
+    """
+
+
+def docstring_with_inline_tabs_and_tab_indentation():
+    """hey
+
+    tab	separated	value
+        tab at start of line and then a tab	separated	value
+                    multiple tabs at the beginning	and	inline
+                mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+
+    line ends with some tabs
+    """
+    pass
+
+
+def backslash_space():
+    """\ """
+
+
+def multiline_backslash_1():
+    """
+  hey\there\
+  \ """
+
+
+def multiline_backslash_2():
+    """
+    hey there \ """
+
+
+# Regression test for #3425
+def multiline_backslash_really_long_dont_crash():
+    """
+    hey there hello guten tag hi hoow are you ola zdravstvuyte ciao como estas ca va \ """
+
+
+def multiline_backslash_3():
+    """
+    already escaped \\"""
+
+
+def my_god_its_full_of_stars_1():
+    "I'm sorry Dave\u2001"
+
+
+# the space below is actually a \u2001, removed in output
+def my_god_its_full_of_stars_2():
+    "I'm sorry Dave"
+
+
+def docstring_almost_at_line_limit():
+    """long docstring................................................................."""
+
+
+def docstring_almost_at_line_limit2():
+    """long docstring.................................................................
+
+    ..................................................................................
+    """
+
+
+def docstring_at_line_limit():
+    """long docstring................................................................"""
+
+
+def multiline_docstring_at_line_limit():
+    """first line-----------------------------------------------------------------------
+
+    second line----------------------------------------------------------------------"""
+
+
+def stable_quote_normalization_with_immediate_inner_single_quote(self):
+    """'<text here>
+
+    <text here, since without another non-empty line black is stable>
+    """
+
+
+def foo():
+    """
+    Docstring with a backslash followed by a space\ 
+    and then another line
+    """
+```
+
+## Black Output
+
+```python
+class MyClass:
+    """Multiline
+    class docstring
+    """
+
+    def method(self):
+        """Multiline
+        method docstring
+        """
+        pass
+
+
+def foo():
+    """This is a docstring with
+    some lines of text here
+    """
+    return
+
+
+def bar():
+    """This is another docstring
+    with more lines of text
+    """
+    return
+
+
+def baz():
+    '''"This" is a string with some
+    embedded "quotes"'''
+    return
+
+
+def troz():
+    """Indentation with tabs
+    is just as OK
+    """
+    return
+
+
+def zort():
+    """Another
+    multiline
+    docstring
+    """
+    pass
+
+
+def poit():
+    """
+    Lorem ipsum dolor sit amet.
+
+    Consectetur adipiscing elit:
+     - sed do eiusmod tempor incididunt ut labore
+     - dolore magna aliqua
+       - enim ad minim veniam
+       - quis nostrud exercitation ullamco laboris nisi
+     - aliquip ex ea commodo consequat
+    """
+    pass
+
+
+def under_indent():
+    """
+      These lines are indented in a way that does not
+    make sense.
+    """
+    pass
+
+
+def over_indent():
+    """
+    This has a shallow indent
+      - But some lines are deeper
+      - And the closing quote is too deep
+    """
+    pass
+
+
+def single_line():
+    """But with a newline after it!"""
+    pass
+
+
+def this():
+    r"""
+    'hey ho'
+    """
+
+
+def that():
+    """ "hey yah" """
+
+
+def and_that():
+    """
+    "hey yah" """
+
+
+def and_this():
+    '''
+    "hey yah"'''
+
+
+def multiline_whitespace():
+    """ """
+
+
+def oneline_whitespace():
+    """ """
+
+
+def empty():
+    """"""
+
+
+def single_quotes():
+    "testing"
+
+
+def believe_it_or_not_this_is_in_the_py_stdlib():
+    '''
+    "hey yah"'''
+
+
+def ignored_docstring():
+    """a => \
+b"""
+
+
+def single_line_docstring_with_whitespace():
+    """This should be stripped"""
+
+
+def docstring_with_inline_tabs_and_space_indentation():
+    """hey
+
+    tab	separated	value
+        tab at start of line and then a tab	separated	value
+                                multiple tabs at the beginning	and	inline
+                        mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+
+    line ends with some tabs
+    """
+
+
+def docstring_with_inline_tabs_and_tab_indentation():
+    """hey
+
+    tab	separated	value
+            tab at start of line and then a tab	separated	value
+                                    multiple tabs at the beginning	and	inline
+                            mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+
+    line ends with some tabs
+    """
+    pass
+
+
+def backslash_space():
+    """\ """
+
+
+def multiline_backslash_1():
+    """
+  hey\there\
+  \ """
+
+
+def multiline_backslash_2():
+    """
+    hey there \ """
+
+
+# Regression test for #3425
+def multiline_backslash_really_long_dont_crash():
+    """
+    hey there hello guten tag hi hoow are you ola zdravstvuyte ciao como estas ca va \ """
+
+
+def multiline_backslash_3():
+    """
+    already escaped \\"""
+
+
+def my_god_its_full_of_stars_1():
+    "I'm sorry Dave\u2001"
+
+
+# the space below is actually a \u2001, removed in output
+def my_god_its_full_of_stars_2():
+    "I'm sorry Dave"
+
+
+def docstring_almost_at_line_limit():
+    """long docstring................................................................."""
+
+
+def docstring_almost_at_line_limit2():
+    """long docstring.................................................................
+
+    ..................................................................................
+    """
+
+
+def docstring_at_line_limit():
+    """long docstring................................................................"""
+
+
+def multiline_docstring_at_line_limit():
+    """first line-----------------------------------------------------------------------
+
+    second line----------------------------------------------------------------------"""
+
+
+def stable_quote_normalization_with_immediate_inner_single_quote(self):
+    """'<text here>
+
+    <text here, since without another non-empty line black is stable>
+    """
+
+
+def foo():
+    """
+    Docstring with a backslash followed by a space\ 
+    and then another line
+    """
+```
+
+

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring.py.snap
@@ -330,7 +330,7 @@ class TabbedIndent:
         """check for correct tabbed formatting
                                     ^^^^^^^^^^
         Normal indented line
-                - autor
+            - autor
         """
 
 
@@ -506,7 +506,7 @@ class TabbedIndent:
     """check for correct tabbed formatting
                                 ^^^^^^^^^^
     Normal indented line
-            - autor
+        - autor
     """
 
 
@@ -680,9 +680,9 @@ def f():
 class TabbedIndent:
 	def tabbed_indent(self):
 		"""check for correct tabbed formatting
-		                            ^^^^^^^^^^
+					    ^^^^^^^^^^
 		Normal indented line
-		        - autor
+			- autor
 		"""
 
 
@@ -856,9 +856,9 @@ def f():
 class TabbedIndent:
 	def tabbed_indent(self):
 		"""check for correct tabbed formatting
-		                            ^^^^^^^^^^
+									^^^^^^^^^^
 		Normal indented line
-		        - autor
+			- autor
 		"""
 
 
@@ -1034,7 +1034,7 @@ class TabbedIndent:
         """check for correct tabbed formatting
                                     ^^^^^^^^^^
         Normal indented line
-                - autor
+            - autor
         """
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
@@ -1872,7 +1872,7 @@ def rst_literal_first_line_indent_uses_tabs_4spaces():
     """
     Do cool stuff::
 
-        cool_stuff( 1 )
+    cool_stuff( 1 )
 
     Done.
     """
@@ -1884,8 +1884,8 @@ def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
     """
     Do cool stuff::
 
-        cool_stuff( 1 )
-        cool_stuff( 2 )
+    cool_stuff( 1 )
+    cool_stuff( 2 )
 
     Done.
     """
@@ -1901,11 +1901,11 @@ def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
 # As with the above example, reST seems to behave the same way here.
 def rst_literal_first_line_indent_uses_tabs_8spaces():
     """
-    Do cool stuff::
+       Do cool stuff::
 
-     cool_stuff( 1 )
+    cool_stuff( 1 )
 
-    Done.
+       Done.
     """
     pass
 
@@ -1913,12 +1913,12 @@ def rst_literal_first_line_indent_uses_tabs_8spaces():
 # Like the test above, but with multiple lines.
 def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
     """
-    Do cool stuff::
+       Do cool stuff::
 
-     cool_stuff( 1 )
-     cool_stuff( 2 )
+    cool_stuff( 1 )
+    cool_stuff( 2 )
 
-    Done.
+       Done.
     """
     pass
 
@@ -1930,7 +1930,7 @@ def rst_literal_first_line_tab_second_line_spaces():
     """
     Do cool stuff::
 
-        cool_stuff( 1 )
+    cool_stuff( 1 )
         cool_stuff( 2 )
 
     Done.
@@ -1960,7 +1960,7 @@ def rst_literal_odd_indentation():
     """
     Do cool stuff::
 
-        cool_stuff( 1 )
+    cool_stuff( 1 )
      cool_stuff( 2 )
 
     Done.
@@ -2082,11 +2082,11 @@ def rst_literal_skipped_first_line_not_indented_then_indented():
 # and doesn't treat it as a literal block.
 def rst_literal_skipped_first_line_not_indented_tab():
     """
-    Do cool stuff::
+        Do cool stuff::
 
     cool_stuff( 1 )
 
-    Done.
+        Done.
     """
     pass
 
@@ -2094,12 +2094,12 @@ def rst_literal_skipped_first_line_not_indented_tab():
 # Like the previous test, but adds a second line.
 def rst_literal_skipped_first_line_not_indented_tab_multiple():
     """
-    Do cool stuff::
+        Do cool stuff::
 
     cool_stuff( 1 )
     cool_stuff( 2 )
 
-    Done.
+        Done.
     """
     pass
 
@@ -2427,7 +2427,7 @@ def markdown_first_line_indent_uses_tabs_4spaces():
     Do cool stuff.
 
     ```py
-        cool_stuff( 1 )
+    cool_stuff( 1 )
     ```
 
     Done.
@@ -2440,8 +2440,8 @@ def markdown_first_line_indent_uses_tabs_4spaces_multiple():
     Do cool stuff.
 
     ```py
-        cool_stuff( 1 )
-        cool_stuff( 2 )
+    cool_stuff( 1 )
+    cool_stuff( 2 )
     ```
 
     Done.
@@ -2451,27 +2451,27 @@ def markdown_first_line_indent_uses_tabs_4spaces_multiple():
 
 def markdown_first_line_indent_uses_tabs_8spaces():
     """
-    Do cool stuff.
+       Do cool stuff.
 
-     ```py
-     cool_stuff( 1 )
-     ```
+    ```py
+    cool_stuff( 1 )
+    ```
 
-    Done.
+       Done.
     """
     pass
 
 
 def markdown_first_line_indent_uses_tabs_8spaces_multiple():
     """
-    Do cool stuff.
+       Do cool stuff.
 
-     ```py
-     cool_stuff( 1 )
-     cool_stuff( 2 )
-     ```
+    ```py
+    cool_stuff( 1 )
+    cool_stuff( 2 )
+    ```
 
-    Done.
+       Done.
     """
     pass
 
@@ -2480,10 +2480,10 @@ def markdown_first_line_tab_second_line_spaces():
     """
     Do cool stuff.
 
-        ```py
-        cool_stuff( 1 )
+    ```py
+    cool_stuff( 1 )
         cool_stuff( 2 )
-        ```
+    ```
 
     Done.
     """
@@ -2494,10 +2494,10 @@ def markdown_odd_indentation():
     """
     Do cool stuff.
 
-        ```py
-        cool_stuff( 1 )
+    ```py
+    cool_stuff( 1 )
         cool_stuff( 2 )
-        ```
+    ```
 
     Done.
     """
@@ -3242,11 +3242,11 @@ def rst_literal_subsequent_line_not_indented():
 # under-specified.)
 def rst_literal_first_line_indent_uses_tabs_4spaces():
   """
-  Do cool stuff::
+    Do cool stuff::
 
-      cool_stuff( 1 )
+  cool_stuff( 1 )
 
-  Done.
+    Done.
   """
   pass
 
@@ -3254,12 +3254,12 @@ def rst_literal_first_line_indent_uses_tabs_4spaces():
 # Like the test above, but with multiple lines.
 def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
   """
-  Do cool stuff::
+    Do cool stuff::
 
-      cool_stuff( 1 )
-      cool_stuff( 2 )
+  cool_stuff( 1 )
+  cool_stuff( 2 )
 
-  Done.
+    Done.
   """
   pass
 
@@ -3273,11 +3273,11 @@ def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
 # As with the above example, reST seems to behave the same way here.
 def rst_literal_first_line_indent_uses_tabs_8spaces():
   """
-  Do cool stuff::
+       Do cool stuff::
 
-   cool_stuff( 1 )
+  cool_stuff( 1 )
 
-  Done.
+       Done.
   """
   pass
 
@@ -3285,12 +3285,12 @@ def rst_literal_first_line_indent_uses_tabs_8spaces():
 # Like the test above, but with multiple lines.
 def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
   """
-  Do cool stuff::
+       Do cool stuff::
 
-   cool_stuff( 1 )
-   cool_stuff( 2 )
+  cool_stuff( 1 )
+  cool_stuff( 2 )
 
-  Done.
+       Done.
   """
   pass
 
@@ -3300,12 +3300,12 @@ def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
 # block and format it.
 def rst_literal_first_line_tab_second_line_spaces():
   """
-  Do cool stuff::
+    Do cool stuff::
 
-      cool_stuff( 1 )
-      cool_stuff( 2 )
+  cool_stuff( 1 )
+        cool_stuff( 2 )
 
-  Done.
+    Done.
   """
   pass
 
@@ -3330,12 +3330,12 @@ def rst_literal_first_line_tab_second_line_spaces():
 # the real world. ---AG
 def rst_literal_odd_indentation():
   """
-  Do cool stuff::
+    Do cool stuff::
 
-      cool_stuff( 1 )
-   cool_stuff( 2 )
+  cool_stuff( 1 )
+     cool_stuff( 2 )
 
-  Done.
+    Done.
   """
   pass
 
@@ -3454,11 +3454,11 @@ def rst_literal_skipped_first_line_not_indented_then_indented():
 # and doesn't treat it as a literal block.
 def rst_literal_skipped_first_line_not_indented_tab():
   """
-  Do cool stuff::
+        Do cool stuff::
 
   cool_stuff( 1 )
 
-  Done.
+        Done.
   """
   pass
 
@@ -3466,12 +3466,12 @@ def rst_literal_skipped_first_line_not_indented_tab():
 # Like the previous test, but adds a second line.
 def rst_literal_skipped_first_line_not_indented_tab_multiple():
   """
-  Do cool stuff::
+        Do cool stuff::
 
   cool_stuff( 1 )
   cool_stuff( 2 )
 
-  Done.
+        Done.
   """
   pass
 
@@ -3796,82 +3796,82 @@ def markdown_with_blank_lines():
 
 def markdown_first_line_indent_uses_tabs_4spaces():
   """
-  Do cool stuff.
+    Do cool stuff.
 
-  ```py
-      cool_stuff( 1 )
-  ```
+    ```py
+  cool_stuff( 1 )
+    ```
 
-  Done.
+    Done.
   """
   pass
 
 
 def markdown_first_line_indent_uses_tabs_4spaces_multiple():
   """
-  Do cool stuff.
+    Do cool stuff.
 
-  ```py
-      cool_stuff( 1 )
-      cool_stuff( 2 )
-  ```
+    ```py
+  cool_stuff( 1 )
+  cool_stuff( 2 )
+    ```
 
-  Done.
+    Done.
   """
   pass
 
 
 def markdown_first_line_indent_uses_tabs_8spaces():
   """
-  Do cool stuff.
+       Do cool stuff.
 
-   ```py
-   cool_stuff( 1 )
-   ```
+  ```py
+  cool_stuff( 1 )
+  ```
 
-  Done.
+       Done.
   """
   pass
 
 
 def markdown_first_line_indent_uses_tabs_8spaces_multiple():
   """
-  Do cool stuff.
+       Do cool stuff.
 
-   ```py
-   cool_stuff( 1 )
-   cool_stuff( 2 )
-   ```
+  ```py
+  cool_stuff( 1 )
+  cool_stuff( 2 )
+  ```
 
-  Done.
+       Done.
   """
   pass
 
 
 def markdown_first_line_tab_second_line_spaces():
   """
-  Do cool stuff.
+    Do cool stuff.
 
-      ```py
-      cool_stuff( 1 )
-      cool_stuff( 2 )
-      ```
+  ```py
+  cool_stuff( 1 )
+        cool_stuff( 2 )
+  ```
 
-  Done.
+    Done.
   """
   pass
 
 
 def markdown_odd_indentation():
   """
-  Do cool stuff.
+    Do cool stuff.
 
-      ```py
-      cool_stuff( 1 )
-      cool_stuff( 2 )
-      ```
+  ```py
+  cool_stuff( 1 )
+        cool_stuff( 2 )
+  ```
 
-  Done.
+    Done.
   """
   pass
 
@@ -4498,7 +4498,7 @@ def rst_literal_simple_continued():
 	Do cool stuff::
 
 	    def cool_stuff( x ):
-	        print( f"hi {x}" );
+		print( f"hi {x}" );
 
 	Done.
 	"""
@@ -4531,10 +4531,10 @@ def rst_literal_with_blank_lines():
 	Do cool stuff::
 
 	    def cool_stuff( x ):
-	        print( f"hi {x}" );
+		print( f"hi {x}" );
 
 	    def other_stuff( y ):
-	        print(    y     )
+		print(    y     )
 
 	Done.
 	"""
@@ -5379,9 +5379,9 @@ def markdown_skipped_unindented_completely():
 	"""
 	    Do cool stuff.
 
-	        ```py
+		```py
 	cool_stuff( 1 )
-	        ```
+		```
 
 	    Done.
 	"""
@@ -5705,8 +5705,8 @@ def doctest_varying_start_column():
 
 	>>> assert    ("Easy!")
 	  >>> import                      math
-	      >>> math.floor(  1.9  )
-	      1
+		  >>> math.floor(  1.9  )
+		  1
 	"""
 	pass
 
@@ -5858,7 +5858,7 @@ def rst_literal_simple():
 	"""
 	Do cool stuff::
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	Done.
 	"""
@@ -5869,8 +5869,8 @@ def rst_literal_simple_continued():
 	"""
 	Do cool stuff::
 
-	    def cool_stuff( x ):
-	        print( f"hi {x}" );
+		def cool_stuff( x ):
+			print( f"hi {x}" );
 
 	Done.
 	"""
@@ -5883,7 +5883,7 @@ def rst_literal_second_to_last():
 	"""
 	Do cool stuff::
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 	"""
 	pass
 
@@ -5894,7 +5894,7 @@ def rst_literal_actually_last():
 	"""
 	Do cool stuff::
 
-	    cool_stuff( 1 )"""
+		cool_stuff( 1 )"""
 	pass
 
 
@@ -5902,11 +5902,11 @@ def rst_literal_with_blank_lines():
 	"""
 	Do cool stuff::
 
-	    def cool_stuff( x ):
-	        print( f"hi {x}" );
+		def cool_stuff( x ):
+			print( f"hi {x}" );
 
-	    def other_stuff( y ):
-	        print(    y     )
+		def other_stuff( y ):
+			print(    y     )
 
 	Done.
 	"""
@@ -5920,7 +5920,7 @@ def rst_literal_extra_blanks():
 
 
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 
 
@@ -5937,7 +5937,7 @@ def rst_literal_extra_blanks_at_end():
 	Do cool stuff::
 
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 
 
@@ -5951,10 +5951,10 @@ def rst_literal_extra_blanks_in_snippet():
 	"""
 	Do cool stuff::
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 
-	    cool_stuff( 2 )
+		cool_stuff( 2 )
 
 	Done.
 	"""
@@ -5968,7 +5968,7 @@ def rst_literal_subsequent_line_not_indented():
 	Do cool stuff::
 
 	 if True:
-	    cool_stuff( '''
+		cool_stuff( '''
 	 hiya''' )
 
 	Done.
@@ -5988,7 +5988,7 @@ def rst_literal_first_line_indent_uses_tabs_4spaces():
 	"""
 	Do cool stuff::
 
-	    cool_stuff( 1 )
+	cool_stuff( 1 )
 
 	Done.
 	"""
@@ -6000,8 +6000,8 @@ def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
 	"""
 	Do cool stuff::
 
-	    cool_stuff( 1 )
-	    cool_stuff( 2 )
+	cool_stuff( 1 )
+	cool_stuff( 2 )
 
 	Done.
 	"""
@@ -6017,11 +6017,11 @@ def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
 # As with the above example, reST seems to behave the same way here.
 def rst_literal_first_line_indent_uses_tabs_8spaces():
 	"""
-	Do cool stuff::
+	   Do cool stuff::
 
-	 cool_stuff( 1 )
+	cool_stuff( 1 )
 
-	Done.
+	   Done.
 	"""
 	pass
 
@@ -6029,12 +6029,12 @@ def rst_literal_first_line_indent_uses_tabs_8spaces():
 # Like the test above, but with multiple lines.
 def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
 	"""
-	Do cool stuff::
+	   Do cool stuff::
 
-	 cool_stuff( 1 )
-	 cool_stuff( 2 )
+	cool_stuff( 1 )
+	cool_stuff( 2 )
 
-	Done.
+	   Done.
 	"""
 	pass
 
@@ -6046,8 +6046,8 @@ def rst_literal_first_line_tab_second_line_spaces():
 	"""
 	Do cool stuff::
 
-	    cool_stuff( 1 )
-	    cool_stuff( 2 )
+	cool_stuff( 1 )
+		cool_stuff( 2 )
 
 	Done.
 	"""
@@ -6076,7 +6076,7 @@ def rst_literal_odd_indentation():
 	"""
 	Do cool stuff::
 
-	    cool_stuff( 1 )
+	cool_stuff( 1 )
 	 cool_stuff( 2 )
 
 	Done.
@@ -6092,7 +6092,7 @@ def rst_literal_lone_colon():
 
 	::
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	Done.
 	"""
@@ -6103,7 +6103,7 @@ def rst_directive_simple():
 	"""
 	.. code-block:: python
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	Done.
 	"""
@@ -6114,7 +6114,7 @@ def rst_directive_case_insensitive():
 	"""
 	.. cOdE-bLoCk:: python
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	Done.
 	"""
@@ -6125,7 +6125,7 @@ def rst_directive_sourcecode():
 	"""
 	.. sourcecode:: python
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	Done.
 	"""
@@ -6135,14 +6135,14 @@ def rst_directive_sourcecode():
 def rst_directive_options():
 	"""
 	.. code-block:: python
-	    :linenos:
-	    :emphasize-lines: 2,3
-	    :name: blah blah
+		:linenos:
+		:emphasize-lines: 2,3
+		:name: blah blah
 
-	    cool_stuff( 1 )
-	    cool_stuff( 2 )
-	    cool_stuff( 3 )
-	    cool_stuff( 4 )
+		cool_stuff( 1 )
+		cool_stuff( 2 )
+		cool_stuff( 3 )
+		cool_stuff( 4 )
 
 	Done.
 	"""
@@ -6156,7 +6156,7 @@ def rst_directive_doctest():
 	"""
 	.. code-block:: pycon
 
-	    >>> cool_stuff( 1 )
+		>>> cool_stuff( 1 )
 
 	Done.
 	"""
@@ -6198,11 +6198,11 @@ def rst_literal_skipped_first_line_not_indented_then_indented():
 # and doesn't treat it as a literal block.
 def rst_literal_skipped_first_line_not_indented_tab():
 	"""
-	Do cool stuff::
+		Do cool stuff::
 
 	cool_stuff( 1 )
 
-	Done.
+		Done.
 	"""
 	pass
 
@@ -6210,12 +6210,12 @@ def rst_literal_skipped_first_line_not_indented_tab():
 # Like the previous test, but adds a second line.
 def rst_literal_skipped_first_line_not_indented_tab_multiple():
 	"""
-	Do cool stuff::
+		Do cool stuff::
 
 	cool_stuff( 1 )
 	cool_stuff( 2 )
 
-	Done.
+		Done.
 	"""
 	pass
 
@@ -6230,7 +6230,7 @@ def rst_literal_skipped_subsequent_line_not_indented():
 	Do cool stuff::
 
 	 if True:
-	    cool_stuff( '''
+		cool_stuff( '''
 	hiya''' )
 
 	Done.
@@ -6248,7 +6248,7 @@ def rst_literal_skipped_not_directive():
 	"""
 	.. code-block::
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	Done.
 	"""
@@ -6267,7 +6267,7 @@ def rst_literal_skipped_possible_false_negative():
 	This is a test.
 	.. This is a test::
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	Done.
 	"""
@@ -6282,7 +6282,7 @@ def rst_literal_skipped_doctest():
 	"""
 	Do cool stuff::
 
-	    >>> cool_stuff( 1 )
+		>>> cool_stuff( 1 )
 
 	Done.
 	"""
@@ -6293,9 +6293,9 @@ def rst_literal_skipped_markdown():
 	"""
 	Do cool stuff::
 
-	    ```py
-	    cool_stuff( 1 )
-	    ```
+		```py
+		cool_stuff( 1 )
+		```
 
 	Done.
 	"""
@@ -6317,7 +6317,7 @@ def rst_directive_skipped_wrong_language():
 	"""
 	.. code-block:: rust
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	Done.
 	"""
@@ -6330,7 +6330,7 @@ def rst_directive_skipped_doctest():
 	"""
 	.. code-block:: python
 
-	    >>> cool_stuff( 1 )
+		>>> cool_stuff( 1 )
 
 	Done.
 	"""
@@ -6366,7 +6366,7 @@ def markdown_simple_continued():
 
 	```python
 	def cool_stuff( x ):
-	    print( f"hi {x}" );
+		print( f"hi {x}" );
 	```
 
 	Done.
@@ -6527,10 +6527,10 @@ def markdown_with_blank_lines():
 
 	```py
 	def cool_stuff( x ):
-	    print( f"hi {x}" );
+		print( f"hi {x}" );
 
 	def other_stuff( y ):
-	    print(    y     )
+		print(    y     )
 	```
 
 	Done.
@@ -6543,7 +6543,7 @@ def markdown_first_line_indent_uses_tabs_4spaces():
 	Do cool stuff.
 
 	```py
-	    cool_stuff( 1 )
+	cool_stuff( 1 )
 	```
 
 	Done.
@@ -6556,8 +6556,8 @@ def markdown_first_line_indent_uses_tabs_4spaces_multiple():
 	Do cool stuff.
 
 	```py
-	    cool_stuff( 1 )
-	    cool_stuff( 2 )
+	cool_stuff( 1 )
+	cool_stuff( 2 )
 	```
 
 	Done.
@@ -6567,27 +6567,27 @@ def markdown_first_line_indent_uses_tabs_4spaces_multiple():
 
 def markdown_first_line_indent_uses_tabs_8spaces():
 	"""
-	Do cool stuff.
+	   Do cool stuff.
 
-	 ```py
-	 cool_stuff( 1 )
-	 ```
+	```py
+	cool_stuff( 1 )
+	```
 
-	Done.
+	   Done.
 	"""
 	pass
 
 
 def markdown_first_line_indent_uses_tabs_8spaces_multiple():
 	"""
-	Do cool stuff.
+	   Do cool stuff.
 
-	 ```py
-	 cool_stuff( 1 )
-	 cool_stuff( 2 )
-	 ```
+	```py
+	cool_stuff( 1 )
+	cool_stuff( 2 )
+	```
 
-	Done.
+	   Done.
 	"""
 	pass
 
@@ -6596,10 +6596,10 @@ def markdown_first_line_tab_second_line_spaces():
 	"""
 	Do cool stuff.
 
-	    ```py
-	    cool_stuff( 1 )
-	    cool_stuff( 2 )
-	    ```
+	```py
+	cool_stuff( 1 )
+		cool_stuff( 2 )
+	```
 
 	Done.
 	"""
@@ -6610,10 +6610,10 @@ def markdown_odd_indentation():
 	"""
 	Do cool stuff.
 
-	    ```py
-	    cool_stuff( 1 )
-	    cool_stuff( 2 )
-	    ```
+	```py
+	cool_stuff( 1 )
+		cool_stuff( 2 )
+	```
 
 	Done.
 	"""
@@ -6665,12 +6665,12 @@ def markdown_weird_closing():
 	  ```python
 	  cool_stuff( 1 )
 
-	       ```
-	    # The above fences look like it shouldn't close the block, but we
-	    # allow it to. The fences below re-open a block (until the end of
-	    # the docstring), but it's invalid Python and thus doesn't get
-	    # reformatted.
-	      a = 10
+		   ```
+		# The above fences look like it shouldn't close the block, but we
+		# allow it to. The fences below re-open a block (until the end of
+		# the docstring), but it's invalid Python and thus doesn't get
+		# reformatted.
+		  a = 10
 	  ```
 
 	  Now the code block is closed
@@ -6681,10 +6681,10 @@ def markdown_weird_closing():
 def markdown_over_indented():
 	"""
 	A docstring
-	    over intended
-	    ```python
-	    print( 5 )
-	    ```
+		over intended
+		```python
+		print( 5 )
+		```
 	"""
 	pass
 
@@ -6749,13 +6749,13 @@ def markdown_skipped_accidental_closure():
 # plausibly, to do normalization *after* code snippets have been formatted.
 def markdown_skipped_unindented_completely():
 	"""
-	    Do cool stuff.
+		Do cool stuff.
 
-	        ```py
+			```py
 	cool_stuff( 1 )
-	        ```
+			```
 
-	    Done.
+		Done.
 	"""
 	pass
 
@@ -6768,9 +6768,9 @@ def markdown_skipped_unindented_somewhat():
 	"""
 	Do cool stuff.
 
-	    ```py
+		```py
 	cool_stuff( 1 )
-	    ```
+		```
 
 	Done.
 	"""
@@ -6789,10 +6789,10 @@ def markdown_skipped_unindented_with_inconsistent_indentation():
 	"""
 	Do cool stuff.
 
-	    ```py
+		```py
 	cool_stuff( 1 )
-	    cool_stuff( 2 )
-	    ```
+		cool_stuff( 2 )
+		```
 
 	Done.
 	"""
@@ -6819,7 +6819,7 @@ def markdown_skipped_rst_literal():
 	```py
 	And do this::
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	```
 
@@ -6835,7 +6835,7 @@ def markdown_skipped_rst_directive():
 	```py
 	.. code-block:: python
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	```
 
@@ -7365,7 +7365,7 @@ def rst_literal_first_line_indent_uses_tabs_4spaces():
     """
     Do cool stuff::
 
-        cool_stuff(1)
+    cool_stuff( 1 )
 
     Done.
     """
@@ -7377,8 +7377,8 @@ def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
     """
     Do cool stuff::
 
-        cool_stuff(1)
-        cool_stuff(2)
+    cool_stuff( 1 )
+    cool_stuff( 2 )
 
     Done.
     """
@@ -7394,11 +7394,11 @@ def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
 # As with the above example, reST seems to behave the same way here.
 def rst_literal_first_line_indent_uses_tabs_8spaces():
     """
-    Do cool stuff::
+       Do cool stuff::
 
-     cool_stuff(1)
+    cool_stuff( 1 )
 
-    Done.
+       Done.
     """
     pass
 
@@ -7406,12 +7406,12 @@ def rst_literal_first_line_indent_uses_tabs_8spaces():
 # Like the test above, but with multiple lines.
 def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
     """
-    Do cool stuff::
+       Do cool stuff::
 
-     cool_stuff(1)
-     cool_stuff(2)
+    cool_stuff( 1 )
+    cool_stuff( 2 )
 
-    Done.
+       Done.
     """
     pass
 
@@ -7423,8 +7423,8 @@ def rst_literal_first_line_tab_second_line_spaces():
     """
     Do cool stuff::
 
-        cool_stuff(1)
-        cool_stuff(2)
+    cool_stuff( 1 )
+        cool_stuff( 2 )
 
     Done.
     """
@@ -7453,8 +7453,8 @@ def rst_literal_odd_indentation():
     """
     Do cool stuff::
 
-     cool_stuff(1)
-     cool_stuff(2)
+    cool_stuff( 1 )
+     cool_stuff( 2 )
 
     Done.
     """
@@ -7575,11 +7575,11 @@ def rst_literal_skipped_first_line_not_indented_then_indented():
 # and doesn't treat it as a literal block.
 def rst_literal_skipped_first_line_not_indented_tab():
     """
-    Do cool stuff::
+        Do cool stuff::
 
     cool_stuff( 1 )
 
-    Done.
+        Done.
     """
     pass
 
@@ -7587,12 +7587,12 @@ def rst_literal_skipped_first_line_not_indented_tab():
 # Like the previous test, but adds a second line.
 def rst_literal_skipped_first_line_not_indented_tab_multiple():
     """
-    Do cool stuff::
+        Do cool stuff::
 
     cool_stuff( 1 )
     cool_stuff( 2 )
 
-    Done.
+        Done.
     """
     pass
 
@@ -7942,27 +7942,27 @@ def markdown_first_line_indent_uses_tabs_4spaces_multiple():
 
 def markdown_first_line_indent_uses_tabs_8spaces():
     """
-    Do cool stuff.
+       Do cool stuff.
 
-     ```py
-     cool_stuff(1)
-     ```
+    ```py
+    cool_stuff(1)
+    ```
 
-    Done.
+       Done.
     """
     pass
 
 
 def markdown_first_line_indent_uses_tabs_8spaces_multiple():
     """
-    Do cool stuff.
+       Do cool stuff.
 
-     ```py
-     cool_stuff(1)
-     cool_stuff(2)
-     ```
+    ```py
+    cool_stuff(1)
+    cool_stuff(2)
+    ```
 
-    Done.
+       Done.
     """
     pass
 
@@ -7971,10 +7971,10 @@ def markdown_first_line_tab_second_line_spaces():
     """
     Do cool stuff.
 
-        ```py
-        cool_stuff(1)
-        cool_stuff(2)
-        ```
+    ```py
+    cool_stuff( 1 )
+        cool_stuff( 2 )
+    ```
 
     Done.
     """
@@ -7985,10 +7985,10 @@ def markdown_odd_indentation():
     """
     Do cool stuff.
 
-        ```py
-        cool_stuff(1)
-        cool_stuff(2)
-        ```
+    ```py
+    cool_stuff( 1 )
+        cool_stuff( 2 )
+    ```
 
     Done.
     """
@@ -8768,11 +8768,11 @@ def rst_literal_subsequent_line_not_indented():
 # under-specified.)
 def rst_literal_first_line_indent_uses_tabs_4spaces():
   """
-  Do cool stuff::
+    Do cool stuff::
 
-      cool_stuff(1)
+  cool_stuff( 1 )
 
-  Done.
+    Done.
   """
   pass
 
@@ -8780,12 +8780,12 @@ def rst_literal_first_line_indent_uses_tabs_4spaces():
 # Like the test above, but with multiple lines.
 def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
   """
-  Do cool stuff::
+    Do cool stuff::
 
-      cool_stuff(1)
-      cool_stuff(2)
+  cool_stuff( 1 )
+  cool_stuff( 2 )
 
-  Done.
+    Done.
   """
   pass
 
@@ -8799,11 +8799,11 @@ def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
 # As with the above example, reST seems to behave the same way here.
 def rst_literal_first_line_indent_uses_tabs_8spaces():
   """
-  Do cool stuff::
+       Do cool stuff::
 
-   cool_stuff(1)
+  cool_stuff( 1 )
 
-  Done.
+       Done.
   """
   pass
 
@@ -8811,12 +8811,12 @@ def rst_literal_first_line_indent_uses_tabs_8spaces():
 # Like the test above, but with multiple lines.
 def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
   """
-  Do cool stuff::
+       Do cool stuff::
 
-   cool_stuff(1)
-   cool_stuff(2)
+  cool_stuff( 1 )
+  cool_stuff( 2 )
 
-  Done.
+       Done.
   """
   pass
 
@@ -8826,12 +8826,12 @@ def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
 # block and format it.
 def rst_literal_first_line_tab_second_line_spaces():
   """
-  Do cool stuff::
+    Do cool stuff::
 
-      cool_stuff(1)
-      cool_stuff(2)
+  cool_stuff( 1 )
+        cool_stuff( 2 )
 
-  Done.
+    Done.
   """
   pass
 
@@ -8856,12 +8856,12 @@ def rst_literal_first_line_tab_second_line_spaces():
 # the real world. ---AG
 def rst_literal_odd_indentation():
   """
-  Do cool stuff::
+    Do cool stuff::
 
-   cool_stuff(1)
-   cool_stuff(2)
+  cool_stuff( 1 )
+     cool_stuff( 2 )
 
-  Done.
+    Done.
   """
   pass
 
@@ -8980,11 +8980,11 @@ def rst_literal_skipped_first_line_not_indented_then_indented():
 # and doesn't treat it as a literal block.
 def rst_literal_skipped_first_line_not_indented_tab():
   """
-  Do cool stuff::
+        Do cool stuff::
 
   cool_stuff( 1 )
 
-  Done.
+        Done.
   """
   pass
 
@@ -8992,12 +8992,12 @@ def rst_literal_skipped_first_line_not_indented_tab():
 # Like the previous test, but adds a second line.
 def rst_literal_skipped_first_line_not_indented_tab_multiple():
   """
-  Do cool stuff::
+        Do cool stuff::
 
   cool_stuff( 1 )
   cool_stuff( 2 )
 
-  Done.
+        Done.
   """
   pass
 
@@ -9320,82 +9320,82 @@ def markdown_with_blank_lines():
 
 def markdown_first_line_indent_uses_tabs_4spaces():
   """
-  Do cool stuff.
+    Do cool stuff.
 
-  ```py
-  cool_stuff(1)
-  ```
+    ```py
+  cool_stuff( 1 )
+    ```
 
-  Done.
+    Done.
   """
   pass
 
 
 def markdown_first_line_indent_uses_tabs_4spaces_multiple():
   """
-  Do cool stuff.
+    Do cool stuff.
 
-  ```py
-  cool_stuff(1)
-  cool_stuff(2)
-  ```
+    ```py
+  cool_stuff( 1 )
+  cool_stuff( 2 )
+    ```
 
-  Done.
+    Done.
   """
   pass
 
 
 def markdown_first_line_indent_uses_tabs_8spaces():
   """
-  Do cool stuff.
+       Do cool stuff.
 
-   ```py
-   cool_stuff(1)
-   ```
+  ```py
+  cool_stuff(1)
+  ```
 
-  Done.
+       Done.
   """
   pass
 
 
 def markdown_first_line_indent_uses_tabs_8spaces_multiple():
   """
-  Do cool stuff.
+       Do cool stuff.
 
-   ```py
-   cool_stuff(1)
-   cool_stuff(2)
-   ```
+  ```py
+  cool_stuff(1)
+  cool_stuff(2)
+  ```
 
-  Done.
+       Done.
   """
   pass
 
 
 def markdown_first_line_tab_second_line_spaces():
   """
-  Do cool stuff.
+    Do cool stuff.
 
-      ```py
-      cool_stuff(1)
-      cool_stuff(2)
-      ```
+  ```py
+  cool_stuff( 1 )
+        cool_stuff( 2 )
+  ```
 
-  Done.
+    Done.
   """
   pass
 
 
 def markdown_odd_indentation():
   """
-  Do cool stuff.
+    Do cool stuff.
 
-      ```py
-      cool_stuff(1)
-      cool_stuff(2)
-      ```
+  ```py
+  cool_stuff( 1 )
+        cool_stuff( 2 )
+  ```
 
-  Done.
+    Done.
   """
   pass
 
@@ -10063,7 +10063,7 @@ def rst_literal_simple_continued():
 	Do cool stuff::
 
 	    def cool_stuff(x):
-	            print(f"hi {x}")
+		    print(f"hi {x}")
 
 	Done.
 	"""
@@ -10096,11 +10096,11 @@ def rst_literal_with_blank_lines():
 	Do cool stuff::
 
 	    def cool_stuff(x):
-	            print(f"hi {x}")
+		    print(f"hi {x}")
 
 
 	    def other_stuff(y):
-	            print(y)
+		    print(y)
 
 	Done.
 	"""
@@ -10162,10 +10162,10 @@ def rst_literal_subsequent_line_not_indented():
 	Do cool stuff::
 
 	 if True:
-	         cool_stuff(
-	                 '''
+		 cool_stuff(
+			 '''
 	 hiya'''
-	         )
+		 )
 
 	Done.
 	"""
@@ -10562,7 +10562,7 @@ def markdown_simple_continued():
 
 	```python
 	def cool_stuff(x):
-	        print(f"hi {x}")
+		print(f"hi {x}")
 	```
 
 	Done.
@@ -10641,7 +10641,7 @@ def markdown_nested_fences():
 
 	``````
 	do_something(
-	        '''
+		'''
 	```
 	did i trick you?
 	```
@@ -10720,11 +10720,11 @@ def markdown_with_blank_lines():
 
 	```py
 	def cool_stuff(x):
-	        print(f"hi {x}")
+		print(f"hi {x}")
 
 
 	def other_stuff(y):
-	        print(y)
+		print(y)
 	```
 
 	Done.
@@ -10939,9 +10939,9 @@ def markdown_skipped_unindented_completely():
 	"""
 	    Do cool stuff.
 
-	        ```py
+		```py
 	cool_stuff( 1 )
-	        ```
+		```
 
 	    Done.
 	"""
@@ -11041,11 +11041,11 @@ def markdown_skipped_rst_directive():
  	Do cool stuff::
  
  	 if True:
--	         cool_stuff(
--	                 '''
+-		 cool_stuff(
+-			 '''
 -	 hiya'''
--	         )
-+	         cool_stuff('''
+-		 )
++		 cool_stuff('''
 +	 hiya''')
  
  	Done.
@@ -11055,7 +11055,7 @@ def markdown_skipped_rst_directive():
  
  	``````
 -	do_something(
--	        '''
+-		'''
 +	do_something('''
  	```
  	did i trick you?
@@ -11299,8 +11299,8 @@ def doctest_varying_start_column():
 
 	>>> assert "Easy!"
 	  >>> import math
-	      >>> math.floor(1.9)
-	      1
+		  >>> math.floor(1.9)
+		  1
 	"""
 	pass
 
@@ -11456,7 +11456,7 @@ def rst_literal_simple():
 	"""
 	Do cool stuff::
 
-	    cool_stuff(1)
+		cool_stuff(1)
 
 	Done.
 	"""
@@ -11467,8 +11467,8 @@ def rst_literal_simple_continued():
 	"""
 	Do cool stuff::
 
-	    def cool_stuff(x):
-	        print(f"hi {x}")
+		def cool_stuff(x):
+			print(f"hi {x}")
 
 	Done.
 	"""
@@ -11481,7 +11481,7 @@ def rst_literal_second_to_last():
 	"""
 	Do cool stuff::
 
-	    cool_stuff(1)
+		cool_stuff(1)
 	"""
 	pass
 
@@ -11492,7 +11492,7 @@ def rst_literal_actually_last():
 	"""
 	Do cool stuff::
 
-	    cool_stuff(1)"""
+		cool_stuff(1)"""
 	pass
 
 
@@ -11500,12 +11500,12 @@ def rst_literal_with_blank_lines():
 	"""
 	Do cool stuff::
 
-	    def cool_stuff(x):
-	        print(f"hi {x}")
+		def cool_stuff(x):
+			print(f"hi {x}")
 
 
-	    def other_stuff(y):
-	        print(y)
+		def other_stuff(y):
+			print(y)
 
 	Done.
 	"""
@@ -11519,7 +11519,7 @@ def rst_literal_extra_blanks():
 
 
 
-	    cool_stuff(1)
+		cool_stuff(1)
 
 
 
@@ -11536,7 +11536,7 @@ def rst_literal_extra_blanks_at_end():
 	Do cool stuff::
 
 
-	    cool_stuff(1)
+		cool_stuff(1)
 
 
 
@@ -11550,10 +11550,10 @@ def rst_literal_extra_blanks_in_snippet():
 	"""
 	Do cool stuff::
 
-	    cool_stuff(1)
+		cool_stuff(1)
 
 
-	    cool_stuff(2)
+		cool_stuff(2)
 
 	Done.
 	"""
@@ -11567,10 +11567,10 @@ def rst_literal_subsequent_line_not_indented():
 	Do cool stuff::
 
 	 if True:
-	     cool_stuff(
-	         '''
+		 cool_stuff(
+			 '''
 	 hiya'''
-	     )
+		 )
 
 	Done.
 	"""
@@ -11589,7 +11589,7 @@ def rst_literal_first_line_indent_uses_tabs_4spaces():
 	"""
 	Do cool stuff::
 
-	    cool_stuff(1)
+	cool_stuff( 1 )
 
 	Done.
 	"""
@@ -11601,8 +11601,8 @@ def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
 	"""
 	Do cool stuff::
 
-	    cool_stuff(1)
-	    cool_stuff(2)
+	cool_stuff( 1 )
+	cool_stuff( 2 )
 
 	Done.
 	"""
@@ -11618,11 +11618,11 @@ def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
 # As with the above example, reST seems to behave the same way here.
 def rst_literal_first_line_indent_uses_tabs_8spaces():
 	"""
-	Do cool stuff::
+	   Do cool stuff::
 
-	 cool_stuff(1)
+	cool_stuff( 1 )
 
-	Done.
+	   Done.
 	"""
 	pass
 
@@ -11630,12 +11630,12 @@ def rst_literal_first_line_indent_uses_tabs_8spaces():
 # Like the test above, but with multiple lines.
 def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
 	"""
-	Do cool stuff::
+	   Do cool stuff::
 
-	 cool_stuff(1)
-	 cool_stuff(2)
+	cool_stuff( 1 )
+	cool_stuff( 2 )
 
-	Done.
+	   Done.
 	"""
 	pass
 
@@ -11647,8 +11647,8 @@ def rst_literal_first_line_tab_second_line_spaces():
 	"""
 	Do cool stuff::
 
-	    cool_stuff(1)
-	    cool_stuff(2)
+	cool_stuff( 1 )
+		cool_stuff( 2 )
 
 	Done.
 	"""
@@ -11677,8 +11677,8 @@ def rst_literal_odd_indentation():
 	"""
 	Do cool stuff::
 
-	 cool_stuff(1)
-	 cool_stuff(2)
+	cool_stuff( 1 )
+	 cool_stuff( 2 )
 
 	Done.
 	"""
@@ -11693,7 +11693,7 @@ def rst_literal_lone_colon():
 
 	::
 
-	    cool_stuff(1)
+		cool_stuff(1)
 
 	Done.
 	"""
@@ -11704,7 +11704,7 @@ def rst_directive_simple():
 	"""
 	.. code-block:: python
 
-	    cool_stuff(1)
+		cool_stuff(1)
 
 	Done.
 	"""
@@ -11715,7 +11715,7 @@ def rst_directive_case_insensitive():
 	"""
 	.. cOdE-bLoCk:: python
 
-	    cool_stuff(1)
+		cool_stuff(1)
 
 	Done.
 	"""
@@ -11726,7 +11726,7 @@ def rst_directive_sourcecode():
 	"""
 	.. sourcecode:: python
 
-	    cool_stuff(1)
+		cool_stuff(1)
 
 	Done.
 	"""
@@ -11736,14 +11736,14 @@ def rst_directive_sourcecode():
 def rst_directive_options():
 	"""
 	.. code-block:: python
-	    :linenos:
-	    :emphasize-lines: 2,3
-	    :name: blah blah
+		:linenos:
+		:emphasize-lines: 2,3
+		:name: blah blah
 
-	    cool_stuff(1)
-	    cool_stuff(2)
-	    cool_stuff(3)
-	    cool_stuff(4)
+		cool_stuff(1)
+		cool_stuff(2)
+		cool_stuff(3)
+		cool_stuff(4)
 
 	Done.
 	"""
@@ -11757,7 +11757,7 @@ def rst_directive_doctest():
 	"""
 	.. code-block:: pycon
 
-	    >>> cool_stuff(1)
+		>>> cool_stuff(1)
 
 	Done.
 	"""
@@ -11799,11 +11799,11 @@ def rst_literal_skipped_first_line_not_indented_then_indented():
 # and doesn't treat it as a literal block.
 def rst_literal_skipped_first_line_not_indented_tab():
 	"""
-	Do cool stuff::
+		Do cool stuff::
 
 	cool_stuff( 1 )
 
-	Done.
+		Done.
 	"""
 	pass
 
@@ -11811,12 +11811,12 @@ def rst_literal_skipped_first_line_not_indented_tab():
 # Like the previous test, but adds a second line.
 def rst_literal_skipped_first_line_not_indented_tab_multiple():
 	"""
-	Do cool stuff::
+		Do cool stuff::
 
 	cool_stuff( 1 )
 	cool_stuff( 2 )
 
-	Done.
+		Done.
 	"""
 	pass
 
@@ -11831,7 +11831,7 @@ def rst_literal_skipped_subsequent_line_not_indented():
 	Do cool stuff::
 
 	 if True:
-	    cool_stuff( '''
+		cool_stuff( '''
 	hiya''' )
 
 	Done.
@@ -11849,7 +11849,7 @@ def rst_literal_skipped_not_directive():
 	"""
 	.. code-block::
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	Done.
 	"""
@@ -11868,7 +11868,7 @@ def rst_literal_skipped_possible_false_negative():
 	This is a test.
 	.. This is a test::
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	Done.
 	"""
@@ -11883,7 +11883,7 @@ def rst_literal_skipped_doctest():
 	"""
 	Do cool stuff::
 
-	    >>> cool_stuff( 1 )
+		>>> cool_stuff( 1 )
 
 	Done.
 	"""
@@ -11894,9 +11894,9 @@ def rst_literal_skipped_markdown():
 	"""
 	Do cool stuff::
 
-	    ```py
-	    cool_stuff( 1 )
-	    ```
+		```py
+		cool_stuff( 1 )
+		```
 
 	Done.
 	"""
@@ -11918,7 +11918,7 @@ def rst_directive_skipped_wrong_language():
 	"""
 	.. code-block:: rust
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	Done.
 	"""
@@ -11931,7 +11931,7 @@ def rst_directive_skipped_doctest():
 	"""
 	.. code-block:: python
 
-	    >>> cool_stuff( 1 )
+		>>> cool_stuff( 1 )
 
 	Done.
 	"""
@@ -11967,7 +11967,7 @@ def markdown_simple_continued():
 
 	```python
 	def cool_stuff(x):
-	    print(f"hi {x}")
+		print(f"hi {x}")
 	```
 
 	Done.
@@ -12046,7 +12046,7 @@ def markdown_nested_fences():
 
 	``````
 	do_something(
-	    '''
+		'''
 	```
 	did i trick you?
 	```
@@ -12125,11 +12125,11 @@ def markdown_with_blank_lines():
 
 	```py
 	def cool_stuff(x):
-	    print(f"hi {x}")
+		print(f"hi {x}")
 
 
 	def other_stuff(y):
-	    print(y)
+		print(y)
 	```
 
 	Done.
@@ -12166,27 +12166,27 @@ def markdown_first_line_indent_uses_tabs_4spaces_multiple():
 
 def markdown_first_line_indent_uses_tabs_8spaces():
 	"""
-	Do cool stuff.
+	   Do cool stuff.
 
-	 ```py
-	 cool_stuff(1)
-	 ```
+	```py
+	cool_stuff(1)
+	```
 
-	Done.
+	   Done.
 	"""
 	pass
 
 
 def markdown_first_line_indent_uses_tabs_8spaces_multiple():
 	"""
-	Do cool stuff.
+	   Do cool stuff.
 
-	 ```py
-	 cool_stuff(1)
-	 cool_stuff(2)
-	 ```
+	```py
+	cool_stuff(1)
+	cool_stuff(2)
+	```
 
-	Done.
+	   Done.
 	"""
 	pass
 
@@ -12195,10 +12195,10 @@ def markdown_first_line_tab_second_line_spaces():
 	"""
 	Do cool stuff.
 
-	    ```py
-	    cool_stuff(1)
-	    cool_stuff(2)
-	    ```
+	```py
+	cool_stuff( 1 )
+		cool_stuff( 2 )
+	```
 
 	Done.
 	"""
@@ -12209,10 +12209,10 @@ def markdown_odd_indentation():
 	"""
 	Do cool stuff.
 
-	    ```py
-	    cool_stuff(1)
-	    cool_stuff(2)
-	    ```
+	```py
+	cool_stuff( 1 )
+		cool_stuff( 2 )
+	```
 
 	Done.
 	"""
@@ -12258,12 +12258,12 @@ def markdown_weird_closing():
 
 	  ```python
 	  cool_stuff(1)
-	       ```
-	    # The above fences look like it shouldn't close the block, but we
-	    # allow it to. The fences below re-open a block (until the end of
-	    # the docstring), but it's invalid Python and thus doesn't get
-	    # reformatted.
-	      a = 10
+		   ```
+		# The above fences look like it shouldn't close the block, but we
+		# allow it to. The fences below re-open a block (until the end of
+		# the docstring), but it's invalid Python and thus doesn't get
+		# reformatted.
+		  a = 10
 	  ```
 
 	  Now the code block is closed
@@ -12274,10 +12274,10 @@ def markdown_weird_closing():
 def markdown_over_indented():
 	"""
 	A docstring
-	    over intended
-	    ```python
-	    print(5)
-	    ```
+		over intended
+		```python
+		print(5)
+		```
 	"""
 	pass
 
@@ -12342,13 +12342,13 @@ def markdown_skipped_accidental_closure():
 # plausibly, to do normalization *after* code snippets have been formatted.
 def markdown_skipped_unindented_completely():
 	"""
-	    Do cool stuff.
+		Do cool stuff.
 
-	        ```py
+			```py
 	cool_stuff( 1 )
-	        ```
+			```
 
-	    Done.
+		Done.
 	"""
 	pass
 
@@ -12361,9 +12361,9 @@ def markdown_skipped_unindented_somewhat():
 	"""
 	Do cool stuff.
 
-	    ```py
+		```py
 	cool_stuff( 1 )
-	    ```
+		```
 
 	Done.
 	"""
@@ -12382,10 +12382,10 @@ def markdown_skipped_unindented_with_inconsistent_indentation():
 	"""
 	Do cool stuff.
 
-	    ```py
+		```py
 	cool_stuff( 1 )
-	    cool_stuff( 2 )
-	    ```
+		cool_stuff( 2 )
+		```
 
 	Done.
 	"""
@@ -12412,7 +12412,7 @@ def markdown_skipped_rst_literal():
 	```py
 	And do this::
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	```
 
@@ -12428,7 +12428,7 @@ def markdown_skipped_rst_directive():
 	```py
 	.. code-block:: python
 
-	    cool_stuff( 1 )
+		cool_stuff( 1 )
 
 	```
 
@@ -12446,11 +12446,11 @@ def markdown_skipped_rst_directive():
  	Do cool stuff::
  
  	 if True:
--	     cool_stuff(
--	         '''
+-		 cool_stuff(
+-			 '''
 -	 hiya'''
--	     )
-+	     cool_stuff('''
+-		 )
++		 cool_stuff('''
 +	 hiya''')
  
  	Done.
@@ -12460,7 +12460,7 @@ def markdown_skipped_rst_directive():
  
  	``````
 -	do_something(
--	    '''
+-		'''
 +	do_something('''
  	```
  	did i trick you?
@@ -13003,7 +13003,7 @@ def rst_literal_first_line_indent_uses_tabs_4spaces():
     """
     Do cool stuff::
 
-        cool_stuff(1)
+    cool_stuff( 1 )
 
     Done.
     """
@@ -13015,8 +13015,8 @@ def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
     """
     Do cool stuff::
 
-        cool_stuff(1)
-        cool_stuff(2)
+    cool_stuff( 1 )
+    cool_stuff( 2 )
 
     Done.
     """
@@ -13032,11 +13032,11 @@ def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
 # As with the above example, reST seems to behave the same way here.
 def rst_literal_first_line_indent_uses_tabs_8spaces():
     """
-    Do cool stuff::
+       Do cool stuff::
 
-     cool_stuff(1)
+    cool_stuff( 1 )
 
-    Done.
+       Done.
     """
     pass
 
@@ -13044,12 +13044,12 @@ def rst_literal_first_line_indent_uses_tabs_8spaces():
 # Like the test above, but with multiple lines.
 def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
     """
-    Do cool stuff::
+       Do cool stuff::
 
-     cool_stuff(1)
-     cool_stuff(2)
+    cool_stuff( 1 )
+    cool_stuff( 2 )
 
-    Done.
+       Done.
     """
     pass
 
@@ -13061,8 +13061,8 @@ def rst_literal_first_line_tab_second_line_spaces():
     """
     Do cool stuff::
 
-        cool_stuff(1)
-        cool_stuff(2)
+    cool_stuff( 1 )
+        cool_stuff( 2 )
 
     Done.
     """
@@ -13091,8 +13091,8 @@ def rst_literal_odd_indentation():
     """
     Do cool stuff::
 
-     cool_stuff(1)
-     cool_stuff(2)
+    cool_stuff( 1 )
+     cool_stuff( 2 )
 
     Done.
     """
@@ -13213,11 +13213,11 @@ def rst_literal_skipped_first_line_not_indented_then_indented():
 # and doesn't treat it as a literal block.
 def rst_literal_skipped_first_line_not_indented_tab():
     """
-    Do cool stuff::
+        Do cool stuff::
 
     cool_stuff( 1 )
 
-    Done.
+        Done.
     """
     pass
 
@@ -13225,12 +13225,12 @@ def rst_literal_skipped_first_line_not_indented_tab():
 # Like the previous test, but adds a second line.
 def rst_literal_skipped_first_line_not_indented_tab_multiple():
     """
-    Do cool stuff::
+        Do cool stuff::
 
     cool_stuff( 1 )
     cool_stuff( 2 )
 
-    Done.
+        Done.
     """
     pass
 
@@ -13580,27 +13580,27 @@ def markdown_first_line_indent_uses_tabs_4spaces_multiple():
 
 def markdown_first_line_indent_uses_tabs_8spaces():
     """
-    Do cool stuff.
+       Do cool stuff.
 
-     ```py
-     cool_stuff(1)
-     ```
+    ```py
+    cool_stuff(1)
+    ```
 
-    Done.
+       Done.
     """
     pass
 
 
 def markdown_first_line_indent_uses_tabs_8spaces_multiple():
     """
-    Do cool stuff.
+       Do cool stuff.
 
-     ```py
-     cool_stuff(1)
-     cool_stuff(2)
-     ```
+    ```py
+    cool_stuff(1)
+    cool_stuff(2)
+    ```
 
-    Done.
+       Done.
     """
     pass
 
@@ -13609,10 +13609,10 @@ def markdown_first_line_tab_second_line_spaces():
     """
     Do cool stuff.
 
-        ```py
-        cool_stuff(1)
-        cool_stuff(2)
-        ```
+    ```py
+    cool_stuff( 1 )
+        cool_stuff( 2 )
+    ```
 
     Done.
     """
@@ -13623,10 +13623,10 @@ def markdown_odd_indentation():
     """
     Do cool stuff.
 
-        ```py
-        cool_stuff(1)
-        cool_stuff(2)
-        ```
+    ```py
+    cool_stuff( 1 )
+        cool_stuff( 2 )
+    ```
 
     Done.
     """
@@ -14408,7 +14408,7 @@ def rst_literal_first_line_indent_uses_tabs_4spaces():
     """
     Do cool stuff::
 
-        cool_stuff(1)
+    cool_stuff( 1 )
 
     Done.
     """
@@ -14420,8 +14420,8 @@ def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
     """
     Do cool stuff::
 
-        cool_stuff(1)
-        cool_stuff(2)
+    cool_stuff( 1 )
+    cool_stuff( 2 )
 
     Done.
     """
@@ -14437,11 +14437,11 @@ def rst_literal_first_line_indent_uses_tabs_4spaces_multiple():
 # As with the above example, reST seems to behave the same way here.
 def rst_literal_first_line_indent_uses_tabs_8spaces():
     """
-    Do cool stuff::
+       Do cool stuff::
 
-     cool_stuff(1)
+    cool_stuff( 1 )
 
-    Done.
+       Done.
     """
     pass
 
@@ -14449,12 +14449,12 @@ def rst_literal_first_line_indent_uses_tabs_8spaces():
 # Like the test above, but with multiple lines.
 def rst_literal_first_line_indent_uses_tabs_8spaces_multiple():
     """
-    Do cool stuff::
+       Do cool stuff::
 
-     cool_stuff(1)
-     cool_stuff(2)
+    cool_stuff( 1 )
+    cool_stuff( 2 )
 
-    Done.
+       Done.
     """
     pass
 
@@ -14466,8 +14466,8 @@ def rst_literal_first_line_tab_second_line_spaces():
     """
     Do cool stuff::
 
-        cool_stuff(1)
-        cool_stuff(2)
+    cool_stuff( 1 )
+        cool_stuff( 2 )
 
     Done.
     """
@@ -14496,8 +14496,8 @@ def rst_literal_odd_indentation():
     """
     Do cool stuff::
 
-     cool_stuff(1)
-     cool_stuff(2)
+    cool_stuff( 1 )
+     cool_stuff( 2 )
 
     Done.
     """
@@ -14618,11 +14618,11 @@ def rst_literal_skipped_first_line_not_indented_then_indented():
 # and doesn't treat it as a literal block.
 def rst_literal_skipped_first_line_not_indented_tab():
     """
-    Do cool stuff::
+        Do cool stuff::
 
     cool_stuff( 1 )
 
-    Done.
+        Done.
     """
     pass
 
@@ -14630,12 +14630,12 @@ def rst_literal_skipped_first_line_not_indented_tab():
 # Like the previous test, but adds a second line.
 def rst_literal_skipped_first_line_not_indented_tab_multiple():
     """
-    Do cool stuff::
+        Do cool stuff::
 
     cool_stuff( 1 )
     cool_stuff( 2 )
 
-    Done.
+        Done.
     """
     pass
 
@@ -14985,27 +14985,27 @@ def markdown_first_line_indent_uses_tabs_4spaces_multiple():
 
 def markdown_first_line_indent_uses_tabs_8spaces():
     """
-    Do cool stuff.
+       Do cool stuff.
 
-     ```py
-     cool_stuff(1)
-     ```
+    ```py
+    cool_stuff(1)
+    ```
 
-    Done.
+       Done.
     """
     pass
 
 
 def markdown_first_line_indent_uses_tabs_8spaces_multiple():
     """
-    Do cool stuff.
+       Do cool stuff.
 
-     ```py
-     cool_stuff(1)
-     cool_stuff(2)
-     ```
+    ```py
+    cool_stuff(1)
+    cool_stuff(2)
+    ```
 
-    Done.
+       Done.
     """
     pass
 
@@ -15014,10 +15014,10 @@ def markdown_first_line_tab_second_line_spaces():
     """
     Do cool stuff.
 
-        ```py
-        cool_stuff(1)
-        cool_stuff(2)
-        ```
+    ```py
+    cool_stuff( 1 )
+        cool_stuff( 2 )
+    ```
 
     Done.
     """
@@ -15028,10 +15028,10 @@ def markdown_odd_indentation():
     """
     Do cool stuff.
 
-        ```py
-        cool_stuff(1)
-        cool_stuff(2)
-        ```
+    ```py
+    cool_stuff( 1 )
+        cool_stuff( 2 )
+    ```
 
     Done.
     """

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_dynamic_line_width.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_dynamic_line_width.py.snap
@@ -878,21 +878,21 @@ def simple():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+		Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
 	):
-	    def abcdefghijklmnopqrstuvwxyz(
-	        self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	    ):
-	        def abcdefghijklmnopqrstuvwxyz(
-	            abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	        ):
-	            # For 4 space indents, this is just one character shy of
-	            # tripping the default line width of 88. So it should not be
-	            # wrapped.
-	            print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
-	            return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
+				return 5
 
-	        self.x = doit(5)
+			self.x = doit(5)
 	```
 
 	Done.
@@ -908,111 +908,111 @@ def repeated():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+		Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
 	):
-	    def abcdefghijklmnopqrstuvwxyz(
-	        self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	    ):
-	        def abcdefghijklmnopqrstuvwxyz(
-	            abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	        ):
-	            # For 4 space indents, this is just one character shy of
-	            # tripping the default line width of 88. So it should not be
-	            # wrapped.
-	            print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
-	            return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
+				return 5
 
-	        self.x = doit(5)
+			self.x = doit(5)
 
-	        def abcdefghijklmnopqrstuvwxyz(
-	            abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	        ):
-	            # For 4 space indents, this is just one character shy of
-	            # tripping the default line width of 88. So it should not be
-	            # wrapped.
-	            print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
-	            return 5
+			def abcdefghijklmnopqrstuvwxyz(
+				abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
+				return 5
 
-	        self.x = doit(5)
+			self.x = doit(5)
 
-	    def abcdefghijklmnopqrstuvwxyz(
-	        self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	    ):
-	        def abcdefghijklmnopqrstuvwxyz(
-	            abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	        ):
-	            # For 4 space indents, this is just one character shy of
-	            # tripping the default line width of 88. So it should not be
-	            # wrapped.
-	            print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
-	            return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
+				return 5
 
-	        self.x = doit(5)
+			self.x = doit(5)
 
-	        def abcdefghijklmnopqrstuvwxyz(
-	            abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	        ):
-	            # For 4 space indents, this is just one character shy of
-	            # tripping the default line width of 88. So it should not be
-	            # wrapped.
-	            print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
-	            return 5
+			def abcdefghijklmnopqrstuvwxyz(
+				abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
+				return 5
 
-	        self.x = doit(5)
+			self.x = doit(5)
 
 
 	class Abcdefghijklmopqrstuvwxyz(
-	    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+		Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
 	):
-	    def abcdefghijklmnopqrstuvwxyz(
-	        self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	    ):
-	        def abcdefghijklmnopqrstuvwxyz(
-	            abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	        ):
-	            # For 4 space indents, this is just one character shy of
-	            # tripping the default line width of 88. So it should not be
-	            # wrapped.
-	            print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
-	            return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
+				return 5
 
-	        self.x = doit(5)
+			self.x = doit(5)
 
-	        def abcdefghijklmnopqrstuvwxyz(
-	            abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	        ):
-	            # For 4 space indents, this is just one character shy of
-	            # tripping the default line width of 88. So it should not be
-	            # wrapped.
-	            print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
-	            return 5
+			def abcdefghijklmnopqrstuvwxyz(
+				abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
+				return 5
 
-	        self.x = doit(5)
+			self.x = doit(5)
 
-	    def abcdefghijklmnopqrstuvwxyz(
-	        self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	    ):
-	        def abcdefghijklmnopqrstuvwxyz(
-	            abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	        ):
-	            # For 4 space indents, this is just one character shy of
-	            # tripping the default line width of 88. So it should not be
-	            # wrapped.
-	            print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
-	            return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
+				return 5
 
-	        self.x = doit(5)
+			self.x = doit(5)
 
-	        def abcdefghijklmnopqrstuvwxyz(
-	            abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	        ):
-	            # For 4 space indents, this is just one character shy of
-	            # tripping the default line width of 88. So it should not be
-	            # wrapped.
-	            print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
-	            return 5
+			def abcdefghijklmnopqrstuvwxyz(
+				abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
+				return 5
 
-	        self.x = doit(5)
+			self.x = doit(5)
 	```
 
 	Done.
@@ -1028,23 +1028,23 @@ def barely_exceeds_limit():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+		Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
 	):
-	    def abcdefghijklmnopqrstuvwxyz(
-	        self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	    ):
-	        def abcdefghijklmnopqrstuvwxyz(
-	            abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	        ):
-	            # For 4 space indents, this is 89 columns, which is one
-	            # more than the limit. Therefore, it should get wrapped for
-	            # indent_width >= 4.
-	            print(
-	                abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a5678
-	            )
-	            return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+			):
+				# For 4 space indents, this is 89 columns, which is one
+				# more than the limit. Therefore, it should get wrapped for
+				# indent_width >= 4.
+				print(
+					abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a5678
+				)
+				return 5
 
-	        self.x = doit(5)
+			self.x = doit(5)
 	```
 
 	Done.
@@ -1056,28 +1056,28 @@ def barely_exceeds_limit():
 # the dynamic line width setting is applied correctly.
 def unindented():
 	"""
-	    First line.
+		First line.
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+		Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
 	):
-	    def abcdefghijklmnopqrstuvwxyz(
-	        self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	    ):
-	        def abcdefghijklmnopqrstuvwxyz(
-	            abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	        ):
-	            # For 4 space indents, this is just one character shy of
-	            # tripping the default line width of 88. So it should not be
-	            # wrapped.
-	            print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
-	            return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a567)
+				return 5
 
-	        self.x = doit(5)
+			self.x = doit(5)
 	```
 
-	    Done.
+		Done.
 	"""
 	pass
 
@@ -1086,30 +1086,30 @@ def unindented():
 # globally configured line width *after* its indentation has been corrected.
 def unindented_barely_exceeds_limit():
 	"""
-	    First line.
+		First line.
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	    Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+		Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
 	):
-	    def abcdefghijklmnopqrstuvwxyz(
-	        self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	    ):
-	        def abcdefghijklmnopqrstuvwxyz(
-	            abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
-	        ):
-	            # For 4 space indents, this is 89 columns, which is one
-	            # more than the limit. Therefore, it should get wrapped for
-	            # indent_width >= 4.
-	            print(
-	                abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a5678
-	            )
-	            return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self, abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4
+			):
+				# For 4 space indents, this is 89 columns, which is one
+				# more than the limit. Therefore, it should get wrapped for
+				# indent_width >= 4.
+				print(
+					abc, ddef, ghi, jkl, mno, pqr, stu, vwx, yz, a1, a2, a3, a4, a5678
+				)
+				return 5
 
-	        self.x = doit(5)
+			self.x = doit(5)
 	```
 
-	    Done.
+		Done.
 	"""
 	pass
 
@@ -1208,61 +1208,61 @@ def simple():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+		Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
 	):
-	        def abcdefghijklmnopqrstuvwxyz(
-	                self,
-	                abc,
-	                ddef,
-	                ghi,
-	                jkl,
-	                mno,
-	                pqr,
-	                stu,
-	                vwx,
-	                yz,
-	                a1,
-	                a2,
-	                a3,
-	                a4,
-	        ):
-	                def abcdefghijklmnopqrstuvwxyz(
-	                        abc,
-	                        ddef,
-	                        ghi,
-	                        jkl,
-	                        mno,
-	                        pqr,
-	                        stu,
-	                        vwx,
-	                        yz,
-	                        a1,
-	                        a2,
-	                        a3,
-	                        a4,
-	                ):
-	                        # For 4 space indents, this is just one character shy of
-	                        # tripping the default line width of 88. So it should not be
-	                        # wrapped.
-	                        print(
-	                                abc,
-	                                ddef,
-	                                ghi,
-	                                jkl,
-	                                mno,
-	                                pqr,
-	                                stu,
-	                                vwx,
-	                                yz,
-	                                a1,
-	                                a2,
-	                                a3,
-	                                a4,
-	                                a567,
-	                        )
-	                        return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self,
+			abc,
+			ddef,
+			ghi,
+			jkl,
+			mno,
+			pqr,
+			stu,
+			vwx,
+			yz,
+			a1,
+			a2,
+			a3,
+			a4,
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc,
+				ddef,
+				ghi,
+				jkl,
+				mno,
+				pqr,
+				stu,
+				vwx,
+				yz,
+				a1,
+				a2,
+				a3,
+				a4,
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(
+					abc,
+					ddef,
+					ghi,
+					jkl,
+					mno,
+					pqr,
+					stu,
+					vwx,
+					yz,
+					a1,
+					a2,
+					a3,
+					a4,
+					a567,
+				)
+				return 5
 
-	                self.x = doit(5)
+			self.x = doit(5)
 	```
 
 	Done.
@@ -1278,379 +1278,379 @@ def repeated():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+		Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
 	):
-	        def abcdefghijklmnopqrstuvwxyz(
-	                self,
-	                abc,
-	                ddef,
-	                ghi,
-	                jkl,
-	                mno,
-	                pqr,
-	                stu,
-	                vwx,
-	                yz,
-	                a1,
-	                a2,
-	                a3,
-	                a4,
-	        ):
-	                def abcdefghijklmnopqrstuvwxyz(
-	                        abc,
-	                        ddef,
-	                        ghi,
-	                        jkl,
-	                        mno,
-	                        pqr,
-	                        stu,
-	                        vwx,
-	                        yz,
-	                        a1,
-	                        a2,
-	                        a3,
-	                        a4,
-	                ):
-	                        # For 4 space indents, this is just one character shy of
-	                        # tripping the default line width of 88. So it should not be
-	                        # wrapped.
-	                        print(
-	                                abc,
-	                                ddef,
-	                                ghi,
-	                                jkl,
-	                                mno,
-	                                pqr,
-	                                stu,
-	                                vwx,
-	                                yz,
-	                                a1,
-	                                a2,
-	                                a3,
-	                                a4,
-	                                a567,
-	                        )
-	                        return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self,
+			abc,
+			ddef,
+			ghi,
+			jkl,
+			mno,
+			pqr,
+			stu,
+			vwx,
+			yz,
+			a1,
+			a2,
+			a3,
+			a4,
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc,
+				ddef,
+				ghi,
+				jkl,
+				mno,
+				pqr,
+				stu,
+				vwx,
+				yz,
+				a1,
+				a2,
+				a3,
+				a4,
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(
+					abc,
+					ddef,
+					ghi,
+					jkl,
+					mno,
+					pqr,
+					stu,
+					vwx,
+					yz,
+					a1,
+					a2,
+					a3,
+					a4,
+					a567,
+				)
+				return 5
 
-	                self.x = doit(5)
+			self.x = doit(5)
 
-	                def abcdefghijklmnopqrstuvwxyz(
-	                        abc,
-	                        ddef,
-	                        ghi,
-	                        jkl,
-	                        mno,
-	                        pqr,
-	                        stu,
-	                        vwx,
-	                        yz,
-	                        a1,
-	                        a2,
-	                        a3,
-	                        a4,
-	                ):
-	                        # For 4 space indents, this is just one character shy of
-	                        # tripping the default line width of 88. So it should not be
-	                        # wrapped.
-	                        print(
-	                                abc,
-	                                ddef,
-	                                ghi,
-	                                jkl,
-	                                mno,
-	                                pqr,
-	                                stu,
-	                                vwx,
-	                                yz,
-	                                a1,
-	                                a2,
-	                                a3,
-	                                a4,
-	                                a567,
-	                        )
-	                        return 5
+			def abcdefghijklmnopqrstuvwxyz(
+				abc,
+				ddef,
+				ghi,
+				jkl,
+				mno,
+				pqr,
+				stu,
+				vwx,
+				yz,
+				a1,
+				a2,
+				a3,
+				a4,
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(
+					abc,
+					ddef,
+					ghi,
+					jkl,
+					mno,
+					pqr,
+					stu,
+					vwx,
+					yz,
+					a1,
+					a2,
+					a3,
+					a4,
+					a567,
+				)
+				return 5
 
-	                self.x = doit(5)
+			self.x = doit(5)
 
-	        def abcdefghijklmnopqrstuvwxyz(
-	                self,
-	                abc,
-	                ddef,
-	                ghi,
-	                jkl,
-	                mno,
-	                pqr,
-	                stu,
-	                vwx,
-	                yz,
-	                a1,
-	                a2,
-	                a3,
-	                a4,
-	        ):
-	                def abcdefghijklmnopqrstuvwxyz(
-	                        abc,
-	                        ddef,
-	                        ghi,
-	                        jkl,
-	                        mno,
-	                        pqr,
-	                        stu,
-	                        vwx,
-	                        yz,
-	                        a1,
-	                        a2,
-	                        a3,
-	                        a4,
-	                ):
-	                        # For 4 space indents, this is just one character shy of
-	                        # tripping the default line width of 88. So it should not be
-	                        # wrapped.
-	                        print(
-	                                abc,
-	                                ddef,
-	                                ghi,
-	                                jkl,
-	                                mno,
-	                                pqr,
-	                                stu,
-	                                vwx,
-	                                yz,
-	                                a1,
-	                                a2,
-	                                a3,
-	                                a4,
-	                                a567,
-	                        )
-	                        return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self,
+			abc,
+			ddef,
+			ghi,
+			jkl,
+			mno,
+			pqr,
+			stu,
+			vwx,
+			yz,
+			a1,
+			a2,
+			a3,
+			a4,
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc,
+				ddef,
+				ghi,
+				jkl,
+				mno,
+				pqr,
+				stu,
+				vwx,
+				yz,
+				a1,
+				a2,
+				a3,
+				a4,
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(
+					abc,
+					ddef,
+					ghi,
+					jkl,
+					mno,
+					pqr,
+					stu,
+					vwx,
+					yz,
+					a1,
+					a2,
+					a3,
+					a4,
+					a567,
+				)
+				return 5
 
-	                self.x = doit(5)
+			self.x = doit(5)
 
-	                def abcdefghijklmnopqrstuvwxyz(
-	                        abc,
-	                        ddef,
-	                        ghi,
-	                        jkl,
-	                        mno,
-	                        pqr,
-	                        stu,
-	                        vwx,
-	                        yz,
-	                        a1,
-	                        a2,
-	                        a3,
-	                        a4,
-	                ):
-	                        # For 4 space indents, this is just one character shy of
-	                        # tripping the default line width of 88. So it should not be
-	                        # wrapped.
-	                        print(
-	                                abc,
-	                                ddef,
-	                                ghi,
-	                                jkl,
-	                                mno,
-	                                pqr,
-	                                stu,
-	                                vwx,
-	                                yz,
-	                                a1,
-	                                a2,
-	                                a3,
-	                                a4,
-	                                a567,
-	                        )
-	                        return 5
+			def abcdefghijklmnopqrstuvwxyz(
+				abc,
+				ddef,
+				ghi,
+				jkl,
+				mno,
+				pqr,
+				stu,
+				vwx,
+				yz,
+				a1,
+				a2,
+				a3,
+				a4,
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(
+					abc,
+					ddef,
+					ghi,
+					jkl,
+					mno,
+					pqr,
+					stu,
+					vwx,
+					yz,
+					a1,
+					a2,
+					a3,
+					a4,
+					a567,
+				)
+				return 5
 
-	                self.x = doit(5)
+			self.x = doit(5)
 
 
 	class Abcdefghijklmopqrstuvwxyz(
-	        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+		Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
 	):
-	        def abcdefghijklmnopqrstuvwxyz(
-	                self,
-	                abc,
-	                ddef,
-	                ghi,
-	                jkl,
-	                mno,
-	                pqr,
-	                stu,
-	                vwx,
-	                yz,
-	                a1,
-	                a2,
-	                a3,
-	                a4,
-	        ):
-	                def abcdefghijklmnopqrstuvwxyz(
-	                        abc,
-	                        ddef,
-	                        ghi,
-	                        jkl,
-	                        mno,
-	                        pqr,
-	                        stu,
-	                        vwx,
-	                        yz,
-	                        a1,
-	                        a2,
-	                        a3,
-	                        a4,
-	                ):
-	                        # For 4 space indents, this is just one character shy of
-	                        # tripping the default line width of 88. So it should not be
-	                        # wrapped.
-	                        print(
-	                                abc,
-	                                ddef,
-	                                ghi,
-	                                jkl,
-	                                mno,
-	                                pqr,
-	                                stu,
-	                                vwx,
-	                                yz,
-	                                a1,
-	                                a2,
-	                                a3,
-	                                a4,
-	                                a567,
-	                        )
-	                        return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self,
+			abc,
+			ddef,
+			ghi,
+			jkl,
+			mno,
+			pqr,
+			stu,
+			vwx,
+			yz,
+			a1,
+			a2,
+			a3,
+			a4,
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc,
+				ddef,
+				ghi,
+				jkl,
+				mno,
+				pqr,
+				stu,
+				vwx,
+				yz,
+				a1,
+				a2,
+				a3,
+				a4,
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(
+					abc,
+					ddef,
+					ghi,
+					jkl,
+					mno,
+					pqr,
+					stu,
+					vwx,
+					yz,
+					a1,
+					a2,
+					a3,
+					a4,
+					a567,
+				)
+				return 5
 
-	                self.x = doit(5)
+			self.x = doit(5)
 
-	                def abcdefghijklmnopqrstuvwxyz(
-	                        abc,
-	                        ddef,
-	                        ghi,
-	                        jkl,
-	                        mno,
-	                        pqr,
-	                        stu,
-	                        vwx,
-	                        yz,
-	                        a1,
-	                        a2,
-	                        a3,
-	                        a4,
-	                ):
-	                        # For 4 space indents, this is just one character shy of
-	                        # tripping the default line width of 88. So it should not be
-	                        # wrapped.
-	                        print(
-	                                abc,
-	                                ddef,
-	                                ghi,
-	                                jkl,
-	                                mno,
-	                                pqr,
-	                                stu,
-	                                vwx,
-	                                yz,
-	                                a1,
-	                                a2,
-	                                a3,
-	                                a4,
-	                                a567,
-	                        )
-	                        return 5
+			def abcdefghijklmnopqrstuvwxyz(
+				abc,
+				ddef,
+				ghi,
+				jkl,
+				mno,
+				pqr,
+				stu,
+				vwx,
+				yz,
+				a1,
+				a2,
+				a3,
+				a4,
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(
+					abc,
+					ddef,
+					ghi,
+					jkl,
+					mno,
+					pqr,
+					stu,
+					vwx,
+					yz,
+					a1,
+					a2,
+					a3,
+					a4,
+					a567,
+				)
+				return 5
 
-	                self.x = doit(5)
+			self.x = doit(5)
 
-	        def abcdefghijklmnopqrstuvwxyz(
-	                self,
-	                abc,
-	                ddef,
-	                ghi,
-	                jkl,
-	                mno,
-	                pqr,
-	                stu,
-	                vwx,
-	                yz,
-	                a1,
-	                a2,
-	                a3,
-	                a4,
-	        ):
-	                def abcdefghijklmnopqrstuvwxyz(
-	                        abc,
-	                        ddef,
-	                        ghi,
-	                        jkl,
-	                        mno,
-	                        pqr,
-	                        stu,
-	                        vwx,
-	                        yz,
-	                        a1,
-	                        a2,
-	                        a3,
-	                        a4,
-	                ):
-	                        # For 4 space indents, this is just one character shy of
-	                        # tripping the default line width of 88. So it should not be
-	                        # wrapped.
-	                        print(
-	                                abc,
-	                                ddef,
-	                                ghi,
-	                                jkl,
-	                                mno,
-	                                pqr,
-	                                stu,
-	                                vwx,
-	                                yz,
-	                                a1,
-	                                a2,
-	                                a3,
-	                                a4,
-	                                a567,
-	                        )
-	                        return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self,
+			abc,
+			ddef,
+			ghi,
+			jkl,
+			mno,
+			pqr,
+			stu,
+			vwx,
+			yz,
+			a1,
+			a2,
+			a3,
+			a4,
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc,
+				ddef,
+				ghi,
+				jkl,
+				mno,
+				pqr,
+				stu,
+				vwx,
+				yz,
+				a1,
+				a2,
+				a3,
+				a4,
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(
+					abc,
+					ddef,
+					ghi,
+					jkl,
+					mno,
+					pqr,
+					stu,
+					vwx,
+					yz,
+					a1,
+					a2,
+					a3,
+					a4,
+					a567,
+				)
+				return 5
 
-	                self.x = doit(5)
+			self.x = doit(5)
 
-	                def abcdefghijklmnopqrstuvwxyz(
-	                        abc,
-	                        ddef,
-	                        ghi,
-	                        jkl,
-	                        mno,
-	                        pqr,
-	                        stu,
-	                        vwx,
-	                        yz,
-	                        a1,
-	                        a2,
-	                        a3,
-	                        a4,
-	                ):
-	                        # For 4 space indents, this is just one character shy of
-	                        # tripping the default line width of 88. So it should not be
-	                        # wrapped.
-	                        print(
-	                                abc,
-	                                ddef,
-	                                ghi,
-	                                jkl,
-	                                mno,
-	                                pqr,
-	                                stu,
-	                                vwx,
-	                                yz,
-	                                a1,
-	                                a2,
-	                                a3,
-	                                a4,
-	                                a567,
-	                        )
-	                        return 5
+			def abcdefghijklmnopqrstuvwxyz(
+				abc,
+				ddef,
+				ghi,
+				jkl,
+				mno,
+				pqr,
+				stu,
+				vwx,
+				yz,
+				a1,
+				a2,
+				a3,
+				a4,
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(
+					abc,
+					ddef,
+					ghi,
+					jkl,
+					mno,
+					pqr,
+					stu,
+					vwx,
+					yz,
+					a1,
+					a2,
+					a3,
+					a4,
+					a567,
+				)
+				return 5
 
-	                self.x = doit(5)
+			self.x = doit(5)
 	```
 
 	Done.
@@ -1666,61 +1666,61 @@ def barely_exceeds_limit():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+		Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
 	):
-	        def abcdefghijklmnopqrstuvwxyz(
-	                self,
-	                abc,
-	                ddef,
-	                ghi,
-	                jkl,
-	                mno,
-	                pqr,
-	                stu,
-	                vwx,
-	                yz,
-	                a1,
-	                a2,
-	                a3,
-	                a4,
-	        ):
-	                def abcdefghijklmnopqrstuvwxyz(
-	                        abc,
-	                        ddef,
-	                        ghi,
-	                        jkl,
-	                        mno,
-	                        pqr,
-	                        stu,
-	                        vwx,
-	                        yz,
-	                        a1,
-	                        a2,
-	                        a3,
-	                        a4,
-	                ):
-	                        # For 4 space indents, this is 89 columns, which is one
-	                        # more than the limit. Therefore, it should get wrapped for
-	                        # indent_width >= 4.
-	                        print(
-	                                abc,
-	                                ddef,
-	                                ghi,
-	                                jkl,
-	                                mno,
-	                                pqr,
-	                                stu,
-	                                vwx,
-	                                yz,
-	                                a1,
-	                                a2,
-	                                a3,
-	                                a4,
-	                                a5678,
-	                        )
-	                        return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self,
+			abc,
+			ddef,
+			ghi,
+			jkl,
+			mno,
+			pqr,
+			stu,
+			vwx,
+			yz,
+			a1,
+			a2,
+			a3,
+			a4,
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc,
+				ddef,
+				ghi,
+				jkl,
+				mno,
+				pqr,
+				stu,
+				vwx,
+				yz,
+				a1,
+				a2,
+				a3,
+				a4,
+			):
+				# For 4 space indents, this is 89 columns, which is one
+				# more than the limit. Therefore, it should get wrapped for
+				# indent_width >= 4.
+				print(
+					abc,
+					ddef,
+					ghi,
+					jkl,
+					mno,
+					pqr,
+					stu,
+					vwx,
+					yz,
+					a1,
+					a2,
+					a3,
+					a4,
+					a5678,
+				)
+				return 5
 
-	                self.x = doit(5)
+			self.x = doit(5)
 	```
 
 	Done.
@@ -1736,61 +1736,61 @@ def unindented():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+		Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
 	):
-	        def abcdefghijklmnopqrstuvwxyz(
-	                self,
-	                abc,
-	                ddef,
-	                ghi,
-	                jkl,
-	                mno,
-	                pqr,
-	                stu,
-	                vwx,
-	                yz,
-	                a1,
-	                a2,
-	                a3,
-	                a4,
-	        ):
-	                def abcdefghijklmnopqrstuvwxyz(
-	                        abc,
-	                        ddef,
-	                        ghi,
-	                        jkl,
-	                        mno,
-	                        pqr,
-	                        stu,
-	                        vwx,
-	                        yz,
-	                        a1,
-	                        a2,
-	                        a3,
-	                        a4,
-	                ):
-	                        # For 4 space indents, this is just one character shy of
-	                        # tripping the default line width of 88. So it should not be
-	                        # wrapped.
-	                        print(
-	                                abc,
-	                                ddef,
-	                                ghi,
-	                                jkl,
-	                                mno,
-	                                pqr,
-	                                stu,
-	                                vwx,
-	                                yz,
-	                                a1,
-	                                a2,
-	                                a3,
-	                                a4,
-	                                a567,
-	                        )
-	                        return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self,
+			abc,
+			ddef,
+			ghi,
+			jkl,
+			mno,
+			pqr,
+			stu,
+			vwx,
+			yz,
+			a1,
+			a2,
+			a3,
+			a4,
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc,
+				ddef,
+				ghi,
+				jkl,
+				mno,
+				pqr,
+				stu,
+				vwx,
+				yz,
+				a1,
+				a2,
+				a3,
+				a4,
+			):
+				# For 4 space indents, this is just one character shy of
+				# tripping the default line width of 88. So it should not be
+				# wrapped.
+				print(
+					abc,
+					ddef,
+					ghi,
+					jkl,
+					mno,
+					pqr,
+					stu,
+					vwx,
+					yz,
+					a1,
+					a2,
+					a3,
+					a4,
+					a567,
+				)
+				return 5
 
-	                self.x = doit(5)
+			self.x = doit(5)
 	```
 
 	    Done.
@@ -1806,61 +1806,61 @@ def unindented_barely_exceeds_limit():
 
 	```py
 	class Abcdefghijklmopqrstuvwxyz(
-	        Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
+		Abc, Def, Ghi, Jkl, Mno, Pqr, Stu, Vwx, Yz, A1, A2, A3, A4, A5
 	):
-	        def abcdefghijklmnopqrstuvwxyz(
-	                self,
-	                abc,
-	                ddef,
-	                ghi,
-	                jkl,
-	                mno,
-	                pqr,
-	                stu,
-	                vwx,
-	                yz,
-	                a1,
-	                a2,
-	                a3,
-	                a4,
-	        ):
-	                def abcdefghijklmnopqrstuvwxyz(
-	                        abc,
-	                        ddef,
-	                        ghi,
-	                        jkl,
-	                        mno,
-	                        pqr,
-	                        stu,
-	                        vwx,
-	                        yz,
-	                        a1,
-	                        a2,
-	                        a3,
-	                        a4,
-	                ):
-	                        # For 4 space indents, this is 89 columns, which is one
-	                        # more than the limit. Therefore, it should get wrapped for
-	                        # indent_width >= 4.
-	                        print(
-	                                abc,
-	                                ddef,
-	                                ghi,
-	                                jkl,
-	                                mno,
-	                                pqr,
-	                                stu,
-	                                vwx,
-	                                yz,
-	                                a1,
-	                                a2,
-	                                a3,
-	                                a4,
-	                                a5678,
-	                        )
-	                        return 5
+		def abcdefghijklmnopqrstuvwxyz(
+			self,
+			abc,
+			ddef,
+			ghi,
+			jkl,
+			mno,
+			pqr,
+			stu,
+			vwx,
+			yz,
+			a1,
+			a2,
+			a3,
+			a4,
+		):
+			def abcdefghijklmnopqrstuvwxyz(
+				abc,
+				ddef,
+				ghi,
+				jkl,
+				mno,
+				pqr,
+				stu,
+				vwx,
+				yz,
+				a1,
+				a2,
+				a3,
+				a4,
+			):
+				# For 4 space indents, this is 89 columns, which is one
+				# more than the limit. Therefore, it should get wrapped for
+				# indent_width >= 4.
+				print(
+					abc,
+					ddef,
+					ghi,
+					jkl,
+					mno,
+					pqr,
+					stu,
+					vwx,
+					yz,
+					a1,
+					a2,
+					a3,
+					a4,
+					a5678,
+				)
+				return 5
 
-	                self.x = doit(5)
+			self.x = doit(5)
 	```
 
 	    Done.


### PR DESCRIPTION
## Summary

Ruff currently always formats docstrings using spaces for indentation. However, when `indent-style` is set to "tab", this leads to E101 (mixed indentation) linter errors.

There are a few approaches to improving the situation, some of which are discussed in https://github.com/astral-sh/ruff/issues/8430. One option which is likely the simplest is to recommend turning off E101 when using the formatter. If this is the preferred route, then Ruff should probably also respect the `indent-width` when expanding tabs in docstrings to avoid the issue [described here](https://github.com/astral-sh/ruff/issues/8430#issuecomment-1822529090).

This PR implements an alternative solution which indents docstrings using the configured `indent-style`. In cases where docstrings have indents that aren't a multiple of the `indent-width`, this may mean E101 is still triggered in the formatted code. However, this should be very uncommon. I did a cursory check of the few codebases across GitHub that use Ruff with tabs and could not find any cases where docstrings would be negatively affected by this change.

Note that this means that Ruff will format code with tabs differently than Black, which always expands tabs to 8 spaces. I think this is acceptable in this case, because Black doesn't support tabs to begin with (so there's no real compatibility issue).

There is also the question of how other tooling treats tabs in docstrings. As of Python 3.13, docstrings will be dedented to save memory. However, tabs will also unfortunately be expanded to 8 spaces by the interpreter, which will negate the memory usage savings, but this difference should also be mostly inconsequential (and this may potentially be fixed in CPython in the future.)

Closes #8430