### PR TITLE
Promote `lint.` settings over top-level settings

### DIFF
--- a/crates/ruff/tests/snapshots/integration_test__explain_status_codes_f401.snap
+++ b/crates/ruff/tests/snapshots/integration_test__explain_status_codes_f401.snap
@@ -51,7 +51,7 @@ else:
 ```
 
 ## Options
-- `pyflakes.extend-generics`
+- `lint.pyflakes.extend-generics`
 
 ## References
 - [Python documentation: `import`](https://docs.python.org/3/reference/simple_stmts.html#the-import-statement)

--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -116,7 +116,7 @@ fn process_documentation(documentation: &str, out: &mut String, rule_name: &str)
                     }
                 }
 
-                let anchor = option.replace('.', "-");
+                let anchor = option.replace('.', "_");
                 out.push_str(&format!("- [`{option}`][{option}]\n"));
                 after.push_str(&format!("[{option}]: ../settings.md#{anchor}\n"));
 
@@ -167,8 +167,8 @@ Something [`else`][other].
 
 [other]: http://example.com.
 
-[lint.task-tags]: ../settings.md#lint-task-tags
-[lint.mccabe.max-complexity]: ../settings.md#lint-mccabe-max-complexity
+[lint.task-tags]: ../settings.md#lint_task-tags
+[lint.mccabe.max-complexity]: ../settings.md#lint_mccabe_max-complexity
 "
         );
     }

--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -142,13 +142,13 @@ mod tests {
         let mut output = String::new();
         process_documentation(
             "
-See also [`mccabe.max-complexity`] and [`task-tags`].
+See also [`lint.mccabe.max-complexity`] and [`lint.task-tags`].
 Something [`else`][other].
 
 ## Options
 
-- `task-tags`
-- `mccabe.max-complexity`
+- `lint.task-tags`
+- `lint.mccabe.max-complexity`
 
 [other]: http://example.com.",
             &mut output,
@@ -157,18 +157,18 @@ Something [`else`][other].
         assert_eq!(
             output,
             "
-See also [`mccabe.max-complexity`][mccabe.max-complexity] and [`task-tags`][task-tags].
+See also [`lint.mccabe.max-complexity`][lint.mccabe.max-complexity] and [`lint.task-tags`][lint.task-tags].
 Something [`else`][other].
 
 ## Options
 
-- [`task-tags`][task-tags]
-- [`mccabe.max-complexity`][mccabe.max-complexity]
+- [`lint.task-tags`][lint.task-tags]
+- [`lint.mccabe.max-complexity`][lint.mccabe.max-complexity]
 
 [other]: http://example.com.
 
-[task-tags]: ../settings.md#task-tags
-[mccabe.max-complexity]: ../settings.md#mccabe-max-complexity
+[lint.task-tags]: ../settings.md#lint-task-tags
+[lint.mccabe.max-complexity]: ../settings.md#lint-mccabe-max-complexity
 "
         );
     }

--- a/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
+++ b/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
@@ -24,7 +24,7 @@ use super::super::detection::comment_contains_code;
 /// ```
 ///
 /// ## Options
-/// - `task-tags`
+/// - `lint.task-tags`
 ///
 /// [#4845]: https://github.com/astral-sh/ruff/issues/4845
 #[violation]

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
@@ -23,11 +23,11 @@ use crate::checkers::ast::Checker;
 /// calls to the function, which can lead to unexpected behaviour.
 ///
 /// Calls can be marked as an exception to this rule with the
-/// [`flake8-bugbear.extend-immutable-calls`] configuration option.
+/// [`lint.flake8-bugbear.extend-immutable-calls`] configuration option.
 ///
 /// Arguments with immutable type annotations will be ignored by this rule.
 /// Types outside of the standard library can be marked as immutable with the
-/// [`flake8-bugbear.extend-immutable-calls`] configuration option as well.
+/// [`lint.flake8-bugbear.extend-immutable-calls`] configuration option as well.
 ///
 /// ## Example
 /// ```python
