### PR TITLE
Parenthesize breaking named expressions in match guards

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/match.py
@@ -109,6 +109,11 @@ match long_lines:
     ):  # another comment
         pass
 
+    case {
+        "long_long_long_key": str(long_long_long_key)
+    } if value := "long long long long long long long long long long long value":
+        pass
+
 
 match pattern_comments:
     case (

--- a/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
@@ -26,10 +26,10 @@ impl FormatNodeRule<ExprNamedExpr> for FormatExprNamedExpr {
         write!(
             f,
             [
-                group(&format_args!(
+                group(&format_args![
                     target.format(),
                     in_parentheses_only_soft_line_break_or_space()
-                )),
+                ]),
                 token(":=")
             ]
         )?;

--- a/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
@@ -3,7 +3,9 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprNamedExpr;
 
 use crate::comments::{dangling_comments, SourceComment};
-use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses};
+use crate::expression::parentheses::{
+    in_parentheses_only_soft_line_break_or_space, NeedsParentheses, OptionalParentheses,
+};
 use crate::prelude::*;
 
 #[derive(Default)]
@@ -24,7 +26,10 @@ impl FormatNodeRule<ExprNamedExpr> for FormatExprNamedExpr {
         write!(
             f,
             [
-                group(&format_args!(target.format(), soft_line_break_or_space())),
+                group(&format_args!(
+                    target.format(),
+                    in_parentheses_only_soft_line_break_or_space()
+                )),
                 token(":=")
             ]
         )?;

--- a/crates/ruff_python_formatter/src/other/match_case.rs
+++ b/crates/ruff_python_formatter/src/other/match_case.rs
@@ -4,7 +4,10 @@ use ruff_python_ast::MatchCase;
 
 use crate::builders::parenthesize_if_expands;
 use crate::comments::SourceComment;
-use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses, Parentheses};
+use crate::expression::maybe_parenthesize_expression;
+use crate::expression::parentheses::{
+    NeedsParentheses, OptionalParentheses, Parentheses, Parenthesize,
+};
 use crate::prelude::*;
 use crate::statement::clause::{clause_body, clause_header, ClauseHeader};
 
@@ -58,7 +61,19 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
                         }
 
                         if let Some(guard) = guard {
-                            write!(f, [space(), token("if"), space(), guard.format()])?;
+                            write!(
+                                f,
+                                [
+                                    space(),
+                                    token("if"),
+                                    space(),
+                                    maybe_parenthesize_expression(
+                                        guard,
+                                        item,
+                                        Parenthesize::Optional
+                                    )
+                                ]
+                            )?;
                         }
 
                         Ok(())

--- a/crates/ruff_python_formatter/src/other/match_case.rs
+++ b/crates/ruff_python_formatter/src/other/match_case.rs
@@ -4,10 +4,7 @@ use ruff_python_ast::MatchCase;
 
 use crate::builders::parenthesize_if_expands;
 use crate::comments::SourceComment;
-use crate::expression::maybe_parenthesize_expression;
-use crate::expression::parentheses::{
-    NeedsParentheses, OptionalParentheses, Parentheses, Parenthesize,
-};
+use crate::expression::parentheses::{NeedsParentheses, OptionalParentheses, Parentheses};
 use crate::prelude::*;
 use crate::statement::clause::{clause_body, clause_header, ClauseHeader};
 
@@ -61,19 +58,7 @@ impl FormatNodeRule<MatchCase> for FormatMatchCase {
                         }
 
                         if let Some(guard) = guard {
-                            write!(
-                                f,
-                                [
-                                    space(),
-                                    token("if"),
-                                    space(),
-                                    maybe_parenthesize_expression(
-                                        guard,
-                                        item,
-                                        Parenthesize::Optional
-                                    )
-                                ]
-                            )?;
+                            write!(f, [space(), token("if"), space(), guard.format()])?;
                         }
 
                         Ok(())

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -682,9 +682,7 @@ match newlines:
 
 
 match long_lines:
-    case "this is a long line for if condition" if (
-        aaaaaaaaahhhhhhhh == 1 and bbbbbbaaaaaaaaaaa == 2
-    ):  # comment
+    case "this is a long line for if condition" if aaaaaaaaahhhhhhhh == 1 and bbbbbbaaaaaaaaaaa == 2:  # comment
         pass
 
     case "this is a long line for if condition with parentheses" if (
@@ -703,9 +701,9 @@ match long_lines:
     ):  # another comment
         pass
 
-    case {"long_long_long_key": str(long_long_long_key)} if (
-        value := "long long long long long long long long long long long value"
-    ):
+    case {
+        "long_long_long_key": str(long_long_long_key)
+    } if value := "long long long long long long long long long long long value":
         pass
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__match.py.snap
@@ -115,6 +115,11 @@ match long_lines:
     ):  # another comment
         pass
 
+    case {
+        "long_long_long_key": str(long_long_long_key)
+    } if value := "long long long long long long long long long long long value":
+        pass
+
 
 match pattern_comments:
     case (
@@ -677,7 +682,9 @@ match newlines:
 
 
 match long_lines:
-    case "this is a long line for if condition" if aaaaaaaaahhhhhhhh == 1 and bbbbbbaaaaaaaaaaa == 2:  # comment
+    case "this is a long line for if condition" if (
+        aaaaaaaaahhhhhhhh == 1 and bbbbbbaaaaaaaaaaa == 2
+    ):  # comment
         pass
 
     case "this is a long line for if condition with parentheses" if (
@@ -694,6 +701,11 @@ match long_lines:
     case "but with already broken long lines" if (
         aaaaaaahhhhhhhhhhh == 1 and bbbbbbbbaaaaaahhhh == 2
     ):  # another comment
+        pass
+
+    case {"long_long_long_key": str(long_long_long_key)} if (
+        value := "long long long long long long long long long long long value"
+    ):
         pass
 
 


### PR DESCRIPTION
## Summary

This is an attempt to solve https://github.com/astral-sh/ruff/issues/9394 by avoiding breaks in named expressions when invalid.