### PR TITLE
Preview minimal f-string formatting

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.options.json
@@ -1,0 +1,8 @@
+[
+  {
+    "preview": "enabled"
+  },
+  {
+    "preview": "disabled"
+  }
+]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -62,3 +62,145 @@ result_f = (
 x = f'''a{""}b'''
 y = f'''c{1}d"""e'''
 z = f'''a{""}b''' f'''c{1}d"""e'''
+
+# F-String formatting test cases (Preview)
+
+# Simple expression with a mix of debug expression and comments.
+x = f"{a}"
+x = f"{
+    a = }"
+x = f"{ # comment
+    a }"
+x = f"{   # comment
+    a = }"
+
+# Remove the parentheses as adding them doesn't make then fit within the line length limit.
+# This is similar to how we format it before f-string formatting.
+aaaaaaaaaaa = (
+    f"asaaaaaaaaaaaaaaaa { aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd } cccccccccc"
+)
+# Here, we would use the best fit layout to put the f-string indented on the next line
+# similar to the next example.
+aaaaaaaaaaa = f"asaaaaaaaaaaaaaaaa { aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc } cccccccccc"
+aaaaaaaaaaa = (
+    f"asaaaaaaaaaaaaaaaa { aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc } cccccccccc"
+)
+
+# This should never add the optional parentheses because even after adding them, the
+# f-string exceeds the line length limit.
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+                                             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+                                             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
+
+# Multiple larger expressions which exceeds the line length limit. Here, we need to decide
+# whether to split at the first or second expression. This should work similarly to the
+# assignment statement formatting where we split from right to left in preview mode.
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+
+# The above example won't split but when we start introducing line breaks:
+x = f"aaaaaaaaaaaa {
+        bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb
+                    } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc {
+        ddddddddddddddd } eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd
+                                                            } eeeeeeeeeeeeee"
+
+# But, in case comments are present, we would split at the expression containing the
+# comments:
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb # comment
+                    } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb
+                    } cccccccccccccccccccc { # comment
+                                            ddddddddddddddd } eeeeeeeeeeeeee"
+
+# Here, the expression part itself starts with a curly brace so we need to add an extra
+# space between the opening curly brace and the expression.
+x = f"{ {'x': 1, 'y': 2} }"
+# Although the extra space isn't required before the ending curly brace, we add it for
+# consistency.
+x = f"{ {'x': 1, 'y': 2}}"
+x = f"{ {'x': 1, 'y': 2} = }"
+x = f"{  # comment
+    {'x': 1, 'y': 2} }"
+x = f"{    # comment
+    {'x': 1, 'y': 2} = }"
+
+# But, in this case, we would split the expression itself because it exceeds the line
+# length limit so we need not add the extra space.
+xxxxxxx = f"{
+    {'aaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbb', 'ccccccccccccccccccccc'}
+}"
+# And, split the expression itself because it exceeds the line length.
+xxxxxxx = f"{
+    {'aaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbb', 'cccccccccccccccccccccccccc'}
+}"
+
+# Triple-quoted strings
+# It's ok to use the same quote char for the inner string if it's single-quoted.
+f"""test {'inner'}"""
+f"""test {"inner"}"""
+# But if the inner string is also triple-quoted then we should preserve the existing quotes.
+f"""test {'''inner'''}"""
+
+# Comments
+
+# No comments should be dropped!
+f"{ # comment 1
+    # comment 2
+    foo # comment 3
+    # comment 4
+}"  # comment 5
+# comment 6
+
+# Conversion flags
+#
+# This is not a valid Python code because of the additional whitespace between the `!`
+# and conversion type. But, our parser isn't strict about this. This should probably be
+# removed once we have a strict parser.
+x = f"aaaaaaaaa { x !  r }"
+
+# Even in the case of debug expresions, we only need to preserve the whitespace within
+# the expression part of the replacement field.
+x = f"aaaaaaaaa { x   = !  r  }"
+
+# Combine conversion flags with format specifiers
+x = f"{x   =   !  s
+         :>0
+
+         }"
+# This is interesting. There can be a comment after the format specifier but only if it's
+# on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
+# We'll format is as trailing comments.
+x = f"{x  !s
+         :>0
+         # comment
+         }"
+
+x = f"""
+{              # dangling comment 1
+ x =   :.0{y # dangling comment 2
+           }f}"""
+
+# Here, the debug expression is in a nested f-string so we should start preserving
+# whitespaces from that point onwards. This means we should format the outer f-string.
+x = f"""{"foo " +    # comment 1
+    f"{   x =
+
+       }"    # comment 2
+ }
+        """
+
+# Mix of various features.
+f"{  # dangling comment 1
+    foo # after foo
+   :>{
+          x # after x
+          }
+    # dangling comment 2
+    # dangling comment 3
+} woah {x}"

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -140,6 +140,19 @@ xxxxxxx = f"{
     {'aaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbb', 'cccccccccccccccccccccccccc'}
 }"
 
+# Quotes
+f"foo 'bar' {x}"
+f"foo \"bar\" {x}"
+f'foo "bar" {x}'
+f'foo \'bar\' {x}'
+f"foo {"bar"}"
+f"foo {'\'bar\''}"
+
+# Here, the formatter will remove the escapes which is correct because they aren't allowed
+# pre 3.12. This means we can assume that the f-string is used in the context of 3.12.
+f"foo {'\"bar\"'}"
+
+
 # Triple-quoted strings
 # It's ok to use the same quote char for the inner string if it's single-quoted.
 f"""test {'inner'}"""
@@ -154,8 +167,35 @@ f"""test {'''inner'''}"""
 # breaks which results in the trailing comma being present. This test case makes sure
 # that the trailing comma is removed as well.
 f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
+
 # And, if the trailing comma is already present, we still need to remove it.
 f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee',]} aaaaaaa"
+
+# Keep this Multiline by breaking it at the square brackets.
+f"""aaaaaa {[
+    xxxxxxxx,
+    yyyyyyyy,
+]} ccc"""
+
+# Add the magic trailing comma because the elements don't fit within the line length limit
+# when collapsed.
+f"aaaaaa {[
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    yyyyyyyyyyyy
+]} ccccccc"
+
+# Remove the parenthese because they aren't required
+xxxxxxxxxxxxxxx = (
+    f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbb {
+        xxxxxxxxxxx  # comment
+        + yyyyyyyyyy
+    } dddddddddd"
+)
 
 # Comments
 
@@ -214,3 +254,29 @@ f"{  # dangling comment 1
     # dangling comment 2
     # dangling comment 3
 } woah {x}"
+
+# Indentation
+
+# What should be the indentation?
+# https://github.com/astral-sh/ruff/discussions/9785#discussioncomment-8470590
+if indent0:
+    if indent1:
+        if indent2:
+            foo = f"""hello world
+hello {
+          f"aaaaaaa {
+              [
+                  'aaaaaaaaaaaaaaaaaaaaa',
+                  'bbbbbbbbbbbbbbbbbbbbb',
+                  'ccccccccccccccccccccc',
+                  'ddddddddddddddddddddd'
+              ]
+          } bbbbbbbb" +
+          [
+              'aaaaaaaaaaaaaaaaaaaaa',
+              'bbbbbbbbbbbbbbbbbbbbb',
+              'ccccccccccccccccccccc',
+              'ddddddddddddddddddddd'
+          ]
+      } --------
+"""

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -147,6 +147,16 @@ f"""test {"inner"}"""
 # But if the inner string is also triple-quoted then we should preserve the existing quotes.
 f"""test {'''inner'''}"""
 
+# Magic trailing comma
+#
+# The expression formatting will result in breaking it across multiple lines with a
+# trailing comma but as the expression isn't already broken, we will remove all the line
+# breaks which results in the trailing comma being present. This test case makes sure
+# that the trailing comma is removed as well.
+f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
+# And, if the trailing comma is already present, we still need to remove it.
+f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee',]} aaaaaaa"
+
 # Comments
 
 # No comments should be dropped!

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -30,22 +30,22 @@ result_f = (
 # an expression inside a formatted value
 (
     f'{1}'
-    # comment
+    # comment 1
     ''
 )
 
 (
-    f'{1}'  # comment
+    f'{1}'  # comment 2
     f'{2}'
 )
 
 (
     f'{1}'
-    f'{2}'  # comment
+    f'{2}'  # comment 3
 )
 
 (
-    1, (  # comment
+    1, (  # comment 4
         f'{2}'
     )
 )
@@ -53,7 +53,7 @@ result_f = (
 (
     (
         f'{1}'
-        # comment
+        # comment 5
     ),
     2
 )
@@ -69,9 +69,9 @@ z = f'''a{""}b''' f'''c{1}d"""e'''
 x = f"{a}"
 x = f"{
     a = }"
-x = f"{ # comment
+x = f"{ # comment 6
     a }"
-x = f"{   # comment
+x = f"{   # comment 7
     a = }"
 
 # Remove the parentheses as adding them doesn't make then fit within the line length limit.
@@ -90,9 +90,9 @@ aaaaaaaaaaa = (
 # f-string exceeds the line length limit.
 x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
 x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
-x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 8
                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
-x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
 
 # Multiple larger expressions which exceeds the line length limit. Here, we need to decide
@@ -112,10 +112,10 @@ x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd
 
 # But, in case comments are present, we would split at the expression containing the
 # comments:
-x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb # comment
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb # comment 10
                     } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
 x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb
-                    } cccccccccccccccccccc { # comment
+                    } cccccccccccccccccccc { # comment 11
                                             ddddddddddddddd } eeeeeeeeeeeeee"
 
 # Here, the expression part itself starts with a curly brace so we need to add an extra
@@ -125,9 +125,9 @@ x = f"{ {'x': 1, 'y': 2} }"
 # consistency.
 x = f"{ {'x': 1, 'y': 2}}"
 x = f"{ {'x': 1, 'y': 2} = }"
-x = f"{  # comment
+x = f"{  # comment 12
     {'x': 1, 'y': 2} }"
-x = f"{    # comment
+x = f"{    # comment 13
     {'x': 1, 'y': 2} = }"
 
 # But, in this case, we would split the expression itself because it exceeds the line
@@ -192,7 +192,7 @@ f"aaaaaa {[
 # Remove the parenthese because they aren't required
 xxxxxxxxxxxxxxx = (
     f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbb {
-        xxxxxxxxxxx  # comment
+        xxxxxxxxxxx  # comment 14
         + yyyyyyyyyy
     } dddddddddd"
 )
@@ -200,12 +200,12 @@ xxxxxxxxxxxxxxx = (
 # Comments
 
 # No comments should be dropped!
-f"{ # comment 1
-    # comment 2
-    foo # comment 3
-    # comment 4
-}"  # comment 5
-# comment 6
+f"{ # comment 15
+    # comment 16
+    foo # comment 17
+    # comment 18
+}"  # comment 19
+# comment 20
 
 # Conversion flags
 #
@@ -228,31 +228,31 @@ x = f"{x   =   !  s
 # We'll format is as trailing comments.
 x = f"{x  !s
          :>0
-         # comment
+         # comment 21
          }"
 
 x = f"""
-{              # dangling comment 1
- x =   :.0{y # dangling comment 2
+{              # comment 22
+ x =   :.0{y # comment 23
            }f}"""
 
 # Here, the debug expression is in a nested f-string so we should start preserving
 # whitespaces from that point onwards. This means we should format the outer f-string.
