### PR TITLE
Use consistent method to detect preview enablement

### DIFF
--- a/crates/ruff_linter/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -8,7 +8,6 @@ use ruff_python_parser::{lexer, Mode, Tok};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::checkers::ast::Checker;
-use crate::settings::types::PreviewMode;
 
 /// ## What it does
 /// Checks for `is` and `is not` comparisons against constant literals, like
@@ -91,7 +90,7 @@ pub(crate) fn invalid_literal_comparison(
         if matches!(op, CmpOp::Is | CmpOp::IsNot)
             && (helpers::is_constant_non_singleton(left)
                 || helpers::is_constant_non_singleton(right)
-                || (matches!(checker.settings.preview, PreviewMode::Enabled)
+                || (checker.settings.preview.is_enabled()
                     && (helpers::is_mutable_iterable_initializer(left)
                         || helpers::is_mutable_iterable_initializer(right))))
         {

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_variable.rs
@@ -12,7 +12,6 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::checkers::ast::Checker;
 use crate::fix::edits::delete_stmt;
-use crate::settings::types::PreviewMode;
 
 /// ## What it does
 /// Checks for the presence of unused variables in function scopes.
@@ -333,8 +332,7 @@ pub(crate) fn unused_variable(checker: &Checker, scope: &Scope, diagnostics: &mu
             if (binding.kind.is_assignment()
                 || binding.kind.is_named_expr_assignment()
                 || binding.kind.is_with_item_var())
-                && (!binding.is_unpacked_assignment()
-                    || matches!(checker.settings.preview, PreviewMode::Enabled))
+                && (!binding.is_unpacked_assignment() || checker.settings.preview.is_enabled())
                 && !binding.is_nonlocal()
                 && !binding.is_global()
                 && !binding.is_used()


### PR DESCRIPTION
I missed these two in the v0.2.0 stabilizations because they use a match instead of the dedicated method.