### PR TITLE
Fix typo in option name: `output_format` -> `output-format`

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -119,7 +119,7 @@ pub struct Options {
         "#
     )]
     #[deprecated(
-        note = "`show_source` is deprecated and is now part of `output_format` in the form of `full` or `concise` options. Please update your configuration."
+        note = "`show_source` is deprecated and is now part of `output-format` in the form of `full` or `concise` options. Please update your configuration."
     )]
     pub show_source: Option<bool>,
 

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -119,7 +119,7 @@ pub struct Options {
         "#
     )]
     #[deprecated(
-        note = "`show_source` is deprecated and is now part of `output-format` in the form of `full` or `concise` options. Please update your configuration."
+        note = "`show-source` is deprecated and is now part of `output-format` in the form of `full` or `concise` options. Please update your configuration."
     )]
     pub show_source: Option<bool>,
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Go to https://docs.astral.sh/ruff/settings/#show-source

Read deprecation notice:

> This option has been deprecated. `show_source` is deprecated and is now part of `output_format` in the form of `full` or `concise` options. Please update your configuration.

Copy and paste show_source into search box.

No results.

Run Ruff and see the similar warning:

> warning: The `show-source` option has been deprecated in favor of `output-format`'s "full" and "concise" variants. Please update your configuration to use `output-format = <full|concise>` instead.



## Test Plan

<!-- How was it tested? -->

Copy and paste show-source into search box.

Get results, including https://docs.astral.sh/ruff/settings/#output-format.

No results.

## Also

It would be great if you can link from `output-format` at https://docs.astral.sh/ruff/settings/#show-source to https://docs.astral.sh/ruff/settings/#output-format

It would also be nice if there was advice -- tell me how the old `show-source` values should be mapped to the new `output-format` options.
