### PR TITLE
Show preview changes for tests with options

### DIFF
--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_dynamic_line_width.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_dynamic_line_width.py.snap
@@ -535,6 +535,28 @@ def doctest_extra_indent3():
 ```
 
 
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -270,9 +270,11 @@
+ 
+         Examples
+         --------
+-        >>> df = pl.DataFrame(
+-        ...     {"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]}
+-        ... )
++        >>> df = pl.DataFrame({
++        ...     "foo": [1, 2, 3],
++        ...     "bar": [6, 7, 8],
++        ...     "ham": ["a", "b", "c"],
++        ... })
+         """
+ 
+ 
+```
+
+
 ### Output 2
 ```
 indent-style               = space
@@ -1136,6 +1158,28 @@ def doctest_extra_indent3():
 	...     df1, df2, df3, on="dt"
 	... )  # doctest: +IGNORE_RESULT
 	"""
+```
+
+
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -270,9 +270,11 @@
+ 
+ 		Examples
+ 		--------
+-		>>> df = pl.DataFrame(
+-		...     {"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]}
+-		... )
++		>>> df = pl.DataFrame({
++		...     "foo": [1, 2, 3],
++		...     "bar": [6, 7, 8],
++		...     "ham": ["a", "b", "c"],
++		... })
+ 		"""
+ 
+ 
 ```
 
 
@@ -1873,6 +1917,28 @@ def doctest_extra_indent3():
 	...         df1, df2, df3, on="dt"
 	... )  # doctest: +IGNORE_RESULT
 	"""
+```
+
+
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -700,9 +700,11 @@
+ 
+ 		Examples
+ 		--------
+-		>>> df = pl.DataFrame(
+-		...         {"foo": [1, 2, 3], "bar": [6, 7, 8], "ham": ["a", "b", "c"]}
+-		... )
++		>>> df = pl.DataFrame({
++		...         "foo": [1, 2, 3],
++		...         "bar": [6, 7, 8],
++		...         "ham": ["a", "b", "c"],
++		... })
+ 		"""
+ 
+ 
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -319,6 +319,19 @@ trailing_preferred_quote_texts = [''' "''', ''' ""''', ''' """''', ''' """"''']
 ```
 
 
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -1,4 +1,5 @@
+ "' test"
++
+ '" test'
+ 
+ '" test'
+```
+
+
 ### Output 2
 ```
 indent-style               = space
@@ -493,6 +506,19 @@ x = (
 
 # https://github.com/astral-sh/ruff/issues/7460
 trailing_preferred_quote_texts = [''' "''', ''' ""''', ''' """''', ''' """"''']
+```
+
+
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -1,4 +1,5 @@
+ "' test"
++
+ '" test'
+ 
+ '" test'
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@preview.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@preview.py.snap
@@ -156,6 +156,78 @@ def f():
 ```
 
 
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -1,13 +1,13 @@
+ """
+ Black's `Preview.module_docstring_newlines`
+ """
++
+ first_stmt_after_module_level_docstring = 1
+ 
+ 
+ class CachedRepository:
+     # Black's `Preview.dummy_implementations`
+-    def get_release_info(self):
+-        ...
++    def get_release_info(self): ...
+ 
+ 
+ def raw_docstring():
+@@ -27,23 +27,22 @@
+ 
+ 
+ class RemoveNewlineBeforeClassDocstring:
+-
+     """Black's `Preview.no_blank_line_before_class_docstring`"""
+ 
+ 
+ def f():
+     """Black's `Preview.prefer_splitting_right_hand_side_of_assignments`"""
+-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+-        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+-    ] = cccccccc.ccccccccccccc.cccccccc
++    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
++        cccccccc.ccccccccccccc.cccccccc
++    )
+ 
+-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+-        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+-    ] = cccccccc.ccccccccccccc().cccccccc
++    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
++        cccccccc.ccccccccccccc().cccccccc
++    )
+ 
+-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+-        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+-    ] = cccccccc.ccccccccccccc(d).cccccccc
++    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
++        cccccccc.ccccccccccccc(d).cccccccc
++    )
+ 
+     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb] = (
+         cccccccc.ccccccccccccc(d).cccccccc + e
+@@ -57,9 +56,9 @@
+         + eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+     )
+ 
+-    self._cache: dict[
+-        DependencyCacheKey, list[list[DependencyPackage]]
+-    ] = collections.defaultdict(list)
+-    self._cached_dependencies_by_level: dict[
+-        int, list[DependencyCacheKey]
+-    ] = collections.defaultdict(list)
++    self._cache: dict[DependencyCacheKey, list[list[DependencyPackage]]] = (
++        collections.defaultdict(list)
++    )
++    self._cached_dependencies_by_level: dict[int, list[DependencyCacheKey]] = (
++        collections.defaultdict(list)
++    )
+```
+
+
 ### Output 2
 ```
 indent-style               = space

--- a/crates/ruff_python_formatter/tests/snapshots/format@quote_style.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@quote_style.py.snap
@@ -129,6 +129,19 @@ def docstring_single():
 ```
 
 
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -1,4 +1,5 @@
+ 'single'
++
+ 'double'
+ r'r single'
+ r'r double'
+```
+
+
 ### Output 2
 ```
 indent-style               = space
@@ -201,6 +214,19 @@ def docstring_single():
 ```
 
 
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -1,4 +1,5 @@
+ "single"
++
+ "double"
+ r"r single"
+ r"r double"
+```
+
+
 ### Output 3
 ```
 indent-style               = space
@@ -270,6 +296,19 @@ def docstring_double():
 
 def docstring_single():
     "single"
+```
+
+
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -1,4 +1,5 @@
+ 'single'
++
+ "double"
+ r'r single'
+ r"r double"
 ```
 
 


### PR DESCRIPTION
## Summary

Our formatter snapshot testing infrastructure shows preview changes for tests without an options file. 

This PR extends (copy paste) the infrastructure to show preview change for tests with an options file. 

## Test Plan

Updated snapshots
