### PR TITLE
Short rule messages should not end with a period

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_any_all.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_any_all.rs
@@ -53,7 +53,7 @@ impl Violation for UnnecessaryComprehensionAnyAll {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary list comprehension.")
+        format!("Unnecessary list comprehension")
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C419_C419.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C419_C419.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_comprehensions/mod.rs
 ---
-C419.py:1:5: C419 [*] Unnecessary list comprehension.
+C419.py:1:5: C419 [*] Unnecessary list comprehension
   |
 1 | any([x.id for x in bar])
   |     ^^^^^^^^^^^^^^^^^^^ C419
@@ -17,7 +17,7 @@ C419.py:1:5: C419 [*] Unnecessary list comprehension.
 3 3 | any(  # first comment
 4 4 |     [x.id for x in bar],  # second comment
 
-C419.py:2:5: C419 [*] Unnecessary list comprehension.
+C419.py:2:5: C419 [*] Unnecessary list comprehension
   |
 1 | any([x.id for x in bar])
 2 | all([x.id for x in bar])
@@ -35,7 +35,7 @@ C419.py:2:5: C419 [*] Unnecessary list comprehension.
 4 4 |     [x.id for x in bar],  # second comment
 5 5 | )  # third comment
 
-C419.py:4:5: C419 [*] Unnecessary list comprehension.
+C419.py:4:5: C419 [*] Unnecessary list comprehension
   |
 2 | all([x.id for x in bar])
 3 | any(  # first comment
@@ -56,7 +56,7 @@ C419.py:4:5: C419 [*] Unnecessary list comprehension.
 6 6 | all(  # first comment
 7 7 |     [x.id for x in bar],  # second comment
 
-C419.py:7:5: C419 [*] Unnecessary list comprehension.
+C419.py:7:5: C419 [*] Unnecessary list comprehension
   |
 5 | )  # third comment
 6 | all(  # first comment
@@ -77,7 +77,7 @@ C419.py:7:5: C419 [*] Unnecessary list comprehension.
 9 9 | any({x.id for x in bar})
 10 10 | 
 
-C419.py:9:5: C419 [*] Unnecessary list comprehension.
+C419.py:9:5: C419 [*] Unnecessary list comprehension
    |
  7 |     [x.id for x in bar],  # second comment
  8 | )  # third comment
@@ -98,7 +98,7 @@ C419.py:9:5: C419 [*] Unnecessary list comprehension.
 11 11 | # OK
 12 12 | all(x.id for x in bar)
 
-C419.py:24:5: C419 [*] Unnecessary list comprehension.
+C419.py:24:5: C419 [*] Unnecessary list comprehension
    |
 22 |   # Special comment handling
 23 |   any(
@@ -133,7 +133,7 @@ C419.py:24:5: C419 [*] Unnecessary list comprehension.
 31 30 | )
 32 31 | 
 
-C419.py:35:5: C419 [*] Unnecessary list comprehension.
+C419.py:35:5: C419 [*] Unnecessary list comprehension
    |
 33 |   # Weird case where the function call, opening bracket, and comment are all
 34 |   # on the same line.

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_index_type.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_index_type.rs
@@ -41,10 +41,10 @@ impl Violation for InvalidIndexType {
             is_slice,
         } = self;
         if *is_slice {
-            format!("Slice in indexed access to type `{value_type}` uses type `{index_type}` instead of an integer.")
+            format!("Slice in indexed access to type `{value_type}` uses type `{index_type}` instead of an integer")
         } else {
             format!(
-                "Indexed access to type `{value_type}` uses type `{index_type}` instead of an integer or slice."
+                "Indexed access to type `{value_type}` uses type `{index_type}` instead of an integer or slice"
             )
         }
     }

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF016_RUF016.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF016_RUF016.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
-RUF016.py:20:13: RUF016 Indexed access to type `str` uses type `str` instead of an integer or slice.
+RUF016.py:20:13: RUF016 Indexed access to type `str` uses type `str` instead of an integer or slice
    |
 19 | # Should emit for invalid access on strings
 20 | var = "abc"["x"]
@@ -9,7 +9,7 @@ RUF016.py:20:13: RUF016 Indexed access to type `str` uses type `str` instead of 
 21 | var = f"abc"["x"]
    |
 
-RUF016.py:21:14: RUF016 Indexed access to type `str` uses type `str` instead of an integer or slice.
+RUF016.py:21:14: RUF016 Indexed access to type `str` uses type `str` instead of an integer or slice
    |
 19 | # Should emit for invalid access on strings
 20 | var = "abc"["x"]
@@ -19,7 +19,7 @@ RUF016.py:21:14: RUF016 Indexed access to type `str` uses type `str` instead of 
 23 | # Should emit for invalid access on bytes
    |
 
-RUF016.py:24:14: RUF016 Indexed access to type `bytes` uses type `str` instead of an integer or slice.
+RUF016.py:24:14: RUF016 Indexed access to type `bytes` uses type `str` instead of an integer or slice
    |
 23 | # Should emit for invalid access on bytes
 24 | var = b"abc"["x"]
@@ -28,7 +28,7 @@ RUF016.py:24:14: RUF016 Indexed access to type `bytes` uses type `str` instead o
 26 | # Should emit for invalid access on lists and tuples
    |
 
-RUF016.py:27:17: RUF016 Indexed access to type `list` uses type `str` instead of an integer or slice.
+RUF016.py:27:17: RUF016 Indexed access to type `list` uses type `str` instead of an integer or slice
    |
 26 | # Should emit for invalid access on lists and tuples
 27 | var = [1, 2, 3]["x"]
@@ -36,7 +36,7 @@ RUF016.py:27:17: RUF016 Indexed access to type `list` uses type `str` instead of
 28 | var = (1, 2, 3)["x"]
    |
 
-RUF016.py:28:17: RUF016 Indexed access to type `tuple` uses type `str` instead of an integer or slice.
+RUF016.py:28:17: RUF016 Indexed access to type `tuple` uses type `str` instead of an integer or slice
    |
 26 | # Should emit for invalid access on lists and tuples
 27 | var = [1, 2, 3]["x"]
@@ -46,7 +46,7 @@ RUF016.py:28:17: RUF016 Indexed access to type `tuple` uses type `str` instead o
 30 | # Should emit for invalid access on list comprehensions
    |
 
-RUF016.py:31:30: RUF016 Indexed access to type `list comprehension` uses type `str` instead of an integer or slice.
+RUF016.py:31:30: RUF016 Indexed access to type `list comprehension` uses type `str` instead of an integer or slice
    |
 30 | # Should emit for invalid access on list comprehensions
 31 | var = [x for x in range(10)]["x"]
@@ -55,7 +55,7 @@ RUF016.py:31:30: RUF016 Indexed access to type `list comprehension` uses type `s
 33 | # Should emit for invalid access using tuple
    |
 
-RUF016.py:34:13: RUF016 Indexed access to type `str` uses type `tuple` instead of an integer or slice.
+RUF016.py:34:13: RUF016 Indexed access to type `str` uses type `tuple` instead of an integer or slice
    |
 33 | # Should emit for invalid access using tuple
 34 | var = "abc"[1, 2]
@@ -64,7 +64,7 @@ RUF016.py:34:13: RUF016 Indexed access to type `str` uses type `tuple` instead o
 36 | # Should emit for invalid access using string
    |
 
-RUF016.py:37:14: RUF016 Indexed access to type `list` uses type `str` instead of an integer or slice.
+RUF016.py:37:14: RUF016 Indexed access to type `list` uses type `str` instead of an integer or slice
    |
 36 | # Should emit for invalid access using string
 37 | var = [1, 2]["x"]
@@ -73,7 +73,7 @@ RUF016.py:37:14: RUF016 Indexed access to type `list` uses type `str` instead of
 39 | # Should emit for invalid access using float
    |
 
-RUF016.py:40:14: RUF016 Indexed access to type `list` uses type `float` instead of an integer or slice.
+RUF016.py:40:14: RUF016 Indexed access to type `list` uses type `float` instead of an integer or slice
    |
 39 | # Should emit for invalid access using float
 40 | var = [1, 2][0.25]
@@ -82,7 +82,7 @@ RUF016.py:40:14: RUF016 Indexed access to type `list` uses type `float` instead 
 42 | # Should emit for invalid access using dict
    |
 
-RUF016.py:43:14: RUF016 Indexed access to type `list` uses type `dict` instead of an integer or slice.
+RUF016.py:43:14: RUF016 Indexed access to type `list` uses type `dict` instead of an integer or slice
    |
 42 | # Should emit for invalid access using dict
 43 | var = [1, 2][{"x": "y"}]
@@ -91,7 +91,7 @@ RUF016.py:43:14: RUF016 Indexed access to type `list` uses type `dict` instead o
 45 | # Should emit for invalid access using dict comp
    |
 
-RUF016.py:46:14: RUF016 Indexed access to type `list` uses type `dict comprehension` instead of an integer or slice.
+RUF016.py:46:14: RUF016 Indexed access to type `list` uses type `dict comprehension` instead of an integer or slice
    |
 45 | # Should emit for invalid access using dict comp
 46 | var = [1, 2][{x: "y" for x in range(2)}]
@@ -100,7 +100,7 @@ RUF016.py:46:14: RUF016 Indexed access to type `list` uses type `dict comprehens
 48 | # Should emit for invalid access using list 
    |
 
-RUF016.py:49:14: RUF016 Indexed access to type `list` uses type `tuple` instead of an integer or slice.
+RUF016.py:49:14: RUF016 Indexed access to type `list` uses type `tuple` instead of an integer or slice
    |
 48 | # Should emit for invalid access using list 
 49 | var = [1, 2][2, 3]
@@ -109,7 +109,7 @@ RUF016.py:49:14: RUF016 Indexed access to type `list` uses type `tuple` instead 
 51 | # Should emit for invalid access using list comp
    |
 
-RUF016.py:52:14: RUF016 Indexed access to type `list` uses type `list comprehension` instead of an integer or slice.
+RUF016.py:52:14: RUF016 Indexed access to type `list` uses type `list comprehension` instead of an integer or slice
    |
 51 | # Should emit for invalid access using list comp
 52 | var = [1, 2][[x for x in range(2)]]
@@ -118,7 +118,7 @@ RUF016.py:52:14: RUF016 Indexed access to type `list` uses type `list comprehens
 54 | # Should emit on invalid access using set
    |
 
-RUF016.py:55:14: RUF016 Indexed access to type `list` uses type `set` instead of an integer or slice.
+RUF016.py:55:14: RUF016 Indexed access to type `list` uses type `set` instead of an integer or slice
    |
 54 | # Should emit on invalid access using set
 55 | var = [1, 2][{"x", "y"}]
@@ -127,7 +127,7 @@ RUF016.py:55:14: RUF016 Indexed access to type `list` uses type `set` instead of
 57 | # Should emit on invalid access using set comp
    |
 
-RUF016.py:58:14: RUF016 Indexed access to type `list` uses type `set comprehension` instead of an integer or slice.
+RUF016.py:58:14: RUF016 Indexed access to type `list` uses type `set comprehension` instead of an integer or slice
    |
 57 | # Should emit on invalid access using set comp
 58 | var = [1, 2][{x for x in range(2)}]
@@ -136,7 +136,7 @@ RUF016.py:58:14: RUF016 Indexed access to type `list` uses type `set comprehensi
 60 | # Should emit on invalid access using bytes
    |
 
-RUF016.py:61:14: RUF016 Indexed access to type `list` uses type `bytes` instead of an integer or slice.
+RUF016.py:61:14: RUF016 Indexed access to type `list` uses type `bytes` instead of an integer or slice
    |
 60 | # Should emit on invalid access using bytes
 61 | var = [1, 2][b"x"]
@@ -145,7 +145,7 @@ RUF016.py:61:14: RUF016 Indexed access to type `list` uses type `bytes` instead 
 63 | # Should emit for non-integer slice start
    |
 
-RUF016.py:64:17: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer.
+RUF016.py:64:17: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
    |
 63 | # Should emit for non-integer slice start
 64 | var = [1, 2, 3]["x":2]
@@ -154,7 +154,7 @@ RUF016.py:64:17: RUF016 Slice in indexed access to type `list` uses type `str` i
 66 | var = [1, 2, 3][1.2:2]
    |
 
-RUF016.py:65:17: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer.
+RUF016.py:65:17: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
    |
 63 | # Should emit for non-integer slice start
 64 | var = [1, 2, 3]["x":2]
@@ -164,7 +164,7 @@ RUF016.py:65:17: RUF016 Slice in indexed access to type `list` uses type `str` i
 67 | var = [1, 2, 3][{"x"}:2]
    |
 
-RUF016.py:66:17: RUF016 Slice in indexed access to type `list` uses type `float` instead of an integer.
+RUF016.py:66:17: RUF016 Slice in indexed access to type `list` uses type `float` instead of an integer
    |
 64 | var = [1, 2, 3]["x":2]
 65 | var = [1, 2, 3][f"x":2]
@@ -174,7 +174,7 @@ RUF016.py:66:17: RUF016 Slice in indexed access to type `list` uses type `float`
 68 | var = [1, 2, 3][{x for x in range(2)}:2]
    |
 
-RUF016.py:67:17: RUF016 Slice in indexed access to type `list` uses type `set` instead of an integer.
+RUF016.py:67:17: RUF016 Slice in indexed access to type `list` uses type `set` instead of an integer
    |
 65 | var = [1, 2, 3][f"x":2]
 66 | var = [1, 2, 3][1.2:2]
@@ -184,7 +184,7 @@ RUF016.py:67:17: RUF016 Slice in indexed access to type `list` uses type `set` i
 69 | var = [1, 2, 3][{"x": x for x in range(2)}:2]
    |
 
-RUF016.py:68:17: RUF016 Slice in indexed access to type `list` uses type `set comprehension` instead of an integer.
+RUF016.py:68:17: RUF016 Slice in indexed access to type `list` uses type `set comprehension` instead of an integer
    |
 66 | var = [1, 2, 3][1.2:2]
 67 | var = [1, 2, 3][{"x"}:2]
@@ -194,7 +194,7 @@ RUF016.py:68:17: RUF016 Slice in indexed access to type `list` uses type `set co
 70 | var = [1, 2, 3][[x for x in range(2)]:2]
    |
 
-RUF016.py:69:17: RUF016 Slice in indexed access to type `list` uses type `dict comprehension` instead of an integer.
+RUF016.py:69:17: RUF016 Slice in indexed access to type `list` uses type `dict comprehension` instead of an integer
    |
 67 | var = [1, 2, 3][{"x"}:2]
 68 | var = [1, 2, 3][{x for x in range(2)}:2]
@@ -203,7 +203,7 @@ RUF016.py:69:17: RUF016 Slice in indexed access to type `list` uses type `dict c
 70 | var = [1, 2, 3][[x for x in range(2)]:2]
    |
 
-RUF016.py:70:17: RUF016 Slice in indexed access to type `list` uses type `list comprehension` instead of an integer.
+RUF016.py:70:17: RUF016 Slice in indexed access to type `list` uses type `list comprehension` instead of an integer
    |
 68 | var = [1, 2, 3][{x for x in range(2)}:2]
 69 | var = [1, 2, 3][{"x": x for x in range(2)}:2]
@@ -213,7 +213,7 @@ RUF016.py:70:17: RUF016 Slice in indexed access to type `list` uses type `list c
 72 | # Should emit for non-integer slice end
    |
 
-RUF016.py:73:19: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer.
+RUF016.py:73:19: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
    |
 72 | # Should emit for non-integer slice end
 73 | var = [1, 2, 3][0:"x"]
@@ -222,7 +222,7 @@ RUF016.py:73:19: RUF016 Slice in indexed access to type `list` uses type `str` i
 75 | var = [1, 2, 3][0:1.2]
    |
 
-RUF016.py:74:19: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer.
+RUF016.py:74:19: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
    |
 72 | # Should emit for non-integer slice end
 73 | var = [1, 2, 3][0:"x"]
@@ -232,7 +232,7 @@ RUF016.py:74:19: RUF016 Slice in indexed access to type `list` uses type `str` i
 76 | var = [1, 2, 3][0:{"x"}]
    |
 
-RUF016.py:75:19: RUF016 Slice in indexed access to type `list` uses type `float` instead of an integer.
+RUF016.py:75:19: RUF016 Slice in indexed access to type `list` uses type `float` instead of an integer
    |
 73 | var = [1, 2, 3][0:"x"]
 74 | var = [1, 2, 3][0:f"x"]
@@ -242,7 +242,7 @@ RUF016.py:75:19: RUF016 Slice in indexed access to type `list` uses type `float`
 77 | var = [1, 2, 3][0:{x for x in range(2)}]
    |
 
-RUF016.py:76:19: RUF016 Slice in indexed access to type `list` uses type `set` instead of an integer.
+RUF016.py:76:19: RUF016 Slice in indexed access to type `list` uses type `set` instead of an integer
    |
 74 | var = [1, 2, 3][0:f"x"]
 75 | var = [1, 2, 3][0:1.2]
@@ -252,7 +252,7 @@ RUF016.py:76:19: RUF016 Slice in indexed access to type `list` uses type `set` i
 78 | var = [1, 2, 3][0:{"x": x for x in range(2)}]
    |
 
-RUF016.py:77:19: RUF016 Slice in indexed access to type `list` uses type `set comprehension` instead of an integer.
+RUF016.py:77:19: RUF016 Slice in indexed access to type `list` uses type `set comprehension` instead of an integer
    |
 75 | var = [1, 2, 3][0:1.2]
 76 | var = [1, 2, 3][0:{"x"}]
@@ -262,7 +262,7 @@ RUF016.py:77:19: RUF016 Slice in indexed access to type `list` uses type `set co
 79 | var = [1, 2, 3][0:[x for x in range(2)]]
    |
 
-RUF016.py:78:19: RUF016 Slice in indexed access to type `list` uses type `dict comprehension` instead of an integer.
+RUF016.py:78:19: RUF016 Slice in indexed access to type `list` uses type `dict comprehension` instead of an integer
    |
 76 | var = [1, 2, 3][0:{"x"}]
 77 | var = [1, 2, 3][0:{x for x in range(2)}]
@@ -271,7 +271,7 @@ RUF016.py:78:19: RUF016 Slice in indexed access to type `list` uses type `dict c
 79 | var = [1, 2, 3][0:[x for x in range(2)]]
    |
 
-RUF016.py:79:19: RUF016 Slice in indexed access to type `list` uses type `list comprehension` instead of an integer.
+RUF016.py:79:19: RUF016 Slice in indexed access to type `list` uses type `list comprehension` instead of an integer
    |
 77 | var = [1, 2, 3][0:{x for x in range(2)}]
 78 | var = [1, 2, 3][0:{"x": x for x in range(2)}]
@@ -281,7 +281,7 @@ RUF016.py:79:19: RUF016 Slice in indexed access to type `list` uses type `list c
 81 | # Should emit for non-integer slice step
    |
 
-RUF016.py:82:21: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer.
+RUF016.py:82:21: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
    |
 81 | # Should emit for non-integer slice step
 82 | var = [1, 2, 3][0:1:"x"]
@@ -290,7 +290,7 @@ RUF016.py:82:21: RUF016 Slice in indexed access to type `list` uses type `str` i
 84 | var = [1, 2, 3][0:1:1.2]
    |
 
-RUF016.py:83:21: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer.
+RUF016.py:83:21: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
    |
 81 | # Should emit for non-integer slice step
 82 | var = [1, 2, 3][0:1:"x"]
@@ -300,7 +300,7 @@ RUF016.py:83:21: RUF016 Slice in indexed access to type `list` uses type `str` i
 85 | var = [1, 2, 3][0:1:{"x"}]
    |
 
-RUF016.py:84:21: RUF016 Slice in indexed access to type `list` uses type `float` instead of an integer.
+RUF016.py:84:21: RUF016 Slice in indexed access to type `list` uses type `float` instead of an integer
    |
 82 | var = [1, 2, 3][0:1:"x"]
 83 | var = [1, 2, 3][0:1:f"x"]
@@ -310,7 +310,7 @@ RUF016.py:84:21: RUF016 Slice in indexed access to type `list` uses type `float`
 86 | var = [1, 2, 3][0:1:{x for x in range(2)}]
    |
 
-RUF016.py:85:21: RUF016 Slice in indexed access to type `list` uses type `set` instead of an integer.
+RUF016.py:85:21: RUF016 Slice in indexed access to type `list` uses type `set` instead of an integer
    |
 83 | var = [1, 2, 3][0:1:f"x"]
 84 | var = [1, 2, 3][0:1:1.2]
@@ -320,7 +320,7 @@ RUF016.py:85:21: RUF016 Slice in indexed access to type `list` uses type `set` i
 87 | var = [1, 2, 3][0:1:{"x": x for x in range(2)}]
    |
 
-RUF016.py:86:21: RUF016 Slice in indexed access to type `list` uses type `set comprehension` instead of an integer.
+RUF016.py:86:21: RUF016 Slice in indexed access to type `list` uses type `set comprehension` instead of an integer
    |
 84 | var = [1, 2, 3][0:1:1.2]
 85 | var = [1, 2, 3][0:1:{"x"}]
@@ -330,7 +330,7 @@ RUF016.py:86:21: RUF016 Slice in indexed access to type `list` uses type `set co
 88 | var = [1, 2, 3][0:1:[x for x in range(2)]]
    |
 
-RUF016.py:87:21: RUF016 Slice in indexed access to type `list` uses type `dict comprehension` instead of an integer.
+RUF016.py:87:21: RUF016 Slice in indexed access to type `list` uses type `dict comprehension` instead of an integer
    |
 85 | var = [1, 2, 3][0:1:{"x"}]
 86 | var = [1, 2, 3][0:1:{x for x in range(2)}]
@@ -339,7 +339,7 @@ RUF016.py:87:21: RUF016 Slice in indexed access to type `list` uses type `dict c
 88 | var = [1, 2, 3][0:1:[x for x in range(2)]]
    |
 
-RUF016.py:88:21: RUF016 Slice in indexed access to type `list` uses type `list comprehension` instead of an integer.
+RUF016.py:88:21: RUF016 Slice in indexed access to type `list` uses type `list comprehension` instead of an integer
    |
 86 | var = [1, 2, 3][0:1:{x for x in range(2)}]
 87 | var = [1, 2, 3][0:1:{"x": x for x in range(2)}]
@@ -349,7 +349,7 @@ RUF016.py:88:21: RUF016 Slice in indexed access to type `list` uses type `list c
 90 | # Should emit for non-integer slice start and end; should emit twice with specific ranges
    |
 
-RUF016.py:91:17: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer.
+RUF016.py:91:17: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
    |
 90 | # Should emit for non-integer slice start and end; should emit twice with specific ranges
 91 | var = [1, 2, 3]["x":"y"]
@@ -358,7 +358,7 @@ RUF016.py:91:17: RUF016 Slice in indexed access to type `list` uses type `str` i
 93 | # Should emit once for repeated invalid access
    |
 
-RUF016.py:91:21: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer.
+RUF016.py:91:21: RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
    |
 90 | # Should emit for non-integer slice start and end; should emit twice with specific ranges
 91 | var = [1, 2, 3]["x":"y"]
@@ -367,7 +367,7 @@ RUF016.py:91:21: RUF016 Slice in indexed access to type `list` uses type `str` i
 93 | # Should emit once for repeated invalid access
    |
 
-RUF016.py:94:17: RUF016 Indexed access to type `list` uses type `str` instead of an integer or slice.
+RUF016.py:94:17: RUF016 Indexed access to type `list` uses type `str` instead of an integer or slice
    |
 93 | # Should emit once for repeated invalid access
 94 | var = [1, 2, 3]["x"]["y"]["z"]


### PR DESCRIPTION
## Summary

Remove the period from a couple short messages, for consistency with all other short messages.

All other short rule messages lack such a period, except for long messages made of multiple sentences.

## Test Plan

Tests modified accordingly.

Not sure if this would qualify as a breaking change because user-visible messages are modified.