### PR TITLE
Use consistent re-export from `ruff_source_file`

### DIFF
--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -336,10 +336,10 @@ pub fn add_noqa_to_path(
     );
 
     // Log any parse errors.
-    if let Some(err) = error {
+    if let Some(error) = error {
         error!(
             "{}",
-            DisplayParseError::new(err, locator.to_source_code(), source_kind)
+            DisplayParseError::new(error, locator.to_source_code(), source_kind)
         );
     }
 

--- a/crates/ruff_python_ast/src/whitespace.rs
+++ b/crates/ruff_python_ast/src/whitespace.rs
@@ -1,5 +1,5 @@
 use ruff_python_trivia::{indentation_at_offset, is_python_whitespace, PythonWhitespace};
-use ruff_source_file::{newlines::UniversalNewlineIterator, Locator};
+use ruff_source_file::{Locator, UniversalNewlineIterator};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::Stmt;

--- a/crates/ruff_python_trivia/src/textwrap.rs
+++ b/crates/ruff_python_trivia/src/textwrap.rs
@@ -4,8 +4,9 @@
 use std::borrow::Cow;
 use std::cmp;
 
+use ruff_source_file::UniversalNewlines;
+
 use crate::PythonWhitespace;
-use ruff_source_file::newlines::UniversalNewlines;
 
 /// Indent each line by the given prefix.
 ///

--- a/crates/ruff_source_file/src/lib.rs
+++ b/crates/ruff_source_file/src/lib.rs
@@ -2,20 +2,21 @@ use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
-use ruff_text_size::{Ranged, TextRange, TextSize};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-pub mod line_index;
-mod locator;
-pub mod newlines;
+use ruff_text_size::{Ranged, TextRange, TextSize};
 
 pub use crate::line_index::{LineIndex, OneIndexed};
-pub use locator::Locator;
-pub use newlines::{
+pub use crate::locator::Locator;
+pub use crate::newlines::{
     find_newline, Line, LineEnding, NewlineWithTrailingNewline, UniversalNewlineIterator,
     UniversalNewlines,
 };
+
+mod line_index;
+mod locator;
+mod newlines;
 
 /// Gives access to the source code of a file and allows mapping between [`TextSize`] and [`SourceLocation`].
 #[derive(Debug)]


### PR DESCRIPTION
Right now, we both re-export (via `pub use`) and mark the modules themselves a `pub`, so they can be imported through two different paths.