### PR TITLE
Port from obsolete wsl crate to is-wsl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1119,16 @@ dependencies = [
  "hermit-abi",
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -2172,6 +2191,7 @@ dependencies = [
  "imperative",
  "insta",
  "is-macro",
+ "is-wsl",
  "itertools 0.11.0",
  "libcst",
  "log",
@@ -2218,7 +2238,6 @@ dependencies = [
  "unicode-width",
  "unicode_names2",
  "url",
- "wsl",
 ]
 
 [[package]]
@@ -3755,12 +3774,6 @@ checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wsl"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ globset = { version = "0.4.14" }
 ignore = { version = "0.4.21" }
 insta = { version = "1.34.0", feature = ["filters", "glob"] }
 is-macro = { version = "0.3.4" }
+is-wsl = { version = "0.4.0" }
 itertools = { version = "0.11.0" }
 libcst = { version = "1.1.0", default-features = false }
 log = { version = "0.4.17" }
@@ -53,7 +54,6 @@ unicode-ident = { version = "1.0.12" }
 unicode_names2 = { version = "1.2.1" }
 unicode-width = { version = "0.1.11" }
 uuid = { version = "1.6.1", features = ["v4", "fast-rng", "macro-diagnostics", "js"] }
-wsl = { version = "0.1.0" }
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -41,6 +41,7 @@ glob = { workspace = true }
 globset = { workspace = true }
 imperative = { version = "1.0.4" }
 is-macro = { workspace = true }
+is-wsl = { workspace = true }
 itertools = { workspace = true }
 libcst = { workspace = true }
 log = { workspace = true }
@@ -72,7 +73,6 @@ typed-arena = { version = "2.0.2" }
 unicode-width = { workspace = true }
 unicode_names2 = { workspace = true }
 url = { version = "2.2.2" }
-wsl = { version = "0.1.0" }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_executable_file.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_missing_executable_file.rs
@@ -3,7 +3,6 @@
 use std::path::Path;
 
 use ruff_text_size::{Ranged, TextRange};
-use wsl;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -45,7 +44,7 @@ impl Violation for ShebangMissingExecutableFile {
 pub(crate) fn shebang_missing_executable_file(filepath: &Path) -> Option<Diagnostic> {
     // WSL supports Windows file systems, which do not have executable bits.
     // Instead, everything is executable. Therefore, we skip this rule on WSL.
-    if wsl::is_wsl() {
+    if is_wsl::is_wsl() {
         return None;
     }
     if let Ok(true) = is_executable(filepath) {

--- a/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/crates/ruff_linter/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -3,7 +3,6 @@
 use std::path::Path;
 
 use ruff_text_size::{Ranged, TextRange};
-use wsl;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -45,7 +44,7 @@ impl Violation for ShebangNotExecutable {
 pub(crate) fn shebang_not_executable(filepath: &Path, range: TextRange) -> Option<Diagnostic> {
     // WSL supports Windows file systems, which do not have executable bits.
     // Instead, everything is executable. Therefore, we skip this rule on WSL.
-    if wsl::is_wsl() {
+    if is_wsl::is_wsl() {
         return None;
     }
 


### PR DESCRIPTION
The "wsl" crate was last touched in 2019, whereas the "is-wsl" crate was last updated in 2023. Additionally, it is unclear whether the "wsl" crate supports both WSL1 and WSL2 (which was announced in 2019), whereas the "is-wsl" crate explicitly supports both WSL1 and WSL2.

The required code changes are minimal, since both crates provide only a `is_wsl() -> bool` function.