### PR TITLE
Use a trie-based router to resolve per-file settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "env_logger"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1328,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +1401,15 @@ name = "nextest-workspace-hack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d906846a98739ed9d73d66e62c2641eef8321f1734b7a1156ab045a0248fb2b3"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "nix"
@@ -1821,6 +1842,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -2490,9 +2521,11 @@ dependencies = [
  "is-macro",
  "itertools 0.12.0",
  "log",
+ "matchit",
  "once_cell",
  "path-absolutize",
  "pep440_rs 0.4.0",
+ "radix_trie",
  "regex",
  "ruff_cache",
  "ruff_formatter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,12 +728,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
 name = "env_logger"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,15 +1397,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d906846a98739ed9d73d66e62c2641eef8321f1734b7a1156ab045a0248fb2b3"
 
 [[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,16 +1827,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
 ]
 
 [[package]]
@@ -2525,7 +2500,6 @@ dependencies = [
  "once_cell",
  "path-absolutize",
  "pep440_rs 0.4.0",
- "radix_trie",
  "regex",
  "ruff_cache",
  "ruff_formatter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,6 +1542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2499,6 +2505,7 @@ dependencies = [
  "matchit",
  "once_cell",
  "path-absolutize",
+ "path-slash",
  "pep440_rs 0.4.0",
  "regex",
  "ruff_cache",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ lalrpop-util = { version = "0.20.0", default-features = false }
 lexical-parse-float = { version = "0.8.0", features = ["format"] }
 libcst = { version = "1.1.0", default-features = false }
 log = { version = "0.4.17" }
+matchit = { version = "0.7.3" }
 memchr = { version = "2.6.4" }
 mimalloc = { version ="0.1.39"}
 natord = { version = "1.0.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ natord = { version = "1.0.9" }
 notify = { version = "6.1.1" }
 once_cell = { version = "1.19.0" }
 path-absolutize = { version = "3.1.1" }
+path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
 pep440_rs = { version = "0.4.0", features = ["serde"] }
 pretty_assertions = "1.3.0"

--- a/crates/ruff_workspace/Cargo.toml
+++ b/crates/ruff_workspace/Cargo.toml
@@ -40,6 +40,8 @@ serde = { workspace = true}
 shellexpand = { workspace = true }
 strum = { workspace = true }
 toml = { workspace = true }
+matchit = "0.7.3"
+radix_trie = "0.2.1"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ruff_workspace/Cargo.toml
+++ b/crates/ruff_workspace/Cargo.toml
@@ -33,6 +33,7 @@ log = { workspace = true }
 matchit = { workspace = true }
 once_cell = { workspace = true }
 path-absolutize = { workspace = true }
+path-slash = { workspace = true }
 pep440_rs = { workspace = true, features = ["serde"] }
 regex = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/ruff_workspace/Cargo.toml
+++ b/crates/ruff_workspace/Cargo.toml
@@ -24,12 +24,13 @@ ruff_macros = { path = "../ruff_macros" }
 anyhow = { workspace = true }
 colored = { workspace = true }
 dirs = { workspace = true }
+glob = { workspace = true }
+globset = { workspace = true }
 ignore = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
-glob = { workspace = true }
-globset = { workspace = true }
+matchit = { workspace = true }
 once_cell = { workspace = true }
 path-absolutize = { workspace = true }
 pep440_rs = { workspace = true, features = ["serde"] }
@@ -40,8 +41,6 @@ serde = { workspace = true}
 shellexpand = { workspace = true }
 strum = { workspace = true }
 toml = { workspace = true }
-matchit = "0.7.3"
-radix_trie = "0.2.1"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -14,6 +14,7 @@ use itertools::Itertools;
 use log::debug;
 use matchit::{InsertError, Router};
 use path_absolutize::path_dedot;
+use path_slash::PathExt;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use ruff_linter::fs;
@@ -105,8 +106,9 @@ impl Resolver {
     /// Add a resolved [`Settings`] under a given [`PathBuf`] scope.
     fn add(&mut self, path: &Path, settings: Settings) -> Result<()> {
         self.settings.push(settings);
+        println!("path: {:?}", path.to_slash_lossy());
         match self.router.insert(
-            format!("{}/*filepath", path.to_string_lossy()),
+            format!("{}/*filepath", path.to_slash_lossy()),
             self.settings.len() - 1,
         ) {
             Ok(()) => Ok(()),
@@ -125,7 +127,7 @@ impl Resolver {
             PyprojectDiscoveryStrategy::Fixed => &pyproject_config.settings,
             PyprojectDiscoveryStrategy::Hierarchical => self
                 .router
-                .at(&path.to_string_lossy())
+                .at(&path.to_slash_lossy())
                 .map(|match_| &self.settings[*match_.value])
                 .unwrap_or(&pyproject_config.settings),
         }


### PR DESCRIPTION
## Summary

This is a small change that I put together a while ago but forgot to clean up. When the formatter is fully cached, it turns out we actually spend meaningful time mapping from file to `Settings` (since we use a hierarchical approach to settings). Using `matchit` rather than `BTreeMap` improves fully-cached performance by anywhere from 2-5% depending on the project, and since these are all implementation details of `Resolver`, it's minimally invasive.

We don't need all the behavior of `matchit`, but I tried other libraries like `radix_trie` and didn't see any speedup vs. `main`, whereas `matchit` shows a consistent improvement.

## Test Plan

```
❯ hyperfine --warmup 20 -i "./target/release/main format ../airflow" "./target/release/ruff format ../airflow"
Benchmark 1: ./target/release/main format ../airflow
  Time (mean ± σ):      73.4 ms ±   1.2 ms    [User: 48.8 ms, System: 76.4 ms]
  Range (min … max):    68.4 ms …  78.2 ms    39 runs

Benchmark 2: ./target/release/ruff format ../airflow
  Time (mean ± σ):      69.7 ms ±   0.9 ms    [User: 41.8 ms, System: 75.7 ms]
  Range (min … max):    68.5 ms …  73.5 ms    42 runs

Summary
  './target/release/ruff format ../airflow' ran
    1.05 ± 0.02 times faster than './target/release/main format ../airflow'
```