### PR TITLE
Add CERN/Indico to "Who's Using Ruff?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ Ruff is used by a number of major open-source projects and companies, including:
 - Benchling ([Refac](https://github.com/benchling/refac))
 - [Bokeh](https://github.com/bokeh/bokeh)
 - [Cryptography (PyCA)](https://github.com/pyca/cryptography)
+- CERN ([Indico](https://getindico.io/))
 - [DVC](https://github.com/iterative/dvc)
 - [Dagger](https://github.com/dagger/dagger)
 - [Dagster](https://github.com/dagster-io/dagster)


### PR DESCRIPTION
Might be a nice name to have in that list ;)

Corresponding PR that added ruff to the project: https://github.com/indico/indico/pull/6037