### PR TITLE
[`pylint`] Show verbatim constant in `magic-value-comparison` (`PLR2004`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/magic_value_comparison.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/magic_value_comparison.py
@@ -68,6 +68,9 @@ if pi_estimation == 3.141592653589793238:  # [magic-value-comparison]
 if pi_estimation == PI:  # correct
     pass
 
+if pi_estimation == 0x3:  # [magic-value-comparison]
+    pass
+
 HELLO_WORLD = b"Hello, World!"
 user_input = b"Hello, There!"
 

--- a/crates/ruff_linter/src/rules/pylint/rules/magic_value_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/magic_value_comparison.rs
@@ -52,7 +52,7 @@ impl Violation for MagicValueComparison {
     fn message(&self) -> String {
         let MagicValueComparison { value } = self;
         format!(
-            "Magic value used in comparison, consider replacing {value} with a constant variable"
+            "Magic value used in comparison, consider replacing `{value}` with a constant variable"
         )
     }
 }
@@ -111,7 +111,7 @@ pub(crate) fn magic_value_comparison(checker: &mut Checker, left: &Expr, compara
             if is_magic_value(value, &checker.settings.pylint.allow_magic_value_types) {
                 checker.diagnostics.push(Diagnostic::new(
                     MagicValueComparison {
-                        value: checker.generator().expr(comparison_expr),
+                        value: checker.locator().slice(comparison_expr).to_string(),
                     },
                     comparison_expr.range(),
                 ));

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR2004_magic_value_comparison.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR2004_magic_value_comparison.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-magic_value_comparison.py:5:4: PLR2004 Magic value used in comparison, consider replacing 10 with a constant variable
+magic_value_comparison.py:5:4: PLR2004 Magic value used in comparison, consider replacing `10` with a constant variable
   |
 3 | user_input = 10
 4 | 
@@ -10,7 +10,7 @@ magic_value_comparison.py:5:4: PLR2004 Magic value used in comparison, consider 
 6 |     pass
   |
 
-magic_value_comparison.py:38:12: PLR2004 Magic value used in comparison, consider replacing 2 with a constant variable
+magic_value_comparison.py:38:12: PLR2004 Magic value used in comparison, consider replacing `2` with a constant variable
    |
 36 |     pass
 37 | 
@@ -19,7 +19,7 @@ magic_value_comparison.py:38:12: PLR2004 Magic value used in comparison, conside
 39 |     pass
    |
 
-magic_value_comparison.py:41:12: PLR2004 Magic value used in comparison, consider replacing -2 with a constant variable
+magic_value_comparison.py:41:12: PLR2004 Magic value used in comparison, consider replacing `-2` with a constant variable
    |
 39 |     pass
 40 | 
@@ -28,7 +28,7 @@ magic_value_comparison.py:41:12: PLR2004 Magic value used in comparison, conside
 42 |     pass
    |
 
-magic_value_comparison.py:44:12: PLR2004 Magic value used in comparison, consider replacing +2 with a constant variable
+magic_value_comparison.py:44:12: PLR2004 Magic value used in comparison, consider replacing `+2` with a constant variable
    |
 42 |     pass
 43 | 
@@ -37,13 +37,22 @@ magic_value_comparison.py:44:12: PLR2004 Magic value used in comparison, conside
 45 |     pass
    |
 
-magic_value_comparison.py:65:21: PLR2004 Magic value used in comparison, consider replacing 3.141592653589793 with a constant variable
+magic_value_comparison.py:65:21: PLR2004 Magic value used in comparison, consider replacing `3.141592653589793238` with a constant variable
    |
 63 | pi_estimation = 3.14
 64 | 
 65 | if pi_estimation == 3.141592653589793238:  # [magic-value-comparison]
    |                     ^^^^^^^^^^^^^^^^^^^^ PLR2004
 66 |     pass
+   |
+
+magic_value_comparison.py:71:21: PLR2004 Magic value used in comparison, consider replacing `0x3` with a constant variable
+   |
+69 |     pass
+70 | 
+71 | if pi_estimation == 0x3:  # [magic-value-comparison]
+   |                     ^^^ PLR2004
+72 |     pass
    |
 
 

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__allow_magic_value_types.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__allow_magic_value_types.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
 ---
-magic_value_comparison.py:59:22: PLR2004 Magic value used in comparison, consider replacing "Hunter2" with a constant variable
+magic_value_comparison.py:59:22: PLR2004 Magic value used in comparison, consider replacing `"Hunter2"` with a constant variable
    |
 57 |     pass
 58 | 
@@ -10,7 +10,7 @@ magic_value_comparison.py:59:22: PLR2004 Magic value used in comparison, conside
 60 |     pass
    |
 
-magic_value_comparison.py:65:21: PLR2004 Magic value used in comparison, consider replacing 3.141592653589793 with a constant variable
+magic_value_comparison.py:65:21: PLR2004 Magic value used in comparison, consider replacing `3.141592653589793238` with a constant variable
    |
 63 | pi_estimation = 3.14
 64 | 
@@ -19,13 +19,13 @@ magic_value_comparison.py:65:21: PLR2004 Magic value used in comparison, conside
 66 |     pass
    |
 
-magic_value_comparison.py:74:18: PLR2004 Magic value used in comparison, consider replacing b"something" with a constant variable
+magic_value_comparison.py:77:18: PLR2004 Magic value used in comparison, consider replacing `b"something"` with a constant variable
    |
-72 | user_input = b"Hello, There!"
-73 | 
-74 | if user_input == b"something":  # correct
+75 | user_input = b"Hello, There!"
+76 | 
+77 | if user_input == b"something":  # correct
    |                  ^^^^^^^^^^^^ PLR2004
-75 |     pass
+78 |     pass
    |
 
 


### PR DESCRIPTION
## Summary

Tweaks PLR2004 to show the literal source text, rather than the constant value.

I noticed this when I had a hexadecimal constant, and the linter turned it into base-10.

Now, if you have `0x300`, it will show `0x300` instead of `768`.

Also, added backticks around the constant in the output message.

## Test Plan

`cargo test`