### PR TITLE
Generate deterministic ids when formatting notebooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,6 +2259,7 @@ dependencies = [
  "insta",
  "itertools 0.12.0",
  "once_cell",
+ "rand",
  "ruff_diagnostics",
  "ruff_source_file",
  "ruff_text_size",

--- a/crates/ruff_notebook/Cargo.toml
+++ b/crates/ruff_notebook/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = { workspace = true }
 serde_with = { workspace = true, default-features = false, features = ["macros"] }
 thiserror = { workspace = true }
 uuid = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/ruff_notebook/src/notebook.rs
+++ b/crates/ruff_notebook/src/notebook.rs
@@ -169,7 +169,7 @@ impl Notebook {
                 if id.is_none() {
                     loop {
                         // https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md#questions
-                        let new_id = uuid::Builder::from_u128(id_index.clone())
+                        let new_id = uuid::Builder::from_u128(id_index)
                             .into_uuid()
                             .as_hyphenated()
                             .to_string();

--- a/crates/ruff_notebook/src/notebook.rs
+++ b/crates/ruff_notebook/src/notebook.rs
@@ -7,7 +7,7 @@ use std::{io, iter};
 
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
-use rand::Rng;
+use rand::{Rng, SeedableRng};
 use serde::Serialize;
 use serde_json::error::Category;
 use thiserror::Error;
@@ -148,8 +148,8 @@ impl Notebook {
         // https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md#required-field
         // https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md#questions
         if raw_notebook.nbformat == 4 && raw_notebook.nbformat_minor >= 5 {
-            // We use a mock random number generator to generate deterministic uuids
-            let mut rng = rand::rngs::mock::StepRng::new(0, 1);
+            // We use a insecure random number generator to generate deterministic uuids
+            let mut rng = rand::rngs::StdRng::seed_from_u64(0);
             let mut existing_ids = HashSet::new();
 
             for cell in &raw_notebook.cells {

--- a/crates/ruff_notebook/src/notebook.rs
+++ b/crates/ruff_notebook/src/notebook.rs
@@ -173,7 +173,7 @@ impl Notebook {
                     loop {
                         let new_id = uuid::Builder::from_random_bytes(rng.gen())
                             .into_uuid()
-                            .as_hyphenated()
+                            .as_simple()
                             .to_string();
 
                         if existing_ids.insert(new_id.clone()) {

--- a/crates/ruff_notebook/src/notebook.rs
+++ b/crates/ruff_notebook/src/notebook.rs
@@ -176,8 +176,7 @@ impl Notebook {
                             .as_hyphenated()
                             .to_string();
 
-                        if !existing_ids.contains(&new_id) {
-                            existing_ids.insert(new_id.clone());
+                        if existing_ids.insert(new_id.clone()) {
                             *id = Some(new_id);
                             break;
                         }


### PR DESCRIPTION
When formatting notebooks, we populate the `id` field for cells that do not have one. Previously, we generated a UUID v4 which resulted in non-deterministic formatting. Here, we generate the UUID from a seeded random number generator instead of using true randomness. For example, here are the first five ids it would generate:

```
7fb27b94-1602-401d-9154-2211134fc71a
acae54e3-7e7d-407b-bb7b-55eff062a284
9a63283c-baf0-4dbc-ab1f-6479b197f3a8
8dd0d809-2fe7-4a7c-9628-1538738b07e2
72eea511-9410-473a-a328-ad9291626812
```

We also add a check that an id is not present in another cell to prevent accidental introduction of duplicate ids.

The specification is lax, and we could just use incrementing integers e.g. `0`, `1`, ... but I have a minor preference for retaining the UUID format. Some discussion [here](https://github.com/astral-sh/ruff/pull/9359#discussion_r1439607121) — I'm happy to go either way though.

Discovered via #9293 