### PR TITLE
Documentation update for URL giving 'page not found'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -618,7 +618,7 @@ Otherwise, follow the instructions from the linux section.
 utils with it:
 
 - `cargo dev print-ast <file>`: Print the AST of a python file using the
-    [RustPython parser](https://github.com/astral-sh/RustPython-Parser/tree/main/parser) that is
+    [RustPython parser](https://github.com/astral-sh/ruff/tree/main/crates/ruff_python_parser) that is
     mainly used in Ruff. For `if True: pass # comment`, you can see the syntax tree, the byte offsets
     for start and stop of each node and also how the `:` token, the comment and whitespace are not
     represented anymore:


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Documentation - update the link in CONTRIBUTING.md to point to the `ruff_python_parser` crate. It currently gives a `page not found`.
