### PR TITLE
Change PLR0917 error message to match other PLR09XX messages

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_positional.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_positional.rs
@@ -51,7 +51,7 @@ impl Violation for TooManyPositional {
     #[derive_message_formats]
     fn message(&self) -> String {
         let TooManyPositional { c_pos, max_pos } = self;
-        format!("Too many positional arguments: ({c_pos}/{max_pos})")
+        format!("Too many positional arguments ({c_pos}/{max_pos})")
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR0917_too_many_positional.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR0917_too_many_positional.py.snap
@@ -1,21 +1,21 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-too_many_positional.py:1:5: PLR0917 Too many positional arguments: (8/5)
+too_many_positional.py:1:5: PLR0917 Too many positional arguments (8/5)
   |
 1 | def f(x, y, z, t, u, v, w, r):  # Too many positional arguments (8/3)
   |     ^ PLR0917
 2 |     pass
   |
 
-too_many_positional.py:21:5: PLR0917 Too many positional arguments: (6/5)
+too_many_positional.py:21:5: PLR0917 Too many positional arguments (6/5)
    |
 21 | def f(x, y, z, /, u, v, w):  # Too many positional arguments (6/3)
    |     ^ PLR0917
 22 |     pass
    |
 
-too_many_positional.py:29:5: PLR0917 Too many positional arguments: (6/5)
+too_many_positional.py:29:5: PLR0917 Too many positional arguments (6/5)
    |
 29 | def f(x, y, z, a, b, c, *, u, v, w):  # Too many positional arguments (6/3)
    |     ^ PLR0917

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__max_positional_args.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__max_positional_args.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-too_many_positional_params.py:3:5: PLR0917 Too many positional arguments: (7/4)
+too_many_positional_params.py:3:5: PLR0917 Too many positional arguments (7/4)
   |
 1 | # Too many positional arguments (7/4) for max_positional=4
 2 | # OK for dummy_variable_rgx ~ "skip_.*"
@@ -10,7 +10,7 @@ too_many_positional_params.py:3:5: PLR0917 Too many positional arguments: (7/4)
 4 |     pass
   |
 
-too_many_positional_params.py:9:5: PLR0917 Too many positional arguments: (7/4)
+too_many_positional_params.py:9:5: PLR0917 Too many positional arguments (7/4)
    |
  7 | # Too many positional arguments (7/4) for max_args=4
  8 | # Too many positional arguments (7/3) for dummy_variable_rgx ~ "skip_.*"


### PR DESCRIPTION
## Summary

Remove `:` for PLR0917 to make all PLR09XX message look the same

```
PLR0904	Too many public methods (21 > 20)
PLR0911	Too many return statements (16 > 6)
PLR0912	Too many branches (13 > 12)
PLR0913	Too many arguments in function definition (10 > 5)
PLR0915	Too many statements (118 > 50)
PLR0917	Too many positional arguments: (15/5)
```
## Test Plan

<!-- How was it tested? -->
