### PR TITLE
Use fake rules for testing deprecation and removal infrastructure

### DIFF
--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -1138,7 +1138,6 @@ fn removed_indirect() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: Selection `RUF93` has no effect because preview is not enabled.
     "###);
 }
 

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -824,7 +824,9 @@ fn nursery_prefix() {
     -:1:1: RUF901 [*] Hey this is a stable test rule with a safe fix.
     -:1:1: RUF902 Hey this is a stable test rule with an unsafe fix.
     -:1:1: RUF903 Hey this is a stable test rule with a display only fix.
-    Found 4 errors.
+    -:1:1: RUF920 Hey this is a deprecated test rule.
+    -:1:1: RUF921 Hey this is another deprecated test rule.
+    Found 6 errors.
     [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
     ----- stderr -----
@@ -846,7 +848,9 @@ fn nursery_all() {
     -:1:1: RUF901 [*] Hey this is a stable test rule with a safe fix.
     -:1:1: RUF902 Hey this is a stable test rule with an unsafe fix.
     -:1:1: RUF903 Hey this is a stable test rule with a display only fix.
-    Found 5 errors.
+    -:1:1: RUF920 Hey this is a deprecated test rule.
+    -:1:1: RUF921 Hey this is another deprecated test rule.
+    Found 7 errors.
     [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
     ----- stderr -----
@@ -1147,9 +1151,11 @@ fn deprecated_direct() {
     // but a warning should be displayed
     let mut cmd = RuffCheck::default().args(["--select", "RUF920"]).build();
     assert_cmd_snapshot!(cmd, @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
+    -:1:1: RUF920 Hey this is a deprecated test rule.
+    Found 1 error.
 
     ----- stderr -----
     warning: Rule `RUF920` is deprecated and will be removed in a future release.
@@ -1162,9 +1168,12 @@ fn deprecated_multiple_direct() {
         .args(["--select", "RUF920", "--select", "RUF921"])
         .build();
     assert_cmd_snapshot!(cmd, @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
+    -:1:1: RUF920 Hey this is a deprecated test rule.
+    -:1:1: RUF921 Hey this is another deprecated test rule.
+    Found 2 errors.
 
     ----- stderr -----
     warning: Rule `RUF921` is deprecated and will be removed in a future release.
@@ -1178,9 +1187,12 @@ fn deprecated_indirect() {
     // since it is not a "direct" selection
     let mut cmd = RuffCheck::default().args(["--select", "RUF92"]).build();
     assert_cmd_snapshot!(cmd, @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
+    -:1:1: RUF920 Hey this is a deprecated test rule.
+    -:1:1: RUF921 Hey this is another deprecated test rule.
+    Found 2 errors.
 
     ----- stderr -----
     "###);
@@ -1756,7 +1768,9 @@ extend-safe-fixes = ["RUF9"]
     -:1:1: RUF901 Hey this is a stable test rule with a safe fix.
     -:1:1: RUF902 [*] Hey this is a stable test rule with an unsafe fix.
     -:1:1: RUF903 Hey this is a stable test rule with a display only fix.
-    Found 4 errors.
+    -:1:1: RUF920 Hey this is a deprecated test rule.
+    -:1:1: RUF921 Hey this is another deprecated test rule.
+    Found 6 errors.
     [*] 1 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
     ----- stderr -----

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -951,6 +951,14 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         #[cfg(feature = "test-rules")]
         #[allow(deprecated)]
         (Ruff, "912") => (RuleGroup::Nursery, rules::ruff::rules::NurseryTestRule),
+        #[cfg(feature = "test-rules")]
+        (Ruff, "920") => (RuleGroup::Deprecated, rules::ruff::rules::DeprecatedTestRule),
+        #[cfg(feature = "test-rules")]
+        (Ruff, "921") => (RuleGroup::Deprecated, rules::ruff::rules::AnotherDeprecatedTestRule),
+        #[cfg(feature = "test-rules")]
+        (Ruff, "930") => (RuleGroup::Removed, rules::ruff::rules::RemovedTestRule),
+        #[cfg(feature = "test-rules")]
+        (Ruff, "931") => (RuleGroup::Removed, rules::ruff::rules::AnotherRemovedTestRule),
 
 
         // flake8-django

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -236,6 +236,16 @@ pub fn check_path(
                 }
                 Rule::NurseryTestRule => test_rules::NurseryTestRule::diagnostic(locator, indexer),
                 Rule::PreviewTestRule => test_rules::PreviewTestRule::diagnostic(locator, indexer),
+                Rule::DeprecatedTestRule => {
+                    test_rules::DeprecatedTestRule::diagnostic(locator, indexer)
+                }
+                Rule::AnotherDeprecatedTestRule => {
+                    test_rules::AnotherDeprecatedTestRule::diagnostic(locator, indexer)
+                }
+                Rule::RemovedTestRule => test_rules::RemovedTestRule::diagnostic(locator, indexer),
+                Rule::AnotherRemovedTestRule => {
+                    test_rules::AnotherRemovedTestRule::diagnostic(locator, indexer)
+                }
                 _ => unreachable!("All test rules must have an implementation"),
             };
             if let Some(diagnostic) = diagnostic {

--- a/crates/ruff_linter/src/rules/ruff/rules/test_rules.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/test_rules.rs
@@ -254,6 +254,7 @@ impl TestRule for PreviewTestRule {
         ))
     }
 }
+
 /// ## What it does
 /// Fake rule for testing.
 ///
@@ -285,6 +286,150 @@ impl TestRule for NurseryTestRule {
     fn diagnostic(_locator: &Locator, _indexer: &Indexer) -> Option<Diagnostic> {
         Some(Diagnostic::new(
             NurseryTestRule,
+            ruff_text_size::TextRange::default(),
+        ))
+    }
+}
+
+/// ## What it does
+/// Fake rule for testing.
+///
+/// ## Why is this bad?
+/// Tests must pass!
+///
+/// ## Example
+/// ```python
+/// foo
+/// ```
+///
+/// Use instead:
+/// ```python
+/// bar
+/// ```
+#[violation]
+pub struct DeprecatedTestRule;
+
+impl Violation for DeprecatedTestRule {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Hey this is a deprecated test rule.")
+    }
+}
+
+impl TestRule for DeprecatedTestRule {
+    fn diagnostic(_locator: &Locator, _indexer: &Indexer) -> Option<Diagnostic> {
+        Some(Diagnostic::new(
+            DeprecatedTestRule,
+            ruff_text_size::TextRange::default(),
+        ))
+    }
+}
+
+/// ## What it does
+/// Fake rule for testing.
+///
+/// ## Why is this bad?
+/// Tests must pass!
+///
+/// ## Example
+/// ```python
+/// foo
+/// ```
+///
+/// Use instead:
+/// ```python
+/// bar
+/// ```
+#[violation]
+pub struct AnotherDeprecatedTestRule;
+
+impl Violation for AnotherDeprecatedTestRule {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Hey this is another deprecated test rule.")
+    }
+}
+
+impl TestRule for AnotherDeprecatedTestRule {
+    fn diagnostic(_locator: &Locator, _indexer: &Indexer) -> Option<Diagnostic> {
+        Some(Diagnostic::new(
+            AnotherDeprecatedTestRule,
+            ruff_text_size::TextRange::default(),
+        ))
+    }
+}
+
+/// ## What it does
+/// Fake rule for testing.
+///
+/// ## Why is this bad?
+/// Tests must pass!
+///
+/// ## Example
+/// ```python
+/// foo
+/// ```
+///
+/// Use instead:
+/// ```python
+/// bar
+/// ```
+#[violation]
+pub struct RemovedTestRule;
+
+impl Violation for RemovedTestRule {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Hey this is a removed test rule.")
+    }
+}
+
+impl TestRule for RemovedTestRule {
+    fn diagnostic(_locator: &Locator, _indexer: &Indexer) -> Option<Diagnostic> {
+        Some(Diagnostic::new(
+            RemovedTestRule,
+            ruff_text_size::TextRange::default(),
+        ))
+    }
+}
+
+/// ## What it does
+/// Fake rule for testing.
+///
+/// ## Why is this bad?
+/// Tests must pass!
+///
+/// ## Example
+/// ```python
+/// foo
+/// ```
+///
+/// Use instead:
+/// ```python
+/// bar
+/// ```
+#[violation]
+pub struct AnotherRemovedTestRule;
+
+impl Violation for AnotherRemovedTestRule {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Hey this is a another removed test rule.")
+    }
+}
+
+impl TestRule for AnotherRemovedTestRule {
+    fn diagnostic(_locator: &Locator, _indexer: &Indexer) -> Option<Diagnostic> {
+        Some(Diagnostic::new(
+            AnotherRemovedTestRule,
             ruff_text_size::TextRange::default(),
         ))
     }

--- a/crates/ruff_linter/src/rules/ruff/rules/test_rules.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/test_rules.rs
@@ -39,6 +39,10 @@ pub(crate) const TEST_RULES: &[Rule] = &[
     Rule::StableTestRuleDisplayOnlyFix,
     Rule::PreviewTestRule,
     Rule::NurseryTestRule,
+    Rule::DeprecatedTestRule,
+    Rule::AnotherDeprecatedTestRule,
+    Rule::RemovedTestRule,
+    Rule::AnotherRemovedTestRule,
 ];
 
 pub(crate) trait TestRule {

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -909,7 +909,15 @@ impl LintConfiguration {
                     }
 
                     // Check if the selector is empty because preview mode is disabled
-                    if selector.rules(&PreviewOptions::default()).next().is_none() {
+                    if selector.rules(&preview).next().is_none()
+                        && selector
+                            .rules(&PreviewOptions {
+                                mode: PreviewMode::Enabled,
+                                require_explicit: preview.require_explicit,
+                            })
+                            .next()
+                            .is_some()
+                    {
                         ignored_preview_selectors.insert(selector);
                     }
                 }


### PR DESCRIPTION
Updates #9689 and #9691 to use rule testing infrastructure from #9747 