### PR TITLE
Use CompactStr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +450,19 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2298,6 +2320,7 @@ name = "ruff_python_ast"
 version = "0.0.0"
 dependencies = [
  "bitflags 2.4.1",
+ "compact_str",
  "insta",
  "is-macro",
  "itertools 0.11.0",
@@ -2310,7 +2333,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "smallvec",
- "smol_str",
  "static_assertions",
 ]
 
@@ -2390,6 +2412,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
+ "compact_str",
  "insta",
  "is-macro",
  "itertools 0.11.0",
@@ -2399,7 +2422,6 @@ dependencies = [
  "ruff_python_ast",
  "ruff_text_size",
  "rustc-hash",
- "smol_str",
  "static_assertions",
  "tiny-keccak",
  "unicode-ident",
@@ -2812,15 +2834,6 @@ name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
-
-[[package]]
-name = "smol_str"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "spin"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,6 +2310,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "smallvec",
+ "smol_str",
  "static_assertions",
 ]
 
@@ -2398,6 +2399,7 @@ dependencies = [
  "ruff_python_ast",
  "ruff_text_size",
  "rustc-hash",
+ "smol_str",
  "static_assertions",
  "tiny-keccak",
  "unicode-ident",
@@ -2810,6 +2812,15 @@ name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
+name = "smol_str"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ bitflags = { version = "2.4.1" }
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 clap = { version = "4.4.7", features = ["derive"] }
 colored = { version = "2.0.0" }
+compact_str = "0.7.1"
 filetime = { version = "0.2.23" }
 glob = { version = "0.3.1" }
 globset = { version = "0.4.14" }
@@ -39,7 +40,6 @@ serde_json = { version = "1.0.108" }
 shellexpand = { version = "3.0.0" }
 similar = { version = "2.3.0", features = ["inline"] }
 smallvec = { version = "1.11.2" }
-smol_str = "0.2.0"
 static_assertions = "1.1.0"
 strum = { version = "0.25.0", features = ["strum_macros"] }
 strum_macros = { version = "0.25.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ serde_json = { version = "1.0.108" }
 shellexpand = { version = "3.0.0" }
 similar = { version = "2.3.0", features = ["inline"] }
 smallvec = { version = "1.11.2" }
+smol_str = "0.2.0"
 static_assertions = "1.1.0"
 strum = { version = "0.25.0", features = ["strum_macros"] }
 strum_macros = { version = "0.25.3" }

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -844,7 +844,7 @@ where
                 range: _,
             }) => {
                 if let Expr::Name(ast::ExprName { id, ctx, range: _ }) = func.as_ref() {
-                    if id == "locals" && ctx.is_load() {
+                    if *id == "locals" && ctx.is_load() {
                         let scope = self.semantic.current_scope_mut();
                         scope.set_uses_locals();
                     }
@@ -1702,21 +1702,21 @@ impl<'a> Checker<'a> {
             && match parent {
                 Stmt::Assign(ast::StmtAssign { targets, .. }) => {
                     if let Some(Expr::Name(ast::ExprName { id, .. })) = targets.first() {
-                        id == "__all__"
+                        *id == "__all__"
                     } else {
                         false
                     }
                 }
                 Stmt::AugAssign(ast::StmtAugAssign { target, .. }) => {
                     if let Expr::Name(ast::ExprName { id, .. }) = target.as_ref() {
-                        id == "__all__"
+                        *id == "__all__"
                     } else {
                         false
                     }
                 }
                 Stmt::AnnAssign(ast::StmtAnnAssign { target, .. }) => {
                     if let Expr::Name(ast::ExprName { id, .. }) = target.as_ref() {
-                        id == "__all__"
+                        *id == "__all__"
                     } else {
                         false
                     }

--- a/crates/ruff_linter/src/checkers/imports.rs
+++ b/crates/ruff_linter/src/checkers/imports.rs
@@ -46,7 +46,7 @@ fn extract_import_map(path: &Path, package: Option<&Path>, blocks: &[&Block]) ->
             }) => {
                 let level = level.unwrap_or_default() as usize;
                 let module = if let Some(module) = module {
-                    let module: &String = module.as_ref();
+                    let module = module.as_str();
                     if level == 0 {
                         Cow::Borrowed(module)
                     } else {

--- a/crates/ruff_linter/src/rules/airflow/rules/task_variable_name.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/task_variable_name.rs
@@ -81,7 +81,7 @@ pub(crate) fn variable_name_task_id(
     let ast::ExprStringLiteral { value: task_id, .. } = keyword.value.as_string_literal_expr()?;
 
     // If the target name is the same as the task_id, no violation.
-    if task_id == id {
+    if task_id == id.as_str() {
         return None;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_annotations/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/helpers.rs
@@ -136,7 +136,7 @@ impl AutoPythonType {
                     )
                     .ok()?;
                 let expr = Expr::Name(ast::ExprName {
-                    id: binding,
+                    id: binding.into(),
                     range: TextRange::default(),
                     ctx: ExprContext::Load,
                 });

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -69,7 +69,7 @@ pub(crate) fn jinja2_autoescape_false(checker: &mut Checker, call: &ast::ExprCal
                 Expr::BooleanLiteral(ast::ExprBooleanLiteral { value: true, .. }) => (),
                 Expr::Call(ast::ExprCall { func, .. }) => {
                     if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
-                        if id != "select_autoescape" {
+                        if *id != "select_autoescape" {
                             checker.diagnostics.push(Diagnostic::new(
                                 Jinja2AutoescapeFalse { value: true },
                                 keyword.range(),

--- a/crates/ruff_linter/src/rules/flake8_blind_except/rules/blind_except.rs
+++ b/crates/ruff_linter/src/rules/flake8_blind_except/rules/blind_except.rs
@@ -77,7 +77,7 @@ pub(crate) fn blind_except(
         if let Stmt::Raise(ast::StmtRaise { exc, .. }) = stmt {
             if let Some(exc) = exc {
                 if let Expr::Name(ast::ExprName { id, .. }) = exc.as_ref() {
-                    name.is_some_and(|name| id == name)
+                    name.is_some_and(|name| *id == name)
                 } else {
                     false
                 }

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_type_hint_positional_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_type_hint_positional_argument.rs
@@ -164,7 +164,7 @@ pub(crate) fn boolean_type_hint_positional_argument(
 fn match_annotation_to_literal_bool(annotation: &Expr) -> bool {
     match annotation {
         // Ex) `True`
-        Expr::Name(name) => &name.id == "bool",
+        Expr::Name(name) => name.id == "bool",
         // Ex) `"True"`
         Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => value == "bool",
         _ => false,
@@ -176,7 +176,7 @@ fn match_annotation_to_literal_bool(annotation: &Expr) -> bool {
 fn match_annotation_to_complex_bool(annotation: &Expr, semantic: &SemanticModel) -> bool {
     match annotation {
         // Ex) `bool`
-        Expr::Name(name) => &name.id == "bool",
+        Expr::Name(name) => name.id == "bool",
         // Ex) `"bool"`
         Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => value == "bool",
         // Ex) `bool | int`

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/assignment_to_os_environ.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/assignment_to_os_environ.rs
@@ -63,7 +63,7 @@ pub(crate) fn assignment_to_os_environ(checker: &mut Checker, targets: &[Expr]) 
     let Expr::Name(ast::ExprName { id, .. }) = value.as_ref() else {
         return;
     };
-    if id != "os" {
+    if *id != "os" {
         return;
     }
     checker

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -85,7 +85,7 @@ pub(crate) fn cached_instance_method(checker: &mut Checker, decorator_list: &[De
         // TODO(charlie): This should take into account `classmethod-decorators` and
         // `staticmethod-decorators`.
         if let Expr::Name(ast::ExprName { id, .. }) = &decorator.expression {
-            if id == "classmethod" || id == "staticmethod" {
+            if *id == "classmethod" || *id == "staticmethod" {
                 return;
             }
         }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
@@ -147,7 +147,7 @@ impl<'a> Visitor<'a> for SuspiciousVariablesVisitor<'a> {
                     Expr::Attribute(ast::ExprAttribute { value, attr, .. }) => {
                         if attr == "reduce" {
                             if let Expr::Name(ast::ExprName { id, .. }) = value.as_ref() {
-                                if id == "functools" {
+                                if *id == "functools" {
                                     for arg in args {
                                         if arg.is_lambda_expr() {
                                             self.safe_functions.push(arg);

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -57,7 +57,7 @@ pub(crate) fn getattr_with_constant(
     let Expr::Name(ast::ExprName { id, .. }) = func else {
         return;
     };
-    if id != "getattr" {
+    if *id != "getattr" {
         return;
     }
     let [obj, arg] = args else {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
@@ -87,7 +87,7 @@ pub(crate) fn raise_without_from_inside_except(
                 if let Some(name) = name {
                     if exc
                         .as_name_expr()
-                        .is_some_and(|ast::ExprName { id, .. }| name == id)
+                        .is_some_and(|ast::ExprName { id, .. }| name == id.as_str())
                     {
                         continue;
                     }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
@@ -83,7 +83,7 @@ impl<'a> GroupNameFinder<'a> {
 
     fn name_matches(&self, expr: &Expr) -> bool {
         if let Expr::Name(ast::ExprName { id, .. }) = expr {
-            id == self.group_name
+            *id == self.group_name
         } else {
             false
         }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -71,7 +71,7 @@ pub(crate) fn setattr_with_constant(
     let Expr::Name(ast::ExprName { id, .. }) = func else {
         return;
     };
-    if id != "setattr" {
+    if *id != "setattr" {
         return;
     }
     let [obj, name, value] = args else {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/unintentional_type_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/unintentional_type_annotation.rs
@@ -54,7 +54,7 @@ pub(crate) fn unintentional_type_annotation(
         }
         Expr::Attribute(ast::ExprAttribute { value, .. }) => {
             if let Expr::Name(ast::ExprName { id, .. }) = value.as_ref() {
-                if id != "self" {
+                if *id != "self" {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(UnintentionalTypeAnnotation, stmt.range()));

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
@@ -75,7 +75,7 @@ pub(crate) fn unreliable_callable_check(
     }
 
     let mut diagnostic = Diagnostic::new(UnreliableCallableCheck, expr.range());
-    if id == "hasattr" {
+    if *id == "hasattr" {
         if checker.semantic().is_builtin("callable") {
             diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 format!("callable({})", checker.locator().slice(obj)),

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -53,7 +53,7 @@ impl AlwaysFixableViolation for ZipWithoutExplicitStrict {
 /// B905
 pub(crate) fn zip_without_explicit_strict(checker: &mut Checker, call: &ast::ExprCall) {
     if let Expr::Name(ast::ExprName { id, .. }) = call.func.as_ref() {
-        if id == "zip"
+        if *id == "zip"
             && checker.semantic().is_builtin("zip")
             && call.arguments.find_keyword("strict").is_none()
             && !call

--- a/crates/ruff_linter/src/rules/flake8_django/rules/all_with_model_form.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/all_with_model_form.rs
@@ -67,7 +67,7 @@ pub(crate) fn all_with_model_form(checker: &mut Checker, class_def: &ast::StmtCl
                 let Expr::Name(ast::ExprName { id, .. }) = target else {
                     continue;
                 };
-                if id != "fields" {
+                if *id != "fields" {
                     continue;
                 }
                 match value.as_ref() {

--- a/crates/ruff_linter/src/rules/flake8_django/rules/exclude_with_model_form.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/exclude_with_model_form.rs
@@ -65,7 +65,7 @@ pub(crate) fn exclude_with_model_form(checker: &mut Checker, class_def: &ast::St
                 let Expr::Name(ast::ExprName { id, .. }) = target else {
                     continue;
                 };
-                if id == "exclude" {
+                if *id == "exclude" {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(DjangoExcludeWithModelForm, target.range()));

--- a/crates/ruff_linter/src/rules/flake8_django/rules/model_without_dunder_str.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/model_without_dunder_str.rs
@@ -98,7 +98,7 @@ fn is_model_abstract(class_def: &ast::StmtClassDef) -> bool {
                 let Expr::Name(ast::ExprName { id, .. }) = target else {
                     continue;
                 };
-                if id != "abstract" {
+                if *id != "abstract" {
                     continue;
                 }
                 if !is_const_true(value) {

--- a/crates/ruff_linter/src/rules/flake8_django/rules/unordered_body_content_in_model.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/unordered_body_content_in_model.rs
@@ -161,7 +161,7 @@ fn get_element_type(element: &Stmt, semantic: &SemanticModel) -> Option<ContentT
             let Expr::Name(ast::ExprName { id, .. }) = expr else {
                 return None;
             };
-            if id == "objects" {
+            if *id == "objects" {
                 Some(ContentType::ManagerDeclaration)
             } else {
                 None

--- a/crates/ruff_linter/src/rules/flake8_gettext/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_gettext/mod.rs
@@ -7,7 +7,7 @@ pub mod settings;
 /// Returns true if the [`Expr`] is an internationalization function call.
 pub(crate) fn is_gettext_func_call(func: &Expr, functions_names: &[String]) -> bool {
     if let Expr::Name(ast::ExprName { id, .. }) = func {
-        functions_names.contains(id)
+        functions_names.contains(&id.to_string())
     } else {
         false
     }

--- a/crates/ruff_linter/src/rules/flake8_gettext/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_gettext/mod.rs
@@ -7,7 +7,9 @@ pub mod settings;
 /// Returns true if the [`Expr`] is an internationalization function call.
 pub(crate) fn is_gettext_func_call(func: &Expr, functions_names: &[String]) -> bool {
     if let Expr::Name(ast::ExprName { id, .. }) = func {
-        functions_names.contains(&id.to_string())
+        functions_names
+            .iter()
+            .any(|function_name| function_name == id)
     } else {
         false
     }

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_range_start.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_range_start.rs
@@ -47,7 +47,7 @@ pub(crate) fn unnecessary_range_start(checker: &mut Checker, call: &ast::ExprCal
     let Expr::Name(ast::ExprName { id, .. }) = call.func.as_ref() else {
         return;
     };
-    if id != "range" {
+    if *id != "range" {
         return;
     };
     if !checker.semantic().is_builtin("range") {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_literal_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_literal_union.rs
@@ -80,7 +80,7 @@ fn make_literal_expr(subscript: Option<Expr>, exprs: Vec<&Expr>) -> Expr {
         subscript.unwrap().clone()
     } else {
         Expr::Name(ast::ExprName {
-            id: "Literal".to_string(),
+            id: "Literal".into(),
             range: TextRange::default(),
             ctx: ast::ExprContext::Load,
         })

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
@@ -133,7 +133,7 @@ pub(crate) fn unnecessary_type_union<'a>(checker: &mut Checker, union: &'a Expr)
                                 .into_iter()
                                 .map(|type_member| {
                                     Expr::Name(ast::ExprName {
-                                        id: type_member,
+                                        id: type_member.into(),
                                         ctx: ExprContext::Load,
                                         range: TextRange::default(),
                                     })

--- a/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
@@ -77,7 +77,8 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
             .settings
             .flake8_self
             .ignore_names
-            .contains(&attr.to_string())
+            .iter()
+            .any(|name| name == attr.as_str())
         {
             return;
         }

--- a/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
@@ -77,7 +77,7 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
             .settings
             .flake8_self
             .ignore_names
-            .contains(attr.as_ref())
+            .contains(&attr.to_string())
         {
             return;
         }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -323,7 +323,7 @@ fn isinstance_target<'a>(call: &'a Expr, semantic: &'a SemanticModel) -> Option<
     let Expr::Name(ast::ExprName { id: func_name, .. }) = func.as_ref() else {
         return None;
     };
-    if func_name != "isinstance" {
+    if *func_name != "isinstance" {
         return None;
     }
     if !semantic.is_builtin("isinstance") {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -194,7 +194,7 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
     let Expr::Name(ast::ExprName { id, .. }) = attr_value.as_ref() else {
         return;
     };
-    if id != "os" || attr != "environ" {
+    if *id != "os" || attr != "environ" {
         return;
     }
     let Expr::StringLiteral(ast::ExprStringLiteral { value: env_var, .. }) = slice.as_ref() else {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
@@ -252,7 +252,7 @@ fn is_main_check(expr: &Expr) -> bool {
     }) = expr
     {
         if let Expr::Name(ast::ExprName { id, .. }) = left.as_ref() {
-            if id == "__name__" {
+            if *id == "__name__" {
                 if let [Expr::StringLiteral(ast::ExprStringLiteral { value, .. })] =
                     comparators.as_slice()
                 {

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/helpers.rs
@@ -13,11 +13,11 @@ fn is_empty_stmt(stmt: &Stmt) -> bool {
                 if let Some(exc) = exc {
                     match exc.as_ref() {
                         Expr::Name(ast::ExprName { id, .. }) => {
-                            return id == "NotImplementedError" || id == "NotImplemented";
+                            return *id == "NotImplementedError" || *id == "NotImplemented";
                         }
                         Expr::Call(ast::ExprCall { func, .. }) => {
                             if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
-                                return id == "NotImplementedError" || id == "NotImplemented";
+                                return *id == "NotImplementedError" || *id == "NotImplemented";
                             }
                         }
                         _ => {}

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/assignment_to_df.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/assignment_to_df.rs
@@ -45,7 +45,7 @@ pub(crate) fn assignment_to_df(targets: &[Expr]) -> Option<Diagnostic> {
     let Expr::Name(ast::ExprName { id, .. }) = target else {
         return None;
     };
-    if id != "df" {
+    if *id != "df" {
         return None;
     }
     Some(Diagnostic::new(PandasDfVariableName, target.range()))

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/pd_merge.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/pd_merge.rs
@@ -58,7 +58,7 @@ impl Violation for PandasUseOfPdMerge {
 pub(crate) fn use_of_pd_merge(checker: &mut Checker, func: &Expr) {
     if let Expr::Attribute(ast::ExprAttribute { attr, value, .. }) = func {
         if let Expr::Name(ast::ExprName { id, .. }) = value.as_ref() {
-            if id == "pd" && attr == "merge" {
+            if *id == "pd" && attr == "merge" {
                 checker
                     .diagnostics
                     .push(Diagnostic::new(PandasUseOfPdMerge, func.range()));

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/error_suffix_on_exception_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/error_suffix_on_exception_name.rs
@@ -56,7 +56,7 @@ pub(crate) fn error_suffix_on_exception_name(
     if !arguments.is_some_and(|arguments| {
         arguments.args.iter().any(|base| {
             if let Expr::Name(ast::ExprName { id, .. }) = &base {
-                id == "Exception" || id.ends_with("Error")
+                *id == "Exception" || id.ends_with("Error")
             } else {
                 false
             }

--- a/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
@@ -72,7 +72,7 @@ pub(crate) fn unnecessary_list_cast(checker: &mut Checker, iter: &Expr, body: &[
         return;
     };
 
-    if !(id == "list" && checker.semantic().is_builtin("list")) {
+    if !(*id == "list" && checker.semantic().is_builtin("list")) {
         return;
     }
 
@@ -142,7 +142,7 @@ fn match_append(stmt: &Stmt, id: &str) -> bool {
     let Some(ast::ExprName { id: target_id, .. }) = value.as_name_expr() else {
         return false;
     };
-    target_id == id
+    *target_id == id
 }
 
 /// Generate a [`Fix`] to remove a `list` cast from an expression.

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
@@ -80,7 +80,7 @@ fn deprecated_type_comparison(checker: &mut Checker, compare: &ast::ExprCompare)
             continue;
         };
 
-        if !(id == "type" && checker.semantic().is_builtin("type")) {
+        if !(*id == "type" && checker.semantic().is_builtin("type")) {
             continue;
         }
 
@@ -94,7 +94,7 @@ fn deprecated_type_comparison(checker: &mut Checker, compare: &ast::ExprCompare)
                     continue;
                 };
 
-                if id == "type" && checker.semantic().is_builtin("type") {
+                if *id == "type" && checker.semantic().is_builtin("type") {
                     // Allow comparison for types which are not obvious.
                     if arguments
                         .args
@@ -184,7 +184,7 @@ fn is_type(expr: &Expr, semantic: &SemanticModel) -> bool {
                 return false;
             };
 
-            if !(id == "type" && semantic.is_builtin("type")) {
+            if !(*id == "type" && semantic.is_builtin("type")) {
                 return false;
             };
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/invalid_print_syntax.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/invalid_print_syntax.rs
@@ -61,7 +61,7 @@ pub(crate) fn invalid_print_syntax(checker: &mut Checker, left: &Expr) {
     let Expr::Name(ast::ExprName { id, .. }) = &left else {
         return;
     };
-    if id != "print" {
+    if *id != "print" {
         return;
     }
     if !checker.semantic().is_builtin("print") {

--- a/crates/ruff_linter/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -54,13 +54,13 @@ fn match_not_implemented(expr: &Expr) -> Option<&Expr> {
     match expr {
         Expr::Call(ast::ExprCall { func, .. }) => {
             if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
-                if id == "NotImplemented" {
+                if *id == "NotImplemented" {
                     return Some(func);
                 }
             }
         }
         Expr::Name(ast::ExprName { id, .. }) => {
-            if id == "NotImplemented" {
+            if *id == "NotImplemented" {
                 return Some(expr);
             }
         }

--- a/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
@@ -747,7 +747,11 @@ pub(crate) fn string_dot_format_extra_named_arguments(
     let missing: Vec<(usize, &str)> = keywords
         .enumerate()
         .filter_map(|(index, keyword)| {
-            if summary.keywords.contains(&keyword.to_string()) {
+            if summary
+                .keywords
+                .iter()
+                .any(|summary_keyword| summary_keyword == keyword.as_str())
+            {
                 None
             } else {
                 Some((index, keyword.as_str()))

--- a/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/strings.rs
@@ -747,7 +747,7 @@ pub(crate) fn string_dot_format_extra_named_arguments(
     let missing: Vec<(usize, &str)> = keywords
         .enumerate()
         .filter_map(|(index, keyword)| {
-            if summary.keywords.contains(keyword.as_ref()) {
+            if summary.keywords.contains(&keyword.to_string()) {
                 None
             } else {
                 Some((index, keyword.as_str()))

--- a/crates/ruff_linter/src/rules/pygrep_hooks/rules/no_eval.rs
+++ b/crates/ruff_linter/src/rules/pygrep_hooks/rules/no_eval.rs
@@ -44,7 +44,7 @@ pub(crate) fn no_eval(checker: &mut Checker, func: &Expr) {
     let Expr::Name(ast::ExprName { id, .. }) = func else {
         return;
     };
-    if id != "eval" {
+    if *id != "eval" {
         return;
     }
     if !checker.semantic().is_builtin("eval") {

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -122,17 +122,17 @@ impl SequenceIndexVisitor<'_> {
         // diagnostics.
         match expr {
             Expr::Name(ast::ExprName { id, .. }) => {
-                id == self.sequence_name || id == self.index_name || id == self.value_name
+                *id == self.sequence_name || *id == self.index_name || *id == self.value_name
             }
             Expr::Subscript(ast::ExprSubscript { value, slice, .. }) => {
                 let Expr::Name(ast::ExprName { id, .. }) = value.as_ref() else {
                     return false;
                 };
-                if id == self.sequence_name {
+                if *id == self.sequence_name {
                     let Expr::Name(ast::ExprName { id, .. }) = slice.as_ref() else {
                         return false;
                     };
-                    if id == self.index_name {
+                    if *id == self.index_name {
                         return true;
                     }
                 }
@@ -184,11 +184,11 @@ impl<'a> Visitor<'_> for SequenceIndexVisitor<'a> {
                 let Expr::Name(ast::ExprName { id, .. }) = value.as_ref() else {
                     return;
                 };
-                if id == self.sequence_name {
+                if *id == self.sequence_name {
                     let Expr::Name(ast::ExprName { id, .. }) = slice.as_ref() else {
                         return;
                     };
-                    if id == self.index_name {
+                    if *id == self.index_name {
                         self.accesses.push(*range);
                     }
                 }

--- a/crates/ruff_linter/src/rules/pylint/rules/eq_without_hash.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/eq_without_hash.rs
@@ -80,7 +80,7 @@ fn has_eq_without_hash(body: &[Stmt]) -> bool {
                 //
                 //     __hash__ = None
                 // ```
-                if id == "__hash__" && value.is_none_literal_expr() {
+                if *id == "__hash__" && value.is_none_literal_expr() {
                     has_hash = true;
                 }
             }

--- a/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
@@ -124,9 +124,11 @@ fn get_undecorated_methods(
                             continue;
                         };
 
-                        let target_name = match targets.first() {
-                            Some(Expr::Name(ast::ExprName { id, .. })) => id,
-                            _ => continue,
+                        let Some(Expr::Name(ast::ExprName {
+                            id: target_name, ..
+                        })) = targets.first()
+                        else {
+                            continue;
                         };
 
                         if let Expr::Name(ast::ExprName { id, .. }) = &arg {

--- a/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
@@ -116,21 +116,21 @@ fn get_undecorated_methods(
             {
                 if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
                     if id == method_name && checker.semantic().is_builtin(method_name) {
-                        if arguments.args.len() != 1 {
-                            continue;
-                        }
-
                         if targets.len() != 1 {
                             continue;
                         }
 
+                        let [arg] = arguments.args.as_slice() else {
+                            continue;
+                        };
+
                         let target_name = match targets.first() {
-                            Some(Expr::Name(ast::ExprName { id, .. })) => id.to_string(),
+                            Some(Expr::Name(ast::ExprName { id, .. })) => id,
                             _ => continue,
                         };
 
-                        if let Expr::Name(ast::ExprName { id, .. }) = &arguments.args[0] {
-                            if target_name == *id {
+                        if let Expr::Name(ast::ExprName { id, .. }) = &arg {
+                            if target_name == id {
                                 explicit_decorator_calls.insert(id.to_string(), stmt.range());
                             }
                         };

--- a/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
@@ -131,7 +131,7 @@ fn get_undecorated_methods(
 
                         if let Expr::Name(ast::ExprName { id, .. }) = &arguments.args[0] {
                             if target_name == *id {
-                                explicit_decorator_calls.insert(id.clone(), stmt.range());
+                                explicit_decorator_calls.insert(id.to_string(), stmt.range());
                             }
                         };
                     }

--- a/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
@@ -115,7 +115,7 @@ fn get_undecorated_methods(
             }) = value.as_ref()
             {
                 if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
-                    if id == method_name && checker.semantic().is_builtin(method_name) {
+                    if *id == method_name && checker.semantic().is_builtin(method_name) {
                         if targets.len() != 1 {
                             continue;
                         }
@@ -160,7 +160,7 @@ fn get_undecorated_methods(
             // if we find the decorator we're looking for, skip
             if decorator_list.iter().any(|decorator| {
                 if let Expr::Name(ast::ExprName { id, .. }) = &decorator.expression {
-                    if id == method_name && checker.semantic().is_builtin(method_name) {
+                    if *id == method_name && checker.semantic().is_builtin(method_name) {
                         return true;
                     }
                 }

--- a/crates/ruff_linter/src/rules/pylint/rules/property_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/property_with_parameters.rs
@@ -55,7 +55,7 @@ pub(crate) fn property_with_parameters(
 ) {
     if !decorator_list
         .iter()
-        .any(|decorator| matches!(&decorator.expression, Expr::Name(ast::ExprName { id, .. }) if id == "property"))
+        .any(|decorator| matches!(&decorator.expression, Expr::Name(ast::ExprName { id, .. }) if *id == "property"))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_isinstance_calls.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_isinstance_calls.rs
@@ -92,7 +92,7 @@ pub(crate) fn repeated_isinstance_calls(
         else {
             continue;
         };
-        if !matches!(func.as_ref(), Expr::Name(ast::ExprName { id, .. }) if id == "isinstance") {
+        if !matches!(func.as_ref(), Expr::Name(ast::ExprName { id, .. }) if *id == "isinstance") {
             continue;
         }
         let [obj, types] = &args[..] else {

--- a/crates/ruff_linter/src/rules/pylint/rules/type_param_name_mismatch.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/type_param_name_mismatch.rs
@@ -78,7 +78,7 @@ pub(crate) fn type_param_name_mismatch(checker: &mut Checker, value: &Expr, targ
         return;
     };
 
-    if var_name == param_name {
+    if var_name.as_str() == param_name {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -190,7 +190,7 @@ fn fields_from_dict_literal(keys: &[Option<Expr>], values: &[Expr]) -> Option<Ve
 
 fn fields_from_dict_call(func: &Expr, keywords: &[Keyword]) -> Option<Vec<Stmt>> {
     let ast::ExprName { id, .. } = func.as_name_expr()?;
-    if id != "dict" {
+    if *id != "dict" {
         return None;
     }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -88,7 +88,7 @@ pub(crate) fn deprecated_unittest_alias(checker: &mut Checker, expr: &Expr) {
     let Expr::Name(ast::ExprName { id, .. }) = value.as_ref() else {
         return;
     };
-    if id != "self" {
+    if *id != "self" {
         return;
     }
     let mut diagnostic = Diagnostic::new(

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -120,7 +120,9 @@ pub(crate) fn super_call_with_parameters(checker: &mut Checker, call: &ast::Expr
         return;
     };
 
-    if !(first_arg_id == parent_name.as_str() && second_arg_id == parent_arg.as_str()) {
+    if !(first_arg_id.as_str() == parent_name.as_str()
+        && second_arg_id.as_str() == parent_arg.as_str())
+    {
         return;
     }
 
@@ -137,7 +139,7 @@ pub(crate) fn super_call_with_parameters(checker: &mut Checker, call: &ast::Expr
 /// Returns `true` if a call is an argumented `super` invocation.
 fn is_super_call_with_arguments(call: &ast::ExprCall) -> bool {
     if let Expr::Name(ast::ExprName { id, .. }) = call.func.as_ref() {
-        id == "super" && !call.arguments.is_empty()
+        *id == "super" && !call.arguments.is_empty()
     } else {
         false
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep695_type_alias.rs
@@ -92,7 +92,12 @@ pub(crate) fn non_pep695_type_alias(checker: &mut Checker, stmt: &StmtAnnAssign)
 
     // TODO(zanie): We should check for generic type variables used in the value and define them
     //              as type params instead
-    let mut diagnostic = Diagnostic::new(NonPEP695TypeAlias { name: name.clone() }, stmt.range());
+    let mut diagnostic = Diagnostic::new(
+        NonPEP695TypeAlias {
+            name: name.to_string(),
+        },
+        stmt.range(),
+    );
     let mut visitor = TypeVarReferenceVisitor {
         vars: vec![],
         semantic: checker.semantic(),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -51,13 +51,13 @@ pub(crate) fn useless_metaclass_type(
     let [Expr::Name(ast::ExprName { id, .. })] = targets else {
         return;
     };
-    if id != "__metaclass__" {
+    if *id != "__metaclass__" {
         return;
     }
     let Expr::Name(ast::ExprName { id, .. }) = value else {
         return;
     };
-    if id != "type" {
+    if *id != "type" {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -54,7 +54,7 @@ pub(crate) fn useless_object_inheritance(checker: &mut Checker, class_def: &ast:
         let Expr::Name(ast::ExprName { id, .. }) = base else {
             continue;
         };
-        if id != "object" {
+        if *id != "object" {
             continue;
         }
         if !checker.semantic().is_builtin("object") {

--- a/crates/ruff_linter/src/rules/refurb/helpers.rs
+++ b/crates/ruff_linter/src/rules/refurb/helpers.rs
@@ -6,7 +6,7 @@ use ruff_text_size::TextRange;
 pub(super) fn generate_method_call(name: &str, method: &str, generator: Generator) -> String {
     // Construct `name`.
     let var = ast::ExprName {
-        id: name.to_string(),
+        id: name.into(),
         ctx: ast::ExprContext::Load,
         range: TextRange::default(),
     };
@@ -43,7 +43,7 @@ pub(super) fn generate_none_identity_comparison(
 ) -> String {
     // Construct `name`.
     let var = ast::ExprName {
-        id: name.to_string(),
+        id: name.into(),
         ctx: ast::ExprContext::Load,
         range: TextRange::default(),
     };

--- a/crates/ruff_linter/src/rules/refurb/rules/read_whole_file.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/read_whole_file.rs
@@ -315,7 +315,7 @@ fn make_suggestion(open: &FileOpen<'_>, generator: Generator) -> SourceCodeSnipp
         ReadMode::Bytes => "read_bytes",
     };
     let name = ast::ExprName {
-        id: method_name.to_string(),
+        id: method_name.into(),
         ctx: ast::ExprContext::Load,
         range: TextRange::default(),
     };

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
@@ -297,7 +297,7 @@ fn try_construct_call(
 /// Construct the call to `itertools.starmap` for suggestion.
 fn construct_starmap_call(starmap_binding: String, iter: &Expr, func: &Expr) -> ast::ExprCall {
     let starmap = ast::ExprName {
-        id: starmap_binding,
+        id: starmap_binding.into(),
         ctx: ast::ExprContext::Load,
         range: TextRange::default(),
     };
@@ -315,7 +315,7 @@ fn construct_starmap_call(starmap_binding: String, iter: &Expr, func: &Expr) -> 
 /// Wrap given function call with yet another call.
 fn wrap_with_call_to(call: ast::ExprCall, func_name: &str) -> ast::ExprCall {
     let name = ast::ExprName {
-        id: func_name.to_string(),
+        id: func_name.into(),
         ctx: ast::ExprContext::Load,
         range: TextRange::default(),
     };

--- a/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
@@ -106,7 +106,7 @@ pub(crate) fn unnecessary_enumerate(checker: &mut Checker, stmt_for: &ast::StmtF
     let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() else {
         return;
     };
-    if id != "enumerate" {
+    if *id != "enumerate" {
         return;
     };
     if !checker.semantic().is_builtin("enumerate") {

--- a/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
@@ -236,7 +236,7 @@ impl fmt::Display for EnumerateSubset {
 fn generate_range_len_call(name: &str, generator: Generator) -> String {
     // Construct `name`.
     let var = ast::ExprName {
-        id: name.to_string(),
+        id: name.into(),
         ctx: ast::ExprContext::Load,
         range: TextRange::default(),
     };
@@ -244,7 +244,7 @@ fn generate_range_len_call(name: &str, generator: Generator) -> String {
     let len = ast::ExprCall {
         func: Box::new(
             ast::ExprName {
-                id: "len".to_string(),
+                id: "len".into(),
                 ctx: ast::ExprContext::Load,
                 range: TextRange::default(),
             }
@@ -261,7 +261,7 @@ fn generate_range_len_call(name: &str, generator: Generator) -> String {
     let range = ast::ExprCall {
         func: Box::new(
             ast::ExprName {
-                id: "range".to_string(),
+                id: "range".into(),
                 ctx: ast::ExprContext::Load,
                 range: TextRange::default(),
             }

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -145,7 +145,7 @@ fn generate_fix(checker: &Checker, conversion_type: ConversionType, expr: &Expr)
             let new_expr = Expr::Subscript(ast::ExprSubscript {
                 range: TextRange::default(),
                 value: Box::new(Expr::Name(ast::ExprName {
-                    id: binding,
+                    id: binding.into(),
                     ctx: ast::ExprContext::Store,
                     range: TextRange::default(),
                 })),

--- a/crates/ruff_linter/src/rules/ruff/rules/pairwise_over_zipped.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/pairwise_over_zipped.rs
@@ -111,7 +111,7 @@ pub(crate) fn pairwise_over_zipped(checker: &mut Checker, func: &Expr, args: &[E
     };
 
     // Require the function to be the builtin `zip`.
-    if !(id == "zip" && checker.semantic().is_builtin(id)) {
+    if !(*id == "zip" && checker.semantic().is_builtin(id)) {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
@@ -124,7 +124,7 @@ fn func_is_builtin(func: &Expr, name: &str, semantic: &SemanticModel) -> bool {
     let Expr::Name(ast::ExprName { id, .. }) = func else {
         return false;
     };
-    id == name && semantic.is_builtin(id)
+    *id == name && semantic.is_builtin(id)
 }
 
 /// Returns `true` if the `start` argument to a `sum()` call is an empty list.

--- a/crates/ruff_linter/src/rules/tryceratops/rules/useless_try_except.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/useless_try_except.rs
@@ -54,7 +54,7 @@ pub(crate) fn useless_try_except(checker: &mut Checker, handlers: &[ExceptHandle
             if let Some(expr) = exc {
                 // E.g., `except ... as e: raise e`
                 if let Expr::Name(ast::ExprName { id, .. }) = expr.as_ref() {
-                    if name.as_ref().is_some_and(|name| name.as_str() == id) {
+                    if name.as_ref().is_some_and(|name| name.as_str() == *id) {
                         return Some(Diagnostic::new(UselessTryExcept, handler.range()));
                     }
                 }

--- a/crates/ruff_linter/src/rules/tryceratops/rules/verbose_raise.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/verbose_raise.rs
@@ -97,7 +97,7 @@ pub(crate) fn verbose_raise(checker: &mut Checker, handlers: &[ExceptHandler]) {
                 if let Some(exc) = raise.exc.as_ref() {
                     // ...and the raised object is bound to the same name...
                     if let Expr::Name(ast::ExprName { id, .. }) = exc.as_ref() {
-                        if id == exception_name.as_str() {
+                        if *id == exception_name.as_str() {
                             let mut diagnostic = Diagnostic::new(VerboseRaise, exc.range());
                             diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                                 "raise".to_string(),

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -26,6 +26,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
 smallvec = { workspace = true }
 static_assertions = "1.1.0"
+smol_str = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -18,6 +18,7 @@ ruff_source_file = { path = "../ruff_source_file" }
 ruff_text_size = { path = "../ruff_text_size" }
 
 bitflags = { workspace = true }
+compact_str = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }
@@ -26,7 +27,6 @@ rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
 smallvec = { workspace = true }
 static_assertions = "1.1.0"
-smol_str = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/ruff_python_ast/src/all.rs
+++ b/crates/ruff_python_ast/src/all.rs
@@ -48,7 +48,7 @@ where
             }
             Expr::Name(ast::ExprName { id, .. }) => {
                 // Ex) `__all__ = __all__ + multiprocessing.__all__`
-                if id == "__all__" {
+                if id.as_str() == "__all__" {
                     return (None, DunderAllFlags::empty());
                 }
             }

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1482,7 +1482,7 @@ pub fn pep_604_union(elts: &[Expr]) -> Expr {
 pub fn typing_optional(elt: Expr, binding: String) -> Expr {
     Expr::Subscript(ast::ExprSubscript {
         value: Box::new(Expr::Name(ast::ExprName {
-            id: binding,
+            id: binding.into(),
             range: TextRange::default(),
             ctx: ExprContext::Load,
         })),
@@ -1513,7 +1513,7 @@ pub fn typing_union(elts: &[Expr], binding: String) -> Expr {
 
     Expr::Subscript(ast::ExprSubscript {
         value: Box::new(Expr::Name(ast::ExprName {
-            id: binding,
+            id: binding.into(),
             range: TextRange::default(),
             ctx: ExprContext::Load,
         })),
@@ -1579,7 +1579,7 @@ mod tests {
     fn any_over_stmt_type_alias() {
         let seen = RefCell::new(Vec::new());
         let name = Expr::Name(ExprName {
-            id: "x".to_string(),
+            id: "x".into(),
             range: TextRange::default(),
             ctx: ExprContext::Load,
         });

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 use itertools::Itertools;
-use smol_str::SmolStr;
 use std::cell::OnceCell;
 
+use compact_str::CompactString;
 use std::fmt;
 use std::fmt::Debug;
 use std::ops::Deref;
@@ -1740,7 +1740,7 @@ impl From<ExprStarred> for Expr {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprName {
     pub range: TextRange,
-    pub id: SmolStr,
+    pub id: CompactString,
     pub ctx: ExprContext,
 }
 
@@ -3226,13 +3226,13 @@ impl IpyEscapeKind {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Identifier {
-    pub id: SmolStr,
+    pub id: CompactString,
     pub range: TextRange,
 }
 
 impl Identifier {
     #[inline]
-    pub fn new(id: impl Into<SmolStr>, range: TextRange) -> Self {
+    pub fn new(id: impl Into<CompactString>, range: TextRange) -> Self {
         Self {
             id: id.into(),
             range,
@@ -3276,9 +3276,9 @@ impl AsRef<str> for Identifier {
     }
 }
 
-impl AsRef<SmolStr> for Identifier {
+impl AsRef<CompactString> for Identifier {
     #[inline]
-    fn as_ref(&self) -> &SmolStr {
+    fn as_ref(&self) -> &CompactString {
         &self.id
     }
 }
@@ -3296,7 +3296,7 @@ impl From<Identifier> for String {
     }
 }
 
-impl From<Identifier> for SmolStr {
+impl From<Identifier> for CompactString {
     #[inline]
     fn from(identifier: Identifier) -> Self {
         identifier.id
@@ -3844,6 +3844,6 @@ mod size_assertions {
     assert_eq_size!(StmtClassDef, [u8; 104]);
     assert_eq_size!(StmtTry, [u8; 112]);
     assert_eq_size!(Expr, [u8; 80]);
-    assert_eq_size!(Pattern, [u8; 88]);
+    assert_eq_size!(Pattern, [u8; 96]);
     assert_eq_size!(Mod, [u8; 32]);
 }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1,12 +1,13 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+use itertools::Itertools;
+use smol_str::SmolStr;
 use std::cell::OnceCell;
+
 use std::fmt;
 use std::fmt::Debug;
 use std::ops::Deref;
 use std::slice::{Iter, IterMut};
-
-use itertools::Itertools;
 
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
@@ -1739,7 +1740,7 @@ impl From<ExprStarred> for Expr {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprName {
     pub range: TextRange,
-    pub id: String,
+    pub id: SmolStr,
     pub ctx: ExprContext,
 }
 
@@ -3225,13 +3226,13 @@ impl IpyEscapeKind {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Identifier {
-    id: String,
-    range: TextRange,
+    pub id: SmolStr,
+    pub range: TextRange,
 }
 
 impl Identifier {
     #[inline]
-    pub fn new(id: impl Into<String>, range: TextRange) -> Self {
+    pub fn new(id: impl Into<SmolStr>, range: TextRange) -> Self {
         Self {
             id: id.into(),
             range,
@@ -3275,9 +3276,9 @@ impl AsRef<str> for Identifier {
     }
 }
 
-impl AsRef<String> for Identifier {
+impl AsRef<SmolStr> for Identifier {
     #[inline]
-    fn as_ref(&self) -> &String {
+    fn as_ref(&self) -> &SmolStr {
         &self.id
     }
 }
@@ -3291,6 +3292,13 @@ impl std::fmt::Display for Identifier {
 impl From<Identifier> for String {
     #[inline]
     fn from(identifier: Identifier) -> String {
+        identifier.id.to_string()
+    }
+}
+
+impl From<Identifier> for SmolStr {
+    #[inline]
+    fn from(identifier: Identifier) -> Self {
         identifier.id
     }
 }
@@ -3836,6 +3844,6 @@ mod size_assertions {
     assert_eq_size!(StmtClassDef, [u8; 104]);
     assert_eq_size!(StmtTry, [u8; 112]);
     assert_eq_size!(Expr, [u8; 80]);
-    assert_eq_size!(Pattern, [u8; 96]);
+    assert_eq_size!(Pattern, [u8; 88]);
     assert_eq_size!(Mod, [u8; 32]);
 }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3257,7 +3257,7 @@ impl PartialEq<str> for Identifier {
 impl PartialEq<String> for Identifier {
     #[inline]
     fn eq(&self, other: &String) -> bool {
-        &self.id == other
+        self.id == other
     }
 }
 

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -23,6 +23,7 @@ is-macro = { workspace = true }
 itertools = { workspace = true }
 lalrpop-util = { version = "0.20.0", default-features = false }
 memchr = { workspace = true }
+smol_str = { workspace = true }
 unicode-ident = { workspace = true }
 unicode_names2 = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -19,11 +19,11 @@ ruff_text_size = { path = "../ruff_text_size" }
 
 anyhow = { workspace = true }
 bitflags = { workspace = true }
+compact_str = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
 lalrpop-util = { version = "0.20.0", default-features = false }
 memchr = { workspace = true }
-smol_str = { workspace = true }
 unicode-ident = { workspace = true }
 unicode_names2 = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -31,6 +31,7 @@
 use std::iter::FusedIterator;
 use std::{char, cmp::Ordering, str::FromStr};
 
+use smol_str::SmolStr;
 use unicode_ident::{is_xid_continue, is_xid_start};
 
 use ruff_python_ast::{Int, IpyEscapeKind};
@@ -241,7 +242,7 @@ impl<'source> Lexer<'source> {
             "yield" => Tok::Yield,
             _ => {
                 return Ok(Tok::Name {
-                    name: text.to_string(),
+                    name: SmolStr::new(text),
                 })
             }
         };

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -28,10 +28,10 @@
 //!
 //! [Lexical analysis]: https://docs.python.org/3/reference/lexical_analysis.html
 
+use compact_str::CompactString;
 use std::iter::FusedIterator;
 use std::{char, cmp::Ordering, str::FromStr};
 
-use smol_str::SmolStr;
 use unicode_ident::{is_xid_continue, is_xid_start};
 
 use ruff_python_ast::{Int, IpyEscapeKind};
@@ -242,7 +242,7 @@ impl<'source> Lexer<'source> {
             "yield" => Tok::Yield,
             _ => {
                 return Ok(Tok::Name {
-                    name: SmolStr::new(text),
+                    name: CompactString::new(text),
                 })
             }
         };

--- a/crates/ruff_python_parser/src/python.lalrpop
+++ b/crates/ruff_python_parser/src/python.lalrpop
@@ -3,6 +3,7 @@
 // See also: file:///usr/share/doc/python/html/reference/compound_stmts.html#function-definitions
 // See also: https://greentreesnakes.readthedocs.io/en/latest/nodes.html#keyword
 
+use smol_str::SmolStr;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
 use crate::{
@@ -289,7 +290,7 @@ ImportAsAlias<I>: ast::Alias = {
 DottedName: ast::Identifier = {
     <location:@L> <n:name> <end_location:@R> => ast::Identifier::new(n, (location..end_location).into()),
     <location:@L> <n:name> <n2: ("." Identifier)+> <end_location:@R> => {
-        let mut r = n;
+        let mut r = n.to_string();
         for x in n2 {
             r.push('.');
             r.push_str(x.1.as_str());
@@ -2069,7 +2070,7 @@ extern {
             value: <String>,
             is_raw: <bool>
         },
-        name => token::Tok::Name { name: <String> },
+        name => token::Tok::Name { name: <SmolStr> },
         ipy_escape_command => token::Tok::IpyEscapeCommand {
             kind: <IpyEscapeKind>,
             value: <String>

--- a/crates/ruff_python_parser/src/python.lalrpop
+++ b/crates/ruff_python_parser/src/python.lalrpop
@@ -3,7 +3,7 @@
 // See also: file:///usr/share/doc/python/html/reference/compound_stmts.html#function-definitions
 // See also: https://greentreesnakes.readthedocs.io/en/latest/nodes.html#keyword
 
-use smol_str::SmolStr;
+use compact_str::CompactString;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
 use crate::{
@@ -2070,7 +2070,7 @@ extern {
             value: <String>,
             is_raw: <bool>
         },
-        name => token::Tok::Name { name: <SmolStr> },
+        name => token::Tok::Name { name: <CompactString> },
         ipy_escape_command => token::Tok::IpyEscapeCommand {
             kind: <IpyEscapeKind>,
             value: <String>

--- a/crates/ruff_python_parser/src/python.rs
+++ b/crates/ruff_python_parser/src/python.rs
@@ -1,6 +1,6 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: d4ee7846b5dfacc84c7fcd86cd6afddd44e4ae968b0a0e48ae8970bb2a7b4d12
-use smol_str::SmolStr;
+// sha3: 3f64d3733e55e1cc00bce1a7d3d7ff1f513d12ebb76767c1af818f1859596114
+use compact_str::CompactString;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
 use crate::{
@@ -25,7 +25,7 @@ extern crate alloc;
 #[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::all)]
 mod __parse__Top {
 
-    use smol_str::SmolStr;
+    use compact_str::CompactString;
     use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
     use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
     use crate::{
@@ -55,7 +55,7 @@ mod __parse__Top {
         Variant3((String, bool)),
         Variant4(Int),
         Variant5((IpyEscapeKind, String)),
-        Variant6(SmolStr),
+        Variant6(CompactString),
         Variant7((String, StringKind, bool)),
         Variant8(core::option::Option<token::Tok>),
         Variant9(Option<Box<ast::Parameter>>),
@@ -18495,6 +18495,16 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
+    fn __pop_Variant6<
+    >(
+        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
+    ) -> (TextSize, CompactString, TextSize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant6(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
     fn __pop_Variant4<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
@@ -18522,16 +18532,6 @@ mod __parse__Top {
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant95(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant6<
-    >(
-        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
-    ) -> (TextSize, SmolStr, TextSize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant6(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -33543,7 +33543,7 @@ fn __action69<
     source_code: &str,
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, n, _): (TextSize, SmolStr, TextSize),
+    (_, n, _): (TextSize, CompactString, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -33557,7 +33557,7 @@ fn __action70<
     source_code: &str,
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, n, _): (TextSize, SmolStr, TextSize),
+    (_, n, _): (TextSize, CompactString, TextSize),
     (_, n2, _): (TextSize, alloc::vec::Vec<(token::Tok, ast::Identifier)>, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
@@ -36516,7 +36516,7 @@ fn __action224<
     (_, location, _): (TextSize, TextSize, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, name_location, _): (TextSize, TextSize, TextSize),
-    (_, s, _): (TextSize, SmolStr, TextSize),
+    (_, s, _): (TextSize, CompactString, TextSize),
 ) -> Result<(TextSize, ast::ConversionFlag),__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     {
@@ -36901,7 +36901,7 @@ fn __action249<
     source_code: &str,
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, s, _): (TextSize, SmolStr, TextSize),
+    (_, s, _): (TextSize, CompactString, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -48029,7 +48029,7 @@ fn __action789<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, SmolStr, TextSize),
+    __0: (TextSize, CompactString, TextSize),
     __1: (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -48057,7 +48057,7 @@ fn __action790<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, SmolStr, TextSize),
+    __0: (TextSize, CompactString, TextSize),
     __1: (TextSize, alloc::vec::Vec<(token::Tok, ast::Identifier)>, TextSize),
     __2: (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
@@ -48410,7 +48410,7 @@ fn __action801<
     source_code: &str,
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, SmolStr, TextSize),
+    __1: (TextSize, CompactString, TextSize),
 ) -> Result<(TextSize, ast::ConversionFlag),__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
@@ -49211,7 +49211,7 @@ fn __action826<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, SmolStr, TextSize),
+    __0: (TextSize, CompactString, TextSize),
     __1: (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -64213,7 +64213,7 @@ fn __action1304<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, SmolStr, TextSize),
+    __0: (TextSize, CompactString, TextSize),
 ) -> ast::Identifier
 {
     let __start0 = __0.2;
@@ -64239,7 +64239,7 @@ fn __action1305<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, SmolStr, TextSize),
+    __0: (TextSize, CompactString, TextSize),
     __1: (TextSize, alloc::vec::Vec<(token::Tok, ast::Identifier)>, TextSize),
 ) -> ast::Identifier
 {
@@ -65037,7 +65037,7 @@ fn __action1333<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, SmolStr, TextSize),
+    __0: (TextSize, CompactString, TextSize),
 ) -> ast::Identifier
 {
     let __start0 = __0.2;

--- a/crates/ruff_python_parser/src/python.rs
+++ b/crates/ruff_python_parser/src/python.rs
@@ -1,5 +1,6 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 031689e389556292d9dbd8a1b1ff8ca29bac76d83f1b345630481d620b89e1c2
+// sha3: d4ee7846b5dfacc84c7fcd86cd6afddd44e4ae968b0a0e48ae8970bb2a7b4d12
+use smol_str::SmolStr;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
 use crate::{
@@ -24,6 +25,7 @@ extern crate alloc;
 #[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::all)]
 mod __parse__Top {
 
+    use smol_str::SmolStr;
     use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
     use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
     use crate::{
@@ -53,7 +55,7 @@ mod __parse__Top {
         Variant3((String, bool)),
         Variant4(Int),
         Variant5((IpyEscapeKind, String)),
-        Variant6(String),
+        Variant6(SmolStr),
         Variant7((String, StringKind, bool)),
         Variant8(core::option::Option<token::Tok>),
         Variant9(Option<Box<ast::Parameter>>),
@@ -18526,7 +18528,7 @@ mod __parse__Top {
     fn __pop_Variant6<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
-    ) -> (TextSize, String, TextSize)
+    ) -> (TextSize, SmolStr, TextSize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant6(__v), __r)) => (__l, __v, __r),
@@ -33541,7 +33543,7 @@ fn __action69<
     source_code: &str,
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, n, _): (TextSize, String, TextSize),
+    (_, n, _): (TextSize, SmolStr, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -33555,13 +33557,13 @@ fn __action70<
     source_code: &str,
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, n, _): (TextSize, String, TextSize),
+    (_, n, _): (TextSize, SmolStr, TextSize),
     (_, n2, _): (TextSize, alloc::vec::Vec<(token::Tok, ast::Identifier)>, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
     {
-        let mut r = n;
+        let mut r = n.to_string();
         for x in n2 {
             r.push('.');
             r.push_str(x.1.as_str());
@@ -36514,7 +36516,7 @@ fn __action224<
     (_, location, _): (TextSize, TextSize, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, name_location, _): (TextSize, TextSize, TextSize),
-    (_, s, _): (TextSize, String, TextSize),
+    (_, s, _): (TextSize, SmolStr, TextSize),
 ) -> Result<(TextSize, ast::ConversionFlag),__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     {
@@ -36899,7 +36901,7 @@ fn __action249<
     source_code: &str,
     mode: Mode,
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, s, _): (TextSize, String, TextSize),
+    (_, s, _): (TextSize, SmolStr, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -48027,7 +48029,7 @@ fn __action789<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, SmolStr, TextSize),
     __1: (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -48055,7 +48057,7 @@ fn __action790<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, SmolStr, TextSize),
     __1: (TextSize, alloc::vec::Vec<(token::Tok, ast::Identifier)>, TextSize),
     __2: (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
@@ -48408,7 +48410,7 @@ fn __action801<
     source_code: &str,
     mode: Mode,
     __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, String, TextSize),
+    __1: (TextSize, SmolStr, TextSize),
 ) -> Result<(TextSize, ast::ConversionFlag),__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
@@ -49209,7 +49211,7 @@ fn __action826<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, SmolStr, TextSize),
     __1: (TextSize, TextSize, TextSize),
 ) -> ast::Identifier
 {
@@ -64211,7 +64213,7 @@ fn __action1304<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, SmolStr, TextSize),
 ) -> ast::Identifier
 {
     let __start0 = __0.2;
@@ -64237,7 +64239,7 @@ fn __action1305<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, SmolStr, TextSize),
     __1: (TextSize, alloc::vec::Vec<(token::Tok, ast::Identifier)>, TextSize),
 ) -> ast::Identifier
 {
@@ -65035,7 +65037,7 @@ fn __action1333<
 >(
     source_code: &str,
     mode: Mode,
-    __0: (TextSize, String, TextSize),
+    __0: (TextSize, SmolStr, TextSize),
 ) -> ast::Identifier
 {
     let __start0 = __0.2;

--- a/crates/ruff_python_parser/src/soft_keywords.rs
+++ b/crates/ruff_python_parser/src/soft_keywords.rs
@@ -202,9 +202,7 @@ fn soft_to_name(tok: &Tok) -> Tok {
         Tok::Type => "type",
         _ => unreachable!("other tokens never reach here"),
     };
-    Tok::Name {
-        name: name.to_owned(),
-    }
+    Tok::Name { name: name.into() }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -8,6 +8,7 @@ use crate::Mode;
 
 use ruff_python_ast::{Int, IpyEscapeKind};
 use ruff_text_size::TextSize;
+use smol_str::SmolStr;
 use std::fmt;
 
 /// The set of tokens the Python source code can be tokenized in.
@@ -16,7 +17,7 @@ pub enum Tok {
     /// Token value for a name, commonly known as an identifier.
     Name {
         /// The name value.
-        name: String,
+        name: SmolStr,
     },
     /// Token value for an integer.
     Int {

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -6,9 +6,9 @@
 //! [CPython source]: https://github.com/python/cpython/blob/dfc2e065a2e71011017077e549cd2f9bf4944c54/Include/internal/pycore_token.h;
 use crate::Mode;
 
+use compact_str::CompactString;
 use ruff_python_ast::{Int, IpyEscapeKind};
 use ruff_text_size::TextSize;
-use smol_str::SmolStr;
 use std::fmt;
 
 /// The set of tokens the Python source code can be tokenized in.
@@ -17,7 +17,7 @@ pub enum Tok {
     /// Token value for a name, commonly known as an identifier.
     Name {
         /// The name value.
-        name: SmolStr,
+        name: CompactString,
     },
     /// Token value for an integer.
     Int {

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -447,7 +447,7 @@ trait BuiltinTypeChecker {
         let Expr::Name(ast::ExprName { id, .. }) = type_expr else {
             return false;
         };
-        id == Self::BUILTIN_TYPE_NAME && semantic.is_builtin(Self::BUILTIN_TYPE_NAME)
+        id.as_str() == Self::BUILTIN_TYPE_NAME && semantic.is_builtin(Self::BUILTIN_TYPE_NAME)
     }
 }
 
@@ -643,7 +643,7 @@ fn match_value<'a>(symbol: &str, target: &Expr, value: &'a Expr) -> Option<&'a E
 /// Returns `true` if the [`Expr`] defines the symbol.
 fn defines(symbol: &str, expr: &Expr) -> bool {
     match expr {
-        Expr::Name(ast::ExprName { id, .. }) => id == symbol,
+        Expr::Name(ast::ExprName { id, .. }) => id.as_str() == symbol,
         Expr::Tuple(ast::ExprTuple { elts, .. })
         | Expr::List(ast::ExprList { elts, .. })
         | Expr::Set(ast::ExprSet { elts, .. }) => elts.iter().any(|elt| defines(symbol, elt)),


### PR DESCRIPTION
## Summary
To get a comparison to `SmolStr` which seems to optimize for 

* `O(1)` clone
* Storing strings longer than 23 that soley consist of Whitespace (not a use case for us)

I found the API a bit clumsy but maybe it's just me being confused by `Deref`.

## Test Plan

`cargo test`
