### PR TITLE
Remove stale preview documentation from stabilized rule behaviors

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -69,10 +69,6 @@ impl Violation for UncapitalizedEnvironmentVariables {
 /// `None` is the default value for `dict.get()`, so it is redundant to pass it
 /// explicitly.
 ///
-/// In [preview], this rule applies to variables that are inferred to be
-/// dictionaries; in stable, it's limited to dictionary literals (e.g.,
-/// `{"foo": 1}.get("foo", None)`).
-///
 /// ## Example
 /// ```python
 /// ages = {"Tom": 23, "Maria": 23, "Dog": 11}
@@ -87,8 +83,6 @@ impl Violation for UncapitalizedEnvironmentVariables {
 ///
 /// ## References
 /// - [Python documentation: `dict.get`](https://docs.python.org/3/library/stdtypes.html#dict.get)
-///
-/// [preview]: https://docs.astral.sh/ruff/preview/
 #[violation]
 pub struct DictGetWithNoneDefault {
     expected: SourceCodeSnippet,

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -31,11 +31,9 @@ use crate::checkers::ast::Checker;
 /// ## Fix safety
 /// Given `key in obj.keys()`, `obj` _could_ be a dictionary, or it could be
 /// another type that defines a `.keys()` method. In the latter case, removing
-/// the `.keys()` attribute could lead to a runtime error.
-///
-/// As such, this rule's fixes are marked as unsafe. In [preview], though,
-/// fixes are marked as safe when Ruff can determine that `obj` is a
-/// dictionary.
+/// the `.keys()` attribute could lead to a runtime error. The fix is marked
+/// as safe when the type of `obj` is known to be a dictionary; otherwise, it
+/// is marked as unsafe.
 ///
 /// ## References
 /// - [Python documentation: Mapping Types](https://docs.python.org/3/library/stdtypes.html#mapping-types-dict)

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/module_import_not_at_top_of_file.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/module_import_not_at_top_of_file.rs
@@ -13,9 +13,9 @@ use crate::checkers::ast::Checker;
 /// According to [PEP 8], "imports are always put at the top of the file, just after any
 /// module comments and docstrings, and before module globals and constants."
 ///
-/// In [preview], this rule makes an exception for `sys.path` modifications,
-/// allowing for `sys.path.insert`, `sys.path.append`, and similar
-/// modifications between import statements.
+/// This rule makes an exception for `sys.path` modifications,  allowing for
+/// `sys.path.insert`, `sys.path.append`, and similar modifications between import
+/// statements.
 ///
 /// ## Example
 /// ```python
@@ -37,7 +37,6 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#imports
-/// [preview]: https://docs.astral.sh/ruff/preview/
 #[violation]
 pub struct ModuleImportNotAtTopOfFile {
     source_type: PySourceType,


### PR DESCRIPTION
These behaviors were stabilized, so the docs referring to them as preview-only are incorrect.