### PR TITLE
Allow `# fmt: skip` with interspersed same-line comments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_skip/reason.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_skip/reason.py
@@ -1,0 +1,9 @@
+# Supported
+x =    1  # fmt: skip
+x =    1  # fmt: skip # reason
+x =    1  # reason # fmt: skip
+
+# Unsupported
+x =    1  # fmt: skip reason
+x =    1  # fmt: skip - reason
+x =    1  # fmt: skip; noqa

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_single_line_format_skip_with_multiple_comments.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_single_line_format_skip_with_multiple_comments.py.snap
@@ -21,8 +21,7 @@ skip_will_not_work2 =  "a" +  "b"  # some text; fmt:skip happens to be part of i
 --- Black
 +++ Ruff
 @@ -1,8 +1,8 @@
--foo =  123  # fmt: skip # noqa: E501 # pylint
-+foo = 123  # fmt: skip # noqa: E501 # pylint
+ foo =  123  # fmt: skip # noqa: E501 # pylint
  bar = (
 -    123   ,
 -    (        1      +           5      )  # pylint # fmt:skip
@@ -38,7 +37,7 @@ skip_will_not_work2 =  "a" +  "b"  # some text; fmt:skip happens to be part of i
 ## Ruff Output
 
 ```python
-foo = 123  # fmt: skip # noqa: E501 # pylint
+foo =  123  # fmt: skip # noqa: E501 # pylint
 bar = (
     123,
     (1 + 5),  # pylint # fmt:skip

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_skip__reason.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_skip__reason.py.snap
@@ -1,0 +1,32 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_skip/reason.py
+---
+## Input
+```python
+# Supported
+x =    1  # fmt: skip
+x =    1  # fmt: skip # reason
+x =    1  # reason # fmt: skip
+
+# Unsupported
+x =    1  # fmt: skip reason
+x =    1  # fmt: skip - reason
+x =    1  # fmt: skip; noqa
+```
+
+## Output
+```python
+# Supported
+x =    1  # fmt: skip
+x =    1  # fmt: skip # reason
+x =    1  # reason # fmt: skip
+
+# Unsupported
+x = 1  # fmt: skip reason
+x = 1  # fmt: skip - reason
+x = 1  # fmt: skip; noqa
+```
+
+
+


### PR DESCRIPTION
## Summary

This is similar to https://github.com/astral-sh/ruff/pull/8876, but more limited in scope:

1. It only applies to `# fmt: skip` (like Black). Like `# isort: on`, `# fmt: on` needs to be on its own line (still).
2. It only delimits on `#`, so you can do `# fmt: skip # noqa`, but not `# fmt: skip - some other content` or `# fmt: skip; noqa`.

If we want to support the `;`-delimited version, we should revisit later, since we don't support that in the linter (so `# fmt: skip; noqa` wouldn't register a `noqa`).

Closes https://github.com/astral-sh/ruff/issues/8892.
