### PR TITLE
Add handling for rules that are both deprecated and redirected

### DIFF
--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -1006,7 +1006,7 @@ fn preview_disabled_direct() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: Selection `FURB145` has no effect because the `--preview` flag was not included.
+    warning: Selection `FURB145` has no effect because preview is not enabled.
     "###);
 }
 
@@ -1021,7 +1021,7 @@ fn preview_disabled_prefix_empty() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: Selection `CPY` has no effect because the `--preview` flag was not included.
+    warning: Selection `CPY` has no effect because preview is not enabled.
     "###);
 }
 
@@ -1244,7 +1244,7 @@ def reciprocal(n):
 
     ----- stderr -----
     ruff failed
-      Cause: Selection of deprecated rule `TRY200` is not allowed when preview mode is enabled.
+      Cause: Selection of deprecated rule `TRY200` is not allowed when preview is enabled.
     "###);
 }
 
@@ -1264,7 +1264,7 @@ x = eval(input("Enter a number: "))
 
     ----- stderr -----
     ruff failed
-      Cause: Selection of deprecated rule `PGH001` is not allowed when preview mode is enabled. Use `S307` instead.
+      Cause: Selection of deprecated rule `PGH001` is not allowed when preview is enabled. Use `S307` instead.
     "###);
 }
 #[test]
@@ -1335,7 +1335,7 @@ def reciprocal(n):
 
     ----- stderr -----
     ruff failed
-      Cause: Selection of deprecated rules is not allowed when preview mode is enabled. Remove selection of:
+      Cause: Selection of deprecated rules is not allowed when preview is enabled. Remove selection of:
     	- ANN102
     	- ANN101
 
@@ -1374,7 +1374,7 @@ def reciprocal(n):
 
     ----- stderr -----
     ruff failed
