### PR TITLE
Visit deferred lambdas before type definitions

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_21.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F401_21.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import cast
+
+
+def get_most_common_fn(k):
+    return lambda c: cast(Counter, c).most_common(k)

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -2045,10 +2045,10 @@ pub(crate) fn check_ast(
     // function can add a deferred lambda, but the opposite is not true.
     checker.visit_deferred_functions();
     checker.visit_deferred_type_param_definitions();
+    checker.visit_deferred_lambdas();
     checker.visit_deferred_future_type_definitions();
     let allocator = typed_arena::Arena::new();
     checker.visit_deferred_string_type_definitions(&allocator);
-    checker.visit_deferred_lambdas();
     checker.visit_exports();
 
     // Check docstrings, bindings, and unresolved references.

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -53,6 +53,7 @@ mod tests {
     #[test_case(Rule::UnusedImport, Path::new("F401_18.py"))]
     #[test_case(Rule::UnusedImport, Path::new("F401_19.py"))]
     #[test_case(Rule::UnusedImport, Path::new("F401_20.py"))]
+    #[test_case(Rule::UnusedImport, Path::new("F401_21.py"))]
     #[test_case(Rule::ImportShadowedByLoopVar, Path::new("F402.py"))]
     #[test_case(Rule::ImportShadowedByLoopVar, Path::new("F402.ipynb"))]
     #[test_case(Rule::UndefinedLocalWithImportStar, Path::new("F403.py"))]

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_F401_21.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_F401_21.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+


### PR DESCRIPTION
## Summary

This is effectively the same problem as https://github.com/astral-sh/ruff/pull/9175. And this just papers over it again, though I'm gonna try a more holistic fix in a follow-up PR. The _real_ fix here is that we need to continue to visit deferred items until they're exhausted since, e.g., we still get this case wrong (flagging `re` as unused):

```python
import re

cast(lambda: re.match, 1)
```

Closes https://github.com/astral-sh/ruff/issues/9534.
