### PR TITLE
Excludes upload and download artifact dependencies from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       actions:
         patterns:
           - "*"
+    ignore:
+      # The latest versions of these are not compatible with our release workflow
+      - dependency-name: "actions/upload-artifact"
+      - dependency-name: "actions/download-artifact"
 
   - package-ecosystem: "cargo"
     directory: "/"


### PR DESCRIPTION
e.g. in https://github.com/astral-sh/ruff/pull/9667 we cannot upgrade them but want to upgrade the rest