-x = f"""{"foo " +    # comment 1
+x = f"""{"foo " +    # comment 24
     f"{   x =
 
-       }"    # comment 2
+       }"    # comment 25
  }
         """
 
 # Mix of various features.
-f"{  # dangling comment 1
+f"{  # comment 26
     foo # after foo
    :>{
           x # after x
           }
-    # dangling comment 2
-    # dangling comment 3
+    # comment 27
+    # comment 28
 } woah {x}"
 
 # Indentation

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring_py312.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring_py312.options.json
@@ -1,0 +1,5 @@
+[
+  {
+    "target_version": "py312"
+  }
+]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring_py312.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring_py312.py
@@ -1,0 +1,6 @@
+# This file contains test cases only for cases where the logic tests for whether
+# the target version is 3.12 or later. A user can have 3.12 syntax even if the target
+# version isn't set.
+
+# Quotes re-use
+f"{'a'}"

--- a/crates/ruff_python_formatter/src/builders.rs
+++ b/crates/ruff_python_formatter/src/builders.rs
@@ -205,16 +205,17 @@ impl<'fmt, 'ast, 'buf> JoinCommaSeparatedBuilder<'fmt, 'ast, 'buf> {
     }
 
     pub(crate) fn finish(&mut self) -> FormatResult<()> {
-        // If the formatter is inside an f-string expression element, and the layout
-        // is flat, then we don't need to add a trailing comma.
-        if let FStringState::InsideExpressionElement(context) = self.fmt.context().f_string_state()
-        {
-            if context.layout().is_flat() {
-                return Ok(());
-            }
-        }
-
         self.result.and_then(|()| {
+            // If the formatter is inside an f-string expression element, and the layout
+            // is flat, then we don't need to add a trailing comma.
+            if let FStringState::InsideExpressionElement(context) =
+                self.fmt.context().f_string_state()
+            {
+                if context.layout().is_flat() {
+                    return Ok(());
+                }
+            }
+
             if let Some(last_end) = self.entries.position() {
                 let magic_trailing_comma = has_magic_trailing_comma(
                     TextRange::new(last_end, self.sequence_end),

--- a/crates/ruff_python_formatter/src/builders.rs
+++ b/crates/ruff_python_formatter/src/builders.rs
@@ -1,7 +1,7 @@
 use ruff_formatter::{write, Argument, Arguments};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
-use crate::context::{NodeLevel, WithNodeLevel};
+use crate::context::{FStringState, NodeLevel, WithNodeLevel};
 use crate::other::commas::has_magic_trailing_comma;
 use crate::prelude::*;
 
@@ -205,6 +205,15 @@ impl<'fmt, 'ast, 'buf> JoinCommaSeparatedBuilder<'fmt, 'ast, 'buf> {
     }
 
     pub(crate) fn finish(&mut self) -> FormatResult<()> {
+        // If the formatter is inside an f-string expression element, and the layout
+        // is flat, then we don't need to add a trailing comma.
+        if let FStringState::InsideExpressionElement(context) = self.fmt.context().f_string_state()
+        {
+            if context.layout().is_flat() {
+                return Ok(());
+            }
+        }
+
         self.result.and_then(|()| {
             if let Some(last_end) = self.entries.position() {
                 let magic_trailing_comma = has_magic_trailing_comma(

--- a/crates/ruff_python_formatter/src/comments/placement.rs
+++ b/crates/ruff_python_formatter/src/comments/placement.rs
@@ -306,7 +306,7 @@ fn handle_enclosed_comment<'a>(
                     AnyNodeRef::FStringExpressionElement(_) | AnyNodeRef::FStringLiteralElement(_)
                 )
             ) {
-                CommentPlacement::dangling(comment.enclosing_node(), comment)
+                CommentPlacement::trailing(comment.enclosing_node(), comment)
             } else {
                 handle_bracketed_end_of_line_comment(comment, locator)
             }

--- a/crates/ruff_python_formatter/src/context.rs
+++ b/crates/ruff_python_formatter/src/context.rs
@@ -107,6 +107,18 @@ impl<'a> PyFormatContext<'a> {
         self.expression_location = expression_location;
     }
 
+    /// Return a new context suitable for formatting an expression inside an
+    /// f-string.
+    ///
+    /// The `quotes` parameter should be the quote information of the f-string
+    /// containing the expression.
+    pub(crate) fn in_f_string(self, quotes: StringQuotes) -> PyFormatContext<'a> {
+        PyFormatContext {
+            expression_location: ExpressionLocation::InsideFString(quotes),
+            ..self
+        }
+    }
+
     /// Returns `true` if preview mode is enabled.
     pub(crate) const fn is_preview(&self) -> bool {
         self.options.preview().is_enabled()

--- a/crates/ruff_python_formatter/src/context.rs
+++ b/crates/ruff_python_formatter/src/context.rs
@@ -6,17 +6,6 @@ use ruff_source_file::Locator;
 use std::fmt::{Debug, Formatter};
 use std::ops::{Deref, DerefMut};
 
-#[derive(Copy, Clone, Debug, Default)]
-pub(crate) enum FStringState {
-    /// The formatter is inside an f-string, in the replacement field i.e., `f"foo {x}"`.
-    ///
-    /// The containing `StringQuotes` is the surrounding f-string quote information.
-    Inside(StringQuotes),
-    /// The formatter is outside an f-string.
-    #[default]
-    Outside,
-}
-
 #[derive(Clone)]
 pub struct PyFormatContext<'a> {
     options: PyFormatOptions,
@@ -141,6 +130,17 @@ impl Debug for PyFormatContext<'_> {
             .field("source", &self.contents)
             .finish()
     }
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) enum FStringState {
+    /// The formatter is inside an f-string, in the replacement field i.e., `f"foo {x}"`.
+    ///
+    /// The containing `StringQuotes` is the surrounding f-string quote information.
+    Inside(StringQuotes),
+    /// The formatter is outside an f-string.
+    #[default]
+    Outside,
 }
 
 /// The position of a top-level statement in the module.

--- a/crates/ruff_python_formatter/src/context.rs
+++ b/crates/ruff_python_formatter/src/context.rs
@@ -108,18 +108,6 @@ impl<'a> PyFormatContext<'a> {
         self.f_string_state = f_string_state;
     }
 
-    /// Return a new context suitable for formatting an expression inside an
-    /// f-string.
-    ///
-    /// The `quotes` parameter should be the quote information of the f-string
-    /// containing the expression.
-    pub(crate) fn in_f_string(self, quotes: StringQuotes) -> PyFormatContext<'a> {
-        PyFormatContext {
-            f_string_state: FStringState::Inside(quotes),
-            ..self
-        }
-    }
-
     /// Returns a new context with the given set of options.
     pub(crate) fn with_options(mut self, options: PyFormatOptions) -> Self {
         self.options = options;

--- a/crates/ruff_python_formatter/src/context.rs
+++ b/crates/ruff_python_formatter/src/context.rs
@@ -134,10 +134,11 @@ impl Debug for PyFormatContext<'_> {
 
 #[derive(Copy, Clone, Debug, Default)]
 pub(crate) enum FStringState {
-    /// The formatter is inside an f-string, in the replacement field i.e., `f"foo {x}"`.
+    /// The formatter is inside an f-string expression element i.e., between the
+    /// curly brace in `f"foo {x}"`.
     ///
     /// The containing `StringQuotes` is the surrounding f-string quote information.
-    Inside(StringQuotes),
+    InsideExpressionElement(StringQuotes),
     /// The formatter is outside an f-string.
     #[default]
     Outside,

--- a/crates/ruff_python_formatter/src/context.rs
+++ b/crates/ruff_python_formatter/src/context.rs
@@ -1,5 +1,6 @@
 use crate::comments::Comments;
-use crate::string::{QuoteChar, StringQuotes};
+use crate::other::f_string::FStringContext;
+use crate::string::QuoteChar;
 use crate::PyFormatOptions;
 use ruff_formatter::{Buffer, FormatContext, GroupId, IndentWidth, SourceCode};
 use ruff_source_file::Locator;
@@ -97,12 +98,6 @@ impl<'a> PyFormatContext<'a> {
         self.f_string_state = f_string_state;
     }
 
-    /// Returns a new context with the given set of options.
-    pub(crate) fn with_options(mut self, options: PyFormatOptions) -> Self {
-        self.options = options;
-        self
-    }
-
     /// Returns `true` if preview mode is enabled.
     pub(crate) const fn is_preview(&self) -> bool {
         self.options.preview().is_enabled()
@@ -137,8 +132,8 @@ pub(crate) enum FStringState {
     /// The formatter is inside an f-string expression element i.e., between the
     /// curly brace in `f"foo {x}"`.
     ///
-    /// The containing `StringQuotes` is the surrounding f-string quote information.
-    InsideExpressionElement(StringQuotes),
+    /// The containing `FStringContext` is the surrounding f-string context.
+    InsideExpressionElement(FStringContext),
     /// The formatter is outside an f-string.
     #[default]
     Outside,

--- a/crates/ruff_python_formatter/src/expression/expr_f_string.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_f_string.rs
@@ -48,6 +48,24 @@ impl NeedsParentheses for ExprFString {
     ) -> OptionalParentheses {
         if self.value.is_implicit_concatenated() {
             OptionalParentheses::Multiline
+        // TODO(dhruvmanila): Ideally what we want here is a new variant which
+        // is something like:
+        // - If the expression fits by just adding the parentheses, then add them and
+        //   avoid breaking the f-string expression. So,
+        //   ```
+        //   xxxxxxxxx = (
+        //       f"aaaaaaaaaaaa { xxxxxxx + yyyyyyyy } bbbbbbbbbbbbb"
+        //   )
+        //   ```
+        // - But, if the expression is too long to fit even with parentheses, then
+        //   don't add the parentheses and instead break the expression at `soft_line_break`.
+        //   ```
+        //   xxxxxxxxx = f"aaaaaaaaaaaa {
+        //       xxxxxxxxx + yyyyyyyyyy
+        //   } bbbbbbbbbbbbb"
+        //   ```
+        // This isn't decided yet, refer to the relevant discussion:
+        // https://github.com/astral-sh/ruff/discussions/9785
         } else if AnyString::FString(self).is_multiline(context.source()) {
             OptionalParentheses::Never
         } else {

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -466,3 +466,12 @@ pub enum PythonVersion {
     Py311,
     Py312,
 }
+
+impl PythonVersion {
+    /// Return `true` if the current version supports [PEP 701].
+    ///
+    /// [PEP 701]: https://peps.python.org/pep-0701/
+    pub fn supports_pep_701(self) -> bool {
+        self >= Self::Py312
+    }
+}

--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -102,6 +102,6 @@ impl FStringContext {
     }
 
     pub(crate) const fn should_remove_soft_line_breaks(self) -> bool {
-        !self.is_multiline
+        !self.quotes.is_triple() && !self.is_multiline
     }
 }

--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -59,7 +59,7 @@ impl Format<PyFormatContext<'_>> for FormatFString<'_> {
             return result;
         }
 
-        // TODO(dhruvmanila): This could probably be simplified for Python 3.12 specifically
+        // This could probably be simplified for Python 3.12 specifically
         // as same quotes can be re-used inside an f-string.
         let quotes = normalizer.choose_quotes(&string, &locator);
 

--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -1,5 +1,6 @@
 use ruff_formatter::write;
 use ruff_python_ast::FString;
+use ruff_source_file::Locator;
 use ruff_text_size::Ranged;
 
 use crate::prelude::*;
@@ -28,7 +29,6 @@ impl<'a> FormatFString<'a> {
 impl Format<PyFormatContext<'_>> for FormatFString<'_> {
     fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
         let locator = f.context().locator();
-        let comments = f.context().comments().clone();
 
         let string = StringPart::from_source(self.value.range(), &locator);
 
@@ -40,6 +40,7 @@ impl Format<PyFormatContext<'_>> for FormatFString<'_> {
         // fall back to the previous behavior of normalizing the f-string.
         if !is_f_string_formatting_enabled(f.context()) {
             let result = normalizer.normalize(&string, &locator).fmt(f);
+            let comments = f.context().comments();
             self.value.elements.iter().for_each(|value| {
                 comments.mark_verbatim_node_comments_formatted(value.into());
                 // Above method doesn't mark the trailing comments of the f-string elements
@@ -62,39 +63,23 @@ impl Format<PyFormatContext<'_>> for FormatFString<'_> {
         // as same quotes can be re-used inside an f-string.
         let quotes = normalizer.choose_quotes(&string, &locator);
 
-        // Heuristic: Allow breaking the f-string expressions across multiple lines
-        // only if there already is at least one multiline expression. This puts the
-        // control in the hands of the user to decide if they want to break the
-        // f-string expressions across multiple lines or not. This is similar to
-        // how Prettier does it for template literals in JavaScript.
-        //
-        // If it's single quoted f-string and it contains a multiline expression, then
-        // we assume that the target version of Python supports it (3.12+). If there are
-        // comments used in any of the expression of the f-string, then it's always going
-        // to be multiline and we assume that the target version of Python supports it.
-        let has_multiline_expression = self
-            .value
-            .elements
-            .iter()
-            .filter_map(|element| element.as_expression())
-            .any(|expr| memchr::memchr2(b'\n', b'\r', locator.slice(expr).as_bytes()).is_some());
-
-        let context = FStringContext::new(string.prefix(), quotes, has_multiline_expression);
+        let context = FStringContext::new(
+            string.prefix(),
+            quotes,
+            FStringLayout::from_f_string(self.value, &locator),
+        );
 
         // Starting prefix and quote
         write!(f, [string.prefix(), quotes])?;
 
-        format_with(|f| {
-            f.join()
-                .entries(
-                    self.value
-                        .elements
-                        .iter()
-                        .map(|element| FormatFStringElement::new(element, context)),
-                )
-                .finish()
-        })
-        .fmt(f)?;
+        f.join()
+            .entries(
+                self.value
+                    .elements
+                    .iter()
+                    .map(|element| FormatFStringElement::new(element, context)),
+            )
+            .finish()?;
 
         // Ending quote
         quotes.fmt(f)
@@ -105,19 +90,15 @@ impl Format<PyFormatContext<'_>> for FormatFString<'_> {
 pub(crate) struct FStringContext {
     prefix: StringPrefix,
     quotes: StringQuotes,
-    has_multiline_expression: bool,
+    layout: FStringLayout,
 }
 
 impl FStringContext {
-    const fn new(
-        prefix: StringPrefix,
-        quotes: StringQuotes,
-        has_multiline_expression: bool,
-    ) -> Self {
+    const fn new(prefix: StringPrefix, quotes: StringQuotes, layout: FStringLayout) -> Self {
         Self {
             prefix,
             quotes,
-            has_multiline_expression,
+            layout,
         }
     }
 
@@ -129,7 +110,48 @@ impl FStringContext {
         self.prefix
     }
 
-    pub(crate) const fn should_remove_soft_line_breaks(self) -> bool {
-        !self.has_multiline_expression
+    pub(crate) const fn layout(self) -> FStringLayout {
+        self.layout
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum FStringLayout {
+    /// Original f-string is flat.
+    /// Don't break expressions to keep the string flat.
+    Flat,
+    /// Original f-string has multiline expressions in the replacement fields.
+    /// Allow breaking expressions across multiple lines.
+    Multiline,
+}
+
+impl FStringLayout {
+    fn from_f_string(f_string: &FString, locator: &Locator) -> Self {
+        // Heuristic: Allow breaking the f-string expressions across multiple lines
+        // only if there already is at least one multiline expression. This puts the
+        // control in the hands of the user to decide if they want to break the
+        // f-string expressions across multiple lines or not. This is similar to
+        // how Prettier does it for template literals in JavaScript.
+        //
+        // If it's single quoted f-string and it contains a multiline expression, then we
+        // assume that the target version of Python supports it (3.12+). If there are comments
+        // used in any of the expression of the f-string, then it's always going to be multiline
+        // and we assume that the target version of Python supports it (3.12+).
+        //
+        // Reference: https://prettier.io/docs/en/next/rationale.html#template-literals
+        if f_string
+            .elements
+            .iter()
+            .filter_map(|element| element.as_expression())
+            .any(|expr| memchr::memchr2(b'\n', b'\r', locator.slice(expr).as_bytes()).is_some())
+        {
+            Self::Multiline
+        } else {
+            Self::Flat
+        }
+    }
+
+    pub(crate) const fn is_flat(self) -> bool {
+        matches!(self, Self::Flat)
     }
 }

--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -42,6 +42,18 @@ impl Format<PyFormatContext<'_>> for FormatFString<'_> {
             let result = normalizer.normalize(&string, &locator).fmt(f);
             self.value.elements.iter().for_each(|value| {
                 comments.mark_verbatim_node_comments_formatted(value.into());
+                // Above method doesn't mark the trailing comments of the f-string elements
+                // as formatted, so we need to do it manually. For example,
+                //
+                // ```python
+                // f"""foo {
+                //     x:.3f
+                //     # comment
+                // }"""
+                // ```
+                for trailing_comment in comments.trailing(value) {
+                    trailing_comment.mark_formatted();
+                }
             });
             return result;
         }

--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -59,8 +59,6 @@ impl Format<PyFormatContext<'_>> for FormatFString<'_> {
             return result;
         }
 
