### PR TITLE
Add ``--preview`` to instruction for running newly added tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ Once you've completed the code for the rule itself, you can define tests with th
     For example, if you're adding a new rule named `E402`, you would run:
 
     ```shell
-    cargo run -p ruff -- check crates/ruff_linter/resources/test/fixtures/pycodestyle/E402.py --no-cache --select E402
+    cargo run -p ruff -- check crates/ruff_linter/resources/test/fixtures/pycodestyle/E402.py --no-cache --preview --select E402
     ```
 
     **Note:** Only a subset of rules are enabled by default. When testing a new rule, ensure that


### PR DESCRIPTION


## Summary

This surprised me while working on adding a test. I thought about adding an additional `note`, but how often is this incorrect? In general, people reading the contributing guidelines probably want to enable this flag and those who don't will know enough about the testing setup to have their own commands/aliases.

## Test Plan

Ran CI on local fork and got an all green.
