### PR TITLE
Fix message for __aenter__ in PLC2801

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
@@ -273,7 +273,7 @@ impl DunderReplacement {
             "__str__" => Some(Self::Builtin("str", "Use `str()` builtin")),
             "__subclasscheck__" => Some(Self::Builtin("issubclass", "Use `issubclass()` builtin")),
 
-            "__aenter__" => Some(Self::MessageOnly("Use `aenter()` builtin")),
+            "__aenter__" => Some(Self::MessageOnly("Invoke context manager directly")),
             "__ceil__" => Some(Self::MessageOnly("Use `math.ceil()` function")),
             "__copy__" => Some(Self::MessageOnly("Use `copy.copy()` function")),
             "__deepcopy__" => Some(Self::MessageOnly("Use `copy.deepcopy()` function")),


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fix the message for `__aenter__ ` in PLC2801 (introduced in https://github.com/astral-sh/ruff/pull/9166)
There is no `aenter` builtin in Python, so the current message is misleading.
I take the message from original lint https://github.com/pylint-dev/pylint/blob/main/pylint/constants.py#L211

P.S. I think here should be more accurate synchronization with original lint (e.g. the current implementation will not lint `__enter__`  on my first sight), but it is out-of-scope of this change.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
