### PR TITLE
Avoid adding return types to stub methods

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_annotations/auto_return_type.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_annotations/auto_return_type.py
@@ -212,3 +212,20 @@ def func(x: int):
         raise ValueError
     else:
         return 1
+
+
+from typing import overload
+
+
+@overload
+def overloaded(i: int) -> "int":
+    ...
+
+
+@overload
+def overloaded(i: "str") -> "str":
+    ...
+
+
+def overloaded(i):
+    return i


### PR DESCRIPTION
We should avoid adding `-> None` to stubs in `.pyi` files, along with a few other cases. (We already ignore abstract methods.)

Closes https://github.com/astral-sh/ruff/issues/9270.