### PR TITLE
Add paths to toml parse errors

### DIFF
--- a/crates/ruff_cli/tests/format.rs
+++ b/crates/ruff_cli/tests/format.rs
@@ -672,7 +672,8 @@ format = "json"
 
         ----- stderr -----
         ruff failed
-          Cause: Failed to parse `[RUFF-TOML-PATH]`: TOML parse error at line 2, column 10
+          Cause: Failed to parse [RUFF-TOML-PATH]
+          Cause: TOML parse error at line 2, column 10
           |
         2 | format = "json"
           |          ^^^^^^

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -1047,7 +1047,10 @@ fn unreadable_pyproject_toml() -> Result<()> {
         err.chain()
             .map(std::string::ToString::to_string)
             .collect::<Vec<_>>(),
-        vec!["Permission denied (os error 13)".to_string()],
+        vec![
+            format!("Failed to read {}/pyproject.toml", tempdir.path().display()),
+            "Permission denied (os error 13)".to_string()
+        ],
     );
     Ok(())
 }

--- a/crates/ruff_workspace/src/pyproject.rs
+++ b/crates/ruff_workspace/src/pyproject.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use log::debug;
 use pep440_rs::VersionSpecifiers;
 use serde::{Deserialize, Serialize};
@@ -41,14 +41,18 @@ impl Pyproject {
 
 /// Parse a `ruff.toml` file.
 fn parse_ruff_toml<P: AsRef<Path>>(path: P) -> Result<Options> {
-    let contents = std::fs::read_to_string(path)?;
-    toml::from_str(&contents).map_err(Into::into)
+    let contents = std::fs::read_to_string(path.as_ref())
+        .with_context(|| format!("Failed to read {}", path.as_ref().display()))?;
+    toml::from_str(&contents)
+        .with_context(|| format!("Failed to parse {}", path.as_ref().display()))
 }
 
 /// Parse a `pyproject.toml` file.
 fn parse_pyproject_toml<P: AsRef<Path>>(path: P) -> Result<Pyproject> {
-    let contents = std::fs::read_to_string(path)?;
-    toml::from_str(&contents).map_err(Into::into)
+    let contents = std::fs::read_to_string(path.as_ref())
+        .with_context(|| format!("Failed to read {}", path.as_ref().display()))?;
+    toml::from_str(&contents)
+        .with_context(|| format!("Failed to parse {}", path.as_ref().display()))
 }
 
 /// Return `true` if a `pyproject.toml` contains a `[tool.ruff]` section.

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -220,8 +220,7 @@ fn resolve_configuration(
         }
 
         // Resolve the current path.
-        let options = pyproject::load_options(&path)
-            .map_err(|err| anyhow!("Failed to parse `{}`: {}", path.display(), err))?;
+        let options = pyproject::load_options(&path)?;
 
         let project_root = relativity.resolve(&path);
         let configuration = Configuration::from_options(options, &project_root)?;


### PR DESCRIPTION
**Summary** Previously, the information which toml file failed to parse was missing in errors.

**Before**
```console
$ ruff check /home/konsti/projects/datasett
ruff failed
  Cause: TOML parse error at line 12, column 8
   |
12 | python "=3.9.2"
   |        ^
expected `.`, `=`
```

**After**
```console
$ ruff check /home/konsti/projects/datasett
ruff failed
  Cause: Failed to parse /home/konsti/projects/datasett/datasett-0.0.1.tar.gz/datasett-0.0.1/pyproject.toml
  Cause: TOML parse error at line 12, column 8
   |
12 | python "=3.9.2"
   |        ^
expected `.`, `=`
```

I avoided pulling in `fs_err` just for this case.