### PR TITLE
Ignore builtins when detecting missing f-strings

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF027.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF027.py
@@ -34,7 +34,7 @@ def tripled_quoted():
     multi_line = a = """b { # comment
     c}  d
     """
-    
+
 def single_quoted_multi_line():
     a = 4
     # RUF027
@@ -66,6 +66,7 @@ def negative_cases():
     c = """  {b} """
     d = "bad variable: {invalid}"
     e = "incorrect syntax: {}"
+    f = "uses a builtin: {max}"
     json = "{ positive: false }"
     json2 = "{ 'positive': false }"
     json3 = "{ 'positive': 'false' }"

--- a/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
@@ -124,7 +124,13 @@ fn should_be_fstring(
             .filter_map(|element| element.as_expression())
         {
             if let ast::Expr::Name(ast::ExprName { id, .. }) = element.expression.as_ref() {
-                if kw_idents.contains(id.as_str()) || semantic.lookup_symbol(id).is_none() {
+                if kw_idents.contains(id.as_str()) {
+                    return false;
+                }
+                if semantic
+                    .lookup_symbol(id)
+                    .map_or(true, |id| semantic.binding(id).kind.is_builtin())
+                {
                     return false;
                 }
                 has_name = true;

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF027_RUF027.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF027_RUF027.py.snap
@@ -175,7 +175,7 @@ RUF027.py:34:22: RUF027 [*] Possible f-string without an `f` prefix
 35 | |     c}  d
 36 | |     """
    | |_______^ RUF027
-37 |       
+37 |   
 38 |   def single_quoted_multi_line():
    |
    = help: Add `f` prefix
@@ -188,7 +188,7 @@ RUF027.py:34:22: RUF027 [*] Possible f-string without an `f` prefix
    34 |+    multi_line = a = f"""b { # comment
 35 35 |     c}  d
 36 36 |     """
-37 37 |     
+37 37 | 
 
 RUF027.py:41:9: RUF027 [*] Possible f-string without an `f` prefix
    |
@@ -276,20 +276,20 @@ RUF027.py:52:9: RUF027 [*] Possible f-string without an `f` prefix
 54 54 | def alternative_formatter(src, **kwargs):
 55 55 |     src.format(**kwargs)
 
-RUF027.py:85:7: RUF027 [*] Possible f-string without an `f` prefix
+RUF027.py:86:7: RUF027 [*] Possible f-string without an `f` prefix
    |
-83 | "always ignore this: {a}"
-84 | 
-85 | print("but don't ignore this: {val}") # RUF027
+84 | "always ignore this: {a}"
+85 | 
+86 | print("but don't ignore this: {val}") # RUF027
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF027
    |
    = help: Add `f` prefix
 
 ℹ Unsafe fix
-82 82 | 
-83 83 | "always ignore this: {a}"
-84 84 | 
-85    |-print("but don't ignore this: {val}") # RUF027
-   85 |+print(f"but don't ignore this: {val}") # RUF027
+83 83 | 
+84 84 | "always ignore this: {a}"
+85 85 | 
+86    |-print("but don't ignore this: {val}") # RUF027
+   86 |+print(f"but don't ignore this: {val}") # RUF027
 
 


### PR DESCRIPTION
## Summary

Reported on Discord: if the name maps to a builtin, it's not bound locally, so is very unlikely to be intended as an f-string expression.