### PR TITLE
Update contributing docs to use `cargo bench -p ruff_benchmark`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -518,10 +518,10 @@ if the benchmark improved/regressed compared to that baseline.
 
 ```shell
 # Run once on your "baseline" code
-cargo benchmark --save-baseline=main
+cargo bench -p ruff_benchmark -- --save-baseline=main
 
 # Then iterate with
-cargo benchmark --baseline=main
+cargo bench -p ruff_benchmark -- --baseline=main
 ```
 
 #### PR Summary
@@ -531,10 +531,10 @@ This is useful to illustrate the improvements of a PR.
 
 ```shell
 # On main
-cargo benchmark --save-baseline=main
+cargo bench -p ruff_benchmark -- --save-baseline=main
 
 # After applying your changes
-cargo benchmark --save-baseline=pr
+cargo bench -p ruff_benchmark -- --save-baseline=pr
 
 critcmp main pr
 ```
@@ -547,10 +547,10 @@ cargo install critcmp
 
 #### Tips
 
-- Use `cargo benchmark <filter>` to only run specific benchmarks. For example: `cargo benchmark linter/pydantic`
-    to only run the pydantic tests.
-- Use `cargo benchmark --quiet` for a more cleaned up output (without statistical relevance)
-- Use `cargo benchmark --quick` to get faster results (more prone to noise)
+- Use `cargo bench -p ruff_benchmark <filter>` to only run specific benchmarks. For example: `cargo benchmark lexer`
+    to only run the lexer benchmarks.
+- Use `cargo bench -p ruff_benchmark -- --quiet` for a more cleaned up output (without statistical relevance)
+- Use `cargo bench -p ruff_benchmark -- --quick` to get faster results (more prone to noise)
 
 ### Profiling Projects
 

--- a/crates/ruff_benchmark/README.md
+++ b/crates/ruff_benchmark/README.md
@@ -1,5 +1,16 @@
 # Ruff Benchmarks
 
-The `ruff_benchmark` crate benchmarks the linter and the formatter on individual files.
+The `ruff_benchmark` crate benchmarks the linter and the formatter on individual files:
+
+```shell
+# Run once on the "baseline".
+cargo bench -p ruff_benchmark -- --save-baseline=main
+
+# Compare against the "baseline".
+cargo bench -p ruff_benchmark -- --baseline=main
+
+# Run the lexer benchmarks.
+cargo bench -p ruff_benchmark lexer -- --baseline=main
+```
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) on how to use these benchmarks.


### PR DESCRIPTION
## Summary

I found that `cargo benchmark lexer` didn't work as expected:

```shell
❯ cargo benchmark lexer
    Finished bench [optimized] target(s) in 0.08s
     Running benches/formatter.rs (target/release/deps/formatter-4e1d9bf9d3ba529d)
     Running benches/linter.rs (target/release/deps/linter-e449086ddfd8ad8c)
```

Turns out that `cargo bench -p ruff_benchmark` is now recommended over `cargo benchmark`, so updating the docs to reflect that.