### PR TITLE
Include global `--config` when determining namespace packages

### DIFF
--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -173,8 +173,7 @@ impl<'a> Resolver<'a> {
         // Determine whether any of the settings require namespace packages. If not, we can save
         // a lookup for every file.
         let has_namespace_packages = self
-            .settings
-            .values()
+            .settings()
             .any(|settings| !settings.linter.namespace_packages.is_empty());
 
         // Search for the package root for each file.


### PR DESCRIPTION
## Summary

When determining whether _any_ settings have namespace packages, we need to consider the global settings (as would be provided via `--config`). This was a subtle fallout of a refactor.

Closes https://github.com/astral-sh/ruff/issues/9579.

## Test Plan

Tested locally by compiling Ruff and running against this [namespace-test](https://github.com/gokay05/namespace-test) repo.