### PR TITLE
Deduplicate deprecation warnings for v0.2.0 release

### DIFF
--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -508,11 +508,9 @@ if __name__ == '__main__':
         say_hy("dear Ruff contributor")
 
     ----- stderr -----
-    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in your configuration:
+    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `ruff.toml`:
       - 'extend-select' -> 'lint.extend-select'
       - 'ignore' -> 'lint.ignore'
-
-
     "###);
     Ok(())
 }
@@ -551,11 +549,9 @@ if __name__ == '__main__':
         say_hy("dear Ruff contributor")
 
     ----- stderr -----
-    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in your configuration:
+    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `ruff.toml`:
       - 'extend-select' -> 'lint.extend-select'
       - 'ignore' -> 'lint.ignore'
-
-
     "###);
     Ok(())
 }

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -27,29 +27,32 @@ inline-quotes = "single"
 "#,
     )?;
 
-    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-        .args(STDIN_BASE_OPTIONS)
-        .arg("--config")
-        .arg(&ruff_toml)
-        .args(["--stdin-filename", "test.py"])
-        .arg("-")
-        .pass_stdin(r#"a = "abcba".strip("aba")"#), @r###"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-    test.py:1:5: Q000 [*] Double quotes found but single quotes preferred
-    test.py:1:5: B005 Using `.strip()` with multi-character strings is misleading
-    test.py:1:19: Q000 [*] Double quotes found but single quotes preferred
-    Found 3 errors.
-    [*] 2 fixable with the `--fix` option.
+    insta::with_settings!({
+        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .args(STDIN_BASE_OPTIONS)
+            .arg("--config")
+            .arg(&ruff_toml)
+            .args(["--stdin-filename", "test.py"])
+            .arg("-")
+            .pass_stdin(r#"a = "abcba".strip("aba")"#), @r###"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+        test.py:1:5: Q000 [*] Double quotes found but single quotes preferred
+        test.py:1:5: B005 Using `.strip()` with multi-character strings is misleading
+        test.py:1:19: Q000 [*] Double quotes found but single quotes preferred
+        Found 3 errors.
+        [*] 2 fixable with the `--fix` option.
 
-    ----- stderr -----
-    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in your configuration:
-      - 'extend-select' -> 'lint.extend-select'
-      - 'flake8-quotes' -> 'lint.flake8-quotes'
+        ----- stderr -----
+        warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `[TMP]/ruff.toml`:
+          - 'extend-select' -> 'lint.extend-select'
+          - 'flake8-quotes' -> 'lint.flake8-quotes'
+        "###);
+    });
 
-
-    "###);
     Ok(())
 }
 
@@ -68,6 +71,9 @@ inline-quotes = "single"
 "#,
     )?;
 
+    insta::with_settings!({
+        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+    }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(STDIN_BASE_OPTIONS)
         .arg("--config")
@@ -85,6 +91,8 @@ inline-quotes = "single"
 
     ----- stderr -----
     "###);
+    });
+
     Ok(())
 }
 
@@ -103,6 +111,9 @@ inline-quotes = "single"
 "#,
     )?;
 
+    insta::with_settings!({
+        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+    }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(STDIN_BASE_OPTIONS)
         .arg("--config")
@@ -119,11 +130,11 @@ inline-quotes = "single"
     [*] 2 fixable with the `--fix` option.
 
     ----- stderr -----
-    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in your configuration:
+    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `[TMP]/ruff.toml`:
       - 'extend-select' -> 'lint.extend-select'
-
-
     "###);
+    });
+
     Ok(())
 }
 
@@ -146,6 +157,9 @@ inline-quotes = "single"
 "#,
     )?;
 
+    insta::with_settings!({
+        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+    }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(STDIN_BASE_OPTIONS)
         .arg("--config")
@@ -162,11 +176,11 @@ inline-quotes = "single"
     [*] 2 fixable with the `--fix` option.
 
     ----- stderr -----
-    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in your configuration:
+    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `[TMP]/ruff.toml`:
       - 'flake8-quotes' -> 'lint.flake8-quotes'
-
-
     "###);
+    });
+
     Ok(())
 }
 
@@ -222,6 +236,9 @@ OTHER = "OTHER"
 
     fs::write(out_dir.join("a.py"), r#"a = "a""#)?;
 
+    insta::with_settings!({
+        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+    }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())
         .arg("check")
@@ -241,11 +258,11 @@ OTHER = "OTHER"
     [*] 3 fixable with the `--fix` option.
 
     ----- stderr -----
-    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in your configuration:
+    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `ruff.toml`:
       - 'extend-select' -> 'lint.extend-select'
-
-
     "###);
+    });
+
     Ok(())
 }
 
