### PR TITLE
Use the deprecated output format `text` for ecosystem checks in release/0.2.0

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/projects.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/projects.py
@@ -207,7 +207,7 @@ class CheckOptions(CommandOptions):
             "--no-cache",
             "--exit-zero",
             "--output-format",
-            "concise",
+            "text",  # TODO(jane): switch to "concise" after the release of 0.2.0
             f"--{'' if self.preview else 'no-'}preview",
         ]
         if self.select:


### PR DESCRIPTION
This prevents us from running into the following error during an ecosystem check against `main`:
```
error: invalid value 'concise' for '--output-format <OUTPUT_FORMAT>'
  [possible values: text, json, json-lines, junit, grouped, github, gitlab, pylint, azure, sarif]
```

This error appears because `main` doesn't support `concise` as an output format yet. The deprecated output format that concise/full replaced will be used until then (`text` falls back to `concise` on the release branch).