### PR TITLE
Update README.md by adding `ivy` repository to the who's using Ruff section

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Ruff is used by a number of major open-source projects and companies, including:
     [Diffusers](https://github.com/huggingface/diffusers))
 - ING Bank ([popmon](https://github.com/ing-bank/popmon), [probatus](https://github.com/ing-bank/probatus))
 - [Ibis](https://github.com/ibis-project/ibis)
+- [ivy](https://github.com/unifyai/ivy)
 - [Jupyter](https://github.com/jupyter-server/jupyter_server)
 - [LangChain](https://github.com/hwchase17/langchain)
 - [Litestar](https://litestar.dev/)


### PR DESCRIPTION
## Summary
I have recently made a contribution to a big python based repo **replacing flake8 with ruff** (https://github.com/unifyai/ivy/pull/27779). So, as per this [discussion](https://github.com/astral-sh/ruff/discussions/9731). I am making this PR to add the [ivy](https://github.com/unifyai/ivy) repository (**with > 13k stars ⭐**) to the Ruff's readme

## Test Plan
No, need of any tests for the changes made.