-        // This could probably be simplified for Python 3.12 specifically
-        // as same quotes can be re-used inside an f-string.
         let quotes = normalizer.choose_quotes(&string, &locator);
 
         let context = FStringContext::new(

--- a/crates/ruff_python_formatter/src/other/f_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_element.rs
@@ -1,0 +1,229 @@
+use std::borrow::Cow;
+
+use ruff_formatter::{format_args, write, RemoveSoftLinesBuffer};
+use ruff_python_ast::{
+    ConversionFlag, Expr, FStringElement, FStringExpressionElement, FStringLiteralElement,
+};
+use ruff_text_size::Ranged;
+
+use crate::comments::{dangling_open_parenthesis_comments, trailing_comments};
+use crate::context::{ExpressionLocation, NodeLevel, WithExprLocation, WithNodeLevel};
+use crate::prelude::*;
+use crate::preview::is_hex_codes_in_unicode_sequences_enabled;
+use crate::string::normalize_string;
+use crate::verbatim::suppressed_node;
+
+use super::f_string::FStringContext;
+
+/// Formats an f-string element which is either a literal or a formatted expression.
+///
+/// This delegates the actual formatting to the appropriate formatter.
+pub(crate) struct FormatFStringElement<'a> {
+    element: &'a FStringElement,
+    context: FStringContext,
+}
+
+impl<'a> FormatFStringElement<'a> {
+    pub(crate) fn new(element: &'a FStringElement, context: FStringContext) -> Self {
+        Self { element, context }
+    }
+}
+
+impl Format<PyFormatContext<'_>> for FormatFStringElement<'_> {
+    fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
+        match self.element {
+            FStringElement::Literal(string_literal) => {
+                FormatFStringLiteralElement::new(string_literal, self.context).fmt(f)
+            }
+            FStringElement::Expression(expression) => {
+                FormatFStringExpressionElement::new(expression, self.context).fmt(f)
+            }
+        }
+    }
+}
+
+/// Formats an f-string literal element.
+pub(crate) struct FormatFStringLiteralElement<'a> {
+    element: &'a FStringLiteralElement,
+    context: FStringContext,
+}
+
+impl<'a> FormatFStringLiteralElement<'a> {
+    pub(crate) fn new(element: &'a FStringLiteralElement, context: FStringContext) -> Self {
+        Self { element, context }
+    }
+}
+
+impl Format<PyFormatContext<'_>> for FormatFStringLiteralElement<'_> {
+    fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
+        let literal_content = f.context().locator().slice(self.element.range());
+        let normalized = normalize_string(
+            literal_content,
+            self.context.quotes(),
+            self.context.prefix(),
+            is_hex_codes_in_unicode_sequences_enabled(f.context()),
+        );
+        match &normalized {
+            Cow::Borrowed(_) => source_text_slice(self.element.range()).fmt(f),
+            Cow::Owned(normalized) => text(normalized).fmt(f),
+        }
+    }
+}
+
+/// Formats an f-string expression element.
+pub(crate) struct FormatFStringExpressionElement<'a> {
+    element: &'a FStringExpressionElement,
+    context: FStringContext,
+}
+
+impl<'a> FormatFStringExpressionElement<'a> {
+    pub(crate) fn new(element: &'a FStringExpressionElement, context: FStringContext) -> Self {
+        Self { element, context }
+    }
+}
+
+impl Format<PyFormatContext<'_>> for FormatFStringExpressionElement<'_> {
+    fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
+        let FStringExpressionElement {
+            expression,
+            debug_text,
+            conversion,
+            format_spec,
+            ..
+        } = self.element;
+
+        let comments = f.context().comments().clone();
+
+        if let Some(debug_text) = debug_text {
+            token("{").fmt(f)?;
+
+            // If debug text is present in a f-string, we'll mark all of the comments
+            // in this f-string as formatted.
+            comments.mark_verbatim_node_comments_formatted(self.element.into());
+
+            write!(
+                f,
+                [
+                    text(&debug_text.leading),
+                    suppressed_node(&**expression),
+                    text(&debug_text.trailing),
+                ]
+            )?;
+
+            // Even if debug text is present, any whitespace between the
+            // conversion flag and the format spec doesn't need to be preserved.
+            match conversion {
+                ConversionFlag::Str => text("!s").fmt(f)?,
+                ConversionFlag::Ascii => text("!a").fmt(f)?,
+                ConversionFlag::Repr => text("!r").fmt(f)?,
+                ConversionFlag::None => (),
+            }
+
+            if let Some(format_spec) = format_spec.as_deref() {
+                write!(f, [token(":"), suppressed_node(format_spec)])?;
+            }
+
+            token("}").fmt(f)
+        } else {
+            let dangling_item_comments = comments.dangling(self.element);
+            let (dangling_open_parentheses_comments, trailing_format_spec_comments) =
+                dangling_item_comments.split_at(
+                    dangling_item_comments
+                        .partition_point(|comment| comment.start() < expression.start()),
+                );
+
+            let item = format_with(|f| {
+                let line_break_or_space = match expression.as_ref() {
+                    // If an expression starts with a `{`, we need to add a space before the
+                    // curly brace to avoid turning it into a literal curly with `{{`.
+                    //
+                    // For example,
+                    // ```python
+                    // f"{ {'x': 1, 'y': 2} }"
+                    // #  ^                ^
+                    // ```
+                    //
+                    // We need to preserve the space highlighted by `^`.
+                    Expr::Dict(_) | Expr::DictComp(_) | Expr::Set(_) | Expr::SetComp(_) => {
+                        Some(soft_line_break_or_space())
+                    }
+                    _ => None,
+                };
+
+                let f = &mut WithExprLocation::new(
+                    ExpressionLocation::InsideFString(self.context.quotes()),
+                    f,
+                );
+
+                write!(f, [line_break_or_space, expression.format()])?;
+
+                // Conversion comes first, then the format spec.
+                match conversion {
+                    ConversionFlag::Str => text("!s").fmt(f)?,
+                    ConversionFlag::Ascii => text("!a").fmt(f)?,
+                    ConversionFlag::Repr => text("!r").fmt(f)?,
+                    ConversionFlag::None => (),
+                }
+
+                if let Some(format_spec) = format_spec.as_deref() {
+                    let elements =
+                        format_with(|f| {
+                            f.join()
+                                .entries(format_spec.elements.iter().map(|element| {
+                                    FormatFStringElement::new(element, self.context)
+                                }))
+                                .finish()
+                        });
+                    write!(
+                        f,
+                        [
+                            token(":"),
+                            elements,
+                            trailing_comments(trailing_format_spec_comments)
+                        ]
+                    )?;
+                }
+
+                line_break_or_space.fmt(f)
+            });
+
+            let inner = format_with(|f| {
+                let mut buffer = RemoveSoftLinesBuffer::new(f);
+
+                if dangling_open_parentheses_comments.is_empty() {
+                    if self.context.should_remove_soft_line_breaks() {
+                        write!(buffer, [group(&soft_block_indent(&item))])
+                    } else {
+                        write!(f, [group(&soft_block_indent(&item))])
+                    }
+                } else {
+                    if self.context.should_remove_soft_line_breaks() {
+                        write!(
+                            buffer,
+                            [group(&format_args![
+                                dangling_open_parenthesis_comments(
+                                    dangling_open_parentheses_comments
+                                ),
+                                soft_block_indent(&item),
+                            ])]
+                        )
+                    } else {
+                        write!(
+                            f,
+                            [group(&format_args![
+                                dangling_open_parenthesis_comments(
+                                    dangling_open_parentheses_comments
+                                ),
+                                soft_block_indent(&item),
+                            ])]
+                        )
+                    }
+                }
+            });
+
+            let mut f = WithNodeLevel::new(NodeLevel::ParenthesizedExpression, f);
+
+            write!(f, [token("{"), inner, token("}")])
+        }
+    }
+}

