### PR TITLE
[RUF021]: Add an autofix

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF021.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF021.py
@@ -10,8 +10,7 @@
 
 a, b, c = 1, 0, 2
 x = a or b and c  # RUF021: => `a or (b and c)`
-x = a or b and c  # looooooooooooong comment but not long enough to prevent an autofix
-x = a or b and c  # looooooooong comment to prevent an autofix (line would be too long)
+x = a or b and c  # looooooooooooooooooooooooooooooong comment but it won't prevent an autofix
 
 a, b, c = 0, 1, 2
 y = a and b or c  # RUF021: => `(a and b) or c`
@@ -41,6 +40,20 @@ assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
 if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
     if (not a and b) or c or d:  # OK
         pass
+
+if (
+    some_reasonably_long_condition
+    or some_other_reasonably_long_condition
+    and some_third_reasonably_long_condition
+    or some_fourth_reasonably_long_condition
+    and some_fifth_reasonably_long_condition
+    # a commment
+    and some_sixth_reasonably_long_condition
+    and some_seventh_reasonably_long_condition
+    # another comment
+    or some_eighth_reasonably_long_condition
+):
+    pass
 
 #############################################
 # If they're all the same operator, it's fine

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF021.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF021.py
@@ -10,6 +10,8 @@
 
 a, b, c = 1, 0, 2
 x = a or b and c  # RUF021: => `a or (b and c)`
+x = a or b and c  # looooooooooooong comment but not long enough to prevent an autofix
+x = a or b and c  # looooooooong comment to prevent an autofix (line would be too long)
 
 a, b, c = 0, 1, 2
 y = a and b or c  # RUF021: => `(a and b) or c`
@@ -30,7 +32,8 @@ while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
     pass
 
 b, c, d, e = 2, 3, 0, 4
-z = [a for a in range(5) if a or b or c or d and e]  # RUF021: => `a or b or c or (d and e)`
+# RUF021: => `a or b or c or (d and e)`:
+z = [a for a in range(5) if a or b or c or d and e]
 
 a, b, c, d = 0, 1, 3, 0
 assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF021_RUF021.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF021_RUF021.py.snap
@@ -1,83 +1,214 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
-RUF021.py:12:10: RUF021 Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+RUF021.py:12:10: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
 11 | a, b, c = 1, 0, 2
 12 | x = a or b and c  # RUF021: => `a or (b and c)`
    |          ^^^^^^^ RUF021
-13 | 
-14 | a, b, c = 0, 1, 2
+13 | x = a or b and c  # looooooooooooong comment but not long enough to prevent an autofix
+14 | x = a or b and c  # looooooooong comment to prevent an autofix (line would be too long)
    |
+   = help: Put parentheses around the `and` subexpression inside the `or` expression
 
-RUF021.py:15:5: RUF021 Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+ℹ Safe fix
+9  9  | # as part of a chain.
+10 10 | 
+11 11 | a, b, c = 1, 0, 2
+12    |-x = a or b and c  # RUF021: => `a or (b and c)`
+   12 |+x = a or (b and c)  # RUF021: => `a or (b and c)`
+13 13 | x = a or b and c  # looooooooooooong comment but not long enough to prevent an autofix
+14 14 | x = a or b and c  # looooooooong comment to prevent an autofix (line would be too long)
+15 15 | 
+
+RUF021.py:13:10: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-14 | a, b, c = 0, 1, 2
-15 | y = a and b or c  # RUF021: => `(a and b) or c`
+11 | a, b, c = 1, 0, 2
+12 | x = a or b and c  # RUF021: => `a or (b and c)`
+13 | x = a or b and c  # looooooooooooong comment but not long enough to prevent an autofix
+   |          ^^^^^^^ RUF021
+14 | x = a or b and c  # looooooooong comment to prevent an autofix (line would be too long)
+   |
+   = help: Put parentheses around the `and` subexpression inside the `or` expression
+
+ℹ Safe fix
+10 10 | 
+11 11 | a, b, c = 1, 0, 2
+12 12 | x = a or b and c  # RUF021: => `a or (b and c)`
+13    |-x = a or b and c  # looooooooooooong comment but not long enough to prevent an autofix
+   13 |+x = a or (b and c)  # looooooooooooong comment but not long enough to prevent an autofix
+14 14 | x = a or b and c  # looooooooong comment to prevent an autofix (line would be too long)
+15 15 | 
+16 16 | a, b, c = 0, 1, 2
+
+RUF021.py:14:10: RUF021 Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+   |
+12 | x = a or b and c  # RUF021: => `a or (b and c)`
+13 | x = a or b and c  # looooooooooooong comment but not long enough to prevent an autofix
+14 | x = a or b and c  # looooooooong comment to prevent an autofix (line would be too long)
+   |          ^^^^^^^ RUF021
+15 | 
+16 | a, b, c = 0, 1, 2
+   |
+   = help: Put parentheses around the `and` subexpression inside the `or` expression
+
+RUF021.py:17:5: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+   |
+16 | a, b, c = 0, 1, 2
+17 | y = a and b or c  # RUF021: => `(a and b) or c`
    |     ^^^^^^^ RUF021
