### PR TITLE
[`pylint`] Exclude `self` and `cls` when counting method arguments

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/too_many_positional.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/too_many_positional.py
@@ -1,4 +1,4 @@
-def f(x, y, z, t, u, v, w, r):  # Too many positional arguments (8/3)
+def f(x, y, z, t, u, v, w, r):  # Too many positional arguments (8/5)
     pass
 
 
@@ -18,7 +18,7 @@ def f(x=1, y=1, z=1):  # OK
     pass
 
 
-def f(x, y, z, /, u, v, w):  # Too many positional arguments (6/3)
+def f(x, y, z, /, u, v, w):  # Too many positional arguments (6/5)
     pass
 
 
@@ -26,5 +26,36 @@ def f(x, y, z, *, u, v, w):  # OK
     pass
 
 
-def f(x, y, z, a, b, c, *, u, v, w):  # Too many positional arguments (6/3)
+def f(x, y, z, a, b, c, *, u, v, w):  # Too many positional arguments (6/5)
     pass
+
+
+class C:
+    def f(self, a, b, c, d, e):  # OK
+        pass
+
+    def f(self, /, a, b, c, d, e):  # OK
+        pass
+
+    def f(weird_self_name, a, b, c, d, e):  # OK
+        pass
+
+    def f(self, a, b, c, d, e, g):  # Too many positional arguments (6/5)
+        pass
+
+    @staticmethod
+    def f(self, a, b, c, d, e):  # Too many positional arguments (6/5)
+        pass
+
+    @classmethod
+    def f(cls, a, b, c, d, e):  # OK
+        pass
+
+    def f(*, self, a, b, c, d, e):  # OK
+        pass
+
+    def f(self=1, a=1, b=1, c=1, d=1, e=1):  # OK
+        pass
+
+    def f():  # OK
+        pass

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR0917_too_many_positional.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR0917_too_many_positional.py.snap
@@ -3,23 +3,40 @@ source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
 too_many_positional.py:1:5: PLR0917 Too many positional arguments (8/5)
   |
-1 | def f(x, y, z, t, u, v, w, r):  # Too many positional arguments (8/3)
+1 | def f(x, y, z, t, u, v, w, r):  # Too many positional arguments (8/5)
   |     ^ PLR0917
 2 |     pass
   |
 
 too_many_positional.py:21:5: PLR0917 Too many positional arguments (6/5)
    |
-21 | def f(x, y, z, /, u, v, w):  # Too many positional arguments (6/3)
+21 | def f(x, y, z, /, u, v, w):  # Too many positional arguments (6/5)
    |     ^ PLR0917
 22 |     pass
    |
 
 too_many_positional.py:29:5: PLR0917 Too many positional arguments (6/5)
    |
-29 | def f(x, y, z, a, b, c, *, u, v, w):  # Too many positional arguments (6/3)
+29 | def f(x, y, z, a, b, c, *, u, v, w):  # Too many positional arguments (6/5)
    |     ^ PLR0917
 30 |     pass
+   |
+
+too_many_positional.py:43:9: PLR0917 Too many positional arguments (6/5)
+   |
+41 |         pass
+42 | 
+43 |     def f(self, a, b, c, d, e, g):  # Too many positional arguments (6/5)
+   |         ^ PLR0917
+44 |         pass
+   |
+
+too_many_positional.py:47:9: PLR0917 Too many positional arguments (6/5)
+   |
+46 |     @staticmethod
+47 |     def f(self, a, b, c, d, e):  # Too many positional arguments (6/5)
+   |         ^ PLR0917
+48 |         pass
    |
 
 


### PR DESCRIPTION
closes #9552

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR detects whether PLR0917 is being applied to a method or class method, and if so, it ignores the first argument for the purposes of counting the number of positional arguments.

## Test Plan

<!-- How was it tested? -->
New tests have been added to the corresponding fixture.
