### PR TITLE
Error if the NURSERY selector is used with preview

### DIFF
--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -878,15 +878,12 @@ fn nursery_group_selector_preview_enabled() {
     assert_cmd_snapshot!(cmd
         .pass_stdin("I=42\n"), @r###"
     success: false
-    exit_code: 1
+    exit_code: 2
     ----- stdout -----
-    -:1:1: CPY001 Missing copyright notice at top of file
-    -:1:2: E225 [*] Missing whitespace around operator
-    Found 2 errors.
-    [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
-    warning: The `NURSERY` selector has been deprecated.
+    ruff failed
+      Cause: The `NURSERY` selector is deprecated and cannot be used with preview mode enabled.
     "###);
 }
 


### PR DESCRIPTION
Changes our warning for combined use of `--preview` and `--select NURSERY` to a hard error.

This should go out _before_ #9680 where we will ban use of `NURSERY` outside of preview as well (see #9683).

Part of https://github.com/astral-sh/ruff/issues/7992