### PR TITLE
[`flake8-simplify`] Avoid some more `enumerate-for-loop` false positives (`SIM113`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM113.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM113.py
@@ -166,3 +166,30 @@ def func():
         for y in range(5):
             g(x, idx)
             idx += 1
+
+
+def func():
+    # OK (index used within inner)
+    idx = 0
+
+    def inner():
+        print(idx)
+
+    for x in range(5):
+        for y in range(5):
+            g(x, idx)
+            idx += 1
+
+
+def func():
+    # OK (index used as nonlocal inner)
+    idx = 0
+
+    def inner():
+        nonlocal idx
+        idx = 3
+
+    for x in range(5):
+        for y in range(5):
+            g(x, idx)
+            idx += 1

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/enumerate_for_loop.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/enumerate_for_loop.rs
@@ -127,11 +127,10 @@ pub(crate) fn enumerate_for_loop(checker: &mut Checker, for_stmt: &ast::StmtFor)
                 binding
             };
 
-            // If the variable is used _after_ the loop, ignore it.
-            // Find the binding for the augmented assignment.
+            // If the variable is used outside the loop, ignore it.
             if binding.references.iter().any(|id| {
                 let reference = checker.semantic().reference(*id);
-                reference.start() > for_stmt.end()
+                !for_stmt.range().contains_range(reference.range())
             }) {
                 continue;
             }


### PR DESCRIPTION
Avoids, e.g., [this false positive](https://github.com/zulip/zulip/blob/a4fad5dda116048e22c3d559d370367e4e1c9b9a/zerver/data_import/slack.py#L634) from the ecosystem check.