### PR TITLE
Set source type: Stub for black tests with options

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/nested_stub.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/nested_stub.options.json
@@ -1,1 +1,1 @@
-{"preview": "enabled"}
+{"preview": "enabled", "source_type": "Stub"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_dict_values.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_dict_values.py
@@ -34,3 +34,23 @@ my_dict = {
                                     }))))
             }),
 }
+
+
+class Random:
+    def func():
+        random_service.status.active_states.inactive = (
+            make_new_top_level_state_from_dict(
+                {
+                    "topLevelBase": {
+                        "secondaryBase": {
+                            "timestamp": 1234,
+                            "latitude": 1,
+                            "longitude": 2,
+                            "actionTimestamp": Timestamp(
+                                seconds=1530584000, nanos=0
+                            ).ToJsonString(),
+                        }
+                    },
+                }
+            )
+        )

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_dict_values.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/preview_long_dict_values.py.expect
@@ -47,3 +47,21 @@ my_dict = {
         }
     ),
 }
+
+
+class Random:
+    def func():
+        random_service.status.active_states.inactive = (
+            make_new_top_level_state_from_dict({
+                "topLevelBase": {
+                    "secondaryBase": {
+                        "timestamp": 1234,
+                        "latitude": 1,
+                        "longitude": 2,
+                        "actionTimestamp": (
+                            Timestamp(seconds=1530584000, nanos=0).ToJsonString()
+                        ),
+                    }
+                },
+            })
+        )

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/walrus_in_dict.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/walrus_in_dict.options.json
@@ -1,0 +1,1 @@
+{"preview": "enabled"}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/walrus_in_dict.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/walrus_in_dict.py
@@ -1,0 +1,3 @@
+{
+    "is_update": (up := commit.hash in update_hashes)
+}

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/cases/walrus_in_dict.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/cases/walrus_in_dict.py.expect
@@ -1,0 +1,1 @@
+{"is_update": (up := commit.hash in update_hashes)}

--- a/crates/ruff_python_formatter/resources/test/fixtures/import_black_tests.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/import_black_tests.py
@@ -68,6 +68,9 @@ def import_fixture(fixture: Path, fixture_set: str):
         options_path = fixture_path.with_suffix(".options.json")
 
         if len(options) > 0:
+            if extension == "pyi":
+                options["source_type"] = "Stub"
+
             with options_path.open("w") as options_file:
                 json.dump(options, options_file)
         elif os.path.exists(options_path):

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__nested_stub.pyi.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__nested_stub.pyi.snap
@@ -42,51 +42,39 @@ class TopLevel:
 ```diff
 --- Black
 +++ Ruff
-@@ -1,7 +1,9 @@
- import sys
- 
-+
+@@ -3,33 +3,27 @@
  class Outer:
      class InnerStub: ...
-+
      outer_attr_after_inner_stub: int
- 
+-
      class Inner:
-@@ -9,27 +11,35 @@
- 
+         inner_attr: int
+-
      outer_attr: int
  
-+
  if sys.version_info > (3, 7):
      if sys.platform == "win32":
          assignment = 1
-+
          def function_definition(self): ...
- 
+-
      def f1(self) -> str: ...
-+
      if sys.platform != "win32":
-+
          def function_definition(self): ...
-+
          assignment = 1
- 
+-
      def f2(self) -> str: ...
  
-+
  class TopLevel:
      class Nested1:
          foo: int
-+
          def bar(self): ...
- 
+-
      field = 1
  
      class Nested2:
          def bar(self): ...
-+
          foo: int
- 
+-
      field = 1
 ```
 
@@ -95,48 +83,32 @@ class TopLevel:
 ```python
 import sys
 
-
 class Outer:
     class InnerStub: ...
-
     outer_attr_after_inner_stub: int
-
     class Inner:
         inner_attr: int
-
     outer_attr: int
-
 
 if sys.version_info > (3, 7):
     if sys.platform == "win32":
         assignment = 1
-
         def function_definition(self): ...
-
     def f1(self) -> str: ...
-
     if sys.platform != "win32":
-
         def function_definition(self): ...
-
         assignment = 1
-
     def f2(self) -> str: ...
-
 
 class TopLevel:
     class Nested1:
         foo: int
-
         def bar(self): ...
-
     field = 1
 
     class Nested2:
         def bar(self): ...
-
         foo: int
-
     field = 1
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_dict_values.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/black_compatibility@cases__preview_long_dict_values.py.snap
@@ -41,6 +41,26 @@ my_dict = {
                                     }))))
             }),
 }
+
+
+class Random:
+    def func():
+        random_service.status.active_states.inactive = (
+            make_new_top_level_state_from_dict(
+                {
+                    "topLevelBase": {
+                        "secondaryBase": {
+                            "timestamp": 1234,
+                            "latitude": 1,
+                            "longitude": 2,
+                            "actionTimestamp": Timestamp(
+                                seconds=1530584000, nanos=0
+                            ).ToJsonString(),
+                        }
+                    },
+                }
+            )
+        )
 ```
 
 ## Black Differences
@@ -94,6 +114,19 @@ my_dict = {
  }
  
  {
+@@ -58,9 +52,9 @@
+                         "timestamp": 1234,
+                         "latitude": 1,
+                         "longitude": 2,
+-                        "actionTimestamp": (
+-                            Timestamp(seconds=1530584000, nanos=0).ToJsonString()
+-                        ),
++                        "actionTimestamp": Timestamp(
++                            seconds=1530584000, nanos=0
++                        ).ToJsonString(),
+                     }
+                 },
+             })
 ```
 
 ## Ruff Output
@@ -142,6 +175,24 @@ my_dict = {
         }
     ),
 }
+
+
+class Random:
+    def func():
+        random_service.status.active_states.inactive = (
+            make_new_top_level_state_from_dict({
+                "topLevelBase": {
+                    "secondaryBase": {
+                        "timestamp": 1234,
+                        "latitude": 1,
+                        "longitude": 2,
+                        "actionTimestamp": Timestamp(
+                            seconds=1530584000, nanos=0
+                        ).ToJsonString(),
+                    }
+                },
+            })
+        )
 ```
 
 ## Black Output
@@ -196,6 +247,24 @@ my_dict = {
         }
     ),
 }
+
+
+class Random:
+    def func():
+        random_service.status.active_states.inactive = (
+            make_new_top_level_state_from_dict({
+                "topLevelBase": {
+                    "secondaryBase": {
+                        "timestamp": 1234,
+                        "latitude": 1,
+                        "longitude": 2,
+                        "actionTimestamp": (
+                            Timestamp(seconds=1530584000, nanos=0).ToJsonString()
+                        ),
+                    }
+                },
+            })
+        )
 ```
 
 


### PR DESCRIPTION
## Summary

Set the `source_type` for black tests with options to `Stub` to ensure they run as stubs and not normal Python files.

## Test Plan

`nested_stub.pyi` now shows a diff
