### PR TITLE
Use Rust 1.75 toolchain

### DIFF
--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -86,6 +86,7 @@ pub(crate) struct Cache {
     changes: Mutex<Vec<Change>>,
     /// The "current" timestamp used as cache for the updates of
     /// [`FileCache::last_seen`]
+    #[allow(clippy::struct_field_names)]
     last_seen_cache: u64,
 }
 

--- a/crates/ruff_cli/src/commands/rule.rs
+++ b/crates/ruff_cli/src/commands/rule.rs
@@ -18,6 +18,7 @@ struct Explanation<'a> {
     summary: &'a str,
     message_formats: &'a [&'a str],
     fix: String,
+    #[allow(clippy::struct_field_names)]
     explanation: Option<&'a str>,
     preview: bool,
 }

--- a/crates/ruff_dev/src/format_dev.rs
+++ b/crates/ruff_dev/src/format_dev.rs
@@ -216,6 +216,7 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) files_with_errors: Option<u32>,
     #[clap(flatten)]
+    #[allow(clippy::struct_field_names)]
     pub(crate) log_level_args: LogLevelArgs,
 }
 

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
@@ -367,7 +367,7 @@ pub(crate) fn fix_unnecessary_literal_dict(expr: &Expr, checker: &Checker) -> Re
                 comma,
             } = element
             {
-                if let Some(Element::Simple { value: key, .. }) = tuple.elements.get(0) {
+                if let Some(Element::Simple { value: key, .. }) = tuple.elements.first() {
                     if let Some(Element::Simple { value, .. }) = tuple.elements.get(1) {
                         return Ok(DictElement::Simple {
                             key: key.clone(),

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/multiple_starts_ends_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/multiple_starts_ends_with.rs
@@ -134,7 +134,7 @@ pub(crate) fn multiple_starts_ends_with(checker: &mut Checker, expr: &Expr) {
                             format!("Indices should only contain `{attr_name}` calls")
                         )
                     };
-                    args.get(0)
+                    args.first()
                         .unwrap_or_else(|| panic!("`{attr_name}` should have one argument"))
                 })
                 .collect();

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -379,7 +379,8 @@ pub(crate) fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
                 ..
             }) = &values[indices[0]]
             {
-                args.get(0).expect("`isinstance` should have two arguments")
+                args.first()
+                    .expect("`isinstance` should have two arguments")
             } else {
                 unreachable!("Indices should only contain `isinstance` calls")
             };

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -142,7 +142,7 @@ pub(crate) fn use_capital_environment_variables(checker: &mut Checker, expr: &Ex
     else {
         return;
     };
-    let Some(arg) = args.get(0) else {
+    let Some(arg) = args.first() else {
         return;
     };
     let Expr::StringLiteral(ast::ExprStringLiteral { value: env_var, .. }) = arg else {
@@ -249,7 +249,7 @@ pub(crate) fn dict_get_with_none_default(checker: &mut Checker, expr: &Expr) {
     if attr != "get" {
         return;
     }
-    let Some(key) = args.get(0) else {
+    let Some(key) = args.first() else {
         return;
     };
     if !(key.is_literal_expr() || key.is_name_expr()) {

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_str_strip_call.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_str_strip_call.rs
@@ -149,7 +149,7 @@ pub(crate) fn bad_str_strip_call(checker: &mut Checker, func: &Expr, args: &[Exp
             Expr::StringLiteral(_) | Expr::BytesLiteral(_)
         ) {
             if let Some(strip) = StripKind::from_str(attr.as_str()) {
-                if let Some(arg) = args.get(0) {
+                if let Some(arg) = args.first() {
                     if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = &arg {
                         if has_duplicates(value) {
                             let removal = if checker.settings.target_version >= PythonVersion::Py39

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
@@ -179,7 +179,7 @@ pub(crate) fn native_literals(
         }
     }
 
-    match args.get(0) {
+    match args.first() {
         None => {
             let mut diagnostic = Diagnostic::new(NativeLiterals { literal_type }, call.range());
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
@@ -44,7 +44,7 @@ impl AlwaysFixableViolation for UnpackedListComprehension {
 
 /// UP027
 pub(crate) fn unpacked_list_comprehension(checker: &mut Checker, targets: &[Expr], value: &Expr) {
-    let Some(target) = targets.get(0) else {
+    let Some(target) = targets.first() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/refurb/rules/isinstance_type_none.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/isinstance_type_none.rs
@@ -95,7 +95,7 @@ fn is_none(expr: &Expr) -> bool {
             }) if arguments.len() == 1 => {
                 if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
                     if id.as_str() == "type" {
-                        return matches!(arguments.args.get(0), Some(Expr::NoneLiteral(_)));
+                        return matches!(arguments.args.first(), Some(Expr::NoneLiteral(_)));
                     }
                 }
                 false

--- a/crates/ruff_python_ast/src/imports.rs
+++ b/crates/ruff_python_ast/src/imports.rs
@@ -160,6 +160,10 @@ impl ImportMap {
     pub fn extend(&mut self, other: Self) {
         self.module_to_imports.extend(other.module_to_imports);
     }
+
+    pub fn iter(&self) -> std::collections::hash_map::Iter<String, Vec<ModuleImport>> {
+        self.module_to_imports.iter()
+    }
 }
 
 impl<'a> IntoIterator for &'a ImportMap {
@@ -167,6 +171,6 @@ impl<'a> IntoIterator for &'a ImportMap {
     type Item = (&'a String, &'a Vec<ModuleImport>);
 
     fn into_iter(self) -> Self::IntoIter {
-        self.module_to_imports.iter()
+        self.iter()
     }
 }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1129,6 +1129,14 @@ impl<'a> IntoIterator for &'a FStringValue {
     }
 }
 
+impl<'a> IntoIterator for &'a mut FStringValue {
+    type Item = &'a mut FStringPart;
+    type IntoIter = IterMut<'a, FStringPart>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 /// An internal representation of [`FStringValue`].
 #[derive(Clone, Debug, PartialEq)]
 enum FStringValueInner {
@@ -1321,6 +1329,14 @@ impl<'a> IntoIterator for &'a StringLiteralValue {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut StringLiteralValue {
+    type Item = &'a mut StringLiteral;
+    type IntoIter = IterMut<'a, StringLiteral>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
     }
 }
 
@@ -1544,6 +1560,14 @@ impl<'a> IntoIterator for &'a BytesLiteralValue {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut BytesLiteralValue {
+    type Item = &'a mut BytesLiteral;
+    type IntoIter = IterMut<'a, BytesLiteral>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
     }
 }
 

--- a/crates/ruff_python_literal/src/escape.rs
+++ b/crates/ruff_python_literal/src/escape.rs
@@ -260,24 +260,6 @@ impl<'a> Escape for UnicodeEscape<'a> {
     }
 }
 
-#[cfg(test)]
-mod unicode_escape_tests {
-    use super::*;
-
-    #[test]
-    fn changed() {
-        fn test(s: &str) -> bool {
-            UnicodeEscape::new_repr(s).changed()
-        }
-        assert!(!test("hello"));
-        assert!(!test("'hello'"));
-        assert!(!test("\"hello\""));
-
-        assert!(test("'\"hello"));
-        assert!(test("hello\n"));
-    }
-}
-
 pub struct AsciiEscape<'a> {
     source: &'a [u8],
     layout: EscapeLayout,
@@ -451,5 +433,23 @@ impl BytesRepr<'_, '_> {
 impl std::fmt::Display for BytesRepr<'_, '_> {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.write(formatter)
+    }
+}
+
+#[cfg(test)]
+mod unicode_escape_tests {
+    use super::*;
+
+    #[test]
+    fn changed() {
+        fn test(s: &str) -> bool {
+            UnicodeEscape::new_repr(s).changed()
+        }
+        assert!(!test("hello"));
+        assert!(!test("'hello'"));
+        assert!(!test("\"hello\""));
+
+        assert!(test("'\"hello"));
+        assert!(test("hello\n"));
     }
 }

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1476,7 +1476,7 @@ impl Radix {
             Radix::Binary => matches!(c, '0'..='1'),
             Radix::Octal => matches!(c, '0'..='7'),
             Radix::Decimal => c.is_ascii_digit(),
-            Radix::Hex => matches!(c, '0'..='9' | 'a'..='f' | 'A'..='F'),
+            Radix::Hex => c.is_ascii_hexdigit(),
         }
     }
 }

--- a/crates/ruff_python_resolver/src/import_result.rs
+++ b/crates/ruff_python_resolver/src/import_result.rs
@@ -76,6 +76,7 @@ pub(crate) struct ImportResult {
 
     /// If the import resolved to a type hint (i.e., a `.pyi` file), then
     /// a non-type-hint resolution will be stored here.
+    #[allow(clippy::struct_field_names)]
     pub(crate) non_stub_import_result: Option<Box<ImportResult>>,
 
     /// Information extracted from the `py.typed` in the package used to

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.74"
+channel = "1.75"


### PR DESCRIPTION
## Summary

Upgrade the rust toolchain from version 1.74 to 1.75. 

This does not change the minimal required Rust version to compile Ruff. It only upgrades Clippy, Rustfmt, Rustc etc used locally and in CI

## Test Plan

cargo test
