### PR TITLE
Add rule deprecation infrastructure

### DIFF
--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -26,13 +26,21 @@ pub(crate) fn main(args: &Args) -> Result<()> {
     for rule in Rule::iter() {
         if let Some(explanation) = rule.explanation() {
             let mut output = String::new();
+
             output.push_str(&format!("# {} ({})", rule.as_ref(), rule.noqa_code()));
-            output.push('\n');
             output.push('\n');
 
             let (linter, _) = Linter::parse_code(&rule.noqa_code().to_string()).unwrap();
             if linter.url().is_some() {
                 output.push_str(&format!("Derived from the **{}** linter.", linter.name()));
+                output.push('\n');
+                output.push('\n');
+            }
+
+            if rule.is_deprecated() {
+                output.push_str(
+                    r"**Warning: This rule is deprecated and will be removed in a future release.**",
+                );
                 output.push('\n');
                 output.push('\n');
             }

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -52,6 +52,9 @@ pub enum RuleGroup {
     Stable,
     /// The rule is unstable, and preview mode must be enabled for usage.
     Preview,
+    /// The rule has been deprecated, warnings will be displayed during selection in stable
+    /// and errors will be raised if used with preview mode enabled.
+    Deprecated,
     /// Legacy category for unstable rules, supports backwards compatible selection.
     #[deprecated(note = "Use `RuleGroup::Preview` for new rules instead")]
     Nursery,
@@ -424,8 +427,8 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8Annotations, "001") => (RuleGroup::Stable, rules::flake8_annotations::rules::MissingTypeFunctionArgument),
         (Flake8Annotations, "002") => (RuleGroup::Stable, rules::flake8_annotations::rules::MissingTypeArgs),
         (Flake8Annotations, "003") => (RuleGroup::Stable, rules::flake8_annotations::rules::MissingTypeKwargs),
-        (Flake8Annotations, "101") => (RuleGroup::Stable, rules::flake8_annotations::rules::MissingTypeSelf),
-        (Flake8Annotations, "102") => (RuleGroup::Stable, rules::flake8_annotations::rules::MissingTypeCls),
+        (Flake8Annotations, "101") => (RuleGroup::Deprecated, rules::flake8_annotations::rules::MissingTypeSelf),
+        (Flake8Annotations, "102") => (RuleGroup::Deprecated, rules::flake8_annotations::rules::MissingTypeCls),
         (Flake8Annotations, "201") => (RuleGroup::Stable, rules::flake8_annotations::rules::MissingReturnTypeUndocumentedPublicFunction),
         (Flake8Annotations, "202") => (RuleGroup::Stable, rules::flake8_annotations::rules::MissingReturnTypePrivateFunction),
         (Flake8Annotations, "204") => (RuleGroup::Stable, rules::flake8_annotations::rules::MissingReturnTypeSpecialMethod),
@@ -842,7 +845,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Tryceratops, "002") => (RuleGroup::Stable, rules::tryceratops::rules::RaiseVanillaClass),
         (Tryceratops, "003") => (RuleGroup::Stable, rules::tryceratops::rules::RaiseVanillaArgs),
         (Tryceratops, "004") => (RuleGroup::Stable, rules::tryceratops::rules::TypeCheckWithoutTypeError),
-        (Tryceratops, "200") => (RuleGroup::Stable, rules::tryceratops::rules::ReraiseNoCause),
+        (Tryceratops, "200") => (RuleGroup::Deprecated, rules::tryceratops::rules::ReraiseNoCause),
         (Tryceratops, "201") => (RuleGroup::Stable, rules::tryceratops::rules::VerboseRaise),
         (Tryceratops, "300") => (RuleGroup::Stable, rules::tryceratops::rules::TryConsiderElse),
         (Tryceratops, "301") => (RuleGroup::Stable, rules::tryceratops::rules::RaiseWithinTry),

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -204,13 +204,15 @@ impl RuleSelector {
         let preview_require_explicit = preview.require_explicit;
         #[allow(deprecated)]
         self.all_rules().filter(move |rule| {
-            // Always include rules that are not in preview or the nursery
-            !(rule.is_preview() || rule.is_nursery())
+            // Always include stable rules
+            rule.is_stable()
             // Backwards compatibility allows selection of nursery rules by exact code or dedicated group
             || ((matches!(self, RuleSelector::Rule { .. }) || matches!(self, RuleSelector::Nursery { .. })) && rule.is_nursery())
             // Enabling preview includes all preview or nursery rules unless explicit selection
             // is turned on
             || (preview_enabled && (matches!(self, RuleSelector::Rule { .. }) || !preview_require_explicit))
+            // Deprecated rules are excluded in preview mode unless explicitly selected
+            || (rule.is_deprecated() && (!preview_enabled || matches!(self, RuleSelector::Rule { .. })))
         })
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -111,6 +111,10 @@ impl Violation for MissingTypeKwargs {
     }
 }
 
+/// ## Deprecation
+/// This rule is commonly disabled because type checkers can infer this type without annotation.
+/// It will be removed in a future release.
+///
 /// ## What it does
 /// Checks that instance method `self` arguments have type annotations.
 ///
@@ -148,6 +152,10 @@ impl Violation for MissingTypeSelf {
     }
 }
 
+/// ## Deprecation
+/// This rule is commonly disabled because type checkers can infer this type without annotation.
+/// It will be removed in a future release.
+///
 /// ## What it does
 /// Checks that class method `cls` arguments have type annotations.
 ///

--- a/crates/ruff_linter/src/rules/tryceratops/rules/reraise_no_cause.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/reraise_no_cause.rs
@@ -7,6 +7,9 @@ use ruff_python_ast::statement_visitor::StatementVisitor;
 
 use crate::checkers::ast::Checker;
 
+/// ## Deprecation
+/// This rule is identical to [B904] which should be used instead.
+///
 /// ## What it does
 /// Checks for exceptions that are re-raised without specifying the cause via
 /// the `from` keyword.
@@ -36,6 +39,8 @@ use crate::checkers::ast::Checker;
 ///
 /// ## References
 /// - [Python documentation: Exception context](https://docs.python.org/3/library/exceptions.html#exception-context)
+///
+/// [B904]: https://docs.astral.sh/ruff/rules/raise-without-from-inside-except/
 #[violation]
 pub struct ReraiseNoCause;
 

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -315,9 +315,17 @@ See also https://github.com/astral-sh/ruff/issues/2186.
                 matches!(self.group(), RuleGroup::Preview)
             }
 
