### PR TITLE
add the "__prepare__" method to the list of recognized dunder method

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
@@ -87,6 +87,10 @@ class Apples:
     def __special_custom_magic__(self):
         pass
 
+    @classmethod
+    def __prepare__():
+        pass
+
 
 def __foo_bar__():  # this is not checked by the [bad-dunder-name] rule
     ...

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -289,6 +289,7 @@ pub(super) fn is_known_dunder_method(method: &str) -> bool {
             | "__pos__"
             | "__post_init__"
             | "__pow__"
+            | "__prepare__"
             | "__radd__"
             | "__rand__"
             | "__rdivmod__"


### PR DESCRIPTION
## Summary
Closes #9508 .
Add `__prepare__` method to dunder method list in `is_known_dunder_method`.

## Test Plan
1. add "__prepare__" method to `Apple` class in crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py.
2. run `cargo test`
