### PR TITLE
Revert "Use publicly available Apple Silicon runners (#9726)"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
           path: dist
 
   macos-x86_64:
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -74,6 +74,11 @@ jobs:
         with:
           target: x86_64
           args: --release --locked --out dist
+      - name: "Test wheel - x86_64"
+        run: |
+          pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+          ruff --help
+          python -m ruff --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v3
         with:
@@ -93,7 +98,7 @@ jobs:
             *.sha256
 
   macos-universal:
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Sadly, the Apple Silicon runners use macOS 14 and produce binaries that segfault when run on macOS 11 (at least), and possibly on macOS 12 and/or macOS 13.

macOS 11 is EOL, but it doesn't seem like a good tradeoff to speed up our release builds at the expense of user support and compatibility.

This reverts commit f0066e1b895ab4e0541c405b27127129dbd34d43.

Closes https://github.com/astral-sh/ruff/issues/9823.