@@ -266,6 +283,9 @@ inline-quotes = "single"
 "#,
     )?;
 
+    insta::with_settings!({
+        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+    }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())
         .arg("check")
@@ -288,11 +308,11 @@ if __name__ == "__main__":
     [*] 2 fixable with the `--fix` option.
 
     ----- stderr -----
-    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in your configuration:
+    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `ruff.toml`:
       - 'extend-select' -> 'lint.extend-select'
-
-
     "###);
+    });
+
     Ok(())
 }
 
@@ -311,6 +331,9 @@ max-line-length = 100
 "#,
     )?;
 
+    insta::with_settings!({
+        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+    }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(STDIN_BASE_OPTIONS)
         .arg("--config")
@@ -330,12 +353,12 @@ _ = "---------------------------------------------------------------------------
     Found 1 error.
 
     ----- stderr -----
-    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in your configuration:
+    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `[TMP]/ruff.toml`:
       - 'select' -> 'lint.select'
       - 'pycodestyle' -> 'lint.pycodestyle'
-
-
     "###);
+    });
+
     Ok(())
 }
 
@@ -353,6 +376,9 @@ inline-quotes = "single"
 "#,
     )?;
 
+    insta::with_settings!({
+        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+    }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())
         .arg("check")
@@ -377,11 +403,11 @@ if __name__ == "__main__":
     [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
-    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in your configuration:
+    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `ruff.toml`:
       - 'extend-select' -> 'lint.extend-select'
-
-
     "###);
+    });
+
     Ok(())
 }
 
@@ -399,6 +425,9 @@ inline-quotes = "single"
 "#,
     )?;
 
+    insta::with_settings!({
+        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+    }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())
         .arg("check")
@@ -423,11 +452,11 @@ if __name__ == "__main__":
     [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
-    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in your configuration:
+    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `ruff.toml`:
       - 'extend-select' -> 'lint.extend-select'
-
-
     "###);
+    });
+
     Ok(())
 }
 
@@ -456,6 +485,9 @@ ignore = ["D203", "D212"]
 "#,
     )?;
 
+    insta::with_settings!({
+        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+    }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(sub_dir)
         .arg("check")
@@ -468,6 +500,8 @@ ignore = ["D203", "D212"]
     ----- stderr -----
     warning: No Python files found under the given path(s)
     "###);
+    });
+
     Ok(())
 }
 
@@ -524,6 +558,9 @@ include = ["*.ipy"]
 "#,
     )?;
 
+    insta::with_settings!({
+        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+    }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())
         .arg("check")
@@ -540,5 +577,7 @@ include = ["*.ipy"]
 
     ----- stderr -----
     "###);
+    });
+
     Ok(())
 }

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -2,6 +2,7 @@
 
 #![cfg(not(target_family = "wasm"))]
 
+use regex::escape;
 use std::fs;
 use std::process::Command;
 use std::str;
@@ -12,6 +13,10 @@ use tempfile::TempDir;
 
 const BIN_NAME: &str = "ruff";
 const STDIN_BASE_OPTIONS: &[&str] = &["--no-cache", "--output-format", "concise"];
