### PR TITLE
Replace `String` with `SmolStr` for nodes `Identifier` and `ExprName`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,6 +2310,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "smallvec",
+ "smol_str",
  "static_assertions",
 ]
 
@@ -2398,6 +2399,7 @@ dependencies = [
  "ruff_python_ast",
  "ruff_text_size",
  "rustc-hash",
+ "smol_str",
  "static_assertions",
  "tiny-keccak",
  "unicode-ident",
@@ -2810,6 +2812,15 @@ name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
+name = "smol_str"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ serde_json = { version = "1.0.108" }
 shellexpand = { version = "3.0.0" }
 similar = { version = "2.3.0", features = ["inline"] }
 smallvec = { version = "1.11.2" }
+smol_str = "0.2.0"
 static_assertions = "1.1.0"
 strum = { version = "0.25.0", features = ["strum_macros"] }
 strum_macros = { version = "0.25.3" }

--- a/crates/ruff_linter/src/checkers/imports.rs
+++ b/crates/ruff_linter/src/checkers/imports.rs
@@ -46,7 +46,7 @@ fn extract_import_map(path: &Path, package: Option<&Path>, blocks: &[&Block]) ->
             }) => {
                 let level = level.unwrap_or_default() as usize;
                 let module = if let Some(module) = module {
-                    let module: &String = module.as_ref();
+                    let module = module.as_str();
                     if level == 0 {
                         Cow::Borrowed(module)
                     } else {

--- a/crates/ruff_linter/src/rules/airflow/rules/task_variable_name.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/task_variable_name.rs
@@ -81,7 +81,7 @@ pub(crate) fn variable_name_task_id(
     let ast::ExprStringLiteral { value: task_id, .. } = keyword.value.as_string_literal_expr()?;
 
     // If the target name is the same as the task_id, no violation.
-    if task_id == id {
+    if task_id == id.as_str() {
         return None;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_annotations/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/helpers.rs
@@ -136,7 +136,7 @@ impl AutoPythonType {
                     )
                     .ok()?;
                 let expr = Expr::Name(ast::ExprName {
-                    id: binding,
+                    id: binding.into(),
                     range: TextRange::default(),
                     ctx: ExprContext::Load,
                 });

--- a/crates/ruff_linter/src/rules/flake8_gettext/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_gettext/mod.rs
@@ -7,7 +7,7 @@ pub mod settings;
 /// Returns true if the [`Expr`] is an internationalization function call.
 pub(crate) fn is_gettext_func_call(func: &Expr, functions_names: &[String]) -> bool {
     if let Expr::Name(ast::ExprName { id, .. }) = func {
-        functions_names.contains(id)
+        functions_names.contains(&id.to_string())
     } else {
         false
     }

--- a/crates/ruff_linter/src/rules/flake8_gettext/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_gettext/mod.rs
@@ -7,7 +7,9 @@ pub mod settings;
 /// Returns true if the [`Expr`] is an internationalization function call.
 pub(crate) fn is_gettext_func_call(func: &Expr, functions_names: &[String]) -> bool {
     if let Expr::Name(ast::ExprName { id, .. }) = func {
-        functions_names.contains(&id.to_string())
+        functions_names
+            .iter()
+            .any(|function_name| function_name == id)
     } else {
         false
     }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_literal_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_literal_union.rs
@@ -80,7 +80,7 @@ fn make_literal_expr(subscript: Option<Expr>, exprs: Vec<&Expr>) -> Expr {
         subscript.unwrap().clone()
     } else {
         Expr::Name(ast::ExprName {
-            id: "Literal".to_string(),
+            id: "Literal".into(),
             range: TextRange::default(),
             ctx: ast::ExprContext::Load,
         })

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
@@ -133,7 +133,7 @@ pub(crate) fn unnecessary_type_union<'a>(checker: &mut Checker, union: &'a Expr)
                                 .into_iter()
                                 .map(|type_member| {
                                     Expr::Name(ast::ExprName {
-                                        id: type_member,
+                                        id: type_member.into(),
                                         ctx: ExprContext::Load,
                                         range: TextRange::default(),
                                     })

--- a/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
@@ -77,7 +77,8 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
             .settings
             .flake8_self
             .ignore_names
-            .contains(&attr.to_string())
+            .iter()
+            .any(|name| name == attr.as_str())
         {
             return;
         }

--- a/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
@@ -77,7 +77,7 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
             .settings
             .flake8_self
             .ignore_names
-            .contains(attr.as_ref())
+            .contains(&attr.to_string())
         {
             return;
         }

--- a/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
@@ -747,7 +747,11 @@ pub(crate) fn string_dot_format_extra_named_arguments(
     let missing: Vec<(usize, &str)> = keywords
         .enumerate()
         .filter_map(|(index, keyword)| {
-            if summary.keywords.contains(&keyword.to_string()) {
+            if summary
+                .keywords
+                .iter()
+                .any(|summary_keyword| summary_keyword == keyword.as_str())
+            {
                 None
             } else {
                 Some((index, keyword.as_str()))

--- a/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
@@ -747,7 +747,7 @@ pub(crate) fn string_dot_format_extra_named_arguments(
     let missing: Vec<(usize, &str)> = keywords
         .enumerate()
         .filter_map(|(index, keyword)| {
-            if summary.keywords.contains(keyword.as_ref()) {
+            if summary.keywords.contains(&keyword.to_string()) {
                 None
             } else {
                 Some((index, keyword.as_str()))

--- a/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
@@ -124,9 +124,11 @@ fn get_undecorated_methods(
                             continue;
                         };
 
-                        let target_name = match targets.first() {
-                            Some(Expr::Name(ast::ExprName { id, .. })) => id,
-                            _ => continue,
+                        let Some(Expr::Name(ast::ExprName {
+                            id: target_name, ..
+                        })) = targets.first()
+                        else {
+                            continue;
                         };
 
                         if let Expr::Name(ast::ExprName { id, .. }) = &arg {

--- a/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
@@ -116,21 +116,21 @@ fn get_undecorated_methods(
             {
                 if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
                     if id == method_name && checker.semantic().is_builtin(method_name) {
-                        if arguments.args.len() != 1 {
-                            continue;
-                        }
-
                         if targets.len() != 1 {
                             continue;
                         }
 
+                        let [arg] = arguments.args.as_slice() else {
+                            continue;
+                        };
+
                         let target_name = match targets.first() {
-                            Some(Expr::Name(ast::ExprName { id, .. })) => id.to_string(),
+                            Some(Expr::Name(ast::ExprName { id, .. })) => id,
                             _ => continue,
                         };
 
-                        if let Expr::Name(ast::ExprName { id, .. }) = &arguments.args[0] {
-                            if target_name == *id {
+                        if let Expr::Name(ast::ExprName { id, .. }) = &arg {
+                            if target_name == id {
                                 explicit_decorator_calls.insert(id.to_string(), stmt.range());
                             }
                         };

--- a/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
@@ -131,7 +131,7 @@ fn get_undecorated_methods(
 
                         if let Expr::Name(ast::ExprName { id, .. }) = &arguments.args[0] {
                             if target_name == *id {
-                                explicit_decorator_calls.insert(id.clone(), stmt.range());
+                                explicit_decorator_calls.insert(id.to_string(), stmt.range());
                             }
                         };
                     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
@@ -92,7 +92,12 @@ pub(crate) fn non_pep695_type_alias(checker: &mut Checker, stmt: &StmtAnnAssign)
 
     // TODO(zanie): We should check for generic type variables used in the value and define them
     //              as type params instead
-    let mut diagnostic = Diagnostic::new(NonPEP695TypeAlias { name: name.clone() }, stmt.range());
+    let mut diagnostic = Diagnostic::new(
+        NonPEP695TypeAlias {
+            name: name.to_string(),
+        },
+        stmt.range(),
+    );
     let mut visitor = TypeVarReferenceVisitor {
         vars: vec![],
         semantic: checker.semantic(),

--- a/crates/ruff_linter/src/rules/refurb/helpers.rs
+++ b/crates/ruff_linter/src/rules/refurb/helpers.rs
@@ -6,7 +6,7 @@ use ruff_text_size::TextRange;
 pub(super) fn generate_method_call(name: &str, method: &str, generator: Generator) -> String {
     // Construct `name`.
     let var = ast::ExprName {
-        id: name.to_string(),
+        id: name.into(),
         ctx: ast::ExprContext::Load,
         range: TextRange::default(),
     };
@@ -43,7 +43,7 @@ pub(super) fn generate_none_identity_comparison(
 ) -> String {
     // Construct `name`.
     let var = ast::ExprName {
-        id: name.to_string(),
+        id: name.into(),
         ctx: ast::ExprContext::Load,
         range: TextRange::default(),
     };

--- a/crates/ruff_linter/src/rules/refurb/rules/read_whole_file.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/read_whole_file.rs
@@ -315,7 +315,7 @@ fn make_suggestion(open: &FileOpen<'_>, generator: Generator) -> SourceCodeSnipp
         ReadMode::Bytes => "read_bytes",
     };
     let name = ast::ExprName {
-        id: method_name.to_string(),
+        id: method_name.into(),
         ctx: ast::ExprContext::Load,
         range: TextRange::default(),
     };

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
@@ -297,7 +297,7 @@ fn try_construct_call(
 /// Construct the call to `itertools.starmap` for suggestion.
 fn construct_starmap_call(starmap_binding: String, iter: &Expr, func: &Expr) -> ast::ExprCall {
     let starmap = ast::ExprName {
-        id: starmap_binding,
+        id: starmap_binding.into(),
         ctx: ast::ExprContext::Load,
         range: TextRange::default(),
     };
@@ -315,7 +315,7 @@ fn construct_starmap_call(starmap_binding: String, iter: &Expr, func: &Expr) -> 
 /// Wrap given function call with yet another call.
 fn wrap_with_call_to(call: ast::ExprCall, func_name: &str) -> ast::ExprCall {
     let name = ast::ExprName {
-        id: func_name.to_string(),
+        id: func_name.into(),
         ctx: ast::ExprContext::Load,
         range: TextRange::default(),
     };

--- a/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
@@ -236,7 +236,7 @@ impl fmt::Display for EnumerateSubset {
 fn generate_range_len_call(name: &str, generator: Generator) -> String {
     // Construct `name`.
     let var = ast::ExprName {
-        id: name.to_string(),
+        id: name.into(),
         ctx: ast::ExprContext::Load,
         range: TextRange::default(),
     };
@@ -244,7 +244,7 @@ fn generate_range_len_call(name: &str, generator: Generator) -> String {
     let len = ast::ExprCall {
         func: Box::new(
             ast::ExprName {
-                id: "len".to_string(),
+                id: "len".into(),
                 ctx: ast::ExprContext::Load,
                 range: TextRange::default(),
             }
@@ -261,7 +261,7 @@ fn generate_range_len_call(name: &str, generator: Generator) -> String {
     let range = ast::ExprCall {
         func: Box::new(
             ast::ExprName {
-                id: "range".to_string(),
+                id: "range".into(),
                 ctx: ast::ExprContext::Load,
                 range: TextRange::default(),
             }

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -145,7 +145,7 @@ fn generate_fix(checker: &Checker, conversion_type: ConversionType, expr: &Expr)
             let new_expr = Expr::Subscript(ast::ExprSubscript {
                 range: TextRange::default(),
                 value: Box::new(Expr::Name(ast::ExprName {
-                    id: binding,
+                    id: binding.into(),
                     ctx: ast::ExprContext::Store,
                     range: TextRange::default(),
                 })),

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -26,6 +26,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
 smallvec = { workspace = true }
 static_assertions = "1.1.0"
+smol_str = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1482,7 +1482,7 @@ pub fn pep_604_union(elts: &[Expr]) -> Expr {
 pub fn typing_optional(elt: Expr, binding: String) -> Expr {
     Expr::Subscript(ast::ExprSubscript {
         value: Box::new(Expr::Name(ast::ExprName {
-            id: binding,
+            id: binding.into(),
             range: TextRange::default(),
             ctx: ExprContext::Load,
         })),
@@ -1513,7 +1513,7 @@ pub fn typing_union(elts: &[Expr], binding: String) -> Expr {
 
     Expr::Subscript(ast::ExprSubscript {
         value: Box::new(Expr::Name(ast::ExprName {
-            id: binding,
+            id: binding.into(),
             range: TextRange::default(),
             ctx: ExprContext::Load,
         })),
@@ -1579,7 +1579,7 @@ mod tests {
     fn any_over_stmt_type_alias() {
         let seen = RefCell::new(Vec::new());
         let name = Expr::Name(ExprName {
-            id: "x".to_string(),
+            id: "x".into(),
             range: TextRange::default(),
             ctx: ExprContext::Load,
         });

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1,12 +1,13 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+use itertools::Itertools;
+use smol_str::SmolStr;
 use std::cell::OnceCell;
+
 use std::fmt;
 use std::fmt::Debug;
 use std::ops::Deref;
 use std::slice::{Iter, IterMut};
-
-use itertools::Itertools;
 
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
@@ -1739,7 +1740,7 @@ impl From<ExprStarred> for Expr {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprName {
     pub range: TextRange,
-    pub id: String,
+    pub id: SmolStr,
     pub ctx: ExprContext,
 }
 
@@ -3225,13 +3226,13 @@ impl IpyEscapeKind {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Identifier {
-    id: String,
-    range: TextRange,
+    pub id: SmolStr,
+    pub range: TextRange,
 }
 
 impl Identifier {
     #[inline]
-    pub fn new(id: impl Into<String>, range: TextRange) -> Self {
+    pub fn new(id: impl Into<SmolStr>, range: TextRange) -> Self {
         Self {
             id: id.into(),
             range,
@@ -3275,9 +3276,9 @@ impl AsRef<str> for Identifier {
     }
 }
 
-impl AsRef<String> for Identifier {
+impl AsRef<SmolStr> for Identifier {
     #[inline]
-    fn as_ref(&self) -> &String {
+    fn as_ref(&self) -> &SmolStr {
         &self.id
     }
 }
@@ -3291,6 +3292,13 @@ impl std::fmt::Display for Identifier {
 impl From<Identifier> for String {
     #[inline]
     fn from(identifier: Identifier) -> String {
+        identifier.id.to_string()
+    }
+}
+
+impl From<Identifier> for SmolStr {
+    #[inline]
+    fn from(identifier: Identifier) -> Self {
         identifier.id
     }
 }
@@ -3836,6 +3844,6 @@ mod size_assertions {
     assert_eq_size!(StmtClassDef, [u8; 104]);
     assert_eq_size!(StmtTry, [u8; 112]);
     assert_eq_size!(Expr, [u8; 80]);
-    assert_eq_size!(Pattern, [u8; 96]);
+    assert_eq_size!(Pattern, [u8; 88]);
     assert_eq_size!(Mod, [u8; 32]);
 }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3257,7 +3257,7 @@ impl PartialEq<str> for Identifier {
 impl PartialEq<String> for Identifier {
     #[inline]
     fn eq(&self, other: &String) -> bool {
-        &self.id == other
+        self.id == other
     }
 }
 

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -23,6 +23,7 @@ is-macro = { workspace = true }
 itertools = { workspace = true }
 lalrpop-util = { version = "0.20.0", default-features = false }
 memchr = { workspace = true }
+smol_str = { workspace = true }
 unicode-ident = { workspace = true }
 unicode_names2 = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -31,6 +31,7 @@
 use std::iter::FusedIterator;
 use std::{char, cmp::Ordering, str::FromStr};
 
+use smol_str::SmolStr;
 use unicode_ident::{is_xid_continue, is_xid_start};
 
 use ruff_python_ast::{Int, IpyEscapeKind};
@@ -241,7 +242,7 @@ impl<'source> Lexer<'source> {
             "yield" => Tok::Yield,
             _ => {
                 return Ok(Tok::Name {
-                    name: text.to_string(),
+                    name: SmolStr::new(text),
                 })
             }
         };

--- a/crates/ruff_python_parser/src/python.lalrpop
+++ b/crates/ruff_python_parser/src/python.lalrpop
@@ -3,6 +3,7 @@
 // See also: file:///usr/share/doc/python/html/reference/compound_stmts.html#function-definitions
 // See also: https://greentreesnakes.readthedocs.io/en/latest/nodes.html#keyword
 
+use smol_str::SmolStr;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
 use crate::{
@@ -289,7 +290,7 @@ ImportAsAlias<I>: ast::Alias = {
 DottedName: ast::Identifier = {
     <location:@L> <n:name> <end_location:@R> => ast::Identifier::new(n, (location..end_location).into()),
     <location:@L> <n:name> <n2: ("." Identifier)+> <end_location:@R> => {
-        let mut r = n;
+        let mut r = n.to_string();
         for x in n2 {
             r.push('.');
             r.push_str(x.1.as_str());
@@ -2069,7 +2070,7 @@ extern {
             value: <String>,
             is_raw: <bool>
         },
-        name => token::Tok::Name { name: <String> },
+        name => token::Tok::Name { name: <SmolStr> },
         ipy_escape_command => token::Tok::IpyEscapeCommand {
             kind: <IpyEscapeKind>,
             value: <String>

--- a/crates/ruff_python_parser/src/python.rs
+++ b/crates/ruff_python_parser/src/python.rs
@@ -1,5 +1,6 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 031689e389556292d9dbd8a1b1ff8ca29bac76d83f1b345630481d620b89e1c2
+// sha3: d4ee7846b5dfacc84c7fcd86cd6afddd44e4ae968b0a0e48ae8970bb2a7b4d12
+use smol_str::SmolStr;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
 use crate::{
@@ -24,6 +25,7 @@ extern crate alloc;
 #[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::all)]
 mod __parse__Top {
 
+    use smol_str::SmolStr;
     use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
     use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
     use crate::{
@@ -53,7 +55,7 @@ mod __parse__Top {
         Variant3((String, bool)),
         Variant4(Int),
         Variant5((IpyEscapeKind, String)),
-        Variant6(String),
+        Variant6(SmolStr),
         Variant7((String, StringKind, bool)),
         Variant8(core::option::Option<token::Tok>),
         Variant9(Option<Box<ast::Parameter>>),
@@ -18526,7 +18528,7 @@ mod __parse__Top {
     fn __pop_Variant6<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
-    ) -> (TextSize, String, TextSize)
+    ) -> (TextSize, SmolStr, TextSize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant6(__v), __r)) => (__l, __v, __r),
@@ -33541,7 +33543,7 @@ fn __action69<
     source_code: &str,
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, n, _): (TextSize, String, TextSize),
+    (_, n, _): (TextSize, SmolStr, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -33555,13 +33557,13 @@ fn __action70<
     source_code: &str,
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, n, _): (TextSize, String, TextSize),
+    (_, n, _): (TextSize, SmolStr, TextSize),
     (_, n2, _): (TextSize, alloc::vec::Vec<(token::Tok, ast::Identifier)>, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
     {
-        let mut r = n;
+        let mut r = n.to_string();
         for x in n2 {
             r.push('.');
             r.push_str(x.1.as_str());
@@ -36514,7 +36516,7 @@ fn __action224<
     (_, location, _): (TextSize, TextSize, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, name_location, _): (TextSize, TextSize, TextSize),
-    (_, s, _): (TextSize, String, TextSize),
+    (_, s, _): (TextSize, SmolStr, TextSize),
 ) -> Result<(TextSize, ast::ConversionFlag),__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     {
@@ -36899,7 +36901,7 @@ fn __action249<
     source_code: &str,
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, s, _): (TextSize, String, TextSize),
+    (_, s, _): (TextSize, SmolStr, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -48027,7 +48029,7 @@ fn __action789<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, SmolStr, TextSize),
     __1: (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -48055,7 +48057,7 @@ fn __action790<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, SmolStr, TextSize),
     __1: (TextSize, alloc::vec::Vec<(token::Tok, ast::Identifier)>, TextSize),
     __2: (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
@@ -48408,7 +48410,7 @@ fn __action801<
     source_code: &str,
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, String, TextSize),
+    __1: (TextSize, SmolStr, TextSize),
 ) -> Result<(TextSize, ast::ConversionFlag),__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
@@ -49209,7 +49211,7 @@ fn __action826<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, SmolStr, TextSize),
     __1: (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -64211,7 +64213,7 @@ fn __action1304<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, SmolStr, TextSize),
 ) -> ast::Identifier
 {
     let __start0 = __0.2;
@@ -64237,7 +64239,7 @@ fn __action1305<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, SmolStr, TextSize),
     __1: (TextSize, alloc::vec::Vec<(token::Tok, ast::Identifier)>, TextSize),
 ) -> ast::Identifier
 {
@@ -65035,7 +65037,7 @@ fn __action1333<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, SmolStr, TextSize),
 ) -> ast::Identifier
 {
     let __start0 = __0.2;

--- a/crates/ruff_python_parser/src/soft_keywords.rs
+++ b/crates/ruff_python_parser/src/soft_keywords.rs
@@ -202,9 +202,7 @@ fn soft_to_name(tok: &Tok) -> Tok {
         Tok::Type => "type",
         _ => unreachable!("other tokens never reach here"),
     };
-    Tok::Name {
-        name: name.to_owned(),
-    }
+    Tok::Name { name: name.into() }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -8,6 +8,7 @@ use crate::Mode;
 
 use ruff_python_ast::{Int, IpyEscapeKind};
 use ruff_text_size::TextSize;
+use smol_str::SmolStr;
 use std::fmt;
 
 /// The set of tokens the Python source code can be tokenized in.
@@ -16,7 +17,7 @@ pub enum Tok {
     /// Token value for a name, commonly known as an identifier.
     Name {
         /// The name value.
-        name: String,
+        name: SmolStr,
     },
     /// Token value for an integer.
     Int {


### PR DESCRIPTION
## Summary

Changes the type of the `id` field in the `Identifier` and `ExprName` nodes from `String` to `SmolStr`.  This is a required change for the new parser.

This PR is part of #9152 

## Test Plan
`cargo test --lib`