### PR TITLE
Set target versions in Black tests

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/comment_type_hint.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/comment_type_hint.py
@@ -1,0 +1,2 @@
+# split out from comments2 as it does not work with line-length=1, losing the comment
+a = "type comment with trailing space"  # type: str

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/comment_type_hint.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/comment_type_hint.py.expect
@@ -1,0 +1,2 @@
+# split out from comments2 as it does not work with line-length=1, losing the comment
+a = "type comment with trailing space"  # type: str

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/comments2.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/comments2.py
@@ -155,8 +155,6 @@ class Test:
             pass
 
 
-a = "type comment with trailing space"  # type: str   
-
 #######################
 ### SECTION COMMENT ###
 #######################

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/comments2.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/comments2.py.expect
@@ -162,8 +162,6 @@ class Test:
             pass
 
 
-a = "type comment with trailing space"  # type: str
-
 #######################
 ### SECTION COMMENT ###
 #######################

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/fmtskip2.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/fmtskip2.py
@@ -1,3 +1,4 @@
+# l2 loses the comment with line-length=1 in preview mode
 l1 = ["This list should be broken up", "into multiple lines", "because it is way too long"]
 l2 = ["But this list shouldn't", "even though it also has", "way too many characters in it"]  # fmt: skip
 l3 = ["I have", "trailing comma", "so I should be braked",]

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/fmtskip2.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/fmtskip2.py.expect
@@ -1,3 +1,4 @@
+# l2 loses the comment with line-length=1 in preview mode
 l1 = [
     "This list should be broken up",
     "into multiple lines",

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/funcdef_return_type_trailing_comma.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/funcdef_return_type_trailing_comma.options.json
@@ -1,1 +1,1 @@
-{"preview": "enabled"}
+{"preview": "enabled", "target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/parenthesized_context_managers.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/parenthesized_context_managers.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pattern_matching_complex.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pattern_matching_complex.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pattern_matching_extras.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pattern_matching_extras.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pattern_matching_generic.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pattern_matching_generic.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pattern_matching_simple.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pattern_matching_simple.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pattern_matching_style.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pattern_matching_style.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep604_union_types_line_breaks.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep604_union_types_line_breaks.options.json
@@ -1,1 +1,1 @@
-{"preview": "enabled"}
+{"preview": "enabled", "target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_570.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_570.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py38"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_572.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_572.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py38"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_572_py310.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_572_py310.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_572_py39.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_572_py39.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py39"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_572_remove_parens.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_572_remove_parens.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py38"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_646.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_646.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py311"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_654.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_654.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py311"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_654_style.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep_654_style.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py311"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_allow_empty_first_line.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_allow_empty_first_line.options.json
@@ -1,0 +1,1 @@
+{"preview": "enabled"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_allow_empty_first_line.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_allow_empty_first_line.py
@@ -1,0 +1,62 @@
+def foo():
+    """
+    Docstring
+    """
+
+    # Here we go
+    if x:
+
+        # This is also now fine
+        a = 123
+
+    else:
+        # But not necessary
+        a = 123
+
+    if y:
+
+        while True:
+
+            """
+            Long comment here
+            """
+            a = 123
+    
+    if z:
+
+        for _ in range(100):
+            a = 123
+    else:
+
+        try:
+
+            # this should be ok
+            a = 123
+        except:
+
+            """also this"""
+            a = 123
+
+
+def bar():
+
+    if x:
+        a = 123
+
+
+def baz():
+
+    # OK
+    if x:
+        a = 123
+
+def quux():
+
+    new_line = here
+
+
+class Cls:
+
+    def method(self):
+
+        pass

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_allow_empty_first_line.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_allow_empty_first_line.py.expect
@@ -1,0 +1,62 @@
+def foo():
+    """
+    Docstring
+    """
+
+    # Here we go
+    if x:
+
+        # This is also now fine
+        a = 123
+
+    else:
+        # But not necessary
+        a = 123
+
+    if y:
+
+        while True:
+
+            """
+            Long comment here
+            """
+            a = 123
+
+    if z:
+
+        for _ in range(100):
+            a = 123
+    else:
+
+        try:
+
+            # this should be ok
+            a = 123
+        except:
+
+            """also this"""
+            a = 123
+
+
+def bar():
+
+    if x:
+        a = 123
+
+
+def baz():
+
+    # OK
+    if x:
+        a = 123
+
+
+def quux():
+
+    new_line = here
+
+
+class Cls:
+    def method(self):
+
+        pass

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_context_managers_38.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_context_managers_38.options.json
@@ -1,1 +1,1 @@
-{"preview": "enabled"}
+{"preview": "enabled", "target_version": "py38"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_context_managers_39.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_context_managers_39.options.json
@@ -1,1 +1,1 @@
-{"preview": "enabled"}
+{"preview": "enabled", "target_version": "py39"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_context_managers_autodetect_310.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_context_managers_autodetect_310.options.json
@@ -1,1 +1,1 @@
-{"preview": "enabled"}
+{"preview": "enabled", "target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_context_managers_autodetect_311.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_context_managers_autodetect_311.options.json
@@ -1,1 +1,1 @@
-{"preview": "enabled"}
+{"preview": "enabled", "target_version": "py311"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_context_managers_autodetect_39.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_context_managers_autodetect_39.options.json
@@ -1,1 +1,1 @@
-{"preview": "enabled"}
+{"preview": "enabled", "target_version": "py39"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_dummy_implementations.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_dummy_implementations.py
@@ -1,8 +1,10 @@
 from typing import NoReturn, Protocol, Union, overload
 
+class Empty:
+    ...
 
 def dummy(a): ...
-def other(b): ...
+async def other(b): ...
 
 
 @overload
@@ -46,3 +48,11 @@ def b(arg: Union[int, str, object]) -> Union[int, str]:
     if not isinstance(arg, (int, str)):
         raise TypeError
     return arg
+
+def has_comment():
+    ...  # still a dummy
+
+if some_condition:
+    ...
+
+if already_dummy: ...

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_dummy_implementations.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_dummy_implementations.py.expect
@@ -1,8 +1,11 @@
 from typing import NoReturn, Protocol, Union, overload
 
 
+class Empty: ...
+
+
 def dummy(a): ...
-def other(b): ...
+async def other(b): ...
 
 
 @overload
@@ -46,3 +49,13 @@ def b(arg: Union[int, str, object]) -> Union[int, str]:
     if not isinstance(arg, (int, str)):
         raise TypeError
     return arg
+
+
+def has_comment(): ...  # still a dummy
+
+
+if some_condition:
+    ...
+
+if already_dummy:
+    ...

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_form_feeds.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_form_feeds.py.expect
@@ -74,6 +74,7 @@ pass
 
 # form feeds are prohibited inside blocks, or on a line with nonwhitespace
 def bar(a=1, b: bool = False):
+
     pass
 
 

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets.py
@@ -124,23 +124,6 @@ func([x for x in "short line"])
 func([x for x in "long line long line long line long line long line long line long line"])
 func([x for x in [x for x in "long line long line long line long line long line long line long line"]])
 
-func({"short line"})
-func({"long line", "long long line", "long long long line", "long long long long line", "long long long long long line"})
-func({{"long line", "long long line", "long long long line", "long long long long line", "long long long long long line"}})
-func(("long line", "long long line", "long long long line", "long long long long line", "long long long long long line"))
-func((("long line", "long long line", "long long long line", "long long long long line", "long long long long long line")))
-func([["long line", "long long line", "long long long line", "long long long long line", "long long long long long line"]])
-
-# Do not hug if the argument fits on a single line.
-func({"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"})
-func(("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"))
-func(["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"])
-func(**{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"})
-func(*("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----"))
-array = [{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}]
-array = [("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")]
-array = [["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]]
-
 foooooooooooooooooooo(
     [{c: n + 1 for c in range(256)} for n in range(100)] + [{}], {size}
 )
@@ -150,13 +133,10 @@ baaaaaaaaaaaaar(
 )
 
 nested_mapping = {"key": [{"a very long key 1": "with a very long value", "a very long key 2": "with a very long value"}]}
-nested_array = [[["long line", "long long line", "long long long line", "long long long long line", "long long long long long line"]]]
 explicit_exploding = [[["short", "line",],],]
 single_item_do_not_explode = Context({
     "version": get_docs_version(),
 })
-
-foo(*["long long long long long line", "long long long long long line", "long long long long long line"])
 
 foo(*[str(i) for i in range(100000000000000000000000000000000000000000000000000000000000)])
 

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets.py.expect
@@ -122,69 +122,6 @@ func([
     ]
 ])
 
-func({"short line"})
-func({
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-})
-func({{
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-}})
-func((
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-))
-func(((
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-)))
-func([[
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-]])
-
-# Do not hug if the argument fits on a single line.
-func(
-    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
-)
-func(
-    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
-)
-func(
-    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
-)
-func(
-    **{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"}
-)
-func(
-    *("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----")
-)
-array = [
-    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
-]
-array = [
-    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
-]
-array = [
-    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
-]
-
 foooooooooooooooooooo(
     [{c: n + 1 for c in range(256)} for n in range(100)] + [{}], {size}
 )
@@ -199,13 +136,6 @@ nested_mapping = {
         "a very long key 2": "with a very long value",
     }]
 }
-nested_array = [[[
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-]]]
 explicit_exploding = [
     [
         [
@@ -217,12 +147,6 @@ explicit_exploding = [
 single_item_do_not_explode = Context({
     "version": get_docs_version(),
 })
-
-foo(*[
-    "long long long long long line",
-    "long long long long long line",
-    "long long long long long line",
-])
 
 foo(*[
     str(i) for i in range(100000000000000000000000000000000000000000000000000000000000)

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets_no_ll1.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets_no_ll1.options.json
@@ -1,0 +1,1 @@
+{"preview": "enabled"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets_no_ll1.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets_no_ll1.py
@@ -1,0 +1,23 @@
+# split out from preview_hug_parens_with_brackes_and_square_brackets, as it produces
+# different code on the second pass with line-length 1 in many cases.
+# Seems to be about whether the last string in a sequence gets wrapped in parens or not.
+foo(*["long long long long long line", "long long long long long line", "long long long long long line"])
+func({"short line"})
+func({"long line", "long long line", "long long long line", "long long long long line", "long long long long long line"})
+func({{"long line", "long long line", "long long long line", "long long long long line", "long long long long long line"}})
+func(("long line", "long long line", "long long long line", "long long long long line", "long long long long long line"))
+func((("long line", "long long line", "long long long line", "long long long long line", "long long long long long line")))
+func([["long line", "long long line", "long long long line", "long long long long line", "long long long long long line"]])
+
+
+# Do not hug if the argument fits on a single line.
+func({"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"})
+func(("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"))
+func(["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"])
+func(**{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"})
+func(*("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----"))
+array = [{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}]
+array = [("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")]
+array = [["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]]
+
+nested_array = [[["long line", "long long line", "long long long line", "long long long long line", "long long long long long line"]]]

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets_no_ll1.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets_no_ll1.py.expect
@@ -1,0 +1,79 @@
+# split out from preview_hug_parens_with_brackes_and_square_brackets, as it produces
+# different code on the second pass with line-length 1 in many cases.
+# Seems to be about whether the last string in a sequence gets wrapped in parens or not.
+foo(*[
+    "long long long long long line",
+    "long long long long long line",
+    "long long long long long line",
+])
+func({"short line"})
+func({
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+})
+func({{
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+}})
+func((
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+))
+func(((
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+)))
+func([[
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+]])
+
+
+# Do not hug if the argument fits on a single line.
+func(
+    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
+)
+func(
+    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
+)
+func(
+    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
+)
+func(
+    **{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"}
+)
+func(
+    *("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----")
+)
+array = [
+    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
+]
+array = [
+    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
+]
+array = [
+    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
+]
+
+nested_array = [[[
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+]]]

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_pattern_matching_long.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_pattern_matching_long.options.json
@@ -1,1 +1,1 @@
-{"preview": "enabled"}
+{"preview": "enabled", "target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_pattern_matching_trailing_comma.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_pattern_matching_trailing_comma.options.json
@@ -1,1 +1,1 @@
-{"preview": "enabled"}
+{"preview": "enabled", "target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/py310_pep572.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/py310_pep572.options.json
@@ -1,1 +1,1 @@
-{"preview": "enabled"}
+{"preview": "enabled", "target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/python37.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/python37.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py37"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/python38.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/python38.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py38"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/python39.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/python39.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py39"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/remove_newline_after_match.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/remove_newline_after_match.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/remove_with_brackets.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/remove_with_brackets.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py39"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/starred_for_target.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/starred_for_target.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py310"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/type_params.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/type_params.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py312"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/import_black_tests.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/import_black_tests.py
@@ -51,6 +51,11 @@ def import_fixture(fixture: Path, fixture_set: str):
                 length = int(length)
                 options["line_width"] = 1 if length == 0 else length
 
+            if "--minimum-version=" in flags:
+                [_, version] = flags.split("--minimum-version=", 1)
+                # Convert 3.10 to py310
+                options["target_version"] = f"py{version.strip().replace('.', '')}"
+
             if "--skip-magic-trailing-comma" in flags:
                 options["magic_trailing_comma"] = "ignore"
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__comments2.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__comments2.py.snap
@@ -162,8 +162,6 @@ class Test:
             pass
 
 
-a = "type comment with trailing space"  # type: str   
-
 #######################
 ### SECTION COMMENT ###
 #######################
@@ -427,8 +425,6 @@ class Test:
             pass
 
 
-a = "type comment with trailing space"  # type: str
-
 #######################
 ### SECTION COMMENT ###
 #######################
@@ -606,8 +602,6 @@ class Test:
         if parsed.hostname is None or not parsed.hostname.strip():  # type: ignore
             pass
 
-
-a = "type comment with trailing space"  # type: str
 
 #######################
 ### SECTION COMMENT ###

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_allow_empty_first_line.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_allow_empty_first_line.py.snap
@@ -1,0 +1,260 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_allow_empty_first_line.py
+---
+## Input
+
+```python
+def foo():
+    """
+    Docstring
+    """
+
+    # Here we go
+    if x:
+
+        # This is also now fine
+        a = 123
+
+    else:
+        # But not necessary
+        a = 123
+
+    if y:
+
+        while True:
+
+            """
+            Long comment here
+            """
+            a = 123
+    
+    if z:
+
+        for _ in range(100):
+            a = 123
+    else:
+
+        try:
+
+            # this should be ok
+            a = 123
+        except:
+
+            """also this"""
+            a = 123
+
+
+def bar():
+
+    if x:
+        a = 123
+
+
+def baz():
+
+    # OK
+    if x:
+        a = 123
+
+def quux():
+
+    new_line = here
+
+
+class Cls:
+
+    def method(self):
+
+        pass
+```
+
+## Black Differences
+
+```diff
+--- Black
++++ Ruff
+@@ -5,7 +5,6 @@
+ 
+     # Here we go
+     if x:
+-
+         # This is also now fine
+         a = 123
+ 
+@@ -14,49 +13,39 @@
+         a = 123
+ 
+     if y:
+-
+         while True:
+-
+             """
+             Long comment here
+             """
+             a = 123
+ 
+     if z:
+-
+         for _ in range(100):
+             a = 123
+     else:
+-
+         try:
+-
+             # this should be ok
+             a = 123
+         except:
+-
+             """also this"""
+             a = 123
+ 
+ 
+ def bar():
+-
+     if x:
+         a = 123
+ 
+ 
+ def baz():
+-
+     # OK
+     if x:
+         a = 123
+ 
+ 
+ def quux():
+-
+     new_line = here
+ 
+ 
+ class Cls:
+     def method(self):
+-
+         pass
+```
+
+## Ruff Output
+
+```python
+def foo():
+    """
+    Docstring
+    """
+
+    # Here we go
+    if x:
+        # This is also now fine
+        a = 123
+
+    else:
+        # But not necessary
+        a = 123
+
+    if y:
+        while True:
+            """
+            Long comment here
+            """
+            a = 123
+
+    if z:
+        for _ in range(100):
+            a = 123
+    else:
+        try:
+            # this should be ok
+            a = 123
+        except:
+            """also this"""
+            a = 123
+
+
+def bar():
+    if x:
+        a = 123
+
+
+def baz():
+    # OK
+    if x:
+        a = 123
+
+
+def quux():
+    new_line = here
+
+
+class Cls:
+    def method(self):
+        pass
+```
+
+## Black Output
+
+```python
+def foo():
+    """
+    Docstring
+    """
+
+    # Here we go
+    if x:
+
+        # This is also now fine
+        a = 123
+
+    else:
+        # But not necessary
+        a = 123
+
+    if y:
+
+        while True:
+
+            """
+            Long comment here
+            """
+            a = 123
+
+    if z:
+
+        for _ in range(100):
+            a = 123
+    else:
+
+        try:
+
+            # this should be ok
+            a = 123
+        except:
+
+            """also this"""
+            a = 123
+
+
+def bar():
+
+    if x:
+        a = 123
+
+
+def baz():
+
+    # OK
+    if x:
+        a = 123
+
+
+def quux():
+
+    new_line = here
+
+
+class Cls:
+    def method(self):
+
+        pass
+```
+
+

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_dummy_implementations.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_dummy_implementations.py.snap
@@ -7,9 +7,11 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/pre
 ```python
 from typing import NoReturn, Protocol, Union, overload
 
+class Empty:
+    ...
 
 def dummy(a): ...
-def other(b): ...
+async def other(b): ...
 
 
 @overload
@@ -53,6 +55,14 @@ def b(arg: Union[int, str, object]) -> Union[int, str]:
     if not isinstance(arg, (int, str)):
         raise TypeError
     return arg
+
+def has_comment():
+    ...  # still a dummy
+
+if some_condition:
+    ...
+
+if already_dummy: ...
 ```
 
 ## Black Differences
@@ -60,13 +70,13 @@ def b(arg: Union[int, str, object]) -> Union[int, str]:
 ```diff
 --- Black
 +++ Ruff
-@@ -2,15 +2,23 @@
+@@ -5,15 +5,23 @@
  
  
  def dummy(a): ...
 +
 +
- def other(b): ...
+ async def other(b): ...
  
  
  @overload
@@ -84,7 +94,7 @@ def b(arg: Union[int, str, object]) -> Union[int, str]:
  def a(arg: Union[int, str, object]) -> Union[int, str]:
      if not isinstance(arg, (int, str)):
          raise TypeError
-@@ -21,10 +29,13 @@
+@@ -24,10 +32,13 @@
      def foo(self, a: int) -> int: ...
  
      def bar(self, b: str) -> str: ...
@@ -98,7 +108,7 @@ def b(arg: Union[int, str, object]) -> Union[int, str]:
  @dummy
  def dummy_three(): ...
  
-@@ -38,6 +49,8 @@
+@@ -41,6 +52,8 @@
  
  @overload
  def b(arg: str) -> str: ...
@@ -107,6 +117,17 @@ def b(arg: Union[int, str, object]) -> Union[int, str]:
  @overload
  def b(arg: object) -> NoReturn: ...
  
+@@ -54,8 +67,6 @@
+ def has_comment(): ...  # still a dummy
+ 
+ 
+-if some_condition:
+-    ...
++if some_condition: ...
+ 
+-if already_dummy:
+-    ...
++if already_dummy: ...
 ```
 
 ## Ruff Output
@@ -115,10 +136,13 @@ def b(arg: Union[int, str, object]) -> Union[int, str]:
 from typing import NoReturn, Protocol, Union, overload
 
 
+class Empty: ...
+
+
 def dummy(a): ...
 
 
-def other(b): ...
+async def other(b): ...
 
 
 @overload
@@ -173,6 +197,14 @@ def b(arg: Union[int, str, object]) -> Union[int, str]:
     if not isinstance(arg, (int, str)):
         raise TypeError
     return arg
+
+
+def has_comment(): ...  # still a dummy
+
+
+if some_condition: ...
+
+if already_dummy: ...
 ```
 
 ## Black Output
@@ -181,8 +213,11 @@ def b(arg: Union[int, str, object]) -> Union[int, str]:
 from typing import NoReturn, Protocol, Union, overload
 
 
+class Empty: ...
+
+
 def dummy(a): ...
-def other(b): ...
+async def other(b): ...
 
 
 @overload
@@ -226,6 +261,16 @@ def b(arg: Union[int, str, object]) -> Union[int, str]:
     if not isinstance(arg, (int, str)):
         raise TypeError
     return arg
+
+
+def has_comment(): ...  # still a dummy
+
+
+if some_condition:
+    ...
+
+if already_dummy:
+    ...
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_form_feeds.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_form_feeds.py.snap
@@ -211,7 +211,7 @@ a = [
  pass
  
  
-@@ -68,7 +68,7 @@
+@@ -68,13 +68,12 @@
  def foo():
      pass
  
@@ -220,7 +220,13 @@ a = [
  pass
  
  
-@@ -84,7 +84,7 @@
+ # form feeds are prohibited inside blocks, or on a line with nonwhitespace
+ def bar(a=1, b: bool = False):
+-
+     pass
+ 
+ 
+@@ -85,7 +84,7 @@
      def something(self):
          pass
  
@@ -416,6 +422,7 @@ pass
 
 # form feeds are prohibited inside blocks, or on a line with nonwhitespace
 def bar(a=1, b: bool = False):
+
     pass
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_hug_parens_with_braces_and_square_brackets.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_hug_parens_with_braces_and_square_brackets.py.snap
@@ -131,23 +131,6 @@ func([x for x in "short line"])
 func([x for x in "long line long line long line long line long line long line long line"])
 func([x for x in [x for x in "long line long line long line long line long line long line long line"]])
 
-func({"short line"})
-func({"long line", "long long line", "long long long line", "long long long long line", "long long long long long line"})
-func({{"long line", "long long line", "long long long line", "long long long long line", "long long long long long line"}})
-func(("long line", "long long line", "long long long line", "long long long long line", "long long long long long line"))
-func((("long line", "long long line", "long long long line", "long long long long line", "long long long long long line")))
-func([["long line", "long long line", "long long long line", "long long long long line", "long long long long long line"]])
-
-# Do not hug if the argument fits on a single line.
-func({"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"})
-func(("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"))
-func(["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"])
-func(**{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"})
-func(*("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----"))
-array = [{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}]
-array = [("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")]
-array = [["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]]
-
 foooooooooooooooooooo(
     [{c: n + 1 for c in range(256)} for n in range(100)] + [{}], {size}
 )
@@ -157,13 +140,10 @@ baaaaaaaaaaaaar(
 )
 
 nested_mapping = {"key": [{"a very long key 1": "with a very long value", "a very long key 2": "with a very long value"}]}
-nested_array = [[["long line", "long long line", "long long long line", "long long long long line", "long long long long long line"]]]
 explicit_exploding = [[["short", "line",],],]
 single_item_do_not_explode = Context({
     "version": get_docs_version(),
 })
-
-foo(*["long long long long long line", "long long long long long line", "long long long long long line"])
 
 foo(*[str(i) for i in range(100000000000000000000000000000000000000000000000000000000000)])
 
@@ -262,115 +242,7 @@ for foo in ["a", "b"]:
      x
      for x in [
          x
-@@ -130,13 +136,15 @@
-     "long long long long line",
-     "long long long long long line",
- })
--func({{
--    "long line",
--    "long long line",
--    "long long long line",
--    "long long long long line",
--    "long long long long long line",
--}})
-+func({
-+    {
-+        "long line",
-+        "long long line",
-+        "long long long line",
-+        "long long long long line",
-+        "long long long long long line",
-+    }
-+})
- func((
-     "long line",
-     "long long line",
-@@ -151,30 +159,62 @@
-     "long long long long line",
-     "long long long long long line",
- )))
--func([[
--    "long line",
--    "long long line",
--    "long long long line",
--    "long long long long line",
--    "long long long long long line",
--]])
-+func([
-+    [
-+        "long line",
-+        "long long line",
-+        "long long long line",
-+        "long long long long line",
-+        "long long long long long line",
-+    ]
-+])
- 
- # Do not hug if the argument fits on a single line.
--func(
--    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
--)
--func(
--    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
--)
--func(
--    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
--)
--func(
--    **{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"}
--)
--func(
--    *("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----")
--)
-+func({
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+})
-+func((
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+))
-+func([
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+])
-+func(**{
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit---",
-+})
-+func(*(
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit line",
-+    "fit----",
-+))
- array = [
-     {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
- ]
-@@ -194,18 +234,24 @@
+@@ -131,10 +137,12 @@
  )
  
  nested_mapping = {
@@ -385,28 +257,9 @@ for foo in ["a", "b"]:
 +        }
 +    ]
  }
--nested_array = [[[
--    "long line",
--    "long long line",
--    "long long long line",
--    "long long long long line",
--    "long long long long long line",
--]]]
-+nested_array = [
-+    [
-+        [
-+            "long line",
-+            "long long line",
-+            "long long long line",
-+            "long long long long line",
-+            "long long long long long line",
-+        ]
-+    ]
-+]
  explicit_exploding = [
      [
-         [
-@@ -240,9 +286,9 @@
+@@ -164,9 +172,9 @@
  })
  
  # Edge case when deciding whether to hug the brackets without inner content.
@@ -554,103 +407,6 @@ func([
     ]
 ])
 
-func({"short line"})
-func({
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-})
-func({
-    {
-        "long line",
-        "long long line",
-        "long long long line",
-        "long long long long line",
-        "long long long long long line",
-    }
-})
-func((
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-))
-func(((
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-)))
-func([
-    [
-        "long line",
-        "long long line",
-        "long long long line",
-        "long long long long line",
-        "long long long long long line",
-    ]
-])
-
-# Do not hug if the argument fits on a single line.
-func({
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-})
-func((
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-))
-func([
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-])
-func(**{
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit---",
-})
-func(*(
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit line",
-    "fit----",
-))
-array = [
-    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
-]
-array = [
-    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
-]
-array = [
-    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
-]
-
 foooooooooooooooooooo(
     [{c: n + 1 for c in range(256)} for n in range(100)] + [{}], {size}
 )
@@ -667,17 +423,6 @@ nested_mapping = {
         }
     ]
 }
-nested_array = [
-    [
-        [
-            "long line",
-            "long long line",
-            "long long long line",
-            "long long long long line",
-            "long long long long long line",
-        ]
-    ]
-]
 explicit_exploding = [
     [
         [
@@ -689,12 +434,6 @@ explicit_exploding = [
 single_item_do_not_explode = Context({
     "version": get_docs_version(),
 })
-
-foo(*[
-    "long long long long long line",
-    "long long long long long line",
-    "long long long long long line",
-])
 
 foo(*[
     str(i) for i in range(100000000000000000000000000000000000000000000000000000000000)
@@ -854,69 +593,6 @@ func([
     ]
 ])
 
-func({"short line"})
-func({
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-})
-func({{
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-}})
-func((
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-))
-func(((
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-)))
-func([[
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-]])
-
-# Do not hug if the argument fits on a single line.
-func(
-    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
-)
-func(
-    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
-)
-func(
-    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
-)
-func(
-    **{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"}
-)
-func(
-    *("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----")
-)
-array = [
-    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
-]
-array = [
-    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
-]
-array = [
-    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
-]
-
 foooooooooooooooooooo(
     [{c: n + 1 for c in range(256)} for n in range(100)] + [{}], {size}
 )
@@ -931,13 +607,6 @@ nested_mapping = {
         "a very long key 2": "with a very long value",
     }]
 }
-nested_array = [[[
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-]]]
 explicit_exploding = [
     [
         [
@@ -949,12 +618,6 @@ explicit_exploding = [
 single_item_do_not_explode = Context({
     "version": get_docs_version(),
 })
-
-foo(*[
-    "long long long long long line",
-    "long long long long long line",
-    "long long long long long line",
-])
 
 foo(*[
     str(i) for i in range(100000000000000000000000000000000000000000000000000000000000)

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_hug_parens_with_braces_and_square_brackets_no_ll1.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_hug_parens_with_braces_and_square_brackets_no_ll1.py.snap
@@ -1,0 +1,377 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_hug_parens_with_braces_and_square_brackets_no_ll1.py
+---
+## Input
+
+```python
+# split out from preview_hug_parens_with_brackes_and_square_brackets, as it produces
+# different code on the second pass with line-length 1 in many cases.
+# Seems to be about whether the last string in a sequence gets wrapped in parens or not.
+foo(*["long long long long long line", "long long long long long line", "long long long long long line"])
+func({"short line"})
+func({"long line", "long long line", "long long long line", "long long long long line", "long long long long long line"})
+func({{"long line", "long long line", "long long long line", "long long long long line", "long long long long long line"}})
+func(("long line", "long long line", "long long long line", "long long long long line", "long long long long long line"))
+func((("long line", "long long line", "long long long line", "long long long long line", "long long long long long line")))
+func([["long line", "long long line", "long long long line", "long long long long line", "long long long long long line"]])
+
+
+# Do not hug if the argument fits on a single line.
+func({"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"})
+func(("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"))
+func(["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"])
+func(**{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"})
+func(*("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----"))
+array = [{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}]
+array = [("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")]
+array = [["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]]
+
+nested_array = [[["long line", "long long line", "long long long line", "long long long long line", "long long long long long line"]]]
+```
+
+## Black Differences
+
+```diff
+--- Black
++++ Ruff
+@@ -14,13 +14,15 @@
+     "long long long long line",
+     "long long long long long line",
+ })
+-func({{
+-    "long line",
+-    "long long line",
+-    "long long long line",
+-    "long long long long line",
+-    "long long long long long line",
+-}})
++func({
++    {
++        "long line",
++        "long long line",
++        "long long long line",
++        "long long long long line",
++        "long long long long long line",
++    }
++})
+ func((
+     "long line",
+     "long long line",
+@@ -35,31 +37,63 @@
+     "long long long long line",
+     "long long long long long line",
+ )))
+-func([[
+-    "long line",
+-    "long long line",
+-    "long long long line",
+-    "long long long long line",
+-    "long long long long long line",
+-]])
++func([
++    [
++        "long line",
++        "long long line",
++        "long long long line",
++        "long long long long line",
++        "long long long long long line",
++    ]
++])
+ 
+ 
+ # Do not hug if the argument fits on a single line.
+-func(
+-    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
+-)
+-func(
+-    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
+-)
+-func(
+-    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
+-)
+-func(
+-    **{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"}
+-)
+-func(
+-    *("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----")
+-)
++func({
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++})
++func((
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++))
++func([
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++])
++func(**{
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit---",
++})
++func(*(
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit line",
++    "fit----",
++))
+ array = [
+     {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
+ ]
+@@ -70,10 +104,14 @@
+     ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
+ ]
+ 
+-nested_array = [[[
+-    "long line",
+-    "long long line",
+-    "long long long line",
+-    "long long long long line",
+-    "long long long long long line",
+-]]]
++nested_array = [
++    [
++        [
++            "long line",
++            "long long line",
++            "long long long line",
++            "long long long long line",
++            "long long long long long line",
++        ]
++    ]
++]
+```
+
+## Ruff Output
+
+```python
+# split out from preview_hug_parens_with_brackes_and_square_brackets, as it produces
+# different code on the second pass with line-length 1 in many cases.
+# Seems to be about whether the last string in a sequence gets wrapped in parens or not.
+foo(*[
+    "long long long long long line",
+    "long long long long long line",
+    "long long long long long line",
+])
+func({"short line"})
+func({
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+})
+func({
+    {
+        "long line",
+        "long long line",
+        "long long long line",
+        "long long long long line",
+        "long long long long long line",
+    }
+})
+func((
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+))
+func(((
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+)))
+func([
+    [
+        "long line",
+        "long long line",
+        "long long long line",
+        "long long long long line",
+        "long long long long long line",
+    ]
+])
+
+
+# Do not hug if the argument fits on a single line.
+func({
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+})
+func((
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+))
+func([
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+])
+func(**{
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit---",
+})
+func(*(
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit line",
+    "fit----",
+))
+array = [
+    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
+]
+array = [
+    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
+]
+array = [
+    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
+]
+
+nested_array = [
+    [
+        [
+            "long line",
+            "long long line",
+            "long long long line",
+            "long long long long line",
+            "long long long long long line",
+        ]
+    ]
+]
+```
+
+## Black Output
+
+```python
+# split out from preview_hug_parens_with_brackes_and_square_brackets, as it produces
+# different code on the second pass with line-length 1 in many cases.
+# Seems to be about whether the last string in a sequence gets wrapped in parens or not.
+foo(*[
+    "long long long long long line",
+    "long long long long long line",
+    "long long long long long line",
+])
+func({"short line"})
+func({
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+})
+func({{
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+}})
+func((
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+))
+func(((
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+)))
+func([[
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+]])
+
+
+# Do not hug if the argument fits on a single line.
+func(
+    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
+)
+func(
+    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
+)
+func(
+    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
+)
+func(
+    **{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"}
+)
+func(
+    *("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----")
+)
+array = [
+    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
+]
+array = [
+    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
+]
+array = [
+    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
+]
+
+nested_array = [[[
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+]]]
+```
+
+


### PR DESCRIPTION
## Summary

This PR updates our black test importer to parse the `--minimum-version` header and set the specified value as a Ruff compliant `target-version` option. 

This PR aso updates the most recent black test set

## Test Plan

`cargo test`
