### PR TITLE
Bump `tj-actions/changed-files` to v41

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: tj-actions/changed-files@v40
+      - uses: tj-actions/changed-files@v41
         id: changed
         with:
           files_yaml: |


### PR DESCRIPTION
This is a subset of https://github.com/astral-sh/ruff/pull/9526 that should be safe to apply.