-16 | 
-17 | a, b, c, d = 1, 2, 0, 3
+18 | 
+19 | a, b, c, d = 1, 2, 0, 3
    |
+   = help: Put parentheses around the `and` subexpression inside the `or` expression
 
-RUF021.py:18:14: RUF021 Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+ℹ Safe fix
+14 14 | x = a or b and c  # looooooooong comment to prevent an autofix (line would be too long)
+15 15 | 
+16 16 | a, b, c = 0, 1, 2
+17    |-y = a and b or c  # RUF021: => `(a and b) or c`
+   17 |+y = (a and b) or c  # RUF021: => `(a and b) or c`
+18 18 | 
+19 19 | a, b, c, d = 1, 2, 0, 3
+20 20 | if a or b or c and d:  # RUF021: => `a or b or (c and d)`
+
+RUF021.py:20:14: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-17 | a, b, c, d = 1, 2, 0, 3
-18 | if a or b or c and d:  # RUF021: => `a or b or (c and d)`
+19 | a, b, c, d = 1, 2, 0, 3
+20 | if a or b or c and d:  # RUF021: => `a or b or (c and d)`
    |              ^^^^^^^ RUF021
-19 |     pass
+21 |     pass
    |
+   = help: Put parentheses around the `and` subexpression inside the `or` expression
 
-RUF021.py:25:11: RUF021 Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+ℹ Safe fix
+17 17 | y = a and b or c  # RUF021: => `(a and b) or c`
+18 18 | 
+19 19 | a, b, c, d = 1, 2, 0, 3
+20    |-if a or b or c and d:  # RUF021: => `a or b or (c and d)`
+   20 |+if a or b or (c and d):  # RUF021: => `a or b or (c and d)`
+21 21 |     pass
+22 22 | 
+23 23 | a, b, c, d = 0, 0, 2, 3
+
+RUF021.py:27:11: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-23 | if bool():
-24 |     pass
-25 | elif a or b and c or d:  # RUF021: => `a or (b and c) or d`
-   |           ^^^^^^^ RUF021
+25 | if bool():
 26 |     pass
+27 | elif a or b and c or d:  # RUF021: => `a or (b and c) or d`
+   |           ^^^^^^^ RUF021
+28 |     pass
    |
+   = help: Put parentheses around the `and` subexpression inside the `or` expression
 
-RUF021.py:29:7: RUF021 Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+ℹ Safe fix
+24 24 | 
+25 25 | if bool():
+26 26 |     pass
+27    |-elif a or b and c or d:  # RUF021: => `a or (b and c) or d`
+   27 |+elif a or (b and c) or d:  # RUF021: => `a or (b and c) or d`
+28 28 |     pass
+29 29 | 
+30 30 | a, b, c, d = 0, 1, 0, 2
+
+RUF021.py:31:7: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-28 | a, b, c, d = 0, 1, 0, 2
-29 | while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
+30 | a, b, c, d = 0, 1, 0, 2
+31 | while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
    |       ^^^^^^^ RUF021
-30 |     pass
+32 |     pass
    |
+   = help: Put parentheses around the `and` subexpression inside the `or` expression
 
-RUF021.py:29:18: RUF021 Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+ℹ Safe fix
+28 28 |     pass
+29 29 | 
+30 30 | a, b, c, d = 0, 1, 0, 2
+31    |-while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
+   31 |+while (a and b) or c and d:  # RUF021: => `(and b) or (c and d)`
+32 32 |     pass
+33 33 | 
+34 34 | b, c, d, e = 2, 3, 0, 4
+
+RUF021.py:31:18: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-28 | a, b, c, d = 0, 1, 0, 2
-29 | while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
+30 | a, b, c, d = 0, 1, 0, 2
+31 | while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
    |                  ^^^^^^^ RUF021
