### PR TITLE
[flake8-bugbear][B006] remove outdated comment

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -83,7 +83,6 @@ impl Violation for MutableArgumentDefault {
 
 /// B006
 pub(crate) fn mutable_argument_default(checker: &mut Checker, function_def: &ast::StmtFunctionDef) {
-    // Scan in reverse order to right-align zip().
     for ParameterWithDefault {
         parameter,
         default,


### PR DESCRIPTION
I noticed that the comment doesn't match the behavior:
- zip function is not used anymore
- parameters are not scanned in reverse

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

No need