--- a/crates/ruff_python_formatter/src/other/f_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_element.rs
@@ -190,11 +190,7 @@ impl Format<PyFormatContext<'_>> for FormatFStringExpressionElement<'_> {
                         .clone()
                         .with_line_width(NonZeroU16::MAX.into())
                         .with_magic_trailing_comma(MagicTrailingComma::Ignore);
-                    let context = f
-                        .context()
-                        .clone()
-                        .in_f_string(self.context.quotes())
-                        .with_options(options);
+                    let context = f.context().clone().with_options(options);
                     let formatted = crate::format!(context, [expression.format()])?;
                     text(formatted.print()?.as_code()).fmt(f)?;
                 } else {

--- a/crates/ruff_python_formatter/src/other/f_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_element.rs
@@ -162,7 +162,13 @@ impl Format<PyFormatContext<'_>> for FormatFStringExpressionElement<'_> {
                     // before the closing curly brace is not strictly necessary, but it's
                     // added to maintain consistency.
                     Expr::Dict(_) | Expr::DictComp(_) | Expr::Set(_) | Expr::SetComp(_) => {
-                        Some(soft_line_break_or_space())
+                        Some(format_with(|f| {
+                            if self.context.layout().is_flat() {
+                                space().fmt(f)
+                            } else {
+                                soft_line_break_or_space().fmt(f)
+                            }
+                        }))
                     }
                     _ => None,
                 };

--- a/crates/ruff_python_formatter/src/other/f_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_element.rs
@@ -176,7 +176,10 @@ impl Format<PyFormatContext<'_>> for FormatFStringExpressionElement<'_> {
                 bracket_spacing.fmt(f)?;
 
                 // Update the context to be inside the f-string.
-                let f = &mut WithFStringState::new(FStringState::Inside(self.context.quotes()), f);
+                let f = &mut WithFStringState::new(
+                    FStringState::InsideExpressionElement(self.context.quotes()),
+                    f,
+                );
 
                 // If we're going to remove the soft line breaks, then there's a chance
                 // that there will be trailing commas in the formatted expression. For

--- a/crates/ruff_python_formatter/src/other/f_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_element.rs
@@ -182,7 +182,7 @@ impl Format<PyFormatContext<'_>> for FormatFStringExpressionElement<'_> {
                 // expression can't contain a trailing comma.
                 if self.context.should_remove_soft_line_breaks() && {
                     let visitor = &mut CanContainTrailingCommaVisitor::default();
-                    AnyNodeRef::from(&**expression).visit_preorder(visitor);
+                    visitor.visit_expr(expression);
                     visitor.can_have_trailing_comma
                 } {
                     let options = f
@@ -284,13 +284,13 @@ impl<'a> PreorderVisitor<'a> for CanContainTrailingCommaVisitor {
             AnyNodeRef::ExprList(ast::ExprList { elts, .. })
             | AnyNodeRef::ExprTuple(ast::ExprTuple { elts, .. })
             | AnyNodeRef::ExprSet(ast::ExprSet { elts, .. }) => {
-                if elts.len() > 1 {
+                if !elts.is_empty() {
                     self.can_have_trailing_comma = true;
                     return TraversalSignal::Skip;
                 }
             }
             AnyNodeRef::ExprDict(ast::ExprDict { keys, values, .. }) => {
-                if keys.len() > 1 || values.len() > 1 {
+                if !keys.is_empty() || !values.is_empty() {
                     self.can_have_trailing_comma = true;
                     return TraversalSignal::Skip;
                 }

--- a/crates/ruff_python_formatter/src/other/mod.rs
+++ b/crates/ruff_python_formatter/src/other/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod decorator;
 pub(crate) mod elif_else_clause;
 pub(crate) mod except_handler_except_handler;
 pub(crate) mod f_string;
+pub(crate) mod f_string_element;
 pub(crate) mod f_string_part;
 pub(crate) mod identifier;
 pub(crate) mod keyword;

--- a/crates/ruff_python_formatter/src/other/string_literal.rs
+++ b/crates/ruff_python_formatter/src/other/string_literal.rs
@@ -1,9 +1,9 @@
 use ruff_python_ast::StringLiteral;
 use ruff_text_size::Ranged;
 
+use crate::options::QuoteStyle;
 use crate::prelude::*;
 use crate::string::{docstring, Quoting, StringNormalizer, StringPart};
-use crate::QuoteStyle;
 
 pub(crate) struct FormatStringLiteral<'a> {
     value: &'a StringLiteral,

--- a/crates/ruff_python_formatter/src/other/string_literal.rs
+++ b/crates/ruff_python_formatter/src/other/string_literal.rs
@@ -1,9 +1,9 @@
 use ruff_python_ast::StringLiteral;
 use ruff_text_size::Ranged;
 
-use crate::options::QuoteStyle;
 use crate::prelude::*;
 use crate::string::{docstring, Quoting, StringNormalizer, StringPart};
+use crate::QuoteStyle;
 
 pub(crate) struct FormatStringLiteral<'a> {
     value: &'a StringLiteral,

--- a/crates/ruff_python_formatter/src/preview.rs
+++ b/crates/ruff_python_formatter/src/preview.rs
@@ -81,3 +81,8 @@ pub(crate) const fn is_multiline_string_handling_enabled(context: &PyFormatConte
 pub(crate) const fn is_format_module_docstring_enabled(context: &PyFormatContext) -> bool {
     context.is_preview()
 }
+
+/// Returns `true` if the [`PEP 701`](https://github.com/astral-sh/ruff/issues/7594) preview style is enabled.
+pub(crate) fn is_pep_701_enabled(context: &PyFormatContext) -> bool {
+    context.is_preview()
+}

--- a/crates/ruff_python_formatter/src/preview.rs
+++ b/crates/ruff_python_formatter/src/preview.rs
@@ -82,7 +82,7 @@ pub(crate) const fn is_format_module_docstring_enabled(context: &PyFormatContext
     context.is_preview()
 }
 
-/// Returns `true` if the [`PEP 701`](https://github.com/astral-sh/ruff/issues/7594) preview style is enabled.
-pub(crate) fn is_pep_701_enabled(context: &PyFormatContext) -> bool {
+/// Returns `true` if the [`f-string formatting`](https://github.com/astral-sh/ruff/issues/7594) preview style is enabled.
+pub(crate) fn is_f_string_formatting_enabled(context: &PyFormatContext) -> bool {
     context.is_preview()
 }

--- a/crates/ruff_python_formatter/src/string/mod.rs
+++ b/crates/ruff_python_formatter/src/string/mod.rs
@@ -1,7 +1,7 @@
 use bitflags::bitflags;
 
 pub(crate) use any::AnyString;
-pub(crate) use normalize::{NormalizedString, StringNormalizer};
+pub(crate) use normalize::{normalize_string, NormalizedString, StringNormalizer};
 use ruff_formatter::format_args;
 use ruff_source_file::Locator;
 use ruff_text_size::{TextLen, TextRange, TextSize};

--- a/crates/ruff_python_formatter/src/string/normalize.rs
+++ b/crates/ruff_python_formatter/src/string/normalize.rs
@@ -103,7 +103,7 @@ impl StringNormalizer {
             self.preferred_quote_style
         };
 
-        let quoting = if let FStringState::InsideExpressionElement(quotes) = self.f_string_state {
+        let quoting = if let FStringState::InsideExpressionElement(context) = self.f_string_state {
             // If we're inside an f-string, we need to make sure to preserve the
             // existing quotes unless we're inside a triple-quoted f-string and
             // the inner string itself isn't triple-quoted. For example:
@@ -118,7 +118,7 @@ impl StringNormalizer {
             // The reason to preserve the quotes is based on the assumption that
             // the original f-string is valid in terms of quoting, and we don't
             // want to change that to make it invalid.
-            if (quotes.is_triple() && !string.quotes().is_triple())
+            if (context.quotes().is_triple() && !string.quotes().is_triple())
                 || self.target_version.supports_pep_701()
             {
                 self.quoting

--- a/crates/ruff_python_formatter/src/string/normalize.rs
+++ b/crates/ruff_python_formatter/src/string/normalize.rs
@@ -103,7 +103,7 @@ impl StringNormalizer {
             self.preferred_quote_style
         };
 
-        let quoting = if let FStringState::Inside(quotes) = self.f_string_state {
+        let quoting = if let FStringState::InsideExpressionElement(quotes) = self.f_string_state {
             // If we're inside an f-string, we need to make sure to preserve the
             // existing quotes unless we're inside a triple-quoted f-string and
             // the inner string itself isn't triple-quoted. For example:

--- a/crates/ruff_python_formatter/src/string/normalize.rs
+++ b/crates/ruff_python_formatter/src/string/normalize.rs
@@ -1,8 +1,11 @@
 use std::borrow::Cow;
 
+use ruff_formatter::FormatContext;
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
 
+use crate::context::FStringState;
+use crate::options::PythonVersion;
 use crate::prelude::*;
 use crate::preview::is_hex_codes_in_unicode_sequences_enabled;
 use crate::string::{QuoteChar, Quoting, StringPart, StringPrefix, StringQuotes};

--- a/crates/ruff_python_formatter/src/verbatim.rs
+++ b/crates/ruff_python_formatter/src/verbatim.rs
@@ -873,11 +873,11 @@ impl Ranged for LogicalLine {
     }
 }
 
-struct VerbatimText {
+pub(crate) struct VerbatimText {
     verbatim_range: TextRange,
 }
 
-fn verbatim_text<T>(item: T) -> VerbatimText
+pub(crate) fn verbatim_text<T>(item: T) -> VerbatimText
 where
     T: Ranged,
 {

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
@@ -902,7 +902,7 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
  )
  
  dict_with_lambda_values = {
-@@ -524,61 +383,54 @@
+@@ -524,65 +383,58 @@
  
  # Complex string concatenations with a method call in the middle.
  code = (
@@ -941,7 +941,7 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
  log.info(
 -    "Skipping:"
 -    f" {desc['db_id']} {foo('bar',x=123)} {'foo' != 'bar'} {(x := 'abc=')} {pos_share=} {desc['status']} {desc['exposure_max']}"
-+    f'Skipping: {desc["db_id"]} {foo("bar",x=123)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
++    f'Skipping: {desc["db_id"]} {foo("bar", x=123,)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
  )
  
  log.info(
@@ -981,6 +981,18 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
  )
  
  log.info(
+-    f"""Skipping: {"a" == 'b'} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
++    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
+ )
+ 
+ log.info(
+@@ -590,5 +442,5 @@
+ )
+ 
+ log.info(
+-    f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share=} {desc['status']} {desc['exposure_max']}"""
++    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
+ )
 ```
 
 ## Ruff Output
@@ -1394,7 +1406,7 @@ log.info(
 )
 
 log.info(
-    f'Skipping: {desc["db_id"]} {foo("bar",x=123)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
+    f'Skipping: {desc["db_id"]} {foo("bar", x=123,)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
 )
 
 log.info(
@@ -1422,7 +1434,7 @@ log.info(
 )
 
 log.info(
-    f"""Skipping: {"a" == 'b'} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
+    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
 )
 
 log.info(
@@ -1430,7 +1442,7 @@ log.info(
 )
 
 log.info(
-    f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share=} {desc['status']} {desc['exposure_max']}"""
+    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
 )
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
@@ -422,10 +422,6 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
 -    "A long and ridiculous {}".format(string_key): (
 -        "This is a really really really long string that has to go i,side of a"
 -        " dictionary. It is soooo bad."
--    ),
--    some_func("calling", "some", "stuff"): (
--        "This is a really really really long string that has to go inside of a"
--        " dictionary. It is {soooo} bad (#{x}).".format(sooo="soooo", x=2)
 +    "A long and ridiculous {}".format(
 +        string_key
 +    ): "This is a really really really long string that has to go i,side of a dictionary. It is soooo bad.",
@@ -434,6 +430,10 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
 +    ): "This is a really really really long string that has to go inside of a dictionary. It is {soooo} bad (#{x}).".format(
 +        sooo="soooo", x=2
      ),
+-    some_func("calling", "some", "stuff"): (
+-        "This is a really really really long string that has to go inside of a"
+-        " dictionary. It is {soooo} bad (#{x}).".format(sooo="soooo", x=2)
+-    ),
      "A %s %s"
 -    % ("formatted", "string"): (
 -        "This is a really really really long string that has to go inside of a"
@@ -902,7 +902,7 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
  )
  
  dict_with_lambda_values = {
-@@ -524,65 +383,58 @@
+@@ -524,71 +383,70 @@
  
  # Complex string concatenations with a method call in the middle.
  code = (
@@ -982,16 +982,23 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
  
  log.info(
 -    f"""Skipping: {"a" == 'b'} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
-+    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
++    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {
++        desc["status"]
++    } {desc["exposure_max"]}"""
  )
  
  log.info(
-@@ -590,5 +442,5 @@
+-    f"""Skipping: {'a' == "b"=} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
++    f"""Skipping: {'a' == "b"=} {desc["ms_name"]} {money=} {dte=} {pos_share=} {
++        desc["status"]
++    } {desc["exposure_max"]}"""
  )
  
  log.info(
 -    f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share=} {desc['status']} {desc['exposure_max']}"""
-+    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
++    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {
++        desc["status"]
++    } {desc["exposure_max"]}"""
  )
 ```
 
@@ -1434,15 +1441,21 @@ log.info(
 )
 
 log.info(
-    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
+    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {
+        desc["status"]
+    } {desc["exposure_max"]}"""
 )
 
 log.info(
-    f"""Skipping: {'a' == "b"=} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
+    f"""Skipping: {'a' == "b"=} {desc["ms_name"]} {money=} {dte=} {pos_share=} {
+        desc["status"]
+    } {desc["exposure_max"]}"""
 )
 
 log.info(
-    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
+    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {
+        desc["status"]
+    } {desc["exposure_max"]}"""
 )
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
@@ -422,6 +422,10 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
 -    "A long and ridiculous {}".format(string_key): (
 -        "This is a really really really long string that has to go i,side of a"
 -        " dictionary. It is soooo bad."
+-    ),
+-    some_func("calling", "some", "stuff"): (
+-        "This is a really really really long string that has to go inside of a"
+-        " dictionary. It is {soooo} bad (#{x}).".format(sooo="soooo", x=2)
 +    "A long and ridiculous {}".format(
 +        string_key
 +    ): "This is a really really really long string that has to go i,side of a dictionary. It is soooo bad.",
@@ -430,10 +434,6 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
 +    ): "This is a really really really long string that has to go inside of a dictionary. It is {soooo} bad (#{x}).".format(
 +        sooo="soooo", x=2
      ),
--    some_func("calling", "some", "stuff"): (
--        "This is a really really really long string that has to go inside of a"
--        " dictionary. It is {soooo} bad (#{x}).".format(sooo="soooo", x=2)
--    ),
      "A %s %s"
 -    % ("formatted", "string"): (
 -        "This is a really really really long string that has to go inside of a"
@@ -902,7 +902,7 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
  )
  
  dict_with_lambda_values = {
-@@ -524,71 +383,70 @@
+@@ -524,65 +383,58 @@
  
  # Complex string concatenations with a method call in the middle.
  code = (
@@ -982,23 +982,16 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
  
  log.info(
 -    f"""Skipping: {"a" == 'b'} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
-+    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {
-+        desc["status"]
-+    } {desc["exposure_max"]}"""
++    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
  )
  
  log.info(
--    f"""Skipping: {'a' == "b"=} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
-+    f"""Skipping: {'a' == "b"=} {desc["ms_name"]} {money=} {dte=} {pos_share=} {
-+        desc["status"]
-+    } {desc["exposure_max"]}"""
+@@ -590,5 +442,5 @@
  )
  
  log.info(
 -    f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share=} {desc['status']} {desc['exposure_max']}"""
-+    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {
-+        desc["status"]
-+    } {desc["exposure_max"]}"""
++    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
  )
 ```
 
@@ -1441,21 +1434,15 @@ log.info(
 )
 
 log.info(
-    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {
-        desc["status"]
-    } {desc["exposure_max"]}"""
+    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
 )
 
 log.info(
-    f"""Skipping: {'a' == "b"=} {desc["ms_name"]} {money=} {dte=} {pos_share=} {
-        desc["status"]
-    } {desc["exposure_max"]}"""
+    f"""Skipping: {'a' == "b"=} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
 )
 
 log.info(
-    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {
-        desc["status"]
-    } {desc["exposure_max"]}"""
+    f"""Skipping: {"a" == "b"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}"""
 )
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings.py.snap
@@ -941,7 +941,7 @@ log.info(f"""Skipping: {'a' == 'b'} {desc['ms_name']} {money=} {dte=} {pos_share
  log.info(
 -    "Skipping:"
 -    f" {desc['db_id']} {foo('bar',x=123)} {'foo' != 'bar'} {(x := 'abc=')} {pos_share=} {desc['status']} {desc['exposure_max']}"
-+    f'Skipping: {desc["db_id"]} {foo("bar", x=123,)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
++    f'Skipping: {desc["db_id"]} {foo("bar", x=123)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
  )
  
  log.info(
@@ -1413,7 +1413,7 @@ log.info(
 )
 
 log.info(
-    f'Skipping: {desc["db_id"]} {foo("bar", x=123,)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
+    f'Skipping: {desc["db_id"]} {foo("bar", x=123)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
 )
 
 log.info(

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings__regression.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_strings__regression.py.snap
@@ -832,7 +832,7 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  
  some_commented_string = (  # This comment stays at the top.
      "This string is long but not so long that it needs hahahah toooooo be so greatttt"
-@@ -279,36 +280,25 @@
+@@ -279,37 +280,26 @@
  )
  
  lpar_and_rpar_have_comments = func_call(  # LPAR Comment
@@ -852,31 +852,32 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
 -    f" {'' if ID is None else ID} | perl -nE 'print if /^{field}:/'"
 -)
 +cmd_fstring = f"sudo -E deluge-console info --detailed --sort-reverse=time_added {'' if ID is None else ID} | perl -nE 'print if /^{field}:/'"
++
++cmd_fstring = f"sudo -E deluge-console info --detailed --sort-reverse=time_added {'{{}}' if ID is None else ID} | perl -nE 'print if /^{field}:/'"
  
 -cmd_fstring = (
 -    "sudo -E deluge-console info --detailed --sort-reverse=time_added"
 -    f" {'{{}}' if ID is None else ID} | perl -nE 'print if /^{field}:/'"
 -)
-+cmd_fstring = f"sudo -E deluge-console info --detailed --sort-reverse=time_added {'{{}}' if ID is None else ID} | perl -nE 'print if /^{field}:/'"
++cmd_fstring = f"sudo -E deluge-console info --detailed --sort-reverse=time_added {{'' if ID is None else ID}} | perl -nE 'print if /^{field}:/'"
  
 -cmd_fstring = (
 -    "sudo -E deluge-console info --detailed --sort-reverse=time_added {'' if ID is"
 -    f" None else ID}} | perl -nE 'print if /^{field}:/'"
 -)
-+cmd_fstring = f"sudo -E deluge-console info --detailed --sort-reverse=time_added {{'' if ID is None else ID}} | perl -nE 'print if /^{field}:/'"
- 
 +fstring = f"This string really doesn't need to be an {{{{fstring}}}}, but this one most certainly, absolutely {does}."
-+
+ 
  fstring = (
 -    "This string really doesn't need to be an {{fstring}}, but this one most"
 -    f" certainly, absolutely {does}."
 +    f"We have to remember to escape {braces}." " Like {these}." f" But not {this}."
  )
--
--fstring = f"We have to remember to escape {braces}. Like {{these}}. But not {this}."
  
+-fstring = f"We have to remember to escape {braces}. Like {{these}}. But not {this}."
+-
  
  class A:
+     class B:
 @@ -364,10 +354,7 @@
          def foo():
              if not hasattr(module, name):
@@ -979,7 +980,13 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
  )
  
  # The parens should NOT be removed in this case.
-@@ -518,88 +494,78 @@
+@@ -513,93 +489,83 @@
+ 
+ 
+ temp_msg = (
+-    f"{f'{humanize_number(pos)}.': <{pound_len+2}} "
++    f"{f'{humanize_number(pos)}.': <{pound_len + 2}} "
+     f"{balance: <{bal_len + 5}} "
      f"<<{author.display_name}>>\n"
  )
  
@@ -1103,7 +1110,13 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
      "6. Click on Create Credential at the top."
      '7. At the top click the link for "API key".'
      "8. No application restrictions are needed. Click Create at the bottom."
-@@ -613,55 +579,40 @@
+@@ -608,60 +574,45 @@
+ 
+ # It shouldn't matter if the string prefixes are capitalized.
+ temp_msg = (
+-    f"{F'{humanize_number(pos)}.': <{pound_len+2}} "
++    f"{f'{humanize_number(pos)}.': <{pound_len + 2}} "
+     f"{balance: <{bal_len + 5}} "
      f"<<{author.display_name}>>\n"
  )
  
@@ -1688,7 +1701,7 @@ class X:
 
 
 temp_msg = (
-    f"{f'{humanize_number(pos)}.': <{pound_len+2}} "
+    f"{f'{humanize_number(pos)}.': <{pound_len + 2}} "
     f"{balance: <{bal_len + 5}} "
     f"<<{author.display_name}>>\n"
 )
@@ -1773,7 +1786,7 @@ message = (
 
 # It shouldn't matter if the string prefixes are capitalized.
 temp_msg = (
-    f"{F'{humanize_number(pos)}.': <{pound_len+2}} "
+    f"{f'{humanize_number(pos)}.': <{pound_len + 2}} "
     f"{balance: <{bal_len + 5}} "
     f"<<{author.display_name}>>\n"
 )

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -68,9 +68,398 @@ result_f = (
 x = f'''a{""}b'''
 y = f'''c{1}d"""e'''
 z = f'''a{""}b''' f'''c{1}d"""e'''
+
+# F-String formatting test cases (Preview)
+
+# Simple expression with a mix of debug expression and comments.
+x = f"{a}"
+x = f"{
+    a = }"
+x = f"{ # comment
+    a }"
+x = f"{   # comment
+    a = }"
+
+# Remove the parentheses as adding them doesn't make then fit within the line length limit.
+# This is similar to how we format it before f-string formatting.
+aaaaaaaaaaa = (
+    f"asaaaaaaaaaaaaaaaa { aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd } cccccccccc"
+)
+# Here, we would use the best fit layout to put the f-string indented on the next line
+# similar to the next example.
+aaaaaaaaaaa = f"asaaaaaaaaaaaaaaaa { aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc } cccccccccc"
+aaaaaaaaaaa = (
+    f"asaaaaaaaaaaaaaaaa { aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc } cccccccccc"
+)
+
+# This should never add the optional parentheses because even after adding them, the
+# f-string exceeds the line length limit.
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+                                             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+                                             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
+
+# Multiple larger expressions which exceeds the line length limit. Here, we need to decide
+# whether to split at the first or second expression. This should work similarly to the
+# assignment statement formatting where we split from right to left in preview mode.
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+
+# The above example won't split but when we start introducing line breaks:
+x = f"aaaaaaaaaaaa {
+        bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb
+                    } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc {
+        ddddddddddddddd } eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd
+                                                            } eeeeeeeeeeeeee"
+
+# But, in case comments are present, we would split at the expression containing the
+# comments:
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb # comment
+                    } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb
+                    } cccccccccccccccccccc { # comment
+                                            ddddddddddddddd } eeeeeeeeeeeeee"
+
+# Here, the expression part itself starts with a curly brace so we need to add an extra
+# space between the opening curly brace and the expression.
+x = f"{ {'x': 1, 'y': 2} }"
+# Although the extra space isn't required before the ending curly brace, we add it for
+# consistency.
+x = f"{ {'x': 1, 'y': 2}}"
+x = f"{ {'x': 1, 'y': 2} = }"
+x = f"{  # comment
+    {'x': 1, 'y': 2} }"
+x = f"{    # comment
+    {'x': 1, 'y': 2} = }"
+
+# But, in this case, we would split the expression itself because it exceeds the line
+# length limit so we need not add the extra space.
+xxxxxxx = f"{
+    {'aaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbb', 'ccccccccccccccccccccc'}
+}"
+# And, split the expression itself because it exceeds the line length.
+xxxxxxx = f"{
+    {'aaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbb', 'cccccccccccccccccccccccccc'}
+}"
+
+# Triple-quoted strings
+# It's ok to use the same quote char for the inner string if it's single-quoted.
+f"""test {'inner'}"""
+f"""test {"inner"}"""
+# But if the inner string is also triple-quoted then we should preserve the existing quotes.
+f"""test {'''inner'''}"""
+
+# Comments
+
+# No comments should be dropped!
+f"{ # comment 1
+    # comment 2
+    foo # comment 3
+    # comment 4
+}"  # comment 5
+# comment 6
+
+# Conversion flags
+#
+# This is not a valid Python code because of the additional whitespace between the `!`
+# and conversion type. But, our parser isn't strict about this. This should probably be
+# removed once we have a strict parser.
+x = f"aaaaaaaaa { x !  r }"
+
+# Even in the case of debug expresions, we only need to preserve the whitespace within
+# the expression part of the replacement field.
+x = f"aaaaaaaaa { x   = !  r  }"
+
+# Combine conversion flags with format specifiers
+x = f"{x   =   !  s
+         :>0
+
+         }"
+# This is interesting. There can be a comment after the format specifier but only if it's
+# on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
+# We'll format is as trailing comments.
+x = f"{x  !s
+         :>0
+         # comment
+         }"
+
+x = f"""
+{              # dangling comment 1
+ x =   :.0{y # dangling comment 2
+           }f}"""
+
+# Here, the debug expression is in a nested f-string so we should start preserving
+# whitespaces from that point onwards. This means we should format the outer f-string.
+x = f"""{"foo " +    # comment 1
+    f"{   x =
+
+       }"    # comment 2
+ }
+        """
+
+# Mix of various features.
+f"{  # dangling comment 1
+    foo # after foo
+   :>{
+          x # after x
+          }
+    # dangling comment 2
+    # dangling comment 3
+} woah {x}"
 ```
 
-## Output
+## Outputs
+### Output 1
+```
+indent-style               = space
+line-width                 = 88
+indent-width               = 4
+quote-style                = Double
+line-ending                = LineFeed
+magic-trailing-comma       = Respect
+docstring-code             = Disabled
+docstring-code-line-width  = "dynamic"
+preview                    = Enabled
+target_version             = Py38
+source_type                = Python
+```
+
+```python
+(f"{one}" f"{two}")
+
+
+rf"Not-so-tricky \"quote"
+
+# Regression test for fstrings dropping comments
+result_f = (
+    "Traceback (most recent call last):\n"
+    f'  File "{__file__}", line {lineno_f + 5}, in _check_recursive_traceback_display\n'
+    "    f()\n"
+    f'  File "{__file__}", line {lineno_f + 1}, in f\n'
+    "    f()\n"
+    f'  File "{__file__}", line {lineno_f + 1}, in f\n'
+    "    f()\n"
+    f'  File "{__file__}", line {lineno_f + 1}, in f\n'
+    "    f()\n"
+    # XXX: The following line changes depending on whether the tests
+    # are run through the interactive interpreter or with -m
+    # It also varies depending on the platform (stack size)
+    # Fortunately, we don't care about exactness here, so we use regex
+    r"  \[Previous line repeated (\d+) more times\]"
+    "\n"
+    "RecursionError: maximum recursion depth exceeded\n"
+)
+
+
+# Regression for fstring dropping comments that were accidentally attached to
+# an expression inside a formatted value
+(
+    f"{1}"
+    # comment
+    ""
+)
+
+(
+    f"{1}"  # comment
+    f"{2}"
+)
+
+(
+    f"{1}" f"{2}"  # comment
+)
+
+(
+    1,
+    (  # comment
+        f"{2}"
+    ),
+)
+
+(
+    (
+        f"{1}"
+        # comment
+    ),
+    2,
+)
+
+# https://github.com/astral-sh/ruff/issues/6841
+x = f"""a{""}b"""
+y = f'''c{1}d"""e'''
+z = f"""a{""}b""" f'''c{1}d"""e'''
+
+# F-String formatting test cases (Preview)
+
+# Simple expression with a mix of debug expression and comments.
+x = f"{a}"
+x = f"{
+    a = }"
+x = f"{  # comment
+    a
+}"
+x = f"{   # comment
+    a = }"
+
+# Remove the parentheses as adding them doesn't make then fit within the line length limit.
+# This is similar to how we format it before f-string formatting.
+aaaaaaaaaaa = f"asaaaaaaaaaaaaaaaa {aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd} cccccccccc"
+# Here, we would use the best fit layout to put the f-string indented on the next line
+# similar to the next example.
+aaaaaaaaaaa = (
+    f"asaaaaaaaaaaaaaaaa {aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc} cccccccccc"
+)
+aaaaaaaaaaa = (
+    f"asaaaaaaaaaaaaaaaa {aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc} cccccccccc"
+)
+
+# This should never add the optional parentheses because even after adding them, the
+# f-string exceeds the line length limit.
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {"bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"} ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {  # comment
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+} ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+                                             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
+
+# Multiple larger expressions which exceeds the line length limit. Here, we need to decide
+# whether to split at the first or second expression. This should work similarly to the
+# assignment statement formatting where we split from right to left in preview mode.
+x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {ddddddddddddddd} eeeeeeeeeeeeee"
+
+# The above example won't split but when we start introducing line breaks:
+x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {
+    ddddddddddddddd
+} eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {
+    ddddddddddddddd
+} eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {
+    ddddddddddddddd
+} eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {
+    ddddddddddddddd
+} eeeeeeeeeeeeee"
+
+# But, in case comments are present, we would split at the expression containing the
+# comments:
+x = f"aaaaaaaaaaaa {
+    bbbbbbbbbbbbbb  # comment
+} cccccccccccccccccccc {ddddddddddddddd} eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {  # comment
+    ddddddddddddddd
+} eeeeeeeeeeeeee"
+
+# Here, the expression part itself starts with a curly brace so we need to add an extra
+# space between the opening curly brace and the expression.
+x = f"{ {'x': 1, 'y': 2} }"
+# Although the extra space isn't required before the ending curly brace, we add it for
+# consistency.
+x = f"{ {'x': 1, 'y': 2} }"
+x = f"{ {'x': 1, 'y': 2} = }"
+x = f"{  # comment
+    {'x': 1, 'y': 2}
+}"
+x = f"{    # comment
+    {'x': 1, 'y': 2} = }"
+
+# But, in this case, we would split the expression itself because it exceeds the line
+# length limit so we need not add the extra space.
+xxxxxxx = f"{
+    {'aaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbb', 'ccccccccccccccccccccc'}
+}"
+# And, split the expression itself because it exceeds the line length.
+xxxxxxx = f"{
+    {
+        'aaaaaaaaaaaaaaaaaaaaaaaaa',
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        'cccccccccccccccccccccccccc',
+    }
+}"
+
+# Triple-quoted strings
+# It's ok to use the same quote char for the inner string if it's single-quoted.
+f"""test {"inner"}"""
+f"""test {"inner"}"""
+# But if the inner string is also triple-quoted then we should preserve the existing quotes.
+f"""test {'''inner'''}"""
+
+# Comments
+
+# No comments should be dropped!
+f"{  # comment 1
+    # comment 2
+    foo  # comment 3
+    # comment 4
+}"  # comment 5
+# comment 6
+
+# Conversion flags
+#
+# This is not a valid Python code because of the additional whitespace between the `!`
+# and conversion type. But, our parser isn't strict about this. This should probably be
+# removed once we have a strict parser.
+x = f"aaaaaaaaa {x!r}"
+
+# Even in the case of debug expresions, we only need to preserve the whitespace within
+# the expression part of the replacement field.
+x = f"aaaaaaaaa { x   = !r}"
+
+# Combine conversion flags with format specifiers
+x = f"{x   =   !s:>0}"
+# This is interesting. There can be a comment after the format specifier but only if it's
+# on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
+# We'll format is as trailing comments.
+x = f"{
+    x!s:>0
+    # comment
+}"
+
+x = f"""
+{              # dangling comment 1
+ x =   :.0{y # dangling comment 2
+           }f}"""
+
+# Here, the debug expression is in a nested f-string so we should start preserving
+# whitespaces from that point onwards. This means we should format the outer f-string.
+x = f"""{
+    "foo "  # comment 1
+    + f"{   x =
+
+       }"  # comment 2
+}
+        """
+
+# Mix of various features.
+f"{  # dangling comment 1
+    foo:>{  # after foo
+        x  # after x
+    }
+    # dangling comment 2
+    # dangling comment 3
+} woah {x}"
+```
+
+
+### Output 2
+```
+indent-style               = space
+line-width                 = 88
+indent-width               = 4
+quote-style                = Double
+line-ending                = LineFeed
+magic-trailing-comma       = Respect
+docstring-code             = Disabled
+docstring-code-line-width  = "dynamic"
+preview                    = Disabled
+target_version             = Py38
+source_type                = Python
+```
+
 ```python
 (f"{one}" f"{two}")
 
@@ -134,6 +523,361 @@ result_f = (
 x = f"""a{""}b"""
 y = f'''c{1}d"""e'''
 z = f"""a{""}b""" f'''c{1}d"""e'''
+
+# F-String formatting test cases (Preview)
+
+# Simple expression with a mix of debug expression and comments.
+x = f"{a}"
+x = f"{
+    a = }"
+x = f"{ # comment
+    a }"
+x = f"{   # comment
+    a = }"
+
+# Remove the parentheses as adding them doesn't make then fit within the line length limit.
+# This is similar to how we format it before f-string formatting.
+aaaaaaaaaaa = f"asaaaaaaaaaaaaaaaa { aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd } cccccccccc"
+# Here, we would use the best fit layout to put the f-string indented on the next line
+# similar to the next example.
+aaaaaaaaaaa = (
+    f"asaaaaaaaaaaaaaaaa { aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc } cccccccccc"
+)
+aaaaaaaaaaa = (
+    f"asaaaaaaaaaaaaaaaa { aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc } cccccccccc"
+)
+
+# This should never add the optional parentheses because even after adding them, the
+# f-string exceeds the line length limit.
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+                                             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+                                             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
+
+# Multiple larger expressions which exceeds the line length limit. Here, we need to decide
+# whether to split at the first or second expression. This should work similarly to the
+# assignment statement formatting where we split from right to left in preview mode.
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+
+# The above example won't split but when we start introducing line breaks:
+x = f"aaaaaaaaaaaa {
+        bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb
+                    } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc {
+        ddddddddddddddd } eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd
+                                                            } eeeeeeeeeeeeee"
+
+# But, in case comments are present, we would split at the expression containing the
+# comments:
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb # comment
+                    } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb
+                    } cccccccccccccccccccc { # comment
+                                            ddddddddddddddd } eeeeeeeeeeeeee"
+
+# Here, the expression part itself starts with a curly brace so we need to add an extra
+# space between the opening curly brace and the expression.
+x = f"{ {'x': 1, 'y': 2} }"
+# Although the extra space isn't required before the ending curly brace, we add it for
+# consistency.
+x = f"{ {'x': 1, 'y': 2}}"
+x = f"{ {'x': 1, 'y': 2} = }"
+x = f"{  # comment
+    {'x': 1, 'y': 2} }"
+x = f"{    # comment
+    {'x': 1, 'y': 2} = }"
+
+# But, in this case, we would split the expression itself because it exceeds the line
+# length limit so we need not add the extra space.
+xxxxxxx = f"{
+    {'aaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbb', 'ccccccccccccccccccccc'}
+}"
+# And, split the expression itself because it exceeds the line length.
+xxxxxxx = f"{
+    {'aaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbb', 'cccccccccccccccccccccccccc'}
+}"
+
+# Triple-quoted strings
+# It's ok to use the same quote char for the inner string if it's single-quoted.
+f"""test {'inner'}"""
+f"""test {"inner"}"""
+# But if the inner string is also triple-quoted then we should preserve the existing quotes.
+f"""test {'''inner'''}"""
+
+# Comments
+
+# No comments should be dropped!
+f"{ # comment 1
+    # comment 2
+    foo # comment 3
+    # comment 4
+}"  # comment 5
+# comment 6
+
+# Conversion flags
+#
+# This is not a valid Python code because of the additional whitespace between the `!`
+# and conversion type. But, our parser isn't strict about this. This should probably be
+# removed once we have a strict parser.
+x = f"aaaaaaaaa { x !  r }"
+
+# Even in the case of debug expresions, we only need to preserve the whitespace within
+# the expression part of the replacement field.
+x = f"aaaaaaaaa { x   = !  r  }"
+
+# Combine conversion flags with format specifiers
+x = f"{x   =   !  s
+         :>0
+
+         }"
+# This is interesting. There can be a comment after the format specifier but only if it's
+# on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
+# We'll format is as trailing comments.
+x = f"{x  !s
+         :>0
+         # comment
+         }"
+
+x = f"""
+{              # dangling comment 1
+ x =   :.0{y # dangling comment 2
+           }f}"""
+
+# Here, the debug expression is in a nested f-string so we should start preserving
+# whitespaces from that point onwards. This means we should format the outer f-string.
+x = f"""{"foo " +    # comment 1
+    f"{   x =
+
+       }"    # comment 2
+ }
+        """
+
+# Mix of various features.
+f"{  # dangling comment 1
+    foo # after foo
+   :>{
+          x # after x
+          }
+    # dangling comment 2
+    # dangling comment 3
+} woah {x}"
+```
+
+
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -6,13 +6,13 @@
+ # Regression test for fstrings dropping comments
+ result_f = (
+     "Traceback (most recent call last):\n"
+-    f'  File "{__file__}", line {lineno_f+5}, in _check_recursive_traceback_display\n'
++    f'  File "{__file__}", line {lineno_f + 5}, in _check_recursive_traceback_display\n'
+     "    f()\n"
+-    f'  File "{__file__}", line {lineno_f+1}, in f\n'
++    f'  File "{__file__}", line {lineno_f + 1}, in f\n'
+     "    f()\n"
+-    f'  File "{__file__}", line {lineno_f+1}, in f\n'
++    f'  File "{__file__}", line {lineno_f + 1}, in f\n'
+     "    f()\n"
+-    f'  File "{__file__}", line {lineno_f+1}, in f\n'
++    f'  File "{__file__}", line {lineno_f + 1}, in f\n'
+     "    f()\n"
+     # XXX: The following line changes depending on whether the tests
+     # are run through the interactive interpreter or with -m
+@@ -67,64 +67,72 @@
+ x = f"{a}"
+ x = f"{
+     a = }"
+-x = f"{ # comment
+-    a }"
++x = f"{  # comment
++    a
++}"
+ x = f"{   # comment
+     a = }"
+ 
+ # Remove the parentheses as adding them doesn't make then fit within the line length limit.
+ # This is similar to how we format it before f-string formatting.
+-aaaaaaaaaaa = f"asaaaaaaaaaaaaaaaa { aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd } cccccccccc"
++aaaaaaaaaaa = f"asaaaaaaaaaaaaaaaa {aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc + dddddddd} cccccccccc"
+ # Here, we would use the best fit layout to put the f-string indented on the next line
+ # similar to the next example.
+ aaaaaaaaaaa = (
+-    f"asaaaaaaaaaaaaaaaa { aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc } cccccccccc"
++    f"asaaaaaaaaaaaaaaaa {aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc} cccccccccc"
+ )
+ aaaaaaaaaaa = (
+-    f"asaaaaaaaaaaaaaaaa { aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc } cccccccccc"
++    f"asaaaaaaaaaaaaaaaa {aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc} cccccccccc"
+ )
+ 
+ # This should never add the optional parentheses because even after adding them, the
+ # f-string exceeds the line length limit.
+-x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
++x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {"bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"} ccccccccccccccc"
+ x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
+-x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+-                                             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
++x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {  # comment
++    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
++} ccccccccccccccc"
+ x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
+ 
+ # Multiple larger expressions which exceeds the line length limit. Here, we need to decide
+ # whether to split at the first or second expression. This should work similarly to the
+ # assignment statement formatting where we split from right to left in preview mode.
+-x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
++x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {ddddddddddddddd} eeeeeeeeeeeeee"
+ 
+ # The above example won't split but when we start introducing line breaks:
+-x = f"aaaaaaaaaaaa {
+-        bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+-x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb
+-                    } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+-x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc {
+-        ddddddddddddddd } eeeeeeeeeeeeee"
+-x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd
+-                                                            } eeeeeeeeeeeeee"
++x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {
++    ddddddddddddddd
++} eeeeeeeeeeeeee"
++x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {
++    ddddddddddddddd
++} eeeeeeeeeeeeee"
++x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {
++    ddddddddddddddd
++} eeeeeeeeeeeeee"
++x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {
++    ddddddddddddddd
++} eeeeeeeeeeeeee"
+ 
+ # But, in case comments are present, we would split at the expression containing the
+ # comments:
+-x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb # comment
+-                    } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
+-x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb
+-                    } cccccccccccccccccccc { # comment
+-                                            ddddddddddddddd } eeeeeeeeeeeeee"
++x = f"aaaaaaaaaaaa {
++    bbbbbbbbbbbbbb  # comment
++} cccccccccccccccccccc {ddddddddddddddd} eeeeeeeeeeeeee"
++x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {  # comment
++    ddddddddddddddd
++} eeeeeeeeeeeeee"
+ 
+ # Here, the expression part itself starts with a curly brace so we need to add an extra
+ # space between the opening curly brace and the expression.
+ x = f"{ {'x': 1, 'y': 2} }"
+ # Although the extra space isn't required before the ending curly brace, we add it for
+ # consistency.
+-x = f"{ {'x': 1, 'y': 2}}"
++x = f"{ {'x': 1, 'y': 2} }"
+ x = f"{ {'x': 1, 'y': 2} = }"
+ x = f"{  # comment
+-    {'x': 1, 'y': 2} }"
++    {'x': 1, 'y': 2}
++}"
+ x = f"{    # comment
+     {'x': 1, 'y': 2} = }"
+ 
+@@ -135,22 +143,26 @@
+ }"
+ # And, split the expression itself because it exceeds the line length.
+ xxxxxxx = f"{
+-    {'aaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbb', 'cccccccccccccccccccccccccc'}
++    {
++        'aaaaaaaaaaaaaaaaaaaaaaaaa',
++        'bbbbbbbbbbbbbbbbbbbbbbbbbbb',
++        'cccccccccccccccccccccccccc',
++    }
+ }"
+ 
+ # Triple-quoted strings
+ # It's ok to use the same quote char for the inner string if it's single-quoted.
+-f"""test {'inner'}"""
+ f"""test {"inner"}"""
++f"""test {"inner"}"""
+ # But if the inner string is also triple-quoted then we should preserve the existing quotes.
+ f"""test {'''inner'''}"""
+ 
+ # Comments
+ 
+ # No comments should be dropped!
+-f"{ # comment 1
++f"{  # comment 1
+     # comment 2
+-    foo # comment 3
++    foo  # comment 3
+     # comment 4
+ }"  # comment 5
+ # comment 6
+@@ -160,24 +172,21 @@
+ # This is not a valid Python code because of the additional whitespace between the `!`
+ # and conversion type. But, our parser isn't strict about this. This should probably be
+ # removed once we have a strict parser.
+-x = f"aaaaaaaaa { x !  r }"
++x = f"aaaaaaaaa {x!r}"
+ 
+ # Even in the case of debug expresions, we only need to preserve the whitespace within
+ # the expression part of the replacement field.
+-x = f"aaaaaaaaa { x   = !  r  }"
++x = f"aaaaaaaaa { x   = !r}"
+ 
+ # Combine conversion flags with format specifiers
+-x = f"{x   =   !  s
+-         :>0
+-
+-         }"
++x = f"{x   =   !s:>0}"
+ # This is interesting. There can be a comment after the format specifier but only if it's
+ # on it's own line. Refer to https://github.com/astral-sh/ruff/pull/7787 for more details.
+ # We'll format is as trailing comments.
+-x = f"{x  !s
+-         :>0
+-         # comment
+-         }"
++x = f"{
++    x!s:>0
++    # comment
++}"
+ 
+ x = f"""
+ {              # dangling comment 1
+@@ -186,19 +195,19 @@
+ 
+ # Here, the debug expression is in a nested f-string so we should start preserving
+ # whitespaces from that point onwards. This means we should format the outer f-string.
+-x = f"""{"foo " +    # comment 1
+-    f"{   x =
++x = f"""{
++    "foo "  # comment 1
++    + f"{   x =
+ 
+-       }"    # comment 2
+- }
++       }"  # comment 2
++}
+         """
+ 
+ # Mix of various features.
+ f"{  # dangling comment 1
+-    foo # after foo
+-   :>{
+-          x # after x
+-          }
++    foo:>{  # after foo
++        x  # after x
++    }
+     # dangling comment 2
+     # dangling comment 3
+ } woah {x}"
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -146,6 +146,19 @@ xxxxxxx = f"{
     {'aaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbb', 'cccccccccccccccccccccccccc'}
 }"
 