+
+fn tempdir_filter(tempdir: &TempDir) -> String {
+    format!(r"{}\\?/?", escape(tempdir.path().to_str().unwrap()))
+}
 
 #[test]
 fn top_level_options() -> Result<()> {
@@ -28,7 +33,7 @@ inline-quotes = "single"
     )?;
 
     insta::with_settings!({
-        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
     }, {
         assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .args(STDIN_BASE_OPTIONS)
@@ -72,7 +77,7 @@ inline-quotes = "single"
     )?;
 
     insta::with_settings!({
-        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(STDIN_BASE_OPTIONS)
@@ -112,7 +117,7 @@ inline-quotes = "single"
     )?;
 
     insta::with_settings!({
-        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(STDIN_BASE_OPTIONS)
@@ -158,7 +163,7 @@ inline-quotes = "single"
     )?;
 
     insta::with_settings!({
-        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(STDIN_BASE_OPTIONS)
@@ -237,7 +242,7 @@ OTHER = "OTHER"
     fs::write(out_dir.join("a.py"), r#"a = "a""#)?;
 
     insta::with_settings!({
-        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())
@@ -284,7 +289,7 @@ inline-quotes = "single"
     )?;
 
     insta::with_settings!({
-        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())
@@ -332,7 +337,7 @@ max-line-length = 100
     )?;
 
     insta::with_settings!({
-        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(STDIN_BASE_OPTIONS)
@@ -377,7 +382,7 @@ inline-quotes = "single"
     )?;
 
     insta::with_settings!({
-        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())
@@ -426,7 +431,7 @@ inline-quotes = "single"
     )?;
 
     insta::with_settings!({
-        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())
@@ -486,7 +491,7 @@ ignore = ["D203", "D212"]
     )?;
 
     insta::with_settings!({
-        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(sub_dir)
@@ -559,7 +564,7 @@ include = ["*.ipy"]
     )?;
 
     insta::with_settings!({
-        filters => vec![(tempdir.path().to_str().unwrap(), "[TMP]")]
+        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())

--- a/crates/ruff/tests/resolve_files.rs
+++ b/crates/ruff/tests/resolve_files.rs
@@ -39,10 +39,8 @@ fn check_project_include_defaults() {
         [BASEPATH]/include-test/subdirectory/c.py
 
         ----- stderr -----
-        warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in your configuration:
+        warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `nested-project/pyproject.toml`:
           - 'select' -> 'lint.select'
-
-
         "###);
     });
 }

--- a/crates/ruff_linter/src/logging.rs
+++ b/crates/ruff_linter/src/logging.rs
@@ -8,6 +8,7 @@ use fern;
 use log::Level;
 use once_cell::sync::Lazy;
 use ruff_python_parser::{ParseError, ParseErrorType};
+use rustc_hash::FxHashSet;
 
 use ruff_source_file::{LineIndex, OneIndexed, SourceCode, SourceLocation};
 
@@ -15,7 +16,7 @@ use crate::fs;
 use crate::source_kind::SourceKind;
 use ruff_notebook::Notebook;
 
-pub static WARNINGS: Lazy<Mutex<Vec<&'static str>>> = Lazy::new(Mutex::default);
+pub static IDENTIFIERS: Lazy<Mutex<Vec<&'static str>>> = Lazy::new(Mutex::default);
 
 /// Warn a user once, with uniqueness determined by the given ID.
 #[macro_export]
@@ -24,11 +25,31 @@ macro_rules! warn_user_once_by_id {
         use colored::Colorize;
         use log::warn;
 
-        if let Ok(mut states) = $crate::logging::WARNINGS.lock() {
+        if let Ok(mut states) = $crate::logging::IDENTIFIERS.lock() {
             if !states.contains(&$id) {
                 let message = format!("{}", format_args!($($arg)*));
                 warn!("{}", message.bold());
                 states.push($id);
+            }
+        }
+    };
+}
+
+pub static MESSAGES: Lazy<Mutex<FxHashSet<String>>> = Lazy::new(Mutex::default);
+
+/// Warn a user once, if warnings are enabled, with uniqueness determined by the content of the
+/// message.
+#[macro_export]
+macro_rules! warn_user_once_by_message {
+    ($($arg:tt)*) => {
+        use colored::Colorize;
+        use log::warn;
+
+        if let Ok(mut states) = $crate::logging::MESSAGES.lock() {
+            let message = format!("{}", format_args!($($arg)*));
+            if !states.contains(&message) {
+                warn!("{}", message.bold());
+                states.insert(message);
             }
         }
     };

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -108,8 +108,8 @@ impl Workspace {
     #[wasm_bindgen(constructor)]
     pub fn new(options: JsValue) -> Result<Workspace, Error> {
         let options: Options = serde_wasm_bindgen::from_value(options).map_err(into_error)?;
-        let configuration =
-            Configuration::from_options(options, Path::new(".")).map_err(into_error)?;
+        let configuration = Configuration::from_options(options, Path::new("."), Path::new("."))
+            .map_err(into_error)?;
         let settings = configuration
             .into_settings(Path::new("."))
             .map_err(into_error)?;

--- a/crates/ruff_workspace/src/resolver.rs
+++ b/crates/ruff_workspace/src/resolver.rs
@@ -264,7 +264,7 @@ fn resolve_configuration(
         let options = pyproject::load_options(&path)?;
 
         let project_root = relativity.resolve(&path);
-        let configuration = Configuration::from_options(options, &project_root)?;
+        let configuration = Configuration::from_options(options, &path, &project_root)?;
 
         // If extending, continue to collect.
         next = configuration.extend.as_ref().map(|extend| {


### PR DESCRIPTION
## Summary

Adds an additional warning macro (we should consolidate these later) that shows a warning once based on the content of the warning itself. This is less efficient than `warn_user_once!` and `warn_user_by_id!`, but this is so expensive that it doesn't matter at all.

Applies this macro to the various warnings for the v0.2.0 release, and also includes the filename in said warnings, so the FastAPI case is now:

```text
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in /Users/crmarsh/workspace/fastapi/pyproject.toml:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'isort' -> 'lint.isort'
  - 'pyupgrade' -> 'lint.pyupgrade'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
```