### PR TITLE
Don't trim last empty line in docstrings

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_newlines.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_newlines.py
@@ -1,0 +1,55 @@
+# Tests that Ruff correctly preserves newlines before the closing quote
+
+def test():
+    """a, b
+c"""
+
+
+def test2():
+    """a, b
+    c
+"""
+
+def test3():
+    """a, b
+
+"""
+
+
+def test4():
+    """
+    a, b
+
+"""
+
+
+def test5():
+    """
+    a, b
+a"""
+
+def test6():
+    """
+    a, b
+
+    c
+"""
+
+
+
+def test7():
+    """
+    a, b
+
+
+
+
+"""
+
+def test7():
+    """
+    a, b
+
+
+
+    """

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_newlines.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_newlines.py.snap
@@ -1,0 +1,125 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_newlines.py
+---
+## Input
+```python
+# Tests that Ruff correctly preserves newlines before the closing quote
+
+def test():
+    """a, b
+c"""
+
+
+def test2():
+    """a, b
+    c
+"""
+
+def test3():
+    """a, b
+
+"""
+
+
+def test4():
+    """
+    a, b
+
+"""
+
+
+def test5():
+    """
+    a, b
+a"""
+
+def test6():
+    """
+    a, b
+
+    c
+"""
+
+
+
+def test7():
+    """
+    a, b
+
+
+
+
+"""
+
+def test7():
+    """
+    a, b
+
+
+
+    """
+```
+
+## Output
+```python
+# Tests that Ruff correctly preserves newlines before the closing quote
+
+
+def test():
+    """a, b
+    c"""
+
+
+def test2():
+    """a, b
+    c
+    """
+
+
+def test3():
+    """a, b"""
+
+
+def test4():
+    """
+    a, b
+
+    """
+
+
+def test5():
+    """
+        a, b
+    a"""
+
+
+def test6():
+    """
+    a, b
+
+    c
+    """
+
+
+def test7():
+    """
+    a, b
+
+
+
+
+    """
+
+
+def test7():
+    """
+    a, b
+
+
+
+    """
+```
+
+
+


### PR DESCRIPTION
## Summary

This PR fixes a bug in our formatter where it would remove the last empty line for docstrings when `"""` is not intented:

```python
def test7():
    """
    a, b
    
    
    
    
"""
```

Would get formatted to 

```python
def test7():
    """
    a, b
    
    
    
"""
```
(Removing the last empty line). 

This is inconsistent with Black and how we format docstrings when the closing quotes are indented. The empty line does not get removed for:

```python
def test7():
    """
    a, b
    
    
    
    
    """
```

The root cause of the divergence was that we use `str::lines()` which uses `split_inclusive` underneath that omits the last element if it matches the separator:

> If the last element of the string is matched, that element will be considered the terminator of the preceding substring. That substring will be the last item returned by the iterator.
  ```rust
  let v: Vec<&str> = "Mary had a little lamb\nlittle lamb\nlittle lamb.\n"
      .split_inclusive('\n').collect();
  assert_eq!(v, ["Mary had a little lamb\n", "little lamb\n", "little lamb.\n"]); 
  ```

The PR fixes the divergence by using `split` instead.

Fixes https://github.com/astral-sh/ruff/issues/9804

## Preview

This change is not gated behind preview because it doesn't change the output for already formatted code. 

## Test Plan

Added snapshot test