-30 |     pass
+32 |     pass
    |
+   = help: Put parentheses around the `and` subexpression inside the `or` expression
 
-RUF021.py:33:44: RUF021 Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+ℹ Safe fix
+28 28 |     pass
+29 29 | 
+30 30 | a, b, c, d = 0, 1, 0, 2
+31    |-while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
+   31 |+while a and b or (c and d):  # RUF021: => `(and b) or (c and d)`
+32 32 |     pass
+33 33 | 
+34 34 | b, c, d, e = 2, 3, 0, 4
+
+RUF021.py:36:44: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-32 | b, c, d, e = 2, 3, 0, 4
-33 | z = [a for a in range(5) if a or b or c or d and e]  # RUF021: => `a or b or c or (d and e)`
+34 | b, c, d, e = 2, 3, 0, 4
+35 | # RUF021: => `a or b or c or (d and e)`:
+36 | z = [a for a in range(5) if a or b or c or d and e]
    |                                            ^^^^^^^ RUF021
-34 | 
-35 | a, b, c, d = 0, 1, 3, 0
+37 | 
+38 | a, b, c, d = 0, 1, 3, 0
    |
+   = help: Put parentheses around the `and` subexpression inside the `or` expression
 
-RUF021.py:36:8: RUF021 Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+ℹ Safe fix
+33 33 | 
+34 34 | b, c, d, e = 2, 3, 0, 4
+35 35 | # RUF021: => `a or b or c or (d and e)`:
+36    |-z = [a for a in range(5) if a or b or c or d and e]
+   36 |+z = [a for a in range(5) if a or b or c or (d and e)]
+37 37 | 
+38 38 | a, b, c, d = 0, 1, 3, 0
+39 39 | assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
+
+RUF021.py:39:8: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-35 | a, b, c, d = 0, 1, 3, 0
-36 | assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
+38 | a, b, c, d = 0, 1, 3, 0
+39 | assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
    |        ^^^^^^^^^^^ RUF021
-37 | 
-38 | if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
+40 | 
+41 | if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
    |
+   = help: Put parentheses around the `and` subexpression inside the `or` expression
 
-RUF021.py:38:4: RUF021 Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+ℹ Safe fix
+36 36 | z = [a for a in range(5) if a or b or c or d and e]
+37 37 | 
+38 38 | a, b, c, d = 0, 1, 3, 0
+39    |-assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
+   39 |+assert (not a and b) or c or d  # RUF021: => `(not a and b) or c or d`
+40 40 | 
+41 41 | if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
+42 42 |     if (not a and b) or c or d:  # OK
+
+RUF021.py:41:4: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-36 | assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
-37 | 
-38 | if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
+39 | assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
+40 | 
+41 | if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
    |    ^^^^^^^^^^^^^ RUF021
-39 |     if (not a and b) or c or d:  # OK
-40 |         pass
+42 |     if (not a and b) or c or d:  # OK
+43 |         pass
    |
+   = help: Put parentheses around the `and` subexpression inside the `or` expression
+
+ℹ Safe fix
+38 38 | a, b, c, d = 0, 1, 3, 0
+39 39 | assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
+40 40 | 
+41    |-if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
+   41 |+if ((not a) and b) or c or d:  # RUF021: => `((not a) and b) or c or d`
+42 42 |     if (not a and b) or c or d:  # OK
+43 43 |         pass
+44 44 | 
 
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF021_RUF021.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF021_RUF021.py.snap
@@ -6,10 +6,9 @@ RUF021.py:12:10: RUF021 [*] Parenthesize `a and b` expressions when chaining `an
 11 | a, b, c = 1, 0, 2
 12 | x = a or b and c  # RUF021: => `a or (b and c)`
    |          ^^^^^^^ RUF021
-13 | x = a or b and c  # looooooooooooong comment but not long enough to prevent an autofix
-14 | x = a or b and c  # looooooooong comment to prevent an autofix (line would be too long)
+13 | x = a or b and c  # looooooooooooooooooooooooooooooong comment but it won't prevent an autofix
    |
-   = help: Put parentheses around the `and` subexpression inside the `or` expression
+   = help: Parenthesize the `and` subexpression
 
 ℹ Safe fix
 9  9  | # as part of a chain.
@@ -17,198 +16,244 @@ RUF021.py:12:10: RUF021 [*] Parenthesize `a and b` expressions when chaining `an
 11 11 | a, b, c = 1, 0, 2
 12    |-x = a or b and c  # RUF021: => `a or (b and c)`
    12 |+x = a or (b and c)  # RUF021: => `a or (b and c)`