@@ -61,7 +61,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## Options
-/// - `flake8-bugbear.extend-immutable-calls`
+/// - `lint.flake8-bugbear.extend-immutable-calls`
 #[violation]
 pub struct FunctionCallInDefaultArgument {
     name: Option<String>,

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -28,7 +28,7 @@ use crate::checkers::ast::Checker;
 ///
 /// Arguments with immutable type annotations will be ignored by this rule.
 /// Types outside of the standard library can be marked as immutable with the
-/// [`flake8-bugbear.extend-immutable-calls`] configuration option.
+/// [`lint.flake8-bugbear.extend-immutable-calls`] configuration option.
 ///
 /// ## Known problems
 /// Mutable argument defaults can be used intentionally to cache computation
@@ -61,7 +61,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## Options
-/// - `flake8-bugbear.extend-immutable-calls`
+/// - `lint.flake8-bugbear.extend-immutable-calls`
 ///
 /// ## References
 /// - [Python documentation: Default Argument Values](https://docs.python.org/3/tutorial/controlflow.html#default-argument-values)

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_argument_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_argument_shadowing.rs
@@ -19,7 +19,7 @@ use super::super::helpers::shadows_builtin;
 /// builtin and vice versa.
 ///
 /// Builtins can be marked as exceptions to this rule via the
-/// [`flake8-builtins.builtins-ignorelist`] configuration option.
+/// [`lint.flake8-builtins.builtins-ignorelist`] configuration option.
 ///
 /// ## Example
 /// ```python
@@ -44,7 +44,7 @@ use super::super::helpers::shadows_builtin;
 /// ```
 ///
 /// ## Options
-/// - `flake8-builtins.builtins-ignorelist`
+/// - `lint.flake8-builtins.builtins-ignorelist`
 ///
 /// ## References
 /// - [_Is it bad practice to use a built-in function name as an attribute or method identifier?_](https://stackoverflow.com/questions/9109333/is-it-bad-practice-to-use-a-built-in-function-name-as-an-attribute-or-method-ide)

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_attribute_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_attribute_shadowing.rs
@@ -37,7 +37,7 @@ use crate::rules::flake8_builtins::helpers::shadows_builtin;
 /// ```
 ///
 /// Builtins can be marked as exceptions to this rule via the
-/// [`flake8-builtins.builtins-ignorelist`] configuration option, or
+/// [`lint.flake8-builtins.builtins-ignorelist`] configuration option, or
 /// converted to the appropriate dunder method. Methods decorated with
 /// `@typing.override` or `@typing_extensions.override` are also
 /// ignored.
@@ -55,7 +55,7 @@ use crate::rules::flake8_builtins::helpers::shadows_builtin;
 /// ```
 ///
 /// ## Options
-/// - `flake8-builtins.builtins-ignorelist`
+/// - `lint.flake8-builtins.builtins-ignorelist`
 #[violation]
 pub struct BuiltinAttributeShadowing {
     kind: Kind,

--- a/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_variable_shadowing.rs
+++ b/crates/ruff_linter/src/rules/flake8_builtins/rules/builtin_variable_shadowing.rs
@@ -18,7 +18,7 @@ use crate::rules::flake8_builtins::helpers::shadows_builtin;
 /// builtin and vice versa.
 ///
 /// Builtins can be marked as exceptions to this rule via the
-/// [`flake8-builtins.builtins-ignorelist`] configuration option.
+/// [`lint.flake8-builtins.builtins-ignorelist`] configuration option.
 ///
 /// ## Example
 /// ```python
@@ -41,7 +41,7 @@ use crate::rules::flake8_builtins::helpers::shadows_builtin;
 /// ```
 ///
 /// ## Options
-/// - `flake8-builtins.builtins-ignorelist`
+/// - `lint.flake8-builtins.builtins-ignorelist`
 ///
 /// ## References
 /// - [_Why is it a bad idea to name a variable `id` in Python?_](https://stackoverflow.com/questions/77552/id-is-a-bad-variable-name-in-python)

--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/implicit.rs
@@ -59,7 +59,7 @@ impl Violation for SingleLineImplicitStringConcatenation {
 ///
 /// By default, this rule will only trigger if the string literal is
 /// concatenated via a backslash. To disallow implicit string concatenation
-/// altogether, set the [`flake8-implicit-str-concat.allow-multiline`] option
+/// altogether, set the [`lint.flake8-implicit-str-concat.allow-multiline`] option
 /// to `false`.
 ///
 /// ## Example
@@ -77,7 +77,7 @@ impl Violation for SingleLineImplicitStringConcatenation {
 /// ```
 ///
 /// ## Options
-/// - `flake8-implicit-str-concat.allow-multiline`
+/// - `lint.flake8-implicit-str-concat.allow-multiline`
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#maximum-line-length
 #[violation]

--- a/crates/ruff_linter/src/rules/flake8_import_conventions/rules/banned_import_alias.rs
+++ b/crates/ruff_linter/src/rules/flake8_import_conventions/rules/banned_import_alias.rs
@@ -29,7 +29,7 @@ use ruff_text_size::Ranged;
 /// ```
 ///
 /// ## Options
-/// - `flake8-import-conventions.banned-aliases`
+/// - `lint.flake8-import-conventions.banned-aliases`
 #[violation]
 pub struct BannedImportAlias {
     name: String,

--- a/crates/ruff_linter/src/rules/flake8_import_conventions/rules/banned_import_from.rs
+++ b/crates/ruff_linter/src/rules/flake8_import_conventions/rules/banned_import_from.rs
@@ -30,7 +30,7 @@ use ruff_text_size::Ranged;
 /// ```
 ///
 /// ## Options
-/// - `flake8-import-conventions.banned-from`
+/// - `lint.flake8-import-conventions.banned-from`
 #[violation]
 pub struct BannedImportFrom {
     name: String,

--- a/crates/ruff_linter/src/rules/flake8_import_conventions/rules/unconventional_import_alias.rs
+++ b/crates/ruff_linter/src/rules/flake8_import_conventions/rules/unconventional_import_alias.rs
@@ -32,8 +32,8 @@ use crate::renamer::Renamer;
 /// ```
 ///
 /// ## Options
-/// - `flake8-import-conventions.aliases`
-/// - `flake8-import-conventions.extend-aliases`
+/// - `lint.flake8-import-conventions.aliases`
+/// - `lint.flake8-import-conventions.extend-aliases`
 #[violation]
 pub struct UnconventionalImportAlias {
     name: String,

--- a/crates/ruff_linter/src/rules/flake8_logging_format/violations.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/violations.rs
@@ -30,9 +30,9 @@ use ruff_macros::{derive_message_formats, violation};
 /// - Uses of `flask.current_app.logger` (e.g., `from flask import current_app; current_app.logger.info(...)`).
 /// - Objects whose name starts with `log` or ends with `logger` or `logging`,
 ///   when used in the same file in which they are defined (e.g., `logger = logging.getLogger(); logger.info(...)`).
-/// - Imported objects marked as loggers via the [`logger-objects`] setting, which can be
+/// - Imported objects marked as loggers via the [`lint.logger-objects`] setting, which can be
 ///   used to enforce these rules against shared logger objects (e.g., `from module import logger; logger.info(...)`,
-///   when [`logger-objects`] is set to `["module.logger"]`).
+///   when [`lint.logger-objects`] is set to `["module.logger"]`).
 ///
 /// ## Example
 /// ```python
@@ -68,7 +68,7 @@ use ruff_macros::{derive_message_formats, violation};
 /// ```
 ///
 /// ## Options
-/// - `logger-objects`
+/// - `lint.logger-objects`
 ///
 /// ## References
 /// - [Python documentation: `logging`](https://docs.python.org/3/library/logging.html)
@@ -114,9 +114,9 @@ impl Violation for LoggingStringFormat {
 /// - Uses of `flask.current_app.logger` (e.g., `from flask import current_app; current_app.logger.info(...)`).
 /// - Objects whose name starts with `log` or ends with `logger` or `logging`,
 ///   when used in the same file in which they are defined (e.g., `logger = logging.getLogger(); logger.info(...)`).
-/// - Imported objects marked as loggers via the [`logger-objects`] setting, which can be
+/// - Imported objects marked as loggers via the [`lint.logger-objects`] setting, which can be
 ///   used to enforce these rules against shared logger objects (e.g., `from module import logger; logger.info(...)`,
-///   when [`logger-objects`] is set to `["module.logger"]`).
+///   when [`lint.logger-objects`] is set to `["module.logger"]`).
 ///
 /// ## Example
 /// ```python
@@ -152,7 +152,7 @@ impl Violation for LoggingStringFormat {
 /// ```
 ///
 /// ## Options
-/// - `logger-objects`
+/// - `lint.logger-objects`
 ///
 /// ## References
 /// - [Python documentation: `logging`](https://docs.python.org/3/library/logging.html)
@@ -197,9 +197,9 @@ impl Violation for LoggingPercentFormat {
 /// - Uses of `flask.current_app.logger` (e.g., `from flask import current_app; current_app.logger.info(...)`).
 /// - Objects whose name starts with `log` or ends with `logger` or `logging`,
 ///   when used in the same file in which they are defined (e.g., `logger = logging.getLogger(); logger.info(...)`).
-/// - Imported objects marked as loggers via the [`logger-objects`] setting, which can be
+/// - Imported objects marked as loggers via the [`lint.logger-objects`] setting, which can be
 ///   used to enforce these rules against shared logger objects (e.g., `from module import logger; logger.info(...)`,
-///   when [`logger-objects`] is set to `["module.logger"]`).
+///   when [`lint.logger-objects`] is set to `["module.logger"]`).
 ///
 /// ## Example
 /// ```python
@@ -235,7 +235,7 @@ impl Violation for LoggingPercentFormat {
 /// ```
 ///
 /// ## Options
-/// - `logger-objects`
+/// - `lint.logger-objects`
 ///
 /// ## References
 /// - [Python documentation: `logging`](https://docs.python.org/3/library/logging.html)
@@ -279,9 +279,9 @@ impl Violation for LoggingStringConcat {
 /// - Uses of `flask.current_app.logger` (e.g., `from flask import current_app; current_app.logger.info(...)`).
 /// - Objects whose name starts with `log` or ends with `logger` or `logging`,
 ///   when used in the same file in which they are defined (e.g., `logger = logging.getLogger(); logger.info(...)`).
-/// - Imported objects marked as loggers via the [`logger-objects`] setting, which can be
+/// - Imported objects marked as loggers via the [`lint.logger-objects`] setting, which can be
 ///   used to enforce these rules against shared logger objects (e.g., `from module import logger; logger.info(...)`,
-///   when [`logger-objects`] is set to `["module.logger"]`).
+///   when [`lint.logger-objects`] is set to `["module.logger"]`).
 ///
 /// ## Example
 /// ```python
@@ -317,7 +317,7 @@ impl Violation for LoggingStringConcat {
 /// ```
 ///
 /// ## Options
-/// - `logger-objects`
+/// - `lint.logger-objects`
 ///
 /// ## References
 /// - [Python documentation: `logging`](https://docs.python.org/3/library/logging.html)
@@ -349,9 +349,9 @@ impl Violation for LoggingFString {
 /// - Uses of `flask.current_app.logger` (e.g., `from flask import current_app; current_app.logger.info(...)`).
 /// - Objects whose name starts with `log` or ends with `logger` or `logging`,
 ///   when used in the same file in which they are defined (e.g., `logger = logging.getLogger(); logger.info(...)`).
-/// - Imported objects marked as loggers via the [`logger-objects`] setting, which can be
+/// - Imported objects marked as loggers via the [`lint.logger-objects`] setting, which can be
 ///   used to enforce these rules against shared logger objects (e.g., `from module import logger; logger.info(...)`,
-///   when [`logger-objects`] is set to `["module.logger"]`).
+///   when [`lint.logger-objects`] is set to `["module.logger"]`).
 ///
 /// ## Example
 /// ```python
@@ -368,7 +368,7 @@ impl Violation for LoggingFString {
 /// ```
 ///
 /// ## Options
-/// - `logger-objects`
+/// - `lint.logger-objects`
 ///
 /// ## References
 /// - [Python documentation: `logging.warning`](https://docs.python.org/3/library/logging.html#logging.warning)
@@ -409,9 +409,9 @@ impl AlwaysFixableViolation for LoggingWarn {
 /// - Uses of `flask.current_app.logger` (e.g., `from flask import current_app; current_app.logger.info(...)`).
 /// - Objects whose name starts with `log` or ends with `logger` or `logging`,
 ///   when used in the same file in which they are defined (e.g., `logger = logging.getLogger(); logger.info(...)`).
-/// - Imported objects marked as loggers via the [`logger-objects`] setting, which can be
+/// - Imported objects marked as loggers via the [`lint.logger-objects`] setting, which can be
 ///   used to enforce these rules against shared logger objects (e.g., `from module import logger; logger.info(...)`,
-///   when [`logger-objects`] is set to `["module.logger"]`).
+///   when [`lint.logger-objects`] is set to `["module.logger"]`).
 ///
 /// ## Example
 /// ```python
@@ -436,7 +436,7 @@ impl AlwaysFixableViolation for LoggingWarn {
 /// ```
 ///
 /// ## Options
-/// - `logger-objects`
+/// - `lint.logger-objects`
 ///
 /// ## References
 /// - [Python documentation: LogRecord attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes)
@@ -470,9 +470,9 @@ impl Violation for LoggingExtraAttrClash {
 /// - Uses of `flask.current_app.logger` (e.g., `from flask import current_app; current_app.logger.info(...)`).
 /// - Objects whose name starts with `log` or ends with `logger` or `logging`,
 ///   when used in the same file in which they are defined (e.g., `logger = logging.getLogger(); logger.info(...)`).
-/// - Imported objects marked as loggers via the [`logger-objects`] setting, which can be
+/// - Imported objects marked as loggers via the [`lint.logger-objects`] setting, which can be
 ///   used to enforce these rules against shared logger objects (e.g., `from module import logger; logger.info(...)`,
-///   when [`logger-objects`] is set to `["module.logger"]`).
+///   when [`lint.logger-objects`] is set to `["module.logger"]`).
 ///
 /// ## Example
 /// ```python
@@ -495,7 +495,7 @@ impl Violation for LoggingExtraAttrClash {
 /// ```
 ///
 /// ## Options
-/// - `logger-objects`
+/// - `lint.logger-objects`
 ///
 /// ## References
 /// - [Python documentation: `logging.exception`](https://docs.python.org/3/library/logging.html#logging.exception)
@@ -531,9 +531,9 @@ impl Violation for LoggingExcInfo {
 /// - Uses of `flask.current_app.logger` (e.g., `from flask import current_app; current_app.logger.info(...)`).
 /// - Objects whose name starts with `log` or ends with `logger` or `logging`,
 ///   when used in the same file in which they are defined (e.g., `logger = logging.getLogger(); logger.info(...)`).
-/// - Imported objects marked as loggers via the [`logger-objects`] setting, which can be
+/// - Imported objects marked as loggers via the [`lint.logger-objects`] setting, which can be
 ///   used to enforce these rules against shared logger objects (e.g., `from module import logger; logger.info(...)`,
-///   when [`logger-objects`] is set to `["module.logger"]`).
+///   when [`lint.logger-objects`] is set to `["module.logger"]`).
 ///
 /// ## Example
 /// ```python
@@ -556,7 +556,7 @@ impl Violation for LoggingExcInfo {
 /// ```
 ///
 /// ## Options
-/// - `logger-objects`
+/// - `lint.logger-objects`
 ///
 /// ## References
 /// - [Python documentation: `logging.exception`](https://docs.python.org/3/library/logging.html#logging.exception)

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -24,7 +24,7 @@ use super::helpers::{
 
 /// ## What it does
 /// Checks for argument-free `@pytest.fixture()` decorators with or without
-/// parentheses, depending on the `flake8-pytest-style.fixture-parentheses`
+/// parentheses, depending on the [`lint.flake8-pytest-style.fixture-parentheses`]
 /// setting.
 ///
 /// ## Why is this bad?
@@ -55,7 +55,7 @@ use super::helpers::{
 /// ```
 ///
 /// ## Options
-/// - `flake8-pytest-style.fixture-parentheses`
+/// - `lint.flake8-pytest-style.fixture-parentheses`
 ///
 /// ## References
 /// - [`pytest` documentation: API Reference: Fixtures](https://docs.pytest.org/en/latest/reference/reference.html#fixtures-api)

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
@@ -11,7 +11,7 @@ use super::helpers::get_mark_decorators;
 
 /// ## What it does
 /// Checks for argument-free `@pytest.mark.<marker>()` decorators with or
-/// without parentheses, depending on the `flake8-pytest-style.mark-parentheses`
+/// without parentheses, depending on the [`lint.flake8-pytest-style.mark-parentheses`]
 /// setting.
 ///
 /// ## Why is this bad?
@@ -42,7 +42,7 @@ use super::helpers::get_mark_decorators;
 /// ```
 ///
 /// ## Options
-/// - `flake8-pytest-style.mark-parentheses`
+/// - `lint.flake8-pytest-style.mark-parentheses`
 ///
 /// ## References
 /// - [`pytest` documentation: Marks](https://docs.pytest.org/en/latest/reference/reference.html#marks)

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -26,7 +26,7 @@ use super::helpers::{is_pytest_parametrize, split_names};
 /// The `argnames` argument of `pytest.mark.parametrize` takes a string or
 /// a sequence of strings. For a single parameter, it's preferable to use a
 /// string. For multiple parameters, it's preferable to use the style
-/// configured via the [`flake8-pytest-style.parametrize-names-type`] setting.
+/// configured via the [`lint.flake8-pytest-style.parametrize-names-type`] setting.
 ///
 /// ## Example
 /// ```python
@@ -67,7 +67,7 @@ use super::helpers::{is_pytest_parametrize, split_names};
 /// ```
 ///
 /// ## Options
-/// - `flake8-pytest-style.parametrize-names-type`
+/// - `lint.flake8-pytest-style.parametrize-names-type`
 ///
 /// ## References
 /// - [`pytest` documentation: How to parametrize fixtures and test functions](https://docs.pytest.org/en/latest/how-to/parametrize.html#pytest-mark-parametrize)
@@ -103,17 +103,17 @@ impl Violation for PytestParametrizeNamesWrongType {
 /// of values.
 ///
 /// The style for the list of values rows can be configured via the
-/// the [`flake8-pytest-style.parametrize-values-type`] setting, while the
+/// the [`lint.flake8-pytest-style.parametrize-values-type`] setting, while the
 /// style for each row of values can be configured via the
-/// the [`flake8-pytest-style.parametrize-values-row-type`] setting.
+/// the [`lint.flake8-pytest-style.parametrize-values-row-type`] setting.
 ///
-/// For example, [`flake8-pytest-style.parametrize-values-type`] will lead to
+/// For example, [`lint.flake8-pytest-style.parametrize-values-type`] will lead to
 /// the following expectations:
 ///
 /// - `tuple`: `@pytest.mark.parametrize("value", ("a", "b", "c"))`
 /// - `list`: `@pytest.mark.parametrize("value", ["a", "b", "c"])`
 ///
-/// Similarly, [`flake8-pytest-style.parametrize-values-row-type`] will lead to
+/// Similarly, [`lint.flake8-pytest-style.parametrize-values-row-type`] will lead to
 /// the following expectations:
 ///
 /// - `tuple`: `@pytest.mark.parametrize(("key", "value"), [("a", "b"), ("c", "d")])`
@@ -170,8 +170,8 @@ impl Violation for PytestParametrizeNamesWrongType {
 /// ```
 ///
 /// ## Options
-/// - `flake8-pytest-style.parametrize-values-type`
-/// - `flake8-pytest-style.parametrize-values-row-type`
+/// - `lint.flake8-pytest-style.parametrize-values-type`
+/// - `lint.flake8-pytest-style.parametrize-values-row-type`
 ///
 /// ## References
 /// - [`pytest` documentation: How to parametrize fixtures and test functions](https://docs.pytest.org/en/latest/how-to/parametrize.html#pytest-mark-parametrize)

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/raises.rs
@@ -64,8 +64,8 @@ impl Violation for PytestRaisesWithMultipleStatements {
 /// unrelated to the code under test. To avoid this, `pytest.raises` should be
 /// called with a `match` parameter. The exception names that require a `match`
 /// parameter can be configured via the
-/// `flake8-pytest-style.raises-require-match-for` and
-/// `flake8-pytest-style.raises-extend-require-match-for` settings.
+/// [`lint.flake8-pytest-style.raises-require-match-for`] and
+/// [`lint.flake8-pytest-style.raises-extend-require-match-for`] settings.
 ///
 /// ## Example
 /// ```python
@@ -92,8 +92,8 @@ impl Violation for PytestRaisesWithMultipleStatements {
 /// ```
 ///
 /// ## Options
-/// - `flake8-pytest-style.raises-require-match-for`
-/// - `flake8-pytest-style.raises-extend-require-match-for`
+/// - `lint.flake8-pytest-style.raises-require-match-for`
+/// - `lint.flake8-pytest-style.raises-extend-require-match-for`
 ///
 /// ## References
 /// - [`pytest` documentation: `pytest.raises`](https://docs.pytest.org/en/latest/reference/reference.html#pytest-raises)

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/check_string_quotes.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/check_string_quotes.rs
@@ -14,7 +14,7 @@ use super::super::settings::Quote;
 
 /// ## What it does
 /// Checks for inline strings that use single quotes or double quotes,
-/// depending on the value of the [`flake8-quotes.inline-quotes`] option.
+/// depending on the value of the [`lint.flake8-quotes.inline-quotes`] option.
 ///
 /// ## Why is this bad?
 /// Consistency is good. Use either single or double quotes for inline
@@ -31,7 +31,7 @@ use super::super::settings::Quote;
 /// ```
 ///
 /// ## Options
-/// - `flake8-quotes.inline-quotes`
+/// - `lint.flake8-quotes.inline-quotes`
 ///
 /// ## Formatter compatibility
 /// We recommend against using this rule alongside the [formatter]. The
@@ -65,7 +65,7 @@ impl AlwaysFixableViolation for BadQuotesInlineString {
 
 /// ## What it does
 /// Checks for multiline strings that use single quotes or double quotes,
-/// depending on the value of the [`flake8-quotes.multiline-quotes`]
+/// depending on the value of the [`lint.flake8-quotes.multiline-quotes`]
 /// setting.
 ///
 /// ## Why is this bad?
@@ -87,7 +87,7 @@ impl AlwaysFixableViolation for BadQuotesInlineString {
 /// ```
 ///
 /// ## Options
-/// - `flake8-quotes.multiline-quotes`
+/// - `lint.flake8-quotes.multiline-quotes`
 ///
 /// ## Formatter compatibility
 /// We recommend against using this rule alongside the [formatter]. The
@@ -121,7 +121,7 @@ impl AlwaysFixableViolation for BadQuotesMultilineString {
 
 /// ## What it does
 /// Checks for docstrings that use single quotes or double quotes, depending
-/// on the value of the [`flake8-quotes.docstring-quotes`] setting.
+/// on the value of the [`lint.flake8-quotes.docstring-quotes`] setting.
 ///
 /// ## Why is this bad?
 /// Consistency is good. Use either single or double quotes for docstring
@@ -142,7 +142,7 @@ impl AlwaysFixableViolation for BadQuotesMultilineString {
 /// ```
 ///
 /// ## Options
-/// - `flake8-quotes.docstring-quotes`
+/// - `lint.flake8-quotes.docstring-quotes`
 ///
 /// ## Formatter compatibility
 /// We recommend against using this rule alongside the [formatter]. The

--- a/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
@@ -43,7 +43,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## Options
-/// - `flake8-self.ignore-names`
+/// - `lint.flake8-self.ignore-names`
 ///
 /// ## References
 /// - [_What is the meaning of single or double underscores before an object name?_](https://stackoverflow.com/questions/1301346/what-is-the-meaning-of-single-and-double-underscore-before-an-object-name)

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/banned_api.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/banned_api.rs
@@ -24,7 +24,7 @@ use crate::rules::flake8_tidy_imports::matchers::NameMatchPolicy;
 /// automatic way.
 ///
 /// ## Options
-/// - `flake8-tidy-imports.banned-api`
+/// - `lint.flake8-tidy-imports.banned-api`
 #[violation]
 pub struct BannedApi {
     name: String,

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/banned_module_level_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/banned_module_level_imports.rs
@@ -38,7 +38,7 @@ use crate::rules::flake8_tidy_imports::matchers::NameMatchPolicy;
 /// ```
 ///
 /// ## Options
-/// - `flake8-tidy-imports.banned-module-level-imports`
+/// - `lint.flake8-tidy-imports.banned-module-level-imports`
 #[violation]
 pub struct BannedModuleLevelImports {
     name: String,

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
@@ -42,7 +42,7 @@ use crate::rules::flake8_tidy_imports::settings::Strictness;
 /// ```
 ///
 /// ## Options
-/// - `flake8-tidy-imports.ban-relative-imports`
+/// - `lint.flake8-tidy-imports.ban-relative-imports`
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#imports
 #[violation]

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -22,7 +22,7 @@ use crate::rules::flake8_type_checking::imports::ImportBinding;
 /// The type-checking block is not executed at runtime, so the import will not
 /// be available at runtime.
 ///
-/// If [`flake8-type-checking.quote-annotations`] is set to `true`,
+/// If [`lint.flake8-type-checking.quote-annotations`] is set to `true`,
 /// annotations will be wrapped in quotes if doing so would enable the
 /// corresponding import to remain in the type-checking block.
 ///
@@ -48,7 +48,7 @@ use crate::rules::flake8_type_checking::imports::ImportBinding;
 /// ```
 ///
 /// ## Options
-/// - `flake8-type-checking.quote-annotations`
+/// - `lint.flake8-type-checking.quote-annotations`
 ///
 /// ## References
 /// - [PEP 535](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -28,14 +28,14 @@ use crate::rules::isort::{categorize, ImportSection, ImportType};
 /// instead be imported conditionally under an `if TYPE_CHECKING:` block to
 /// minimize runtime overhead.
 ///
-/// If [`flake8-type-checking.quote-annotations`] is set to `true`,
+/// If [`lint.flake8-type-checking.quote-annotations`] is set to `true`,
 /// annotations will be wrapped in quotes if doing so would enable the
 /// corresponding import to be moved into an `if TYPE_CHECKING:` block.
 ///
 /// If a class _requires_ that type annotations be available at runtime (as is
 /// the case for Pydantic, SQLAlchemy, and other libraries), consider using
-/// the [`flake8-type-checking.runtime-evaluated-base-classes`] and
-/// [`flake8-type-checking.runtime-evaluated-decorators`] settings to mark them
+/// the [`lint.flake8-type-checking.runtime-evaluated-base-classes`] and
+/// [`lint.flake8-type-checking.runtime-evaluated-decorators`] settings to mark them
 /// as such.
 ///
 /// ## Example
@@ -64,9 +64,9 @@ use crate::rules::isort::{categorize, ImportSection, ImportType};
 /// ```
 ///
 /// ## Options
-/// - `flake8-type-checking.quote-annotations`
-/// - `flake8-type-checking.runtime-evaluated-base-classes`
-/// - `flake8-type-checking.runtime-evaluated-decorators`
+/// - `lint.flake8-type-checking.quote-annotations`
+/// - `lint.flake8-type-checking.runtime-evaluated-base-classes`
+/// - `lint.flake8-type-checking.runtime-evaluated-decorators`
 ///
 /// ## References
 /// - [PEP 536](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
@@ -101,14 +101,14 @@ impl Violation for TypingOnlyFirstPartyImport {
 /// instead be imported conditionally under an `if TYPE_CHECKING:` block to
 /// minimize runtime overhead.
 ///
-/// If [`flake8-type-checking.quote-annotations`] is set to `true`,
+/// If [`lint.flake8-type-checking.quote-annotations`] is set to `true`,
 /// annotations will be wrapped in quotes if doing so would enable the
 /// corresponding import to be moved into an `if TYPE_CHECKING:` block.
 ///
 /// If a class _requires_ that type annotations be available at runtime (as is
 /// the case for Pydantic, SQLAlchemy, and other libraries), consider using
-/// the [`flake8-type-checking.runtime-evaluated-base-classes`] and
-/// [`flake8-type-checking.runtime-evaluated-decorators`] settings to mark them
+/// the [`lint.flake8-type-checking.runtime-evaluated-base-classes`] and
+/// [`lint.flake8-type-checking.runtime-evaluated-decorators`] settings to mark them
 /// as such.
 ///
 /// ## Example
@@ -137,9 +137,9 @@ impl Violation for TypingOnlyFirstPartyImport {
 /// ```
 ///
 /// ## Options
-/// - `flake8-type-checking.quote-annotations`
-/// - `flake8-type-checking.runtime-evaluated-base-classes`
-/// - `flake8-type-checking.runtime-evaluated-decorators`
+/// - `lint.flake8-type-checking.quote-annotations`
+/// - `lint.flake8-type-checking.runtime-evaluated-base-classes`
+/// - `lint.flake8-type-checking.runtime-evaluated-decorators`
 ///
 /// ## References
 /// - [PEP 536](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
@@ -174,14 +174,14 @@ impl Violation for TypingOnlyThirdPartyImport {
 /// instead be imported conditionally under an `if TYPE_CHECKING:` block to
 /// minimize runtime overhead.
 ///
-/// If [`flake8-type-checking.quote-annotations`] is set to `true`,
+/// If [`lint.flake8-type-checking.quote-annotations`] is set to `true`,
 /// annotations will be wrapped in quotes if doing so would enable the
 /// corresponding import to be moved into an `if TYPE_CHECKING:` block.
 ///
 /// If a class _requires_ that type annotations be available at runtime (as is
 /// the case for Pydantic, SQLAlchemy, and other libraries), consider using
-/// the [`flake8-type-checking.runtime-evaluated-base-classes`] and
-/// [`flake8-type-checking.runtime-evaluated-decorators`] settings to mark them
+/// the [`lint.flake8-type-checking.runtime-evaluated-base-classes`] and
+/// [`lint.flake8-type-checking.runtime-evaluated-decorators`] settings to mark them
 /// as such.
 ///
 /// ## Example
@@ -210,9 +210,9 @@ impl Violation for TypingOnlyThirdPartyImport {
 /// ```
 ///
 /// ## Options
-/// - `flake8-type-checking.quote-annotations`
-/// - `flake8-type-checking.runtime-evaluated-base-classes`
-/// - `flake8-type-checking.runtime-evaluated-decorators`
+/// - `lint.flake8-type-checking.quote-annotations`
+/// - `lint.flake8-type-checking.runtime-evaluated-base-classes`
+/// - `lint.flake8-type-checking.runtime-evaluated-decorators`
 ///
 /// ## References
 /// - [PEP 536](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)

--- a/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
+++ b/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
@@ -44,7 +44,7 @@ use ruff_python_ast::identifier::Identifier;
 /// ```
 ///
 /// ## Options
-/// - `mccabe.max-complexity`
+/// - `lint.mccabe.max-complexity`
 #[violation]
 pub struct ComplexStructure {
     name: String,

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
@@ -22,10 +22,10 @@ use crate::checkers::ast::Checker;
 /// > append a single trailing underscore rather than use an abbreviation or spelling corruption.
 /// > Thus `class_` is better than `clss`. (Perhaps better is to avoid such clashes by using a synonym.)
 ///
-/// Names can be excluded from this rule using the [`pep8-naming.ignore-names`]
-/// or [`pep8-naming.extend-ignore-names`] configuration options. For example,
+/// Names can be excluded from this rule using the [`lint.pep8-naming.ignore-names`]
+/// or [`lint.pep8-naming.extend-ignore-names`] configuration options. For example,
 /// to allow the use of `klass` as the first argument to class methods, set
-/// the [`pep8-naming.extend-ignore-names`] option to `["klass"]`.
+/// the [`lint.pep8-naming.extend-ignore-names`] option to `["klass"]`.
 ///
 /// ## Example
 /// ```python
@@ -44,10 +44,10 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## Options
-/// - `pep8-naming.classmethod-decorators`
-/// - `pep8-naming.staticmethod-decorators`
-/// - `pep8-naming.ignore-names`
-/// - `pep8-naming.extend-ignore-names`
+/// - `lint.pep8-naming.classmethod-decorators`
+/// - `lint.pep8-naming.staticmethod-decorators`
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#function-and-method-arguments
 #[violation]

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
@@ -22,10 +22,10 @@ use crate::checkers::ast::Checker;
 /// > append a single trailing underscore rather than use an abbreviation or spelling corruption.
 /// > Thus `class_` is better than `clss`. (Perhaps better is to avoid such clashes by using a synonym.)
 ///
-/// Names can be excluded from this rule using the [`pep8-naming.ignore-names`]
-/// or [`pep8-naming.extend-ignore-names`] configuration options. For example,
+/// Names can be excluded from this rule using the [`lint.pep8-naming.ignore-names`]
+/// or [`lint.pep8-naming.extend-ignore-names`] configuration options. For example,
 /// to allow the use of `this` as the first argument to instance methods, set
-/// the [`pep8-naming.extend-ignore-names`] option to `["this"]`.
+/// the [`lint.pep8-naming.extend-ignore-names`] option to `["this"]`.
 ///
 /// ## Example
 /// ```python
@@ -42,10 +42,10 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## Options
-/// - `pep8-naming.classmethod-decorators`
-/// - `pep8-naming.staticmethod-decorators`
-/// - `pep8-naming.ignore-names`
-/// - `pep8-naming.extend-ignore-names`
+/// - `lint.pep8-naming.classmethod-decorators`
+/// - `lint.pep8-naming.staticmethod-decorators`
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#function-and-method-arguments
 #[violation]

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_function_name.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/invalid_function_name.rs
@@ -20,10 +20,10 @@ use crate::settings::types::IdentifierPattern;
 /// > improve readability. mixedCase is allowed only in contexts where that’s already the
 /// > prevailing style (e.g. threading.py), to retain backwards compatibility.
 ///
-/// Names can be excluded from this rule using the [`pep8-naming.ignore-names`]
-/// or [`pep8-naming.extend-ignore-names`] configuration options. For example,
+/// Names can be excluded from this rule using the [`lint.pep8-naming.ignore-names`]
+/// or [`lint.pep8-naming.extend-ignore-names`] configuration options. For example,
 /// to ignore all functions starting with `test_` from this rule, set the
-/// [`pep8-naming.extend-ignore-names`] option to `["test_*"]`.
+/// [`lint.pep8-naming.extend-ignore-names`] option to `["test_*"]`.
 ///
 /// ## Example
 /// ```python
@@ -38,8 +38,8 @@ use crate::settings::types::IdentifierPattern;
 /// ```
 ///
 /// ## Options
-/// - `pep8-naming.ignore-names`
-/// - `pep8-naming.extend-ignore-names`
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#function-and-variable-names
 #[violation]

--- a/crates/ruff_linter/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
@@ -34,8 +34,8 @@ use crate::rules::pep8_naming::helpers;
 /// ```
 ///
 /// ## Options
-/// - `pep8-naming.ignore-names`
-/// - `pep8-naming.extend-ignore-names`
+/// - `lint.pep8-naming.ignore-names`
+/// - `lint.pep8-naming.extend-ignore-names`
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#function-and-variable-names
 #[violation]

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/doc_line_too_long.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/doc_line_too_long.rs
@@ -13,7 +13,7 @@ use crate::settings::LinterSettings;
 /// For flowing long blocks of text (docstrings or comments), overlong lines
 /// can hurt readability. [PEP 8], for example, recommends that such lines be
 /// limited to 72 characters, while this rule enforces the limit specified by
-/// the [`pycodestyle.max-doc-length`] setting. (If no value is provided, this
+/// the [`lint.pycodestyle.max-doc-length`] setting. (If no value is provided, this
 /// rule will be ignored, even if it's added to your `--select` list.)
 ///
 /// In the context of this rule, a "doc line" is defined as a line consisting
@@ -32,8 +32,8 @@ use crate::settings::LinterSettings;
 ///    overlong if a pragma comment _causes_ it to exceed the line length.
 ///    (This behavior aligns with that of the Ruff formatter.)
 ///
-/// If [`pycodestyle.ignore-overlong-task-comments`] is `true`, this rule will
-/// also ignore comments that start with any of the specified [`task-tags`]
+/// If [`lint.pycodestyle.ignore-overlong-task-comments`] is `true`, this rule will
+/// also ignore comments that start with any of the specified [`lint.task-tags`]
 /// (e.g., `# TODO:`).
 ///
 /// ## Example
@@ -65,9 +65,9 @@ use crate::settings::LinterSettings;
 /// ```
 ///
 /// ## Options
-/// - `task-tags`
-/// - `pycodestyle.max-doc-length`
-/// - `pycodestyle.ignore-overlong-task-comments`
+/// - `lint.task-tags`
+/// - `lint.pycodestyle.max-doc-length`
+/// - `lint.pycodestyle.ignore-overlong-task-comments`
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#maximum-line-length
 #[violation]

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/line_too_long.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/line_too_long.rs
@@ -28,8 +28,8 @@ use crate::settings::LinterSettings;
 ///    overlong if a pragma comment _causes_ it to exceed the line length.
 ///    (This behavior aligns with that of the Ruff formatter.)
 ///
-/// If [`pycodestyle.ignore-overlong-task-comments`] is `true`, this rule will
-/// also ignore comments that start with any of the specified [`task-tags`]
+/// If [`lint.pycodestyle.ignore-overlong-task-comments`] is `true`, this rule will
+/// also ignore comments that start with any of the specified [`lint.task-tags`]
 /// (e.g., `# TODO:`).
 ///
 /// ## Example
@@ -60,9 +60,9 @@ use crate::settings::LinterSettings;
 ///
 /// ## Options
 /// - `line-length`
-/// - `task-tags`
-/// - `pycodestyle.ignore-overlong-task-comments`
-/// - `pycodestyle.max-line-length`
+/// - `lint.task-tags`
+/// - `lint.pycodestyle.ignore-overlong-task-comments`
+/// - `lint.pycodestyle.max-line-length`
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#maximum-line-length
 #[violation]

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -37,7 +37,7 @@ use crate::registry::Rule;
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// [D211]: https://docs.astral.sh/ruff/rules/blank-line-before-class
 #[violation]
@@ -84,7 +84,7 @@ impl AlwaysFixableViolation for OneBlankLineBeforeClass {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -134,7 +134,7 @@ impl AlwaysFixableViolation for OneBlankLineAfterClass {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// [D203]: https://docs.astral.sh/ruff/rules/one-blank-line-before-class
 #[violation]

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_period.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_period.rs
@@ -36,7 +36,7 @@ use crate::rules::pydocstyle::helpers::logical_line;
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_punctuation.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_punctuation.rs
@@ -37,7 +37,7 @@ use crate::rules::pydocstyle::helpers::logical_line;
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/no_signature.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/no_signature.rs
@@ -32,7 +32,7 @@ use crate::docstrings::Docstring;
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/non_imperative_mood.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/non_imperative_mood.rs
@@ -43,7 +43,7 @@ static MOOD: Lazy<Mood> = Lazy::new(Mood::new);
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/sections.rs
@@ -76,7 +76,7 @@ use crate::rules::pydocstyle::settings::Convention;
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -175,7 +175,7 @@ impl AlwaysFixableViolation for SectionNotOverIndented {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -253,7 +253,7 @@ impl AlwaysFixableViolation for SectionUnderlineNotOverIndented {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -350,7 +350,7 @@ impl AlwaysFixableViolation for CapitalizeSectionName {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -446,7 +446,7 @@ impl AlwaysFixableViolation for NewLineAfterSectionName {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -548,7 +548,7 @@ impl AlwaysFixableViolation for DashedUnderlineAfterSection {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -647,7 +647,7 @@ impl AlwaysFixableViolation for SectionUnderlineAfterName {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -741,7 +741,7 @@ impl AlwaysFixableViolation for SectionUnderlineMatchesSectionLength {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -835,7 +835,7 @@ impl AlwaysFixableViolation for NoBlankLineAfterSection {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -931,7 +931,7 @@ impl AlwaysFixableViolation for NoBlankLineBeforeSection {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -1021,7 +1021,7 @@ impl AlwaysFixableViolation for BlankLineAfterLastSection {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -1098,7 +1098,7 @@ impl Violation for EmptyDocstringSection {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -1180,7 +1180,7 @@ impl AlwaysFixableViolation for SectionNameEndsInColon {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
@@ -1264,7 +1264,7 @@ impl Violation for UndocumentedParam {
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/starts_with_this.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/starts_with_this.rs
@@ -33,7 +33,7 @@ use crate::rules::pydocstyle::helpers::normalize_word;
 /// ```
 ///
 /// ## Options
-/// - `pydocstyle.convention`
+/// - `lint.pydocstyle.convention`
 ///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -54,7 +54,7 @@ enum UnusedImportContext {
 /// ```
 ///
 /// ## Options
-/// - `pyflakes.extend-generics`
+/// - `lint.pyflakes.extend-generics`
 ///
 /// ## References
 /// - [Python documentation: `import`](https://docs.python.org/3/reference/simple_stmts.html#the-import-statement)

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_variable.rs
@@ -23,7 +23,7 @@ use crate::settings::types::PreviewMode;
 ///
 /// If a variable is intentionally defined-but-not-used, it should be
 /// prefixed with an underscore, or some other value that adheres to the
-/// [`dummy-variable-rgx`] pattern.
+/// [`lint.dummy-variable-rgx`] pattern.
 ///
 /// Under [preview mode](https://docs.astral.sh/ruff/preview), this rule also
 /// triggers on unused unpacked assignments (for example, `x, y = foo()`).
@@ -44,7 +44,7 @@ use crate::settings::types::PreviewMode;
 /// ```
 ///
 /// ## Options
-/// - `dummy-variable-rgx`
+/// - `lint.dummy-variable-rgx`
 #[violation]
 pub struct UnusedVariable {
     pub name: String,

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_dunder_method_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_dunder_method_name.rs
@@ -24,7 +24,7 @@ use crate::rules::pylint::helpers::is_known_dunder_method;
 /// `__init__`), as well as methods that are marked with `@override`.
 ///
 /// Additional dunder methods names can be allowed via the
-/// [`pylint.allow-dunder-method-names`] setting.
+/// [`lint.pylint.allow-dunder-method-names`] setting.
 ///
 /// ## Example
 /// ```python
@@ -41,7 +41,7 @@ use crate::rules::pylint::helpers::is_known_dunder_method;
 /// ```
 ///
 /// ## Options
-/// - `pylint.allow-dunder-method-names`
+/// - `lint.pylint.allow-dunder-method-names`
 #[violation]
 pub struct BadDunderMethodName {
     name: String,

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_arguments.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_arguments.rs
@@ -10,7 +10,7 @@ use crate::checkers::ast::Checker;
 /// Checks for function definitions that include too many arguments.
 ///
 /// By default, this rule allows up to five arguments, as configured by the
-/// [`pylint.max-args`] option.
+/// [`lint.pylint.max-args`] option.
 ///
 /// ## Why is this bad?
 /// Functions with many arguments are harder to understand, maintain, and call.
@@ -42,7 +42,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## Options
-/// - `pylint.max-args`
+/// - `lint.pylint.max-args`
 #[violation]
 pub struct TooManyArguments {
     c_args: usize,

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_boolean_expressions.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_boolean_expressions.rs
@@ -10,7 +10,7 @@ use crate::checkers::ast::Checker;
 /// Checks for too many Boolean expressions in an `if` statement.
 ///
 /// By default, this rule allows up to 5 expressions. This can be configured
-/// using the [`pylint.max-bool-expr`] option.
+/// using the [`lint.pylint.max-bool-expr`] option.
 ///
 /// ## Why is this bad?
 /// `if` statements with many Boolean expressions are harder to understand
@@ -24,7 +24,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## Options
-/// - `pylint.max-bool-expr`
+/// - `lint.pylint.max-bool-expr`
 #[violation]
 pub struct TooManyBooleanExpressions {
     expressions: usize,

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_branches.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_branches.rs
@@ -8,7 +8,7 @@ use ruff_python_ast::identifier::Identifier;
 /// Checks for functions or methods with too many branches.
 ///
 /// By default, this rule allows up to 12 branches. This can be configured
-/// using the [`pylint.max-branches`] option.
+/// using the [`lint.pylint.max-branches`] option.
 ///
 /// ## Why is this bad?
 /// Functions or methods with many branches are harder to understand
@@ -67,7 +67,7 @@ use ruff_python_ast::identifier::Identifier;
 /// ```
 ///
 /// ## Options
-/// - `pylint.max-branches`
+/// - `lint.pylint.max-branches`
 #[violation]
 pub struct TooManyBranches {
     branches: usize,

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_locals.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_locals.rs
@@ -9,7 +9,7 @@ use crate::checkers::ast::Checker;
 /// Checks for functions that include too many local variables.
 ///
 /// By default, this rule allows up to fifteen locals, as configured by the
-/// [`pylint.max-locals`] option.
+/// [`lint.pylint.max-locals`] option.
 ///
 /// ## Why is this bad?
 /// Functions with many local variables are harder to understand and maintain.
@@ -18,7 +18,7 @@ use crate::checkers::ast::Checker;
 /// functions with fewer assignments.
 ///
 /// ## Options
-/// - `pylint.max-locals`
+/// - `lint.pylint.max-locals`
 #[violation]
 pub struct TooManyLocals {
     current_amount: usize,

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_nested_blocks.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_nested_blocks.rs
@@ -10,14 +10,14 @@ use crate::checkers::ast::Checker;
 /// Checks for functions or methods with too many nested blocks.
 ///
 /// By default, this rule allows up to five nested blocks.
-/// This can be configured using the [`pylint.max-nested-blocks`] option.
+/// This can be configured using the [`lint.pylint.max-nested-blocks`] option.
 ///
 /// ## Why is this bad?
 /// Functions or methods with too many nested blocks are harder to understand
 /// and maintain.
 ///
 /// ## Options
-/// - `pylint.max-nested-blocks`
+/// - `lint.pylint.max-nested-blocks`
 #[violation]
 pub struct TooManyNestedBlocks {
     nested_blocks: usize,

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_positional.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_positional.rs
@@ -9,7 +9,7 @@ use crate::checkers::ast::Checker;
 /// Checks for function definitions that include too many positional arguments.
 ///
 /// By default, this rule allows up to five arguments, as configured by the
-/// [`pylint.max-positional-args`] option.
+/// [`lint.pylint.max-positional-args`] option.
 ///
 /// ## Why is this bad?
 /// Functions with many arguments are harder to understand, maintain, and call.
@@ -40,7 +40,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## Options
-/// - `pylint.max-positional-args`
+/// - `lint.pylint.max-positional-args`
 #[violation]
 pub struct TooManyPositional {
     c_pos: usize,

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_public_methods.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_public_methods.rs
@@ -10,7 +10,7 @@ use crate::checkers::ast::Checker;
 /// Checks for classes with too many public methods
 ///
 /// By default, this rule allows up to 20 public methods, as configured by
-/// the [`pylint.max-public-methods`] option.
+/// the [`lint.pylint.max-public-methods`] option.
 ///
 /// ## Why is this bad?
 /// Classes with many public methods are harder to understand
@@ -81,7 +81,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## Options
-/// - `pylint.max-public-methods`
+/// - `lint.pylint.max-public-methods`
 #[violation]
 pub struct TooManyPublicMethods {
     methods: usize,

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_return_statements.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_return_statements.rs
@@ -10,7 +10,7 @@ use ruff_python_ast::visitor::Visitor;
 /// Checks for functions or methods with too many return statements.
 ///
 /// By default, this rule allows up to six return statements, as configured by
-/// the [`pylint.max-returns`] option.
+/// the [`lint.pylint.max-returns`] option.
 ///
 /// ## Why is this bad?
 /// Functions or methods with many return statements are harder to understand
@@ -50,7 +50,7 @@ use ruff_python_ast::visitor::Visitor;
 /// ```
 ///
 /// ## Options
-/// - `pylint.max-returns`
+/// - `lint.pylint.max-returns`
 #[violation]
 pub struct TooManyReturnStatements {
     returns: usize,

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_statements.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_statements.rs
@@ -8,7 +8,7 @@ use ruff_python_ast::identifier::Identifier;
 /// Checks for functions or methods with too many statements.
 ///
 /// By default, this rule allows up to 50 statements, as configured by the
-/// [`pylint.max-statements`] option.
+/// [`lint.pylint.max-statements`] option.
 ///
 /// ## Why is this bad?
 /// Functions or methods with many statements are harder to understand
@@ -44,7 +44,7 @@ use ruff_python_ast::identifier::Identifier;
 /// ```
 ///
 /// ## Options
-/// - `pylint.max-statements`
+/// - `lint.pylint.max-statements`
 #[violation]
 pub struct TooManyStatements {
     statements: usize,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -30,7 +30,7 @@ use crate::settings::types::PythonVersion;
 /// `__future__` annotations are not evaluated at runtime. If your code relies
 /// on runtime type annotations (either directly or via a library like
 /// Pydantic), you can disable this behavior for Python versions prior to 3.9
-/// by setting [`pyupgrade.keep-runtime-typing`] to `true`.
+/// by setting [`lint.pyupgrade.keep-runtime-typing`] to `true`.
 ///
 /// ## Example
 /// ```python
@@ -51,7 +51,7 @@ use crate::settings::types::PythonVersion;
 ///
 /// ## Options
 /// - `target-version`
-/// - `pyupgrade.keep-runtime-typing`
+/// - `lint.pyupgrade.keep-runtime-typing`
 ///
 /// [PEP 585]: https://peps.python.org/pep-0585/
 #[violation]

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -23,7 +23,7 @@ use crate::settings::types::PythonVersion;
 /// `__future__` annotations are not evaluated at runtime. If your code relies
 /// on runtime type annotations (either directly or via a library like
 /// Pydantic), you can disable this behavior for Python versions prior to 3.10
-/// by setting [`pyupgrade.keep-runtime-typing`] to `true`.
+/// by setting [`lint.pyupgrade.keep-runtime-typing`] to `true`.
 ///
 /// ## Example
 /// ```python
@@ -46,7 +46,7 @@ use crate::settings::types::PythonVersion;
 ///
 /// ## Options
 /// - `target-version`
-/// - `pyupgrade.keep-runtime-typing`
+/// - `lint.pyupgrade.keep-runtime-typing`
 ///
 /// [PEP 604]: https://peps.python.org/pep-0604/
 #[violation]

--- a/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -28,7 +28,7 @@ use crate::settings::LinterSettings;
 /// spec recommends `GREEK CAPITAL LETTER OMEGA` over `OHM SIGN`.
 ///
 /// You can omit characters from being flagged as ambiguous via the
-/// [`allowed-confusables`] setting.
+/// [`lint.allowed-confusables`] setting.
 ///
 /// ## Example
 /// ```python
@@ -41,7 +41,7 @@ use crate::settings::LinterSettings;
 /// ```
 ///
 /// ## Options
-/// - `allowed-confusables`
+/// - `lint.allowed-confusables`
 ///
 /// [preview]: https://docs.astral.sh/ruff/preview/
 #[violation]
@@ -94,7 +94,7 @@ impl Violation for AmbiguousUnicodeCharacterString {
 /// ```
 ///
 /// ## Options
-/// - `allowed-confusables`
+/// - `lint.allowed-confusables`
 ///
 /// [preview]: https://docs.astral.sh/ruff/preview/
 #[violation]
@@ -147,7 +147,7 @@ impl Violation for AmbiguousUnicodeCharacterDocstring {
 /// ```
 ///
 /// ## Options
-/// - `allowed-confusables`
+/// - `lint.allowed-confusables`
 ///
 /// [preview]: https://docs.astral.sh/ruff/preview/
 #[violation]

--- a/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
@@ -53,7 +53,7 @@ use crate::rules::ruff::rules::helpers::{
 /// ```
 ///
 /// ## Options
-/// - `flake8-bugbear.extend-immutable-calls`
+/// - `lint.flake8-bugbear.extend-immutable-calls`
 #[violation]
 pub struct FunctionCallInDataclassDefaultArgument {
     name: Option<String>,

--- a/crates/ruff_linter/src/rules/ruff/rules/never_union.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/never_union.rs
@@ -30,7 +30,7 @@ use crate::checkers::ast::Checker;
 ///     ...
 /// ```
 ///
-/// ## Options
+/// ## References
 /// - [Python documentation: `typing.Never`](https://docs.python.org/3/library/typing.html#typing.Never)
 /// - [Python documentation: `typing.NoReturn`](https://docs.python.org/3/library/typing.html#typing.NoReturn)
 #[violation]

--- a/crates/ruff_linter/src/rules/ruff/rules/unused_noqa.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unused_noqa.rs
@@ -36,7 +36,7 @@ pub struct UnusedCodes {
 /// ```
 ///
 /// ## Options
-/// - `external`
+/// - `lint.external`
 ///
 /// ## References
 /// - [Ruff error suppression](https://docs.astral.sh/ruff/linter/#error-suppression)

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -396,11 +396,11 @@ impl Configuration {
 
     pub fn from_options(options: Options, project_root: &Path) -> Result<Self> {
         let lint = if let Some(mut lint) = options.lint {
-            lint.common = lint.common.combine(options.lint_top_level);
+            lint.common = lint.common.combine(options.lint_top_level.common);
             lint
         } else {
             LintOptions {
-                common: options.lint_top_level,
+                common: options.lint_top_level.common,
                 ..LintOptions::default()
             }
         };

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -321,16 +321,16 @@ leading to [`line-too-long`](rules/line-too-long.md) (`E501`) errors.
 
 None of the above are included in Ruff's default configuration. However, if you've enabled
 any of these rules or their parent categories (like `Q`), we recommend disabling them via the
-linter's [`ignore`](settings.md#ignore) setting.
+linter's [`lint.ignore`](settings.md#lint_ignore) setting.
 
 Similarly, we recommend avoiding the following isort settings, which are incompatible with the
 formatter's treatment of import statements when set to non-default values:
 
-- [`force-single-line`](settings.md#isort-force-single-line)
-- [`force-wrap-aliases`](settings.md#isort-force-wrap-aliases)
-- [`lines-after-imports`](settings.md#isort-lines-after-imports)
-- [`lines-between-types`](settings.md#isort-lines-between-types)
-- [`split-on-trailing-comma`](settings.md#isort-split-on-trailing-comma)
+- [`force-single-line`](settings.md#lint_isort_force-single-line)
+- [`force-wrap-aliases`](settings.md#lint_isort_force-wrap-aliases)
+- [`lines-after-imports`](settings.md#lint_isort_lines-after-imports)
+- [`lines-between-types`](settings.md#lint_isort_lines-between-types)
+- [`split-on-trailing-comma`](settings.md#lint_isort_split-on-trailing-comma)
 
 If you've configured any of these settings to take on non-default values, we recommend removing
 them from your Ruff configuration.

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -24,14 +24,14 @@ For the full list of supported options, run `ruff check --help`.
 
 ## Rule selection
 
-The set of enabled rules is controlled via the [`select`](settings.md#select),
-[`extend-select`](settings.md#extend-select), and [`ignore`](settings.md#ignore) settings.
+The set of enabled rules is controlled via the [`lint.select`](settings.md#lint_select),
+[`lint.extend-select`](settings.md#lint_extend-select), and [`lint.ignore`](settings.md#lint_ignore) settings.
 
 Ruff's linter mirrors Flake8's rule code system, in which each rule code consists of a one-to-three
 letter prefix, followed by three digits (e.g., `F401`). The prefix indicates that "source" of the rule
 (e.g., `F` for Pyflakes, `E` for pycodestyle, `ANN` for flake8-annotations).
 
-Rule selectors like [`select`](settings.md#select) and [`ignore`](settings.md#ignore) accept either
+Rule selectors like [`lint.select`](settings.md#lint_select) and [`lint.ignore`](settings.md#lint_ignore) accept either
 a full rule code (e.g., `F401`) or any valid prefix (e.g., `F`). For example, given the following
 configuration file:
 
@@ -60,7 +60,7 @@ formats. Ruff will automatically disable any conflicting rules when `ALL` is ena
 
 If you're wondering how to configure Ruff, here are some **recommended guidelines**:
 
-- Prefer [`select`](settings.md#select) over [`extend-select`](settings.md#extend-select) to make your rule set explicit.
+- Prefer [`lint.select`](settings.md#lint_select) over [`lint.extend-select`](settings.md#lint_extend-select) to make your rule set explicit.
 - Use `ALL` with discretion. Enabling `ALL` will implicitly enable new rules whenever you upgrade.
 - Start with a small set of rules (`select = ["E", "F"]`) and add a category at-a-time. For example,
     you might consider expanding to `select = ["E", "F", "B"]` to enable the popular flake8-bugbear
@@ -109,13 +109,13 @@ pedantic) might look like the following:
     ]
     ```
 
-To resolve the enabled rule set, Ruff may need to reconcile [`select`](settings.md#select) and
-[`ignore`](settings.md#ignore) from a variety of sources, including the current `pyproject.toml`,
-any inherited `pyproject.toml` files, and the CLI (e.g., [`--select`](settings.md#select)).
+To resolve the enabled rule set, Ruff may need to reconcile [`lint.select`](settings.md#lint_select) and
+[`lint.ignore`](settings.md#lint_ignore) from a variety of sources, including the current `pyproject.toml`,
+any inherited `pyproject.toml` files, and the CLI (e.g., [`--select`](settings.md#lint_select)).
 
-In those scenarios, Ruff uses the "highest-priority" [`select`](settings.md#select) as the basis for
-the rule set, and then applies [`extend-select`](settings.md#extend-select) and
-[`ignore`](settings.md#ignore) adjustments. CLI options are given higher priority than
+In those scenarios, Ruff uses the "highest-priority" [`select`](settings.md#lint_select) as the basis for
+the rule set, and then applies [`extend-select`](settings.md#lint_extend-select) and
+[`ignore`](settings.md#lint_ignore) adjustments. CLI options are given higher priority than
 `pyproject.toml` options, and the current `pyproject.toml` file is given higher priority than any
 inherited `pyproject.toml` files.
 
@@ -233,9 +233,9 @@ You may use prefixes to select rules as well, e.g., `F` can be used to promote f
 
 ### Disabling fixes
 
-To limit the set of rules that Ruff should fix, use the [`fixable`](settings.md#fixable) and
-[`unfixable`](settings.md#unfixable) settings, along with their [`extend-fixable`](settings.md#extend-fixable)
-and [`extend-unfixable`](settings.md#extend-unfixable) variants.
+To limit the set of rules that Ruff should fix, use the [`lint.fixable`](settings.md#lint_fixable) and
+[`lint.unfixable`](settings.md#lint_unfixable) settings, along with their [`lint.extend-fixable`](settings.md#lint_extend-fixable)
+and [`lint.extend-unfixable`](settings.md#lint_extend-unfixable) variants.
 
 For example, the following configuration would enable fixes for all rules except
 [`unused-imports`](rules/unused-import.md) (`F401`):
@@ -277,7 +277,7 @@ Conversely, the following configuration would only enable fixes for `F401`:
 Ruff supports several mechanisms for suppressing lint errors, be they false positives or
 permissible violations.
 
-To omit a lint rule entirely, add it to the "ignore" list via the [`ignore`](settings.md#ignore)
+To omit a lint rule entirely, add it to the "ignore" list via the [`lint.ignore`](settings.md#lint_ignore)
 setting, either on the command-line or in your `pyproject.toml` or `ruff.toml` file.
 
 To suppress a violation inline, Ruff uses a `noqa` system similar to [Flake8](https://flake8.pycqa.org/en/3.1.1/user/ignoring-errors.html).
@@ -326,7 +326,7 @@ file, preferably towards the top, like so:
 # ruff: noqa: F841
 ```
 
-Or see the [`per-file-ignores`](settings.md#per-file-ignores) setting, which enables the same
+Or see the [`lint.per-file-ignores`](settings.md#lint_per-file-ignores) setting, which enables the same
 functionality from within your `pyproject.toml` or `ruff.toml` file.
 
 Global `noqa` comments must be on their own line to disambiguate from comments which ignore

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -5,6 +5,7 @@
   "properties": {
     "allowed-confusables": {
       "description": "A list of allowed \"confusable\" Unicode characters to ignore when enforcing `RUF001`, `RUF002`, and `RUF003`.",
+      "deprecated": true,
       "type": [
         "array",
         "null"
@@ -34,6 +35,7 @@
     },
     "dummy-variable-rgx": {
       "description": "A regular expression used to identify \"dummy\" variables, or those which should be ignored when enforcing (e.g.) unused-variable rules. The default expression matches `_`, `__`, and `_var`, but not `_var_`.",
+      "deprecated": true,
       "type": [
         "string",
         "null"
@@ -51,6 +53,7 @@
     },
     "explicit-preview-rules": {
       "description": "Whether to require exact codes to select preview rules. When enabled, preview rules will not be selected by prefixes — the full code of each preview rule will be required to enable the rule.",
+      "deprecated": true,
       "type": [
         "boolean",
         "null"
@@ -75,6 +78,7 @@
     },
     "extend-fixable": {
       "description": "A list of rule codes or prefixes to consider fixable, in addition to those specified by `fixable`.",
+      "deprecated": true,
       "type": [
         "array",
         "null"
@@ -106,6 +110,7 @@
     },
     "extend-per-file-ignores": {
       "description": "A list of mappings from file pattern to rule codes or prefixes to exclude, in addition to any rules excluded by `per-file-ignores`.",
+      "deprecated": true,
       "type": [
         "object",
         "null"
@@ -119,6 +124,7 @@
     },
     "extend-safe-fixes": {
       "description": "A list of rule codes or prefixes for which unsafe fixes should be considered safe.",
+      "deprecated": true,
       "type": [
         "array",
         "null"
@@ -129,6 +135,7 @@
     },
     "extend-select": {
       "description": "A list of rule codes or prefixes to enable, in addition to those specified by `select`.",
+      "deprecated": true,
       "type": [
         "array",
         "null"
@@ -150,6 +157,7 @@
     },
     "extend-unsafe-fixes": {
       "description": "A list of rule codes or prefixes for which safe fixes should be considered unsafe.",
+      "deprecated": true,
       "type": [
         "array",
         "null"
@@ -160,6 +168,7 @@
     },
     "external": {
       "description": "A list of rule codes or prefixes that are unsupported by Ruff, but should be preserved when (e.g.) validating `# noqa` directives. Useful for retaining `# noqa` directives that cover plugins not yet implemented by Ruff.",
+      "deprecated": true,
       "type": [
         "array",
         "null"
@@ -184,6 +193,7 @@
     },
     "fixable": {
       "description": "A list of rule codes or prefixes to consider fixable. By default, all rules are considered fixable.",
+      "deprecated": true,
       "type": [
         "array",
         "null"
@@ -194,6 +204,7 @@
     },
     "flake8-annotations": {
       "description": "Options for the `flake8-annotations` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8AnnotationsOptions"
@@ -205,6 +216,7 @@
     },
     "flake8-bandit": {
       "description": "Options for the `flake8-bandit` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8BanditOptions"
@@ -216,6 +228,7 @@
     },
     "flake8-bugbear": {
       "description": "Options for the `flake8-bugbear` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8BugbearOptions"
@@ -227,6 +240,7 @@
     },
     "flake8-builtins": {
       "description": "Options for the `flake8-builtins` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8BuiltinsOptions"
@@ -238,6 +252,7 @@
     },
     "flake8-comprehensions": {
       "description": "Options for the `flake8-comprehensions` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8ComprehensionsOptions"
@@ -249,6 +264,7 @@
     },
     "flake8-copyright": {
       "description": "Options for the `flake8-copyright` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8CopyrightOptions"
@@ -260,6 +276,7 @@
     },
     "flake8-errmsg": {
       "description": "Options for the `flake8-errmsg` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8ErrMsgOptions"
@@ -271,6 +288,7 @@
     },
     "flake8-gettext": {
       "description": "Options for the `flake8-gettext` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8GetTextOptions"
@@ -282,6 +300,7 @@
     },
     "flake8-implicit-str-concat": {
       "description": "Options for the `flake8-implicit-str-concat` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8ImplicitStrConcatOptions"
@@ -293,6 +312,7 @@
     },
     "flake8-import-conventions": {
       "description": "Options for the `flake8-import-conventions` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8ImportConventionsOptions"
@@ -304,6 +324,7 @@
     },
     "flake8-pytest-style": {
       "description": "Options for the `flake8-pytest-style` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8PytestStyleOptions"
@@ -315,6 +336,7 @@
     },
     "flake8-quotes": {
       "description": "Options for the `flake8-quotes` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8QuotesOptions"
@@ -326,6 +348,7 @@
     },
     "flake8-self": {
       "description": "Options for the `flake8_self` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8SelfOptions"
@@ -337,6 +360,7 @@
     },
     "flake8-tidy-imports": {
       "description": "Options for the `flake8-tidy-imports` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8TidyImportsOptions"
@@ -348,6 +372,7 @@
     },
     "flake8-type-checking": {
       "description": "Options for the `flake8-type-checking` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8TypeCheckingOptions"
@@ -359,6 +384,7 @@
     },
     "flake8-unused-arguments": {
       "description": "Options for the `flake8-unused-arguments` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Flake8UnusedArgumentsOptions"
@@ -388,6 +414,7 @@
     },
     "ignore": {
       "description": "A list of rule codes or prefixes to ignore. Prefixes can specify exact rules (like `F841`), entire categories (like `F`), or anything in between.\n\nWhen breaking ties between enabled and disabled rules (via `select` and `ignore`, respectively), more specific prefixes override less specific prefixes.",
+      "deprecated": true,
       "type": [
         "array",
         "null"
@@ -398,6 +425,7 @@
     },
     "ignore-init-module-imports": {
       "description": "Avoid automatically removing unused imports in `__init__.py` files. Such imports will still be flagged, but with a dedicated message suggesting that the import is either added to the module's `__all__` symbol, or re-exported with a redundant alias (e.g., `import os as os`).",
+      "deprecated": true,
       "type": [
         "boolean",
         "null"
@@ -426,6 +454,7 @@
     },
     "isort": {
       "description": "Options for the `isort` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/IsortOptions"
@@ -458,6 +487,7 @@
     },
     "logger-objects": {
       "description": "A list of objects that should be treated equivalently to a `logging.Logger` object.\n\nThis is useful for ensuring proper diagnostics (e.g., to identify `logging` deprecations and other best-practices) for projects that re-export a `logging.Logger` object from a common module.\n\nFor example, if you have a module `logging_setup.py` with the following contents: ```python import logging\n\nlogger = logging.getLogger(__name__) ```\n\nAdding `\"logging_setup.logger\"` to `logger-objects` will ensure that `logging_setup.logger` is treated as a `logging.Logger` object when imported from other modules (e.g., `from logging_setup import logger`).",
+      "deprecated": true,
       "type": [
         "array",
         "null"
@@ -468,6 +498,7 @@
     },
     "mccabe": {
       "description": "Options for the `mccabe` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/McCabeOptions"
@@ -500,6 +531,7 @@
     },
     "pep8-naming": {
       "description": "Options for the `pep8-naming` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/Pep8NamingOptions"
@@ -511,6 +543,7 @@
     },
     "per-file-ignores": {
       "description": "A list of mappings from file pattern to rule codes or prefixes to exclude, when considering any matching files.",
+      "deprecated": true,
       "type": [
         "object",
         "null"
@@ -531,6 +564,7 @@
     },
     "pycodestyle": {
       "description": "Options for the `pycodestyle` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/PycodestyleOptions"
@@ -542,6 +576,7 @@
     },
     "pydocstyle": {
       "description": "Options for the `pydocstyle` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/PydocstyleOptions"
@@ -553,6 +588,7 @@
     },
     "pyflakes": {
       "description": "Options for the `pyflakes` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/PyflakesOptions"
@@ -564,6 +600,7 @@
     },
     "pylint": {
       "description": "Options for the `pylint` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/PylintOptions"
@@ -575,6 +612,7 @@
     },
     "pyupgrade": {
       "description": "Options for the `pyupgrade` plugin.",
+      "deprecated": true,
       "anyOf": [
         {
           "$ref": "#/definitions/PyUpgradeOptions"
@@ -604,6 +642,7 @@
     },
     "select": {
       "description": "A list of rule codes or prefixes to enable. Prefixes can specify exact rules (like `F841`), entire categories (like `F`), or anything in between.\n\nWhen breaking ties between enabled and disabled rules (via `select` and `ignore`, respectively), more specific prefixes override less specific prefixes.",
+      "deprecated": true,
       "type": [
         "array",
         "null"
@@ -661,6 +700,7 @@
     },
     "task-tags": {
       "description": "A list of task tags to recognize (e.g., \"TODO\", \"FIXME\", \"XXX\").\n\nComments starting with these tags will be ignored by commented-out code detection (`ERA`), and skipped by line-length rules (`E501`) if `ignore-overlong-task-comments` is set to `true`.",
+      "deprecated": true,
       "type": [
         "array",
         "null"
@@ -671,6 +711,7 @@
     },
     "typing-modules": {
       "description": "A list of modules whose exports should be treated equivalently to members of the `typing` module.\n\nThis is useful for ensuring proper type annotation inference for projects that re-export `typing` and `typing_extensions` members from a compatibility module. If omitted, any members imported from modules apart from `typing` and `typing_extensions` will be treated as ordinary Python objects.",
+      "deprecated": true,
       "type": [
         "array",
         "null"
@@ -681,6 +722,7 @@
     },
     "unfixable": {
       "description": "A list of rule codes or prefixes to consider non-fixable.",
+      "deprecated": true,
       "type": [
         "array",
         "null"
@@ -1269,7 +1311,7 @@
       "additionalProperties": false
     },
     "FormatOptions": {
-      "description": "Experimental: Configures how `ruff format` formats your code.\n\nPlease provide feedback in [this discussion](https://github.com/astral-sh/ruff/discussions/7310).",
+      "description": "Configures the way ruff formats your code.",
       "type": "object",
       "properties": {
         "docstring-code-format": {
@@ -1701,7 +1743,7 @@
       "minimum": 1.0
     },
     "LintOptions": {
-      "description": "Experimental section to configure Ruff's linting. This new section will eventually replace the top-level linting options.\n\nOptions specified in the `lint` section take precedence over the top-level settings.",
+      "description": "Configures how ruff checks your code.\n\nOptions specified in the `lint` section take precedence over the deprecated top-level settings.",
       "type": "object",
       "properties": {
         "allowed-confusables": {


### PR DESCRIPTION
## Summary

This PR marks the top-level lint settings as deprecated (schema only) and updates the website to document the options under the lint section (removes the top-level settings). 

I had to make changes to the documentation generation to now support 3-level deep options

* The documentation now shows the entire name for sub-sub-sections (e.g. `lint.pydocstyle` instead of `pydocstyle`) because sub-sub-sections are rendered at the same level as sub-sections. 
* The anchor link now contains the entire parent chain: `lint.pycodestyle.xxx` instead of `pycodestyle.xxx`. 
* The anchor link now use `_` instead of `-` as a separator to disambiguate between the subsection `lint.pydocstyle` and option `lint-pydocstyle`

I feel undecided about one open question: Should we use the full setting name in READMEs or only the name? For example. Should we write `lint.ignore` or `ignore`? Or a more extreme example. Should we write max-complexity` or `lint.mccabe.max-complexity`. We currently use a mix of both:

* The tutorial mainly uses the short names
* Rules use the full name (until today without the `lint` prefix)

I changed the tutorial to use long names in most positions but it didn't always feel right.  

## Considerations

One downside of removing the top-level settings from the website is that Ruff's documentation isn't versioned. Users using an older version of ruff that only supports the global settings or use the global options might be confused why the options are missing. 

A possible solution is adding aliasing support to our documentation generation, although that might be tricky.

IMO, removing is fine because the `lint` section has been supported since [v0.0.292](https://github.com/astral-sh/ruff/releases/tag/v0.0.292), which feels like a very long time ago. 

## Next steps

Emit deprecation messages when a configuration uses any deprecated top-level settings.

## Test Plan

* I built the documentation locally and verified that the lint options are only listed once under the `lint` section (which helps discoverability). 
* I read through the documentation and clicked through the setting options to verify that the anchor links work
* I reviewed the schema changes and it marks the top level lint settings as deprecated.


![image](https://github.com/astral-sh/ruff/assets/1203881/ea5d8bc5-e525-45bb-98ff-57af032b5513)


> **Danger**: Only merge before the 0.2.0 release
