### PR TITLE
Add an explicit fast path for whitespace to `is_identifier_continuation`

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1498,9 +1498,10 @@ fn is_unicode_identifier_start(c: char) -> bool {
 // Checks if the character c is a valid continuation character as described
 // in https://docs.python.org/3/reference/lexical_analysis.html#identifiers
 fn is_identifier_continuation(c: char) -> bool {
-    match c {
-        'a'..='z' | 'A'..='Z' | '_' | '0'..='9' => true,
-        c => is_xid_continue(c),
+    if c.is_ascii() {
+        matches!(c, 'a'..='z' | 'A'..='Z' | '_' | '0'..='9')
+    } else {
+        is_xid_continue(c)
     }
 }
 

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1498,6 +1498,8 @@ fn is_unicode_identifier_start(c: char) -> bool {
 // Checks if the character c is a valid continuation character as described
 // in https://docs.python.org/3/reference/lexical_analysis.html#identifiers
 fn is_identifier_continuation(c: char) -> bool {
+    // Arrange things such that ASCII codepoints never
+    // result in the slower `is_xid_continue` getting called.
     if c.is_ascii() {
         matches!(c, 'a'..='z' | 'A'..='Z' | '_' | '0'..='9')
     } else {

--- a/crates/ruff_python_stdlib/src/identifiers.rs
+++ b/crates/ruff_python_stdlib/src/identifiers.rs
@@ -33,9 +33,10 @@ fn is_identifier_start(c: char) -> bool {
 // Checks if the character c is a valid continuation character as described
 // in https://docs.python.org/3/reference/lexical_analysis.html#identifiers
 fn is_identifier_continuation(c: char) -> bool {
-    match c {
-        'a'..='z' | 'A'..='Z' | '_' | '0'..='9' => true,
-        c => is_xid_continue(c),
+    if c.is_ascii() {
+        matches!(c, 'a'..='z' | 'A'..='Z' | '_' | '0'..='9')
+    } else {
+        is_xid_continue(c)
     }
 }
 

--- a/crates/ruff_python_stdlib/src/identifiers.rs
+++ b/crates/ruff_python_stdlib/src/identifiers.rs
@@ -33,6 +33,8 @@ fn is_identifier_start(c: char) -> bool {
 // Checks if the character c is a valid continuation character as described
 // in https://docs.python.org/3/reference/lexical_analysis.html#identifiers
 fn is_identifier_continuation(c: char) -> bool {
+    // Arrange things such that ASCII codepoints never
+    // result in the slower `is_xid_continue` getting called.
     if c.is_ascii() {
         matches!(c, 'a'..='z' | 'A'..='Z' | '_' | '0'..='9')
     } else {

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -136,6 +136,8 @@ fn is_identifier_start(c: char) -> bool {
 // Checks if the character c is a valid continuation character as described
 // in https://docs.python.org/3/reference/lexical_analysis.html#identifiers
 fn is_identifier_continuation(c: char) -> bool {
+    // Arrange things such that ASCII codepoints never
+    // result in the slower `is_xid_continue` getting called.
     if c.is_ascii() {
         matches!(c, 'a'..='z' | 'A'..='Z' | '_' | '0'..='9')
     } else {


### PR DESCRIPTION
## Summary

Avoid calling into `is_xid_continue` for ascii characters (all ascii characters not handled by the match are implicitly `false`)

## Test Plan

`cargo test`
