### PR TITLE
Always unset the `required-version` option during ecosystem checks

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/projects.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/projects.py
@@ -95,11 +95,15 @@ class ConfigOverrides(Serializable):
         """
         Temporarily patch the Ruff configuration file in the given directory.
         """
+        dot_ruff_toml = dirpath / ".ruff.toml"
         ruff_toml = dirpath / "ruff.toml"
         pyproject_toml = dirpath / "pyproject.toml"
 
         # Prefer `ruff.toml` over `pyproject.toml`
-        if ruff_toml.exists():
+        if dot_ruff_toml.exists():
+            path = dot_ruff_toml
+            base = []
+        elif ruff_toml.exists():
             path = ruff_toml
             base = []
         else:


### PR DESCRIPTION
Uses our existing configuration overrides to unset the `required-version` option in ecosystem projects during checks.

The downside to this approach, is we will now update the config file of _every_ project. This roughly normalizes the configuration file, as we don't preserve comments and such. We could instead do a more targeted approach applying this override to projects which we know use this setting 🤷‍♀️ 