### PR TITLE
Add a non-latin project to the ecosystem checks

### DIFF
--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -128,6 +128,7 @@ REPOSITORIES: list[Repository] = [
     Repository("docker", "docker-py", "main"),
     Repository("freedomofpress", "securedrop", "develop"),
     Repository("fronzbot", "blinkpy", "dev"),
+    Repository("binary-husky", "gpt_academic", "master"),
     Repository("ibis-project", "ibis", "master"),
     Repository("ing-bank", "probatus", "main"),
     Repository("jrnl-org", "jrnl", "develop"),


### PR DESCRIPTION
We've had bugs related to non-latin scripts, most recently #9145, where just starting a docstring with multi-byte characters would panic. I've added https://github.com/binary-husky/gpt_academic to catch those in the ecosystem checks, it's a popular repo with mixed english and chinese comments and symbols.