### PR TITLE
Range formatting: Fix invalid syntax after parenthesizing expression

### DIFF
--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -308,11 +308,8 @@ impl std::fmt::Debug for Token {
 /// assert_eq!(printed.as_code(), r#""Hello 'Ruff'""#);
 /// assert_eq!(printed.sourcemap(), [
 ///     SourceMarker { source: TextSize::new(0), dest: TextSize::new(0) },
-///     SourceMarker { source: TextSize::new(0), dest: TextSize::new(7) },
 ///     SourceMarker { source: TextSize::new(8), dest: TextSize::new(7) },
-///     SourceMarker { source: TextSize::new(8), dest: TextSize::new(13) },
 ///     SourceMarker { source: TextSize::new(14), dest: TextSize::new(13) },
-///     SourceMarker { source: TextSize::new(14), dest: TextSize::new(14) },
 ///     SourceMarker { source: TextSize::new(20), dest: TextSize::new(14) },
 /// ]);
 ///
@@ -2288,7 +2285,7 @@ impl<Context, T> std::fmt::Debug for FormatWith<Context, T> {
 ///                 let mut join = f.join_with(&separator);
 ///
 ///                 for item in &self.items {
-///                     join.entry(&format_with(|f| write!(f, [text(item, None)])));
+///                     join.entry(&format_with(|f| write!(f, [text(item)])));
 ///                 }
 ///                 join.finish()
 ///             })),
@@ -2373,7 +2370,7 @@ where
 /// let mut count = 0;
 ///
 /// let value = format_once(|f| {
-///     write!(f, [text(&std::format!("Formatted {count}."), None)])
+///     write!(f, [text(&std::format!("Formatted {count}."))])
 /// });
 ///
 /// format!(SimpleFormatContext::default(), [value]).expect("Formatting once works fine");

--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -340,18 +340,18 @@ impl<Context> Format<Context> for SourcePosition {
     }
 }
 
-/// Creates a text from a dynamic string with its optional start-position in the source document.
+/// Creates a text from a dynamic string.
+///
 /// This is done by allocating a new string internally.
-pub fn text(text: &str, position: Option<TextSize>) -> Text {
+pub fn text(text: &str) -> Text {
     debug_assert_no_newlines(text);
 
-    Text { text, position }
+    Text { text }
 }
 
 #[derive(Eq, PartialEq)]
 pub struct Text<'a> {
     text: &'a str,
-    position: Option<TextSize>,
 }
 
 impl<Context> Format<Context> for Text<'_>
@@ -359,10 +359,6 @@ where
     Context: FormatContext,
 {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        if let Some(position) = self.position {
-            source_position(position).fmt(f)?;
-        }
-
         f.write_element(FormatElement::Text {
             text: self.text.to_string().into_boxed_str(),
             text_width: TextWidth::from_text(self.text, f.options().indent_width()),

--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -346,10 +346,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                 }
 
                 FormatElement::SourcePosition(position) => {
-                    write!(
-                        f,
-                        [text(&std::format!("source_position({position:?})"), None)]
-                    )?;
+                    write!(f, [text(&std::format!("source_position({position:?})"))])?;
                 }
 
                 FormatElement::LineSuffixBoundary => {
@@ -360,7 +357,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                     write!(f, [token("best_fitting(")])?;
 
                     if *mode != BestFittingMode::FirstLine {
-                        write!(f, [text(&std::format!("mode: {mode:?}, "), None)])?;
+                        write!(f, [text(&std::format!("mode: {mode:?}, "))])?;
                     }
 
                     write!(f, [token("[")])?;
@@ -392,17 +389,14 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                             write!(
                                 f,
                                 [
-                                    text(&std::format!("<interned {index}>"), None),
+                                    text(&std::format!("<interned {index}>")),
                                     space(),
                                     &&**interned,
                                 ]
                             )?;
                         }
                         Some(reference) => {
-                            write!(
-                                f,
-                                [text(&std::format!("<ref interned *{reference}>"), None)]
-                            )?;
+                            write!(f, [text(&std::format!("<ref interned *{reference}>"))])?;
                         }
                     }
                 }
@@ -421,7 +415,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                                     f,
                                     [
                                         token("<END_TAG_WITHOUT_START<"),
-                                        text(&std::format!("{:?}", tag.kind()), None),
+                                        text(&std::format!("{:?}", tag.kind())),
                                         token(">>"),
                                     ]
                                 )?;
