### PR TITLE
Hug multiline-strings preview style

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/multiline_string_deviations.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/multiline_string_deviations.py
@@ -1,0 +1,43 @@
+# This file documents the deviations for formatting multiline strings with black.
+
+# Black hugs the parentheses for `%` usages -> convert to fstring.
+# Can get unreadable if the arguments split
+# This could be solved by using `best_fitting` to try to format the arguments on a single
+# line. Let's consider adding this later.
+# ```python
+# call(
+#    3,
+#    "dogsay",
+#    textwrap.dedent(
+#        """dove
+#    coo""" % "cowabunga",
+#        more,
+#        and_more,
+#        "aaaaaaa",
+#        "bbbbbbbbb",
+#        "cccccccc",
+#    ),
+# )
+# ```
+call(3, "dogsay", textwrap.dedent("""dove
+    coo""" % "cowabunga"))
+
+# Black applies the hugging recursively. We don't (consistent with the hugging style).
+path.write_text(textwrap.dedent("""\
+    A triple-quoted string
+    actually leveraging the textwrap.dedent functionality
+    that ends in a trailing newline,
+    representing e.g. file contents.
+"""))
+
+
+
+# Black avoids parenthesizing the following lambda. We could potentially support
+# this by changing `Lambda::needs_parentheses` to return `BestFit` but it causes
+# issues when the lambda has comments.
+# Let's keep this as a known deviation for now.
+generated_readme = lambda project_name: """
+{}
+
+<Add content here!>
+""".strip().format(project_name)