-13 13 | x = a or b and c  # looooooooooooong comment but not long enough to prevent an autofix
-14 14 | x = a or b and c  # looooooooong comment to prevent an autofix (line would be too long)
-15 15 | 
+13 13 | x = a or b and c  # looooooooooooooooooooooooooooooong comment but it won't prevent an autofix
+14 14 | 
+15 15 | a, b, c = 0, 1, 2
 
 RUF021.py:13:10: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
 11 | a, b, c = 1, 0, 2
 12 | x = a or b and c  # RUF021: => `a or (b and c)`
-13 | x = a or b and c  # looooooooooooong comment but not long enough to prevent an autofix
+13 | x = a or b and c  # looooooooooooooooooooooooooooooong comment but it won't prevent an autofix
    |          ^^^^^^^ RUF021
-14 | x = a or b and c  # looooooooong comment to prevent an autofix (line would be too long)
+14 | 
+15 | a, b, c = 0, 1, 2
    |
-   = help: Put parentheses around the `and` subexpression inside the `or` expression
+   = help: Parenthesize the `and` subexpression
 
 ℹ Safe fix
 10 10 | 
 11 11 | a, b, c = 1, 0, 2
 12 12 | x = a or b and c  # RUF021: => `a or (b and c)`
-13    |-x = a or b and c  # looooooooooooong comment but not long enough to prevent an autofix
-   13 |+x = a or (b and c)  # looooooooooooong comment but not long enough to prevent an autofix
-14 14 | x = a or b and c  # looooooooong comment to prevent an autofix (line would be too long)
-15 15 | 
-16 16 | a, b, c = 0, 1, 2
+13    |-x = a or b and c  # looooooooooooooooooooooooooooooong comment but it won't prevent an autofix
+   13 |+x = a or (b and c)  # looooooooooooooooooooooooooooooong comment but it won't prevent an autofix
+14 14 | 
+15 15 | a, b, c = 0, 1, 2
+16 16 | y = a and b or c  # RUF021: => `(a and b) or c`
 
-RUF021.py:14:10: RUF021 Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+RUF021.py:16:5: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-12 | x = a or b and c  # RUF021: => `a or (b and c)`
-13 | x = a or b and c  # looooooooooooong comment but not long enough to prevent an autofix
-14 | x = a or b and c  # looooooooong comment to prevent an autofix (line would be too long)
-   |          ^^^^^^^ RUF021
-15 | 
-16 | a, b, c = 0, 1, 2
-   |
-   = help: Put parentheses around the `and` subexpression inside the `or` expression
-
-RUF021.py:17:5: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
-   |
-16 | a, b, c = 0, 1, 2
-17 | y = a and b or c  # RUF021: => `(a and b) or c`
+15 | a, b, c = 0, 1, 2
+16 | y = a and b or c  # RUF021: => `(a and b) or c`
    |     ^^^^^^^ RUF021
-18 | 
-19 | a, b, c, d = 1, 2, 0, 3
+17 | 
+18 | a, b, c, d = 1, 2, 0, 3
    |
-   = help: Put parentheses around the `and` subexpression inside the `or` expression
+   = help: Parenthesize the `and` subexpression
 
 ℹ Safe fix
-14 14 | x = a or b and c  # looooooooong comment to prevent an autofix (line would be too long)
-15 15 | 
-16 16 | a, b, c = 0, 1, 2
-17    |-y = a and b or c  # RUF021: => `(a and b) or c`
-   17 |+y = (a and b) or c  # RUF021: => `(a and b) or c`
-18 18 | 
-19 19 | a, b, c, d = 1, 2, 0, 3
-20 20 | if a or b or c and d:  # RUF021: => `a or b or (c and d)`
+13 13 | x = a or b and c  # looooooooooooooooooooooooooooooong comment but it won't prevent an autofix
+14 14 | 
+15 15 | a, b, c = 0, 1, 2
+16    |-y = a and b or c  # RUF021: => `(a and b) or c`
+   16 |+y = (a and b) or c  # RUF021: => `(a and b) or c`
+17 17 | 
+18 18 | a, b, c, d = 1, 2, 0, 3
+19 19 | if a or b or c and d:  # RUF021: => `a or b or (c and d)`
 
