### PR TITLE
[flake8-pyi] Fix PYI047 false negatives on PEP-695 type aliases

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI047.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI047.py
@@ -20,3 +20,12 @@ else:
 
 
 def func2(arg: _PrivateTypeAlias) -> None: ...
+
+type _UnusedPEP695 = int
+type _UnusedGeneric695[T] = list[T]
+
+type _UsedPEP695 = str
+type _UsedGeneric695[T] = tuple[T, ...]
+
+def func4(arg: _UsedPEP695) -> None: ...
+def func5(arg: _UsedGeneric695[bytes]) -> None: ...

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI047.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI047.pyi
@@ -20,3 +20,12 @@ else:
 
 
 def func2(arg: _PrivateTypeAlias) -> None: ...
+
+type _UnusedPEP695 = int
+type _UnusedGeneric695[T] = list[T]
+
+type _UsedPEP695 = str
+type _UsedGeneric695[T] = tuple[T, ...]
+
+def func4(arg: _UsedPEP695) -> None: ...
+def func5(arg: _UsedGeneric695[bytes]) -> None: ...

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI047_PYI047.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI047_PYI047.py.snap
@@ -17,4 +17,22 @@ PYI047.py:7:1: PYI047 Private TypeAlias `_T` is never used
 9 | # OK
   |
 
+PYI047.py:24:6: PYI047 Private TypeAlias `_UnusedPEP695` is never used
+   |
+22 | def func2(arg: _PrivateTypeAlias) -> None: ...
+23 | 
+24 | type _UnusedPEP695 = int
+   |      ^^^^^^^^^^^^^ PYI047
+25 | type _UnusedGeneric695[T] = list[T]
+   |
+
+PYI047.py:25:6: PYI047 Private TypeAlias `_UnusedGeneric695` is never used
+   |
+24 | type _UnusedPEP695 = int
+25 | type _UnusedGeneric695[T] = list[T]
+   |      ^^^^^^^^^^^^^^^^^ PYI047
+26 | 
+27 | type _UsedPEP695 = str
+   |
+
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI047_PYI047.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI047_PYI047.pyi.snap
@@ -17,4 +17,22 @@ PYI047.pyi:7:1: PYI047 Private TypeAlias `_T` is never used
 9 | # OK
   |
 
+PYI047.pyi:24:6: PYI047 Private TypeAlias `_UnusedPEP695` is never used
+   |
+22 | def func2(arg: _PrivateTypeAlias) -> None: ...
+23 | 
+24 | type _UnusedPEP695 = int
+   |      ^^^^^^^^^^^^^ PYI047
+25 | type _UnusedGeneric695[T] = list[T]
+   |
+
+PYI047.pyi:25:6: PYI047 Private TypeAlias `_UnusedGeneric695` is never used
+   |
+24 | type _UnusedPEP695 = int
+25 | type _UnusedGeneric695[T] = list[T]
+   |      ^^^^^^^^^^^^^^^^^ PYI047
+26 | 
+27 | type _UsedPEP695 = str
+   |
+
 


### PR DESCRIPTION
## Summary

Fixes one of the issues listed in https://github.com/astral-sh/ruff/issues/8771. Fairly straightforward!

## Test Plan

`cargo test` / `cargo insta review`
