### PR TITLE
Move `adjust_indentation` to a shared home

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
@@ -1,28 +1,27 @@
-use anyhow::Result;
 use std::ops::Add;
 
-use ruff_python_ast::{self as ast, ElifElseClause, Expr, Stmt};
-use ruff_text_size::{Ranged, TextRange, TextSize};
+use anyhow::Result;
 
 use ruff_diagnostics::{AlwaysFixableViolation, FixAvailability, Violation};
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-
 use ruff_python_ast::helpers::{is_const_false, is_const_true};
 use ruff_python_ast::stmt_if::elif_else_range;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::whitespace::indentation;
+use ruff_python_ast::{self as ast, ElifElseClause, Expr, Stmt};
 use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;
 use ruff_python_semantic::SemanticModel;
 use ruff_python_trivia::{is_python_whitespace, SimpleTokenKind, SimpleTokenizer};
 use ruff_source_file::Locator;
+use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::checkers::ast::Checker;
 use crate::fix::edits;
+use crate::fix::edits::adjust_indentation;
 use crate::registry::{AsRule, Rule};
 use crate::rules::flake8_return::helpers::end_of_last_statement;
-use crate::rules::pyupgrade::fixes::adjust_indentation;
 
 use super::super::branch::Branch;
 use super::super::helpers::result_exists;

--- a/crates/ruff_linter/src/rules/pylint/rules/collapsible_else_if.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/collapsible_else_if.rs
@@ -9,7 +9,7 @@ use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
-use crate::rules::pyupgrade::fixes::adjust_indentation;
+use crate::fix::edits::adjust_indentation;
 
 /// ## What it does
 /// Checks for `else` blocks that consist of a single `if` statement.

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_else_on_loop.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_else_on_loop.rs
@@ -10,7 +10,7 @@ use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
-use crate::rules::pyupgrade::fixes::adjust_indentation;
+use crate::fix::edits::adjust_indentation;
 
 /// ## What it does
 /// Checks for `else` clauses on loops without a `break` statement.

--- a/crates/ruff_linter/src/rules/pyupgrade/fixes.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/fixes.rs
@@ -1,38 +1,6 @@
-use anyhow::Result;
-
-use ruff_python_codegen::Stylist;
 use ruff_python_parser::{lexer, Mode, Tok};
 use ruff_source_file::Locator;
 use ruff_text_size::{TextRange, TextSize};
-
-use crate::cst::matchers::{match_function_def, match_indented_block, match_statement};
-use crate::fix::codemods::CodegenStylist;
-
-/// Safely adjust the indentation of the indented block at [`TextRange`].
-pub(crate) fn adjust_indentation(
-    range: TextRange,
-    indentation: &str,
-    locator: &Locator,
-    stylist: &Stylist,
-) -> Result<String> {
-    let contents = locator.slice(range);
-
-    let module_text = format!("def f():{}{contents}", stylist.line_ending().as_str());
-
-    let mut tree = match_statement(&module_text)?;
-
-    let embedding = match_function_def(&mut tree)?;
-
-    let indented_block = match_indented_block(&mut embedding.body)?;
-    indented_block.indent = Some(indentation);
-
-    let module_text = indented_block.codegen_stylist(stylist);
-    let module_text = module_text
-        .strip_prefix(stylist.line_ending().as_str())
-        .unwrap()
-        .to_string();
-    Ok(module_text)
-}
 
 /// Remove any imports matching `members` from an import-from statement.
 pub(crate) fn remove_import_members(contents: &str, members: &[&str]) -> String {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 
 use anyhow::Result;
+
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::map_subscript;
@@ -10,9 +11,7 @@ use ruff_python_ast::{self as ast, CmpOp, ElifElseClause, Expr, Int, StmtIf};
 use ruff_text_size::{Ranged, TextLen, TextRange};
 
 use crate::checkers::ast::Checker;
-use crate::fix::edits::delete_stmt;
-
-use crate::rules::pyupgrade::fixes::adjust_indentation;
+use crate::fix::edits::{adjust_indentation, delete_stmt};
 use crate::settings::types::PythonVersion;
 
 /// ## What it does


### PR DESCRIPTION
Now that this method is used in multiple linters, it should be moved out of the `pyupgrade` module.