### PR TITLE
Avoid rendering display-only rules as fixable

### DIFF
--- a/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
+++ b/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
+use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_index::Indexer;
 use ruff_source_file::Locator;
@@ -30,14 +30,16 @@ use super::super::detection::comment_contains_code;
 #[violation]
 pub struct CommentedOutCode;
 
-impl AlwaysFixableViolation for CommentedOutCode {
+impl Violation for CommentedOutCode {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("Found commented-out code")
     }
 
-    fn fix_title(&self) -> String {
-        "Remove commented-out code".to_string()
+    fn fix_title(&self) -> Option<String> {
+        Some(format!("Remove commented-out code"))
     }
 }
 
@@ -65,7 +67,6 @@ pub(crate) fn commented_out_code(
         // Verify that the comment is on its own line, and that it contains code.
         if is_standalone_comment(line) && comment_contains_code(line, &settings.task_tags[..]) {
             let mut diagnostic = Diagnostic::new(CommentedOutCode, *range);
-
             diagnostic.set_fix(Fix::display_only_edit(Edit::range_deletion(
                 locator.full_lines_range(*range),
             )));

--- a/crates/ruff_linter/src/test.rs
+++ b/crates/ruff_linter/src/test.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
 
-use ruff_diagnostics::{Diagnostic, FixAvailability};
+use ruff_diagnostics::{Applicability, Diagnostic, FixAvailability};
 use ruff_python_ast::PySourceType;
 use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;
@@ -241,7 +241,7 @@ Source with applied fixes:
         .into_iter()
         .map(|diagnostic| {
             let rule = diagnostic.kind.rule();
-            let fixable = diagnostic.fix.is_some();
+            let fixable = diagnostic.fix.as_ref().is_some_and(|fix| matches!(fix.applicability(), Applicability::Safe | Applicability::Unsafe));
 
             match (fixable, rule.fixable()) {
                 (true, FixAvailability::Sometimes | FixAvailability::Always)


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/9505.

The `ERA` rule is no longer marked as fixable:

![Screenshot 2024-01-26 at 9 17 48 AM](https://github.com/astral-sh/ruff/assets/1309177/fdc6217f-38ff-4098-b6ca-37ff51b710ab)