-RUF021.py:20:14: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+RUF021.py:19:14: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-19 | a, b, c, d = 1, 2, 0, 3
-20 | if a or b or c and d:  # RUF021: => `a or b or (c and d)`
+18 | a, b, c, d = 1, 2, 0, 3
+19 | if a or b or c and d:  # RUF021: => `a or b or (c and d)`
    |              ^^^^^^^ RUF021
-21 |     pass
+20 |     pass
    |
-   = help: Put parentheses around the `and` subexpression inside the `or` expression
+   = help: Parenthesize the `and` subexpression
 
 ℹ Safe fix
-17 17 | y = a and b or c  # RUF021: => `(a and b) or c`
-18 18 | 
-19 19 | a, b, c, d = 1, 2, 0, 3
-20    |-if a or b or c and d:  # RUF021: => `a or b or (c and d)`
-   20 |+if a or b or (c and d):  # RUF021: => `a or b or (c and d)`
-21 21 |     pass
-22 22 | 
-23 23 | a, b, c, d = 0, 0, 2, 3
+16 16 | y = a and b or c  # RUF021: => `(a and b) or c`
+17 17 | 
+18 18 | a, b, c, d = 1, 2, 0, 3
+19    |-if a or b or c and d:  # RUF021: => `a or b or (c and d)`
+   19 |+if a or b or (c and d):  # RUF021: => `a or b or (c and d)`
+20 20 |     pass
+21 21 | 
+22 22 | a, b, c, d = 0, 0, 2, 3
 
-RUF021.py:27:11: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+RUF021.py:26:11: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-25 | if bool():
-26 |     pass
-27 | elif a or b and c or d:  # RUF021: => `a or (b and c) or d`
+24 | if bool():
+25 |     pass
+26 | elif a or b and c or d:  # RUF021: => `a or (b and c) or d`
    |           ^^^^^^^ RUF021
-28 |     pass
+27 |     pass
    |
-   = help: Put parentheses around the `and` subexpression inside the `or` expression
+   = help: Parenthesize the `and` subexpression
 
 ℹ Safe fix
-24 24 | 
-25 25 | if bool():
-26 26 |     pass
-27    |-elif a or b and c or d:  # RUF021: => `a or (b and c) or d`
-   27 |+elif a or (b and c) or d:  # RUF021: => `a or (b and c) or d`
-28 28 |     pass
-29 29 | 
-30 30 | a, b, c, d = 0, 1, 0, 2
+23 23 | 
+24 24 | if bool():
+25 25 |     pass
+26    |-elif a or b and c or d:  # RUF021: => `a or (b and c) or d`
+   26 |+elif a or (b and c) or d:  # RUF021: => `a or (b and c) or d`
+27 27 |     pass
+28 28 | 
+29 29 | a, b, c, d = 0, 1, 0, 2
 
-RUF021.py:31:7: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+RUF021.py:30:7: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-30 | a, b, c, d = 0, 1, 0, 2
-31 | while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
+29 | a, b, c, d = 0, 1, 0, 2
+30 | while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
    |       ^^^^^^^ RUF021
-32 |     pass
+31 |     pass
    |
-   = help: Put parentheses around the `and` subexpression inside the `or` expression
+   = help: Parenthesize the `and` subexpression
 
 ℹ Safe fix
-28 28 |     pass
-29 29 | 
-30 30 | a, b, c, d = 0, 1, 0, 2
-31    |-while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
-   31 |+while (a and b) or c and d:  # RUF021: => `(and b) or (c and d)`
-32 32 |     pass
-33 33 | 
-34 34 | b, c, d, e = 2, 3, 0, 4
+27 27 |     pass
+28 28 | 
+29 29 | a, b, c, d = 0, 1, 0, 2
+30    |-while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
+   30 |+while (a and b) or c and d:  # RUF021: => `(and b) or (c and d)`
+31 31 |     pass
+32 32 | 
+33 33 | b, c, d, e = 2, 3, 0, 4
 
-RUF021.py:31:18: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+RUF021.py:30:18: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-30 | a, b, c, d = 0, 1, 0, 2
-31 | while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
+29 | a, b, c, d = 0, 1, 0, 2
+30 | while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
    |                  ^^^^^^^ RUF021
