### PR TITLE
Tweak `relative-imports` message

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
@@ -56,8 +56,10 @@ impl Violation for RelativeImports {
     #[derive_message_formats]
     fn message(&self) -> String {
         match self.strictness {
-            Strictness::Parents => format!("Relative imports from parent modules are banned"),
-            Strictness::All => format!("Relative imports are banned"),
+            Strictness::Parents => {
+                format!("Prefer absolute imports over relative imports from parent modules")
+            }
+            Strictness::All => format!("Prefer absolute imports over relative imports"),
         }
     }
 

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/snapshots/ruff_linter__rules__flake8_tidy_imports__tests__ban_all_imports.snap
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/snapshots/ruff_linter__rules__flake8_tidy_imports__tests__ban_all_imports.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_tidy_imports/mod.rs
 ---
-TID252.py:7:1: TID252 Relative imports are banned
+TID252.py:7:1: TID252 Prefer absolute imports over relative imports
   |
 6 | # TID252
 7 | from . import sibling
@@ -11,7 +11,7 @@ TID252.py:7:1: TID252 Relative imports are banned
   |
   = help: Replace relative imports with absolute imports
 
-TID252.py:8:1: TID252 Relative imports are banned
+TID252.py:8:1: TID252 Prefer absolute imports over relative imports
    |
  6 | # TID252
  7 | from . import sibling
@@ -22,7 +22,7 @@ TID252.py:8:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:9:1: TID252 Relative imports are banned
+TID252.py:9:1: TID252 Prefer absolute imports over relative imports
    |
  7 | from . import sibling
  8 | from .sibling import example
@@ -33,7 +33,7 @@ TID252.py:9:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:10:1: TID252 Relative imports are banned
+TID252.py:10:1: TID252 Prefer absolute imports over relative imports
    |
  8 | from .sibling import example
  9 | from .. import parent
@@ -44,7 +44,7 @@ TID252.py:10:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:11:1: TID252 Relative imports are banned
+TID252.py:11:1: TID252 Prefer absolute imports over relative imports
    |
  9 | from .. import parent
 10 | from ..parent import example
@@ -55,7 +55,7 @@ TID252.py:11:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:12:1: TID252 Relative imports are banned
+TID252.py:12:1: TID252 Prefer absolute imports over relative imports
    |
 10 | from ..parent import example
 11 | from ... import grandparent
@@ -66,7 +66,7 @@ TID252.py:12:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:13:1: TID252 Relative imports are banned
+TID252.py:13:1: TID252 Prefer absolute imports over relative imports
    |
 11 | from ... import grandparent
 12 | from ...grandparent import example
@@ -77,7 +77,7 @@ TID252.py:13:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:14:1: TID252 Relative imports are banned
+TID252.py:14:1: TID252 Prefer absolute imports over relative imports
    |
 12 |   from ...grandparent import example
 13 |   from  .parent import hello
@@ -90,7 +90,7 @@ TID252.py:14:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:17:1: TID252 Relative imports are banned
+TID252.py:17:1: TID252 Prefer absolute imports over relative imports
    |
 15 |       parent import \
 16 |           hello_world
@@ -104,7 +104,7 @@ TID252.py:17:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:21:1: TID252 Relative imports are banned
+TID252.py:21:1: TID252 Prefer absolute imports over relative imports
    |
 19 |     import \
 20 |     world_hello
@@ -115,7 +115,7 @@ TID252.py:21:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:22:1: TID252 Relative imports are banned
+TID252.py:22:1: TID252 Prefer absolute imports over relative imports
    |
 20 |     world_hello
 21 | from ..... import ultragrantparent
@@ -126,7 +126,7 @@ TID252.py:22:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:23:1: TID252 Relative imports are banned
+TID252.py:23:1: TID252 Prefer absolute imports over relative imports
    |
 21 | from ..... import ultragrantparent
 22 | from ...... import ultragrantparent
@@ -137,7 +137,7 @@ TID252.py:23:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:24:1: TID252 Relative imports are banned
+TID252.py:24:1: TID252 Prefer absolute imports over relative imports
    |
 22 | from ...... import ultragrantparent
 23 | from ....... import ultragrantparent
@@ -148,7 +148,7 @@ TID252.py:24:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:25:1: TID252 Relative imports are banned
+TID252.py:25:1: TID252 Prefer absolute imports over relative imports
    |
 23 | from ....... import ultragrantparent
 24 | from ......... import ultragrantparent
@@ -159,7 +159,7 @@ TID252.py:25:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:26:1: TID252 Relative imports are banned
+TID252.py:26:1: TID252 Prefer absolute imports over relative imports
    |
 24 | from ......... import ultragrantparent
 25 | from ........................... import ultragrantparent
@@ -170,7 +170,7 @@ TID252.py:26:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:27:1: TID252 Relative imports are banned
+TID252.py:27:1: TID252 Prefer absolute imports over relative imports
    |
 25 | from ........................... import ultragrantparent
 26 | from .....parent import ultragrantparent
@@ -180,7 +180,7 @@ TID252.py:27:1: TID252 Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:28:1: TID252 Relative imports are banned
+TID252.py:28:1: TID252 Prefer absolute imports over relative imports
    |
 26 | from .....parent import ultragrantparent
 27 | from .........parent import ultragrantparent

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/snapshots/ruff_linter__rules__flake8_tidy_imports__tests__ban_parent_imports.snap
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/snapshots/ruff_linter__rules__flake8_tidy_imports__tests__ban_parent_imports.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_tidy_imports/mod.rs
 ---
-TID252.py:9:1: TID252 Relative imports from parent modules are banned
+TID252.py:9:1: TID252 Prefer absolute imports over relative imports from parent modules
    |
  7 | from . import sibling
  8 | from .sibling import example
@@ -12,7 +12,7 @@ TID252.py:9:1: TID252 Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:10:1: TID252 Relative imports from parent modules are banned
+TID252.py:10:1: TID252 Prefer absolute imports over relative imports from parent modules
    |
  8 | from .sibling import example
  9 | from .. import parent
@@ -23,7 +23,7 @@ TID252.py:10:1: TID252 Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:11:1: TID252 Relative imports from parent modules are banned
+TID252.py:11:1: TID252 Prefer absolute imports over relative imports from parent modules
    |
  9 | from .. import parent
 10 | from ..parent import example
@@ -34,7 +34,7 @@ TID252.py:11:1: TID252 Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:12:1: TID252 Relative imports from parent modules are banned
+TID252.py:12:1: TID252 Prefer absolute imports over relative imports from parent modules
    |
 10 | from ..parent import example
 11 | from ... import grandparent
@@ -45,7 +45,7 @@ TID252.py:12:1: TID252 Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:17:1: TID252 Relative imports from parent modules are banned
+TID252.py:17:1: TID252 Prefer absolute imports over relative imports from parent modules
    |
 15 |       parent import \
 16 |           hello_world
@@ -59,7 +59,7 @@ TID252.py:17:1: TID252 Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:21:1: TID252 Relative imports from parent modules are banned
+TID252.py:21:1: TID252 Prefer absolute imports over relative imports from parent modules
    |
 19 |     import \
 20 |     world_hello
@@ -70,7 +70,7 @@ TID252.py:21:1: TID252 Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:22:1: TID252 Relative imports from parent modules are banned
+TID252.py:22:1: TID252 Prefer absolute imports over relative imports from parent modules
    |
 20 |     world_hello
 21 | from ..... import ultragrantparent
@@ -81,7 +81,7 @@ TID252.py:22:1: TID252 Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:23:1: TID252 Relative imports from parent modules are banned
+TID252.py:23:1: TID252 Prefer absolute imports over relative imports from parent modules
    |
 21 | from ..... import ultragrantparent
 22 | from ...... import ultragrantparent
@@ -92,7 +92,7 @@ TID252.py:23:1: TID252 Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:24:1: TID252 Relative imports from parent modules are banned
+TID252.py:24:1: TID252 Prefer absolute imports over relative imports from parent modules
    |
 22 | from ...... import ultragrantparent
 23 | from ....... import ultragrantparent
@@ -103,7 +103,7 @@ TID252.py:24:1: TID252 Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:25:1: TID252 Relative imports from parent modules are banned
+TID252.py:25:1: TID252 Prefer absolute imports over relative imports from parent modules
    |
 23 | from ....... import ultragrantparent
 24 | from ......... import ultragrantparent
@@ -114,7 +114,7 @@ TID252.py:25:1: TID252 Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:26:1: TID252 Relative imports from parent modules are banned
+TID252.py:26:1: TID252 Prefer absolute imports over relative imports from parent modules
    |
 24 | from ......... import ultragrantparent
 25 | from ........................... import ultragrantparent
@@ -125,7 +125,7 @@ TID252.py:26:1: TID252 Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:27:1: TID252 Relative imports from parent modules are banned
+TID252.py:27:1: TID252 Prefer absolute imports over relative imports from parent modules
    |
 25 | from ........................... import ultragrantparent
 26 | from .....parent import ultragrantparent
@@ -135,7 +135,7 @@ TID252.py:27:1: TID252 Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:28:1: TID252 Relative imports from parent modules are banned
+TID252.py:28:1: TID252 Prefer absolute imports over relative imports from parent modules
    |
 26 | from .....parent import ultragrantparent
 27 | from .........parent import ultragrantparent

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/snapshots/ruff_linter__rules__flake8_tidy_imports__tests__ban_parent_imports_package.snap
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/snapshots/ruff_linter__rules__flake8_tidy_imports__tests__ban_parent_imports_package.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_tidy_imports/mod.rs
 ---
-application.py:5:1: TID252 Relative imports from parent modules are banned
+application.py:5:1: TID252 Prefer absolute imports over relative imports from parent modules
   |
 3 | import attrs
 4 | 
@@ -12,7 +12,7 @@ application.py:5:1: TID252 Relative imports from parent modules are banned
   |
   = help: Replace relative imports from parent modules with absolute imports
 
-application.py:6:1: TID252 [*] Relative imports from parent modules are banned
+application.py:6:1: TID252 [*] Prefer absolute imports over relative imports from parent modules
   |
 5 | from ....import unknown
 6 | from ..protocol import commands, definitions, responses
@@ -32,7 +32,7 @@ application.py:6:1: TID252 [*] Relative imports from parent modules are banned
 8 8 | from .. import server
 9 9 | from . import logger, models
 
-application.py:6:1: TID252 [*] Relative imports from parent modules are banned
+application.py:6:1: TID252 [*] Prefer absolute imports over relative imports from parent modules
   |
 5 | from ....import unknown
 6 | from ..protocol import commands, definitions, responses
@@ -52,7 +52,7 @@ application.py:6:1: TID252 [*] Relative imports from parent modules are banned
 8 8 | from .. import server
 9 9 | from . import logger, models
 
-application.py:6:1: TID252 [*] Relative imports from parent modules are banned
+application.py:6:1: TID252 [*] Prefer absolute imports over relative imports from parent modules
   |
 5 | from ....import unknown
 6 | from ..protocol import commands, definitions, responses
@@ -72,7 +72,7 @@ application.py:6:1: TID252 [*] Relative imports from parent modules are banned
 8 8 | from .. import server
 9 9 | from . import logger, models
 
-application.py:7:1: TID252 [*] Relative imports from parent modules are banned
+application.py:7:1: TID252 [*] Prefer absolute imports over relative imports from parent modules
   |
 5 | from ....import unknown
 6 | from ..protocol import commands, definitions, responses
@@ -93,7 +93,7 @@ application.py:7:1: TID252 [*] Relative imports from parent modules are banned
 9 9 | from . import logger, models
 10 10 | from ..protocol.UpperCaseModule import some_function
 
-application.py:8:1: TID252 [*] Relative imports from parent modules are banned
+application.py:8:1: TID252 [*] Prefer absolute imports over relative imports from parent modules
    |
  6 | from ..protocol import commands, definitions, responses
  7 | from ..server import example
@@ -113,7 +113,7 @@ application.py:8:1: TID252 [*] Relative imports from parent modules are banned
 9 9 | from . import logger, models
 10 10 | from ..protocol.UpperCaseModule import some_function
 
-application.py:10:1: TID252 [*] Relative imports from parent modules are banned
+application.py:10:1: TID252 [*] Prefer absolute imports over relative imports from parent modules
    |
  8 | from .. import server
  9 | from . import logger, models


### PR DESCRIPTION
## Summary

Changes message from `"Relative imports are banned"` to `"Prefer absolute imports over relative imports from parent modules"`.

Closes #9363.

## Test Plan

`cargo test`
