### PR TITLE
Display deprecation warnings for prefix and linter selections with all rules deprecated

### DIFF
--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -161,6 +161,16 @@ impl RuleSelector {
             }
         }
     }
+
+    pub fn display_kind(&self) -> &'static str {
+        match self {
+            #[allow(deprecated)]
+            Self::All | Self::T | Self::Nursery | Self::C => "rule selector",
+            Self::Rule { .. } => "rule",
+            Self::Prefix { .. } => "rule prefix",
+            Self::Linter(_) => "rule category",
+        }
+    }
 }
 
 impl Serialize for RuleSelector {


### PR DESCRIPTION
If _all_ of the rules in a prefix or lint rule selector are deprecated then we warn. This means that if you select `PGH` we will throw a warning instead of silently deselecting the rules.