+# Quotes
+f"foo 'bar' {x}"
+f"foo \"bar\" {x}"
+f'foo "bar" {x}'
+f'foo \'bar\' {x}'
+f"foo {"bar"}"
+f"foo {'\'bar\''}"
+
+# Here, the formatter will remove the escapes which is correct because they aren't allowed
+# pre 3.12. This means we can assume that the f-string is used in the context of 3.12.
+f"foo {'\"bar\"'}"
+
+
 # Triple-quoted strings
 # It's ok to use the same quote char for the inner string if it's single-quoted.
 f"""test {'inner'}"""
@@ -160,8 +173,35 @@ f"""test {'''inner'''}"""
 # breaks which results in the trailing comma being present. This test case makes sure
 # that the trailing comma is removed as well.
 f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
+
 # And, if the trailing comma is already present, we still need to remove it.
 f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee',]} aaaaaaa"
+
+# Keep this Multiline by breaking it at the square brackets.
+f"""aaaaaa {[
+    xxxxxxxx,
+    yyyyyyyy,
+]} ccc"""
+
+# Add the magic trailing comma because the elements don't fit within the line length limit
+# when collapsed.
+f"aaaaaa {[
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    yyyyyyyyyyyy
+]} ccccccc"
+
+# Remove the parenthese because they aren't required
+xxxxxxxxxxxxxxx = (
+    f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbb {
+        xxxxxxxxxxx  # comment
+        + yyyyyyyyyy
+    } dddddddddd"
+)
 
 # Comments
 