--- a/crates/ruff_python_formatter/src/expression/binary_like.rs
+++ b/crates/ruff_python_formatter/src/expression/binary_like.rs
@@ -394,12 +394,12 @@ impl Format<PyFormatContext<'_>> for BinaryLike<'_> {
                             f,
                             [
                                 operand.leading_binary_comments().map(leading_comments),
-                                leading_comments(comments.leading(&string_constant)),
+                                leading_comments(comments.leading(string_constant)),
                                 // Call `FormatStringContinuation` directly to avoid formatting
                                 // the implicitly concatenated string with the enclosing group
                                 // because the group is added by the binary like formatting.
                                 FormatStringContinuation::new(&string_constant),
-                                trailing_comments(comments.trailing(&string_constant)),
+                                trailing_comments(comments.trailing(string_constant)),
                                 operand.trailing_binary_comments().map(trailing_comments),
                                 line_suffix_boundary(),
                             ]
@@ -413,12 +413,12 @@ impl Format<PyFormatContext<'_>> for BinaryLike<'_> {
                         write!(
                             f,
                             [
-                                leading_comments(comments.leading(&string_constant)),
+                                leading_comments(comments.leading(string_constant)),
                                 // Call `FormatStringContinuation` directly to avoid formatting
                                 // the implicitly concatenated string with the enclosing group
                                 // because the group is added by the binary like formatting.
                                 FormatStringContinuation::new(&string_constant),
-                                trailing_comments(comments.trailing(&string_constant)),
+                                trailing_comments(comments.trailing(string_constant)),
                             ]
                         )?;
                     }

--- a/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
@@ -3,10 +3,10 @@ use ruff_python_ast::ExprBinOp;
 
 use crate::comments::SourceComment;
 use crate::expression::binary_like::BinaryLike;
-use crate::expression::expr_string_literal::is_multiline_string;
 use crate::expression::has_parentheses;
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
+use crate::string::AnyString;
 
 #[derive(Default)]
 pub struct FormatExprBinOp;
@@ -35,13 +35,13 @@ impl NeedsParentheses for ExprBinOp {
     ) -> OptionalParentheses {
         if parent.is_expr_await() {
             OptionalParentheses::Always
-        } else if let Some(literal_expr) = self.left.as_literal_expr() {
+        } else if let Some(string) = AnyString::from_expression(&self.left) {
             // Multiline strings are guaranteed to never fit, avoid adding unnecessary parentheses
-            if !literal_expr.is_implicit_concatenated()
-                && is_multiline_string(literal_expr.into(), context.source())
+            if !string.is_implicit_concatenated()
+                && string.is_multiline(context.source())
                 && has_parentheses(&self.right, context).is_some()
                 && !context.comments().has_dangling(self)
-                && !context.comments().has(literal_expr)
+                && !context.comments().has(string)
                 && !context.comments().has(self.right.as_ref())
             {
                 OptionalParentheses::Never

--- a/crates/ruff_python_formatter/src/expression/expr_bytes_literal.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bytes_literal.rs
@@ -2,7 +2,6 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprBytesLiteral;
 
 use crate::comments::SourceComment;
-use crate::expression::expr_string_literal::is_multiline_string;
 use crate::expression::parentheses::{
     in_parentheses_only_group, NeedsParentheses, OptionalParentheses,
 };
@@ -41,7 +40,7 @@ impl NeedsParentheses for ExprBytesLiteral {
     ) -> OptionalParentheses {
         if self.value.is_implicit_concatenated() {
             OptionalParentheses::Multiline
-        } else if is_multiline_string(self.into(), context.source()) {
+        } else if AnyString::Bytes(self).is_multiline(context.source()) {
             OptionalParentheses::Never
         } else {
             OptionalParentheses::BestFit

--- a/crates/ruff_python_formatter/src/expression/expr_compare.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_compare.rs
@@ -4,10 +4,10 @@ use ruff_python_ast::{CmpOp, ExprCompare};
 
 use crate::comments::SourceComment;
 use crate::expression::binary_like::BinaryLike;
-use crate::expression::expr_string_literal::is_multiline_string;
 use crate::expression::has_parentheses;
 use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
 use crate::prelude::*;
+use crate::string::AnyString;
 
 #[derive(Default)]
 pub struct FormatExprCompare;
@@ -37,11 +37,11 @@ impl NeedsParentheses for ExprCompare {
     ) -> OptionalParentheses {
         if parent.is_expr_await() {
             OptionalParentheses::Always
-        } else if let Some(literal_expr) = self.left.as_literal_expr() {
+        } else if let Some(string) = AnyString::from_expression(&self.left) {
             // Multiline strings are guaranteed to never fit, avoid adding unnecessary parentheses
-            if !literal_expr.is_implicit_concatenated()
-                && is_multiline_string(literal_expr.into(), context.source())
-                && !context.comments().has(literal_expr)
+            if !string.is_implicit_concatenated()
+                && string.is_multiline(context.source())
+                && !context.comments().has(string)
                 && self.comparators.first().is_some_and(|right| {
                     has_parentheses(right, context).is_some() && !context.comments().has(right)
                 })

--- a/crates/ruff_python_formatter/src/expression/expr_f_string.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_f_string.rs
@@ -1,5 +1,3 @@
-use memchr::memchr2;
-
 use ruff_python_ast::{AnyNodeRef, ExprFString};
 use ruff_source_file::Locator;
 use ruff_text_size::Ranged;
@@ -50,10 +48,10 @@ impl NeedsParentheses for ExprFString {
     ) -> OptionalParentheses {
         if self.value.is_implicit_concatenated() {
             OptionalParentheses::Multiline
-        } else if memchr2(b'\n', b'\r', context.source()[self.range].as_bytes()).is_none() {
-            OptionalParentheses::BestFit
-        } else {
+        } else if AnyString::FString(self).is_multiline(context.source()) {
             OptionalParentheses::Never
+        } else {
+            OptionalParentheses::BestFit
         }
     }
 }

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -17,11 +17,14 @@ use crate::context::{NodeLevel, WithNodeLevel};
 use crate::expression::expr_generator_exp::is_generator_parenthesized;
 use crate::expression::expr_tuple::is_tuple_parenthesized;
 use crate::expression::parentheses::{
-    is_expression_parenthesized, optional_parentheses, parenthesized, NeedsParentheses,
-    OptionalParentheses, Parentheses, Parenthesize,
+    is_expression_parenthesized, optional_parentheses, parenthesized, HuggingStyle,
+    NeedsParentheses, OptionalParentheses, Parentheses, Parenthesize,
 };
 use crate::prelude::*;
-use crate::preview::is_hug_parens_with_braces_and_square_brackets_enabled;
+use crate::preview::{
+    is_hug_parens_with_braces_and_square_brackets_enabled, is_multiline_string_handling_enabled,
+};
+use crate::string::AnyString;
 
 mod binary_like;
 pub(crate) mod expr_attribute;
@@ -126,7 +129,7 @@ impl FormatRule<Expr, PyFormatContext<'_>> for FormatExpr {
             let node_comments = comments.leading_dangling_trailing(expression);
             if !node_comments.has_leading() && !node_comments.has_trailing() {
                 parenthesized("(", &format_expr, ")")
-                    .with_indent(!is_expression_huggable(expression, f.context()))
+                    .with_hugging(is_expression_huggable(expression, f.context()))
                     .fmt(f)
             } else {
                 format_with_parentheses_comments(expression, &node_comments, f)
@@ -444,7 +447,7 @@ impl Format<PyFormatContext<'_>> for MaybeParenthesizeExpression<'_> {
             OptionalParentheses::Never => match parenthesize {
                 Parenthesize::IfBreaksOrIfRequired => {
                     parenthesize_if_expands(&expression.format().with_options(Parentheses::Never))
-                        .with_indent(!is_expression_huggable(expression, f.context()))
+                        .with_indent(is_expression_huggable(expression, f.context()).is_none())
                         .fmt(f)
                 }
 
@@ -1084,7 +1087,7 @@ pub(crate) fn has_own_parentheses(
 }
 
 /// Returns `true` if the expression can hug directly to enclosing parentheses, as in Black's
-/// `hug_parens_with_braces_and_square_brackets` preview style behavior.
+/// `hug_parens_with_braces_and_square_brackets` or `multiline_string_handling` preview styles behavior.
 ///
 /// For example, in preview style, given:
 /// ```python
@@ -1110,11 +1113,10 @@ pub(crate) fn has_own_parentheses(
 ///     ]
 /// )
 /// ```
-pub(crate) fn is_expression_huggable(expr: &Expr, context: &PyFormatContext) -> bool {
-    if !is_hug_parens_with_braces_and_square_brackets_enabled(context) {
-        return false;
-    }
-
+pub(crate) fn is_expression_huggable(
+    expr: &Expr,
+    context: &PyFormatContext,
+) -> Option<HuggingStyle> {
     match expr {
         Expr::Tuple(_)
         | Expr::List(_)
@@ -1122,18 +1124,14 @@ pub(crate) fn is_expression_huggable(expr: &Expr, context: &PyFormatContext) -> 
         | Expr::Dict(_)
         | Expr::ListComp(_)
         | Expr::SetComp(_)
-        | Expr::DictComp(_) => true,
+        | Expr::DictComp(_) => is_hug_parens_with_braces_and_square_brackets_enabled(context)
+            .then_some(HuggingStyle::Always),
 
-        Expr::Starred(ast::ExprStarred { value, .. }) => matches!(
-            value.as_ref(),
-            Expr::Tuple(_)
-                | Expr::List(_)
-                | Expr::Set(_)
-                | Expr::Dict(_)
-                | Expr::ListComp(_)
-                | Expr::SetComp(_)
-                | Expr::DictComp(_)
-        ),
+        Expr::Starred(ast::ExprStarred { value, .. }) => is_expression_huggable(value, context),
+
+        Expr::StringLiteral(string) => is_huggable_string(AnyString::String(string), context),
+        Expr::BytesLiteral(bytes) => is_huggable_string(AnyString::Bytes(bytes), context),
+        Expr::FString(fstring) => is_huggable_string(AnyString::FString(fstring), context),
 
         Expr::BoolOp(_)
         | Expr::NamedExpr(_)
@@ -1147,18 +1145,28 @@ pub(crate) fn is_expression_huggable(expr: &Expr, context: &PyFormatContext) -> 
         | Expr::YieldFrom(_)
         | Expr::Compare(_)
         | Expr::Call(_)
-        | Expr::FString(_)
         | Expr::Attribute(_)
         | Expr::Subscript(_)
         | Expr::Name(_)
         | Expr::Slice(_)
         | Expr::IpyEscapeCommand(_)
-        | Expr::StringLiteral(_)
-        | Expr::BytesLiteral(_)
         | Expr::NumberLiteral(_)
         | Expr::BooleanLiteral(_)
         | Expr::NoneLiteral(_)
-        | Expr::EllipsisLiteral(_) => false,
+        | Expr::EllipsisLiteral(_) => None,
+    }
+}
+
+/// Returns `true` if `string` is a multiline string that is not implicitly concatenated.
+fn is_huggable_string(string: AnyString, context: &PyFormatContext) -> Option<HuggingStyle> {
+    if !is_multiline_string_handling_enabled(context) {
+        return None;
+    }
+
+    if !string.is_implicit_concatenated() && string.is_multiline(context.source()) {
+        Some(HuggingStyle::IfFirstLineFits)
+    } else {
+        None
     }
 }
 

--- a/crates/ruff_python_formatter/src/preview.rs
+++ b/crates/ruff_python_formatter/src/preview.rs
@@ -62,3 +62,8 @@ pub(crate) const fn is_dummy_implementations_enabled(context: &PyFormatContext) 
 pub(crate) const fn is_hex_codes_in_unicode_sequences_enabled(context: &PyFormatContext) -> bool {
     context.is_preview()
 }
+
+/// Returns `true` if the [`multiline_string_handling`](https://github.com/astral-sh/ruff/issues/8896) preview style is enabled.
+pub(crate) const fn is_multiline_string_handling_enabled(context: &PyFormatContext) -> bool {
+    context.is_preview()
+}

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_multiline_strings.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_multiline_strings.py.snap
@@ -187,7 +187,7 @@ this_will_also_become_one_line = (  # comment
 ```diff
 --- Black
 +++ Ruff
-@@ -1,95 +1,138 @@
+@@ -1,46 +1,69 @@
 -"""cow
 +(
 +    """cow
@@ -271,41 +271,21 @@ this_will_also_become_one_line = (  # comment
 +    ),
  )
  textwrap.dedent("""A one-line triple-quoted string.""")
--textwrap.dedent("""A two-line triple-quoted string
--since it goes to the next line.""")
--textwrap.dedent("""A three-line triple-quoted string
-+textwrap.dedent(
-+    """A two-line triple-quoted string
-+since it goes to the next line."""
-+)
-+textwrap.dedent(
-+    """A three-line triple-quoted string
- that not only goes to the next line
--but also goes one line beyond.""")
--textwrap.dedent("""\
-+but also goes one line beyond."""
-+)
-+textwrap.dedent(
-+    """\
-     A triple-quoted string
-     actually leveraging the textwrap.dedent functionality
+ textwrap.dedent("""A two-line triple-quoted string
+@@ -54,18 +77,24 @@
      that ends in a trailing newline,
      representing e.g. file contents.
--""")
+ """)
 -path.write_text(textwrap.dedent("""\
-+"""
-+)
 +path.write_text(
-+    textwrap.dedent(
-+        """\
++    textwrap.dedent("""\
      A triple-quoted string
      actually leveraging the textwrap.dedent functionality
      that ends in a trailing newline,
      representing e.g. file contents.
 -"""))
 -path.write_text(textwrap.dedent("""\
-+"""
-+    )
++""")
 +)
 +path.write_text(
 +    textwrap.dedent(
@@ -319,29 +299,9 @@ this_will_also_become_one_line = (  # comment
 +    )
 +)
  # Another use case
--data = yaml.load("""\
-+data = yaml.load(
-+    """\
+ data = yaml.load("""\
  a: 1
- b: 2
--""")
-+"""
-+)
- data = yaml.load(
-     """\
- a: 1
- b: 2
- """,
- )
--data = yaml.load("""\
-+data = yaml.load(
-+    """\
-     a: 1
-     b: 2
--""")
-+"""
-+)
- 
+@@ -85,11 +114,13 @@
  MULTILINE = """
  foo
  """.replace("\n", "")
@@ -356,7 +316,7 @@ this_will_also_become_one_line = (  # comment
  parser.usage += """
  Custom extra help summary.
  
-@@ -156,16 +199,24 @@
+@@ -156,16 +187,24 @@
               10 LOAD_CONST               0 (None)
               12 RETURN_VALUE
  """ % (_C.__init__.__code__.co_firstlineno + 1,)
@@ -387,36 +347,7 @@ this_will_also_become_one_line = (  # comment
  [
      """cow
  moos""",
-@@ -177,28 +228,32 @@
- 
- 
- def dastardly_default_value(
--    cow: String = json.loads("""this
-+    cow: String = json.loads(
-+        """this
- is
- quite
- the
- dastadardly
--value!"""),
-+value!"""
-+    ),
-     **kwargs,
- ):
-     pass
- 
- 
--print(f"""
-+print(
-+    f"""
-     This {animal}
-     moos and barks
- {animal} say
--""")
-+"""
-+)
- msg = f"""The arguments {bad_arguments} were passed in.
- Please use `--build-option` instead,
+@@ -198,7 +237,7 @@
  `--global-option` is reserved to flags like `--verbose` or `--quiet`.
  """
  
@@ -425,7 +356,7 @@ this_will_also_become_one_line = (  # comment
  
  this_will_stay_on_three_lines = (
      "a"  # comment
-@@ -206,4 +261,6 @@
+@@ -206,4 +245,6 @@
      "c"
  )
  
@@ -506,32 +437,24 @@ call(
     ),
 )
 textwrap.dedent("""A one-line triple-quoted string.""")
-textwrap.dedent(
-    """A two-line triple-quoted string
-since it goes to the next line."""
-)
-textwrap.dedent(
-    """A three-line triple-quoted string
+textwrap.dedent("""A two-line triple-quoted string
+since it goes to the next line.""")
+textwrap.dedent("""A three-line triple-quoted string
 that not only goes to the next line
-but also goes one line beyond."""
-)
-textwrap.dedent(
-    """\
+but also goes one line beyond.""")
+textwrap.dedent("""\
     A triple-quoted string
     actually leveraging the textwrap.dedent functionality
     that ends in a trailing newline,
     representing e.g. file contents.
-"""
-)
+""")
 path.write_text(
-    textwrap.dedent(
-        """\
+    textwrap.dedent("""\
     A triple-quoted string
     actually leveraging the textwrap.dedent functionality
     that ends in a trailing newline,
     representing e.g. file contents.
-"""
-    )
+""")
 )
 path.write_text(
     textwrap.dedent(
@@ -544,24 +467,20 @@ path.write_text(
     )
 )
 # Another use case
-data = yaml.load(
-    """\
+data = yaml.load("""\
 a: 1
 b: 2
-"""
-)
+""")
 data = yaml.load(
     """\
 a: 1
 b: 2
 """,
 )
-data = yaml.load(
-    """\
+data = yaml.load("""\
     a: 1
     b: 2
-"""
-)
+""")
 
 MULTILINE = """
 foo
@@ -668,26 +587,22 @@ barks""",
 
 
 def dastardly_default_value(
-    cow: String = json.loads(
-        """this
+    cow: String = json.loads("""this
 is
 quite
 the
 dastadardly
-value!"""
-    ),
+value!"""),
     **kwargs,
 ):
     pass
 
 
-print(
-    f"""
+print(f"""
     This {animal}
     moos and barks
 {animal} say
-"""
-)
+""")
 msg = f"""The arguments {bad_arguments} were passed in.
 Please use `--build-option` instead,
 `--global-option` is reserved to flags like `--verbose` or `--quiet`.

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
@@ -8209,6 +8209,42 @@ def markdown_skipped_rst_directive():
 ```
 
 
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -480,10 +480,8 @@
+     Do cool stuff::
+ 
+      if True:
+-         cool_stuff(
+-             '''
+-     hiya'''
+-         )
++         cool_stuff('''
++     hiya''')
+ 
+     Done.
+     """
+@@ -958,13 +956,11 @@
+     Do cool stuff.
+ 
+     ``````
+-    do_something(
+-        '''
++    do_something('''
+     ```
+     did i trick you?
+     ```
+-    '''
+-    )
++    ''')
+     ``````
+ 
+     Done.
+```
+
+
 ### Output 6
 ```
 indent-style               = space
@@ -9574,6 +9610,42 @@ def markdown_skipped_rst_directive():
   Done.
   """
   pass
+```
+
+
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -480,10 +480,8 @@
+   Do cool stuff::
+ 
+    if True:
+-     cool_stuff(
+-       '''
+-   hiya'''
+-     )
++     cool_stuff('''
++   hiya''')
+ 
+   Done.
+   """
+@@ -958,13 +956,11 @@
+   Do cool stuff.
+ 
+   ``````
+-  do_something(
+-    '''
++  do_something('''
+   ```
+   did i trick you?
+   ```
+-  '''
+-  )
++  ''')
+   ``````
+ 
+   Done.
 ```
 
 
@@ -10954,6 +11026,42 @@ def markdown_skipped_rst_directive():
 ```
 
 
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -489,10 +489,8 @@
+ 	Do cool stuff::
+ 
+ 	 if True:
+-	         cool_stuff(
+-	                 '''
+-	 hiya'''
+-	         )
++	         cool_stuff('''
++	 hiya''')
+ 
+ 	Done.
+ 	"""
+@@ -967,13 +965,11 @@
+ 	Do cool stuff.
+ 
+ 	``````
+-	do_something(
+-	        '''
++	do_something('''
+ 	```
+ 	did i trick you?
+ 	```
+-	'''
+-	)
++	''')
+ 	``````
+ 
+ 	Done.
+```
+
+
 ### Output 8
 ```
 indent-style               = tab
@@ -12319,6 +12427,42 @@ def markdown_skipped_rst_directive():
 	Done.
 	"""
 	pass
+```
+
+
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -480,10 +480,8 @@
+ 	Do cool stuff::
+ 
+ 	 if True:
+-	     cool_stuff(
+-	         '''
+-	 hiya'''
+-	     )
++	     cool_stuff('''
++	 hiya''')
+ 
+ 	Done.
+ 	"""
+@@ -958,13 +956,11 @@
+ 	Do cool stuff.
+ 
+ 	``````
+-	do_something(
+-	    '''
++	do_something('''
+ 	```
+ 	did i trick you?
+ 	```
+-	'''
+-	)
++	''')
+ 	``````
+ 
+ 	Done.
 ```
 
 
@@ -13699,6 +13843,42 @@ def markdown_skipped_rst_directive():
 ```
 
 
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -489,10 +489,8 @@
+     Do cool stuff::
+ 
+      if True:
+-         cool_stuff(
+-             '''
+-     hiya'''
+-         )
++         cool_stuff('''
++     hiya''')
+ 
+     Done.
+     """
+@@ -967,13 +965,11 @@
+     Do cool stuff.
+ 
+     ``````
+-    do_something(
+-        '''
++    do_something('''
+     ```
+     did i trick you?
+     ```
+-    '''
+-    )
++    ''')
+     ``````
+ 
+     Done.
+```
+
+
 ### Output 10
 ```
 indent-style               = space
@@ -15064,6 +15244,42 @@ def markdown_skipped_rst_directive():
     Done.
     """
     pass
+```
+
+
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -480,10 +480,8 @@
+     Do cool stuff::
+ 
+      if True:
+-         cool_stuff(
+-             '''
+-     hiya'''
+-         )
++         cool_stuff('''
++     hiya''')
+ 
+     Done.
+     """
+@@ -958,13 +956,11 @@
+     Do cool stuff.
+ 
+     ``````
+-    do_something(
+-        '''
++    do_something('''
+     ```
+     did i trick you?
+     ```
+-    '''
+-    )
++    ''')
+     ``````
+ 
+     Done.
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@multiline_string_deviations.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@multiline_string_deviations.py.snap
@@ -1,0 +1,136 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/multiline_string_deviations.py
+---
+## Input
+```python
+# This file documents the deviations for formatting multiline strings with black.
+
+# Black hugs the parentheses for `%` usages -> convert to fstring.
+# Can get unreadable if the arguments split
+# This could be solved by using `best_fitting` to try to format the arguments on a single
+# line. Let's consider adding this later.
+# ```python
+# call(
+#    3,
+#    "dogsay",
+#    textwrap.dedent(
+#        """dove
+#    coo""" % "cowabunga",
+#        more,
+#        and_more,
+#        "aaaaaaa",
+#        "bbbbbbbbb",
+#        "cccccccc",
+#    ),
+# )
+# ```
+call(3, "dogsay", textwrap.dedent("""dove
+    coo""" % "cowabunga"))
+
+# Black applies the hugging recursively. We don't (consistent with the hugging style).
+path.write_text(textwrap.dedent("""\
+    A triple-quoted string
+    actually leveraging the textwrap.dedent functionality
+    that ends in a trailing newline,
+    representing e.g. file contents.
+"""))
+
+
+
+# Black avoids parenthesizing the following lambda. We could potentially support
+# this by changing `Lambda::needs_parentheses` to return `BestFit` but it causes
+# issues when the lambda has comments.
+# Let's keep this as a known deviation for now.
+generated_readme = lambda project_name: """
+{}
+
+<Add content here!>
+""".strip().format(project_name)
+```
+
+## Output
+```python
+# This file documents the deviations for formatting multiline strings with black.
+
+# Black hugs the parentheses for `%` usages -> convert to fstring.
+# Can get unreadable if the arguments split
+# This could be solved by using `best_fitting` to try to format the arguments on a single
+# line. Let's consider adding this later.
+# ```python
+# call(
+#    3,
+#    "dogsay",
+#    textwrap.dedent(
+#        """dove
+#    coo""" % "cowabunga",
+#        more,
+#        and_more,
+#        "aaaaaaa",
+#        "bbbbbbbbb",
+#        "cccccccc",
+#    ),
+# )
+# ```
+call(
+    3,
+    "dogsay",
+    textwrap.dedent(
+        """dove
+    coo"""
+        % "cowabunga"
+    ),
+)
+
+# Black applies the hugging recursively. We don't (consistent with the hugging style).
+path.write_text(
+    textwrap.dedent(
+        """\
+    A triple-quoted string
+    actually leveraging the textwrap.dedent functionality
+    that ends in a trailing newline,
+    representing e.g. file contents.
+"""
+    )
+)
+
+
+# Black avoids parenthesizing the following lambda. We could potentially support
+# this by changing `Lambda::needs_parentheses` to return `BestFit` but it causes
+# issues when the lambda has comments.
+# Let's keep this as a known deviation for now.
+generated_readme = (
+    lambda project_name: """
+{}
+
+<Add content here!>
+""".strip().format(project_name)
+)
+```
+
+
+## Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -31,14 +31,12 @@
+ 
+ # Black applies the hugging recursively. We don't (consistent with the hugging style).
+ path.write_text(
+-    textwrap.dedent(
+-        """\
++    textwrap.dedent("""\
+     A triple-quoted string
+     actually leveraging the textwrap.dedent functionality
+     that ends in a trailing newline,
+     representing e.g. file contents.
+-"""
+-    )
++""")
+ )
+ 
+ 
+```
+
+
+


### PR DESCRIPTION
## Summary

This PR implements the hugging for multiline strings in call expression. 

The implementation doesn't match black's behavior exactly yet:

1. Black removes the hugging for nested calls `call(nested("""multiline\nstring"))`. Ruff will not to ensure consistency with `hug_parentheses` 
2. Black applies the hugging even for `"multiline" % placeholder` strings. This can get pretty hard to read if the formatting has many arguments. The solution here is to use f-strings instead.
3. Black avoids parenthesizing lambdas with a multiline string body, Ruff parenthesizes it. 

I find 1 and 2 acceptable and wouldn't support them. 3. is a pre-existing deviation that we should tackle separately.

## Test Plan

* I added tests documenting the deviations
* I reviewed the snapshot changes
* This PR increases the poetry compatbility from 0.99905 to 0.99934
* I reviewed the ecosystem changes. I like what I see. I only noticed that the last line of the multiline string now tends to have one indent too much. There isn't anything we can do about it without knowing if it is safe to trim the last string or not (depends on the called function). This is something that requires manual intervention. 

```python
a = call(
	"""
	Multiline string
	"""
)
```

becomes

```python
a = call("""
	Multiline string
	""")

```
