### PR TITLE
Fix default for `max-positional-args`

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2756,7 +2756,7 @@ pub struct PylintOptions {
     ///
     /// If not specified, defaults to the value of `max-args`.
     #[option(
-        default = r"3",
+        default = r"5", // Needs to be in sync with default of `max-args`.
         value_type = "int",
         example = r"max-positional-args = 3"
     )]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
`max-positional-args` defaults to `max-args` if it's not specified and the default to `max-args` is 5, so saying that the default is 3 is definitely wrong. Ideally, we wouldn't specify a default at all for this config option, but I don't think that's possible?

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
Not sure.