### PR TITLE
Add `--extension` support to the formatter

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -290,6 +290,10 @@ pub struct CheckCommand {
     /// The name of the file when passing it through stdin.
     #[arg(long, help_heading = "Miscellaneous")]
     pub stdin_filename: Option<PathBuf>,
+    /// List of mappings from file extension to language (one of ["python", "ipynb", "pyi"]). For
+    /// example, to treat `.ipy` files as IPython notebooks, use `--extension ipy:ipynb`.
+    #[arg(long, value_delimiter = ',')]
+    pub extension: Option<Vec<ExtensionPair>>,
     /// Exit with status code "0", even upon detecting lint violations.
     #[arg(
         short,
@@ -352,9 +356,6 @@ pub struct CheckCommand {
         conflicts_with = "watch",
     )]
     pub show_settings: bool,
-    /// List of mappings from file extension to language (one of ["python", "ipynb", "pyi"]).
-    #[arg(long, value_delimiter = ',', hide = true)]
-    pub extension: Option<Vec<ExtensionPair>>,
     /// Dev-only argument to show fixes
     #[arg(long, hide = true)]
     pub ecosystem_ci: bool,
@@ -423,6 +424,10 @@ pub struct FormatCommand {
     /// The name of the file when passing it through stdin.
     #[arg(long, help_heading = "Miscellaneous")]
     pub stdin_filename: Option<PathBuf>,
+    /// List of mappings from file extension to language (one of ["python", "ipynb", "pyi"]). For
+    /// example, to treat `.ipy` files as IPython notebooks, use `--extension ipy:ipynb`.
+    #[arg(long, value_delimiter = ',')]
+    pub extension: Option<Vec<ExtensionPair>>,
     /// The minimum Python version that should be supported.
     #[arg(long, value_enum)]
     pub target_version: Option<PythonVersion>,
@@ -571,6 +576,7 @@ impl FormatCommand {
                 force_exclude: resolve_bool_arg(self.force_exclude, self.no_force_exclude),
                 target_version: self.target_version,
                 cache_dir: self.cache_dir,
+                extension: self.extension,
 
                 // Unsupported on the formatter CLI, but required on `Overrides`.
                 ..CliOverrides::default()
@@ -739,7 +745,7 @@ impl ConfigurationTransformer for CliOverrides {
             config.target_version = Some(*target_version);
         }
         if let Some(extension) = &self.extension {
-            config.lint.extension = Some(extension.clone().into_iter().collect());
+            config.extension = Some(extension.iter().cloned().collect());
         }
 
         config

--- a/crates/ruff_cli/tests/format.rs
+++ b/crates/ruff_cli/tests/format.rs
@@ -1468,3 +1468,73 @@ fn test_notebook_trailing_semicolon() {
     ----- stderr -----
     "###);
 }
+
+#[test]
+fn extension() -> Result<()> {
+    let tempdir = TempDir::new()?;
+
+    let ruff_toml = tempdir.path().join("ruff.toml");
+    fs::write(
+        &ruff_toml,
+        r#"
+include = ["*.ipy"]
+"#,
+    )?;
+
+    fs::write(
+        tempdir.path().join("main.ipy"),
+        r#"
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad6f36d9-4b7d-4562-8d00-f15a0f1fbb6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x=1"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}
+"#,
+    )?;
+
+    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+        .current_dir(tempdir.path())
+        .arg("format")
+        .arg("--no-cache")
+        .args(["--config", &ruff_toml.file_name().unwrap().to_string_lossy()])
+        .args(["--extension", "ipy:ipynb"])
+        .arg("."), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    1 file reformatted
+
+    ----- stderr -----
+    "###);
+    Ok(())
+}

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -41,6 +41,7 @@ pub mod types;
 #[derive(Debug, CacheKey)]
 pub struct LinterSettings {
     pub exclude: FilePatternSet,
+    pub extension: ExtensionMapping,
     pub project_root: PathBuf,
 
     pub rules: RuleTable,
@@ -50,7 +51,6 @@ pub struct LinterSettings {
     pub target_version: PythonVersion,
     pub preview: PreviewMode,
     pub explicit_preview_rules: bool,
-    pub extension: ExtensionMapping,
 
     // Rule-specific settings
     pub allowed_confusables: FxHashSet<char>,

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -388,9 +388,10 @@ pub struct ExtensionMapping {
 }
 
 impl ExtensionMapping {
-    /// Return the [`Language`] for the given extension.
-    pub fn get(&self, extension: &str) -> Option<Language> {
-        self.mapping.get(extension).copied()
+    /// Return the [`Language`] for the given file.
+    pub fn get(&self, path: &Path) -> Option<Language> {
+        let ext = path.extension()?.to_str()?;
+        self.mapping.get(ext).copied()
     }
 }
 

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -1,7 +1,9 @@
 use path_absolutize::path_dedot;
 use ruff_cache::cache_dir;
 use ruff_formatter::{FormatOptions, IndentStyle, IndentWidth, LineWidth};
-use ruff_linter::settings::types::{FilePattern, FilePatternSet, SerializationFormat, UnsafeFixes};
+use ruff_linter::settings::types::{
+    ExtensionMapping, FilePattern, FilePatternSet, SerializationFormat, UnsafeFixes,
+};
 use ruff_linter::settings::LinterSettings;
 use ruff_macros::CacheKey;
 use ruff_python_ast::PySourceType;
@@ -116,6 +118,7 @@ impl FileResolverSettings {
 #[derive(CacheKey, Clone, Debug)]
 pub struct FormatterSettings {
     pub exclude: FilePatternSet,
+    pub extension: ExtensionMapping,
     pub preview: PreviewMode,
     pub target_version: ruff_python_formatter::PythonVersion,
 
@@ -177,6 +180,7 @@ impl Default for FormatterSettings {
 
         Self {
             exclude: FilePatternSet::default(),
+            extension: ExtensionMapping::default(),
             target_version: default_options.target_version(),
             preview: PreviewMode::Disabled,
             line_width: default_options.line_width(),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -528,6 +528,8 @@ Options:
           Enable preview mode; checks will include unstable rules and fixes. Use `--no-preview` to disable
       --config <CONFIG>
           Path to the `pyproject.toml` or `ruff.toml` file to use for configuration
+      --extension <EXTENSION>
+          List of mappings from file extension to language (one of ["python", "ipynb", "pyi"]). For example, to treat `.ipy` files as IPython notebooks, use `--extension ipy:ipynb`
       --statistics
           Show counts for every rule with at least one violation
       --add-noqa
@@ -604,6 +606,8 @@ Options:
           Avoid writing any formatted files back; instead, exit with a non-zero status code and the difference between the current file and how the formatted file would look like
       --config <CONFIG>
           Path to the `pyproject.toml` or `ruff.toml` file to use for configuration
+      --extension <EXTENSION>
+          List of mappings from file extension to language (one of ["python", "ipynb", "pyi"]). For example, to treat `.ipy` files as IPython notebooks, use `--extension ipy:ipynb`
       --target-version <TARGET_VERSION>
           The minimum Python version that should be supported [possible values: py37, py38, py39, py310, py311, py312]
       --preview


### PR DESCRIPTION
## Summary

We added `--extension` to `ruff check`, but it's equally applicable to `ruff format`.

Closes https://github.com/astral-sh/ruff/issues/9482.

Resolves https://github.com/astral-sh/ruff/discussions/9481.

## Test Plan

`cargo test`