### PR TITLE
Import Black's type aliases test

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/type_aliases.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/type_aliases.options.json
@@ -1,0 +1,1 @@
+{"target_version": "py312"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/type_aliases.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/type_aliases.py
@@ -1,0 +1,10 @@
+type A=int
+type Gen[T]=list[T]
+type Alias[T]=lambda: T
+type And[T]=T and T
+type IfElse[T]=T if T else T
+type One = int; type Another = str
+class X: type InClass = int
+
+type = aliased
+print(type(42))

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/type_aliases.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/type_aliases.py.expect
@@ -1,0 +1,15 @@
+type A = int
+type Gen[T] = list[T]
+type Alias[T] = lambda: T
+type And[T] = T and T
+type IfElse[T] = T if T else T
+type One = int
+type Another = str
+
+
+class X:
+    type InClass = int
+
+
+type = aliased
+print(type(42))

--- a/crates/ruff_python_formatter/resources/test/fixtures/import_black_tests.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/import_black_tests.py
@@ -96,9 +96,6 @@ IGNORE_LIST = [
 
     # Uses a different output format
     "decorators.py",
-
-    # Ruff fails to parse because of a parser bug
-    "type_aliases.py"  # #8900 #8899
 ]
 
 


### PR DESCRIPTION
## Summary

Import Black's type aliases test now that our parser bugs are fixed.

## Test Plan

`cargo test`
