### PR TITLE
[`pylint`] Add `__mro_entries__` to known dunder methods (`PLW3201`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/bad_dunder_method_name.py
@@ -91,6 +91,9 @@ class Apples:
     def __prepare__():
         pass
 
+    def __mro_entries__(self, bases):
+        pass
+
 
 def __foo_bar__():  # this is not checked by the [bad-dunder-name] rule
     ...

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -280,6 +280,7 @@ pub(super) fn is_known_dunder_method(method: &str) -> bool {
             | "__missing__"
             | "__mod__"
             | "__module__"
+            | "__mro_entries__"
             | "__mul__"
             | "__ne__"
             | "__neg__"


### PR DESCRIPTION
Yes, I actually need this dunder in my project.

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This change adds [`__mro_entries__`](https://docs.python.org/3/reference/datamodel.html#object.__mro_entries__) to the list of known dunder methods.

## Test Plan

<!-- How was it tested? -->
8893a3ca5784034101701bad8024e8bf59c6f8b6.