### PR TITLE
Use `DisplayParseError` for stdin parser errors

### DIFF
--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -497,10 +497,10 @@ pub(crate) fn lint_stdin(
 
     let imports = imports.unwrap_or_default();
 
-    if let Some(err) = parse_error {
+    if let Some(error) = parse_error {
         error!(
-            "Failed to parse {}: {err}",
-            path.map_or_else(|| "-".into(), fs::relativize_path).bold()
+            "{}",
+            DisplayParseError::from_source_kind(error, path.map(Path::to_path_buf), &transformed)
         );
     }
 

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -727,6 +727,22 @@ fn stdin_format_jupyter() {
 }
 
 #[test]
+fn stdin_parse_error() {
+    let mut cmd = RuffCheck::default().build();
+    assert_cmd_snapshot!(cmd
+        .pass_stdin("from foo import =\n"), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:17: E999 SyntaxError: Unexpected token '='
+    Found 1 error.
+
+    ----- stderr -----
+    error: Failed to parse at 1:17: Unexpected token '='
+    "###);
+}
+
+#[test]
 fn show_source() {
     let mut cmd = RuffCheck::default().args(["--show-source"]).build();
     assert_cmd_snapshot!(cmd
@@ -750,6 +766,7 @@ fn show_source() {
 fn explain_status_codes_f401() {
     assert_cmd_snapshot!(ruff_cmd().args(["--explain", "F401"]));
 }
+
 #[test]
 fn explain_status_codes_ruf404() {
     assert_cmd_snapshot!(ruff_cmd().args(["--explain", "RUF404"]), @r###"

--- a/crates/ruff_linter/src/logging.rs
+++ b/crates/ruff_linter/src/logging.rs
@@ -216,12 +216,7 @@ impl Display for DisplayParseError {
                 colon = ":".cyan(),
             )?;
         } else {
-            write!(
-                f,
-                "{header}{colon}",
-                header = "Failed to parse".bold(),
-                colon = ":".cyan(),
-            )?;
+            write!(f, "{header}", header = "Failed to parse at ".bold())?;
         }
         match &self.location {
             ErrorLocation::File(location) => {


### PR DESCRIPTION
Just looks like an oversight in refactoring.