@@ -220,6 +260,32 @@ f"{  # dangling comment 1
     # dangling comment 2
     # dangling comment 3
 } woah {x}"
+
+# Indentation
+
+# What should be the indentation?
+# https://github.com/astral-sh/ruff/discussions/9785#discussioncomment-8470590
+if indent0:
+    if indent1:
+        if indent2:
+            foo = f"""hello world
+hello {
+          f"aaaaaaa {
+              [
+                  'aaaaaaaaaaaaaaaaaaaaa',
+                  'bbbbbbbbbbbbbbbbbbbbb',
+                  'ccccccccccccccccccccc',
+                  'ddddddddddddddddddddd'
+              ]
+          } bbbbbbbb" +
+          [
+              'aaaaaaaaaaaaaaaaaaaaa',
+              'bbbbbbbbbbbbbbbbbbbbb',
+              'ccccccccccccccccccccc',
+              'ddddddddddddddddddddd'
+          ]
+      } --------
+"""
 ```
 
 ## Outputs
@@ -391,6 +457,19 @@ xxxxxxx = f"{
     }
 }"
 
+# Quotes
+f"foo 'bar' {x}"
+f'foo "bar" {x}'
+f'foo "bar" {x}'
+f"foo 'bar' {x}"
+f"foo {"bar"}"
+f"foo {'\'bar\''}"
+
+# Here, the formatter will remove the escapes which is correct because they aren't allowed
+# pre 3.12. This means we can assume that the f-string is used in the context of 3.12.
+f"foo {'"bar"'}"
+
+
 # Triple-quoted strings
 # It's ok to use the same quote char for the inner string if it's single-quoted.
 f"""test {"inner"}"""
@@ -405,8 +484,37 @@ f"""test {'''inner'''}"""
 # breaks which results in the trailing comma being present. This test case makes sure
 # that the trailing comma is removed as well.
 f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
+
 # And, if the trailing comma is already present, we still need to remove it.
 f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
+
+# Keep this Multiline by breaking it at the square brackets.
+f"""aaaaaa {
+    [
+        xxxxxxxx,
+        yyyyyyyy,
+    ]
+} ccc"""
+
+# Add the magic trailing comma because the elements don't fit within the line length limit
+# when collapsed.
+f"aaaaaa {
+    [
+        xxxxxxxxxxxx,
+        xxxxxxxxxxxx,
+        xxxxxxxxxxxx,
+        xxxxxxxxxxxx,
+        xxxxxxxxxxxx,
+        xxxxxxxxxxxx,
+        yyyyyyyyyyyy,
+    ]
+} ccccccc"
+
+# Remove the parenthese because they aren't required
+xxxxxxxxxxxxxxx = f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbb {
+    xxxxxxxxxxx  # comment
+    + yyyyyyyyyy
+} dddddddddd"
 
 # Comments
 
@@ -462,6 +570,32 @@ f"{  # dangling comment 1
     # dangling comment 2
     # dangling comment 3
 } woah {x}"
+
+# Indentation
+
+# What should be the indentation?
+# https://github.com/astral-sh/ruff/discussions/9785#discussioncomment-8470590
+if indent0:
+    if indent1:
+        if indent2:
+            foo = f"""hello world
+hello {
+                f"aaaaaaa {
+                    [
+                        'aaaaaaaaaaaaaaaaaaaaa',
+                        'bbbbbbbbbbbbbbbbbbbbb',
+                        'ccccccccccccccccccccc',
+                        'ddddddddddddddddddddd',
+                    ]
+                } bbbbbbbb"
+                + [
+                    "aaaaaaaaaaaaaaaaaaaaa",
+                    "bbbbbbbbbbbbbbbbbbbbb",
+                    "ccccccccccccccccccccc",
+                    "ddddddddddddddddddddd",
+                ]
+            } --------
+"""
 ```
 
 
@@ -621,6 +755,19 @@ xxxxxxx = f"{
     {'aaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbb', 'cccccccccccccccccccccccccc'}
 }"
 
+# Quotes
+f"foo 'bar' {x}"
+f'foo "bar" {x}'
+f'foo "bar" {x}'
+f"foo 'bar' {x}"
+f"foo {"bar"}"
+f"foo {'\'bar\''}"
+
+# Here, the formatter will remove the escapes which is correct because they aren't allowed
+# pre 3.12. This means we can assume that the f-string is used in the context of 3.12.
+f"foo {'\"bar\"'}"
+
+
 # Triple-quoted strings
 # It's ok to use the same quote char for the inner string if it's single-quoted.
 f"""test {'inner'}"""
@@ -635,8 +782,33 @@ f"""test {'''inner'''}"""
 # breaks which results in the trailing comma being present. This test case makes sure
 # that the trailing comma is removed as well.
 f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
+
 # And, if the trailing comma is already present, we still need to remove it.
 f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee',]} aaaaaaa"
+
+# Keep this Multiline by breaking it at the square brackets.
+f"""aaaaaa {[
+    xxxxxxxx,
+    yyyyyyyy,
+]} ccc"""
+
+# Add the magic trailing comma because the elements don't fit within the line length limit
+# when collapsed.
+f"aaaaaa {[
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    xxxxxxxxxxxx,
+    yyyyyyyyyyyy
+]} ccccccc"
+
+# Remove the parenthese because they aren't required
+xxxxxxxxxxxxxxx = f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbb {
+        xxxxxxxxxxx  # comment
+        + yyyyyyyyyy
+    } dddddddddd"
 
 # Comments
 
@@ -695,6 +867,32 @@ f"{  # dangling comment 1
     # dangling comment 2
     # dangling comment 3
 } woah {x}"
