### PR TITLE
Add cell indexes to all diagnostics

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F402.ipynb
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F402.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33faf7ad-a3fd-4ac4-a0c3-52e507ed49df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import os.path as path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "481fb4bf-c1b9-47da-927f-3cfdfe4b49ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for os in range(3):\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "for path in range(3):\n",
+    "    pass"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "2f0c65a5-0a0e-4080-afce-5a8ed0d706df"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (ruff-playground)",
+   "language": "python",
+   "name": "ruff-playground"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
@@ -151,13 +151,10 @@ pub(crate) fn deferred_scopes(checker: &mut Checker) {
                         continue;
                     }
 
-                    #[allow(deprecated)]
-                    let line = checker.locator.compute_line_index(shadowed.start());
-
                     checker.diagnostics.push(Diagnostic::new(
                         pyflakes::rules::ImportShadowedByLoopVar {
                             name: name.to_string(),
-                            line,
+                            row: checker.compute_source_row(shadowed.start()),
                         },
                         binding.range(),
                     ));
@@ -243,12 +240,10 @@ pub(crate) fn deferred_scopes(checker: &mut Checker) {
                         continue;
                     }
 
-                    #[allow(deprecated)]
-                    let line = checker.locator.compute_line_index(shadowed.start());
                     let mut diagnostic = Diagnostic::new(
                         pyflakes::rules::RedefinedWhileUnused {
                             name: (*name).to_string(),
-                            line,
+                            row: checker.compute_source_row(shadowed.start()),
                         },
                         binding.range(),
                     );

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -148,6 +148,7 @@ pub fn check_path(
         match tokens.into_ast_source(source_kind, source_type) {
             Ok(python_ast) => {
                 let cell_offsets = source_kind.as_ipy_notebook().map(Notebook::cell_offsets);
+                let notebook_index = source_kind.as_ipy_notebook().map(Notebook::index);
                 if use_ast {
                     diagnostics.extend(check_ast(
                         &python_ast,
@@ -161,6 +162,7 @@ pub fn check_path(
                         package,
                         source_type,
                         cell_offsets,
+                        notebook_index,
                     ));
                 }
                 if use_imports {

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -54,6 +54,7 @@ mod tests {
     #[test_case(Rule::UnusedImport, Path::new("F401_19.py"))]
     #[test_case(Rule::UnusedImport, Path::new("F401_20.py"))]
     #[test_case(Rule::ImportShadowedByLoopVar, Path::new("F402.py"))]
+    #[test_case(Rule::ImportShadowedByLoopVar, Path::new("F402.ipynb"))]
     #[test_case(Rule::UndefinedLocalWithImportStar, Path::new("F403.py"))]
     #[test_case(Rule::LateFutureImport, Path::new("F404_0.py"))]
     #[test_case(Rule::LateFutureImport, Path::new("F404_1.py"))]

--- a/crates/ruff_linter/src/rules/pyflakes/rules/imports.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/imports.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-use ruff_source_file::OneIndexed;
+use ruff_source_file::SourceRow;
 
 /// ## What it does
 /// Checks for import bindings that are shadowed by loop variables.
@@ -32,14 +32,14 @@ use ruff_source_file::OneIndexed;
 #[violation]
 pub struct ImportShadowedByLoopVar {
     pub(crate) name: String,
-    pub(crate) line: OneIndexed,
+    pub(crate) row: SourceRow,
 }
 
 impl Violation for ImportShadowedByLoopVar {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let ImportShadowedByLoopVar { name, line } = self;
-        format!("Import `{name}` from line {line} shadowed by loop variable")
+        let ImportShadowedByLoopVar { name, row } = self;
+        format!("Import `{name}` from {row} shadowed by loop variable")
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-use ruff_source_file::OneIndexed;
+use ruff_source_file::SourceRow;
 
 /// ## What it does
 /// Checks for variable definitions that redefine (or "shadow") unused
@@ -25,13 +25,13 @@ use ruff_source_file::OneIndexed;
 #[violation]
 pub struct RedefinedWhileUnused {
     pub name: String,
-    pub line: OneIndexed,
+    pub row: SourceRow,
 }
 
 impl Violation for RedefinedWhileUnused {
     #[derive_message_formats]
     fn message(&self) -> String {
-        let RedefinedWhileUnused { name, line } = self;
-        format!("Redefinition of unused `{name}` from line {line}")
+        let RedefinedWhileUnused { name, row } = self;
+        format!("Redefinition of unused `{name}` from {row}")
     }
 }

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F402_F402.ipynb.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F402_F402.ipynb.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+F402.ipynb:3:5: F402 Import `os` from cell 1, line 1 shadowed by loop variable
+  |
+1 | import os
+2 | import os.path as path
+3 | for os in range(3):
+  |     ^^ F402
+4 |     pass
+5 | for path in range(3):
+  |
+
+F402.ipynb:5:5: F402 Import `path` from cell 1, line 2 shadowed by loop variable
+  |
+3 | for os in range(3):
+4 |     pass
+5 | for path in range(3):
+  |     ^^^^ F402
+6 |     pass
+  |
+
+

--- a/crates/ruff_source_file/src/lib.rs
+++ b/crates/ruff_source_file/src/lib.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
 
 #[cfg(feature = "serde")]
@@ -251,5 +251,22 @@ impl Debug for SourceLocation {
             .field("row", &self.row.get())
             .field("column", &self.column.get())
             .finish()
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum SourceRow {
+    /// A row within a cell in a Jupyter Notebook.
+    Notebook { cell: OneIndexed, line: OneIndexed },
+    /// A row within a source file.
+    SourceFile { line: OneIndexed },
+}
+
+impl Display for SourceRow {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SourceRow::Notebook { cell, line } => write!(f, "cell {cell}, line {line}"),
+            SourceRow::SourceFile { line } => write!(f, "line {line}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Ensures that any lint rules that include line locations render them as relative to the cell (and include the cell number) when inside a Jupyter notebook.

Closes https://github.com/astral-sh/ruff/issues/6672.

## Test Plan

`cargo test`
