### PR TITLE
Skip empty lines when determining base indentation

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_return/RET505.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_return/RET505.py
@@ -198,3 +198,13 @@ else:
 def sb(self):
     if self._sb is not None: return self._sb
     else: self._sb = '\033[01;%dm'; self._sa = '\033[0;0m';
+
+
+def indent(x, y, w, z):
+    if x:  # [no-else-return]
+        a = 1
+        return y
+    else:
+
+        c = 3
+        return z

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET505_RET505.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__RET505_RET505.py.snap
@@ -171,4 +171,15 @@ RET505.py:200:5: RET505 Unnecessary `else` after `return` statement
     |
     = help: Remove unnecessary `else`
 
+RET505.py:207:5: RET505 Unnecessary `else` after `return` statement
+    |
+205 |         a = 1
+206 |         return y
+207 |     else:
+    |     ^^^^ RET505
+208 | 
+209 |         c = 3
+    |
+    = help: Remove unnecessary `else`
+
 

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__preview__RET505_RET505.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__preview__RET505_RET505.py.snap
@@ -358,5 +358,30 @@ RET505.py:200:5: RET505 [*] Unnecessary `else` after `return` statement
 199 199 |     if self._sb is not None: return self._sb
 200     |-    else: self._sb = '\033[01;%dm'; self._sa = '\033[0;0m';
     200 |+    self._sb = '\033[01;%dm'; self._sa = '\033[0;0m';
+201 201 | 
+202 202 | 
+203 203 | def indent(x, y, w, z):
+
+RET505.py:207:5: RET505 [*] Unnecessary `else` after `return` statement
+    |
+205 |         a = 1
+206 |         return y
+207 |     else:
+    |     ^^^^ RET505
+208 | 
+209 |         c = 3
+    |
+    = help: Remove unnecessary `else`
+
+ℹ Safe fix
+204 204 |     if x:  # [no-else-return]
+205 205 |         a = 1
+206 206 |         return y
+207     |-    else:
+208 207 | 
+209     |-        c = 3
+210     |-        return z
+    208 |+    c = 3
+    209 |+    return z
 
 

--- a/crates/ruff_python_trivia/src/textwrap.rs
+++ b/crates/ruff_python_trivia/src/textwrap.rs
@@ -138,11 +138,18 @@ pub fn dedent(text: &str) -> Cow<'_, str> {
 /// # Panics
 /// If the first line is indented by less than the provided indent.
 pub fn dedent_to(text: &str, indent: &str) -> String {
-    // Look at the indentation of the first line, to determine the "baseline" indentation.
+    // Look at the indentation of the first non-empty line, to determine the "baseline" indentation.
     let existing_indent_len = text
         .universal_newlines()
-        .next()
-        .map_or(0, |line| line.len() - line.trim_start().len());
+        .find_map(|line| {
+            let trimmed = line.trim_whitespace_start();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(line.len() - trimmed.len())
+            }
+        })
+        .unwrap_or_default();
 
     // Determine the amount of indentation to remove.
     let dedent_len = existing_indent_len - indent.len();


### PR DESCRIPTION
## Summary

It turns out we saw a panic in cases when dedenting blocks like the `def wrapper` here:

```python
def instrument_url(f: UrlFuncT) -> UrlFuncT:
    # TODO: Type this with ParamSpec to preserve the function signature.
    if not INSTRUMENTING:  # nocoverage -- option is always enabled; should we remove?
        return f
    else:

        def wrapper(
            self: "ZulipTestCase", url: str, info: object = {}, **kwargs: Union[bool, str]
        ) -> HttpResponseBase:
```

Since we relied on the first line to determine the indentation, instead of the first non-empty line.

## Test Plan

`cargo test`
