### PR TITLE
Remove deprecated configuration '--show-source`

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -18,8 +18,8 @@ use ruff_linter::line_width::LineLength;
 use ruff_linter::logging::LogLevel;
 use ruff_linter::registry::Rule;
 use ruff_linter::settings::types::{
-    ExtensionPair, FilePattern, PatternPrefixPair, PerFileIgnore, PreviewMode, PythonVersion,
-    SerializationFormat, UnsafeFixes,
+    ExtensionPair, FilePattern, OutputFormat, PatternPrefixPair, PerFileIgnore, PreviewMode,
+    PythonVersion, UnsafeFixes,
 };
 use ruff_linter::{warn_user, RuleParser, RuleSelector, RuleSelectorParser};
 use ruff_source_file::{LineIndex, OneIndexed};
@@ -187,7 +187,7 @@ pub struct CheckCommand {
     /// The default serialization format is "concise".
     /// In preview mode, the default serialization format is "full".
     #[arg(long, value_enum, env = "RUFF_OUTPUT_FORMAT")]
-    pub output_format: Option<SerializationFormat>,
+    pub output_format: Option<OutputFormat>,
 
     /// Specify file to write the linter output to (default: stdout).
     #[arg(short, long, env = "RUFF_OUTPUT_FILE")]
@@ -925,16 +925,16 @@ The path `{value}` does not point to a configuration file"
 }
 
 fn resolve_output_format(
-    output_format: Option<SerializationFormat>,
+    output_format: Option<OutputFormat>,
     preview: bool,
-) -> Option<SerializationFormat> {
+) -> Option<OutputFormat> {
     Some(match output_format {
         Some(o) => o,
         None => return None
     }).map(|format| match format {
-        SerializationFormat::Text => {
-            warn_user!("`--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `{}`.", SerializationFormat::default(preview));
-            SerializationFormat::default(preview)
+        OutputFormat::Text => {
+            warn_user!("`--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `{}`.", OutputFormat::default(preview));
+            OutputFormat::default(preview)
         },
         other => other
     })
@@ -1189,7 +1189,7 @@ struct ExplicitConfigOverrides {
     fix_only: Option<bool>,
     unsafe_fixes: Option<UnsafeFixes>,
     force_exclude: Option<bool>,
-    output_format: Option<SerializationFormat>,
+    output_format: Option<OutputFormat>,
     show_fixes: Option<bool>,
     extension: Option<Vec<ExtensionPair>>,
 }

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -16,7 +16,7 @@ use notify::{recommended_watcher, RecursiveMode, Watcher};
 
 use ruff_linter::logging::{set_up_logging, LogLevel};
 use ruff_linter::settings::flags::FixMode;
-use ruff_linter::settings::types::SerializationFormat;
+use ruff_linter::settings::types::OutputFormat;
 use ruff_linter::{fs, warn_user, warn_user_once};
 use ruff_workspace::Settings;
 
@@ -351,10 +351,10 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
     let preview = pyproject_config.settings.linter.preview.is_enabled();
 
     if cli.watch {
-        if output_format != SerializationFormat::default(preview) {
+        if output_format != OutputFormat::default(preview) {
             warn_user!(
                 "`--output-format {}` is always used in watch mode.",
-                SerializationFormat::default(preview)
+                OutputFormat::default(preview)
             );
         }
 

--- a/crates/ruff/tests/deprecation.rs
+++ b/crates/ruff/tests/deprecation.rs
@@ -9,58 +9,21 @@ const BIN_NAME: &str = "ruff";
 
 const STDIN: &str = "l = 1";
 
-fn ruff_check(show_source: Option<bool>, output_format: Option<String>) -> Command {
+fn ruff_check(output_format: Option<String>) -> Command {
     let mut cmd = Command::new(get_cargo_bin(BIN_NAME));
     let output_format = output_format.unwrap_or(format!("{}", SerializationFormat::default(false)));
     cmd.arg("check")
         .arg("--output-format")
         .arg(output_format)
         .arg("--no-cache");
-    match show_source {
-        Some(true) => {
-            cmd.arg("--show-source");
-        }
-        Some(false) => {
-            cmd.arg("--no-show-source");
-        }
-        None => {}
-    }
     cmd.arg("-");
 
     cmd
 }
 
 #[test]
-fn ensure_show_source_is_deprecated() {
-    assert_cmd_snapshot!(ruff_check(Some(true), None).pass_stdin(STDIN), @r###"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-    -:1:1: E741 Ambiguous variable name: `l`
-    Found 1 error.
-
-    ----- stderr -----
-    warning: The `--show-source` argument is deprecated and has been ignored in favor of `--output-format=concise`.
-    "###);
-}
-
-#[test]
-fn ensure_no_show_source_is_deprecated() {
-    assert_cmd_snapshot!(ruff_check(Some(false), None).pass_stdin(STDIN), @r###"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-    -:1:1: E741 Ambiguous variable name: `l`
-    Found 1 error.
-
-    ----- stderr -----
-    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `--output-format=concise`.
-    "###);
-}
-
-#[test]
 fn ensure_output_format_is_deprecated() {
-    assert_cmd_snapshot!(ruff_check(None, Some("text".into())).pass_stdin(STDIN), @r###"
+    assert_cmd_snapshot!(ruff_check(Some("text".into())).pass_stdin(STDIN), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -68,83 +31,6 @@ fn ensure_output_format_is_deprecated() {
     Found 1 error.
 
     ----- stderr -----
-    warning: `--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `concise`.
-    "###);
-}
-
-#[test]
-fn ensure_output_format_overrides_show_source() {
-    assert_cmd_snapshot!(ruff_check(Some(true), Some("concise".into())).pass_stdin(STDIN), @r###"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-    -:1:1: E741 Ambiguous variable name: `l`
-    Found 1 error.
-
-    ----- stderr -----
-    warning: The `--show-source` argument is deprecated and has been ignored in favor of `--output-format=concise`.
-    "###);
-}
-
-#[test]
-fn ensure_full_output_format_overrides_no_show_source() {
-    assert_cmd_snapshot!(ruff_check(Some(false), Some("full".into())).pass_stdin(STDIN), @r###"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-    -:1:1: E741 Ambiguous variable name: `l`
-      |
-    1 | l = 1
-      | ^ E741
-      |
-
-    Found 1 error.
-
-    ----- stderr -----
-    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `--output-format=full`.
-    "###);
-}
-
-#[test]
-fn ensure_output_format_uses_concise_over_no_show_source() {
-    assert_cmd_snapshot!(ruff_check(Some(false), Some("concise".into())).pass_stdin(STDIN), @r###"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-    -:1:1: E741 Ambiguous variable name: `l`
-    Found 1 error.
-
-    ----- stderr -----
-    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `--output-format=concise`.
-    "###);
-}
-
-#[test]
-fn ensure_deprecated_output_format_overrides_show_source() {
-    assert_cmd_snapshot!(ruff_check(Some(true), Some("text".into())).pass_stdin(STDIN), @r###"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-    -:1:1: E741 Ambiguous variable name: `l`
-    Found 1 error.
-
-    ----- stderr -----
-    warning: The `--show-source` argument is deprecated and has been ignored in favor of `--output-format=text`.
-    warning: `--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `concise`.
-    "###);
-}
-
-#[test]
-fn ensure_deprecated_output_format_overrides_no_show_source() {
-    assert_cmd_snapshot!(ruff_check(Some(false), Some("text".into())).pass_stdin(STDIN), @r###"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-    -:1:1: E741 Ambiguous variable name: `l`
-    Found 1 error.
-
-    ----- stderr -----
-    warning: The `--no-show-source` argument is deprecated and has been ignored in favor of `--output-format=text`.
     warning: `--output-format=text` is deprecated. Use `--output-format=full` or `--output-format=concise` instead. `text` will be treated as `concise`.
     "###);
 }

--- a/crates/ruff/tests/deprecation.rs
+++ b/crates/ruff/tests/deprecation.rs
@@ -1,6 +1,6 @@
 //! A test suite that ensures deprecated command line options have appropriate warnings / behaviors
 
-use ruff_linter::settings::types::SerializationFormat;
+use ruff_linter::settings::types::OutputFormat;
 use std::process::Command;
 
 use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
@@ -11,7 +11,7 @@ const STDIN: &str = "l = 1";
 
 fn ruff_check(output_format: Option<String>) -> Command {
     let mut cmd = Command::new(get_cargo_bin(BIN_NAME));
-    let output_format = output_format.unwrap_or(format!("{}", SerializationFormat::default(false)));
+    let output_format = output_format.unwrap_or(format!("{}", OutputFormat::default(false)));
     cmd.arg("check")
         .arg("--output-format")
         .arg(output_format)

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -504,7 +504,7 @@ impl FromIterator<ExtensionPair> for ExtensionMapping {
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub enum SerializationFormat {
+pub enum OutputFormat {
     Text,
     Concise,
     Full,
@@ -520,7 +520,7 @@ pub enum SerializationFormat {
     Sarif,
 }
 
-impl Display for SerializationFormat {
+impl Display for OutputFormat {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Text => write!(f, "text"),
@@ -540,7 +540,7 @@ impl Display for SerializationFormat {
     }
 }
 
-impl SerializationFormat {
+impl OutputFormat {
     pub fn default(preview: bool) -> Self {
         if preview {
             Self::Full

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -431,12 +431,6 @@ impl Configuration {
 
         #[allow(deprecated)]
         let output_format = {
-            if options.show_source.is_some() {
-                warn_user_once!(
-                    r#"The `show-source` option has been deprecated in favor of `output-format`'s "full" and "concise" variants. Please update your configuration to use `output-format = <full|concise>` instead."#
-                );
-            }
-
             options
                 .output_format
                 .map(|format| match format {
@@ -446,13 +440,6 @@ impl Configuration {
                     },
                     other => other
                 })
-                .or(options.show_source.map(|show_source| {
-                    if show_source {
-                        SerializationFormat::Full
-                    } else {
-                        SerializationFormat::Concise
-                    }
-                }))
         };
 
         Ok(Self {

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -27,8 +27,8 @@ use ruff_linter::rules::pycodestyle;
 use ruff_linter::settings::fix_safety_table::FixSafetyTable;
 use ruff_linter::settings::rule_table::RuleTable;
 use ruff_linter::settings::types::{
-    CompiledPerFileIgnoreList, ExtensionMapping, FilePattern, FilePatternSet, PerFileIgnore,
-    PreviewMode, PythonVersion, RequiredVersion, SerializationFormat, UnsafeFixes,
+    CompiledPerFileIgnoreList, ExtensionMapping, FilePattern, FilePatternSet, OutputFormat,
+    PerFileIgnore, PreviewMode, PythonVersion, RequiredVersion, UnsafeFixes,
 };
 use ruff_linter::settings::{LinterSettings, DEFAULT_SELECTORS, DUMMY_VARIABLE_RGX, TASK_TAGS};
 use ruff_linter::{
@@ -116,7 +116,7 @@ pub struct Configuration {
     pub fix: Option<bool>,
     pub fix_only: Option<bool>,
     pub unsafe_fixes: Option<UnsafeFixes>,
-    pub output_format: Option<SerializationFormat>,
+    pub output_format: Option<OutputFormat>,
     pub preview: Option<PreviewMode>,
     pub required_version: Option<RequiredVersion>,
     pub extension: Option<ExtensionMapping>,
@@ -222,7 +222,7 @@ impl Configuration {
             unsafe_fixes: self.unsafe_fixes.unwrap_or_default(),
             output_format: self
                 .output_format
-                .unwrap_or_else(|| SerializationFormat::default(global_preview.is_enabled())),
+                .unwrap_or_else(|| OutputFormat::default(global_preview.is_enabled())),
             show_fixes: self.show_fixes.unwrap_or(false),
 
             file_resolver: FileResolverSettings {
@@ -429,14 +429,13 @@ impl Configuration {
             options.indent_width.or(options.tab_size)
         };
 
-        #[allow(deprecated)]
         let output_format = {
             options
                 .output_format
                 .map(|format| match format {
-                    SerializationFormat::Text => {
-                        warn_user_once!(r#"Setting `output_format` to "text" is deprecated. Use "full" or "concise" instead. "text" will be treated as "{}"."#, SerializationFormat::default(options.preview.unwrap_or_default()));
-                        SerializationFormat::default(options.preview.unwrap_or_default())
+                    OutputFormat::Text => {
+                        warn_user_once!(r#"Setting `output_format` to "text" is deprecated. Use "full" or "concise" instead. "text" will be treated as "{}"."#, OutputFormat::default(options.preview.unwrap_or_default()));
+                        OutputFormat::default(options.preview.unwrap_or_default())
                     },
                     other => other
                 })

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -24,7 +24,7 @@ use ruff_linter::rules::{
     pycodestyle, pydocstyle, pyflakes, pylint, pyupgrade,
 };
 use ruff_linter::settings::types::{
-    IdentifierPattern, PythonVersion, RequiredVersion, SerializationFormat,
+    IdentifierPattern, OutputFormat, PythonVersion, RequiredVersion,
 };
 use ruff_linter::{warn_user_once, RuleSelector};
 use ruff_macros::{CombineOptions, OptionsMetadata};
@@ -86,7 +86,7 @@ pub struct Options {
             output-format = "grouped"
         "#
     )]
-    pub output_format: Option<SerializationFormat>,
+    pub output_format: Option<OutputFormat>,
 
     /// Enable fix behavior by-default when running `ruff` (overridden
     /// by the `--fix` and `--no-fix` command-line flags).

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -108,21 +108,6 @@ pub struct Options {
     #[option(default = "false", value_type = "bool", example = "fix-only = true")]
     pub fix_only: Option<bool>,
 
-    /// Whether to show source code snippets when reporting lint violations
-    /// (overridden by the `--show-source` command-line flag).
-    #[option(
-        default = "false",
-        value_type = "bool",
-        example = r#"
-            # By default, always show source code snippets.
-            show-source = true
-        "#
-    )]
-    #[deprecated(
-        note = "`show-source` is deprecated and is now part of `output-format` in the form of `full` or `concise` options. Please update your configuration."
-    )]
-    pub show_source: Option<bool>,
-
     /// Whether to show an enumeration of all fixed lint violations
     /// (overridden by the `--show-fixes` command-line flag).
     #[option(

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -3,7 +3,7 @@ use ruff_cache::cache_dir;
 use ruff_formatter::{FormatOptions, IndentStyle, IndentWidth, LineWidth};
 use ruff_linter::display_settings;
 use ruff_linter::settings::types::{
-    ExtensionMapping, FilePattern, FilePatternSet, SerializationFormat, UnsafeFixes,
+    ExtensionMapping, FilePattern, FilePatternSet, OutputFormat, UnsafeFixes,
 };
 use ruff_linter::settings::LinterSettings;
 use ruff_macros::CacheKey;
@@ -28,7 +28,7 @@ pub struct Settings {
     #[cache_key(ignore)]
     pub unsafe_fixes: UnsafeFixes,
     #[cache_key(ignore)]
-    pub output_format: SerializationFormat,
+    pub output_format: OutputFormat,
     #[cache_key(ignore)]
     pub show_fixes: bool,
 
@@ -44,7 +44,7 @@ impl Default for Settings {
             cache_dir: cache_dir(project_root),
             fix: false,
             fix_only: false,
-            output_format: SerializationFormat::default(false),
+            output_format: OutputFormat::default(false),
             show_fixes: false,
             unsafe_fixes: UnsafeFixes::default(),
             linter: LinterSettings::new(project_root),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -576,10 +576,6 @@ Options:
       --unsafe-fixes
           Include fixes that may not retain the original intent of the code.
           Use `--no-unsafe-fixes` to disable
-      --show-source
-          Show violations with source code. Use `--no-show-source` to disable.
-          (Deprecated: use `--output-format=full` or `--output-format=concise`
-          instead of `--show-source` and `--no-show-source`, respectively)
       --show-fixes
           Show an enumeration of all fixed lint violations. Use
           `--no-show-fixes` to disable

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -670,14 +670,6 @@
         "null"
       ]
     },
-    "show-source": {
-      "description": "Whether to show source code snippets when reporting lint violations (overridden by the `--show-source` command-line flag).",
-      "deprecated": true,
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
     "src": {
       "description": "The directories to consider when resolving first- vs. third-party imports.\n\nAs an example: given a Python package structure like:\n\n```text my_project ├── pyproject.toml └── src └── my_package ├── __init__.py ├── foo.py └── bar.py ```\n\nThe `./src` directory should be included in the `src` option (e.g., `src = [\"src\"]`), such that when resolving imports, `my_package.foo` is considered a first-party import.\n\nWhen omitted, the `src` directory will typically default to the directory containing the nearest `pyproject.toml`, `ruff.toml`, or `.ruff.toml` file (the \"project root\"), unless a configuration file is explicitly provided (e.g., via the `--config` command-line flag).\n\nThis field supports globs. For example, if you have a series of Python packages in a `python_modules` directory, `src = [\"python_modules/*\"]` would expand to incorporate all of the packages in that directory. User home directory and environment variables will also be expanded.",
       "type": [

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -534,7 +534,7 @@
       "description": "The style in which violation messages should be formatted: `\"full\"` (shows source),`\"concise\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report), `\"pylint\"` (Pylint text format) or `\"azure\"` (Azure Pipeline logging commands).",
       "anyOf": [
         {
-          "$ref": "#/definitions/SerializationFormat"
+          "$ref": "#/definitions/OutputFormat"
         },
         {
           "type": "null"
@@ -2293,6 +2293,24 @@
       },
       "additionalProperties": false
     },
+    "OutputFormat": {
+      "type": "string",
+      "enum": [
+        "text",
+        "concise",
+        "full",
+        "json",
+        "json-lines",
+        "junit",
+        "grouped",
+        "github",
+        "gitlab",
+        "pylint",
+        "rdjson",
+        "azure",
+        "sarif"
+      ]
+    },
     "ParametrizeNameType": {
       "type": "string",
       "enum": [
@@ -3929,24 +3947,6 @@
         "YTT301",
         "YTT302",
         "YTT303"
-      ]
-    },
-    "SerializationFormat": {
-      "type": "string",
-      "enum": [
-        "text",
-        "concise",
-        "full",
-        "json",
-        "json-lines",
-        "junit",
-        "grouped",
-        "github",
-        "gitlab",
-        "pylint",
-        "rdjson",
-        "azure",
-        "sarif"
       ]
     },
     "Strictness": {


### PR DESCRIPTION
Fixes parts of https://github.com/astral-sh/ruff/issues/7650:

<details>
<summary>Extracted from this PR</summary>
1. removes the deprecated configuration 'format'. It was deprecated in https://github.com/astral-sh/ruff/pull/8203 in favor of 'output-format'.
Update: Was merged in https://github.com/astral-sh/ruff/pull/10170
Tests:
- `cargo run -p ruff -- --explain RET505` works
- `cargo run -p ruff -- --explain RET505 --output-format json` works
- `cargo run -p ruff -- --explain RET505 --format json` does not work anymore
</details>

2. removes deprecated configurations 'show-source' and 'no-show-source'.
Tests:
- `cargo run -p ruff -- --show-source` does not work anymore
- `cargo run -p ruff -- --no-show-source` does not work anymore 

resolves: #7349 
Part of https://github.com/astral-sh/ruff/issues/7650