### PR TITLE
Include base pyproject when initializing cache settings

### DIFF
--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use anyhow::{anyhow, bail};
 use globset::{Candidate, GlobSet};
 use ignore::{WalkBuilder, WalkState};
-use itertools::{Either, Itertools};
+use itertools::Itertools;
 use log::debug;
 use path_absolutize::path_dedot;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -204,12 +204,7 @@ impl<'a> Resolver<'a> {
 
     /// Return an iterator over the resolved [`Settings`] in this [`Resolver`].
     pub fn settings(&self) -> impl Iterator<Item = &Settings> {
-        match self.pyproject_config.strategy {
-            PyprojectDiscoveryStrategy::Fixed => {
-                Either::Left(std::iter::once(&self.pyproject_config.settings))
-            }
-            PyprojectDiscoveryStrategy::Hierarchical => Either::Right(self.settings.values()),
-        }
+        std::iter::once(&self.pyproject_config.settings).chain(self.settings.values())
     }
 }
 


### PR DESCRIPTION
## Summary

Regression from https://github.com/astral-sh/ruff/pull/9453/files#diff-80a9c2637c432502a7075c792cc60db92282dd786999a78bfa9bb6f025afab35L482.

Closes https://github.com/astral-sh/ruff/issues/9478.

## Test Plan

```
rm -rf .ruff_cache
cargo run -p ruff_cli -- check ../foo.py
```

Failed prior to this PR; passes afterwards. The file must be outside of the current working directory, and must not have a `pyproject.toml` in any parent directory.
