### PR TITLE
ruff-ecosystem: Add indico/indico repo

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -95,6 +95,10 @@ DEFAULT_TARGETS = [
         repo=Repository(owner="zulip", name="zulip", ref="main"),
         check_options=CheckOptions(select="ALL"),
     ),
+    Project(
+        repo=Repository(owner="indico", name="indico", ref="master"),
+        check_options=CheckOptions(select="ALL"),
+    ),
     # Jupyter Notebooks
     Project(
         # fork of `huggingface` without syntax errors in notebooks

--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -97,7 +97,6 @@ DEFAULT_TARGETS = [
     ),
     Project(
         repo=Repository(owner="indico", name="indico", ref="master"),
-        check_options=CheckOptions(select="ALL"),
     ),
     # Jupyter Notebooks
     Project(


### PR DESCRIPTION
It's a pretty big codebase using lots of different stuff, so a good candidate for finding obscure problems.

I didn't look more closely which options are used (I have the feeling `--select ALL` is not implied, since I see you adding it via `check_options` for certain entries but not for others), the repo itself has a pretty large ruff.toml - but assuming ecosystem just cares about differences between base and head of a PR, `ALL` most likely makes sense.