### PR TITLE
update lock file from v0.1.9 release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -326,6 +326,7 @@ We use an experimental in-house tool for managing releases.
     - Often labels will be missing from pull requests they will need to be manually organized into the proper section
     - Changes should be edited to be user-facing descriptions, avoiding internal details
 1. Highlight any breaking changes in `BREAKING_CHANGES.md`
+1. Run `cargo check`. This should update the lock file with new versions.
 1. Create a pull request with the changelog and version updates
 1. Merge the PR
 1. Run the [release workflow](https://github.com/astral-sh/ruff/actions/workflows/release.yaml) with:
@@ -345,7 +346,10 @@ We use an experimental in-house tool for managing releases.
     1. Copy the changelog for the release into the GitHub release
         - See previous releases for formatting of section headers
     1. Generate the contributor list with `rooster contributors` and add to the release notes
-1. If needed, [update the schemastore](https://github.com/charliermarsh/ruff/blob/main/scripts/update_schemastore.py)
+1. If needed, [update the schemastore](https://github.com/charliermarsh/ruff/blob/main/scripts/update_schemastore.py).
+    1. One can determine if an update is needed when
+        `git diff old-version-tag new-version-tag -- ruff.schema.json` returns a non-empty diff.
+    1. Once run successfully, you should follow the link in the output to create a PR.
 1. If needed, update the `ruff-lsp` and `ruff-vscode` repositories.
 
 ## Ecosystem CI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flake8-to-ruff"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "annotate-snippets 0.9.2",
  "anyhow",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_linter"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aho-corasick",
  "annotate-snippets 0.9.2",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_shrinking"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
This should have been done before the actual release, so we add another step to `CONTRIBUTING.md` to make sure it gets done in the future.

This doesn't fix https://github.com/astral-sh/ruff/issues/9234 completely, but it's a step in the right direction.