### PR TITLE
Replace `--show-source` and `--no-show-source` with `--output_format=<full|concise>`

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -132,7 +132,7 @@ pub struct CheckCommand {
     ignore_noqa: bool,
 
     /// Output serialization format for violations.
-    /// The default serialization format is "full".
+    /// The default serialization format is "concise".
     #[arg(long, value_enum, env = "RUFF_OUTPUT_FORMAT")]
     pub output_format: Option<SerializationFormat>,
 
@@ -609,11 +609,11 @@ fn resolve_output_format(
             SerializationFormat::Grouped
         }
         (Some(fmt), Some(true)) => {
-            warn_user!("The `--show-source` argument is deprecated and has been ignored in favor of `output-format={fmt}`.");
+            warn_user!("The `--show-source` argument is deprecated and has been ignored in favor of `--output-format={fmt}`.");
             fmt
         }
         (Some(fmt), Some(false)) => {
-            warn_user!("The `--no-show-source` argument is deprecated and has been ignored in favor of `output-format={fmt}`.");
+            warn_user!("The `--no-show-source` argument is deprecated and has been ignored in favor of `--output-format={fmt}`.");
             fmt
         }
         (None, Some(true)) => {

--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -133,6 +133,7 @@ pub struct CheckCommand {
 
     /// Output serialization format for violations.
     /// The default serialization format is "concise".
+    /// In preview mode, the default serialization format is "full".
     #[arg(long, value_enum, env = "RUFF_OUTPUT_FORMAT")]
     pub output_format: Option<SerializationFormat>,
 
@@ -547,7 +548,7 @@ impl CheckCommand {
                 output_format: resolve_output_format(
                     self.output_format,
                     resolve_bool_arg(self.show_source, self.no_show_source),
-                    self.preview,
+                    resolve_bool_arg(self.preview, self.no_preview).unwrap_or_default(),
                 ),
                 show_fixes: resolve_bool_arg(self.show_fixes, self.no_show_fixes),
                 extension: self.extension,

--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -605,7 +605,7 @@ fn resolve_output_format(
     Some(match (output_format, show_sources) {
         (Some(o), None) => o,
         (Some(SerializationFormat::Grouped), Some(true)) => {
-            warn_user!("`--show-source` with `--output-format=grouped` is deprecated. Source display will not be available for `--output-format=grouped` in future releases.");
+            warn_user!("`--show-source` with `--output-format=grouped` is deprecated, and will not show source files. Use `--output-format=full` to show source information.");
             SerializationFormat::Grouped
         }
         (Some(fmt), Some(true)) => {
@@ -627,7 +627,7 @@ fn resolve_output_format(
         (None, None) => return None
     }).map(|format| match format {
         SerializationFormat::Text => {
-            warn_user!("`--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead.");
+            warn_user!("`--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `{}`.", SerializationFormat::default());
             SerializationFormat::default()
         },
         other => other

--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -547,6 +547,7 @@ impl CheckCommand {
                 output_format: resolve_output_format(
                     self.output_format,
                     resolve_bool_arg(self.show_source, self.no_show_source),
+                    self.preview,
                 ),
                 show_fixes: resolve_bool_arg(self.show_fixes, self.no_show_fixes),
                 extension: self.extension,
@@ -601,6 +602,7 @@ fn resolve_bool_arg(yes: bool, no: bool) -> Option<bool> {
 fn resolve_output_format(
     output_format: Option<SerializationFormat>,
     show_sources: Option<bool>,
+    preview: bool,
 ) -> Option<SerializationFormat> {
     Some(match (output_format, show_sources) {
         (Some(o), None) => o,
@@ -627,8 +629,8 @@ fn resolve_output_format(
         (None, None) => return None
     }).map(|format| match format {
         SerializationFormat::Text => {
-            warn_user!("`--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `{}`.", SerializationFormat::default());
-            SerializationFormat::default()
+            warn_user!("`--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `{}`.", SerializationFormat::default(preview));
+            SerializationFormat::default(preview)
         },
         other => other
     })

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -321,9 +321,14 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
         printer_flags,
     );
 
+    let preview = overrides.preview.unwrap_or_default().is_enabled();
+
     if cli.watch {
-        if output_format != SerializationFormat::Full {
-            warn_user!("`--output-format full` is always used in watch mode.");
+        if output_format != SerializationFormat::default(preview) {
+            warn_user!(
+                "`--output-format {}` is always used in watch mode.",
+                SerializationFormat::default(preview)
+            );
         }
 
         // Configure the file watcher.
@@ -349,7 +354,7 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
             fix_mode,
             unsafe_fixes,
         )?;
-        printer.write_continuously(&mut writer, &messages)?;
+        printer.write_continuously(&mut writer, &messages, preview)?;
 
         // In watch mode, we may need to re-resolve the configuration.
         // TODO(charlie): Re-compute other derivative values, like the `printer`.
@@ -382,7 +387,7 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
                         fix_mode,
                         unsafe_fixes,
                     )?;
-                    printer.write_continuously(&mut writer, &messages)?;
+                    printer.write_continuously(&mut writer, &messages, preview)?;
                 }
                 Err(err) => return Err(err.into()),
             }

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -255,7 +255,6 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
         unsafe_fixes,
         output_format,
         show_fixes,
-        show_source,
         ..
     } = pyproject_config.settings;
 
@@ -284,7 +283,7 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
     if show_fixes {
         printer_flags |= PrinterFlags::SHOW_FIX_SUMMARY;
     }
-    if show_source {
+    if output_format == SerializationFormat::Full {
         printer_flags |= PrinterFlags::SHOW_SOURCE;
     }
     if cli.ecosystem_ci {
@@ -326,8 +325,8 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
     );
 
     if cli.watch {
-        if output_format != SerializationFormat::Text {
-            warn_user!("`--output-format text` is always used in watch mode.");
+        if output_format != SerializationFormat::Full {
+            warn_user!("`--output-format full` is always used in watch mode.");
         }
 
         // Configure the file watcher.

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -283,9 +283,6 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
     if show_fixes {
         printer_flags |= PrinterFlags::SHOW_FIX_SUMMARY;
     }
-    if output_format == SerializationFormat::Full {
-        printer_flags |= PrinterFlags::SHOW_SOURCE;
-    }
     if cli.ecosystem_ci {
         warn_user!(
             "The formatting of fixes emitted by this option is a work-in-progress, subject to \

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -407,6 +407,7 @@ impl Printer {
         &self,
         writer: &mut dyn Write,
         diagnostics: &Diagnostics,
+        preview: bool,
     ) -> Result<()> {
         if matches!(self.log_level, LogLevel::Silent) {
             return Ok(());
@@ -434,7 +435,7 @@ impl Printer {
             let context = EmitterContext::new(&diagnostics.notebook_indexes);
             TextEmitter::default()
                 .with_show_fix_status(show_fix_status(self.fix_mode, fixables.as_ref()))
-                .with_show_source(true)
+                .with_show_source(preview)
                 .with_unsafe_fixes(self.unsafe_fixes)
                 .emit(writer, &diagnostics.messages, &context)?;
         }

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -218,7 +218,10 @@ impl Printer {
         if !self.flags.intersects(Flags::SHOW_VIOLATIONS) {
             if matches!(
                 self.format,
-                SerializationFormat::Text | SerializationFormat::Grouped
+                SerializationFormat::Text
+                    | SerializationFormat::Full
+                    | SerializationFormat::Concise
+                    | SerializationFormat::Grouped
             ) {
                 if self.flags.intersects(Flags::SHOW_FIX_SUMMARY) {
                     if !diagnostics.fixed.is_empty() {
@@ -347,7 +350,9 @@ impl Printer {
         }
 
         match self.format {
-            SerializationFormat::Text => {
+            SerializationFormat::Text
+            | SerializationFormat::Full
+            | SerializationFormat::Concise => {
                 // Compute the maximum number of digits in the count and code, for all messages,
                 // to enable pretty-printing.
                 let count_width = num_digits(

--- a/crates/ruff/tests/deprecation.rs
+++ b/crates/ruff/tests/deprecation.rs
@@ -11,7 +11,7 @@ const STDIN: &str = "l = 1";
 
 fn ruff_check(show_source: Option<bool>, output_format: Option<String>) -> Command {
     let mut cmd = Command::new(get_cargo_bin(BIN_NAME));
-    let output_format = output_format.unwrap_or(format!("{}", SerializationFormat::default()));
+    let output_format = output_format.unwrap_or(format!("{}", SerializationFormat::default(false)));
     cmd.arg("--output-format");
     cmd.arg(output_format);
     cmd.arg("--no-cache");

--- a/crates/ruff/tests/deprecation.rs
+++ b/crates/ruff/tests/deprecation.rs
@@ -2,7 +2,7 @@
 
 use std::process::Command;
 
-use insta_cmd::{assert_cmd_snapshot, get_cargo_bin, SpawnExt};
+use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
 
 const BIN_NAME: &str = "ruff";
 
@@ -28,17 +28,59 @@ fn ruff_check(show_source: Option<bool>, output_format: Option<&str>) -> Command
 
 #[test]
 fn ensure_show_source_is_deprecated() {
-    assert_cmd_snapshot!(ruff_check(Some(true), None).pass_stdin(STDIN));
+    assert_cmd_snapshot!(ruff_check(Some(true), None).pass_stdin(STDIN), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:1: E741 Ambiguous variable name: `l`
+      |
+    1 | l = 1
+      | ^ E741
+      |
+
+    Found 1 error.
+
+    ----- stderr -----
+    warning: The `--show-source` argument is deprecated and has been ignored in favor of `output-format=full`.
+    "###);
 }
 
 #[test]
 fn ensure_no_show_source_is_deprecated() {
-    assert_cmd_snapshot!(ruff_check(Some(false), None).pass_stdin(STDIN));
+    assert_cmd_snapshot!(ruff_check(Some(false), None).pass_stdin(STDIN), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:1: E741 Ambiguous variable name: `l`
+      |
+    1 | l = 1
+      | ^ E741
+      |
+
+    Found 1 error.
+
+    ----- stderr -----
+    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `output-format=full`.
+    "###);
 }
 
 #[test]
 fn ensure_output_format_is_deprecated() {
-    assert_cmd_snapshot!(ruff_check(None, Some("text")).pass_stdin(STDIN));
+    assert_cmd_snapshot!(ruff_check(None, Some("text")).pass_stdin(STDIN), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:1: E741 Ambiguous variable name: `l`
+      |
+    1 | l = 1
+      | ^ E741
+      |
+
+    Found 1 error.
+
+    ----- stderr -----
+    warning: `--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `full`.
+    "###);
 }
 
 #[test]

--- a/crates/ruff/tests/deprecation.rs
+++ b/crates/ruff/tests/deprecation.rs
@@ -1,0 +1,129 @@
+//! A test suite that ensures deprecated command line options have appropriate warnings / behaviors
+
+use std::process::Command;
+
+use insta_cmd::{assert_cmd_snapshot, get_cargo_bin, SpawnExt};
+
+const BIN_NAME: &str = "ruff";
+
+const STDIN: &str = "l = 1";
+
+fn ruff_check(show_source: Option<bool>, output_format: Option<&str>) -> Command {
+    let mut cmd = Command::new(get_cargo_bin(BIN_NAME));
+    let output_format = output_format.unwrap_or("full");
+    cmd.args(["--output-format", output_format, "--no-cache", "--isolated"]);
+    match show_source {
+        Some(true) => {
+            cmd.arg("--show-source");
+        }
+        Some(false) => {
+            cmd.arg("--no-show-source");
+        }
+        None => {}
+    }
+    cmd.arg("-");
+
+    cmd
+}
+
+#[test]
+fn ensure_show_source_is_deprecated() {
+    assert_cmd_snapshot!(ruff_check(Some(true), None).pass_stdin(STDIN));
+}
+
+#[test]
+fn ensure_no_show_source_is_deprecated() {
+    assert_cmd_snapshot!(ruff_check(Some(false), None).pass_stdin(STDIN));
+}
+
+#[test]
+fn ensure_output_format_is_deprecated() {
+    assert_cmd_snapshot!(ruff_check(None, Some("text")).pass_stdin(STDIN));
+}
+
+#[test]
+fn ensure_output_format_overrides_show_source() {
+    assert_cmd_snapshot!(ruff_check(Some(true), Some("concise")).pass_stdin(STDIN), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:1: E741 Ambiguous variable name: `l`
+    Found 1 error.
+
+    ----- stderr -----
+    warning: The `--show-source` argument is deprecated and has been ignored in favor of `output-format=concise`.
+    "###);
+}
+
+#[test]
+fn ensure_full_output_format_overrides_no_show_source() {
+    assert_cmd_snapshot!(ruff_check(Some(false), Some("full")).pass_stdin(STDIN), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:1: E741 Ambiguous variable name: `l`
+      |
+    1 | l = 1
+      | ^ E741
+      |
+
+    Found 1 error.
+
+    ----- stderr -----
+    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `output-format=full`.
+    "###);
+}
+
+#[test]
+fn ensure_output_format_uses_concise_over_no_show_source() {
+    assert_cmd_snapshot!(ruff_check(Some(false), Some("concise")).pass_stdin(STDIN), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:1: E741 Ambiguous variable name: `l`
+    Found 1 error.
+
+    ----- stderr -----
+    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `output-format=concise`.
+    "###);
+}
+
+#[test]
+fn ensure_deprecated_output_format_overrides_show_source() {
+    assert_cmd_snapshot!(ruff_check(Some(true), Some("text")).pass_stdin(STDIN), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:1: E741 Ambiguous variable name: `l`
+      |
+    1 | l = 1
+      | ^ E741
+      |
+
+    Found 1 error.
+
+    ----- stderr -----
+    warning: The `--show-source` argument is deprecated and has been ignored in favor of `output-format=text`.
+    warning: `--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `full`.
+    "###);
+}
+
+#[test]
+fn ensure_deprecated_output_format_overrides_no_show_source() {
+    assert_cmd_snapshot!(ruff_check(Some(false), Some("text")).pass_stdin(STDIN), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:1: E741 Ambiguous variable name: `l`
+      |
+    1 | l = 1
+      | ^ E741
+      |
+
+    Found 1 error.
+
+    ----- stderr -----
+    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `output-format=text`.
+    warning: `--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `full`.
+    "###);
+}

--- a/crates/ruff/tests/deprecation.rs
+++ b/crates/ruff/tests/deprecation.rs
@@ -1,5 +1,6 @@
 //! A test suite that ensures deprecated command line options have appropriate warnings / behaviors
 
+use ruff_linter::settings::types::SerializationFormat;
 use std::process::Command;
 
 use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
@@ -8,10 +9,12 @@ const BIN_NAME: &str = "ruff";
 
 const STDIN: &str = "l = 1";
 
-fn ruff_check(show_source: Option<bool>, output_format: Option<&str>) -> Command {
+fn ruff_check(show_source: Option<bool>, output_format: Option<String>) -> Command {
     let mut cmd = Command::new(get_cargo_bin(BIN_NAME));
-    let output_format = output_format.unwrap_or("full");
-    cmd.args(["--output-format", output_format, "--no-cache", "--isolated"]);
+    let output_format = output_format.unwrap_or(format!("{}", SerializationFormat::default()));
+    cmd.arg("--output-format");
+    cmd.arg(output_format);
+    cmd.arg("--no-cache");
     match show_source {
         Some(true) => {
             cmd.arg("--show-source");
@@ -33,15 +36,10 @@ fn ensure_show_source_is_deprecated() {
     exit_code: 1
     ----- stdout -----
     -:1:1: E741 Ambiguous variable name: `l`
-      |
-    1 | l = 1
-      | ^ E741
-      |
-
     Found 1 error.
 
     ----- stderr -----
-    warning: The `--show-source` argument is deprecated and has been ignored in favor of `output-format=full`.
+    warning: The `--show-source` argument is deprecated and has been ignored in favor of `--output-format=concise`.
     "###);
 }
 
@@ -52,40 +50,30 @@ fn ensure_no_show_source_is_deprecated() {
     exit_code: 1
     ----- stdout -----
     -:1:1: E741 Ambiguous variable name: `l`
-      |
-    1 | l = 1
-      | ^ E741
-      |
-
     Found 1 error.
 
     ----- stderr -----
-    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `output-format=full`.
+    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `--output-format=concise`.
     "###);
 }
 
 #[test]
 fn ensure_output_format_is_deprecated() {
-    assert_cmd_snapshot!(ruff_check(None, Some("text")).pass_stdin(STDIN), @r###"
+    assert_cmd_snapshot!(ruff_check(None, Some("text".into())).pass_stdin(STDIN), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
     -:1:1: E741 Ambiguous variable name: `l`
-      |
-    1 | l = 1
-      | ^ E741
-      |
-
     Found 1 error.
 
     ----- stderr -----
-    warning: `--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `full`.
+    warning: `--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `concise`.
     "###);
 }
 
 #[test]
 fn ensure_output_format_overrides_show_source() {
-    assert_cmd_snapshot!(ruff_check(Some(true), Some("concise")).pass_stdin(STDIN), @r###"
+    assert_cmd_snapshot!(ruff_check(Some(true), Some("concise".into())).pass_stdin(STDIN), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -93,13 +81,13 @@ fn ensure_output_format_overrides_show_source() {
     Found 1 error.
 
     ----- stderr -----
-    warning: The `--show-source` argument is deprecated and has been ignored in favor of `output-format=concise`.
+    warning: The `--show-source` argument is deprecated and has been ignored in favor of `--output-format=concise`.
     "###);
 }
 
 #[test]
 fn ensure_full_output_format_overrides_no_show_source() {
-    assert_cmd_snapshot!(ruff_check(Some(false), Some("full")).pass_stdin(STDIN), @r###"
+    assert_cmd_snapshot!(ruff_check(Some(false), Some("full".into())).pass_stdin(STDIN), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -112,13 +100,13 @@ fn ensure_full_output_format_overrides_no_show_source() {
     Found 1 error.
 
     ----- stderr -----
-    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `output-format=full`.
+    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `--output-format=full`.
     "###);
 }
 
 #[test]
 fn ensure_output_format_uses_concise_over_no_show_source() {
-    assert_cmd_snapshot!(ruff_check(Some(false), Some("concise")).pass_stdin(STDIN), @r###"
+    assert_cmd_snapshot!(ruff_check(Some(false), Some("concise".into())).pass_stdin(STDIN), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -126,46 +114,36 @@ fn ensure_output_format_uses_concise_over_no_show_source() {
     Found 1 error.
 
     ----- stderr -----
-    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `output-format=concise`.
+    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `--output-format=concise`.
     "###);
 }
 
 #[test]
 fn ensure_deprecated_output_format_overrides_show_source() {
-    assert_cmd_snapshot!(ruff_check(Some(true), Some("text")).pass_stdin(STDIN), @r###"
+    assert_cmd_snapshot!(ruff_check(Some(true), Some("text".into())).pass_stdin(STDIN), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
     -:1:1: E741 Ambiguous variable name: `l`
-      |
-    1 | l = 1
-      | ^ E741
-      |
-
     Found 1 error.
 
     ----- stderr -----
-    warning: The `--show-source` argument is deprecated and has been ignored in favor of `output-format=text`.
-    warning: `--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `full`.
+    warning: The `--show-source` argument is deprecated and has been ignored in favor of `--output-format=text`.
+    warning: `--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `concise`.
     "###);
 }
 
 #[test]
 fn ensure_deprecated_output_format_overrides_no_show_source() {
-    assert_cmd_snapshot!(ruff_check(Some(false), Some("text")).pass_stdin(STDIN), @r###"
+    assert_cmd_snapshot!(ruff_check(Some(false), Some("text".into())).pass_stdin(STDIN), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
     -:1:1: E741 Ambiguous variable name: `l`
-      |
-    1 | l = 1
-      | ^ E741
-      |
-
     Found 1 error.
 
     ----- stderr -----
-    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `output-format=text`.
-    warning: `--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `full`.
+    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `--output-format=text`.
+    warning: `--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `concise`.
     "###);
 }

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -743,8 +743,8 @@ fn stdin_parse_error() {
 }
 
 #[test]
-fn show_source() {
-    let mut cmd = RuffCheck::default().args(["--show-source"]).build();
+fn full_output_format() {
+    let mut cmd = RuffCheck::default().args(["--output-format=full"]).build();
     assert_cmd_snapshot!(cmd
         .pass_stdin("l = 1"), @r###"
     success: false

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -43,7 +43,7 @@ struct RuffCheck<'a> {
 impl<'a> Default for RuffCheck<'a> {
     fn default() -> RuffCheck<'a> {
         RuffCheck {
-            output_format: format!("{}", SerializationFormat::default()),
+            output_format: format!("{}", SerializationFormat::default(false)),
             config: None,
             filename: None,
             args: vec![],

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -42,7 +42,7 @@ struct RuffCheck<'a> {
 impl<'a> Default for RuffCheck<'a> {
     fn default() -> RuffCheck<'a> {
         RuffCheck {
-            output_format: "text",
+            output_format: "full",
             config: None,
             filename: None,
             args: vec![],
@@ -121,6 +121,12 @@ fn stdin_error() {
     exit_code: 1
     ----- stdout -----
     -:1:8: F401 [*] `os` imported but unused
+      |
+    1 | import os
+      |        ^^ F401
+      |
+      = help: Remove unused import: `os`
+
     Found 1 error.
     [*] 1 fixable with the `--fix` option.
 
@@ -139,6 +145,12 @@ fn stdin_filename() {
     exit_code: 1
     ----- stdout -----
     F401.py:1:8: F401 [*] `os` imported but unused
+      |
+    1 | import os
+      |        ^^ F401
+      |
+      = help: Remove unused import: `os`
+
     Found 1 error.
     [*] 1 fixable with the `--fix` option.
 
@@ -168,7 +180,19 @@ import bar   # unused import
     exit_code: 1
     ----- stdout -----
     bar.py:2:8: F401 [*] `bar` imported but unused
+      |
+    2 | import bar   # unused import
+      |        ^^^ F401
+      |
+      = help: Remove unused import: `bar`
+
     foo.py:2:8: F401 [*] `foo` imported but unused
+      |
+    2 | import foo   # unused import
+      |        ^^^ F401
+      |
+      = help: Remove unused import: `foo`
+
     Found 2 errors.
     [*] 2 fixable with the `--fix` option.
 
@@ -190,6 +214,12 @@ fn check_warn_stdin_filename_with_files() {
     exit_code: 1
     ----- stdout -----
     F401.py:1:8: F401 [*] `os` imported but unused
+      |
+    1 | import os
+      |        ^^ F401
+      |
+      = help: Remove unused import: `os`
+
     Found 1 error.
     [*] 1 fixable with the `--fix` option.
 
@@ -210,6 +240,12 @@ fn stdin_source_type_py() {
     exit_code: 1
     ----- stdout -----
     TCH.py:1:8: F401 [*] `os` imported but unused
+      |
+    1 | import os
+      |        ^^ F401
+      |
+      = help: Remove unused import: `os`
+
     Found 1 error.
     [*] 1 fixable with the `--fix` option.
 
@@ -440,6 +476,11 @@ fn stdin_fix_jupyter() {
     }
     ----- stderr -----
     Jupyter.ipynb:cell 3:1:7: F821 Undefined name `x`
+      |
+    1 | print(x)
+      |       ^ F821
+      |
+
     Found 3 errors (2 fixed, 1 remaining).
     "###);
 }
@@ -533,7 +574,19 @@ fn stdin_override_parser_ipynb() {
     exit_code: 1
     ----- stdout -----
     Jupyter.py:cell 1:1:8: F401 [*] `os` imported but unused
+      |
+    1 | import os
+      |        ^^ F401
+      |
+      = help: Remove unused import: `os`
+
     Jupyter.py:cell 3:1:8: F401 [*] `sys` imported but unused
+      |
+    1 | import sys
+      |        ^^^ F401
+      |
+      = help: Remove unused import: `sys`
+
     Found 2 errors.
     [*] 2 fixable with the `--fix` option.
 
@@ -557,6 +610,12 @@ fn stdin_override_parser_py() {
     exit_code: 1
     ----- stdout -----
     F401.ipynb:1:8: F401 [*] `os` imported but unused
+      |
+    1 | import os
+      |        ^^ F401
+      |
+      = help: Remove unused import: `os`
+
     Found 1 error.
     [*] 1 fixable with the `--fix` option.
 
@@ -579,6 +638,14 @@ fn stdin_fix_when_not_fixable_should_still_print_contents() {
 
     ----- stderr -----
     -:3:4: F634 If test is a tuple, which is always `True`
+      |
+    1 | import sys
+    2 | 
+    3 | if (1, 2):
+      |    ^^^^^^ F634
+    4 |      print(sys.version)
+      |
+
     Found 2 errors (1 fixed, 1 remaining).
     "###);
 }
@@ -735,6 +802,11 @@ fn stdin_parse_error() {
     exit_code: 1
     ----- stdout -----
     -:1:17: E999 SyntaxError: Unexpected token '='
+      |
+    1 | from foo import =
+      |                 ^ E999
+      |
+
     Found 1 error.
 
     ----- stderr -----
@@ -744,7 +816,7 @@ fn stdin_parse_error() {
 
 #[test]
 fn full_output_format() {
-    let mut cmd = RuffCheck::default().args(["--output-format=full"]).build();
+    let mut cmd = RuffCheck::default().output_format("full").build();
     assert_cmd_snapshot!(cmd
         .pass_stdin("l = 1"), @r###"
     success: false
@@ -807,6 +879,11 @@ fn nursery_prefix() {
     exit_code: 1
     ----- stdout -----
     -:1:1: E741 Ambiguous variable name: `I`
+      |
+    1 | I=42
+      | ^ E741
+      |
+
     Found 1 error.
 
     ----- stderr -----
@@ -823,7 +900,17 @@ fn nursery_all() {
     exit_code: 1
     ----- stdout -----
     -:1:1: E741 Ambiguous variable name: `I`
+      |
+    1 | I=42
+      | ^ E741
+      |
+
     -:1:1: D100 Missing docstring in public module
+      |
+    1 | I=42
+      |  D100
+      |
+
     Found 2 errors.
 
     ----- stderr -----
@@ -842,6 +929,12 @@ fn nursery_direct() {
     exit_code: 1
     ----- stdout -----
     -:1:2: E225 [*] Missing whitespace around operator
+      |
+    1 | I=42
+      |  ^ E225
+      |
+      = help: Add missing whitespace
+
     Found 1 error.
     [*] 1 fixable with the `--fix` option.
 
@@ -860,7 +953,18 @@ fn nursery_group_selector() {
     exit_code: 1
     ----- stdout -----
     -:1:1: CPY001 Missing copyright notice at top of file
+      |
+    1 | I=42
+      |  CPY001
+      |
+
     -:1:2: E225 [*] Missing whitespace around operator
+      |
+    1 | I=42
+      |  ^ E225
+      |
+      = help: Add missing whitespace
+
     Found 2 errors.
     [*] 1 fixable with the `--fix` option.
 
@@ -899,7 +1003,18 @@ fn preview_enabled_prefix() {
     exit_code: 1
     ----- stdout -----
     -:1:1: E741 Ambiguous variable name: `I`
+      |
+    1 | I=42
+      | ^ E741
+      |
+
     -:1:2: E225 [*] Missing whitespace around operator
+      |
+    1 | I=42
+      |  ^ E225
+      |
+      = help: Add missing whitespace
+
     Found 2 errors.
     [*] 1 fixable with the `--fix` option.
 
@@ -918,9 +1033,30 @@ fn preview_enabled_all() {
     exit_code: 1
     ----- stdout -----
     -:1:1: E741 Ambiguous variable name: `I`
+      |
+    1 | I=42
+      | ^ E741
+      |
+
     -:1:1: D100 Missing docstring in public module
+      |
+    1 | I=42
+      |  D100
+      |
+
     -:1:1: CPY001 Missing copyright notice at top of file
+      |
+    1 | I=42
+      |  CPY001
+      |
+
     -:1:2: E225 [*] Missing whitespace around operator
+      |
+    1 | I=42
+      |  ^ E225
+      |
+      = help: Add missing whitespace
+
     Found 4 errors.
     [*] 1 fixable with the `--fix` option.
 
@@ -942,6 +1078,12 @@ fn preview_enabled_direct() {
     exit_code: 1
     ----- stdout -----
     -:1:2: E225 [*] Missing whitespace around operator
+      |
+    1 | I=42
+      |  ^ E225
+      |
+      = help: Add missing whitespace
+
     Found 1 error.
     [*] 1 fixable with the `--fix` option.
 
@@ -989,6 +1131,11 @@ fn preview_disabled_does_not_warn_for_empty_ignore_selections() {
     exit_code: 1
     ----- stdout -----
     -:1:1: E741 Ambiguous variable name: `I`
+      |
+    1 | I=42
+      | ^ E741
+      |
+
     Found 1 error.
 
     ----- stderr -----
@@ -1005,6 +1152,11 @@ fn preview_disabled_does_not_warn_for_empty_fixable_selections() {
     exit_code: 1
     ----- stdout -----
     -:1:1: E741 Ambiguous variable name: `I`
+      |
+    1 | I=42
+      | ^ E741
+      |
+
     Found 1 error.
 
     ----- stderr -----
@@ -1137,6 +1289,12 @@ fn check_input_from_argfile() -> Result<()> {
         exit_code: 1
         ----- stdout -----
         /path/to/a.py:1:8: F401 [*] `os` imported but unused
+          |
+        1 | import os
+          |        ^^ F401
+          |
+          = help: Remove unused import: `os`
+
         Found 1 error.
         [*] 1 fixable with the `--fix` option.
 
@@ -1159,7 +1317,21 @@ fn check_hints_hidden_unsafe_fixes() {
     exit_code: 1
     ----- stdout -----
     -:1:14: F601 Dictionary key literal `'a'` repeated
+      |
+    1 | x = {'a': 1, 'a': 1}
+      |              ^^^ F601
+    2 | print(('foo'))
+      |
+      = help: Remove repeated key literal `'a'`
+
     -:2:7: UP034 [*] Avoid extraneous parentheses
+      |
+    1 | x = {'a': 1, 'a': 1}
+    2 | print(('foo'))
+      |       ^^^^^^^ UP034
+      |
+      = help: Remove extraneous parentheses
+
     Found 2 errors.
     [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
@@ -1177,6 +1349,12 @@ fn check_hints_hidden_unsafe_fixes_with_no_safe_fixes() {
     exit_code: 1
     ----- stdout -----
     -:1:14: F601 Dictionary key literal `'a'` repeated
+      |
+    1 | x = {'a': 1, 'a': 1}
+      |              ^^^ F601
+      |
+      = help: Remove repeated key literal `'a'`
+
     Found 1 error.
     No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
@@ -1196,7 +1374,21 @@ fn check_no_hint_for_hidden_unsafe_fixes_when_disabled() {
     exit_code: 1
     ----- stdout -----
     -:1:14: F601 Dictionary key literal `'a'` repeated
+      |
+    1 | x = {'a': 1, 'a': 1}
+      |              ^^^ F601
+    2 | print(('foo'))
+      |
+      = help: Remove repeated key literal `'a'`
+
     -:2:7: UP034 [*] Avoid extraneous parentheses
+      |
+    1 | x = {'a': 1, 'a': 1}
+    2 | print(('foo'))
+      |       ^^^^^^^ UP034
+      |
+      = help: Remove extraneous parentheses
+
     Found 2 errors.
     [*] 1 fixable with the --fix option.
 
@@ -1216,6 +1408,12 @@ fn check_no_hint_for_hidden_unsafe_fixes_with_no_safe_fixes_when_disabled() {
     exit_code: 1
     ----- stdout -----
     -:1:14: F601 Dictionary key literal `'a'` repeated
+      |
+    1 | x = {'a': 1, 'a': 1}
+      |              ^^^ F601
+      |
+      = help: Remove repeated key literal `'a'`
+
     Found 1 error.
 
     ----- stderr -----
@@ -1234,7 +1432,21 @@ fn check_shows_unsafe_fixes_with_opt_in() {
     exit_code: 1
     ----- stdout -----
     -:1:14: F601 [*] Dictionary key literal `'a'` repeated
+      |
+    1 | x = {'a': 1, 'a': 1}
+      |              ^^^ F601
+    2 | print(('foo'))
+      |
+      = help: Remove repeated key literal `'a'`
+
     -:2:7: UP034 [*] Avoid extraneous parentheses
+      |
+    1 | x = {'a': 1, 'a': 1}
+    2 | print(('foo'))
+      |       ^^^^^^^ UP034
+      |
+      = help: Remove extraneous parentheses
+
     Found 2 errors.
     [*] 2 fixable with the --fix option.
 
@@ -1258,6 +1470,13 @@ fn fix_applies_safe_fixes_by_default() {
 
     ----- stderr -----
     -:1:14: F601 Dictionary key literal `'a'` repeated
+      |
+    1 | x = {'a': 1, 'a': 1}
+      |              ^^^ F601
+    2 | print('foo')
+      |
+      = help: Remove repeated key literal `'a'`
+
     Found 2 errors (1 fixed, 1 remaining).
     No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).
     "###);
@@ -1296,6 +1515,12 @@ fn fix_does_not_apply_display_only_fixes() {
     def add_to_list(item, some_list=[]): ...
     ----- stderr -----
     -:1:33: B006 Do not use mutable data structures for argument defaults
+      |
+    1 | def add_to_list(item, some_list=[]): ...
+      |                                 ^^ B006
+      |
+      = help: Replace with `None`; initialize within function
+
     Found 1 error.
     "###);
 }
@@ -1314,6 +1539,12 @@ fn fix_does_not_apply_display_only_fixes_with_unsafe_fixes_enabled() {
     def add_to_list(item, some_list=[]): ...
     ----- stderr -----
     -:1:33: B006 Do not use mutable data structures for argument defaults
+      |
+    1 | def add_to_list(item, some_list=[]): ...
+      |                                 ^^ B006
+      |
+      = help: Replace with `None`; initialize within function
+
     Found 1 error.
     "###);
 }
@@ -1334,6 +1565,13 @@ fn fix_only_unsafe_fixes_available() {
 
     ----- stderr -----
     -:1:14: F601 Dictionary key literal `'a'` repeated
+      |
+    1 | x = {'a': 1, 'a': 1}
+      |              ^^^ F601
+    2 | print(('foo'))
+      |
+      = help: Remove repeated key literal `'a'`
+
     Found 1 error.
     No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).
     "###);
@@ -1481,7 +1719,21 @@ extend-unsafe-fixes = ["UP034"]
     exit_code: 1
     ----- stdout -----
     -:1:14: F601 Dictionary key literal `'a'` repeated
+      |
+    1 | x = {'a': 1, 'a': 1}
+      |              ^^^ F601
+    2 | print(('foo'))
+      |
+      = help: Remove repeated key literal `'a'`
+
     -:2:7: UP034 Avoid extraneous parentheses
+      |
+    1 | x = {'a': 1, 'a': 1}
+    2 | print(('foo'))
+      |       ^^^^^^^ UP034
+      |
+      = help: Remove extraneous parentheses
+
     Found 2 errors.
     No fixes available (2 hidden fixes can be enabled with the `--unsafe-fixes` option).
 
@@ -1514,7 +1766,21 @@ extend-safe-fixes = ["F601"]
     exit_code: 1
     ----- stdout -----
     -:1:14: F601 [*] Dictionary key literal `'a'` repeated
+      |
+    1 | x = {'a': 1, 'a': 1}
+      |              ^^^ F601
+    2 | print(('foo'))
+      |
+      = help: Remove repeated key literal `'a'`
+
     -:2:7: UP034 [*] Avoid extraneous parentheses
+      |
+    1 | x = {'a': 1, 'a': 1}
+    2 | print(('foo'))
+      |       ^^^^^^^ UP034
+      |
+      = help: Remove extraneous parentheses
+
     Found 2 errors.
     [*] 2 fixable with the `--fix` option.
 
@@ -1549,7 +1815,21 @@ extend-safe-fixes = ["UP034"]
     exit_code: 1
     ----- stdout -----
     -:1:14: F601 Dictionary key literal `'a'` repeated
+      |
+    1 | x = {'a': 1, 'a': 1}
+      |              ^^^ F601
+    2 | print(('foo'))
+      |
+      = help: Remove repeated key literal `'a'`
+
     -:2:7: UP034 Avoid extraneous parentheses
+      |
+    1 | x = {'a': 1, 'a': 1}
+    2 | print(('foo'))
+      |       ^^^^^^^ UP034
+      |
+      = help: Remove extraneous parentheses
+
     Found 2 errors.
     No fixes available (2 hidden fixes can be enabled with the `--unsafe-fixes` option).
 
@@ -1585,9 +1865,43 @@ extend-safe-fixes = ["UP03"]
     exit_code: 1
     ----- stdout -----
     -:1:14: F601 Dictionary key literal `'a'` repeated
+      |
+    1 | x = {'a': 1, 'a': 1}
+      |              ^^^ F601
+    2 | print(('foo'))
+    3 | print(str('foo'))
+      |
+      = help: Remove repeated key literal `'a'`
+
     -:2:7: UP034 Avoid extraneous parentheses
+      |
+    1 | x = {'a': 1, 'a': 1}
+    2 | print(('foo'))
+      |       ^^^^^^^ UP034
+    3 | print(str('foo'))
+    4 | isinstance(x, (int, str))
+      |
+      = help: Remove extraneous parentheses
+
     -:3:7: UP018 Unnecessary `str` call (rewrite as a literal)
+      |
+    1 | x = {'a': 1, 'a': 1}
+    2 | print(('foo'))
+    3 | print(str('foo'))
+      |       ^^^^^^^^^^ UP018
+    4 | isinstance(x, (int, str))
+      |
+      = help: Replace with string literal
+
     -:4:1: UP038 [*] Use `X | Y` in `isinstance` call instead of `(X, Y)`
+      |
+    2 | print(('foo'))
+    3 | print(str('foo'))
+    4 | isinstance(x, (int, str))
+      | ^^^^^^^^^^^^^^^^^^^^^^^^^ UP038
+      |
+      = help: Convert to `X | Y`
+
     Found 4 errors.
     [*] 1 fixable with the `--fix` option (3 hidden fixes can be enabled with the `--unsafe-fixes` option).
 
@@ -1648,6 +1962,12 @@ def log(x, base) -> float:
     exit_code: 1
     ----- stdout -----
     -:2:5: D417 Missing argument description in the docstring for `log`: `base`
+      |
+    2 | def log(x, base) -> float:
+      |     ^^^ D417
+    3 |     """Calculate natural log of a value
+      |
+
     Found 1 error.
 
     ----- stderr -----
@@ -1678,6 +1998,14 @@ select = ["RUF017"]
     exit_code: 1
     ----- stdout -----
     -:3:1: RUF017 Avoid quadratic list summation
+      |
+    1 | x = [1, 2, 3]
+    2 | y = [4, 5, 6]
+    3 | sum([x, y], [])
+      | ^^^^^^^^^^^^^^^ RUF017
+      |
+      = help: Replace with `functools.reduce`
+
     Found 1 error.
     No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
@@ -1710,6 +2038,14 @@ unfixable = ["RUF"]
     exit_code: 1
     ----- stdout -----
     -:3:1: RUF017 Avoid quadratic list summation
+      |
+    1 | x = [1, 2, 3]
+    2 | y = [4, 5, 6]
+    3 | sum([x, y], [])
+      | ^^^^^^^^^^^^^^^ RUF017
+      |
+      = help: Replace with `functools.reduce`
+
     Found 1 error.
 
     ----- stderr -----

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -31,23 +31,12 @@ fn ruff_cmd() -> Command {
 }
 
 /// Builder for `ruff check` commands.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct RuffCheck<'a> {
     output_format: Option<&'a str>,
     config: Option<&'a Path>,
     filename: Option<&'a str>,
     args: Vec<&'a str>,
-}
-
-impl<'a> Default for RuffCheck<'a> {
-    fn default() -> RuffCheck<'a> {
-        RuffCheck {
-            output_format: None,
-            config: None,
-            filename: None,
-            args: vec![],
-        }
-    }
 }
 
 impl<'a> RuffCheck<'a> {

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -11,7 +11,7 @@ use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
 use tempfile::TempDir;
 
 const BIN_NAME: &str = "ruff";
-const STDIN_BASE_OPTIONS: &[&str] = &["--no-cache", "--output-format", "full"];
+const STDIN_BASE_OPTIONS: &[&str] = &["--no-cache", "--output-format", "concise"];
 
 #[test]
 fn top_level_options() -> Result<()> {
@@ -38,25 +38,8 @@ inline-quotes = "single"
     exit_code: 1
     ----- stdout -----
     test.py:1:5: Q000 [*] Double quotes found but single quotes preferred
-      |
-    1 | a = "abcba".strip("aba")
-      |     ^^^^^^^ Q000
-      |
-      = help: Replace double quotes with single quotes
-
     test.py:1:5: B005 Using `.strip()` with multi-character strings is misleading
-      |
-    1 | a = "abcba".strip("aba")
-      |     ^^^^^^^^^^^^^^^^^^^^ B005
-      |
-
     test.py:1:19: Q000 [*] Double quotes found but single quotes preferred
-      |
-    1 | a = "abcba".strip("aba")
-      |                   ^^^^^ Q000
-      |
-      = help: Replace double quotes with single quotes
-
     Found 3 errors.
     [*] 2 fixable with the `--fix` option.
 
@@ -95,25 +78,8 @@ inline-quotes = "single"
     exit_code: 1
     ----- stdout -----
     -:1:5: Q000 [*] Double quotes found but single quotes preferred
-      |
-    1 | a = "abcba".strip("aba")
-      |     ^^^^^^^ Q000
-      |
-      = help: Replace double quotes with single quotes
-
     -:1:5: B005 Using `.strip()` with multi-character strings is misleading
-      |
-    1 | a = "abcba".strip("aba")
-      |     ^^^^^^^^^^^^^^^^^^^^ B005
-      |
-
     -:1:19: Q000 [*] Double quotes found but single quotes preferred
-      |
-    1 | a = "abcba".strip("aba")
-      |                   ^^^^^ Q000
-      |
-      = help: Replace double quotes with single quotes
-
     Found 3 errors.
     [*] 2 fixable with the `--fix` option.
 
@@ -147,25 +113,8 @@ inline-quotes = "single"
     exit_code: 1
     ----- stdout -----
     -:1:5: Q000 [*] Double quotes found but single quotes preferred
-      |
-    1 | a = "abcba".strip("aba")
-      |     ^^^^^^^ Q000
-      |
-      = help: Replace double quotes with single quotes
-
     -:1:5: B005 Using `.strip()` with multi-character strings is misleading
-      |
-    1 | a = "abcba".strip("aba")
-      |     ^^^^^^^^^^^^^^^^^^^^ B005
-      |
-
     -:1:19: Q000 [*] Double quotes found but single quotes preferred
-      |
-    1 | a = "abcba".strip("aba")
-      |                   ^^^^^ Q000
-      |
-      = help: Replace double quotes with single quotes
-
     Found 3 errors.
     [*] 2 fixable with the `--fix` option.
 
@@ -207,25 +156,8 @@ inline-quotes = "single"
     exit_code: 1
     ----- stdout -----
     -:1:5: Q000 [*] Double quotes found but single quotes preferred
-      |
-    1 | a = "abcba".strip("aba")
-      |     ^^^^^^^ Q000
-      |
-      = help: Replace double quotes with single quotes
-
     -:1:5: B005 Using `.strip()` with multi-character strings is misleading
-      |
-    1 | a = "abcba".strip("aba")
-      |     ^^^^^^^^^^^^^^^^^^^^ B005
-      |
-
     -:1:19: Q000 [*] Double quotes found but single quotes preferred
-      |
-    1 | a = "abcba".strip("aba")
-      |                   ^^^^^ Q000
-      |
-      = help: Replace double quotes with single quotes
-
     Found 3 errors.
     [*] 2 fixable with the `--fix` option.
 
@@ -303,31 +235,8 @@ OTHER = "OTHER"
     exit_code: 1
     ----- stdout -----
     main.py:4:16: Q000 [*] Double quotes found but single quotes preferred
-      |
-    2 | from test import say_hy
-    3 | 
-    4 | if __name__ == "__main__":
-      |                ^^^^^^^^^^ Q000
-    5 |     say_hy("dear Ruff contributor")
-      |
-      = help: Replace double quotes with single quotes
-
     main.py:5:12: Q000 [*] Double quotes found but single quotes preferred
-      |
-    4 | if __name__ == "__main__":
-    5 |     say_hy("dear Ruff contributor")
-      |            ^^^^^^^^^^^^^^^^^^^^^^^ Q000
-      |
-      = help: Replace double quotes with single quotes
-
     test.py:3:15: Q000 [*] Double quotes found but single quotes preferred
-      |
-    2 | def say_hy(name: str):
-    3 |         print(f"Hy {name}")
-      |               ^^^^^^^^^^^^ Q000
-      |
-      = help: Replace double quotes with single quotes
-
     Found 3 errors.
     [*] 3 fixable with the `--fix` option.
 
@@ -374,23 +283,7 @@ if __name__ == "__main__":
     exit_code: 1
     ----- stdout -----
     generated.py:4:16: Q000 [*] Double quotes found but single quotes preferred
-      |
-    2 | from test import say_hy
-    3 | 
-    4 | if __name__ == "__main__":
-      |                ^^^^^^^^^^ Q000
-    5 |     say_hy("dear Ruff contributor")
-      |
-      = help: Replace double quotes with single quotes
-
     generated.py:5:12: Q000 [*] Double quotes found but single quotes preferred
-      |
-    4 | if __name__ == "__main__":
-    5 |     say_hy("dear Ruff contributor")
-      |            ^^^^^^^^^^^^^^^^^^^^^^^ Q000
-      |
-      = help: Replace double quotes with single quotes
-
     Found 2 errors.
     [*] 2 fixable with the `--fix` option.
 
@@ -434,13 +327,6 @@ _ = "---------------------------------------------------------------------------
     exit_code: 1
     ----- stdout -----
     test.py:5:91: E501 Line too long (109 > 100)
-      |
-    3 | _ = "---------------------------------------------------------------------------亜亜亜亜亜亜"
-    4 | # longer than 100
-    5 | _ = "---------------------------------------------------------------------------亜亜亜亜亜亜亜亜亜亜亜亜亜亜"
-      |                                                                                                     ^^^^^^^^^ E501
-      |
-
     Found 1 error.
 
     ----- stderr -----
@@ -487,14 +373,6 @@ if __name__ == "__main__":
     exit_code: 1
     ----- stdout -----
     generated.py:2:8: F401 [*] `os` imported but unused
-      |
-    2 | import os
-      |        ^^ F401
-    3 | 
-    4 | from test import say_hy
-      |
-      = help: Remove unused import: `os`
-
     Found 1 error.
     [*] 1 fixable with the `--fix` option.
 
@@ -541,14 +419,6 @@ if __name__ == "__main__":
     exit_code: 1
     ----- stdout -----
     generated.py:2:8: F401 [*] `os` imported but unused
-      |
-    2 | import os
-      |        ^^ F401
-    3 | 
-    4 | from test import say_hy
-      |
-      = help: Remove unused import: `os`
-
     Found 1 error.
     [*] 1 fixable with the `--fix` option.
 
@@ -665,12 +535,6 @@ include = ["*.ipy"]
     exit_code: 1
     ----- stdout -----
     main.ipy:cell 1:1:8: F401 [*] `os` imported but unused
-      |
-    1 | import os
-      |        ^^ F401
-      |
-      = help: Remove unused import: `os`
-
     Found 1 error.
     [*] 1 fixable with the `--fix` option.
 

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -11,7 +11,7 @@ use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
 use tempfile::TempDir;
 
 const BIN_NAME: &str = "ruff";
-const STDIN_BASE_OPTIONS: &[&str] = &["--no-cache", "--output-format", "text"];
+const STDIN_BASE_OPTIONS: &[&str] = &["--no-cache", "--output-format", "full"];
 
 #[test]
 fn top_level_options() -> Result<()> {
@@ -38,8 +38,25 @@ inline-quotes = "single"
     exit_code: 1
     ----- stdout -----
     test.py:1:5: Q000 [*] Double quotes found but single quotes preferred
+      |
+    1 | a = "abcba".strip("aba")
+      |     ^^^^^^^ Q000
+      |
+      = help: Replace double quotes with single quotes
+
     test.py:1:5: B005 Using `.strip()` with multi-character strings is misleading
+      |
+    1 | a = "abcba".strip("aba")
+      |     ^^^^^^^^^^^^^^^^^^^^ B005
+      |
+
     test.py:1:19: Q000 [*] Double quotes found but single quotes preferred
+      |
+    1 | a = "abcba".strip("aba")
+      |                   ^^^^^ Q000
+      |
+      = help: Replace double quotes with single quotes
+
     Found 3 errors.
     [*] 2 fixable with the `--fix` option.
 
@@ -78,8 +95,25 @@ inline-quotes = "single"
     exit_code: 1
     ----- stdout -----
     -:1:5: Q000 [*] Double quotes found but single quotes preferred
+      |
+    1 | a = "abcba".strip("aba")
+      |     ^^^^^^^ Q000
+      |
+      = help: Replace double quotes with single quotes
+
     -:1:5: B005 Using `.strip()` with multi-character strings is misleading
+      |
+    1 | a = "abcba".strip("aba")
+      |     ^^^^^^^^^^^^^^^^^^^^ B005
+      |
+
     -:1:19: Q000 [*] Double quotes found but single quotes preferred
+      |
+    1 | a = "abcba".strip("aba")
+      |                   ^^^^^ Q000
+      |
+      = help: Replace double quotes with single quotes
+
     Found 3 errors.
     [*] 2 fixable with the `--fix` option.
 
@@ -113,8 +147,25 @@ inline-quotes = "single"
     exit_code: 1
     ----- stdout -----
     -:1:5: Q000 [*] Double quotes found but single quotes preferred
+      |
+    1 | a = "abcba".strip("aba")
+      |     ^^^^^^^ Q000
+      |
+      = help: Replace double quotes with single quotes
+
     -:1:5: B005 Using `.strip()` with multi-character strings is misleading
+      |
+    1 | a = "abcba".strip("aba")
+      |     ^^^^^^^^^^^^^^^^^^^^ B005
+      |
+
     -:1:19: Q000 [*] Double quotes found but single quotes preferred
+      |
+    1 | a = "abcba".strip("aba")
+      |                   ^^^^^ Q000
+      |
+      = help: Replace double quotes with single quotes
+
     Found 3 errors.
     [*] 2 fixable with the `--fix` option.
 
@@ -156,8 +207,25 @@ inline-quotes = "single"
     exit_code: 1
     ----- stdout -----
     -:1:5: Q000 [*] Double quotes found but single quotes preferred
+      |
+    1 | a = "abcba".strip("aba")
+      |     ^^^^^^^ Q000
+      |
+      = help: Replace double quotes with single quotes
+
     -:1:5: B005 Using `.strip()` with multi-character strings is misleading
+      |
+    1 | a = "abcba".strip("aba")
+      |     ^^^^^^^^^^^^^^^^^^^^ B005
+      |
+
     -:1:19: Q000 [*] Double quotes found but single quotes preferred
+      |
+    1 | a = "abcba".strip("aba")
+      |                   ^^^^^ Q000
+      |
+      = help: Replace double quotes with single quotes
+
     Found 3 errors.
     [*] 2 fixable with the `--fix` option.
 
@@ -235,8 +303,31 @@ OTHER = "OTHER"
     exit_code: 1
     ----- stdout -----
     main.py:4:16: Q000 [*] Double quotes found but single quotes preferred
+      |
+    2 | from test import say_hy
+    3 | 
+    4 | if __name__ == "__main__":
+      |                ^^^^^^^^^^ Q000
+    5 |     say_hy("dear Ruff contributor")
+      |
+      = help: Replace double quotes with single quotes
+
     main.py:5:12: Q000 [*] Double quotes found but single quotes preferred
+      |
+    4 | if __name__ == "__main__":
+    5 |     say_hy("dear Ruff contributor")
+      |            ^^^^^^^^^^^^^^^^^^^^^^^ Q000
+      |
+      = help: Replace double quotes with single quotes
+
     test.py:3:15: Q000 [*] Double quotes found but single quotes preferred
+      |
+    2 | def say_hy(name: str):
+    3 |         print(f"Hy {name}")
+      |               ^^^^^^^^^^^^ Q000
+      |
+      = help: Replace double quotes with single quotes
+
     Found 3 errors.
     [*] 3 fixable with the `--fix` option.
 
@@ -283,7 +374,23 @@ if __name__ == "__main__":
     exit_code: 1
     ----- stdout -----
     generated.py:4:16: Q000 [*] Double quotes found but single quotes preferred
+      |
+    2 | from test import say_hy
+    3 | 
+    4 | if __name__ == "__main__":
+      |                ^^^^^^^^^^ Q000
+    5 |     say_hy("dear Ruff contributor")
+      |
+      = help: Replace double quotes with single quotes
+
     generated.py:5:12: Q000 [*] Double quotes found but single quotes preferred
+      |
+    4 | if __name__ == "__main__":
+    5 |     say_hy("dear Ruff contributor")
+      |            ^^^^^^^^^^^^^^^^^^^^^^^ Q000
+      |
+      = help: Replace double quotes with single quotes
+
     Found 2 errors.
     [*] 2 fixable with the `--fix` option.
 
@@ -327,6 +434,13 @@ _ = "---------------------------------------------------------------------------
     exit_code: 1
     ----- stdout -----
     test.py:5:91: E501 Line too long (109 > 100)
+      |
+    3 | _ = "---------------------------------------------------------------------------亜亜亜亜亜亜"
+    4 | # longer than 100
+    5 | _ = "---------------------------------------------------------------------------亜亜亜亜亜亜亜亜亜亜亜亜亜亜"
+      |                                                                                                     ^^^^^^^^^ E501
+      |
+
     Found 1 error.
 
     ----- stderr -----
@@ -373,6 +487,14 @@ if __name__ == "__main__":
     exit_code: 1
     ----- stdout -----
     generated.py:2:8: F401 [*] `os` imported but unused
+      |
+    2 | import os
+      |        ^^ F401
+    3 | 
+    4 | from test import say_hy
+      |
+      = help: Remove unused import: `os`
+
     Found 1 error.
     [*] 1 fixable with the `--fix` option.
 
@@ -419,6 +541,14 @@ if __name__ == "__main__":
     exit_code: 1
     ----- stdout -----
     generated.py:2:8: F401 [*] `os` imported but unused
+      |
+    2 | import os
+      |        ^^ F401
+    3 | 
+    4 | from test import say_hy
+      |
+      = help: Remove unused import: `os`
+
     Found 1 error.
     [*] 1 fixable with the `--fix` option.
 
@@ -535,6 +665,12 @@ include = ["*.ipy"]
     exit_code: 1
     ----- stdout -----
     main.ipy:cell 1:1:8: F401 [*] `os` imported but unused
+      |
+    1 | import os
+      |        ^^ F401
+      |
+      = help: Remove unused import: `os`
+
     Found 1 error.
     [*] 1 fixable with the `--fix` option.
 

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -17,9 +17,8 @@ Settings path: "[BASEPATH]/pyproject.toml"
 cache_dir = "[BASEPATH]/.ruff_cache"
 fix = false
 fix_only = false
-output_format = text
+output_format = full
 show_fixes = false
-show_source = false
 unsafe_fixes = hint
 
 # File Resolver Settings

--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -17,7 +17,7 @@ Settings path: "[BASEPATH]/pyproject.toml"
 cache_dir = "[BASEPATH]/.ruff_cache"
 fix = false
 fix_only = false
-output_format = full
+output_format = concise
 show_fixes = false
 unsafe_fixes = hint
 

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -486,13 +486,12 @@ impl FromIterator<ExtensionPair> for ExtensionMapping {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, Default, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, Hash)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum SerializationFormat {
     Text,
-    #[default]
     Concise,
     Full,
     Json,
@@ -521,6 +520,16 @@ impl Display for SerializationFormat {
             Self::Pylint => write!(f, "pylint"),
             Self::Azure => write!(f, "azure"),
             Self::Sarif => write!(f, "sarif"),
+        }
+    }
+}
+
+impl SerializationFormat {
+    pub fn default(preview: bool) -> Self {
+        if preview {
+            Self::Full
+        } else {
+            Self::Concise
         }
     }
 }

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -492,8 +492,8 @@ impl FromIterator<ExtensionPair> for ExtensionMapping {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum SerializationFormat {
     Text,
-    Concise,
     #[default]
+    Concise,
     Full,
     Json,
     JsonLines,

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -486,12 +486,15 @@ impl FromIterator<ExtensionPair> for ExtensionMapping {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, Default, Hash)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum SerializationFormat {
     Text,
+    Concise,
+    #[default]
+    Full,
     Json,
     JsonLines,
     Junit,
@@ -507,6 +510,8 @@ impl Display for SerializationFormat {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Text => write!(f, "text"),
+            Self::Concise => write!(f, "concise"),
+            Self::Full => write!(f, "full"),
             Self::Json => write!(f, "json"),
             Self::JsonLines => write!(f, "json_lines"),
             Self::Junit => write!(f, "junit"),
@@ -517,12 +522,6 @@ impl Display for SerializationFormat {
             Self::Azure => write!(f, "azure"),
             Self::Sarif => write!(f, "sarif"),
         }
-    }
-}
-
-impl Default for SerializationFormat {
-    fn default() -> Self {
-        Self::Text
     }
 }
 

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -425,6 +425,13 @@ impl Configuration {
 
             options
                 .output_format
+                .map(|format| match format {
+                    SerializationFormat::Text => {
+                        warn_user!(r#"Setting `output_format` to "text" is deprecated. Use "full" or "concise" instead. "text" will be treated as "{}"."#, SerializationFormat::default());
+                        SerializationFormat::default()
+                    },
+                    other => other
+                })
                 .or(options.show_source.map(|show_source| {
                     if show_source {
                         SerializationFormat::Full

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -220,7 +220,9 @@ impl Configuration {
             fix: self.fix.unwrap_or(false),
             fix_only: self.fix_only.unwrap_or(false),
             unsafe_fixes: self.unsafe_fixes.unwrap_or_default(),
-            output_format: self.output_format.unwrap_or_default(),
+            output_format: self
+                .output_format
+                .unwrap_or_else(|| SerializationFormat::default(global_preview.is_enabled())),
             show_fixes: self.show_fixes.unwrap_or(false),
 
             file_resolver: FileResolverSettings {
@@ -427,8 +429,8 @@ impl Configuration {
                 .output_format
                 .map(|format| match format {
                     SerializationFormat::Text => {
-                        warn_user!(r#"Setting `output_format` to "text" is deprecated. Use "full" or "concise" instead. "text" will be treated as "{}"."#, SerializationFormat::default());
-                        SerializationFormat::default()
+                        warn_user!(r#"Setting `output_format` to "text" is deprecated. Use "full" or "concise" instead. "text" will be treated as "{}"."#, SerializationFormat::default(options.preview.unwrap_or_default()));
+                        SerializationFormat::default(options.preview.unwrap_or_default())
                     },
                     other => other
                 })

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -73,12 +73,12 @@ pub struct Options {
     pub extend: Option<String>,
 
     /// The style in which violation messages should be formatted: `"full"`
-    /// (default),`"concise"` (omits source display), `"grouped"` (group messages by file), `"json"`
+    /// (shows source),`"concise"` (default), `"grouped"` (group messages by file), `"json"`
     /// (machine-readable), `"junit"` (machine-readable XML), `"github"` (GitHub
     /// Actions annotations), `"gitlab"` (GitLab CI code quality report),
     /// `"pylint"` (Pylint text format) or `"azure"` (Azure Pipeline logging commands).
     #[option(
-        default = r#""full""#,
+        default = r#""concise""#,
         value_type = r#""full" | "concise" | "grouped" | "json" | "junit" | "github" | "gitlab" | "pylint" | "azure""#,
         example = r#"
             # Group violations by containing file.

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -72,14 +72,14 @@ pub struct Options {
     )]
     pub extend: Option<String>,
 
-    /// The style in which violation messages should be formatted: `"text"`
-    /// (default), `"grouped"` (group messages by file), `"json"`
+    /// The style in which violation messages should be formatted: `"full"`
+    /// (default),`"concise"` (omits source display), `"grouped"` (group messages by file), `"json"`
     /// (machine-readable), `"junit"` (machine-readable XML), `"github"` (GitHub
     /// Actions annotations), `"gitlab"` (GitLab CI code quality report),
     /// `"pylint"` (Pylint text format) or `"azure"` (Azure Pipeline logging commands).
     #[option(
-        default = r#""text""#,
-        value_type = r#""text" | "json" | "junit" | "github" | "gitlab" | "pylint" | "azure""#,
+        default = r#""full""#,
+        value_type = r#""full" | "concise" | "grouped" | "json" | "junit" | "github" | "gitlab" | "pylint" | "azure""#,
         example = r#"
             # Group violations by containing file.
             output-format = "grouped"
@@ -116,6 +116,9 @@ pub struct Options {
             # By default, always show source code snippets.
             show-source = true
         "#
+    )]
+    #[deprecated(
+        note = "`show_source` is deprecated and is now part of `output_format` in the form of `full` or `concise` options. Please update your configuration."
     )]
     pub show_source: Option<bool>,
 

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -44,7 +44,7 @@ impl Default for Settings {
             cache_dir: cache_dir(project_root),
             fix: false,
             fix_only: false,
-            output_format: SerializationFormat::default(),
+            output_format: SerializationFormat::default(false),
             show_fixes: false,
             unsafe_fixes: UnsafeFixes::default(),
             linter: LinterSettings::new(project_root),

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -31,8 +31,6 @@ pub struct Settings {
     pub output_format: SerializationFormat,
     #[cache_key(ignore)]
     pub show_fixes: bool,
-    #[cache_key(ignore)]
-    pub show_source: bool,
 
     pub file_resolver: FileResolverSettings,
     pub linter: LinterSettings,
@@ -48,7 +46,6 @@ impl Default for Settings {
             fix_only: false,
             output_format: SerializationFormat::default(),
             show_fixes: false,
-            show_source: false,
             unsafe_fixes: UnsafeFixes::default(),
             linter: LinterSettings::new(project_root),
             file_resolver: FileResolverSettings::new(project_root),
@@ -70,7 +67,6 @@ impl fmt::Display for Settings {
                 self.fix_only,
                 self.output_format,
                 self.show_fixes,
-                self.show_source,
                 self.unsafe_fixes,
                 self.file_resolver | nested,
                 self.linter        | nested,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -528,9 +528,10 @@ Options:
       --ignore-noqa
           Ignore any `# noqa` comments
       --output-format <OUTPUT_FORMAT>
-          Output serialization format for violations [env: RUFF_OUTPUT_FORMAT=]
-          [possible values: text, concise, full, json, json-lines, junit,
-          grouped, github, gitlab, pylint, azure, sarif]
+          Output serialization format for violations. The default serialization
+          format is "full" [env: RUFF_OUTPUT_FORMAT=] [possible values: text,
+          concise, full, json, json-lines, junit, grouped, github, gitlab,
+          pylint, azure, sarif]
   -o, --output-file <OUTPUT_FILE>
           Specify file to write the linter output to (default: stdout)
       --target-version <TARGET_VERSION>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -510,7 +510,9 @@ Options:
           Include fixes that may not retain the original intent of the code.
           Use `--no-unsafe-fixes` to disable
       --show-source
-          Show violations with source code. Use `--no-show-source` to disable
+          Show violations with source code. Use `--no-show-source` to disable.
+          (Deprecated: use `--output-format=full` or `--output-format=concise`
+          instead of `--show-source` and `--no-show-source`, respectively)
       --show-fixes
           Show an enumeration of all fixed lint violations. Use
           `--no-show-fixes` to disable
@@ -527,8 +529,8 @@ Options:
           Ignore any `# noqa` comments
       --output-format <OUTPUT_FORMAT>
           Output serialization format for violations [env: RUFF_OUTPUT_FORMAT=]
-          [possible values: text, json, json-lines, junit, grouped, github,
-          gitlab, pylint, azure, sarif]
+          [possible values: text, concise, full, json, json-lines, junit,
+          grouped, github, gitlab, pylint, azure, sarif]
   -o, --output-file <OUTPUT_FILE>
           Specify file to write the linter output to (default: stdout)
       --target-version <TARGET_VERSION>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -529,9 +529,9 @@ Options:
           Ignore any `# noqa` comments
       --output-format <OUTPUT_FORMAT>
           Output serialization format for violations. The default serialization
-          format is "full" [env: RUFF_OUTPUT_FORMAT=] [possible values: text,
-          concise, full, json, json-lines, junit, grouped, github, gitlab,
-          pylint, azure, sarif]
+          format is "concise" [env: RUFF_OUTPUT_FORMAT=] [possible values:
+          text, concise, full, json, json-lines, junit, grouped, github,
+          gitlab, pylint, azure, sarif]
   -o, --output-file <OUTPUT_FILE>
           Specify file to write the linter output to (default: stdout)
       --target-version <TARGET_VERSION>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -529,9 +529,10 @@ Options:
           Ignore any `# noqa` comments
       --output-format <OUTPUT_FORMAT>
           Output serialization format for violations. The default serialization
-          format is "concise" [env: RUFF_OUTPUT_FORMAT=] [possible values:
-          text, concise, full, json, json-lines, junit, grouped, github,
-          gitlab, pylint, azure, sarif]
+          format is "concise". In preview mode, the default serialization
+          format is "full" [env: RUFF_OUTPUT_FORMAT=] [possible values: text,
+          concise, full, json, json-lines, junit, grouped, github, gitlab,
+          pylint, azure, sarif]
   -o, --output-file <OUTPUT_FILE>
           Specify file to write the linter output to (default: stdout)
       --target-version <TARGET_VERSION>

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -519,7 +519,7 @@
       }
     },
     "output-format": {
-      "description": "The style in which violation messages should be formatted: `\"full\"` (default),`\"concise\"` (omits source display), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report), `\"pylint\"` (Pylint text format) or `\"azure\"` (Azure Pipeline logging commands).",
+      "description": "The style in which violation messages should be formatted: `\"full\"` (shows source),`\"concise\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report), `\"pylint\"` (Pylint text format) or `\"azure\"` (Azure Pipeline logging commands).",
       "anyOf": [
         {
           "$ref": "#/definitions/SerializationFormat"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -519,7 +519,7 @@
       }
     },
     "output-format": {
-      "description": "The style in which violation messages should be formatted: `\"text\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report), `\"pylint\"` (Pylint text format) or `\"azure\"` (Azure Pipeline logging commands).",
+      "description": "The style in which violation messages should be formatted: `\"full\"` (default),`\"concise\"` (omits source display), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report), `\"pylint\"` (Pylint text format) or `\"azure\"` (Azure Pipeline logging commands).",
       "anyOf": [
         {
           "$ref": "#/definitions/SerializationFormat"
@@ -660,6 +660,7 @@
     },
     "show-source": {
       "description": "Whether to show source code snippets when reporting lint violations (overridden by the `--show-source` command-line flag).",
+      "deprecated": true,
       "type": [
         "boolean",
         "null"
@@ -3816,6 +3817,8 @@
       "type": "string",
       "enum": [
         "text",
+        "concise",
+        "full",
         "json",
         "json-lines",
         "junit",


### PR DESCRIPTION
Fixes #7350

## Summary

* `--show-source` and `--no-show-source` are now deprecated.
* `output-format` supports two new variants, `full` and `concise`. `text` is now a deprecated variant, and any use of it is treated as the default serialization format.
* `--output-format` now default to `concise`
* In preview mode, `--output-format` defaults to `full`
* `--show-source` will still set `--output-format` to `full` if the output format is not otherwise specified.
* likewise, `--no-show-source` can override an output format that was set in a file-based configuration, though it will also be overridden by `--output-format`

## Test Plan

A lot of tests were updated to use `--output-format=full`. Additional tests were added to ensure the correct deprecation warnings appeared, and that deprecated options behaved as intended.
