### PR TITLE
[`flake8-pie`] Omit bound tuples passed to `.startswith` or `.endswith`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE810.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE810.py
@@ -9,6 +9,22 @@ obj.startswith(foo) or obj.startswith("foo")
 # error
 obj.endswith(foo) or obj.startswith(foo) or obj.startswith("foo")
 
+def func():
+    msg = "hello world"
+
+    x = "h"
+    y = ("h", "e", "l", "l", "o")  
+    z = "w"
+
+    if msg.startswith(x) or msg.startswith(y) or msg.startswith(z): # Error
+        print("yes") 
+
+def func():
+    msg = "hello world"
+
+    if msg.startswith(("h", "e", "l", "l", "o")) or msg.startswith("h") or msg.startswith("w"): # Error
+        print("yes") 
+
 # ok
 obj.startswith(("foo",  "bar"))
 # ok
@@ -17,3 +33,46 @@ obj.endswith(("foo",  "bar"))
 obj.startswith("foo") or obj.endswith("bar")
 # ok
 obj.startswith("foo") or abc.startswith("bar")
+
+def func():
+    msg = "hello world"
+
+    x = "h"
+    y = ("h", "e", "l", "l", "o")  
+
+    if msg.startswith(x) or msg.startswith(y): # OK
+        print("yes") 
+
+def func():
+    msg = "hello world"
+
+    y = ("h", "e", "l", "l", "o")  
+
+    if msg.startswith(y): # OK
+        print("yes") 
+
+def func():
+    msg = "hello world"
+
+    y = ("h", "e", "l", "l", "o")  
+
+    if msg.startswith(y) or msg.startswith(y): # OK
+        print("yes") 
+
+def func():
+    msg = "hello world"
+
+    y = ("h", "e", "l", "l", "o")  
+    x = ("w", "o", "r", "l", "d")
+
+    if msg.startswith(y) or msg.startswith(x) or msg.startswith("h"): # OK
+        print("yes") 
+
+def func():
+    msg = "hello world"
+
+    y = ("h", "e", "l", "l", "o")  
+    x = ("w", "o", "r", "l", "d")
+
+    if msg.startswith(y) or msg.endswith(x) or msg.startswith("h"): # OK
+        print("yes")

--- a/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE810_PIE810.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE810_PIE810.py.snap
@@ -89,7 +89,7 @@ PIE810.py:10:1: PIE810 [*] Call `startswith` once with a `tuple`
 10 | obj.endswith(foo) or obj.startswith(foo) or obj.startswith("foo")
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PIE810
 11 | 
-12 | # ok
+12 | def func():
    |
    = help: Merge into a single `startswith` call
 
@@ -100,7 +100,47 @@ PIE810.py:10:1: PIE810 [*] Call `startswith` once with a `tuple`
 10    |-obj.endswith(foo) or obj.startswith(foo) or obj.startswith("foo")
    10 |+obj.endswith(foo) or obj.startswith((foo, "foo"))
 11 11 | 
-12 12 | # ok
-13 13 | obj.startswith(("foo",  "bar"))
+12 12 | def func():
+13 13 |     msg = "hello world"
+
+PIE810.py:19:8: PIE810 [*] Call `startswith` once with a `tuple`
+   |
+17 |     z = "w"
+18 | 
+19 |     if msg.startswith(x) or msg.startswith(y) or msg.startswith(z): # Error
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PIE810
+20 |         print("yes") 
+   |
+   = help: Merge into a single `startswith` call
+
+ℹ Unsafe fix
+16 16 |     y = ("h", "e", "l", "l", "o")  
+17 17 |     z = "w"
+18 18 | 
+19    |-    if msg.startswith(x) or msg.startswith(y) or msg.startswith(z): # Error
+   19 |+    if msg.startswith((x, z)) or msg.startswith(y): # Error
+20 20 |         print("yes") 
+21 21 | 
+22 22 | def func():
+
+PIE810.py:25:8: PIE810 [*] Call `startswith` once with a `tuple`
+   |
+23 |     msg = "hello world"
+24 | 
+25 |     if msg.startswith(("h", "e", "l", "l", "o")) or msg.startswith("h") or msg.startswith("w"): # Error
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PIE810
+26 |         print("yes") 
+   |
+   = help: Merge into a single `startswith` call
+
+ℹ Unsafe fix
+22 22 | def func():
+23 23 |     msg = "hello world"
+24 24 | 
+25    |-    if msg.startswith(("h", "e", "l", "l", "o")) or msg.startswith("h") or msg.startswith("w"): # Error
+   25 |+    if msg.startswith(("h", "e", "l", "l", "o")) or msg.startswith(("h", "w")): # Error
+26 26 |         print("yes") 
+27 27 | 
+28 28 | # ok
 
 

--- a/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE810_PIE810.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pie/snapshots/ruff_linter__rules__flake8_pie__tests__PIE810_PIE810.py.snap
@@ -138,7 +138,7 @@ PIE810.py:25:8: PIE810 [*] Call `startswith` once with a `tuple`
 23 23 |     msg = "hello world"
 24 24 | 
 25    |-    if msg.startswith(("h", "e", "l", "l", "o")) or msg.startswith("h") or msg.startswith("w"): # Error
-   25 |+    if msg.startswith(("h", "e", "l", "l", "o")) or msg.startswith(("h", "w")): # Error
+   25 |+    if msg.startswith(("h", "e", "l", "l", "o", "h", "w")): # Error
 26 26 |         print("yes") 
 27 27 | 
 28 28 | # ok


### PR DESCRIPTION
## Summary

This review contains a fix for [PIE810](https://docs.astral.sh/ruff/rules/multiple-starts-ends-with/) (multiple-starts-ends-with)

The problem is that ruff suggests combining multiple startswith/endswith calls into a single call even though there might be a call with tuple of strs. This leads to calling startswith/endswith with tuple of tuple of strs which is incorrect and violates startswith/endswith conctract and results in runtime failure.

However the following will be valid and fixed correctly => 
```python
x = ("hello", "world")
y = "h"
z = "w"
msg = "hello world"

if msg.startswith(x) or msg.startswith(y) or msg.startswith(z) :
      sys.exit(1)
```
```
ruff --fix --select PIE810 --unsafe-fixes
```
=> 
```python
if msg.startswith(x) or msg.startswith((y,z)):
      sys.exit(1)
```

See: https://github.com/astral-sh/ruff/issues/8906

## Test Plan

```bash
cargo test
```
