### PR TITLE
Mention a related setting in C408 description

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
@@ -36,6 +36,9 @@ use crate::rules::flake8_comprehensions::settings::Settings;
 /// ## Fix safety
 /// This rule's fix is marked as unsafe, as it may occasionally drop comments
 /// when rewriting the call. In most cases, though, comments will be preserved.
+///
+/// ## Options
+/// - `lint.flake8-comprehensions.allow-dict-calls-with-keyword-arguments`
 #[violation]
 pub struct UnnecessaryCollectionCall {
     obj_type: String,


### PR DESCRIPTION
#2977 added the `allow-dict-calls-with-keyword-arguments` configuration option for the `unnecessary-collection-call (C408)` rule, but it did not update the rule description.