### PR TITLE
Delete `is_node_with_body` method

### DIFF
--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -5968,22 +5968,6 @@ impl<'a> AnyNodeRef<'a> {
         }
     }
 
-    pub const fn is_node_with_body(self) -> bool {
-        matches!(
-            self,
-            AnyNodeRef::StmtIf(_)
-                | AnyNodeRef::StmtFor(_)
-                | AnyNodeRef::StmtWhile(_)
-                | AnyNodeRef::StmtWith(_)
-                | AnyNodeRef::StmtMatch(_)
-                | AnyNodeRef::StmtFunctionDef(_)
-                | AnyNodeRef::StmtClassDef(_)
-                | AnyNodeRef::StmtTry(_)
-                | AnyNodeRef::ExceptHandlerExceptHandler(_)
-                | AnyNodeRef::ElifElseClause(_)
-        )
-    }
-
     /// In our AST, only some alternative branches are represented as a node. This has historical
     /// reasons, e.g. we added a node for elif/else in if statements which was not originally
     /// present in the parser.


### PR DESCRIPTION
## Summary

I noticed that the `is_node_with_body` function returns false for `WithItem` and `MatchCase` which looks like a bug. 

I searched for where the function is used to add tests showing that returning `true` for these two nodes has the desired result and noticed the function isn't used. 

This PR removes the unused function.

## Test Plan

`cargo build`
