### PR TITLE
[`flake8-pyi`] Mark `unaliased-collections-abc-set-import` fix as safe

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unaliased_collections_abc_set_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unaliased_collections_abc_set_import.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{Diagnostic, Fix, FixAvailability, Violation};
+use ruff_diagnostics::{Applicability, Diagnostic, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_semantic::Imported;
 use ruff_python_semantic::{Binding, BindingKind};
@@ -29,6 +29,12 @@ use crate::renamer::Renamer;
 /// ```python
 /// from collections.abc import Set as AbstractSet
 /// ```
+///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe for `Set` imports defined at the
+/// top-level of a module. Top-level symbols are implicitly exported by the
+/// module, and so renaming a top-level symbol may break downstream modules
+/// that import it.
 #[violation]
 pub struct UnaliasedCollectionsAbcSetImport;
 
@@ -69,7 +75,15 @@ pub(crate) fn unaliased_collections_abc_set_import(
         diagnostic.try_set_fix(|| {
             let scope = &checker.semantic().scopes[binding.scope];
             let (edit, rest) = Renamer::rename(name, "AbstractSet", scope, checker.semantic())?;
-            Ok(Fix::unsafe_edits(edit, rest))
+            Ok(Fix::applicable_edits(
+                edit,
+                rest,
+                if scope.kind.is_module() {
+                    Applicability::Unsafe
+                } else {
+                    Applicability::Safe
+                },
+            ))
         });
     }
     Some(diagnostic)

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI025_PYI025.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI025_PYI025.py.snap
@@ -9,7 +9,7 @@ PYI025.py:10:33: PYI025 [*] Use `from collections.abc import Set as AbstractSet`
    |
    = help: Alias `Set` to `AbstractSet`
 
-ℹ Unsafe fix
+ℹ Safe fix
 7  7  | 
 8  8  | 
 9  9  | def f():
@@ -29,7 +29,7 @@ PYI025.py:14:51: PYI025 [*] Use `from collections.abc import Set as AbstractSet`
    |
    = help: Alias `Set` to `AbstractSet`
 
-ℹ Unsafe fix
+ℹ Safe fix
 11 11 | 
 12 12 | 
 13 13 | def f():

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI025_PYI025.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI025_PYI025.pyi.snap
@@ -11,7 +11,7 @@ PYI025.pyi:8:33: PYI025 [*] Use `from collections.abc import Set as AbstractSet`
    |
    = help: Alias `Set` to `AbstractSet`
 
-ℹ Unsafe fix
+ℹ Safe fix
 5 5 |     from collections.abc import Container, Sized, Set as AbstractSet, ValuesView  # Ok
 6 6 | 
 7 7 | def f():
@@ -31,7 +31,7 @@ PYI025.pyi:11:51: PYI025 [*] Use `from collections.abc import Set as AbstractSet
    |
    = help: Alias `Set` to `AbstractSet`
 
-ℹ Unsafe fix
+ℹ Safe fix
 8  8  |     from collections.abc import Set  # PYI025
 9  9  | 
 10 10 | def f():
@@ -52,7 +52,7 @@ PYI025.pyi:16:37: PYI025 [*] Use `from collections.abc import Set as AbstractSet
    |
    = help: Alias `Set` to `AbstractSet`
 
-ℹ Unsafe fix
+ℹ Safe fix
 13 13 | def f():
 14 14 |     """Test: local symbol renaming."""
 15 15 |     if True:
@@ -130,7 +130,7 @@ PYI025.pyi:44:33: PYI025 [*] Use `from collections.abc import Set as AbstractSet
    |
    = help: Alias `Set` to `AbstractSet`
 
-ℹ Unsafe fix
+ℹ Safe fix
 41 41 | 
 42 42 | def f():
 43 43 |     """Test: nonlocal symbol renaming."""


### PR DESCRIPTION
## Summary

Prompted by https://github.com/astral-sh/ruff/issues/8482#issuecomment-1859299411. The rename is only unsafe when the symbol is exported, so we can narrow the conditions.