### PR TITLE
Exclude failing sphinx file in ecosytem checks

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -62,7 +62,17 @@ DEFAULT_TARGETS = [
     Project(
         repo=Repository(owner="scikit-build", name="scikit-build-core", ref="main")
     ),
-    Project(repo=Repository(owner="sphinx-doc", name="sphinx", ref="master")),
+    Project(
+        repo=Repository(
+            owner="sphinx-doc",
+            name="sphinx",
+            ref="master",
+        ),
+        format_options=FormatOptions(
+            # Does not contain valid UTF-8
+            exclude="tests/roots/test-pycode/cp_1251_coded.py"
+        ),
+    ),
     Project(repo=Repository(owner="spruceid", name="siwe-py", ref="main")),
     Project(repo=Repository(owner="tiangolo", name="fastapi", ref="master")),
     Project(repo=Repository(owner="yandex", name="ch-backup", ref="main")),


### PR DESCRIPTION
Failing due to

> error: Failed to read tests/roots/test-pycode/cp_1251_coded.py: stream did not contain valid UTF-8

Unclear to me if ignoring is the correct response.