### PR TITLE
[`pycodestyle`] Allow `dtype` comparisons in `type-comparison`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E721.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E721.py
@@ -126,3 +126,15 @@ class Foo:
         # Okay
         if type(value) is str:
             ...
+
+
+import numpy as np
+
+#: Okay
+x.dtype == float
+
+#: Okay
+np.dtype(int) == float
+
+#: E721
+dtype == float

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__E721_E721.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__E721_E721.py.snap
@@ -129,4 +129,11 @@ E721.py:59:4: E721 Use `is` and `is not` for type comparisons, or `isinstance()`
 61 | #: Okay
    |
 
+E721.py:140:1: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
+    |
+139 | #: E721
+140 | dtype == float
+    | ^^^^^^^^^^^^^^ E721
+    |
+
 


### PR DESCRIPTION
## Summary

Per https://github.com/astral-sh/ruff/issues/9570:

> `dtype` are a bit of a strange beast, but definitely best thought of as instances, not classes, and they are meant to be comparable not just to their own class, but also to the corresponding scalar types (e.g., `x.dtype == np.float32`) and strings (e.g., `x.dtype == ['i1,i4']`; basically, `__eq__` always tries to do `dtype(other)`.

This PR thus allows comparisons to `dtype` in preview.

Closes https://github.com/astral-sh/ruff/issues/9570.

## Test Plan

`cargo test`
