### PR TITLE
Drop unused "ureq" dev-dependency from ruff_cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,7 +2094,6 @@ dependencies = [
  "thiserror",
  "tikv-jemallocator",
  "tracing",
- "ureq",
  "walkdir",
  "wild",
 ]

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -63,7 +63,6 @@ insta = { workspace = true, features = ["filters", "json"] }
 insta-cmd = { version = "0.4.0" }
 tempfile = "3.8.1"
 test-case = { workspace = true }
-ureq = { version = "2.9.1", features = [] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = "0.1.39"


### PR DESCRIPTION
## Summary

The `ureq` dev-dependency in the ruff_cli workspace member is unused. There are no code references to `ureq` in that crate.

## Test Plan

ruff and its tests continues to compile with the dependency removed. :)
