### PR TITLE
Preserve indent around multiline strings

### DIFF
--- a/crates/ruff_python_formatter/src/other/arguments.rs
+++ b/crates/ruff_python_formatter/src/other/arguments.rs
@@ -1,16 +1,16 @@
 use ruff_formatter::{write, FormatContext};
 use ruff_python_ast::{ArgOrKeyword, Arguments, Expr};
-use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
-use ruff_text_size::{Ranged, TextRange, TextSize};
+use ruff_python_trivia::{PythonWhitespace, SimpleTokenKind, SimpleTokenizer};
+use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
 use crate::comments::SourceComment;
 use crate::expression::expr_generator_exp::GeneratorExpParentheses;
 use crate::expression::is_expression_huggable;
-use crate::expression::parentheses::{
-    empty_parenthesized, parenthesized, HuggingStyle, Parentheses,
-};
+use crate::expression::parentheses::{empty_parenthesized, parenthesized, Parentheses};
 use crate::other::commas;
 use crate::prelude::*;
+use crate::preview::is_multiline_string_handling_enabled;
+use crate::string::AnyString;
 
 #[derive(Default)]
 pub struct FormatArguments;
@@ -178,33 +178,75 @@ fn is_single_argument_parenthesized(argument: &Expr, call_end: TextSize, source:
 ///
 /// Hugging should only be applied to single-argument collections, like lists, or starred versions
 /// of those collections.
-fn is_arguments_huggable(item: &Arguments, context: &PyFormatContext) -> Option<HuggingStyle> {
+fn is_arguments_huggable(arguments: &Arguments, context: &PyFormatContext) -> bool {
     // Find the lone argument or `**kwargs` keyword.
-    let arg = match (item.args.as_slice(), item.keywords.as_slice()) {
+    let arg = match (arguments.args.as_slice(), arguments.keywords.as_slice()) {
         ([arg], []) => arg,
         ([], [keyword]) if keyword.arg.is_none() && !context.comments().has(keyword) => {
             &keyword.value
         }
-        _ => return None,
+        _ => return false,
     };
 
     // If the expression itself isn't huggable, then we can't hug it.
-    let hugging_style = is_expression_huggable(arg, context)?;
+    if !(is_expression_huggable(arg, context)
+        || AnyString::from_expression(arg)
+            .is_some_and(|string| is_huggable_string_argument(string, arguments, context)))
+    {
+        return false;
+    }
 
     // If the expression has leading or trailing comments, then we can't hug it.
     let comments = context.comments().leading_dangling_trailing(arg);
     if comments.has_leading() || comments.has_trailing() {
-        return None;
+        return false;
     }
 
     let options = context.options();
 
     // If the expression has a trailing comma, then we can't hug it.
     if options.magic_trailing_comma().is_respect()
-        && commas::has_magic_trailing_comma(TextRange::new(arg.end(), item.end()), options, context)
+        && commas::has_magic_trailing_comma(
+            TextRange::new(arg.end(), arguments.end()),
+            options,
+            context,
+        )
     {
-        return None;
+        return false;
     }
 
-    Some(hugging_style)
+    true
+}
+
+/// Returns `true` if `string` is a multiline string that is not implicitly concatenated and there's no
+/// newline between the opening parentheses of arguments and the quotes of the string:
+///
+/// ```python
+/// # Hug this string
+/// call("""test
+/// multiline""")
+///
+/// # Don't hug because there's a newline between the opening parentheses and the quotes:
+/// call(
+///     """"
+///     test
+///     """"
+/// )
+/// ```
+fn is_huggable_string_argument(
+    string: AnyString,
+    arguments: &Arguments,
+    context: &PyFormatContext,
+) -> bool {
+    if !is_multiline_string_handling_enabled(context) {
+        return false;
+    }
+
+    if string.is_implicit_concatenated() || !string.is_multiline(context.source()) {
+        return false;
+    }
+
+    let between_parens_range = TextRange::new(arguments.start() + '('.text_len(), string.start());
+    let between_parens = &context.source()[between_parens_range];
+    !between_parens.trim_whitespace_end().ends_with(['\n', '\r'])
 }

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_multiline_strings.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_multiline_strings.py.snap
@@ -301,7 +301,19 @@ this_will_also_become_one_line = (  # comment
  # Another use case
  data = yaml.load("""\
  a: 1
-@@ -85,11 +114,13 @@
+@@ -77,19 +106,23 @@
+ b: 2
+ """,
+ )
+-data = yaml.load("""\
++data = yaml.load(
++    """\
+     a: 1
+     b: 2
+-""")
++"""
++)
+ 
  MULTILINE = """
  foo
  """.replace("\n", "")
@@ -316,7 +328,7 @@ this_will_also_become_one_line = (  # comment
  parser.usage += """
  Custom extra help summary.
  
-@@ -156,16 +187,24 @@
+@@ -156,16 +189,24 @@
               10 LOAD_CONST               0 (None)
               12 RETURN_VALUE
  """ % (_C.__init__.__code__.co_firstlineno + 1,)
@@ -347,7 +359,7 @@ this_will_also_become_one_line = (  # comment
  [
      """cow
  moos""",
-@@ -198,7 +237,7 @@
+@@ -198,7 +239,7 @@
  `--global-option` is reserved to flags like `--verbose` or `--quiet`.
  """
  
@@ -356,7 +368,7 @@ this_will_also_become_one_line = (  # comment
  
  this_will_stay_on_three_lines = (
      "a"  # comment
-@@ -206,4 +245,6 @@
+@@ -206,4 +247,6 @@
      "c"
  )
  
@@ -477,10 +489,12 @@ a: 1
 b: 2
 """,
 )
-data = yaml.load("""\
+data = yaml.load(
+    """\
     a: 1
     b: 2
-""")
+"""
+)
 
 MULTILINE = """
 foo


### PR DESCRIPTION
## Summary

This PR changes our `multiline_string` preview style implementation (added in https://github.com/astral-sh/ruff/pull/9243) to only hug strings in call arguments when there's no newline between the `(` and the string's quotes.

This is to address the feedback raised in Black's repository ([issue](https://github.com/psf/black/issues/4159))

The stable formatting always indents strings:

```python
dedent(
    """
    value
    """
)
```

The preview style as it is implemented today (not this PR) tries to hug multiline strings, and only falls back to indenting the string if the first line of the string exceeds the configured line width:

```python
dedent("""
    value
""")
```

The benefit of the new style is that it reduces vertical spacing (The two strings in the examples aren't equivalent because of the whitespace before the closing quotes but the whitespace before the closing quotes with `indent` is only used to align the quotes. 

The main concern with the new preview style is that it messes up the multiline string formatting for existing Black users because it can dealign the quotes and fixing the quote alignment isn't possible without knowing if the argument is whitespace sensitive or not. 

For example, it turns...

```python
dedent(
    """
    value
    """
)
```

into...

```python
dedent("""
    value
    """)
```

which looks worse. 

However, the preview style improves formatting for new black users or new code written when you have:

```python
def test():
    a = dedent("""
      Some code
      that needs dedenting
    """)
```

because it no longer changes it to

```python
def test():
    a = dedent(
        """
      Some code
      that needs dedenting
    """
    )
```


This PR refiens the `multiline_string` preview style with a heuristic of when to hug the multiline string and when not. 

The idea is to honor the author's decision by checking if the opening parentheses and the string both start on the same line. If so, hug the multline string, otherwise don't. 

There are two advantages to this:

* Existing Blacked code won't change because the formatter detects the newline between the opening parentheses and the quotes and continues to indent the multiline string
* Existing Blacked or Ruffed code using preview style won't change because the formatter detects that there's no newline between the opening parentheses and the string start and, because of it, won't indent the multiline string. 

This heuristic is the same as Prettier uses for single-argument, multiline string call expressions. 

## Downsides

The downside of this heuristic over always hugging single argument multiline strings is that existing calls to `dedent` need manual updating to match the desired formatting. I think that's fine because the new formatting also requires to manually updating the spacing before the closing `"""` to match indentation:

```python
dedent("""
	Multiline
	""")
```

Doesn't look good. You want 

```python
dedent("""
	Multiline
""")
```

which ruff can't do without changing the string's semantics.

## Test Plan

**Running Ruff before introducing the `multline-string` preview style and then this branch**:

There are no upgrade changes, compared to the original `multiline-string` preview style PR that changed+2971 -5900 lines in 374 files in 31 projects. 

ℹ️ ecosystem check **detected format changes**. (+7 -8 lines in 3 files in 3 projects; 1 project error; 39 projects unchanged)

<details><summary><a href="https://github.com/demisto/content">demisto/content</a> (+2 -5 lines across 1 file)</summary>
<p>
<pre>ruff format --preview --exclude Packs/ThreatQ/Integrations/ThreatQ/ThreatQ.py</pre>
</p>
<p>

<a href='https://github.com/demisto/content/blob/3d621f512f4575d87e68e317570dcd90411b9607/Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks.py#L107'>Packs/IntegrationsAndIncidentsHealthCheck/Scripts/GetFailedTasks/GetFailedTasks.py~L107</a>
```diff
     )
 
     if is_error(response):
-        error = (
-            f'Failed retrieving tasks for incident ID {incident["id"]}.\n \
+        error = f'Failed retrieving tasks for incident ID {incident["id"]}.\n \
            Make sure that the API key configured in the Core REST API integration \
-is one with sufficient permissions to access that incident.\n'
-            + get_error(response)
-        )
+is one with sufficient permissions to access that incident.\n' + get_error(response)
         raise Exception(error)
 
     return response[0]["Contents"]["response"]
```

</p>
</details>
<details><summary><a href="https://github.com/reflex-dev/reflex">reflex-dev/reflex</a> (+3 -1 lines across 1 file)</summary>
<p>
<pre>ruff format --preview</pre>
</p>
<p>

<a href='https://github.com/reflex-dev/reflex/blob/0d8efb9b5570425615db00cd65e6070317488f6f/reflex/components/markdown/markdown.py#L253'>reflex/components/markdown/markdown.py~L253</a>
```diff
         }
 
         # Separate out inline code and code blocks.
-        components["code"] = f"""{{({{node, inline, className, {_CHILDREN._var_name}, {_PROPS._var_name}}}) => {{
+        components[
+            "code"
+        ] = f"""{{({{node, inline, className, {_CHILDREN._var_name}, {_PROPS._var_name}}}) => {{
     const match = (className || '').match(/language-(?<lang>.*)/);
     const language = match ? match[1] : '';
     if (language) {{
```

</p>
</details>
<details><summary><a href="https://github.com/rotki/rotki">rotki/rotki</a> (+2 -2 lines across 1 file)</summary>
<p>
<pre>ruff format --preview</pre>
</p>
<p>

<a href='https://github.com/rotki/rotki/blob/5b72d2f90a87d5f82df519cbe385edd7a61474fd/rotkehlchen/rotkehlchen.py#L1196'>rotkehlchen/rotkehlchen.py~L1196</a>
```diff
         if oracle != HistoricalPriceOracle.CRYPTOCOMPARE:
             return  # only for cryptocompare for now
 
-        with (
-            contextlib.suppress(UnknownAsset)
+        with contextlib.suppress(
+            UnknownAsset
         ):  # if suppress -> assets are not crypto or fiat, so we can't query cryptocompare  # noqa: E501
             self.cryptocompare.create_cache(
                 from_asset=from_asset,
```

</p>
</details>
<details><summary><a href="https://github.com/openai/openai-cookbook">openai/openai-cookbook</a> (error)</summary>
<p>
<pre>ruff format --preview</pre>
</p>
<p>

```
error: Failed to parse examples/dalle/Image_generations_edits_and_variations_with_DALL-E.ipynb:3:7:8: Unexpected token 'prompt'
```

</p>
</details>

**Running ruff preview (main) and then this branch**:

Results in no changes

ℹ️ ecosystem check **encountered format errors**. (no format changes; 1 project error)

<details><summary><a href="https://github.com/openai/openai-cookbook">openai/openai-cookbook</a> (error)</summary>
<p>
<pre>ruff format --preview</pre>
</p>
<p>

```
error: Failed to parse examples/dalle/Image_generations_edits_and_variations_with_DALL-E.ipynb:3:7:8: Unexpected token 'prompt'
```

</p>
</details>


