### PR TITLE
Disable the fuzzer CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,7 +168,7 @@ jobs:
   cargo-fuzz:
     runs-on: ubuntu-latest
     needs: determine_changes
-    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+    if: false # ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     name: "cargo fuzz"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The job is failing to compile. We should resolve separately but I am disabling for now since it breaks pull requests.

See https://github.com/astral-sh/ruff/issues/9368