### PR TITLE
Fix typos found by codespell

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM117.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM117.py
@@ -159,7 +159,7 @@ async with asyncio.timeout(1):
                                 async with trio.move_on_at(1):
                                     pass
 
-# Do not supress combination, if a context manager is already combined with another.
+# Do not suppress combination, if a context manager is already combined with another.
 async with asyncio.timeout(1), A():
     async with B():
         pass

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.py
@@ -39,7 +39,7 @@ class Foo:
     TCLS = typing.TypeVar["TCLS"]
     y: typing.TypeAlias = list[TCLS]
 
-# UP040 wont add generics in fix
+# UP040 won't add generics in fix
 T = typing.TypeVar(*args)
 x: typing.TypeAlias = list[T]
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM117_SIM117.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM117_SIM117.py.snap
@@ -322,7 +322,7 @@ SIM117.py:126:1: SIM117 [*] Use a single `with` statement with multiple contexts
 
 SIM117.py:163:1: SIM117 [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
     |
-162 |   # Do not supress combination, if a context manager is already combined with another.
+162 |   # Do not suppress combination, if a context manager is already combined with another.
 163 | / async with asyncio.timeout(1), A():
 164 | |     async with B():
     | |___________________^ SIM117
@@ -333,7 +333,7 @@ SIM117.py:163:1: SIM117 [*] Use a single `with` statement with multiple contexts
 ℹ Unsafe fix
 160 160 |                                     pass
 161 161 | 
-162 162 | # Do not supress combination, if a context manager is already combined with another.
+162 162 | # Do not suppress combination, if a context manager is already combined with another.
 163     |-async with asyncio.timeout(1), A():
 164     |-    async with B():
 165     |-        pass

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py.snap
@@ -195,7 +195,7 @@ UP040.py:40:5: UP040 [*] Type alias `y` uses `TypeAlias` annotation instead of t
 40 |     y: typing.TypeAlias = list[TCLS]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
 41 | 
-42 | # UP040 wont add generics in fix
+42 | # UP040 won't add generics in fix
    |
    = help: Use the `type` keyword
 
@@ -206,12 +206,12 @@ UP040.py:40:5: UP040 [*] Type alias `y` uses `TypeAlias` annotation instead of t
 40    |-    y: typing.TypeAlias = list[TCLS]
    40 |+    type y[TCLS] = list[TCLS]
 41 41 | 
-42 42 | # UP040 wont add generics in fix
+42 42 | # UP040 won't add generics in fix
 43 43 | T = typing.TypeVar(*args)
 
 UP040.py:44:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
    |
-42 | # UP040 wont add generics in fix
+42 | # UP040 won't add generics in fix
 43 | T = typing.TypeVar(*args)
 44 | x: typing.TypeAlias = list[T]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
@@ -222,7 +222,7 @@ UP040.py:44:1: UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of t
 
 ℹ Unsafe fix
 41 41 | 
-42 42 | # UP040 wont add generics in fix
+42 42 | # UP040 won't add generics in fix
 43 43 | T = typing.TypeVar(*args)
 44    |-x: typing.TypeAlias = list[T]
    44 |+type x = list[T]

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/line_ranges_basic.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/line_ranges_basic.py
@@ -5,7 +5,7 @@ def foo2(parameter_1, parameter_2, parameter_3, parameter_4, parameter_5, parame
 def foo3(parameter_1, parameter_2, parameter_3, parameter_4, parameter_5, parameter_6, parameter_7): pass
 def foo4(parameter_1, parameter_2, parameter_3, parameter_4, parameter_5, parameter_6, parameter_7): pass
 
-# Adding some unformated code covering a wide range of syntaxes.
+# Adding some unformatted code covering a wide range of syntaxes.
 
 if True:
       # Incorrectly indented prefix comments.

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/line_ranges_basic.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/line_ranges_basic.py.expect
@@ -28,7 +28,7 @@ def foo3(
 
 def foo4(parameter_1, parameter_2, parameter_3, parameter_4, parameter_5, parameter_6, parameter_7): pass
 
-# Adding some unformated code covering a wide range of syntaxes.
+# Adding some unformatted code covering a wide range of syntaxes.
 
 if True:
       # Incorrectly indented prefix comments.

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep604_union_types_line_breaks.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep604_union_types_line_breaks.py
@@ -19,7 +19,7 @@ z: (Short
 z: (int) = 2.3
 z: ((int)) = foo()
 
-# In case I go for not enforcing parantheses, this might get improved at the same time
+# In case I go for not enforcing parentheses, this might get improved at the same time
 x = (
     z
     == 9999999999999999999999999999999999999999

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep604_union_types_line_breaks.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/pep604_union_types_line_breaks.py.expect
@@ -28,7 +28,7 @@ z: Short | Short2 | Short3 | Short4 = 8
 z: int = 2.3
 z: int = foo()
 
-# In case I go for not enforcing parantheses, this might get improved at the same time
+# In case I go for not enforcing parentheses, this might get improved at the same time
 x = (
     z
     == 9999999999999999999999999999999999999999

--- a/crates/ruff_python_formatter/resources/test/fixtures/import_black_tests.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/import_black_tests.py
@@ -32,7 +32,7 @@ def import_fixture(fixture: Path, fixture_set: str):
                 input.append(line)
 
         if not expected:
-            # If there's no output marker, tread the whole file as already pre-formatted
+            # If there's no output marker, treat the whole file as already pre-formatted
             expected = input
 
         options = {}

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_code_examples.py
@@ -227,7 +227,7 @@ def doctest_varying_start_column():
 # actually extend past the configured line limit.
 #
 # It's not quite clear whether this is desirable or not. We could in
-# theory compute the intendation length of a code snippet and then
+# theory compute the indentation length of a code snippet and then
 # adjust the line-width setting on a recursive call to the formatter.
 # But there are assuredly pathological cases to consider. Another path
 # would be to expose another formatter option for controlling the
@@ -244,7 +244,7 @@ def doctest_long_lines():
     But this one is long enough to get wrapped.
     >>> foo, bar, quux = this_is_a_long_line(lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard)
     '''
-    # This demostrates a normal line that will get wrapped but won't
+    # This demonstrates a normal line that will get wrapped but won't
     # get wrapped in the docstring above because of how the line-width
     # setting gets reset at the first column in each code snippet.
     foo, bar, quux = this_is_a_long_line(lion, giraffe, hippo, zeba, lemur, penguin, monkey)

--- a/crates/ruff_python_formatter/src/expression/binary_like.rs
+++ b/crates/ruff_python_formatter/src/expression/binary_like.rs
@@ -657,7 +657,7 @@ impl<'a> FlatBinaryExpressionSlice<'a> {
 /// The formatting is recursive (with a depth of `O(operators)` where `operators` are operators with different precedences).
 ///
 /// Comments before or after the first operand must be formatted by the caller because they shouldn't be part of the group
-/// wrapping the whole binary chain. This is to avoid that `b * c` expands in the following example because of its trailing comemnt:
+/// wrapping the whole binary chain. This is to avoid that `b * c` expands in the following example because of its trailing comment:
 ///
 /// ```python
 ///

--- a/crates/ruff_python_formatter/src/string/mod.rs
+++ b/crates/ruff_python_formatter/src/string/mod.rs
@@ -941,7 +941,7 @@ impl UnicodeEscape {
                             }
                         }
                     } else {
-                        // Unterminated escape sequence, dont' normalise it.
+                        // Unterminated escape sequence, don't normalise it.
                         return None;
                     }
                 }

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__line_ranges_basic.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__line_ranges_basic.py.snap
@@ -12,7 +12,7 @@ def foo2(parameter_1, parameter_2, parameter_3, parameter_4, parameter_5, parame
 def foo3(parameter_1, parameter_2, parameter_3, parameter_4, parameter_5, parameter_6, parameter_7): pass
 def foo4(parameter_1, parameter_2, parameter_3, parameter_4, parameter_5, parameter_6, parameter_7): pass
 
-# Adding some unformated code covering a wide range of syntaxes.
+# Adding some unformatted code covering a wide range of syntaxes.
 
 if True:
       # Incorrectly indented prefix comments.
@@ -89,7 +89,7 @@ async  def  test_async_unformatted(  ):    # Trailing comment with extra leading
 +    pass
 +
  
- # Adding some unformated code covering a wide range of syntaxes.
+ # Adding some unformatted code covering a wide range of syntaxes.
  
  if True:
 -      # Incorrectly indented prefix comments.
@@ -207,7 +207,7 @@ def foo4(
     pass
 
 
-# Adding some unformated code covering a wide range of syntaxes.
+# Adding some unformatted code covering a wide range of syntaxes.
 
 if True:
     # Incorrectly indented prefix comments.
@@ -279,7 +279,7 @@ def foo3(
 
 def foo4(parameter_1, parameter_2, parameter_3, parameter_4, parameter_5, parameter_6, parameter_7): pass
 
-# Adding some unformated code covering a wide range of syntaxes.
+# Adding some unformatted code covering a wide range of syntaxes.
 
 if True:
       # Incorrectly indented prefix comments.

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pep604_union_types_line_breaks.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__pep604_union_types_line_breaks.py.snap
@@ -26,7 +26,7 @@ z: (Short
 z: (int) = 2.3
 z: ((int)) = foo()
 
-# In case I go for not enforcing parantheses, this might get improved at the same time
+# In case I go for not enforcing parentheses, this might get improved at the same time
 x = (
     z
     == 9999999999999999999999999999999999999999
@@ -165,7 +165,7 @@ z: Short | Short2 | Short3 | Short4 = 8
 z: int = 2.3
 z: int = foo()
 
-# In case I go for not enforcing parantheses, this might get improved at the same time
+# In case I go for not enforcing parentheses, this might get improved at the same time
 x = (
     z
     == 9999999999999999999999999999999999999999
@@ -269,7 +269,7 @@ z: Short | Short2 | Short3 | Short4 = 8
 z: int = 2.3
 z: int = foo()
 
-# In case I go for not enforcing parantheses, this might get improved at the same time
+# In case I go for not enforcing parentheses, this might get improved at the same time
 x = (
     z
     == 9999999999999999999999999999999999999999

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
@@ -233,7 +233,7 @@ def doctest_varying_start_column():
 # actually extend past the configured line limit.
 #
 # It's not quite clear whether this is desirable or not. We could in
-# theory compute the intendation length of a code snippet and then
+# theory compute the indentation length of a code snippet and then
 # adjust the line-width setting on a recursive call to the formatter.
 # But there are assuredly pathological cases to consider. Another path
 # would be to expose another formatter option for controlling the
@@ -250,7 +250,7 @@ def doctest_long_lines():
     But this one is long enough to get wrapped.
     >>> foo, bar, quux = this_is_a_long_line(lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard)
     '''
-    # This demostrates a normal line that will get wrapped but won't
+    # This demonstrates a normal line that will get wrapped but won't
     # get wrapped in the docstring above because of how the line-width
     # setting gets reset at the first column in each code snippet.
     foo, bar, quux = this_is_a_long_line(lion, giraffe, hippo, zeba, lemur, penguin, monkey)
@@ -1601,7 +1601,7 @@ def doctest_varying_start_column():
 # actually extend past the configured line limit.
 #
 # It's not quite clear whether this is desirable or not. We could in
-# theory compute the intendation length of a code snippet and then
+# theory compute the indentation length of a code snippet and then
 # adjust the line-width setting on a recursive call to the formatter.
 # But there are assuredly pathological cases to consider. Another path
 # would be to expose another formatter option for controlling the
@@ -1618,7 +1618,7 @@ def doctest_long_lines():
     But this one is long enough to get wrapped.
     >>> foo, bar, quux = this_is_a_long_line(lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard)
     """
-    # This demostrates a normal line that will get wrapped but won't
+    # This demonstrates a normal line that will get wrapped but won't
     # get wrapped in the docstring above because of how the line-width
     # setting gets reset at the first column in each code snippet.
     foo, bar, quux = this_is_a_long_line(
@@ -2972,7 +2972,7 @@ def doctest_varying_start_column():
 # actually extend past the configured line limit.
 #
 # It's not quite clear whether this is desirable or not. We could in
-# theory compute the intendation length of a code snippet and then
+# theory compute the indentation length of a code snippet and then
 # adjust the line-width setting on a recursive call to the formatter.
 # But there are assuredly pathological cases to consider. Another path
 # would be to expose another formatter option for controlling the
@@ -2989,7 +2989,7 @@ def doctest_long_lines():
   But this one is long enough to get wrapped.
   >>> foo, bar, quux = this_is_a_long_line(lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard)
   """
-  # This demostrates a normal line that will get wrapped but won't
+  # This demonstrates a normal line that will get wrapped but won't
   # get wrapped in the docstring above because of how the line-width
   # setting gets reset at the first column in each code snippet.
   foo, bar, quux = this_is_a_long_line(
@@ -4343,7 +4343,7 @@ def doctest_varying_start_column():
 # actually extend past the configured line limit.
 #
 # It's not quite clear whether this is desirable or not. We could in
-# theory compute the intendation length of a code snippet and then
+# theory compute the indentation length of a code snippet and then
 # adjust the line-width setting on a recursive call to the formatter.
 # But there are assuredly pathological cases to consider. Another path
 # would be to expose another formatter option for controlling the
@@ -4360,7 +4360,7 @@ def doctest_long_lines():
 	But this one is long enough to get wrapped.
 	>>> foo, bar, quux = this_is_a_long_line(lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard)
 	"""
-	# This demostrates a normal line that will get wrapped but won't
+	# This demonstrates a normal line that will get wrapped but won't
 	# get wrapped in the docstring above because of how the line-width
 	# setting gets reset at the first column in each code snippet.
 	foo, bar, quux = this_is_a_long_line(
@@ -5714,7 +5714,7 @@ def doctest_varying_start_column():
 # actually extend past the configured line limit.
 #
 # It's not quite clear whether this is desirable or not. We could in
-# theory compute the intendation length of a code snippet and then
+# theory compute the indentation length of a code snippet and then
 # adjust the line-width setting on a recursive call to the formatter.
 # But there are assuredly pathological cases to consider. Another path
 # would be to expose another formatter option for controlling the
@@ -5731,7 +5731,7 @@ def doctest_long_lines():
 	But this one is long enough to get wrapped.
 	>>> foo, bar, quux = this_is_a_long_line(lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard)
 	"""
-	# This demostrates a normal line that will get wrapped but won't
+	# This demonstrates a normal line that will get wrapped but won't
 	# get wrapped in the docstring above because of how the line-width
 	# setting gets reset at the first column in each code snippet.
 	foo, bar, quux = this_is_a_long_line(
@@ -7083,7 +7083,7 @@ def doctest_varying_start_column():
 # actually extend past the configured line limit.
 #
 # It's not quite clear whether this is desirable or not. We could in
-# theory compute the intendation length of a code snippet and then
+# theory compute the indentation length of a code snippet and then
 # adjust the line-width setting on a recursive call to the formatter.
 # But there are assuredly pathological cases to consider. Another path
 # would be to expose another formatter option for controlling the
@@ -7104,7 +7104,7 @@ def doctest_long_lines():
     ...     lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard
     ... )
     """
-    # This demostrates a normal line that will get wrapped but won't
+    # This demonstrates a normal line that will get wrapped but won't
     # get wrapped in the docstring above because of how the line-width
     # setting gets reset at the first column in each code snippet.
     foo, bar, quux = this_is_a_long_line(
@@ -8451,7 +8451,7 @@ def doctest_varying_start_column():
 # actually extend past the configured line limit.
 #
 # It's not quite clear whether this is desirable or not. We could in
-# theory compute the intendation length of a code snippet and then
+# theory compute the indentation length of a code snippet and then
 # adjust the line-width setting on a recursive call to the formatter.
 # But there are assuredly pathological cases to consider. Another path
 # would be to expose another formatter option for controlling the
@@ -8472,7 +8472,7 @@ def doctest_long_lines():
   ...   lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard
   ... )
   """
-  # This demostrates a normal line that will get wrapped but won't
+  # This demonstrates a normal line that will get wrapped but won't
   # get wrapped in the docstring above because of how the line-width
   # setting gets reset at the first column in each code snippet.
   foo, bar, quux = this_is_a_long_line(
@@ -9819,7 +9819,7 @@ def doctest_varying_start_column():
 # actually extend past the configured line limit.
 #
 # It's not quite clear whether this is desirable or not. We could in
-# theory compute the intendation length of a code snippet and then
+# theory compute the indentation length of a code snippet and then
 # adjust the line-width setting on a recursive call to the formatter.
 # But there are assuredly pathological cases to consider. Another path
 # would be to expose another formatter option for controlling the
@@ -9849,7 +9849,7 @@ def doctest_long_lines():
 	...         leopard,
 	... )
 	"""
-	# This demostrates a normal line that will get wrapped but won't
+	# This demonstrates a normal line that will get wrapped but won't
 	# get wrapped in the docstring above because of how the line-width
 	# setting gets reset at the first column in each code snippet.
 	foo, bar, quux = this_is_a_long_line(
@@ -11196,7 +11196,7 @@ def doctest_varying_start_column():
 # actually extend past the configured line limit.
 #
 # It's not quite clear whether this is desirable or not. We could in
-# theory compute the intendation length of a code snippet and then
+# theory compute the indentation length of a code snippet and then
 # adjust the line-width setting on a recursive call to the formatter.
 # But there are assuredly pathological cases to consider. Another path
 # would be to expose another formatter option for controlling the
@@ -11217,7 +11217,7 @@ def doctest_long_lines():
 	...     lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard
 	... )
 	"""
-	# This demostrates a normal line that will get wrapped but won't
+	# This demonstrates a normal line that will get wrapped but won't
 	# get wrapped in the docstring above because of how the line-width
 	# setting gets reset at the first column in each code snippet.
 	foo, bar, quux = this_is_a_long_line(
@@ -12564,7 +12564,7 @@ def doctest_varying_start_column():
 # actually extend past the configured line limit.
 #
 # It's not quite clear whether this is desirable or not. We could in
-# theory compute the intendation length of a code snippet and then
+# theory compute the indentation length of a code snippet and then
 # adjust the line-width setting on a recursive call to the formatter.
 # But there are assuredly pathological cases to consider. Another path
 # would be to expose another formatter option for controlling the
@@ -12594,7 +12594,7 @@ def doctest_long_lines():
     ...     leopard,
     ... )
     """
-    # This demostrates a normal line that will get wrapped but won't
+    # This demonstrates a normal line that will get wrapped but won't
     # get wrapped in the docstring above because of how the line-width
     # setting gets reset at the first column in each code snippet.
     foo, bar, quux = this_is_a_long_line(
@@ -13941,7 +13941,7 @@ def doctest_varying_start_column():
 # actually extend past the configured line limit.
 #
 # It's not quite clear whether this is desirable or not. We could in
-# theory compute the intendation length of a code snippet and then
+# theory compute the indentation length of a code snippet and then
 # adjust the line-width setting on a recursive call to the formatter.
 # But there are assuredly pathological cases to consider. Another path
 # would be to expose another formatter option for controlling the
@@ -13962,7 +13962,7 @@ def doctest_long_lines():
     ...     lion, giraffe, hippo, zeba, lemur, penguin, monkey, spider, bear, leopard
     ... )
     """
-    # This demostrates a normal line that will get wrapped but won't
+    # This demonstrates a normal line that will get wrapped but won't
     # get wrapped in the docstring above because of how the line-width
     # setting gets reset at the first column in each code snippet.
     foo, bar, quux = this_is_a_long_line(


### PR DESCRIPTION
## Summary

Fix typos found by [codespell](https://github.com/codespell-project/codespell).

## Test Plan

CI tests.
