### PR TITLE
Error if nursery rules are selected without preview

### DIFF
--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -839,14 +839,12 @@ fn nursery_direct() {
     assert_cmd_snapshot!(cmd
         .pass_stdin("I=42\n"), @r###"
     success: false
-    exit_code: 1
+    exit_code: 2
     ----- stdout -----
-    -:1:2: E225 [*] Missing whitespace around operator
-    Found 1 error.
-    [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
-    warning: Selection of nursery rule `E225` without the `--preview` flag is deprecated.
+    ruff failed
+      Cause: Selection of unstable rule `E225` without the `--preview` flag is not allowed.
     "###);
 }
 
@@ -857,15 +855,12 @@ fn nursery_group_selector() {
     assert_cmd_snapshot!(cmd
         .pass_stdin("I=42\n"), @r###"
     success: false
-    exit_code: 1
+    exit_code: 2
     ----- stdout -----
-    -:1:1: CPY001 Missing copyright notice at top of file
-    -:1:2: E225 [*] Missing whitespace around operator
-    Found 2 errors.
-    [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
-    warning: The `NURSERY` selector has been deprecated. Use the `--preview` flag instead.
+    ruff failed
+      Cause: The `NURSERY` selector was removed. Use the `--preview` flag instead.
     "###);
 }
 
@@ -883,7 +878,7 @@ fn nursery_group_selector_preview_enabled() {
 
     ----- stderr -----
     ruff failed
-      Cause: The `NURSERY` selector is deprecated and cannot be used with preview mode enabled.
+      Cause: The `NURSERY` selector was removed. Unstable rules should be selected by their respective group or individually.
     "###);
 }
 

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -878,7 +878,7 @@ fn nursery_group_selector_preview_enabled() {
 
     ----- stderr -----
     ruff failed
-      Cause: The `NURSERY` selector was removed. Unstable rules should be selected by their respective group or individually.
+      Cause: The `NURSERY` selector was removed. Unstable rules should be selected individually or by their respective groups.
     "###);
 }
 

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -1787,7 +1787,7 @@ mod tests {
 
     #[test]
     #[allow(deprecated)]
-    fn select_nursery() -> Result<()> {
+    fn select_nursery() {
         // We no longer allow use of the NURSERY selector and should error in both cases
         assert!(resolve_rules(
             [RuleSelection {
@@ -1811,8 +1811,6 @@ mod tests {
             }),
         )
         .is_err());
-
-        Ok(())
     }
 
     #[test]

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -906,23 +906,20 @@ impl LintConfiguration {
             );
         }
 
-        match deprecated_nursery_selectors
-            .iter()
-            .collect::<Vec<_>>()
-            .as_slice()
-        {
+        let deprecated_nursery_selectors = deprecated_nursery_selectors.iter().collect::<Vec<_>>();
+        match deprecated_nursery_selectors.as_slice() {
             [] => (),
             [selection] => {
                 let (prefix, code) = selection.prefix_and_code();
                 return Err(anyhow!("Selection of unstable rule `{prefix}{code}` without the `--preview` flag is not allowed."));
             }
-            [selections @ ..] => {
+            [..] => {
                 let mut message = "Selection of unstable rules without the `--preview` flag is not allowed. Enable preview or remove selection of:".to_string();
-                for selection in selections {
+                for selection in deprecated_nursery_selectors {
                     let (prefix, code) = selection.prefix_and_code();
                     message.push_str("\n\t- ");
                     message.push_str(prefix);
-                    message.push_str(code)
+                    message.push_str(code);
                 }
                 message.push('\n');
                 return Err(anyhow!(message));

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -1356,51 +1356,6 @@ mod tests {
     use ruff_linter::RuleSelector;
     use std::str::FromStr;
 
-    const NURSERY_RULES: &[Rule] = &[
-        Rule::MissingCopyrightNotice,
-        Rule::IndentationWithInvalidMultiple,
-        Rule::NoIndentedBlock,
-        Rule::UnexpectedIndentation,
-        Rule::IndentationWithInvalidMultipleComment,
-        Rule::NoIndentedBlockComment,
-        Rule::UnexpectedIndentationComment,
-        Rule::OverIndented,
-        Rule::WhitespaceAfterOpenBracket,
-        Rule::WhitespaceBeforeCloseBracket,
-        Rule::WhitespaceBeforePunctuation,
-        Rule::WhitespaceBeforeParameters,
-        Rule::MultipleSpacesBeforeOperator,
-        Rule::MultipleSpacesAfterOperator,
-        Rule::TabBeforeOperator,
-        Rule::TabAfterOperator,
-        Rule::MissingWhitespaceAroundOperator,
-        Rule::MissingWhitespaceAroundArithmeticOperator,
-        Rule::MissingWhitespaceAroundBitwiseOrShiftOperator,
-        Rule::MissingWhitespaceAroundModuloOperator,
-        Rule::MissingWhitespace,
-        Rule::MultipleSpacesAfterComma,
-        Rule::TabAfterComma,
-        Rule::UnexpectedSpacesAroundKeywordParameterEquals,
-        Rule::MissingWhitespaceAroundParameterEquals,
-        Rule::TooFewSpacesBeforeInlineComment,
-        Rule::NoSpaceAfterInlineComment,
-        Rule::NoSpaceAfterBlockComment,
-        Rule::MultipleLeadingHashesForBlockComment,
-        Rule::MultipleSpacesAfterKeyword,
-        Rule::MultipleSpacesBeforeKeyword,
-        Rule::TabAfterKeyword,
-        Rule::TabBeforeKeyword,
-        Rule::MissingWhitespaceAfterKeyword,
-        Rule::CompareToEmptyString,
-        Rule::NoSelfUse,
-        Rule::EqWithoutHash,
-        Rule::BadDunderMethodName,
-        Rule::RepeatedAppend,
-        Rule::DeleteFullSlice,
-        Rule::CheckAndRemoveFromSet,
-        Rule::QuadraticListSummation,
-    ];
-
     const PREVIEW_RULES: &[Rule] = &[
         Rule::AndOrTernary,
         Rule::AssignmentInAssert,
@@ -1802,9 +1757,8 @@ mod tests {
 
     #[test]
     fn nursery_select_code() -> Result<()> {
-        // Backwards compatible behavior allows selection of nursery rules with their exact code
-        // when preview is disabled
-        let actual = resolve_rules(
+        // We do not allow selection of nursery rules when preview is disabled
+        assert!(resolve_rules(
             [RuleSelection {
                 select: Some(vec![Flake8Copyright::_001.into()]),
                 ..RuleSelection::default()
@@ -1813,9 +1767,8 @@ mod tests {
                 mode: PreviewMode::Disabled,
                 ..PreviewOptions::default()
             }),
-        )?;
-        let expected = RuleSet::from_rule(Rule::MissingCopyrightNotice);
-        assert_eq!(actual, expected);
+        )
+        .is_err());
 
         let actual = resolve_rules(
             [RuleSelection {
@@ -1835,9 +1788,8 @@ mod tests {
     #[test]
     #[allow(deprecated)]
     fn select_nursery() -> Result<()> {
-        // Backwards compatible behavior allows selection of nursery rules with the nursery selector
-        // when preview is disabled
-        let actual = resolve_rules(
+        // We no longer allow use of the NURSERY selector and should error in both cases
+        assert!(resolve_rules(
             [RuleSelection {
                 select: Some(vec![RuleSelector::Nursery]),
                 ..RuleSelection::default()
@@ -1846,11 +1798,8 @@ mod tests {
                 mode: PreviewMode::Disabled,
                 ..PreviewOptions::default()
             }),
-        )?;
-        let expected = RuleSet::from_rules(NURSERY_RULES);
-        assert_eq!(actual, expected);
-
-        // When preview is enabled, use of NURSERY is banned
+        )
+        .is_err());
         assert!(resolve_rules(
             [RuleSelection {
                 select: Some(vec![RuleSelector::Nursery]),

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -143,12 +143,3 @@ In our previous example, `--select` with `ALL` `HYP`, `HYP0`, or `HYP00` would n
 rule will need to be selected with its exact code, e.g. `--select ALL,HYP001`.
 
 If preview mode is not enabled, this setting has no effect.
-
-## Legacy behavior
-
-Before the preview mode was introduced, new rules were added in a "nursery" category that required selection of
-rules with their exact codes — similar to if `explicit-preview-rules` is enabled.
-
-The nursery category has been deprecated and all rules in the nursery are now considered to be in preview.
-For backwards compatibility, nursery rules are selectable with their exact codes without enabling preview mode.
-However, this behavior will display a warning and support will be removed in a future release.


### PR DESCRIPTION
Extends #9682 to error if the nursery selector is used or nursery rules are selected without preview.

Part of #7992 — we will remove this in 0.3.0 instead so we can provide nice errors in 0.2.0.
