### PR TITLE
Use `Display` for formatter parse errors

### DIFF
--- a/crates/ruff_cli/src/commands/format.rs
+++ b/crates/ruff_cli/src/commands/format.rs
@@ -408,11 +408,13 @@ pub(crate) fn format_source(
 pub(crate) enum FormatResult {
     /// The file was formatted.
     Formatted,
+
     /// The file was formatted, [`SourceKind`] contains the formatted code
     Diff {
         unformatted: SourceKind,
         formatted: SourceKind,
     },
+
     /// The file was unchanged, as the formatted contents matched the existing contents.
     Unchanged,
 

--- a/crates/ruff_cli/tests/format.rs
+++ b/crates/ruff_cli/tests/format.rs
@@ -329,6 +329,32 @@ OTHER = "OTHER"
 }
 
 #[test]
+fn syntax_error() -> Result<()> {
+    let tempdir = TempDir::new()?;
+
+    fs::write(
+        tempdir.path().join("main.py"),
+        r#"
+from module import =
+"#,
+    )?;
+
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .current_dir(tempdir.path())
+        .args(["format", "--no-cache", "--isolated", "--check"])
+        .arg("main.py"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to format main.py: source contains syntax errors: invalid syntax. Got unexpected token '=' at byte offset 20
+    "###);
+
+    Ok(())
+}
+
+#[test]
 fn messages() -> Result<()> {
     let tempdir = TempDir::new()?;
 

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -108,9 +108,9 @@ where
 
 #[derive(Error, Debug)]
 pub enum FormatModuleError {
-    #[error("source contains syntax errors: {0:?}")]
+    #[error("source contains syntax errors: {0}")]
     LexError(LexicalError),
-    #[error("source contains syntax errors: {0:?}")]
+    #[error("source contains syntax errors: {0}")]
     ParseError(ParseError),
     #[error(transparent)]
     FormatError(#[from] FormatError),

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1308,6 +1308,31 @@ impl LexicalError {
     }
 }
 
+impl std::ops::Deref for LexicalError {
+    type Target = LexicalErrorType;
+
+    fn deref(&self) -> &Self::Target {
+        &self.error
+    }
+}
+
+impl std::error::Error for LexicalError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+impl std::fmt::Display for LexicalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{} at byte offset {}",
+            &self.error,
+            u32::from(self.location)
+        )
+    }
+}
+
 /// Represents the different types of errors that can occur during lexing.
 #[derive(Debug, Clone, PartialEq)]
 pub enum LexicalErrorType {
@@ -1349,6 +1374,8 @@ pub enum LexicalErrorType {
     /// An unexpected error occurred.
     OtherError(String),
 }
+
+impl std::error::Error for LexicalErrorType {}
 
 impl std::fmt::Display for LexicalErrorType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/crates/ruff_python_parser/src/parser.rs
+++ b/crates/ruff_python_parser/src/parser.rs
@@ -305,12 +305,6 @@ impl fmt::Display for ParseError {
     }
 }
 
-impl ParseError {
-    pub fn error(self) -> ParseErrorType {
-        self.error
-    }
-}
-
 /// Represents the different types of errors that can occur during parsing.
 #[derive(Debug, PartialEq)]
 pub enum ParseErrorType {


### PR DESCRIPTION
## Summary

This helps a bit with (but does not close) the issues described in https://github.com/astral-sh/ruff/issues/9311. E.g., now, we at least see: `error: Failed to format main.py: source contains syntax errors: invalid syntax. Got unexpected token '=' at byte offset 20`.
