### PR TITLE
Make `ruff` the default binary

### DIFF
--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -10,6 +10,7 @@ documentation = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 readme = "../../README.md"
+default-run = "ruff"
 
 [dependencies]
 ruff_cache = { path = "../ruff_cache" }


### PR DESCRIPTION
## Summary

This makes `cargo run` equivalent to `cargo run -p ruff` which is almost always what you want.
