### PR TITLE
Respect `unused-noqa` via `per-file-ignores`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/ruff_per_file_ignores.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/ruff_per_file_ignores.py
@@ -1,0 +1,2 @@
+import os
+import foo  # noqa: F401

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -11,11 +11,12 @@ use ruff_source_file::Locator;
 
 use crate::noqa;
 use crate::noqa::{Directive, FileExemption, NoqaDirectives, NoqaMapping};
-use crate::registry::{AsRule, Rule};
+use crate::registry::{AsRule, Rule, RuleSet};
 use crate::rule_redirects::get_redirect_target;
 use crate::rules::ruff::rules::{UnusedCodes, UnusedNOQA};
 use crate::settings::LinterSettings;
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn check_noqa(
     diagnostics: &mut Vec<Diagnostic>,
     path: &Path,
@@ -23,6 +24,7 @@ pub(crate) fn check_noqa(
     comment_ranges: &CommentRanges,
     noqa_line_for: &NoqaMapping,
     analyze_directives: bool,
+    per_file_ignores: &RuleSet,
     settings: &LinterSettings,
 ) -> Vec<usize> {
     // Identify any codes that are globally exempted (within the current file).
@@ -119,7 +121,7 @@ pub(crate) fn check_noqa(
                     let mut unknown_codes = vec![];
                     let mut unmatched_codes = vec![];
                     let mut valid_codes = vec![];
-                    let mut self_ignore = false;
+                    let mut self_ignore = per_file_ignores.contains(Rule::UnusedNOQA);
                     for code in directive.codes() {
                         let code = get_redirect_target(code).unwrap_or(code);
                         if Rule::UnusedNOQA.noqa_code() == code {

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -224,6 +224,25 @@ mod tests {
         assert_messages!(diagnostics);
         Ok(())
     }
+
+    #[test]
+    fn ruff_per_file_ignores() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("ruff/ruff_per_file_ignores.py"),
+            &settings::LinterSettings {
+                per_file_ignores: resolve_per_file_ignores(vec![PerFileIgnore::new(
+                    "ruff_per_file_ignores.py".to_string(),
+                    &["F401".parse().unwrap(), "RUF100".parse().unwrap()],
+                    None,
+                )])
+                .unwrap(),
+                ..settings::LinterSettings::for_rules(vec![Rule::UnusedImport, Rule::UnusedNOQA])
+            },
+        )?;
+        assert_messages!(diagnostics);
+        Ok(())
+    }
+
     #[test]
     fn flake8_noqa() -> Result<()> {
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruff_per_file_ignores.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruff_per_file_ignores.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+


### PR DESCRIPTION
## Summary

If `RUF100` is ignored via `per-file-ignores`, we need to avoid raising it. `RUF100` has special "self-ignore" logic, since the rule itself deals with `# noqa` directives. This PR wires up `per-file-ignores` to that "self-ignore" logic.

Closes https://github.com/astral-sh/ruff/issues/9297.
