### PR TITLE
Use named preview test functions

### DIFF
--- a/crates/ruff_python_formatter/src/preview.rs
+++ b/crates/ruff_python_formatter/src/preview.rs
@@ -33,3 +33,13 @@ pub(crate) const fn is_no_blank_line_before_class_docstring_enabled(
 ) -> bool {
     context.is_preview()
 }
+
+/// Returns `true` if the [`module_docstring_newlines`](https://github.com/astral-sh/ruff/issues/7995) preview style is enabled.
+pub(crate) const fn is_module_docstring_newlines_enabled(context: &PyFormatContext) -> bool {
+    context.is_preview()
+}
+
+/// Returns `true` if the [`dummy_implementations`](https://github.com/astral-sh/ruff/issues/8357) preview style is enabled.
+pub(crate) const fn is_dummy_implementations_enabled(context: &PyFormatContext) -> bool {
+    context.is_preview()
+}

--- a/crates/ruff_python_formatter/src/statement/clause.rs
+++ b/crates/ruff_python_formatter/src/statement/clause.rs
@@ -11,6 +11,7 @@ use crate::comments::{
     leading_alternate_branch_comments, trailing_comments, SourceComment, SuppressionKind,
 };
 use crate::prelude::*;
+use crate::preview::is_dummy_implementations_enabled;
 use crate::statement::suite::{contains_only_an_ellipsis, SuiteKind};
 use crate::verbatim::write_suppressed_clause_header;
 
@@ -393,7 +394,7 @@ impl Format<PyFormatContext<'_>> for FormatClauseBody<'_> {
     fn fmt(&self, f: &mut Formatter<PyFormatContext<'_>>) -> FormatResult<()> {
         // In stable, stubs are only collapsed in stub files, in preview this is consistently
         // applied everywhere
-        if (f.options().source_type().is_stub() || f.options().preview().is_enabled())
+        if (f.options().source_type().is_stub() || is_dummy_implementations_enabled(f.context()))
             && contains_only_an_ellipsis(self.body, f.context().comments())
             && self.trailing_comments.is_empty()
         {

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -11,7 +11,9 @@ use crate::comments::{
 use crate::context::{NodeLevel, TopLevelStatementPosition, WithIndentLevel, WithNodeLevel};
 use crate::expression::expr_string_literal::ExprStringLiteralKind;
 use crate::prelude::*;
-use crate::preview::is_no_blank_line_before_class_docstring_enabled;
+use crate::preview::{
+    is_module_docstring_newlines_enabled, is_no_blank_line_before_class_docstring_enabled,
+};
 use crate::statement::stmt_expr::FormatStmtExpr;
 use crate::verbatim::{
     suppressed_node, write_suppressed_statements_starting_with_leading_comment,
@@ -166,7 +168,7 @@ impl FormatRule<Suite, PyFormatContext<'_>> for FormatSuite {
                 && self.kind == SuiteKind::Class
             {
                 true
-            } else if f.options().preview().is_enabled()
+            } else if is_module_docstring_newlines_enabled(f.context())
                 && self.kind == SuiteKind::TopLevel
                 && DocstringStmt::try_from_statement(first.statement(), self.kind).is_some()
             {


### PR DESCRIPTION
## Summary

Use preview style specific `is_..._enabled` instead of the generic `options().preview().is_enabled()` to better document
which preview style a preview test is gating.

## Test Plan

`cargo test`