+            pub fn is_stable(&self) -> bool {
+                matches!(self.group(), RuleGroup::Stable)
+            }
+
             #[allow(deprecated)]
             pub fn is_nursery(&self) -> bool {
                 matches!(self.group(), RuleGroup::Nursery)
+            }
+
+            pub fn is_deprecated(&self) -> bool {
+                matches!(self.group(), RuleGroup::Deprecated)
             }
         }
 

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -971,15 +971,16 @@ impl LintConfiguration {
                 );
             }
         } else {
-            match deprecated_selectors.iter().collect::<Vec<_>>().as_slice() {
+            let deprecated_selectors = deprecated_selectors.iter().collect::<Vec<_>>();
+            match deprecated_selectors.as_slice() {
                 [] => (),
                 [selection] => {
                     let (prefix, code) = selection.prefix_and_code();
                     return Err(anyhow!("Selection of deprecated rule `{prefix}{code}` is not allowed when preview mode is enabled."));
                 }
-                [selections @ ..] => {
+                [..] => {
                     let mut message = "Selection of deprecated rules is not allowed when preview mode is enabled. Remove selection of:".to_string();
-                    for selection in selections {
+                    for selection in deprecated_selectors {
                         let (prefix, code) = selection.prefix_and_code();
                         message.push_str("\n\t- ");
                         message.push_str(prefix);

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -143,3 +143,8 @@ In our previous example, `--select` with `ALL` `HYP`, `HYP0`, or `HYP00` would n
 rule will need to be selected with its exact code, e.g. `--select ALL,HYP001`.
 
 If preview mode is not enabled, this setting has no effect.
+
+## Deprecated rules
+
+When preview mode is enabled, deprecated rules will be disabled. If a deprecated rule is selected explicitly, an
+error will be raised. Deprecated rules will not be included if selected via a rule category or prefix.


### PR DESCRIPTION
Adds a new `Deprecated` rule group in addition to `Stable` and `Preview`.

Deprecated rules:
- Warn on explicit selection without preview
- Error on explicit selection with preview
- Are excluded when selected by prefix with preview

Deprecates `TRY200`, `ANN101`, and `ANN102` as a proof of concept. We can consider deprecating them separately.