@@ -436,9 +430,9 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                                         token(")"),
                                         soft_line_break_or_space(),
                                         token("ERROR<START_END_TAG_MISMATCH<start: "),
-                                        text(&std::format!("{start_kind:?}"), None),
+                                        text(&std::format!("{start_kind:?}")),
                                         token(", end: "),
-                                        text(&std::format!("{:?}", tag.kind()), None),
+                                        text(&std::format!("{:?}", tag.kind())),
                                         token(">>")
                                     ]
                                 )?;
@@ -470,7 +464,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                                 f,
                                 [
                                     token("align("),
-                                    text(&count.to_string(), None),
+                                    text(&count.to_string()),
                                     token(","),
                                     space(),
                                 ]
@@ -482,7 +476,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                                 f,
                                 [
                                     token("line_suffix("),
-                                    text(&std::format!("{reserved_width:?}"), None),
+                                    text(&std::format!("{reserved_width:?}")),
                                     token(","),
                                     space(),
                                 ]
@@ -499,11 +493,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                             if let Some(group_id) = group.id() {
                                 write!(
                                     f,
-                                    [
-                                        text(&std::format!("\"{group_id:?}\""), None),
-                                        token(","),
-                                        space(),
-                                    ]
+                                    [text(&std::format!("\"{group_id:?}\"")), token(","), space(),]
                                 )?;
                             }
 
@@ -524,11 +514,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                             if let Some(group_id) = id {
                                 write!(
                                     f,
-                                    [
-                                        text(&std::format!("\"{group_id:?}\""), None),
-                                        token(","),
-                                        space(),
-                                    ]
+                                    [text(&std::format!("\"{group_id:?}\"")), token(","), space(),]
                                 )?;
                             }
                         }
@@ -561,7 +547,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                                 f,
                                 [
                                     token("indent_if_group_breaks("),
-                                    text(&std::format!("\"{id:?}\""), None),
+                                    text(&std::format!("\"{id:?}\"")),
                                     token(","),
                                     space(),
                                 ]
@@ -581,11 +567,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                             if let Some(group_id) = condition.group_id {
                                 write!(
                                     f,
-                                    [
-                                        text(&std::format!("\"{group_id:?}\""), None),
-                                        token(","),
-                                        space(),
-                                    ]
+                                    [text(&std::format!("\"{group_id:?}\"")), token(","), space()]
                                 )?;
                             }
                         }
@@ -595,7 +577,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                                 f,
                                 [
                                     token("label("),
-                                    text(&std::format!("\"{label_id:?}\""), None),
+                                    text(&std::format!("\"{label_id:?}\"")),
                                     token(","),
                                     space(),
                                 ]
@@ -664,7 +646,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                     ContentArrayEnd,
                     token(")"),
                     soft_line_break_or_space(),
-                    text(&std::format!("<START_WITHOUT_END<{top:?}>>"), None),
+                    text(&std::format!("<START_WITHOUT_END<{top:?}>>")),
                 ]
             )?;
         }
@@ -807,7 +789,7 @@ impl Format<IrFormatContext<'_>> for Condition {
                 f,
                 [
                     token("if_group_fits_on_line("),
-                    text(&std::format!("\"{id:?}\""), None),
+                    text(&std::format!("\"{id:?}\"")),
                     token(")")
                 ]
             ),
@@ -816,7 +798,7 @@ impl Format<IrFormatContext<'_>> for Condition {
                 f,
                 [
                     token("if_group_breaks("),
-                    text(&std::format!("\"{id:?}\""), None),
+                    text(&std::format!("\"{id:?}\"")),
                     token(")")
                 ]
             ),

