### PR TITLE
[`pyupgrade`] Document more fix unsafety for UP007

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -40,7 +40,9 @@ use crate::settings::types::PythonVersion;
 /// ## Fix safety
 /// This rule's fix is marked as unsafe, as it may lead to runtime errors when
 /// alongside libraries that rely on runtime type annotations, like Pydantic,
-/// on Python versions prior to Python 3.10.
+/// on Python versions prior to Python 3.10. It may also lead to runtime errors
+/// in unusual and likely incorrect type annotations where the type does not
+/// support the `|` operator.
 ///
 /// ## Options
 /// - `target-version`


### PR DESCRIPTION
```
from typing import Optional
x = "asdf"
def foo(a: Optional[x]):
    pass
```