### PR TITLE
Always request the concise output format during ecosystem checks

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/projects.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/projects.py
@@ -206,6 +206,8 @@ class CheckOptions(CommandOptions):
             "check",
             "--no-cache",
             "--exit-zero",
+            "--output-format",
+            "concise",
             f"--{'' if self.preview else 'no-'}preview",
         ]
         if self.select:


### PR DESCRIPTION
Fixes a regression in the ecosystem checks from https://github.com/astral-sh/ruff/pull/9687 which was causing them to run for multiple hours due to the size of the output.

We need the concise format for comparisons.

We should probably update the ecosystem checks to actually diff the full output in the future because that'd be nice.