### PR TITLE
[`pycodestyle`] - add autofixes for `type-comparison` / `E721`

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E721_E721.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E721_E721.py.snap
@@ -9,6 +9,7 @@ E721.py:2:4: E721 Do not compare types, use `isinstance()`
 3 |     pass
 4 | #: E721
   |
+  = help: Replace with `isinstance()`
 
 E721.py:5:4: E721 Do not compare types, use `isinstance()`
   |
@@ -19,6 +20,7 @@ E721.py:5:4: E721 Do not compare types, use `isinstance()`
 6 |     pass
 7 | #: E721
   |
+  = help: Replace with `isinstance()`
 
 E721.py:8:4: E721 Do not compare types, use `isinstance()`
    |
@@ -29,6 +31,7 @@ E721.py:8:4: E721 Do not compare types, use `isinstance()`
  9 |     pass
 10 | #: Okay
    |
+   = help: Replace with `isinstance()`
 
 E721.py:18:4: E721 Do not compare types, use `isinstance()`
    |
@@ -39,6 +42,7 @@ E721.py:18:4: E721 Do not compare types, use `isinstance()`
 19 |     pass
 20 | #: E721
    |
+   = help: Replace with `isinstance()`
 
 E721.py:21:8: E721 Do not compare types, use `isinstance()`
    |
@@ -49,6 +53,7 @@ E721.py:21:8: E721 Do not compare types, use `isinstance()`
 22 | #: E721
 23 | assert type(res) == type([])
    |
+   = help: Replace with `isinstance()`
 
 E721.py:23:8: E721 Do not compare types, use `isinstance()`
    |
@@ -59,6 +64,7 @@ E721.py:23:8: E721 Do not compare types, use `isinstance()`
 24 | #: E721
 25 | assert type(res) == type(())
    |
+   = help: Replace with `isinstance()`
 
 E721.py:25:8: E721 Do not compare types, use `isinstance()`
    |
@@ -69,6 +75,7 @@ E721.py:25:8: E721 Do not compare types, use `isinstance()`
 26 | #: E721
 27 | assert type(res) == type((0,))
    |
+   = help: Replace with `isinstance()`
 
 E721.py:27:8: E721 Do not compare types, use `isinstance()`
    |
@@ -79,6 +86,7 @@ E721.py:27:8: E721 Do not compare types, use `isinstance()`
 28 | #: E721
 29 | assert type(res) == type((0))
    |
+   = help: Replace with `isinstance()`
 
 E721.py:29:8: E721 Do not compare types, use `isinstance()`
    |
@@ -89,6 +97,7 @@ E721.py:29:8: E721 Do not compare types, use `isinstance()`
 30 | #: E721
 31 | assert type(res) != type((1, ))
    |
+   = help: Replace with `isinstance()`
 
 E721.py:31:8: E721 Do not compare types, use `isinstance()`
    |
@@ -99,6 +108,7 @@ E721.py:31:8: E721 Do not compare types, use `isinstance()`
 32 | #: Okay
 33 | assert type(res) is type((1, ))
    |
+   = help: Replace with `isinstance()`
 
 E721.py:33:8: E721 Do not compare types, use `isinstance()`
    |
@@ -109,6 +119,7 @@ E721.py:33:8: E721 Do not compare types, use `isinstance()`
 34 | #: Okay
 35 | assert type(res) is not type((1, ))
    |
+   = help: Replace with `isinstance()`
 
 E721.py:35:8: E721 Do not compare types, use `isinstance()`
    |
@@ -119,6 +130,7 @@ E721.py:35:8: E721 Do not compare types, use `isinstance()`
 36 | #: E211 E721
 37 | assert type(res) == type ([2, ])
    |
+   = help: Replace with `isinstance()`
 
 E721.py:37:8: E721 Do not compare types, use `isinstance()`
    |
@@ -129,6 +141,7 @@ E721.py:37:8: E721 Do not compare types, use `isinstance()`
 38 | #: E201 E201 E202 E721
 39 | assert type(res) == type( ( ) )
    |
+   = help: Replace with `isinstance()`
 
 E721.py:39:8: E721 Do not compare types, use `isinstance()`
    |
@@ -139,6 +152,7 @@ E721.py:39:8: E721 Do not compare types, use `isinstance()`
 40 | #: E201 E202 E721
 41 | assert type(res) == type( (0, ) )
    |
