### PR TITLE
SIM108: preserve quoting style in autofixes; don't flag `if`/`else` blocks where the `if`-statement spans multiple lines

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM108.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM108.py
@@ -143,3 +143,34 @@ if TYPE_CHECKING:
     x = 3
 else:
     x = 5
+
+
+# OK (line breaks in the if-value)
+if link:
+    response = problem(
+        status=exception.status,
+        title=exception.title,
+        detail=exception.detail,
+        type=link,
+        instance=exception.instance,
+        headers=exception.headers,
+        ext=exception.ext,
+    )
+else:
+    response = 42
+
+
+# OK (line breaks in the else-value)
+
+if link:
+    response = 42
+else:
+    response = problem(
+        status=exception.status,
+        title=exception.title,
+        detail=exception.detail,
+        type=link,
+        instance=exception.instance,
+        headers=exception.headers,
+        ext=exception.ext,
+    )

--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM108.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM108.py
@@ -120,6 +120,14 @@ else:
     x = 5
 
 
+# SIM108
+# quoting style should be preserved here in the autofix:
+if 1:
+    a = f"# {"".join([])}"
+else:
+    a = ""
+
+
 # OK
 def f():
     if True:

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_if_exp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_if_exp.rs
@@ -111,6 +111,17 @@ pub(crate) fn if_else_block_instead_of_if_exp(checker: &mut Checker, stmt_if: &a
         return;
     }
 
+    let locator = checker.locator();
+
+    // If the original expression has a line break
+    // in either the "if-value" or the "else-value",
+    // don't suggest to turn it into a ternary expression
+    if locator.contains_line_break(body_value.range())
+        || locator.contains_line_break(else_value.range())
+    {
+        return;
+    }
+
     // Avoid suggesting ternary for `if sys.version_info >= ...`-style checks.
     if is_sys_version_block(stmt_if, checker.semantic()) {
         return;
@@ -120,8 +131,6 @@ pub(crate) fn if_else_block_instead_of_if_exp(checker: &mut Checker, stmt_if: &a
     if is_type_checking_block(stmt_if, checker.semantic()) {
         return;
     }
-
-    let locator = checker.locator();
 
     let possible_replacement = format!(
         "{} = {} if {} else {}",

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM108_SIM108.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM108_SIM108.py.snap
@@ -119,4 +119,29 @@ SIM108.py:117:1: SIM108 Use ternary operator `x = 3 if True else 5` instead of `
     |
     = help: Replace `if`-`else`-block with `x = 3 if True else 5`
 
+SIM108.py:125:1: SIM108 [*] Use ternary operator `a = f"# {"".join([])}" if 1 else ""` instead of `if`-`else`-block
+    |
+123 |   # SIM108
+124 |   # quoting style should be preserved here in the autofix:
+125 | / if 1:
+126 | |     a = f"# {"".join([])}"
+127 | | else:
+128 | |     a = ""
+    | |__________^ SIM108
+    |
+    = help: Replace `if`-`else`-block with `a = f"# {"".join([])}" if 1 else ""`
+
+ℹ Unsafe fix
+122 122 | 
+123 123 | # SIM108
+124 124 | # quoting style should be preserved here in the autofix:
+125     |-if 1:
+126     |-    a = f"# {"".join([])}"
+127     |-else:
+128     |-    a = ""
+    125 |+a = f"# {"".join([])}" if 1 else ""
+129 126 | 
+130 127 | 
+131 128 | # OK
+
 


### PR DESCRIPTION
Fixes #9660. Instead of using the expression generator, copy and paste the source-code expression exactly as it is.