### PR TITLE
Update SchemaStore script to install npm dependencies

### DIFF
--- a/scripts/update_schemastore.py
+++ b/scripts/update_schemastore.py
@@ -17,7 +17,7 @@ ruff_repo = "https://github.com/astral-sh/ruff"
 root = Path(
     check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip(),
 )
-ruff_json = Path("src/schemas/json/ruff.json")
+ruff_json = Path("schemas/json/ruff.json")
 
 
 def update_schemastore(schemastore: Path) -> None:
@@ -47,13 +47,17 @@ def update_schemastore(schemastore: Path) -> None:
         cwd=schemastore,
     )
 
+    # Run npm install
+    src = schemastore.joinpath("src")
+    check_call(["npm", "install"], cwd=src)
+
     # Update the schema and format appropriately
     schema = json.loads(root.joinpath("ruff.schema.json").read_text())
     schema["$id"] = "https://json.schemastore.org/ruff.json"
-    schemastore.joinpath(ruff_json).write_text(
+    src.joinpath(ruff_json).write_text(
         json.dumps(dict(sorted(schema.items())), indent=2, ensure_ascii=False),
     )
-    check_call(["prettier", "--write", ruff_json], cwd=schemastore)
+    check_call(["node_modules/.bin/prettier", "--write", ruff_json], cwd=src)
 
     # Check if the schema has changed
     # https://stackoverflow.com/a/9393642/3549270


### PR DESCRIPTION
## Summary

SchemaStore now depends on some Prettier plugins, so we need to install Prettier and its plugins as part of the project (rather than relying on a global install).

## Test Plan

Ran the script!