### PR TITLE
Fix issue where output format mode would not change to `full` if preview mode was set in configuration file

### DIFF
--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -323,6 +323,8 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
 
     // the settings should already be combined with the CLI overrides at this point
     // TODO(jane): let's make this `PreviewMode`
+    // TODO: this should reference the global preview mode once https://github.com/astral-sh/ruff/issues/8232
+    //   is resolved.
     let preview = pyproject_config.settings.linter.preview.is_enabled();
 
     if cli.watch {

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -321,7 +321,9 @@ pub fn check(args: CheckCommand, log_level: LogLevel) -> Result<ExitStatus> {
         printer_flags,
     );
 
-    let preview = overrides.preview.unwrap_or_default().is_enabled();
+    // the settings should already be combined with the CLI overrides at this point
+    // TODO(jane): let's make this `PreviewMode`
+    let preview = pyproject_config.settings.linter.preview.is_enabled();
 
     if cli.watch {
         if output_format != SerializationFormat::default(preview) {

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -756,6 +756,35 @@ fn full_output_preview() {
 }
 
 #[test]
+fn full_output_preview_config() {
+    let tempdir = TempDir::new().unwrap();
+    let pyproject_toml = tempdir.path().join("pyproject.toml");
+    fs::write(
+        &pyproject_toml,
+        r#"
+[tool.ruff]
+preview = true
+"#,
+    )
+    .unwrap();
+    let mut cmd = RuffCheck::default().config(&pyproject_toml).build();
+    assert_cmd_snapshot!(cmd.pass_stdin("l = 1"), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    -:1:1: E741 Ambiguous variable name: `l`
+      |
+    1 | l = 1
+      | ^ E741
+      |
+
+    Found 1 error.
+
+    ----- stderr -----
+    "###);
+}
+
+#[test]
 fn full_output_format() {
     let mut cmd = RuffCheck::default().output_format("full").build();
     assert_cmd_snapshot!(cmd

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -756,8 +756,8 @@ fn full_output_preview() {
 }
 
 #[test]
-fn full_output_preview_config() {
-    let tempdir = TempDir::new().unwrap();
+fn full_output_preview_config() -> Result<()> {
+    let tempdir = TempDir::new()?;
     let pyproject_toml = tempdir.path().join("pyproject.toml");
     fs::write(
         &pyproject_toml,
@@ -765,8 +765,7 @@ fn full_output_preview_config() {
 [tool.ruff]
 preview = true
 "#,
-    )
-    .unwrap();
+    )?;
     let mut cmd = RuffCheck::default().config(&pyproject_toml).build();
     assert_cmd_snapshot!(cmd.pass_stdin("l = 1"), @r###"
     success: false
@@ -782,6 +781,7 @@ preview = true
 
     ----- stderr -----
     "###);
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This was causing build failures for #9599. We were referencing the command line overrides instead of the merged configuration data, hence the issue.

## Test Plan

A snapshot test was added.