--- a/crates/ruff_formatter/src/format_extensions.rs
+++ b/crates/ruff_formatter/src/format_extensions.rs
@@ -32,7 +32,7 @@ pub trait MemoizeFormat<Context> {
     ///         let value = self.value.get();
     ///         self.value.set(value + 1);
     ///
-    ///         write!(f, [text(&std::format!("Formatted {value} times."), None)])
+    ///         write!(f, [text(&std::format!("Formatted {value} times."))])
     ///     }
     /// }
     ///
@@ -110,7 +110,7 @@ where
     ///         write!(f, [
     ///             token("Count:"),
     ///             space(),
-    ///             text(&std::format!("{current}"), None),
+    ///             text(&std::format!("{current}")),
     ///             hard_line_break()
     ///         ])?;
     ///

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -41,7 +41,7 @@ use std::marker::PhantomData;
 use std::num::{NonZeroU16, NonZeroU8, TryFromIntError};
 
 use crate::format_element::document::Document;
-use crate::printer::{Printer, PrinterOptions, SourceMapGeneration};
+use crate::printer::{Printer, PrinterOptions};
 pub use arguments::{Argument, Arguments};
 pub use buffer::{
     Buffer, BufferExtensions, BufferSnapshot, Inspect, RemoveSoftLinesBuffer, VecBuffer,
@@ -269,7 +269,6 @@ impl FormatOptions for SimpleFormatOptions {
             line_width: self.line_width,
             indent_style: self.indent_style,
             indent_width: self.indent_width,
-            source_map_generation: SourceMapGeneration::Enabled,
             ..PrinterOptions::default()
         }
     }

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -575,7 +575,7 @@ pub type FormatResult<F> = Result<F, FormatError>;
 /// impl Format<SimpleFormatContext> for Paragraph {
 ///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>) -> FormatResult<()> {
 ///         write!(f, [
-///             text(&self.0, None),
+///             text(&self.0),
 ///             hard_line_break(),
 ///         ])
 ///     }

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -432,28 +432,40 @@ impl Printed {
         std::mem::take(&mut self.verbatim_ranges)
     }
 
-    /// Slices the formatted code to the sub-slices that covers the passed `source_range`.
+    /// Slices the formatted code to the sub-slices that covers the passed `source_range` in `source`.
     ///
     /// The implementation uses the source map generated during formatting to find the closest range
     /// in the formatted document that covers `source_range` or more. The returned slice
     /// matches the `source_range` exactly (except indent, see below) if the formatter emits [`FormatElement::SourcePosition`] for
     /// the range's offsets.
     ///
+    /// ## Indentation
+    /// The indentation before `source_range.start` is replaced with the indentation returned by the formatter
+    /// to fix up incorrectly intended code.
+    ///
     /// Returns the entire document if the source map is empty.
+    ///
+    /// # Panics
+    /// If `source_range` points to offsets that are not in the bounds of `source`.
     #[must_use]
-    pub fn slice_range(self, source_range: TextRange) -> PrintedRange {
+    pub fn slice_range(self, source_range: TextRange, source: &str) -> PrintedRange {
         let mut start_marker: Option<SourceMarker> = None;
         let mut end_marker: Option<SourceMarker> = None;
 
         // Note: The printer can generate multiple source map entries for the same source position.
         // For example if you have:
+        // * token("a + b")
         // * `source_position(276)`
-        // * `token("def")`
-        // * `token("foo")`
-        // * `source_position(284)`
-        // The printer uses the source position 276 for both the tokens `def` and `foo` because that's the only position it knows of.
+        // * `token(")")`
+        // * `source_position(276)`
+        // *  `hard_line_break`
+        // The printer uses the source position 276 for both the tokens `)` and the `\n` because
+        // there were multiple `source_position` entries in the IR with the same offset.
+        // This can happen if multiple nodes start or end at the same position. A common example
+        // for this are expressions and expression statement that always end at the same offset.
         //
-        // Warning: Source markers are often emitted sorted by their source position but it's not guaranteed.
+        // Warning: Source markers are often emitted sorted by their source position but it's not guaranteed
+        // and depends on the emitted `IR`.
         // They are only guaranteed to be sorted in increasing order by their destination position.
         for marker in self.sourcemap {
             // Take the closest start marker, but skip over start_markers that have the same start.
@@ -470,15 +482,42 @@ impl Printed {
             }
         }
 
-        let start = start_marker.map(|marker| marker.dest).unwrap_or_default();
-        let end = end_marker.map_or_else(|| self.code.text_len(), |marker| marker.dest);
-        let code_range = TextRange::new(start, end);
+        let (source_start, formatted_start) = start_marker
+            .map(|marker| (marker.source, marker.dest))
+            .unwrap_or_default();
+
+        let (source_end, formatted_end) = end_marker
+            .map_or((source.text_len(), self.code.text_len()), |marker| {
+                (marker.source, marker.dest)
+            });
+
+        let source_range = TextRange::new(source_start, source_end);
+        let formatted_range = TextRange::new(formatted_start, formatted_end);
+
+        // Extend both ranges to include the indentation
+        let source_range = extend_range_to_include_indent(source_range, source);
+        let formatted_range = extend_range_to_include_indent(formatted_range, &self.code);
 
         PrintedRange {
-            code: self.code[code_range].to_string(),
+            code: self.code[formatted_range].to_string(),
             source_range,
         }
     }
+}
+
+/// Extends `range` backwards (by reducing `range.start`) to include any directly preceding whitespace (`\t` or ` `).
+///
+/// # Panics
+/// If `range.start` is out of `source`'s bounds.
+fn extend_range_to_include_indent(range: TextRange, source: &str) -> TextRange {
+    let whitespace_len: TextSize = source[..usize::from(range.start())]
+        .chars()
+        .rev()
+        .take_while(|c| matches!(c, ' ' | '\t'))
+        .map(TextLen::text_len)
+        .sum();
+
+    TextRange::new(range.start() - whitespace_len, range.end())
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -1729,7 +1729,7 @@ a",
         let result = format_with_options(
             &format_args![
                 token("function main() {"),
-                block_indent(&text("let x = `This is a multiline\nstring`;", None)),
+                block_indent(&text("let x = `This is a multiline\nstring`;")),
                 token("}"),
                 hard_line_break()
             ],
@@ -1746,7 +1746,7 @@ a",
     fn it_breaks_a_group_if_a_string_contains_a_newline() {
         let result = format(&FormatArrayElements {
             items: vec![
-                &text("`This is a string spanning\ntwo lines`", None),
+                &text("`This is a string spanning\ntwo lines`"),
                 &token("\"b\""),
             ],
         });

--- a/crates/ruff_formatter/src/printer/printer_options/mod.rs
+++ b/crates/ruff_formatter/src/printer/printer_options/mod.rs
@@ -14,10 +14,6 @@ pub struct PrinterOptions {
 
     /// The type of line ending to apply to the printed input
     pub line_ending: LineEnding,
-
-    /// Whether the printer should build a source map that allows mapping positions in the source document
-    /// to positions in the formatted document.
-    pub source_map_generation: SourceMapGeneration,
 }
 
 impl<'a, O> From<&'a O> for PrinterOptions

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/range_formatting/end_of_file.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/range_formatting/end_of_file.py
@@ -1,0 +1,1 @@
+a + b<RANGE_START><RANGE_END>

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/range_formatting/parentheses.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/range_formatting/parentheses.py
@@ -1,0 +1,13 @@
+def needs_parentheses( ) -> bool:
+    return item.sizing_mode is None and <RANGE_START>item.width_policy == "auto" and item.height_policy == "automatic"<RANGE_END>
+
+def no_longer_needs_parentheses( ) -> bool:
+    return (
+        <RANGE_START>item.width_policy == "auto"
+        and item.height_policy == "automatic"<RANGE_END>
+    )
+
+
+def format_range_after_inserted_parens   ():
+    a and item.sizing_mode is None and item.width_policy == "auto" and item.height_policy == "automatic"<RANGE_START>
+    print("Format this" ) <RANGE_END>

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/range_formatting/regressions.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/range_formatting/regressions.py
@@ -67,3 +67,19 @@ def convert_str(value: str) -> str:  # Trailing comment
 <RANGE_END>
 def test  ():
     pass
+
+
+def test_comment_indent():
+<RANGE_START># A misaligned comment<RANGE_END>
+    print("test")
+
+
+# This demonstrates the use case where a user inserts a new function or class after an existing function.
+# In this case, we should avoid formatting the node that directly precedes the new function/class.
+# However, the problem is that the preceding node **must** be formatted to determine the whitespace between the two statements.
+def test_start ():
+    print("Ideally this gets not reformatted" )
+
+<RANGE_START>
+def new_function_inserted_after_test_start ():
+    print("This should get formatted" )<RANGE_END>

--- a/crates/ruff_python_formatter/src/expression/expr_number_literal.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_number_literal.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<ExprNumberLiteral> for FormatExprNumberLiteral {
 
                 match normalized {
                     Cow::Borrowed(_) => source_text_slice(range).fmt(f),
-                    Cow::Owned(normalized) => text(&normalized, Some(range.start())).fmt(f),
+                    Cow::Owned(normalized) => text(&normalized).fmt(f),
                 }
             }
             Number::Float(_) => {
@@ -30,7 +30,7 @@ impl FormatNodeRule<ExprNumberLiteral> for FormatExprNumberLiteral {
 
                 match normalized {
                     Cow::Borrowed(_) => source_text_slice(range).fmt(f),
-                    Cow::Owned(normalized) => text(&normalized, Some(range.start())).fmt(f),
+                    Cow::Owned(normalized) => text(&normalized).fmt(f),
                 }
             }
             Number::Complex { .. } => {
@@ -43,7 +43,7 @@ impl FormatNodeRule<ExprNumberLiteral> for FormatExprNumberLiteral {
                         source_text_slice(range.sub_end(TextSize::from(1))).fmt(f)?;
                     }
                     Cow::Owned(normalized) => {
-                        text(&normalized, Some(range.start())).fmt(f)?;
+                        text(&normalized).fmt(f)?;
                     }
                 }
 

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -304,30 +304,25 @@ fn format_with_parentheses_comments(
     // Custom FormatNodeRule::fmt variant that only formats the inner comments
     let format_node_rule_fmt = format_with(|f| {
         // No need to handle suppression comments, those are statement only
-        leading_comments(leading_inner).fmt(f)?;
-
-        let is_source_map_enabled = f.options().source_map_generation().is_enabled();
-
-        if is_source_map_enabled {
-            source_position(expression.start()).fmt(f)?;
-        }
-
-        fmt_fields.fmt(f)?;
-
-        if is_source_map_enabled {
-            source_position(expression.end()).fmt(f)?;
-        }
-
-        trailing_comments(trailing_inner).fmt(f)
+        write!(
+            f,
+            [
+                leading_comments(leading_inner),
+                fmt_fields,
+                trailing_comments(trailing_inner)
+            ]
+        )
     });
 
     // The actual parenthesized formatting
-    parenthesized("(", &format_node_rule_fmt, ")")
-        .with_dangling_comments(parentheses_comment)
-        .fmt(f)?;
-    trailing_comments(trailing_outer).fmt(f)?;
-
-    Ok(())
+    write!(
+        f,
+        [
+            parenthesized("(", &format_node_rule_fmt, ")")
+                .with_dangling_comments(parentheses_comment),
+            trailing_comments(trailing_outer)
+        ]
+    )
 }
 
 /// Wraps an expression in an optional parentheses except if its [`NeedsParentheses::needs_parentheses`] implementation

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -300,7 +300,7 @@ def main() -> None:
                     while let Some(word) = words.next() {
                         let is_last = words.peek().is_none();
                         let format_word = format_with(|f| {
-                            write!(f, [text(word, None)])?;
+                            write!(f, [text(word)])?;
 
                             if is_last {
                                 write!(f, [token("\"")])?;

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -3,7 +3,7 @@ use tracing::Level;
 
 pub use range::format_range;
 use ruff_formatter::prelude::*;
-use ruff_formatter::{format, FormatError, Formatted, PrintError, Printed, SourceCode};
+use ruff_formatter::{format, write, FormatError, Formatted, PrintError, Printed, SourceCode};
 use ruff_python_ast::AstNode;
 use ruff_python_ast::Mod;
 use ruff_python_index::tokens_and_ranges;
@@ -19,6 +19,7 @@ pub use crate::options::{
     DocstringCode, DocstringCodeLineWidth, MagicTrailingComma, PreviewMode, PyFormatOptions,
     PythonVersion, QuoteStyle,
 };
+use crate::range::is_logical_line;
 pub use crate::shared_traits::{AsFormat, FormattedIter, FormattedIterExt, IntoFormat};
 use crate::verbatim::suppressed_node;
 
@@ -59,19 +60,27 @@ where
         } else {
             leading_comments(node_comments.leading).fmt(f)?;
 
-            let is_source_map_enabled = f.options().source_map_generation().is_enabled();
+            let node_ref = node.as_any_node_ref();
 
-            if is_source_map_enabled {
-                source_position(node.start()).fmt(f)?;
-            }
+            // Emit source map information for nodes that are valid "narrowing" targets
+            // in range formatting. Never emit source map information if they're disabled
+            // for performance reasons.
+            let emit_source_position = (is_logical_line(node_ref) || node_ref.is_mod_module())
+                && f.options().source_map_generation().is_enabled();
+
+            emit_source_position
+                .then_some(source_position(node.start()))
+                .fmt(f)?;
 
             self.fmt_fields(node, f)?;
 
-            if is_source_map_enabled {
-                source_position(node.end()).fmt(f)?;
-            }
-
-            trailing_comments(node_comments.trailing).fmt(f)
+            write!(
+                f,
+                [
+                    emit_source_position.then_some(source_position(node.end())),
+                    trailing_comments(node_comments.trailing)
+                ]
+            )
         }
     }
 
@@ -249,15 +258,36 @@ def main() -> None:
     #[ignore]
     #[test]
     fn range_formatting_quick_test() {
-        let source = r#"def  test2(  a):    print("body"  )
-    "#;
+        let source = r#"def convert_str(value: str) -> str:  # Trailing comment
+    """Return a string as-is."""
 
-        let start = TextSize::new(20);
-        let end = TextSize::new(35);
+<RANGE_START>
+
+    return value  # Trailing comment
+<RANGE_END>"#;
+
+        let mut source = source.to_string();
+
+        let start = TextSize::try_from(
+            source
+                .find("<RANGE_START>")
+                .expect("Start marker not found"),
+        )
+        .unwrap();
+
+        source.replace_range(
+            start.to_usize()..start.to_usize() + "<RANGE_START>".len(),
+            "",
+        );
+
+        let end =
+            TextSize::try_from(source.find("<RANGE_END>").expect("End marker not found")).unwrap();
+
+        source.replace_range(end.to_usize()..end.to_usize() + "<RANGE_END>".len(), "");
 
         let source_type = PySourceType::Python;
         let options = PyFormatOptions::from_source_type(source_type);
-        let printed = format_range(source, TextRange::new(start, end), options).unwrap();
+        let printed = format_range(&source, TextRange::new(start, end), options).unwrap();
 
         let mut formatted = source.to_string();
         formatted.replace_range(
@@ -267,9 +297,11 @@ def main() -> None:
 
         assert_eq!(
             formatted,
-            r#"def test2(a):
-    print("body")
-    "#
+            r#"print ( "format me" )
+print("format me")
+print("format me")
+print ( "format me" )
+print ( "format me" )"#
         );
     }
 

--- a/crates/ruff_python_formatter/src/options.rs
+++ b/crates/ruff_python_formatter/src/options.rs
@@ -230,7 +230,6 @@ impl FormatOptions for PyFormatOptions {
             line_width: self.line_width,
             line_ending: self.line_ending,
             indent_style: self.indent_style,
-            source_map_generation: self.source_map_generation,
         }
     }
 }

--- a/crates/ruff_python_formatter/src/other/identifier.rs
+++ b/crates/ruff_python_formatter/src/other/identifier.rs
@@ -74,7 +74,7 @@ impl Format<PyFormatContext<'_>> for DotDelimitedIdentifier<'_> {
                 .chars()
                 .filter(|c| !is_python_whitespace(*c) && !matches!(c, '\n' | '\r' | '\\'))
                 .collect();
-            text(&no_whitespace, Some(self.0.start())).fmt(f)
+            text(&no_whitespace).fmt(f)
         } else {
             source_text_slice(self.0.range()).fmt(f)
         }

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -772,9 +772,17 @@ impl Format<PyFormatContext<'_>> for DocstringStmt<'_> {
                 f,
                 [
                     leading_comments(node_comments.leading),
+                    f.options()
+                        .source_map_generation()
+                        .is_enabled()
+                        .then_some(source_position(self.docstring.start())),
                     string_literal
                         .format()
                         .with_options(ExprStringLiteralKind::Docstring),
+                    f.options()
+                        .source_map_generation()
+                        .is_enabled()
+                        .then_some(source_position(self.docstring.end())),
                 ]
             )?;
 

--- a/crates/ruff_python_formatter/src/string/docstring.rs
+++ b/crates/ruff_python_formatter/src/string/docstring.rs
@@ -117,14 +117,7 @@ pub(crate) fn format(normalized: &NormalizedString, f: &mut PyFormatter) -> Form
     let mut lines = docstring.lines().peekable();
 
     // Start the string
-    write!(
-        f,
-        [
-            normalized.prefix,
-            normalized.quotes,
-            source_position(normalized.start()),
-        ]
-    )?;
+    write!(f, [normalized.prefix, normalized.quotes])?;
     // We track where in the source docstring we are (in source code byte offsets)
     let mut offset = normalized.start();
 
@@ -206,7 +199,7 @@ pub(crate) fn format(normalized: &NormalizedString, f: &mut PyFormatter) -> Form
         space().fmt(f)?;
     }
 
-    write!(f, [source_position(normalized.end()), normalized.quotes])
+    write!(f, [normalized.quotes])
 }
 
 fn contains_unescaped_newline(haystack: &str) -> bool {

--- a/crates/ruff_python_formatter/src/string/mod.rs
+++ b/crates/ruff_python_formatter/src/string/mod.rs
@@ -417,7 +417,7 @@ impl Format<PyFormatContext<'_>> for NormalizedString<'_> {
                 source_text_slice(self.range()).fmt(f)?;
             }
             Cow::Owned(normalized) => {
-                text(normalized, Some(self.start())).fmt(f)?;
+                text(normalized).fmt(f)?;
             }
         }
         self.quotes.fmt(f)

--- a/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__end_of_file.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__end_of_file.py.snap
@@ -1,0 +1,14 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/range_formatting/end_of_file.py
+---
+## Input
+```python
+a + b<RANGE_START><RANGE_END>```
+
+## Output
+```python
+a + b```
+
+
+

--- a/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__parentheses.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__parentheses.py.snap
@@ -1,0 +1,41 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/range_formatting/parentheses.py
+---
+## Input
+```python
+def needs_parentheses( ) -> bool:
+    return item.sizing_mode is None and <RANGE_START>item.width_policy == "auto" and item.height_policy == "automatic"<RANGE_END>
+
+def no_longer_needs_parentheses( ) -> bool:
+    return (
+        <RANGE_START>item.width_policy == "auto"
+        and item.height_policy == "automatic"<RANGE_END>
+    )
+
+
+def format_range_after_inserted_parens   ():
+    a and item.sizing_mode is None and item.width_policy == "auto" and item.height_policy == "automatic"<RANGE_START>
+    print("Format this" ) <RANGE_END>
+```
+
+## Output
+```python
+def needs_parentheses( ) -> bool:
+    return (
+        item.sizing_mode is None
+        and item.width_policy == "auto"
+        and item.height_policy == "automatic"
+    )
+
+def no_longer_needs_parentheses( ) -> bool:
+    return item.width_policy == "auto" and item.height_policy == "automatic"
+
+
+def format_range_after_inserted_parens   ():
+    a and item.sizing_mode is None and item.width_policy == "auto" and item.height_policy == "automatic"
+    print("Format this")
+```
+
+
+

--- a/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__regressions.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@range_formatting__regressions.py.snap
@@ -73,6 +73,22 @@ def convert_str(value: str) -> str:  # Trailing comment
 <RANGE_END>
 def test  ():
     pass
+
+
+def test_comment_indent():
+<RANGE_START># A misaligned comment<RANGE_END>
+    print("test")
+
+
+# This demonstrates the use case where a user inserts a new function or class after an existing function.
+# In this case, we should avoid formatting the node that directly precedes the new function/class.
+# However, the problem is that the preceding node **must** be formatted to determine the whitespace between the two statements.
+def test_start ():
+    print("Ideally this gets not reformatted" )
+
+<RANGE_START>
+def new_function_inserted_after_test_start ():
+    print("This should get formatted" )<RANGE_END>
 ```
 
 ## Output
@@ -133,6 +149,22 @@ def convert_str(value: str) -> str:  # Trailing comment
 
 def test  ():
     pass
+
+
+def test_comment_indent():
+    # A misaligned comment
+    print("test")
+
+
+# This demonstrates the use case where a user inserts a new function or class after an existing function.
+# In this case, we should avoid formatting the node that directly precedes the new function/class.
+# However, the problem is that the preceding node **must** be formatted to determine the whitespace between the two statements.
+def test_start ():
+    print("Ideally this gets not reformatted" )
+
+
+def new_function_inserted_after_test_start():
+    print("This should get formatted")
 ```
 
 

--- a/crates/ruff_text_size/src/size.rs
+++ b/crates/ruff_text_size/src/size.rs
@@ -72,7 +72,7 @@ impl TextSize {
     /// # use ruff_text_size::*;
     /// assert_eq!(TextSize::from(4).to_u32(), 4);
     /// ```
-    pub fn to_u32(&self) -> u32 {
+    pub const fn to_u32(&self) -> u32 {
         self.raw
     }
 
@@ -84,7 +84,7 @@ impl TextSize {
     /// # use ruff_text_size::*;
     /// assert_eq!(TextSize::from(4).to_usize(), 4);
     /// ```
-    pub fn to_usize(&self) -> usize {
+    pub const fn to_usize(&self) -> usize {
         self.raw as usize
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes an issue where range formatting omitted the closing parentheses when formatting a range that end's at an expression that gets parenthesized. 

The issue is there's no unambiguous mapping for the position after `"automatic"` in the following example:

```python
def needs_parentheses( ) -> bool:
    return item.sizing_mode is None and item.width_policy == "auto" and item.height_policy == "automatic"
```

This gets reformatted to 

```python
def needs_parentheses() -> bool:
    return (
        item.sizing_mode is None
        and item.width_policy == "auto"
        and item.height_policy == "automatic"
    )

```

The generated IR ending after "automatic" roughly is (where 139 is the position after the closing quote of `"automatic"`)

```
source_position(139), // end position from the expression statement
soft_line_break(),
if_group_breaks(&text(")"))
hard_line_break(), 
source_position(139)
```

The printer will generate multiple source map entries for this

```
139 => 164 // Right after "automatic"
139 => 169 // The closing parentheses
139 => 170 // After the closing parentheses
139 => 171 // After the hard line break
```

Generating multiple mappings for the same position is correct because, depending on the use case, you either want to know where position 139 starts (you pick the first) or where it ends (you pick the last) in the formatted code. That's why the proper fix to this problem would be to include whether we look for the end or start of a node for both offsets passed to `Printed::slice_range`. This way, the source map lookup logic could pick the correct entry if multiple entries point to the same source location... However, this doesn't work for us because the suite ranges in the AST are off. 

Looking at the example from above again: Both the expression and the expression statement end at position 139. If the statement is the last in the body (which is the case in the example above), then the body, and with it, potentially the enclosing node, also ends at position 139 in our AST because the body's end position is equal to the last statement's end position. However, this is incorrect. The end offset of the body should be the position of the `Dedent` token (after the hard line break). We might fix this with the new parser, but it is as it is now. 

The problem with the body ending at offset 139 is that we incorrectly include the `hard_line_break` that ends the body even when formatting the expression statement alone because it's impossible to disambiguate the end of the expression statement from the end of the body. Including the `hard_line_break` results in inserting a new line every time we format the expression statement. 

I'm not too fond of the solution taken by this PR but it works :shrug: 

First, we reduce the granularity of the source map to only generate positions we care about. We no longer generate source map entries for:

* Text elements
* or anything below logical line level (expression, with items, etc)

This solves the problem that we can't disambiguate between the end of the expression and the expression statement. 
This also solves the problem where we can't disambiguate between the expression statement and the body because we'll now always take the first source mapping position. This can produce incorrect* results if we start inserting tokens around the statement, similar to the problem with parenthesizing expressions. However, I'm unaware of a case where we do this today or why this should be needed in the future. If it's needed in the future, than let's hope that we have our new parser by then and can fix the ranges of compound statements.

The first commit removes the automatic source map generation for text elements from the Printer. It now always requires explicit `source_position` element. 

The second commit changes the python formatter to only emit source positions for logical-line like nodes. It also fixes an issue where we didn't fix a comment's indent.


## Test Plan

Added snapshot tests.
