### PR TITLE
Corrected code block hyperlink

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
@@ -31,7 +31,7 @@ use crate::checkers::ast::Checker;
 /// Does not ignore private name imports from within the module that defines
 /// the private name if the module is defined with [PEP 420] namespace packages
 /// (i.e., directories that omit the `__init__.py` file). Namespace packages
-/// must be configured via the [`namespace-packages`] setting.
+/// must be configured via the [`namespace-packages`][namespace-packages] setting.
 ///
 /// ## Example
 /// ```python
@@ -39,7 +39,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## Options
-/// - [`namespace-packages`]: List of packages that are defined as namespace
+/// - [`namespace-packages`][namespace-packages]: List of packages that are defined as namespace
 ///   packages.
 ///
 /// ## References
@@ -48,7 +48,7 @@ use crate::checkers::ast::Checker;
 ///
 /// [PEP 8]: https://www.python.org/dev/peps/pep-0008/
 /// [PEP 420]: https://www.python.org/dev/peps/pep-0420/
-/// [`namespace-packages`]: https://beta.ruff.rs/docs/settings/#namespace-packages
+/// [namespace-packages]: https://beta.ruff.rs/docs/settings/#namespace-packages
 #[violation]
 pub struct ImportPrivateName {
     name: String,

--- a/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
@@ -31,7 +31,7 @@ use crate::checkers::ast::Checker;
 /// Does not ignore private name imports from within the module that defines
 /// the private name if the module is defined with [PEP 420] namespace packages
 /// (i.e., directories that omit the `__init__.py` file). Namespace packages
-/// must be configured via the [`namespace-packages`][namespace-packages] setting.
+/// must be configured via the [`namespace-packages`] setting.
 ///
 /// ## Example
 /// ```python
@@ -39,8 +39,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// ## Options
-/// - [`namespace-packages`][namespace-packages]: List of packages that are defined as namespace
-///   packages.
+/// - `namespace-packages`
 ///
 /// ## References
 /// - [PEP 8: Naming Conventions](https://peps.python.org/pep-0008/#naming-conventions)
@@ -48,7 +47,6 @@ use crate::checkers::ast::Checker;
 ///
 /// [PEP 8]: https://www.python.org/dev/peps/pep-0008/
 /// [PEP 420]: https://www.python.org/dev/peps/pep-0420/
-/// [namespace-packages]: https://beta.ruff.rs/docs/settings/#namespace-packages
 #[violation]
 pub struct ImportPrivateName {
     name: String,


### PR DESCRIPTION
## Summary

Apparently MkDocs doesn't like when reference-style links have formatting inside :)

<details>
<summary>Screenshots (before and after the change)</summary>
<img width="1235" alt="61353" src="https://github.com/astral-sh/ruff/assets/77130613/e32a82bd-0c5d-4edb-998f-b53659a6c54d">

<img width="1237" alt="15526" src="https://github.com/astral-sh/ruff/assets/77130613/bdafcda5-eb9c-4af6-af03-b4849c1e5c81">
</details>
