### PR TITLE
Remove type parameter from `parse_*` methods

### DIFF
--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -55,7 +55,7 @@ fn benchmark_linter(mut group: BenchmarkGroup, settings: &LinterSettings) {
             &case,
             |b, case| {
                 // Tokenize the source.
-                let tokens = lexer::lex(case.code(), Mode::Module).collect::<Vec<_>>();
+                let tokens: Vec<_> = lexer::lex(case.code(), Mode::Module).collect();
 
                 // Parse the source.
                 let ast = parse_program_tokens(tokens.clone(), case.code(), false).unwrap();

--- a/crates/ruff_python_ast/tests/preorder.rs
+++ b/crates/ruff_python_ast/tests/preorder.rs
@@ -149,7 +149,7 @@ fn f_strings() {
 
 fn trace_preorder_visitation(source: &str) -> String {
     let tokens = lex(source, Mode::Module);
-    let parsed = parse_tokens(tokens, source, Mode::Module).unwrap();
+    let parsed = parse_tokens(tokens.collect(), source, Mode::Module).unwrap();
 
     let mut visitor = RecordVisitor::default();
     visitor.visit_mod(&parsed);

--- a/crates/ruff_python_ast/tests/visitor.rs
+++ b/crates/ruff_python_ast/tests/visitor.rs
@@ -160,7 +160,7 @@ fn f_strings() {
 
 fn trace_visitation(source: &str) -> String {
     let tokens = lex(source, Mode::Module);
-    let parsed = parse_tokens(tokens, source, Mode::Module).unwrap();
+    let parsed = parse_tokens(tokens.collect(), source, Mode::Module).unwrap();
 
     let mut visitor = RecordVisitor::default();
     walk_module(&mut visitor, &parsed);

--- a/crates/ruff_python_formatter/src/cli.rs
+++ b/crates/ruff_python_formatter/src/cli.rs
@@ -8,7 +8,7 @@ use clap::{command, Parser, ValueEnum};
 use ruff_formatter::SourceCode;
 use ruff_python_ast::PySourceType;
 use ruff_python_index::tokens_and_ranges;
-use ruff_python_parser::{parse_ok_tokens, AsMode};
+use ruff_python_parser::{parse_tokens, AsMode};
 use ruff_text_size::Ranged;
 
 use crate::comments::collect_comments;
@@ -51,7 +51,7 @@ pub fn format_and_debug_print(source: &str, cli: &Cli, source_path: &Path) -> Re
 
     // Parse the AST.
     let module =
-        parse_ok_tokens(tokens, source, source_type.as_mode()).context("Syntax error in input")?;
+        parse_tokens(tokens, source, source_type.as_mode()).context("Syntax error in input")?;
 
     let options = PyFormatOptions::from_extension(source_path)
         .with_preview(if cli.preview {

--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -102,12 +102,12 @@ use ruff_python_ast::Mod;
 use ruff_python_trivia::{CommentRanges, PythonWhitespace};
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
+pub(crate) use visitor::collect_comments;
 
 use crate::comments::debug::{DebugComment, DebugComments};
 use crate::comments::map::{LeadingDanglingTrailing, MultiMap};
 use crate::comments::node_key::NodeRefEqualityKey;
 use crate::comments::visitor::{CommentsMapBuilder, CommentsVisitor};
-pub(crate) use visitor::collect_comments;
 
 mod debug;
 pub(crate) mod format;
@@ -563,8 +563,7 @@ mod tests {
     use ruff_formatter::SourceCode;
     use ruff_python_ast::{Mod, PySourceType};
     use ruff_python_index::tokens_and_ranges;
-
-    use ruff_python_parser::{parse_ok_tokens, AsMode};
+    use ruff_python_parser::{parse_tokens, AsMode};
     use ruff_python_trivia::CommentRanges;
 
     use crate::comments::Comments;
@@ -581,7 +580,7 @@ mod tests {
             let source_type = PySourceType::Python;
             let (tokens, comment_ranges) =
                 tokens_and_ranges(source, source_type).expect("Expect source to be valid Python");
-            let parsed = parse_ok_tokens(tokens, source, source_type.as_mode())
+            let parsed = parse_tokens(tokens, source, source_type.as_mode())
                 .expect("Expect source to be valid Python");
 
             CommentsTestCase {

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -6,7 +6,7 @@ use ruff_formatter::{format, FormatError, Formatted, PrintError, Printed, Source
 use ruff_python_ast::AstNode;
 use ruff_python_ast::Mod;
 use ruff_python_index::tokens_and_ranges;
-use ruff_python_parser::{parse_ok_tokens, AsMode, ParseError, ParseErrorType};
+use ruff_python_parser::{parse_tokens, AsMode, ParseError, ParseErrorType};
 use ruff_python_trivia::CommentRanges;
 use ruff_source_file::Locator;
 
@@ -126,7 +126,7 @@ pub fn format_module_source(
             offset: err.location,
             error: ParseErrorType::Lexical(err.error),
         })?;
-    let module = parse_ok_tokens(tokens, source, source_type.as_mode())?;
+    let module = parse_tokens(tokens, source, source_type.as_mode())?;
     let formatted = format_module_ast(&module, &comment_ranges, source, options)?;
     Ok(formatted.print()?)
 }
@@ -169,7 +169,7 @@ mod tests {
 
     use ruff_python_ast::PySourceType;
     use ruff_python_index::tokens_and_ranges;
-    use ruff_python_parser::{parse_ok_tokens, AsMode};
+    use ruff_python_parser::{parse_tokens, AsMode};
 
     use crate::{format_module_ast, format_module_source, PyFormatOptions};
 
@@ -213,7 +213,7 @@ def main() -> None:
 
         // Parse the AST.
         let source_path = "code_inline.py";
-        let module = parse_ok_tokens(tokens, source, source_type.as_mode()).unwrap();
+        let module = parse_tokens(tokens, source, source_type.as_mode()).unwrap();
         let options = PyFormatOptions::from_extension(Path::new(source_path));
         let formatted = format_module_ast(&module, &comment_ranges, source, options).unwrap();
 

--- a/crates/ruff_python_formatter/src/string/docstring.rs
+++ b/crates/ruff_python_formatter/src/string/docstring.rs
@@ -1516,7 +1516,7 @@ fn docstring_format_source(
     let source_type = options.source_type();
     let (tokens, comment_ranges) =
         ruff_python_index::tokens_and_ranges(source, source_type).map_err(ParseError::from)?;
-    let module = ruff_python_parser::parse_ok_tokens(tokens, source, source_type.as_mode())?;
+    let module = ruff_python_parser::parse_tokens(tokens, source, source_type.as_mode())?;
     let source_code = ruff_formatter::SourceCode::new(source);
     let comments = crate::Comments::from_ast(&module, source_code, &comment_ranges);
     let locator = Locator::new(source);

--- a/crates/ruff_python_parser/src/invalid.rs
+++ b/crates/ruff_python_parser/src/invalid.rs
@@ -687,7 +687,7 @@ mod tests {
 
         let src = r"!foo = 42";
         let tokens = crate::lexer::lex(src, Mode::Ipython);
-        let ast = crate::parse_tokens(tokens, src, Mode::Ipython);
+        let ast = crate::parse_tokens(tokens.collect(), src, Mode::Ipython);
         insta::assert_debug_snapshot!(ast);
     }
 

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -85,7 +85,7 @@
 //!    return bool(i & 1)
 //! "#;
 //! let tokens = lex(python_source, Mode::Module);
-//! let ast = parse_tokens(tokens, python_source, Mode::Module);
+//! let ast = parse_tokens(tokens.collect(), python_source, Mode::Module);
 //!
 //! assert!(ast.is_ok());
 //! ```
@@ -110,8 +110,8 @@
 //! [lexer]: crate::lexer
 
 pub use parser::{
-    parse, parse_expression, parse_expression_starts_at, parse_ok_tokens, parse_program,
-    parse_starts_at, parse_suite, parse_tokens, ParseError, ParseErrorType,
+    parse, parse_expression, parse_expression_starts_at, parse_program, parse_starts_at,
+    parse_suite, parse_tokens, ParseError, ParseErrorType,
 };
 use ruff_python_ast::{Mod, PySourceType, Suite};
 pub use string::FStringErrorType;
@@ -128,6 +128,7 @@ mod parser;
 mod soft_keywords;
 mod string;
 mod token;
+mod token_source;
 pub mod typing;
 
 /// Collect tokens up to and including the first error.
@@ -145,7 +146,7 @@ pub fn tokenize(contents: &str, mode: Mode) -> Vec<LexResult> {
 
 /// Parse a full Python program from its tokens.
 pub fn parse_program_tokens(
-    lxr: Vec<LexResult>,
+    tokens: Vec<LexResult>,
     source: &str,
     is_jupyter_notebook: bool,
 ) -> anyhow::Result<Suite, ParseError> {
@@ -154,7 +155,7 @@ pub fn parse_program_tokens(
     } else {
         Mode::Module
     };
-    match parse_tokens(lxr, source, mode)? {
+    match parse_tokens(tokens, source, mode)? {
         Mod::Module(m) => Ok(m.body),
         Mod::Expression(_) => unreachable!("Mode::Module doesn't return other variant"),
     }

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -1,0 +1,46 @@
+use crate::lexer::LexResult;
+use crate::Tok;
+use std::iter::FusedIterator;
+
+#[derive(Clone, Debug)]
+pub(crate) struct TokenSource {
+    tokens: std::vec::IntoIter<LexResult>,
+}
+
+impl TokenSource {
+    pub(crate) fn new(tokens: Vec<LexResult>) -> Self {
+        Self {
+            tokens: tokens.into_iter(),
+        }
+    }
+}
+
+impl FromIterator<LexResult> for TokenSource {
+    #[inline]
+    fn from_iter<T: IntoIterator<Item = LexResult>>(iter: T) -> Self {
+        Self::new(Vec::from_iter(iter))
+    }
+}
+
+impl Iterator for TokenSource {
+    type Item = LexResult;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let next = self.tokens.next()?;
+
+            if is_trivia(&next) {
+                continue;
+            }
+
+            break Some(next);
+        }
+    }
+}
+
+impl FusedIterator for TokenSource {}
+
+const fn is_trivia(result: &LexResult) -> bool {
+    matches!(result, Ok((Tok::Comment(_) | Tok::NonLogicalNewline, _)))
+}

--- a/crates/ruff_python_trivia/src/comment_ranges.rs
+++ b/crates/ruff_python_trivia/src/comment_ranges.rs
@@ -216,7 +216,7 @@ mod tests {
     fn block_comments_two_line_block_at_start() {
         // arrange
         let source = "# line 1\n# line 2\n";
-        let tokens: Vec<LexResult> = tokenize(source, Mode::Module);
+        let tokens = tokenize(source, Mode::Module);
         let locator = Locator::new(source);
         let indexer = Indexer::from_tokens(&tokens, &locator);
 
@@ -231,7 +231,7 @@ mod tests {
     fn block_comments_indented_block() {
         // arrange
         let source = "    # line 1\n    # line 2\n";
-        let tokens: Vec<LexResult> = tokenize(source, Mode::Module);
+        let tokens = tokenize(source, Mode::Module);
         let locator = Locator::new(source);
         let indexer = Indexer::from_tokens(&tokens, &locator);
 
@@ -261,7 +261,7 @@ mod tests {
     fn block_comments_lines_with_code_not_a_block() {
         // arrange
         let source = "x = 1  # line 1\ny = 2  # line 2\n";
-        let tokens: Vec<LexResult> = tokenize(source, Mode::Module);
+        let tokens = tokenize(source, Mode::Module);
         let locator = Locator::new(source);
         let indexer = Indexer::from_tokens(&tokens, &locator);
 
@@ -276,7 +276,7 @@ mod tests {
     fn block_comments_sequential_lines_not_in_block() {
         // arrange
         let source = "    # line 1\n        # line 2\n";
-        let tokens: Vec<LexResult> = tokenize(source, Mode::Module);
+        let tokens = tokenize(source, Mode::Module);
         let locator = Locator::new(source);
         let indexer = Indexer::from_tokens(&tokens, &locator);
 
@@ -296,7 +296,7 @@ mod tests {
         # line 2
         """
         "#;
-        let tokens: Vec<LexResult> = tokenize(source, Mode::Module);
+        let tokens = tokenize(source, Mode::Module);
         let locator = Locator::new(source);
         let indexer = Indexer::from_tokens(&tokens, &locator);
 
@@ -333,7 +333,7 @@ y = 2  # do not form a block comment
 # therefore do not form a block comment
 """
         "#;
-        let tokens: Vec<LexResult> = tokenize(source, Mode::Module);
+        let tokens = tokenize(source, Mode::Module);
         let locator = Locator::new(source);
         let indexer = Indexer::from_tokens(&tokens, &locator);
 


### PR DESCRIPTION
This PR removes the `I` (tokens iterator) type parameter from all `parse_*` methods. This is done in preparation for https://github.com/astral-sh/ruff/pull/9152 to avoid accidentally monomorphizing the parser more than once. 

The `Parser` struct defined in https://github.com/astral-sh/ruff/pull/9152 is parametrized by the underlying tokens iterator. This is dangerous because Rust will monomorphize the entire parser for each distinct `I` type parameter. 

This PR removes the `I` type parameters from all `parse_*` methods and introduces a new `TokenSource` type in the parser that:

* Filters out trivia tokens
* Allows lookahead without the need for `MultiPeek` (which has an overhead when reading tokens)
* Is a single type used by our `Parser` to read tokens. 

The downside is that all `parse_` methods now take a `Vec<LexResult>`, which requires collecting the lexer result into a Vec before parsing. Our micro-benchmarks show that this is slower than streaming the tokens one by one. 

However, it turns out that both the linter and formatter both collect the tokens before parsing them to an AST. That means the path tested by the micro-benchmark isn't used in the actual product and the introduced regression doesn't affect users. 

You may wonder why this is only a problem now but hasn't been a problem with lalrpop. The problem existed with lalrpop as well but to a much smaller extent because lalrpop separates the parser into two parts:

* A state machine parametrized by `I` that consumes the tokens and calls into the parser methods (only passing the tokens)
* The actual parsing methods

Only the state machine gets monomorphized, which is fine because it is limited in size. Another way to think about it is that the lalrpop pushes the tokens into the parser (and, therefore, the parser is decoupled from I). In contrast, the handwritten parser pulls the tokens (and, therefore, is generic over I).

## Alternatives

Alternatives that may be less affected by the performance regression are

* A `TokenSource` enum with two variants: One storing the lexed tokens and the other storing the lexer to consume the tokens lazily.
* Storing a `Box<impl Iterator>` in the hand written parser

I went with the above approach because we don't need the flexibility of either lexing lazily or eagerly in Ruff outside the parser benchmark. Thus, using a `Vec<LexResult>` seemed the easiest solution.

CC: @LaBatata101 