### PR TITLE
[S507] fix doc recommended fix

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/ssh_no_host_key_verification.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/ssh_no_host_key_verification.rs
@@ -28,7 +28,7 @@ use crate::checkers::ast::Checker;
 /// from paramiko import client
 ///
 /// ssh_client = client.SSHClient()
-/// ssh_client.set_missing_host_key_policy()
+/// ssh_client.set_missing_host_key_policy(client.RejectPolicy)
 /// ```
 ///
 /// ## References


### PR DESCRIPTION
paramiko `set_missing_host_key_policy` has mandatory positional arg.
The [current documentation](https://docs.astral.sh/ruff/rules/ssh-no-host-key-verification/#example) leads to non-running code

```
>>> from paramiko import client
>>> ssh_client = client.SSHClient()
>>> ssh_client.set_missing_host_key_policy()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: SSHClient.set_missing_host_key_policy() missing 1 required positional argument: 'policy'
```

This PR modifies the documentation to set the policy to the [default `RejectPolicy`](https://docs.paramiko.org/en/latest/api/client.html#paramiko.client.SSHClient.set_missing_host_key_policy)