### PR TITLE
Allow config-file overrides in ecosystem checks

### DIFF
--- a/python/ruff-ecosystem/pyproject.toml
+++ b/python/ruff-ecosystem/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "ruff-ecosystem"
 version = "0.0.0"
-dependencies = ["unidiff==0.7.5"]
+dependencies = ["unidiff==0.7.5", "tomli_w==1.0.0", "tomli==2.0.1"]
 
 [project.scripts]
 ruff-ecosystem = "ruff_ecosystem.cli:entrypoint"

--- a/python/ruff-ecosystem/ruff_ecosystem/check.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/check.py
@@ -28,7 +28,12 @@ from ruff_ecosystem.types import (
 )
 
 if TYPE_CHECKING:
-    from ruff_ecosystem.projects import CheckOptions, ClonedRepository, Project
+    from ruff_ecosystem.projects import (
+        CheckOptions,
+        ClonedRepository,
+        ConfigOverrides,
+        Project,
+    )
 
 
 # Matches lines that are summaries rather than diagnostics
@@ -477,9 +482,10 @@ async def compare_check(
     ruff_baseline_executable: Path,
     ruff_comparison_executable: Path,
     options: CheckOptions,
+    config_overrides: ConfigOverrides,
     cloned_repo: ClonedRepository,
 ) -> Comparison:
-    with options.update_toml(cloned_repo.path):
+    with config_overrides.patch_config(cloned_repo.path, options.preview):
         async with asyncio.TaskGroup() as tg:
             baseline_task = tg.create_task(
                 ruff_check(

--- a/python/ruff-ecosystem/ruff_ecosystem/check.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/check.py
@@ -479,23 +479,24 @@ async def compare_check(
     options: CheckOptions,
     cloned_repo: ClonedRepository,
 ) -> Comparison:
-    async with asyncio.TaskGroup() as tg:
-        baseline_task = tg.create_task(
-            ruff_check(
-                executable=ruff_baseline_executable.resolve(),
-                path=cloned_repo.path,
-                name=cloned_repo.fullname,
-                options=options,
-            ),
-        )
-        comparison_task = tg.create_task(
-            ruff_check(
-                executable=ruff_comparison_executable.resolve(),
-                path=cloned_repo.path,
-                name=cloned_repo.fullname,
-                options=options,
-            ),
-        )
+    with options.update_toml(cloned_repo.path):
+        async with asyncio.TaskGroup() as tg:
+            baseline_task = tg.create_task(
+                ruff_check(
+                    executable=ruff_baseline_executable.resolve(),
+                    path=cloned_repo.path,
+                    name=cloned_repo.fullname,
+                    options=options,
+                ),
+            )
+            comparison_task = tg.create_task(
+                ruff_check(
+                    executable=ruff_comparison_executable.resolve(),
+                    path=cloned_repo.path,
+                    name=cloned_repo.fullname,
+                    options=options,
+                ),
+            )
 
     baseline_output, comparison_output = (
         baseline_task.result(),

--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -1,7 +1,13 @@
 """
 Default projects for ecosystem checks
 """
-from ruff_ecosystem.projects import CheckOptions, FormatOptions, Project, Repository
+from ruff_ecosystem.projects import (
+    CheckOptions,
+    ConfigOverrides,
+    FormatOptions,
+    Project,
+    Repository,
+)
 
 # TODO(zanieb): Consider exporting this as JSON and loading from there instead
 DEFAULT_TARGETS = [
@@ -49,12 +55,7 @@ DEFAULT_TARGETS = [
         repo=Repository(owner="pypa", name="setuptools", ref="main"),
         # Since `setuptools` opts into the "preserve" quote style which
         # require preview mode, we must disable it during the `--no-preview` run
-        check_options=CheckOptions(
-            toml_overrides=(("no-preview::format.quote-style", "double"),)
-        ),
-        format_options=FormatOptions(
-            toml_overrides=(("no-preview::format.quote-style", "double"),)
-        ),
+        config_overrides=ConfigOverrides(no_preview={"format.quote-style": "double"}),
     ),
     Project(repo=Repository(owner="python", name="mypy", ref="master")),
     Project(

--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -55,7 +55,9 @@ DEFAULT_TARGETS = [
         repo=Repository(owner="pypa", name="setuptools", ref="main"),
         # Since `setuptools` opts into the "preserve" quote style which
         # require preview mode, we must disable it during the `--no-preview` run
-        config_overrides=ConfigOverrides(no_preview={"format.quote-style": "double"}),
+        config_overrides=ConfigOverrides(
+            when_no_preview={"format.quote-style": "double"}
+        ),
     ),
     Project(repo=Repository(owner="python", name="mypy", ref="master")),
     Project(

--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -45,7 +45,12 @@ DEFAULT_TARGETS = [
     Project(repo=Repository(owner="pypa", name="build", ref="main")),
     Project(repo=Repository(owner="pypa", name="cibuildwheel", ref="main")),
     Project(repo=Repository(owner="pypa", name="pip", ref="main")),
-    Project(repo=Repository(owner="pypa", name="setuptools", ref="main")),
+    Project(
+        repo=Repository(owner="pypa", name="setuptools", ref="main"),
+        check_options=CheckOptions(
+            toml_overrides=(("no-preview.format.quote-style", "double"),)
+        ),
+    ),
     Project(repo=Repository(owner="python", name="mypy", ref="master")),
     Project(
         repo=Repository(

--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -47,8 +47,13 @@ DEFAULT_TARGETS = [
     Project(repo=Repository(owner="pypa", name="pip", ref="main")),
     Project(
         repo=Repository(owner="pypa", name="setuptools", ref="main"),
+        # Since `setuptools` opts into the "preserve" quote style which
+        # require preview mode, we must disable it during the `--no-preview` run
         check_options=CheckOptions(
-            toml_overrides=(("no-preview.format.quote-style", "double"),)
+            toml_overrides=(("no-preview::format.quote-style", "double"),)
+        ),
+        format_options=FormatOptions(
+            toml_overrides=(("no-preview::format.quote-style", "double"),)
         ),
     ),
     Project(repo=Repository(owner="python", name="mypy", ref="master")),

--- a/python/ruff-ecosystem/ruff_ecosystem/main.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/main.py
@@ -113,11 +113,17 @@ async def clone_and_compare(
 
     match command:
         case RuffCommand.check:
-            compare, options, kwargs = (compare_check, target.check_options, {})
+            compare, options, overrides, kwargs = (
+                compare_check,
+                target.check_options,
+                target.config_overrides,
+                {},
+            )
         case RuffCommand.format:
-            compare, options, kwargs = (
+            compare, options, overrides, kwargs = (
                 compare_format,
                 target.format_options,
+                target.config_overrides,
                 {"format_comparison": format_comparison},
             )
         case _:
@@ -131,6 +137,7 @@ async def clone_and_compare(
             baseline_executable,
             comparison_executable,
             options,
+            overrides,
             cloned_repo,
             **kwargs,
         )


### PR DESCRIPTION
Adds the ability to override `ruff.toml` or `pyproject.toml` settings per-project during ecosystem checks.

Exploring this as a fix for the `setuptools` project error. 

Also useful for including Jupyter Notebooks in the ecosystem checks, see #9293

Note the remaining `sphinx` project error is resolved in #9294 