### PR TITLE
Move `is_tuple_parenthesized` from the formatter to `ruff_python_ast`

### DIFF
--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -8,6 +8,7 @@ use std::slice::{Iter, IterMut};
 
 use itertools::Itertools;
 
+use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::{int, LiteralExpressionRef};
@@ -1798,6 +1799,37 @@ pub struct ExprTuple {
 impl From<ExprTuple> for Expr {
     fn from(payload: ExprTuple) -> Self {
         Expr::Tuple(payload)
+    }
+}
+
+impl ExprTuple {
+    /// Return `true` if a tuple is parenthesized in the source code.
+    pub fn is_parenthesized(&self, source: &str) -> bool {
+        let Some(elt) = self.elts.first() else {
+            return true;
+        };
+
+        // Count the number of open parentheses between the start of the tuple and the first element.
+        let open_parentheses_count =
+            SimpleTokenizer::new(source, TextRange::new(self.start(), elt.start()))
+                .skip_trivia()
+                .filter(|token| token.kind() == SimpleTokenKind::LParen)
+                .count();
+        if open_parentheses_count == 0 {
+            return false;
+        }
+
+        // Count the number of parentheses between the end of the first element and its trailing comma.
+        let close_parentheses_count =
+            SimpleTokenizer::new(source, TextRange::new(elt.end(), self.end()))
+                .skip_trivia()
+                .take_while(|token| token.kind() != SimpleTokenKind::Comma)
+                .filter(|token| token.kind() == SimpleTokenKind::RParen)
+                .count();
+
+        // If the number of open parentheses is greater than the number of close parentheses, the tuple
+        // is parenthesized.
+        open_parentheses_count > close_parentheses_count
     }
 }
 

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -14,7 +14,6 @@ use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use crate::comments::visitor::{CommentPlacement, DecoratedComment};
 use crate::expression::expr_generator_exp::is_generator_parenthesized;
 use crate::expression::expr_slice::{assign_comment_in_slice, ExprSliceCommentSection};
-use crate::expression::expr_tuple::is_tuple_parenthesized;
 use crate::other::parameters::{
     assign_argument_separator_comment_placement, find_parameter_separators,
 };
@@ -294,7 +293,7 @@ fn handle_enclosed_comment<'a>(
         | AnyNodeRef::ExprSet(_)
         | AnyNodeRef::ExprListComp(_)
         | AnyNodeRef::ExprSetComp(_) => handle_bracketed_end_of_line_comment(comment, locator),
-        AnyNodeRef::ExprTuple(tuple) if is_tuple_parenthesized(tuple, locator.contents()) => {
+        AnyNodeRef::ExprTuple(tuple) if tuple.is_parenthesized(locator.contents()) => {
             handle_bracketed_end_of_line_comment(comment, locator)
         }
         AnyNodeRef::ExprGeneratorExp(generator)

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -15,7 +15,6 @@ use crate::builders::parenthesize_if_expands;
 use crate::comments::{leading_comments, trailing_comments, LeadingDanglingTrailingComments};
 use crate::context::{NodeLevel, WithNodeLevel};
 use crate::expression::expr_generator_exp::is_generator_parenthesized;
-use crate::expression::expr_tuple::is_tuple_parenthesized;
 use crate::expression::parentheses::{
     is_expression_parenthesized, optional_parentheses, parenthesized, HuggingStyle,
     NeedsParentheses, OptionalParentheses, Parentheses, Parenthesize,
@@ -670,7 +669,7 @@ impl<'input> CanOmitOptionalParenthesesVisitor<'input> {
                 return;
             }
 
-            Expr::Tuple(tuple) if is_tuple_parenthesized(tuple, self.context.source()) => {
+            Expr::Tuple(tuple) if tuple.is_parenthesized(self.context.source()) => {
                 self.any_parenthesized_expressions = true;
                 // The values are always parenthesized, don't visit.
                 return;
@@ -1059,7 +1058,7 @@ pub(crate) fn has_own_parentheses(
             }
         }
 
-        Expr::Tuple(tuple) if is_tuple_parenthesized(tuple, context.source()) => {
+        Expr::Tuple(tuple) if tuple.is_parenthesized(context.source()) => {
             if !tuple.elts.is_empty() || context.comments().has_dangling(AnyNodeRef::from(expr)) {
                 Some(OwnParentheses::NonEmpty)
             } else {


### PR DESCRIPTION
This allows it to be used in the linter as well as the formatter. It will be useful in #9474