### PR TITLE
Avoid infinite loop in constant vs. `None` comparisons

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E711.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E711.py
@@ -51,3 +51,5 @@ if (True) == TrueElement or x == TrueElement:
 assert (not foo) in bar
 assert {"x": not foo} in bar
 assert [42, not foo] in bar
+
+assert x in c > 0 == None

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -200,39 +200,37 @@ pub(crate) fn literal_comparisons(checker: &mut Checker, compare: &ast::ExprComp
             continue;
         }
 
-        let Some(op) = EqCmpOp::try_from(*op) else {
-            continue;
-        };
-
-        if checker.enabled(Rule::NoneComparison) && next.is_none_literal_expr() {
-            match op {
-                EqCmpOp::Eq => {
-                    let diagnostic = Diagnostic::new(NoneComparison(op), next.range());
-                    bad_ops.insert(index, CmpOp::Is);
-                    diagnostics.push(diagnostic);
-                }
-                EqCmpOp::NotEq => {
-                    let diagnostic = Diagnostic::new(NoneComparison(op), next.range());
-                    bad_ops.insert(index, CmpOp::IsNot);
-                    diagnostics.push(diagnostic);
-                }
-            }
-        }
-
-        if checker.enabled(Rule::TrueFalseComparison) {
-            if let Expr::BooleanLiteral(ast::ExprBooleanLiteral { value, .. }) = next {
+        if let Some(op) = EqCmpOp::try_from(*op) {
+            if checker.enabled(Rule::NoneComparison) && next.is_none_literal_expr() {
                 match op {
                     EqCmpOp::Eq => {
-                        let diagnostic =
-                            Diagnostic::new(TrueFalseComparison(*value, op), next.range());
+                        let diagnostic = Diagnostic::new(NoneComparison(op), next.range());
                         bad_ops.insert(index, CmpOp::Is);
                         diagnostics.push(diagnostic);
                     }
                     EqCmpOp::NotEq => {
-                        let diagnostic =
-                            Diagnostic::new(TrueFalseComparison(*value, op), next.range());
+                        let diagnostic = Diagnostic::new(NoneComparison(op), next.range());
                         bad_ops.insert(index, CmpOp::IsNot);
                         diagnostics.push(diagnostic);
+                    }
+                }
+            }
+
+            if checker.enabled(Rule::TrueFalseComparison) {
+                if let Expr::BooleanLiteral(ast::ExprBooleanLiteral { value, .. }) = next {
+                    match op {
+                        EqCmpOp::Eq => {
+                            let diagnostic =
+                                Diagnostic::new(TrueFalseComparison(*value, op), next.range());
+                            bad_ops.insert(index, CmpOp::Is);
+                            diagnostics.push(diagnostic);
+                        }
+                        EqCmpOp::NotEq => {
+                            let diagnostic =
+                                Diagnostic::new(TrueFalseComparison(*value, op), next.range());
+                            bad_ops.insert(index, CmpOp::IsNot);
+                            diagnostics.push(diagnostic);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

We had an early `continue` in this loop, and we weren't setting `comparator = next;` when continuing... This PR removes the early continue altogether for clarity.

Closes https://github.com/astral-sh/ruff/issues/9374.

## Test Plan

`cargo test`
