### PR TITLE
fix(docs): admonition in dark mode

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -99,6 +99,7 @@
 }
 
 /* See: https://github.com/astral-sh/ruff/issues/9046 */
-[data-md-color-scheme="astral-dark"] div.admonition p a {
-  color: var(--flare);
+[data-md-color-scheme="astral-dark"] div.admonition {
+  color: var(--md-code-fg-color);
+  background-color: var(--md-code-bg-color);
 }


### PR DESCRIPTION
## Summary

The admonition in dark mode are in actually same as in light mode here: https://docs.astral.sh/ruff/formatter/#ruff-format

I propose to move admonition in real dark mode as shown below:
- Before the PR https://github.com/astral-sh/ruff/pull/9385
![image](https://github.com/astral-sh/ruff/assets/45884742/abb7e0db-bf12-49cd-9f9b-e353accd571f)
- Current version
![image](https://github.com/astral-sh/ruff/assets/45884742/da8ab46d-dc87-412e-be2b-ac937cd87666)
- Proposal
![image](https://github.com/astral-sh/ruff/assets/45884742/7279cb02-e6af-4320-9dee-486fbfddcbc8)

Close #9501

## Test Plan

Documentation was regenerated via mkdocs and the supplied requirements.