-32 |     pass
+31 |     pass
    |
-   = help: Put parentheses around the `and` subexpression inside the `or` expression
+   = help: Parenthesize the `and` subexpression
 
 ℹ Safe fix
-28 28 |     pass
-29 29 | 
-30 30 | a, b, c, d = 0, 1, 0, 2
-31    |-while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
-   31 |+while a and b or (c and d):  # RUF021: => `(and b) or (c and d)`
-32 32 |     pass
-33 33 | 
-34 34 | b, c, d, e = 2, 3, 0, 4
+27 27 |     pass
+28 28 | 
+29 29 | a, b, c, d = 0, 1, 0, 2
+30    |-while a and b or c and d:  # RUF021: => `(and b) or (c and d)`
+   30 |+while a and b or (c and d):  # RUF021: => `(and b) or (c and d)`
+31 31 |     pass
+32 32 | 
+33 33 | b, c, d, e = 2, 3, 0, 4
 
-RUF021.py:36:44: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+RUF021.py:35:44: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-34 | b, c, d, e = 2, 3, 0, 4
-35 | # RUF021: => `a or b or c or (d and e)`:
-36 | z = [a for a in range(5) if a or b or c or d and e]
+33 | b, c, d, e = 2, 3, 0, 4
+34 | # RUF021: => `a or b or c or (d and e)`:
+35 | z = [a for a in range(5) if a or b or c or d and e]
    |                                            ^^^^^^^ RUF021
-37 | 
-38 | a, b, c, d = 0, 1, 3, 0
+36 | 
+37 | a, b, c, d = 0, 1, 3, 0
    |
-   = help: Put parentheses around the `and` subexpression inside the `or` expression
+   = help: Parenthesize the `and` subexpression
 
 ℹ Safe fix
-33 33 | 
-34 34 | b, c, d, e = 2, 3, 0, 4
-35 35 | # RUF021: => `a or b or c or (d and e)`:
-36    |-z = [a for a in range(5) if a or b or c or d and e]
-   36 |+z = [a for a in range(5) if a or b or c or (d and e)]
-37 37 | 
-38 38 | a, b, c, d = 0, 1, 3, 0
-39 39 | assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
+32 32 | 
+33 33 | b, c, d, e = 2, 3, 0, 4
+34 34 | # RUF021: => `a or b or c or (d and e)`:
+35    |-z = [a for a in range(5) if a or b or c or d and e]
+   35 |+z = [a for a in range(5) if a or b or c or (d and e)]
+36 36 | 
+37 37 | a, b, c, d = 0, 1, 3, 0
+38 38 | assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
 
-RUF021.py:39:8: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+RUF021.py:38:8: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-38 | a, b, c, d = 0, 1, 3, 0
-39 | assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
+37 | a, b, c, d = 0, 1, 3, 0
+38 | assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
    |        ^^^^^^^^^^^ RUF021
-40 | 
-41 | if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
+39 | 
+40 | if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
    |
-   = help: Put parentheses around the `and` subexpression inside the `or` expression
+   = help: Parenthesize the `and` subexpression
 
 ℹ Safe fix
-36 36 | z = [a for a in range(5) if a or b or c or d and e]
-37 37 | 
-38 38 | a, b, c, d = 0, 1, 3, 0
-39    |-assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
-   39 |+assert (not a and b) or c or d  # RUF021: => `(not a and b) or c or d`
-40 40 | 
-41 41 | if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
-42 42 |     if (not a and b) or c or d:  # OK
+35 35 | z = [a for a in range(5) if a or b or c or d and e]
+36 36 | 
+37 37 | a, b, c, d = 0, 1, 3, 0
+38    |-assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
+   38 |+assert (not a and b) or c or d  # RUF021: => `(not a and b) or c or d`
+39 39 | 
+40 40 | if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
+41 41 |     if (not a and b) or c or d:  # OK
 
-RUF021.py:41:4: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+RUF021.py:40:4: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
    |
-39 | assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
-40 | 
-41 | if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
+38 | assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
+39 | 
+40 | if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
    |    ^^^^^^^^^^^^^ RUF021
-42 |     if (not a and b) or c or d:  # OK
-43 |         pass
+41 |     if (not a and b) or c or d:  # OK
+42 |         pass
    |
