### PR TITLE
Made hyperlink on homepage correctly redirect to GitHub

### DIFF
--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -51,6 +51,7 @@ LINK_REWRITES: dict[str, str] = {
     "https://docs.astral.sh/ruff/installation/": "installation.md",
     "https://docs.astral.sh/ruff/rules/": "rules.md",
     "https://docs.astral.sh/ruff/settings/": "settings.md",
+    "#whos-using-ruff": "https://github.com/astral-sh/ruff#whos-using-ruff",
 }
 
 


### PR DESCRIPTION
## Summary

Closes #9783. Feels hacky because of the different key so there *might* be a nicer way to do this 😄

## Test Plan
Tested locally with `mkdocs serve`.