### PR TITLE
Fix backticks in RUF021 docs

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/parenthesize_logical_operators.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/parenthesize_logical_operators.rs
@@ -32,7 +32,7 @@ use crate::checkers::ast::Checker;
 ///
 /// d, e, f = 0, 1, 2
 /// y = (d and e) or f
-/// ````
+/// ```
 #[violation]
 pub struct ParenthesizeChainedOperators;
 


### PR DESCRIPTION
The docs for this rule aren't generating properly: https://docs.astral.sh/ruff/rules/parenthesize-chained-operators/#why-is-this-bad. I assume this is the reason why!