-      Cause: Selection of deprecated rules is not allowed when preview mode is enabled. Remove selection of:
+      Cause: Selection of deprecated rules is not allowed when preview is enabled. Remove selection of:
     	- ANN102
     	- ANN101
     	- PGH001 (use `S307` instead)

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -1235,16 +1235,9 @@ fn deprecated_indirect_redirect() {
         .pass_stdin(r###"
 x = eval(input("Enter a number: "))
 "###), @r###"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
-    -:2:5: PGH001 No builtin `eval()` allowed
-      |
-    2 | x = eval(input("Enter a number: "))
-      |     ^^^^ PGH001
-      |
-
-    Found 1 error.
 
     ----- stderr -----
     "###);
@@ -1325,16 +1318,9 @@ fn deprecated_indirect_redirect_preview_enabled() {
         .pass_stdin(r###"
 x = eval(input("Enter a number: "))
 "###), @r###"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
-    -:2:5: PGH001 No builtin `eval()` allowed
-      |
-    2 | x = eval(input("Enter a number: "))
-      |     ^^^^ PGH001
-      |
-
-    Found 1 error.
 
     ----- stderr -----
     "###);

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -1225,6 +1225,31 @@ x = eval(input("Enter a number: "))
 }
 
 #[test]
+fn deprecated_indirect_redirect() {
+    // e.g. `PGH001` is deprecated and redirected, we see a violation in stable
+    // without any warnings
+    let mut cmd = RuffCheck::default()
+        .args(["--select", "PGH", "--preview"])
+        .build();
+    assert_cmd_snapshot!(cmd
+        .pass_stdin(r###"
+x = eval(input("Enter a number: "))
+"###), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:2:5: PGH001 No builtin `eval()` allowed
+      |
+    2 | x = eval(input("Enter a number: "))
+      |     ^^^^ PGH001
+      |
+
+    Found 1 error.
+
+    ----- stderr -----
+    "###);
+}
+#[test]
 fn deprecated_direct_preview_enabled() {
     // Direct selection of a deprecated rule in preview should fail
     let mut cmd = RuffCheck::default()
@@ -1267,6 +1292,7 @@ x = eval(input("Enter a number: "))
       Cause: Selection of deprecated rule `PGH001` is not allowed when preview is enabled. Use `S307` instead.
     "###);
 }
+
 #[test]
 fn deprecated_indirect_preview_enabled() {
     // `TRY200` is deprecated and should be off by default in preview.

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -1299,9 +1299,16 @@ fn deprecated_indirect_redirect_preview_enabled() {
         .pass_stdin(r###"
 x = eval(input("Enter a number: "))
 "###), @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
+    -:2:5: PGH001 No builtin `eval()` allowed
+      |
+    2 | x = eval(input("Enter a number: "))
+      |     ^^^^ PGH001
+      |
+
+    Found 1 error.
 
     ----- stderr -----
     "###);

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -705,11 +705,11 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8Datetimez, "012") => (RuleGroup::Stable, rules::flake8_datetimez::rules::CallDateFromtimestamp),
 
         // pygrep-hooks
-        (PygrepHooks, "001") => (RuleGroup::Stable, rules::pygrep_hooks::rules::Eval),
-        (PygrepHooks, "002") => (RuleGroup::Stable, rules::pygrep_hooks::rules::DeprecatedLogWarn),
-        (PygrepHooks, "003") => (RuleGroup::Stable, rules::pygrep_hooks::rules::BlanketTypeIgnore),
-        (PygrepHooks, "004") => (RuleGroup::Stable, rules::pygrep_hooks::rules::BlanketNOQA),
-        (PygrepHooks, "005") => (RuleGroup::Stable, rules::pygrep_hooks::rules::InvalidMockAccess),
+        (PygrepHooks, "001") => (RuleGroup::Deprecated, rules::pygrep_hooks::rules::Eval),
+        (PygrepHooks, "002") => (RuleGroup::Deprecated, rules::pygrep_hooks::rules::DeprecatedLogWarn),
+        (PygrepHooks, "003") => (RuleGroup::Deprecated, rules::pygrep_hooks::rules::BlanketTypeIgnore),
+        (PygrepHooks, "004") => (RuleGroup::Deprecated, rules::pygrep_hooks::rules::BlanketNOQA),
+        (PygrepHooks, "005") => (RuleGroup::Deprecated, rules::pygrep_hooks::rules::InvalidMockAccess),
 
         // pandas-vet
         (PandasVet, "002") => (RuleGroup::Stable, rules::pandas_vet::rules::PandasUseOfInplaceArgument),

--- a/crates/ruff_linter/src/lib.rs
+++ b/crates/ruff_linter/src/lib.rs
@@ -34,7 +34,7 @@ pub mod packaging;
 pub mod pyproject_toml;
 pub mod registry;
 mod renamer;
-mod rule_redirects;
+pub mod rule_redirects;
 pub mod rule_selector;
 pub mod rules;
 pub mod settings;

--- a/crates/ruff_linter/src/registry.rs
+++ b/crates/ruff_linter/src/registry.rs
@@ -31,7 +31,7 @@ pub enum FromCodeError {
     Unknown,
 }
 
-#[derive(EnumIter, Debug, PartialEq, Eq, Clone, Hash, RuleNamespace)]
+#[derive(EnumIter, Debug, PartialEq, Eq, Clone, Hash, Copy, RuleNamespace)]
 pub enum Linter {
     /// [Pyflakes](https://pypi.org/project/pyflakes/)
     #[prefix = "F"]

--- a/crates/ruff_linter/src/rule_redirects.rs
+++ b/crates/ruff_linter/src/rule_redirects.rs
@@ -21,6 +21,9 @@ static REDIRECTS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
         ("C9", "C90"),
         ("T1", "T10"),
         ("T2", "T20"),
+        // The PGH category is deprecated
+        ("PGH001", "S307"),
+        ("PGH002", "G010"),
         // TODO(charlie): Remove by 2023-02-01.
         ("R", "RET"),
         ("R5", "RET5"),

--- a/crates/ruff_linter/src/rule_redirects.rs
+++ b/crates/ruff_linter/src/rule_redirects.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use once_cell::sync::Lazy;
 
 /// Returns the redirect target for the given code.
-pub(crate) fn get_redirect_target(code: &str) -> Option<&'static str> {
+pub fn get_redirect_target(code: &str) -> Option<&'static str> {
     REDIRECTS.get(code).copied()
 }
 
@@ -21,9 +21,6 @@ static REDIRECTS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
         ("C9", "C90"),
         ("T1", "T10"),
         ("T2", "T20"),
-        // The PGH category is deprecated
-        ("PGH001", "S307"),
-        ("PGH002", "G010"),
         // TODO(charlie): Remove by 2023-02-01.
         ("R", "RET"),
         ("R5", "RET5"),

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -8,7 +8,7 @@ use strum_macros::EnumIter;
 use crate::codes::RuleCodePrefix;
 use crate::codes::RuleIter;
 use crate::registry::{Linter, Rule, RuleNamespace};
-use crate::rule_redirects::get_redirect;
+use crate::rule_redirects::{get_redirect, get_redirect_target};
 use crate::settings::types::PreviewMode;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -207,7 +207,7 @@ impl Visitor<'_> for SelectorVisitor {
 }
 
 impl RuleSelector {
-    /// Return all matching rules, regardless of whether they're in preview.
+    /// Return all matching rules, regardless of rule group filters like preview and deprecated.
     pub fn all_rules(&self) -> impl Iterator<Item = Rule> + '_ {
         match self {
             RuleSelector::All => RuleSelectorIter::All(Rule::iter()),
@@ -233,7 +233,7 @@ impl RuleSelector {
         }
     }
 
-    /// Returns rules matching the selector, taking into account preview options enabled.
+    /// Returns rules matching the selector, taking into account rule groups like preview and deprecated.
     pub fn rules<'a>(&'a self, preview: &PreviewOptions) -> impl Iterator<Item = Rule> + 'a {
         let preview_enabled = preview.mode.is_enabled();
         let preview_require_explicit = preview.require_explicit;
@@ -245,7 +245,7 @@ impl RuleSelector {
             || ((self.is_exact() || matches!(self, RuleSelector::Nursery { .. })) && rule.is_nursery())
             // Enabling preview includes all preview or nursery rules unless explicit selection
             // is turned on
-            || (preview_enabled && (self.is_exact() || !preview_require_explicit))
+            || ((rule.is_preview() || rule.is_nursery()) && preview_enabled && (self.is_exact() || !preview_require_explicit))
             // Deprecated rules are excluded in preview mode unless explicitly selected
             || (rule.is_deprecated() && (!preview_enabled || self.is_exact()))
             // Removed rules are included if explicitly selected but will error downstream

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -903,8 +903,8 @@ impl LintConfiguration {
 
                 // Unstable rules
                 if preview.mode.is_disabled() && kind.is_enable() {
-                    if let RuleSelector::Rule { prefix, .. } = selector {
-                        if prefix.rules().any(|rule| rule.is_nursery()) {
+                    if selector.is_exact() {
+                        if selector.all_rules().all(|rule| rule.is_nursery()) {
                             deprecated_nursery_selectors.insert(selector);
                         }
                     }
@@ -931,8 +931,8 @@ impl LintConfiguration {
                 }
 
                 // Removed rules
-                if let RuleSelector::Rule { prefix, .. } = selector {
-                    if prefix.rules().any(|rule| rule.is_removed()) {
+                if selector.is_exact() {
+                    if selector.all_rules().all(|rule| rule.is_removed()) {
                         removed_selectors.insert(selector);
                     }
                 }

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -1033,14 +1033,14 @@ impl LintConfiguration {
                     let (prefix, code) = selection.prefix_and_code();
                     let err = if let Some(redirect) = redirect {
                         let (redirect_prefix, redirect_code) = redirect.prefix_and_code();
-                        anyhow!("Selection of deprecated rule `{prefix}{code}` is not allowed when preview mode is enabled. Use `{redirect_prefix}{redirect_code}` instead.")
+                        anyhow!("Selection of deprecated rule `{prefix}{code}` is not allowed when preview is enabled. Use `{redirect_prefix}{redirect_code}` instead.")
                     } else {
-                        anyhow!("Selection of deprecated rule `{prefix}{code}` is not allowed when preview mode is enabled.")
+                        anyhow!("Selection of deprecated rule `{prefix}{code}` is not allowed when preview is enabled.")
                     };
                     return Err(err);
                 }
                 [..] => {
-                    let mut message = "Selection of deprecated rules is not allowed when preview mode is enabled. Remove selection of:".to_string();
+                    let mut message = "Selection of deprecated rules is not allowed when preview is enabled. Remove selection of:".to_string();
                     for (selection, redirect) in deprecated_selectors {
                         let (prefix, code) = selection.prefix_and_code();
                         message.push_str("\n\t- ");
@@ -1061,9 +1061,7 @@ impl LintConfiguration {
 
         for selection in ignored_preview_selectors {
             let (prefix, code) = selection.prefix_and_code();
-            warn_user!(
-                "Selection `{prefix}{code}` has no effect because the `--preview` flag was not included.",
-            );
+            warn_user!("Selection `{prefix}{code}` has no effect because preview is not enabled.",);
         }
 
         let mut rules = RuleTable::empty();

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -1069,10 +1069,9 @@ impl LintConfiguration {
                         if let Some(redirect) = redirect {
                             let (redirect_prefix, redirect_code) =
                                 (redirect.linter().common_prefix(), redirect.short_code());
-                            message.push_str(
-                                format!(" (use `{redirect_prefix}{redirect_code}` instead)")
-                                    .as_str(),
-                            )
+                            message.push_str(&format!(
+                                " (use `{redirect_prefix}{redirect_code}` instead)"
+                            ));
                         }
                     }
                     message.push('\n');


### PR DESCRIPTION
Follow up to #9689 adds tooling for warning on rules that are deprecated because we replaced them with another rule.

Previously we would display no warnings for deprecated redirected rules because the redirect took place before the warnings could be displayed.

As with the other changes, this is immediately used for testing. Deprecates all of the `PGH` rules and adds redirects where relevant.

Closes https://github.com/astral-sh/ruff/issues/8931