-   = help: Put parentheses around the `and` subexpression inside the `or` expression
+   = help: Parenthesize the `and` subexpression
 
 ℹ Safe fix
-38 38 | a, b, c, d = 0, 1, 3, 0
-39 39 | assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
-40 40 | 
-41    |-if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
-   41 |+if ((not a) and b) or c or d:  # RUF021: => `((not a) and b) or c or d`
-42 42 |     if (not a and b) or c or d:  # OK
-43 43 |         pass
-44 44 | 
+37 37 | a, b, c, d = 0, 1, 3, 0
+38 38 | assert not a and b or c or d  # RUF021: => `(not a and b) or c or d`
+39 39 | 
+40    |-if (not a) and b or c or d:  # RUF021: => `((not a) and b) or c or d`
+   40 |+if ((not a) and b) or c or d:  # RUF021: => `((not a) and b) or c or d`
+41 41 |     if (not a and b) or c or d:  # OK
+42 42 |         pass
+43 43 | 
+
+RUF021.py:46:8: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+   |
+44 |   if (
+45 |       some_reasonably_long_condition
+46 |       or some_other_reasonably_long_condition
+   |  ________^
+47 | |     and some_third_reasonably_long_condition
+   | |____________________________________________^ RUF021
+48 |       or some_fourth_reasonably_long_condition
+49 |       and some_fifth_reasonably_long_condition
+   |
+   = help: Parenthesize the `and` subexpression
+
+ℹ Safe fix
+43 43 | 
+44 44 | if (
+45 45 |     some_reasonably_long_condition
+46    |-    or some_other_reasonably_long_condition
+47    |-    and some_third_reasonably_long_condition
+   46 |+    or (some_other_reasonably_long_condition
+   47 |+    and some_third_reasonably_long_condition)
+48 48 |     or some_fourth_reasonably_long_condition
+49 49 |     and some_fifth_reasonably_long_condition
+50 50 |     # a commment
+
+RUF021.py:48:8: RUF021 [*] Parenthesize `a and b` expressions when chaining `and` and `or` together, to make the precedence clear
+   |
+46 |       or some_other_reasonably_long_condition
+47 |       and some_third_reasonably_long_condition
+48 |       or some_fourth_reasonably_long_condition
+   |  ________^
+49 | |     and some_fifth_reasonably_long_condition
+50 | |     # a commment
+51 | |     and some_sixth_reasonably_long_condition
+52 | |     and some_seventh_reasonably_long_condition
+   | |______________________________________________^ RUF021
+53 |       # another comment
+54 |       or some_eighth_reasonably_long_condition
+   |
+   = help: Parenthesize the `and` subexpression
+
+ℹ Safe fix
+45 45 |     some_reasonably_long_condition
+46 46 |     or some_other_reasonably_long_condition
+47 47 |     and some_third_reasonably_long_condition
+48    |-    or some_fourth_reasonably_long_condition
+   48 |+    or (some_fourth_reasonably_long_condition
+49 49 |     and some_fifth_reasonably_long_condition
+50 50 |     # a commment
+51 51 |     and some_sixth_reasonably_long_condition
+52    |-    and some_seventh_reasonably_long_condition
+   52 |+    and some_seventh_reasonably_long_condition)
+53 53 |     # another comment
+54 54 |     or some_eighth_reasonably_long_condition
+55 55 | ):
 
 


### PR DESCRIPTION
## Summary

This adds an autofix for the newly added RUF021 (see #9440).

The PR currently only adds an autofix to the diagnostic if:
1. There are no line breaks inside the expression as it currently exists;
2. We determine that we could safely add parentheses to the subexpression in question without the line getting too long.

If we know that both of the above are true, the fix is pretty simple to implement. I _think_ it should also be pretty safe, as well -- we shouldn't be making any changes here that impact the AST.

Two remarks:
1. It would be _possible_ to add an autofix if the pre-existing expression spanned multiple lines, but it would be _much_ harder, I think. You'd have to worry about whether there were comments at the end of lines or in between lines; you'd have to worry about indentation; you'd have to worry about whether the newly parenthesized subexpression should be formatted into a single line or should itself be split into several lines. (But maybe there's an easy way of resolving all those things that I'm not aware of 😄.)
2. Currently the PR just doesn't add a fix if the resulting fix would cause the line to be too long. But maybe we _could_ add the fix even then, but just mark it as unsafe? Not sure.

## Test Plan

`cargo test` / `cargo insta review`
