### PR TITLE
Show source-type in formatter snapshot tests with options

### DIFF
--- a/crates/ruff_python_formatter/tests/fixtures.rs
+++ b/crates/ruff_python_formatter/tests/fixtures.rs
@@ -381,7 +381,8 @@ magic-trailing-comma       = {magic_trailing_comma:?}
 docstring-code             = {docstring_code:?}
 docstring-code-line-width  = {docstring_code_line_width:?}
 preview                    = {preview:?}
-target_version             = {target_version:?}"#,
+target_version             = {target_version:?}
+source_type                = {source_type:?}"#,
             indent_style = self.0.indent_style(),
             indent_width = self.0.indent_width().value(),
             line_width = self.0.line_width().value(),
@@ -391,7 +392,8 @@ target_version             = {target_version:?}"#,
             docstring_code = self.0.docstring_code(),
             docstring_code_line_width = self.0.docstring_code_line_width(),
             preview = self.0.preview(),
-            target_version = self.0.target_version()
+            target_version = self.0.target_version(),
+            source_type = self.0.source_type()
         )
     }
 }

--- a/crates/ruff_python_formatter/tests/snapshots/format@blank_line_before_class_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@blank_line_before_class_docstring.py.snap
@@ -57,6 +57,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring.py.snap
@@ -176,6 +176,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -351,6 +352,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -526,6 +528,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -701,6 +704,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -876,6 +880,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples.py.snap
@@ -1369,6 +1369,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -2740,6 +2741,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -4111,6 +4113,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -5482,6 +5485,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -6853,6 +6857,7 @@ docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -8257,6 +8262,7 @@ docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -9661,6 +9667,7 @@ docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -11074,6 +11081,7 @@ docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -12478,6 +12486,7 @@ docstring-code             = Enabled
 docstring-code-line-width  = 60
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -13891,6 +13900,7 @@ docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_crlf.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_crlf.py.snap
@@ -28,6 +28,7 @@ docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_dynamic_line_width.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_code_examples_dynamic_line_width.py.snap
@@ -240,6 +240,7 @@ docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -569,6 +570,7 @@ docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -866,6 +868,7 @@ docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -1195,6 +1198,7 @@ docstring-code             = Enabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__bytes.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__bytes.py.snap
@@ -141,6 +141,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -296,6 +297,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__string.py.snap
@@ -159,6 +159,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -365,6 +366,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__fmt_off_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__fmt_off_docstring.py.snap
@@ -38,6 +38,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -75,6 +76,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__indent.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__indent.py.snap
@@ -19,6 +19,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -37,6 +38,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -55,6 +57,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__mixed_space_and_tab.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__mixed_space_and_tab.py.snap
@@ -34,6 +34,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -68,6 +69,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -102,6 +104,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@preview.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@preview.py.snap
@@ -85,6 +85,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -240,6 +241,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@quote_style.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@quote_style.py.snap
@@ -69,6 +69,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -154,6 +155,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -239,6 +241,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@skip_magic_trailing_comma.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@skip_magic_trailing_comma.py.snap
@@ -52,6 +52,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -109,6 +110,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__assignment_split_value_first.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__assignment_split_value_first.py.snap
@@ -254,6 +254,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
@@ -328,6 +328,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -698,6 +699,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = Py39
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with_39.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with_39.py.snap
@@ -107,6 +107,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Enabled
 target_version             = Py39
+source_type                = Python
 ```
 
 ```python

--- a/crates/ruff_python_formatter/tests/snapshots/format@tab_width.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@tab_width.py.snap
@@ -27,6 +27,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -53,6 +54,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python
@@ -82,6 +84,7 @@ docstring-code             = Disabled
 docstring-code-line-width  = "dynamic"
 preview                    = Disabled
 target_version             = Py38
+source_type                = Python
 ```
 
 ```python


### PR DESCRIPTION
## Summary

Show the source type in formatter snapshot tests with an `.options.json` file to ease debugging.

## Test Plan

Reviewed snapshots