+
+# Indentation
+
+# What should be the indentation?
+# https://github.com/astral-sh/ruff/discussions/9785#discussioncomment-8470590
+if indent0:
+    if indent1:
+        if indent2:
+            foo = f"""hello world
+hello {
+          f"aaaaaaa {
+              [
+                  'aaaaaaaaaaaaaaaaaaaaa',
+                  'bbbbbbbbbbbbbbbbbbbbb',
+                  'ccccccccccccccccccccc',
+                  'ddddddddddddddddddddd'
+              ]
+          } bbbbbbbb" +
+          [
+              'aaaaaaaaaaaaaaaaaaaaa',
+              'bbbbbbbbbbbbbbbbbbbbb',
+              'ccccccccccccccccccccc',
+              'ddddddddddddddddddddd'
+          ]
+      } --------
+"""
 ```
 
 
@@ -817,7 +1015,7 @@ f"{  # dangling comment 1
  x = f"{    # comment
      {'x': 1, 'y': 2} = }"
  
-@@ -135,13 +143,17 @@
+@@ -135,7 +143,11 @@
  }"
  # And, split the expression itself because it exceeds the line length.
  xxxxxxx = f"{
@@ -829,6 +1027,15 @@ f"{  # dangling comment 1
 +    }
  }"
  
+ # Quotes
+@@ -148,13 +160,13 @@
+ 
+ # Here, the formatter will remove the escapes which is correct because they aren't allowed
+ # pre 3.12. This means we can assume that the f-string is used in the context of 3.12.
+-f"foo {'\"bar\"'}"
++f"foo {'"bar"'}"
+ 
+ 
  # Triple-quoted strings
  # It's ok to use the same quote char for the inner string if it's single-quoted.
 -f"""test {'inner'}"""
@@ -837,12 +1044,56 @@ f"{  # dangling comment 1
  # But if the inner string is also triple-quoted then we should preserve the existing quotes.
  f"""test {'''inner'''}"""
  
-@@ -153,14 +165,14 @@
- # that the trailing comma is removed as well.
+@@ -167,38 +179,42 @@
  f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
+ 
  # And, if the trailing comma is already present, we still need to remove it.
 -f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee',]} aaaaaaa"
 +f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
+ 
+ # Keep this Multiline by breaking it at the square brackets.
+-f"""aaaaaa {[
+-    xxxxxxxx,
+-    yyyyyyyy,
+-]} ccc"""
++f"""aaaaaa {
++    [
++        xxxxxxxx,
++        yyyyyyyy,
++    ]
++} ccc"""
+ 
+ # Add the magic trailing comma because the elements don't fit within the line length limit
+ # when collapsed.
+-f"aaaaaa {[
+-    xxxxxxxxxxxx,
+-    xxxxxxxxxxxx,
+-    xxxxxxxxxxxx,
+-    xxxxxxxxxxxx,
+-    xxxxxxxxxxxx,
+-    xxxxxxxxxxxx,
+-    yyyyyyyyyyyy
+-]} ccccccc"
++f"aaaaaa {
++    [
++        xxxxxxxxxxxx,
++        xxxxxxxxxxxx,
++        xxxxxxxxxxxx,
++        xxxxxxxxxxxx,
++        xxxxxxxxxxxx,
++        xxxxxxxxxxxx,
++        yyyyyyyyyyyy,
++    ]
++} ccccccc"
+ 
+ # Remove the parenthese because they aren't required
+ xxxxxxxxxxxxxxx = f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbb {
+-        xxxxxxxxxxx  # comment
+-        + yyyyyyyyyy
+-    } dddddddddd"
++    xxxxxxxxxxx  # comment
++    + yyyyyyyyyy
++} dddddddddd"
  
  # Comments
  
@@ -855,7 +1106,7 @@ f"{  # dangling comment 1
      # comment 4
  }"  # comment 5
  # comment 6
-@@ -170,24 +182,21 @@
+@@ -208,24 +224,21 @@
  # This is not a valid Python code because of the additional whitespace between the `!`
  # and conversion type. But, our parser isn't strict about this. This should probably be
  # removed once we have a strict parser.
@@ -887,7 +1138,7 @@ f"{  # dangling comment 1
  
  x = f"""
  {              # dangling comment 1
-@@ -196,19 +205,19 @@
+@@ -234,19 +247,19 @@
  
  # Here, the debug expression is in a nested f-string so we should start preserving
  # whitespaces from that point onwards. This means we should format the outer f-string.
@@ -915,6 +1166,41 @@ f"{  # dangling comment 1
      # dangling comment 2
      # dangling comment 3
  } woah {x}"
+@@ -260,19 +273,19 @@
+         if indent2:
+             foo = f"""hello world
+ hello {
+-          f"aaaaaaa {
+-              [
+-                  'aaaaaaaaaaaaaaaaaaaaa',
+-                  'bbbbbbbbbbbbbbbbbbbbb',
+-                  'ccccccccccccccccccccc',
+-                  'ddddddddddddddddddddd'
+-              ]
+-          } bbbbbbbb" +
+-          [
+-              'aaaaaaaaaaaaaaaaaaaaa',
+-              'bbbbbbbbbbbbbbbbbbbbb',
+-              'ccccccccccccccccccccc',
+-              'ddddddddddddddddddddd'
+-          ]
+-      } --------
++                f"aaaaaaa {
++                    [
++                        'aaaaaaaaaaaaaaaaaaaaa',
++                        'bbbbbbbbbbbbbbbbbbbbb',
++                        'ccccccccccccccccccccc',
++                        'ddddddddddddddddddddd',
++                    ]
++                } bbbbbbbb"
++                + [
++                    "aaaaaaaaaaaaaaaaaaaaa",
++                    "bbbbbbbbbbbbbbbbbbbbb",
++                    "ccccccccccccccccccccc",
++                    "ddddddddddddddddddddd",
++                ]
++            } --------
+ """
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -153,6 +153,16 @@ f"""test {"inner"}"""
 # But if the inner string is also triple-quoted then we should preserve the existing quotes.
 f"""test {'''inner'''}"""
 
+# Magic trailing comma
+#
+# The expression formatting will result in breaking it across multiple lines with a
+# trailing comma but as the expression isn't already broken, we will remove all the line
+# breaks which results in the trailing comma being present. This test case makes sure
+# that the trailing comma is removed as well.
+f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
+# And, if the trailing comma is already present, we still need to remove it.
+f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee',]} aaaaaaa"
+
 # Comments
 
 # No comments should be dropped!
@@ -388,6 +398,16 @@ f"""test {"inner"}"""
 # But if the inner string is also triple-quoted then we should preserve the existing quotes.
 f"""test {'''inner'''}"""
 
+# Magic trailing comma
+#
+# The expression formatting will result in breaking it across multiple lines with a
+# trailing comma but as the expression isn't already broken, we will remove all the line
+# breaks which results in the trailing comma being present. This test case makes sure
+# that the trailing comma is removed as well.
+f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
+# And, if the trailing comma is already present, we still need to remove it.
+f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
+
 # Comments
 
 # No comments should be dropped!
@@ -608,6 +628,16 @@ f"""test {"inner"}"""
 # But if the inner string is also triple-quoted then we should preserve the existing quotes.
 f"""test {'''inner'''}"""
 
+# Magic trailing comma
+#
+# The expression formatting will result in breaking it across multiple lines with a
+# trailing comma but as the expression isn't already broken, we will remove all the line
+# breaks which results in the trailing comma being present. This test case makes sure
+# that the trailing comma is removed as well.
+f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
+# And, if the trailing comma is already present, we still need to remove it.
+f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee',]} aaaaaaa"
+
 # Comments
 
 # No comments should be dropped!
@@ -787,7 +817,7 @@ f"{  # dangling comment 1
  x = f"{    # comment
      {'x': 1, 'y': 2} = }"
  
-@@ -135,22 +143,26 @@
+@@ -135,13 +143,17 @@
  }"
  # And, split the expression itself because it exceeds the line length.
  xxxxxxx = f"{
@@ -807,6 +837,13 @@ f"{  # dangling comment 1
  # But if the inner string is also triple-quoted then we should preserve the existing quotes.
  f"""test {'''inner'''}"""
  
+@@ -153,14 +165,14 @@
+ # that the trailing comma is removed as well.
+ f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
+ # And, if the trailing comma is already present, we still need to remove it.
+-f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee',]} aaaaaaa"
++f"aaaaaaa {['aaaaaaaaaaaaaaa', 'bbbbbbbbbbbbb', 'ccccccccccccccccc', 'ddddddddddddddd', 'eeeeeeeeeeeeee']} aaaaaaa"
+ 
  # Comments
  
  # No comments should be dropped!
@@ -818,7 +855,7 @@ f"{  # dangling comment 1
      # comment 4
  }"  # comment 5
  # comment 6
-@@ -160,24 +172,21 @@
+@@ -170,24 +182,21 @@
  # This is not a valid Python code because of the additional whitespace between the `!`
  # and conversion type. But, our parser isn't strict about this. This should probably be
  # removed once we have a strict parser.
@@ -850,7 +887,7 @@ f"{  # dangling comment 1
  
  x = f"""
  {              # dangling comment 1
-@@ -186,19 +195,19 @@
+@@ -196,19 +205,19 @@
  
  # Here, the debug expression is in a nested f-string so we should start preserving
  # whitespaces from that point onwards. This means we should format the outer f-string.

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -36,22 +36,22 @@ result_f = (
 # an expression inside a formatted value
 (
     f'{1}'
-    # comment
+    # comment 1
     ''
 )
 
 (
-    f'{1}'  # comment
+    f'{1}'  # comment 2
     f'{2}'
 )
 
 (
     f'{1}'
-    f'{2}'  # comment
+    f'{2}'  # comment 3
 )
 
 (
-    1, (  # comment
+    1, (  # comment 4
         f'{2}'
     )
 )
@@ -59,7 +59,7 @@ result_f = (
 (
     (
         f'{1}'
-        # comment
+        # comment 5
     ),
     2
 )
@@ -75,9 +75,9 @@ z = f'''a{""}b''' f'''c{1}d"""e'''
 x = f"{a}"
 x = f"{
     a = }"
-x = f"{ # comment
+x = f"{ # comment 6
     a }"
-x = f"{   # comment
+x = f"{   # comment 7
     a = }"
 
 # Remove the parentheses as adding them doesn't make then fit within the line length limit.
@@ -96,9 +96,9 @@ aaaaaaaaaaa = (
 # f-string exceeds the line length limit.
 x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
 x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
-x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 8
                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
-x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
 
 # Multiple larger expressions which exceeds the line length limit. Here, we need to decide
@@ -118,10 +118,10 @@ x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd
 
 # But, in case comments are present, we would split at the expression containing the
 # comments:
-x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb # comment
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb # comment 10
                     } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
 x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb
-                    } cccccccccccccccccccc { # comment
+                    } cccccccccccccccccccc { # comment 11
                                             ddddddddddddddd } eeeeeeeeeeeeee"
 
 # Here, the expression part itself starts with a curly brace so we need to add an extra
@@ -131,9 +131,9 @@ x = f"{ {'x': 1, 'y': 2} }"
 # consistency.
 x = f"{ {'x': 1, 'y': 2}}"
 x = f"{ {'x': 1, 'y': 2} = }"
-x = f"{  # comment
+x = f"{  # comment 12
     {'x': 1, 'y': 2} }"
-x = f"{    # comment
+x = f"{    # comment 13
     {'x': 1, 'y': 2} = }"
 
 # But, in this case, we would split the expression itself because it exceeds the line
@@ -198,7 +198,7 @@ f"aaaaaa {[
 # Remove the parenthese because they aren't required
 xxxxxxxxxxxxxxx = (
     f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbb {
-        xxxxxxxxxxx  # comment
+        xxxxxxxxxxx  # comment 14
         + yyyyyyyyyy
     } dddddddddd"
 )
@@ -206,12 +206,12 @@ xxxxxxxxxxxxxxx = (
 # Comments
 
 # No comments should be dropped!
-f"{ # comment 1
-    # comment 2
-    foo # comment 3
-    # comment 4
-}"  # comment 5
-# comment 6
+f"{ # comment 15
+    # comment 16
+    foo # comment 17
+    # comment 18
+}"  # comment 19
+# comment 20
 
 # Conversion flags
 #
@@ -234,31 +234,31 @@ x = f"{x   =   !  s
 # We'll format is as trailing comments.
 x = f"{x  !s
          :>0
-         # comment
+         # comment 21
          }"
 
 x = f"""
-{              # dangling comment 1
- x =   :.0{y # dangling comment 2
+{              # comment 22
+ x =   :.0{y # comment 23
            }f}"""
 
 # Here, the debug expression is in a nested f-string so we should start preserving
 # whitespaces from that point onwards. This means we should format the outer f-string.
-x = f"""{"foo " +    # comment 1
+x = f"""{"foo " +    # comment 24
     f"{   x =
 
-       }"    # comment 2
+       }"    # comment 25
  }
         """
 
 # Mix of various features.
-f"{  # dangling comment 1
+f"{  # comment 26
     foo # after foo
    :>{
           x # after x
           }
-    # dangling comment 2
-    # dangling comment 3
+    # comment 27
+    # comment 28
 } woah {x}"
 
 # Indentation
@@ -335,22 +335,22 @@ result_f = (
 # an expression inside a formatted value
 (
     f"{1}"
-    # comment
+    # comment 1
     ""
 )
 
 (
-    f"{1}"  # comment
+    f"{1}"  # comment 2
     f"{2}"
 )
 
 (
-    f"{1}" f"{2}"  # comment
+    f"{1}" f"{2}"  # comment 3
 )
 
 (
     1,
-    (  # comment
+    (  # comment 4
         f"{2}"
     ),
 )
@@ -358,7 +358,7 @@ result_f = (
 (
     (
         f"{1}"
-        # comment
+        # comment 5
     ),
     2,
 )
@@ -374,10 +374,10 @@ z = f"""a{""}b""" f'''c{1}d"""e'''
 x = f"{a}"
 x = f"{
     a = }"
-x = f"{  # comment
+x = f"{  # comment 6
     a
 }"
-x = f"{   # comment
+x = f"{   # comment 7
     a = }"
 
 # Remove the parentheses as adding them doesn't make then fit within the line length limit.
@@ -396,10 +396,10 @@ aaaaaaaaaaa = (
 # f-string exceeds the line length limit.
 x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {"bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"} ccccccccccccccc"
 x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
-x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {  # comment
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {  # comment 8
     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 } ccccccccccccccc"
-x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
 
 # Multiple larger expressions which exceeds the line length limit. Here, we need to decide
@@ -424,9 +424,9 @@ x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {
 # But, in case comments are present, we would split at the expression containing the
 # comments:
 x = f"aaaaaaaaaaaa {
-    bbbbbbbbbbbbbb  # comment
+    bbbbbbbbbbbbbb  # comment 10
 } cccccccccccccccccccc {ddddddddddddddd} eeeeeeeeeeeeee"
-x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {  # comment
+x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {  # comment 11
     ddddddddddddddd
 } eeeeeeeeeeeeee"
 
@@ -437,10 +437,10 @@ x = f"{ {'x': 1, 'y': 2} }"
 # consistency.
 x = f"{ {'x': 1, 'y': 2} }"
 x = f"{ {'x': 1, 'y': 2} = }"
-x = f"{  # comment
+x = f"{  # comment 12
     {'x': 1, 'y': 2}
 }"
-x = f"{    # comment
+x = f"{    # comment 13
     {'x': 1, 'y': 2} = }"
 
 # But, in this case, we would split the expression itself because it exceeds the line
@@ -512,19 +512,19 @@ f"aaaaaa {
 
 # Remove the parenthese because they aren't required
 xxxxxxxxxxxxxxx = f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbb {
-    xxxxxxxxxxx  # comment
+    xxxxxxxxxxx  # comment 14
     + yyyyyyyyyy
 } dddddddddd"
 
 # Comments
 
 # No comments should be dropped!
-f"{  # comment 1
-    # comment 2
-    foo  # comment 3
-    # comment 4
-}"  # comment 5
-# comment 6
+f"{  # comment 15
+    # comment 16
+    foo  # comment 17
+    # comment 18
+}"  # comment 19
+# comment 20
 
 # Conversion flags
 #
@@ -544,31 +544,31 @@ x = f"{x   =   !s:>0}"
 # We'll format is as trailing comments.
 x = f"{
     x!s:>0
-    # comment
+    # comment 21
 }"
 
 x = f"""
-{              # dangling comment 1
- x =   :.0{y # dangling comment 2
+{              # comment 22
+ x =   :.0{y # comment 23
            }f}"""
 
 # Here, the debug expression is in a nested f-string so we should start preserving
 # whitespaces from that point onwards. This means we should format the outer f-string.
 x = f"""{
-    "foo "  # comment 1
+    "foo "  # comment 24
     + f"{   x =
 
-       }"  # comment 2
+       }"  # comment 25
 }
         """
 
 # Mix of various features.
-f"{  # dangling comment 1
+f"{  # comment 26
     foo:>{  # after foo
         x  # after x
     }
-    # dangling comment 2
-    # dangling comment 3
+    # comment 27
+    # comment 28
 } woah {x}"
 
 # Indentation
@@ -645,22 +645,22 @@ result_f = (
 # an expression inside a formatted value
 (
     f"{1}"
-    # comment
+    # comment 1
     ""
 )
 
 (
-    f"{1}"  # comment
+    f"{1}"  # comment 2
     f"{2}"
 )
 
 (
-    f"{1}" f"{2}"  # comment
+    f"{1}" f"{2}"  # comment 3
 )
 
 (
     1,
-    (  # comment
+    (  # comment 4
         f"{2}"
     ),
 )
@@ -668,7 +668,7 @@ result_f = (
 (
     (
         f"{1}"
-        # comment
+        # comment 5
     ),
     2,
 )
@@ -684,9 +684,9 @@ z = f"""a{""}b""" f'''c{1}d"""e'''
 x = f"{a}"
 x = f"{
     a = }"
-x = f"{ # comment
+x = f"{ # comment 6
     a }"
-x = f"{   # comment
+x = f"{   # comment 7
     a = }"
 
 # Remove the parentheses as adding them doesn't make then fit within the line length limit.
@@ -705,9 +705,9 @@ aaaaaaaaaaa = (
 # f-string exceeds the line length limit.
 x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
 x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
-x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 8
                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
-x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
                                              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
 
 # Multiple larger expressions which exceeds the line length limit. Here, we need to decide
@@ -727,10 +727,10 @@ x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb } cccccccccccccccccccc { ddddddddddddddd
 
 # But, in case comments are present, we would split at the expression containing the
 # comments:
-x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb # comment
+x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb # comment 10
                     } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
 x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb
-                    } cccccccccccccccccccc { # comment
+                    } cccccccccccccccccccc { # comment 11
                                             ddddddddddddddd } eeeeeeeeeeeeee"
 
 # Here, the expression part itself starts with a curly brace so we need to add an extra
@@ -740,9 +740,9 @@ x = f"{ {'x': 1, 'y': 2} }"
 # consistency.
 x = f"{ {'x': 1, 'y': 2}}"
 x = f"{ {'x': 1, 'y': 2} = }"
-x = f"{  # comment
+x = f"{  # comment 12
     {'x': 1, 'y': 2} }"
-x = f"{    # comment
+x = f"{    # comment 13
     {'x': 1, 'y': 2} = }"
 
 # But, in this case, we would split the expression itself because it exceeds the line
@@ -806,19 +806,19 @@ f"aaaaaa {[
 
 # Remove the parenthese because they aren't required
 xxxxxxxxxxxxxxx = f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbb {
-        xxxxxxxxxxx  # comment
+        xxxxxxxxxxx  # comment 14
         + yyyyyyyyyy
     } dddddddddd"
 
 # Comments
 
 # No comments should be dropped!
-f"{ # comment 1
-    # comment 2
-    foo # comment 3
-    # comment 4
-}"  # comment 5
-# comment 6
+f"{ # comment 15
+    # comment 16
+    foo # comment 17
+    # comment 18
+}"  # comment 19
+# comment 20
 
 # Conversion flags
 #
@@ -841,31 +841,31 @@ x = f"{x   =   !  s
 # We'll format is as trailing comments.
 x = f"{x  !s
          :>0
-         # comment
+         # comment 21
          }"
 
 x = f"""
-{              # dangling comment 1
- x =   :.0{y # dangling comment 2
+{              # comment 22
+ x =   :.0{y # comment 23
            }f}"""
 
 # Here, the debug expression is in a nested f-string so we should start preserving
 # whitespaces from that point onwards. This means we should format the outer f-string.
-x = f"""{"foo " +    # comment 1
+x = f"""{"foo " +    # comment 24
     f"{   x =
 
-       }"    # comment 2
+       }"    # comment 25
  }
         """
 
 # Mix of various features.
-f"{  # dangling comment 1
+f"{  # comment 26
     foo # after foo
    :>{
           x # after x
           }
-    # dangling comment 2
-    # dangling comment 3
+    # comment 27
+    # comment 28
 } woah {x}"
 
 # Indentation
@@ -922,12 +922,12 @@ hello {
  x = f"{a}"
  x = f"{
      a = }"
--x = f"{ # comment
+-x = f"{ # comment 6
 -    a }"
-+x = f"{  # comment
++x = f"{  # comment 6
 +    a
 +}"
- x = f"{   # comment
+ x = f"{   # comment 7
      a = }"
  
  # Remove the parentheses as adding them doesn't make then fit within the line length limit.
@@ -950,12 +950,12 @@ hello {
 -x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
 +x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {"bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"} ccccccccccccccc"
  x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
--x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+-x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 8
 -                                             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } ccccccccccccccc"
-+x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {  # comment
++x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {  # comment 8
 +    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 +} ccccccccccccccc"
- x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment
+ x = f"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa { # comment 9
                                               "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb" = } ccccccccccccccc"
  
  # Multiple larger expressions which exceeds the line length limit. Here, we need to decide
@@ -988,15 +988,15 @@ hello {
  
  # But, in case comments are present, we would split at the expression containing the
  # comments:
--x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb # comment
+-x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb # comment 10
 -                    } cccccccccccccccccccc { ddddddddddddddd } eeeeeeeeeeeeee"
 -x = f"aaaaaaaaaaaa { bbbbbbbbbbbbbb
--                    } cccccccccccccccccccc { # comment
+-                    } cccccccccccccccccccc { # comment 11
 -                                            ddddddddddddddd } eeeeeeeeeeeeee"
 +x = f"aaaaaaaaaaaa {
-+    bbbbbbbbbbbbbb  # comment
++    bbbbbbbbbbbbbb  # comment 10
 +} cccccccccccccccccccc {ddddddddddddddd} eeeeeeeeeeeeee"
-+x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {  # comment
++x = f"aaaaaaaaaaaa {bbbbbbbbbbbbbb} cccccccccccccccccccc {  # comment 11
 +    ddddddddddddddd
 +} eeeeeeeeeeeeee"
  
@@ -1008,11 +1008,11 @@ hello {
 -x = f"{ {'x': 1, 'y': 2}}"
 +x = f"{ {'x': 1, 'y': 2} }"
  x = f"{ {'x': 1, 'y': 2} = }"
- x = f"{  # comment
+ x = f"{  # comment 12
 -    {'x': 1, 'y': 2} }"
 +    {'x': 1, 'y': 2}
 +}"
- x = f"{    # comment
+ x = f"{    # comment 13
      {'x': 1, 'y': 2} = }"
  
 @@ -135,7 +143,11 @@
@@ -1088,24 +1088,24 @@ hello {
  
  # Remove the parenthese because they aren't required
  xxxxxxxxxxxxxxx = f"aaaaaaaaaaaaaaaa bbbbbbbbbbbbbbb {
--        xxxxxxxxxxx  # comment
+-        xxxxxxxxxxx  # comment 14
 -        + yyyyyyyyyy
 -    } dddddddddd"
-+    xxxxxxxxxxx  # comment
++    xxxxxxxxxxx  # comment 14
 +    + yyyyyyyyyy
 +} dddddddddd"
  
  # Comments
  
  # No comments should be dropped!
--f"{ # comment 1
-+f"{  # comment 1
-     # comment 2
--    foo # comment 3
-+    foo  # comment 3
-     # comment 4
- }"  # comment 5
- # comment 6
+-f"{ # comment 15
++f"{  # comment 15
+     # comment 16
+-    foo # comment 17
++    foo  # comment 17
+     # comment 18
+ }"  # comment 19
+ # comment 20
 @@ -208,24 +224,21 @@
  # This is not a valid Python code because of the additional whitespace between the `!`
  # and conversion type. But, our parser isn't strict about this. This should probably be
@@ -1129,33 +1129,33 @@ hello {
  # We'll format is as trailing comments.
 -x = f"{x  !s
 -         :>0
--         # comment
+-         # comment 21
 -         }"
 +x = f"{
 +    x!s:>0
-+    # comment
++    # comment 21
 +}"
  
  x = f"""
- {              # dangling comment 1
+ {              # comment 22
 @@ -234,19 +247,19 @@
  
  # Here, the debug expression is in a nested f-string so we should start preserving
  # whitespaces from that point onwards. This means we should format the outer f-string.
--x = f"""{"foo " +    # comment 1
+-x = f"""{"foo " +    # comment 24
 -    f"{   x =
 +x = f"""{
-+    "foo "  # comment 1
++    "foo "  # comment 24
 +    + f"{   x =
  
--       }"    # comment 2
+-       }"    # comment 25
 - }
-+       }"  # comment 2
++       }"  # comment 25
 +}
          """
  
  # Mix of various features.
- f"{  # dangling comment 1
+ f"{  # comment 26
 -    foo # after foo
 -   :>{
 -          x # after x
@@ -1163,8 +1163,8 @@ hello {
 +    foo:>{  # after foo
 +        x  # after x
 +    }
-     # dangling comment 2
-     # dangling comment 3
+     # comment 27
+     # comment 28
  } woah {x}"
 @@ -260,19 +273,19 @@
          if indent2:

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring_py312.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring_py312.py.snap
@@ -1,0 +1,54 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring_py312.py
+---
+## Input
+```python
+# This file contains test cases only for cases where the logic tests for whether
+# the target version is 3.12 or later. A user can have 3.12 syntax even if the target
+# version isn't set.
+
+# Quotes re-use
+f"{'a'}"
+```
+
+## Outputs
+### Output 1
+```
+indent-style               = space
+line-width                 = 88
+indent-width               = 4
+quote-style                = Double
+line-ending                = LineFeed
+magic-trailing-comma       = Respect
+docstring-code             = Disabled
+docstring-code-line-width  = "dynamic"
+preview                    = Disabled
+target_version             = Py312
+source_type                = Python
+```
+
+```python
+# This file contains test cases only for cases where the logic tests for whether
+# the target version is 3.12 or later. A user can have 3.12 syntax even if the target
+# version isn't set.
+
+# Quotes re-use
+f"{'a'}"
+```
+
+
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -3,4 +3,4 @@
+ # version isn't set.
+ 
+ # Quotes re-use
+-f"{'a'}"
++f"{"a"}"
+```
+
+
+


