### PR TITLE
Make parent non-Optional in traverse_union

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
@@ -56,7 +56,7 @@ pub(crate) fn duplicate_union_member<'a>(checker: &mut Checker, expr: &'a Expr) 
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
 
     // Adds a member to `literal_exprs` if it is a `Literal` annotation
-    let mut check_for_duplicate_members = |expr: &'a Expr, parent: Option<&'a Expr>| {
+    let mut check_for_duplicate_members = |expr: &'a Expr, parent: &'a Expr| {
         // If we've already seen this union member, raise a violation.
         if !seen_nodes.insert(expr.into()) {
             let mut diagnostic = Diagnostic::new(
@@ -69,7 +69,7 @@ pub(crate) fn duplicate_union_member<'a>(checker: &mut Checker, expr: &'a Expr) 
             // parent without the duplicate.
 
             // If the parent node is not a `BinOp` we will not perform a fix
-            if let Some(parent @ Expr::BinOp(ast::ExprBinOp { left, right, .. })) = parent {
+            if let Expr::BinOp(ast::ExprBinOp { left, right, .. }) = parent {
                 // Replace the parent with its non-duplicate child.
                 let child = if expr == left.as_ref() { right } else { left };
                 diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
@@ -82,12 +82,7 @@ pub(crate) fn duplicate_union_member<'a>(checker: &mut Checker, expr: &'a Expr) 
     };
 
     // Traverse the union, collect all diagnostic members
-    traverse_union(
-        &mut check_for_duplicate_members,
-        checker.semantic(),
-        expr,
-        None,
-    );
+    traverse_union(&mut check_for_duplicate_members, checker.semantic(), expr);
 
     // Add all diagnostics to the checker
     checker.diagnostics.append(&mut diagnostics);

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs
@@ -66,7 +66,7 @@ pub(crate) fn redundant_literal_union<'a>(checker: &mut Checker, union: &'a Expr
 
     // Adds a member to `literal_exprs` for each value in a `Literal`, and any builtin types
     // to `builtin_types_in_union`.
-    let mut func = |expr: &'a Expr, _| {
+    let mut func = |expr: &'a Expr, _parent: &'a Expr| {
         if let Expr::Subscript(ast::ExprSubscript { value, slice, .. }) = expr {
             if checker.semantic().match_typing_expr(value, "Literal") {
                 if let Expr::Tuple(ast::ExprTuple { elts, .. }) = slice.as_ref() {
@@ -84,7 +84,7 @@ pub(crate) fn redundant_literal_union<'a>(checker: &mut Checker, union: &'a Expr
         builtin_types_in_union.insert(builtin_type);
     };
 
-    traverse_union(&mut func, checker.semantic(), union, None);
+    traverse_union(&mut func, checker.semantic(), union);
 
     for typing_literal_expr in typing_literal_exprs {
         let Some(literal_type) = match_literal_type(typing_literal_expr) else {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
@@ -89,7 +89,7 @@ fn check_annotation(checker: &mut Checker, annotation: &Expr) {
     let mut has_complex = false;
     let mut has_int = false;
 
-    let mut func = |expr: &Expr, _parent: Option<&Expr>| {
+    let mut func = |expr: &Expr, _parent: &Expr| {
         let Some(call_path) = checker.semantic().resolve_call_path(expr) else {
             return;
         };
@@ -102,7 +102,7 @@ fn check_annotation(checker: &mut Checker, annotation: &Expr) {
         }
     };
 
-    traverse_union(&mut func, checker.semantic(), annotation, None);
+    traverse_union(&mut func, checker.semantic(), annotation);
 
     if has_complex {
         if has_float {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_literal_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_literal_union.rs
@@ -1,4 +1,4 @@
-use ast::{ExprSubscript, Operator};
+use ast::Operator;
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::{self as ast, Expr};
@@ -61,7 +61,7 @@ fn concatenate_bin_ors(exprs: Vec<&Expr>) -> Expr {
     })
 }
 
-fn make_union(subscript: &ExprSubscript, exprs: Vec<&Expr>) -> Expr {
+fn make_union(subscript: &ast::ExprSubscript, exprs: Vec<&Expr>) -> Expr {
     Expr::Subscript(ast::ExprSubscript {
         value: subscript.value.clone(),
         slice: Box::new(Expr::Tuple(ast::ExprTuple {
@@ -107,7 +107,7 @@ pub(crate) fn unnecessary_literal_union<'a>(checker: &mut Checker, expr: &'a Exp
     let mut total_literals = 0;
 
     // Split members into `literal_exprs` if they are a `Literal` annotation  and `other_exprs` otherwise
-    let mut collect_literal_expr = |expr: &'a Expr, _| {
+    let mut collect_literal_expr = |expr: &'a Expr, _parent: &'a Expr| {
         if let Expr::Subscript(ast::ExprSubscript { value, slice, .. }) = expr {
             if checker.semantic().match_typing_expr(value, "Literal") {
                 total_literals += 1;
@@ -136,7 +136,7 @@ pub(crate) fn unnecessary_literal_union<'a>(checker: &mut Checker, expr: &'a Exp
     };
 
     // Traverse the union, collect all members, split out the literals from the rest.
-    traverse_union(&mut collect_literal_expr, checker.semantic(), expr, None);
+    traverse_union(&mut collect_literal_expr, checker.semantic(), expr);
 
     let union_subscript = expr.as_subscript_expr();
     if union_subscript.is_some_and(|subscript| {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
@@ -83,7 +83,7 @@ pub(crate) fn unnecessary_type_union<'a>(checker: &mut Checker, union: &'a Expr)
     let mut type_exprs = Vec::new();
     let mut other_exprs = Vec::new();
 
-    let mut collect_type_exprs = |expr: &'a Expr, _| {
+    let mut collect_type_exprs = |expr: &'a Expr, _parent: &'a Expr| {
         let subscript = expr.as_subscript_expr();
 
         if subscript.is_none() {
@@ -102,7 +102,7 @@ pub(crate) fn unnecessary_type_union<'a>(checker: &mut Checker, union: &'a Expr)
         }
     };
 
-    traverse_union(&mut collect_type_exprs, checker.semantic(), union, None);
+    traverse_union(&mut collect_type_exprs, checker.semantic(), union);
 
     if type_exprs.len() > 1 {
         let type_members: Vec<String> = type_exprs


### PR DESCRIPTION
## Summary

This protects callers from having to pass in `None`, and allows the callback to operate as if it's always a union member.