### PR TITLE
Make all dependencies workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
 ]
@@ -2041,7 +2041,7 @@ dependencies = [
  "filetime",
  "glob",
  "globset",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "regex",
  "ruff_macros",
  "seahash",
@@ -2067,7 +2067,7 @@ dependencies = [
  "insta",
  "insta-cmd",
  "is-macro",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "log",
  "mimalloc",
  "notify",
@@ -2108,8 +2108,9 @@ dependencies = [
  "imara-diff",
  "indicatif",
  "indoc",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "libcst",
+ "once_cell",
  "pretty_assertions",
  "rayon",
  "regex",
@@ -2191,7 +2192,7 @@ dependencies = [
  "insta",
  "is-macro",
  "is-wsl",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "libcst",
  "log",
  "memchr",
@@ -2243,7 +2244,7 @@ dependencies = [
 name = "ruff_macros"
 version = "0.0.0"
 dependencies = [
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "proc-macro2",
  "quote",
  "ruff_python_trivia",
@@ -2256,7 +2257,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "insta",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "once_cell",
  "ruff_diagnostics",
  "ruff_source_file",
@@ -2276,7 +2277,7 @@ dependencies = [
  "bitflags 2.4.1",
  "insta",
  "is-macro",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "ruff_python_parser",
  "ruff_python_trivia",
  "ruff_source_file",
@@ -2307,7 +2308,7 @@ dependencies = [
  "clap",
  "countme",
  "insta",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "memchr",
  "once_cell",
  "regex",
@@ -2350,7 +2351,7 @@ dependencies = [
  "bitflags 2.4.1",
  "hexf-parse",
  "is-macro",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "lexical-parse-float",
  "rand",
  "unic-ucd-category",
@@ -2364,7 +2365,7 @@ dependencies = [
  "bitflags 2.4.1",
  "insta",
  "is-macro",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "lalrpop",
  "lalrpop-util",
  "memchr",
@@ -2415,7 +2416,7 @@ name = "ruff_python_trivia"
 version = "0.0.0"
 dependencies = [
  "insta",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "ruff_python_ast",
  "ruff_python_index",
  "ruff_python_parser",
@@ -2497,7 +2498,7 @@ dependencies = [
  "globset",
  "ignore",
  "is-macro",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "log",
  "once_cell",
  "path-absolutize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,48 +12,103 @@ authors = ["Charlie Marsh <charlie.r.marsh@gmail.com>"]
 license = "MIT"
 
 [workspace.dependencies]
+aho-corasick = { version = "1.1.2" }
+annotate-snippets = { version = "0.9.2", features = ["color"] }
 anyhow = { version = "1.0.76" }
+argfile = { version = "0.1.6" }
+assert_cmd = { version = "2.0.8" }
+bincode = { version = "1.3.3" }
 bitflags = { version = "2.4.1" }
+cachedir = { version = "0.3.1" }
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 clap = { version = "4.4.12", features = ["derive"] }
+clap_complete_command = { version = "0.5.1" }
+clearscreen = { version = "2.0.0" }
+codspeed-criterion-compat = { version = "2.3.3", default-features = false }
 colored = { version = "2.1.0" }
+configparser = { version = "3.0.3" }
+console_error_panic_hook = { version = "0.1.7" }
+console_log = { version = "1.0.0" }
+countme = { version ="3.0.1"}
+criterion = { version = "0.5.1", default-features = false }
+dirs = { version = "5.0.0" }
+drop_bomb = { version = "0.1.5" }
+env_logger = { version ="0.10.1"}
+fern = { version = "0.6.1" }
 filetime = { version = "0.2.23" }
+fs-err = { version ="2.11.0"}
 glob = { version = "0.3.1" }
 globset = { version = "0.4.14" }
+hexf-parse = { version ="0.2.1"}
 ignore = { version = "0.4.21" }
+imara-diff ={ version = "0.1.5"}
+imperative = { version = "1.0.4" }
+indicatif ={ version = "0.17.7"}
+indoc ={ version = "2.0.4"}
 insta = { version = "1.34.0", feature = ["filters", "glob"] }
+insta-cmd = { version = "0.4.0" }
 is-macro = { version = "0.3.4" }
 is-wsl = { version = "0.4.0" }
-itertools = { version = "0.11.0" }
+itertools = { version = "0.12.0" }
+js-sys = { version = "0.3.66" }
+lalrpop-util = { version = "0.20.0", default-features = false }
+lexical-parse-float = { version = "0.8.0", features = ["format"] }
 libcst = { version = "1.1.0", default-features = false }
 log = { version = "0.4.17" }
 memchr = { version = "2.6.4" }
+mimalloc = { version ="0.1.39"}
+natord = { version = "1.0.9" }
+notify = { version = "6.1.1" }
 once_cell = { version = "1.19.0" }
 path-absolutize = { version = "3.1.1" }
+pathdiff = { version = "0.2.1" }
+pep440_rs = { version = "0.4.0", features = ["serde"] }
+pretty_assertions = "1.3.0"
 proc-macro2 = { version = "1.0.73" }
+pyproject-toml = { version = "0.8.1" }
+quick-junit = { version = "0.3.5" }
 quote = { version = "1.0.23" }
+rand = { version = "0.8.5" }
+rayon = { version = "1.8.0" }
 regex = { version = "1.10.2" }
+result-like = { version = "0.5.0" }
 rustc-hash = { version = "1.1.0" }
 schemars = { version = "0.8.16" }
+seahash = { version ="4.1.0"}
+semver = { version = "1.0.20" }
 serde = { version = "1.0.193", features = ["derive"] }
+serde-wasm-bindgen = { version = "0.6.3" }
 serde_json = { version = "1.0.109" }
+serde_test = { version = "1.0.152" }
+serde_with = { version = "3.4.0", default-features = false, features = ["macros"] }
 shellexpand = { version = "3.0.0" }
+shlex = { version ="1.2.0"}
 similar = { version = "2.3.0", features = ["inline"] }
 smallvec = { version = "1.11.2" }
 static_assertions = "1.1.0"
 strum = { version = "0.25.0", features = ["strum_macros"] }
 strum_macros = { version = "0.25.3" }
 syn = { version = "2.0.40" }
+tempfile = { version ="3.8.1"}
 test-case = { version = "3.3.1" }
 thiserror = { version = "1.0.51" }
+tikv-jemallocator = { version ="0.5.0"}
 toml = { version = "0.8.8" }
 tracing = { version = "0.1.40" }
 tracing-indicatif = { version = "0.3.6" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+typed-arena = { version = "2.0.2" }
+unic-ucd-category = { version ="0.9"}
 unicode-ident = { version = "1.0.12" }
-unicode_names2 = { version = "1.2.1" }
 unicode-width = { version = "0.1.11" }
+unicode_names2 = { version = "1.2.1" }
+ureq = { version = "2.9.1" }
+url = { version = "2.5.0" }
 uuid = { version = "1.6.1", features = ["v4", "fast-rng", "macro-diagnostics", "js"] }
+walkdir = { version = "2.3.2" }
+wasm-bindgen = { version = "0.2.84" }
+wasm-bindgen-test = { version = "0.3.39" }
+wild = { version = "2" }
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -31,17 +31,17 @@ name = "formatter"
 harness = false
 
 [dependencies]
-once_cell.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-url = "2.5.0"
-ureq = "2.9.1"
-criterion = { version = "0.5.1", default-features = false }
-codspeed-criterion-compat = { version="2.3.3", default-features = false, optional = true}
+once_cell = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+url = { workspace = true }
+ureq = { workspace = true }
+criterion = { workspace = true, default-features = false }
+codspeed-criterion-compat = { workspace = true, default-features = false, optional = true}
 
 [dev-dependencies]
-ruff_linter.path = "../ruff_linter"
-ruff_python_ast.path = "../ruff_python_ast"
+ruff_linter = { path = "../ruff_linter" }
+ruff_python_ast = { path = "../ruff_python_ast" }
 ruff_python_formatter = { path = "../ruff_python_formatter" }
 ruff_python_index = { path = "../ruff_python_index" }
 ruff_python_parser = { path = "../ruff_python_parser" }
@@ -53,7 +53,7 @@ workspace = true
 codspeed = ["codspeed-criterion-compat"]
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
-mimalloc = "0.1.39"
+mimalloc = { workspace = true }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dev-dependencies]
-tikv-jemallocator = "0.5.0"
+tikv-jemallocator = { workspace = true }

--- a/crates/ruff_cache/Cargo.toml
+++ b/crates/ruff_cache/Cargo.toml
@@ -16,7 +16,7 @@ glob = { workspace = true }
 globset = { workspace = true }
 regex = { workspace = true }
 filetime = { workspace = true }
-seahash = "4.1.0"
+seahash = { workspace = true }
 
 [dev-dependencies]
 ruff_macros = { path = "../ruff_macros" }

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -27,23 +27,23 @@ ruff_text_size = { path = "../ruff_text_size" }
 ruff_workspace = { path = "../ruff_workspace" }
 
 anyhow = { workspace = true }
-argfile = { version = "0.1.6" }
-bincode = { version = "1.3.3" }
+argfile = { workspace = true }
+bincode = { workspace = true }
 bitflags = { workspace = true }
-cachedir = { version = "0.3.1" }
+cachedir = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
-clap_complete_command = { version = "0.5.1" }
-clearscreen = { version = "2.0.0" }
+clap_complete_command = { workspace = true }
+clearscreen = { workspace = true }
 colored = { workspace = true }
 filetime = { workspace = true }
 ignore = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
-notify = { version = "6.1.1" }
+notify = { workspace = true }
 path-absolutize = { workspace = true, features = ["once_cell_cache"] }
-rayon = { version = "1.8.0" }
+rayon = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
@@ -52,23 +52,23 @@ shellexpand = { workspace = true }
 strum = { workspace = true, features = [] }
 thiserror = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
-walkdir = { version = "2.3.2" }
-wild = { version = "2" }
+walkdir = { workspace = true }
+wild = { workspace = true }
 
 [dev-dependencies]
-assert_cmd = { version = "2.0.8" }
+assert_cmd = { workspace = true }
 # Avoid writing colored snapshots when running tests from the terminal
 colored = { workspace = true, features = ["no-color"]}
 insta = { workspace = true, features = ["filters", "json"] }
-insta-cmd = { version = "0.4.0" }
-tempfile = "3.8.1"
+insta-cmd = { workspace = true }
+tempfile = { workspace = true }
 test-case = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mimalloc = "0.1.39"
+mimalloc = { workspace = true }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
-tikv-jemallocator = "0.5.0"
+tikv-jemallocator = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -27,26 +27,27 @@ ruff_workspace = { path = "../ruff_workspace", features = ["schemars"]}
 anyhow = { workspace = true }
 clap = { workspace = true }
 ignore = { workspace = true }
-imara-diff = "0.1.5"
-indicatif = "0.17.7"
+imara-diff = { workspace = true }
+indicatif = { workspace = true }
 itertools = { workspace = true }
 libcst = { workspace = true }
-pretty_assertions = { version = "1.3.0" }
-rayon = "1.8.0"
+once_cell = { workspace = true }
+pretty_assertions = { workspace = true }
+rayon = { workspace = true }
 regex = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 similar = { workspace = true }
 strum = { workspace = true }
-tempfile = "3.8.1"
+tempfile = { workspace = true }
 toml = { workspace = true, features = ["parse"] }
 tracing = { workspace = true }
 tracing-indicatif = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [dev-dependencies]
-indoc = "2.0.4"
+indoc = { workspace = true }
 
 [features]
 # Turn off rayon for profiling

--- a/crates/ruff_formatter/Cargo.toml
+++ b/crates/ruff_formatter/Cargo.toml
@@ -15,7 +15,7 @@ ruff_cache = { path = "../ruff_cache" }
 ruff_macros = { path = "../ruff_macros" }
 ruff_text_size = { path = "../ruff_text_size" }
 
-drop_bomb = { version = "0.1.5" }
+drop_bomb = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/ruff_index/Cargo.toml
+++ b/crates/ruff_index/Cargo.toml
@@ -16,7 +16,7 @@ license = { workspace = true }
 ruff_macros = { path = "../ruff_macros" }
 
 [dev-dependencies]
-static_assertions = "1.1.0"
+static_assertions = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -29,38 +29,38 @@ ruff_python_parser = { path = "../ruff_python_parser" }
 ruff_source_file = { path = "../ruff_source_file", features = ["serde"] }
 ruff_text_size = { path = "../ruff_text_size" }
 
-aho-corasick = { version = "1.1.2" }
-annotate-snippets = { version = "0.9.2", features = ["color"] }
+aho-corasick = { workspace = true }
+annotate-snippets = { workspace = true, features = ["color"] }
 anyhow = { workspace = true }
 bitflags = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "string"], optional = true }
 colored = { workspace = true }
-fern = { version = "0.6.1" }
+fern = { workspace = true }
 glob = { workspace = true }
 globset = { workspace = true }
-imperative = { version = "1.0.4" }
+imperative = { workspace = true }
 is-macro = { workspace = true }
 is-wsl = { workspace = true }
 itertools = { workspace = true }
 libcst = { workspace = true }
 log = { workspace = true }
 memchr = { workspace = true }
-natord = { version = "1.0.9" }
+natord = { workspace = true }
 once_cell = { workspace = true }
 path-absolutize = { workspace = true, features = [
   "once_cell_cache",
   "use_unix_paths_on_wasm",
 ] }
-pathdiff = { version = "0.2.1" }
-pep440_rs = { version = "0.4.0", features = ["serde"] }
-pyproject-toml = { version = "0.8.1" }
-quick-junit = { version = "0.3.5" }
+pathdiff = { workspace = true }
+pep440_rs = { workspace = true, features = ["serde"] }
+pyproject-toml = { workspace = true }
+quick-junit = { workspace = true }
 regex = { workspace = true }
-result-like = { version = "0.5.0" }
+result-like = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
-semver = { version = "1.0.20" }
+semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 similar = { workspace = true }
@@ -69,18 +69,18 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
-typed-arena = { version = "2.0.2" }
+typed-arena = { workspace = true }
 unicode-width = { workspace = true }
 unicode_names2 = { workspace = true }
-url = { version = "2.2.2" }
+url = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-pretty_assertions = "1.3.0"
+pretty_assertions = { workspace = true }
 test-case = { workspace = true }
 # Disable colored output in tests
 colored = { workspace = true, features = ["no-color"] }
-tempfile = "3.8.1"
+tempfile = { workspace = true }
 
 [features]
 default = []

--- a/crates/ruff_notebook/Cargo.toml
+++ b/crates/ruff_notebook/Cargo.toml
@@ -22,7 +22,7 @@ itertools = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_with = { version = "3.4.0", default-features = false, features = ["macros"] }
+serde_with = { workspace = true, default-features = false, features = ["macros"] }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -23,7 +23,7 @@ itertools = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
 smallvec = { workspace = true }
-static_assertions = "1.1.0"
+static_assertions = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/ruff_python_formatter/Cargo.toml
+++ b/crates/ruff_python_formatter/Cargo.toml
@@ -24,7 +24,7 @@ ruff_text_size = { path = "../ruff_text_size" }
 anyhow = { workspace = true }
 bitflags = { workspace = true }
 clap = { workspace = true }
-countme = "3.0.1"
+countme = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/ruff_python_index/Cargo.toml
+++ b/crates/ruff_python_index/Cargo.toml
@@ -13,10 +13,9 @@ license = { workspace = true }
 [lib]
 
 [dependencies]
-ruff_python_trivia = { path = "../ruff_python_trivia" }
-
 ruff_python_ast = { path = "../ruff_python_ast" }
 ruff_python_parser = { path = "../ruff_python_parser" }
+ruff_python_trivia = { path = "../ruff_python_trivia" }
 ruff_source_file = { path = "../ruff_source_file" }
 ruff_text_size = { path = "../ruff_text_size" }
 

--- a/crates/ruff_python_literal/Cargo.toml
+++ b/crates/ruff_python_literal/Cargo.toml
@@ -13,14 +13,14 @@ license = { workspace = true }
 
 [dependencies]
 bitflags = { workspace = true }
-hexf-parse = "0.2.1"
-is-macro.workspace = true
+hexf-parse = { workspace = true }
+is-macro = { workspace = true }
 itertools = { workspace = true }
-lexical-parse-float = { version = "0.8.0", features = ["format"] }
-unic-ucd-category = "0.9"
+lexical-parse-float = { workspace = true, features = ["format"] }
+unic-ucd-category = { workspace = true }
 
 [dev-dependencies]
-rand = "0.8.5"
+rand = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -21,12 +21,12 @@ anyhow = { workspace = true }
 bitflags = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
-lalrpop-util = { version = "0.20.0", default-features = false }
+lalrpop-util = { workspace = true, default-features = false }
 memchr = { workspace = true }
 unicode-ident = { workspace = true }
 unicode_names2 = { workspace = true }
 rustc-hash = { workspace = true }
-static_assertions = "1.1.0"
+static_assertions = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/ruff_python_resolver/Cargo.toml
+++ b/crates/ruff_python_resolver/Cargo.toml
@@ -17,8 +17,8 @@ license = { workspace = true }
 log = { workspace = true }
 
 [dev-dependencies]
-env_logger = "0.10.1"
-tempfile = "3.8.1"
+env_logger = { workspace = true }
+tempfile = { workspace = true }
 insta = { workspace = true }
 
 [lints]

--- a/crates/ruff_shrinking/Cargo.toml
+++ b/crates/ruff_shrinking/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-fs-err = "2.11.0"
+fs-err = { workspace = true }
 regex = { workspace = true }
 ruff_python_ast = { path = "../ruff_python_ast" }
 ruff_python_parser = { path = "../ruff_python_parser" }
 ruff_text_size = { path = "../ruff_text_size" }
-shlex = "1.2.0"
+shlex = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/crates/ruff_text_size/Cargo.toml
+++ b/crates/ruff_text_size/Cargo.toml
@@ -10,8 +10,8 @@ serde = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
-serde_test = { version = "1.0.152" }
-static_assertions = { version = "1.1.0" }
+serde_test = { workspace = true }
+static_assertions = { workspace = true }
 
 [features]
 serde = ["dep:serde"]

--- a/crates/ruff_wasm/Cargo.toml
+++ b/crates/ruff_wasm/Cargo.toml
@@ -30,17 +30,16 @@ ruff_text_size = { path = "../ruff_text_size" }
 ruff_python_trivia = { path = "../ruff_python_trivia" }
 ruff_workspace = { path = "../ruff_workspace" }
 
-console_error_panic_hook = { version = "0.1.7", optional = true }
-console_log = { version = "1.0.0" }
+console_error_panic_hook = { workspace = true, optional = true }
+console_log = { workspace = true }
+js-sys = { workspace = true }
 log = { workspace = true }
-
 serde = { workspace = true }
-serde-wasm-bindgen = { version = "0.6.3" }
-wasm-bindgen = { version = "0.2.84" }
-js-sys = { version = "0.3.66" }
+serde-wasm-bindgen = { workspace = true }
+wasm-bindgen = { workspace = true }
 
 [dev-dependencies]
-wasm-bindgen-test = { version = "0.3.39" }
+wasm-bindgen-test = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ruff_workspace/Cargo.toml
+++ b/crates/ruff_workspace/Cargo.toml
@@ -23,7 +23,7 @@ ruff_macros = { path = "../ruff_macros" }
 
 anyhow = { workspace = true }
 colored = { workspace = true }
-dirs = { version = "5.0.0" }
+dirs = { workspace = true }
 ignore = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
@@ -32,7 +32,7 @@ glob = { workspace = true }
 globset = { workspace = true }
 once_cell = { workspace = true }
 path-absolutize = { workspace = true }
-pep440_rs = { version = "0.4.0", features = ["serde"] }
+pep440_rs = { workspace = true, features = ["serde"] }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
@@ -42,7 +42,7 @@ strum = { workspace = true }
 toml = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.8.1"
+tempfile = { workspace = true }
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

This PR modifies our `Cargo.toml` files to use workspace dependencies for _all_ dependencies, rather than the status quo of sporadically trying to use workspace dependencies for those dependencies that are used across multiple crates. I find the current situation more confusing and harder to manage, since we have a mix of workspace and crate-local dependencies, whereas this setup consistently uses the same approach for all dependencies.