### PR DESCRIPTION
## Summary

_This is preview only feature and is available using the `--preview` command-line flag._

With the implementation of [PEP 701] in Python 3.12, f-strings can now be broken into multiple lines, can contain comments, and can re-use the same quote character. Currently, no other Python formatter formats the f-strings so there's some discussion which needs to happen in defining the style used for f-string formatting. Relevant discussion: https://github.com/astral-sh/ruff/discussions/9785

The goal for this PR is to add minimal support for f-string formatting. This would be to format expression within the replacement field without introducing any major style changes.

### Newlines

The heuristics for adding newline is similar to that of [Prettier](https://prettier.io/docs/en/next/rationale.html#template-literals) where the formatter would only split an expression in the replacement field across multiple lines if there was already a line break within the replacement field.

In other words, the formatter would not add any newlines unless they were already present i.e., they were added by the user. This makes breaking any expression inside an f-string optional and in control of the user. For example,

```python
# We wouldn't break this
aaaaaaaaaaa = f"asaaaaaaaaaaaaaaaa { aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc } cccccccccc"

# But, we would break the following as there's already a newline
aaaaaaaaaaa = f"asaaaaaaaaaaaaaaaa {
	aaaaaaaaaaaa + bbbbbbbbbbbb + ccccccccccccccc } cccccccccc"
```


If there are comments in any of the replacement field of the f-string, then it will always be a multi-line f-string in which case the formatter would prefer to break expressions i.e., introduce newlines. For example,

```python
x = f"{ # comment
    a }"
```

### Quotes

The logic for formatting quotes remains unchanged. The existing logic is used to determine the necessary quote char and is used accordingly.

Now, if the expression inside an f-string is itself a string like, then we need to make sure to preserve the existing quote and not change it to the preferred quote unless it's 3.12. For example,

```python
f"outer {'inner'} outer"

# For pre 3.12, preserve the single quote
f"outer {'inner'} outer"

# While for 3.12 and later, the quotes can be changed
f"outer {"inner"} outer"
```

But, for triple-quoted strings, we can re-use the same quote char unless the inner string is itself a triple-quoted string.

```python
f"""outer {"inner"} outer"""  # valid
f"""outer {'''inner'''} outer"""  # preserve the single quote char for the inner string
```

### Debug expressions

If debug expressions are present in the replacement field of a f-string, then the whitespace needs to be preserved as they will be rendered as it is (for example, `f"{  x  = }"`. If there are any nested f-strings, then the whitespace in them needs to be preserved as well which means that we'll stop formatting the f-string as soon as we encounter a debug expression.

```python
f"outer {   x =  !s  :.3f}"
#                  ^^
#                  We can remove these whitespaces
```

Now, the whitespace doesn't need to be preserved around conversion spec and format specifiers, so we'll format them as usual but we won't be formatting any nested f-string within the format specifier.

### Miscellaneous

- The [`hug_parens_with_braces_and_square_brackets`](https://github.com/astral-sh/ruff/issues/8279) preview style isn't implemented w.r.t. the f-string curly braces.
- The [indentation](https://github.com/astral-sh/ruff/discussions/9785#discussioncomment-8470590) is always relative to the f-string containing statement

## Test Plan

* Add new test cases
* Review existing snapshot changes
* Review the ecosystem changes

[PEP 701]: https://peps.python.org/pep-0701/
