### PR TITLE
Fix continuation detection following multi-line strings

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/W293.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/W293.py
@@ -1,0 +1,16 @@
+# See: https://github.com/astral-sh/ruff/issues/9323
+class Chassis(RobotModuleTemplate):
+    """底盘信息推送控制
+    
+    """\
+
+
+"""""" \
+    \
+    
+
+
+"abc\
+ " \
+    \
+    

--- a/crates/ruff_linter/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/mod.rs
@@ -29,6 +29,7 @@ mod tests {
     #[test_case(Rule::LambdaAssignment, Path::new("E731.py"))]
     #[test_case(Rule::BareExcept, Path::new("E722.py"))]
     #[test_case(Rule::BlankLineWithWhitespace, Path::new("W29.py"))]
+    #[test_case(Rule::BlankLineWithWhitespace, Path::new("W293.py"))]
     #[test_case(Rule::InvalidEscapeSequence, Path::new("W605_0.py"))]
     #[test_case(Rule::InvalidEscapeSequence, Path::new("W605_1.py"))]
     #[test_case(Rule::LineTooLong, Path::new("E501.py"))]

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__W293_W293.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__W293_W293.py.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+W293.py:4:1: W293 [*] Blank line contains whitespace
+  |
+2 | class Chassis(RobotModuleTemplate):
+3 |     """底盘信息推送控制
+4 |     
+  | ^^^^ W293
+5 |     """\
+  |
+  = help: Remove whitespace from blank line
+
+ℹ Safe fix
+1 1 | # See: https://github.com/astral-sh/ruff/issues/9323
+2 2 | class Chassis(RobotModuleTemplate):
+3 3 |     """底盘信息推送控制
+4   |-    
+  4 |+
+5 5 |     """\
+6 6 | 
+7 7 | 
+
+W293.py:10:1: W293 [*] Blank line contains whitespace
+   |
+ 8 | """""" \
+ 9 |     \
+10 |     
+   | ^^^^ W293
+   |
+   = help: Remove whitespace from blank line
+
+ℹ Safe fix
+5  5  |     """\
+6  6  | 
+7  7  | 
+8     |-"""""" \
+9     |-    \
+10    |-    
+   8  |+"""""" 
+11 9  | 
+12 10 | 
+13 11 | "abc\
+
+W293.py:16:1: W293 [*] Blank line contains whitespace
+   |
+14 |  " \
+15 |     \
+16 |     
+   | ^^^^ W293
+   |
+   = help: Remove whitespace from blank line
+
+ℹ Safe fix
+11 11 | 
+12 12 | 
+13 13 | "abc\
+14    |- " \
+15    |-    \
+16    |-    
+   14 |+ " 
+
+

--- a/crates/ruff_python_index/src/indexer.rs
+++ b/crates/ruff_python_index/src/indexer.rs
@@ -62,13 +62,22 @@ impl Indexer {
             comment_ranges_builder.visit_token(tok, *range);
             fstring_ranges_builder.visit_token(tok, *range);
 
-            if matches!(tok, Tok::Newline | Tok::NonLogicalNewline) {
-                line_start = range.end();
+            match tok {
+                Tok::Newline | Tok::NonLogicalNewline => {
+                    line_start = range.end();
+                }
+                Tok::String { .. } => {
+                    // If the previous token was a string, find the start of the line that contains
+                    // the closing delimiter, since the token itself can span multiple lines.
+                    line_start = locator.line_start(range.end());
+                }
+                _ => {}
             }
 
             prev_token = Some(tok);
             prev_end = range.end();
         }
+
         Self {
             comment_ranges: comment_ranges_builder.finish(),
             continuation_lines,


### PR DESCRIPTION
## Summary

The logic that detects continuations assumed that tokens themselves cannot span multiple lines. However, strings _can_ -- even single-quoted strings.

Closes https://github.com/astral-sh/ruff/issues/9323.