+   = help: Replace with `isinstance()`
 
 E721.py:41:8: E721 Do not compare types, use `isinstance()`
    |
@@ -148,6 +162,7 @@ E721.py:41:8: E721 Do not compare types, use `isinstance()`
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
 42 | #:
    |
+   = help: Replace with `isinstance()`
 
 E721.py:107:12: E721 Do not compare types, use `isinstance()`
     |
@@ -157,6 +172,7 @@ E721.py:107:12: E721 Do not compare types, use `isinstance()`
     |            ^^^^^^^^^^^^^^^^^^ E721
 108 |             ...
     |
+    = help: Replace with `isinstance()`
 
 E721.py:117:12: E721 Do not compare types, use `isinstance()`
     |
@@ -166,5 +182,6 @@ E721.py:117:12: E721 Do not compare types, use `isinstance()`
     |            ^^^^^^^^^^^^^^^^^^ E721
 118 |             ...
     |
+    = help: Replace with `isinstance()`
 
 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__E721_E721.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__E721_E721.py.snap
@@ -9,6 +9,7 @@ E721.py:2:4: E721 Use `is` and `is not` for type comparisons, or `isinstance()` 
 3 |     pass
 4 | #: E721
   |
+  = help: Replace with `is` or `is not`
 
 E721.py:5:4: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
   |
@@ -19,6 +20,7 @@ E721.py:5:4: E721 Use `is` and `is not` for type comparisons, or `isinstance()` 
 6 |     pass
 7 | #: E721
   |
+  = help: Replace with `is` or `is not`
 
 E721.py:8:4: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
@@ -29,6 +31,7 @@ E721.py:8:4: E721 Use `is` and `is not` for type comparisons, or `isinstance()` 
  9 |     pass
 10 | #: Okay
    |
+   = help: Replace with `is` or `is not`
 
 E721.py:21:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
@@ -39,6 +42,7 @@ E721.py:21:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()`
 22 | #: E721
 23 | assert type(res) == type([])
    |
+   = help: Replace with `is` or `is not`
 
 E721.py:23:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
@@ -49,6 +53,7 @@ E721.py:23:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()`
 24 | #: E721
 25 | assert type(res) == type(())
    |
+   = help: Replace with `is` or `is not`
 
 E721.py:25:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
@@ -59,6 +64,7 @@ E721.py:25:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()`
 26 | #: E721
 27 | assert type(res) == type((0,))
    |
+   = help: Replace with `is` or `is not`
 
 E721.py:27:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
@@ -69,6 +75,7 @@ E721.py:27:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()`
 28 | #: E721
 29 | assert type(res) == type((0))
    |
+   = help: Replace with `is` or `is not`
 
 E721.py:29:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
@@ -79,6 +86,7 @@ E721.py:29:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()`
 30 | #: E721
 31 | assert type(res) != type((1, ))
    |
+   = help: Replace with `is` or `is not`
 
 E721.py:31:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
@@ -89,6 +97,7 @@ E721.py:31:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()`
 32 | #: Okay
 33 | assert type(res) is type((1, ))
    |
+   = help: Replace with `is` or `is not`
 
 E721.py:37:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
@@ -99,6 +108,7 @@ E721.py:37:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()`
 38 | #: E201 E201 E202 E721
 39 | assert type(res) == type( ( ) )
    |
+   = help: Replace with `is` or `is not`
 
 E721.py:39:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
@@ -109,6 +119,7 @@ E721.py:39:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()`
 40 | #: E201 E202 E721
 41 | assert type(res) == type( (0, ) )
    |
+   = help: Replace with `is` or `is not`
 
 E721.py:41:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
@@ -118,6 +129,7 @@ E721.py:41:8: E721 Use `is` and `is not` for type comparisons, or `isinstance()`
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
 42 | #:
    |
+   = help: Replace with `is` or `is not`
 
 E721.py:59:4: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
    |
@@ -128,5 +140,6 @@ E721.py:59:4: E721 Use `is` and `is not` for type comparisons, or `isinstance()`
 60 |     pass
 61 | #: Okay
    |
+   = help: Replace with `is` or `is not`
 
 


### PR DESCRIPTION
## Summary

Adds autofixes to `type-comparison` / `E721`

## Test Plan

`cargo test`
