### PR TITLE
Add a fix for `never-union`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF020.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF020.py
@@ -5,3 +5,4 @@ Union[NoReturn, int]
 Never | int
 NoReturn | int
 Union[Union[Never, int], Union[NoReturn, int]]
+Union[NoReturn, int, float]

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -98,10 +98,11 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                     if checker.enabled(Rule::UnnecessaryTypeUnion) {
                         flake8_pyi::rules::unnecessary_type_union(checker, expr);
                     }
-                    if checker.enabled(Rule::NeverUnion) {
-                        ruff::rules::never_union(checker, expr);
-                    }
                 }
+            }
+
+            if checker.enabled(Rule::NeverUnion) {
+                ruff::rules::never_union(checker, expr);
             }
 
             if checker.any_enabled(&[
@@ -1158,6 +1159,10 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 }
             }
 
+            if checker.enabled(Rule::NeverUnion) {
+                ruff::rules::never_union(checker, expr);
+            }
+
             // Avoid duplicate checks if the parent is a union, since these rules already
             // traverse nested unions.
             if !checker.semantic.in_nested_union() {
@@ -1177,9 +1182,6 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
                 }
                 if checker.enabled(Rule::RuntimeStringUnion) {
                     flake8_type_checking::rules::runtime_string_union(checker, expr);
-                }
-                if checker.enabled(Rule::NeverUnion) {
-                    ruff::rules::never_union(checker, expr);
                 }
             }
         }

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF020_RUF020.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF020_RUF020.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
-RUF020.py:3:7: RUF020 `Union[Never, T]` is equivalent to `T`
+RUF020.py:3:7: RUF020 [*] `Union[Never, T]` is equivalent to `T`
   |
 1 | from typing import Never, NoReturn, Union
 2 | 
@@ -10,8 +10,18 @@ RUF020.py:3:7: RUF020 `Union[Never, T]` is equivalent to `T`
 4 | Union[NoReturn, int]
 5 | Never | int
   |
+  = help: Remove `Never`
 
-RUF020.py:4:7: RUF020 `Union[NoReturn, T]` is equivalent to `T`
+ℹ Safe fix
+1 1 | from typing import Never, NoReturn, Union
+2 2 | 
+3   |-Union[Never, int]
+  3 |+int
+4 4 | Union[NoReturn, int]
+5 5 | Never | int
+6 6 | NoReturn | int
+
+RUF020.py:4:7: RUF020 [*] `Union[NoReturn, T]` is equivalent to `T`
   |
 3 | Union[Never, int]
 4 | Union[NoReturn, int]
@@ -19,8 +29,19 @@ RUF020.py:4:7: RUF020 `Union[NoReturn, T]` is equivalent to `T`
 5 | Never | int
 6 | NoReturn | int
   |
+  = help: Remove `NoReturn`
 
-RUF020.py:5:1: RUF020 `Never | T` is equivalent to `T`
+ℹ Safe fix
+1 1 | from typing import Never, NoReturn, Union
+2 2 | 
+3 3 | Union[Never, int]
+4   |-Union[NoReturn, int]
+  4 |+int
+5 5 | Never | int
+6 6 | NoReturn | int
+7 7 | Union[Union[Never, int], Union[NoReturn, int]]
+
+RUF020.py:5:1: RUF020 [*] `Never | T` is equivalent to `T`
   |
 3 | Union[Never, int]
 4 | Union[NoReturn, int]
@@ -29,30 +50,88 @@ RUF020.py:5:1: RUF020 `Never | T` is equivalent to `T`
 6 | NoReturn | int
 7 | Union[Union[Never, int], Union[NoReturn, int]]
   |
+  = help: Remove `Never`
 
-RUF020.py:6:1: RUF020 `NoReturn | T` is equivalent to `T`
+ℹ Safe fix
+2 2 | 
+3 3 | Union[Never, int]
+4 4 | Union[NoReturn, int]
+5   |-Never | int
+  5 |+int
+6 6 | NoReturn | int
+7 7 | Union[Union[Never, int], Union[NoReturn, int]]
+8 8 | Union[NoReturn, int, float]
+
+RUF020.py:6:1: RUF020 [*] `NoReturn | T` is equivalent to `T`
   |
 4 | Union[NoReturn, int]
 5 | Never | int
 6 | NoReturn | int
   | ^^^^^^^^ RUF020
 7 | Union[Union[Never, int], Union[NoReturn, int]]
+8 | Union[NoReturn, int, float]
   |
+  = help: Remove `NoReturn`
 
-RUF020.py:7:13: RUF020 `Union[Never, T]` is equivalent to `T`
+ℹ Safe fix
+3 3 | Union[Never, int]
+4 4 | Union[NoReturn, int]
+5 5 | Never | int
+6   |-NoReturn | int
+  6 |+int
+7 7 | Union[Union[Never, int], Union[NoReturn, int]]
+8 8 | Union[NoReturn, int, float]
+
+RUF020.py:7:13: RUF020 [*] `Union[Never, T]` is equivalent to `T`
   |
 5 | Never | int
 6 | NoReturn | int
 7 | Union[Union[Never, int], Union[NoReturn, int]]
   |             ^^^^^ RUF020
+8 | Union[NoReturn, int, float]
   |
+  = help: Remove `Never`
 
-RUF020.py:7:32: RUF020 `Union[NoReturn, T]` is equivalent to `T`
+ℹ Safe fix
+4 4 | Union[NoReturn, int]
+5 5 | Never | int
+6 6 | NoReturn | int
+7   |-Union[Union[Never, int], Union[NoReturn, int]]
+  7 |+Union[int, Union[NoReturn, int]]
+8 8 | Union[NoReturn, int, float]
+
+RUF020.py:7:32: RUF020 [*] `Union[NoReturn, T]` is equivalent to `T`
   |
 5 | Never | int
 6 | NoReturn | int
 7 | Union[Union[Never, int], Union[NoReturn, int]]
   |                                ^^^^^^^^ RUF020
+8 | Union[NoReturn, int, float]
   |
+  = help: Remove `NoReturn`
+
+ℹ Safe fix
+4 4 | Union[NoReturn, int]
+5 5 | Never | int
+6 6 | NoReturn | int
+7   |-Union[Union[Never, int], Union[NoReturn, int]]
+  7 |+Union[Union[Never, int], int]
+8 8 | Union[NoReturn, int, float]
+
+RUF020.py:8:7: RUF020 [*] `Union[NoReturn, T]` is equivalent to `T`
+  |
+6 | NoReturn | int
+7 | Union[Union[Never, int], Union[NoReturn, int]]
+8 | Union[NoReturn, int, float]
+  |       ^^^^^^^^ RUF020
+  |
+  = help: Remove `NoReturn`
+
+ℹ Safe fix
+5 5 | Never | int
+6 6 | NoReturn | int
+7 7 | Union[Union[Never, int], Union[NoReturn, int]]
+8   |-Union[NoReturn, int, float]
+  8 |+Union[int, float]
 
 


### PR DESCRIPTION
## Summary

Enables us to rewrite `Never | int` as `int`.