### PR TITLE
Reduce `LexResult` size by boxing `LexicalError`

### DIFF
--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -134,8 +134,8 @@ pub fn format_module_source(
     let source_type = options.source_type();
     let (tokens, comment_ranges) =
         tokens_and_ranges(source, source_type).map_err(|err| ParseError {
-            offset: err.location,
-            error: ParseErrorType::Lexical(err.error),
+            offset: err.location(),
+            error: ParseErrorType::Lexical(err.into_error()),
         })?;
     let module = parse_tokens(tokens, source, source_type.as_mode())?;
     let formatted = format_module_ast(&module, &comment_ranges, source, options)?;

--- a/crates/ruff_python_formatter/src/range.rs
+++ b/crates/ruff_python_formatter/src/range.rs
@@ -73,8 +73,8 @@ pub fn format_range(
 
     let (tokens, comment_ranges) =
         tokens_and_ranges(source, options.source_type()).map_err(|err| ParseError {
-            offset: err.location,
-            error: ParseErrorType::Lexical(err.error),
+            offset: err.location(),
+            error: ParseErrorType::Lexical(err.into_error()),
         })?;
 
     assert_valid_char_boundaries(range, source);

--- a/crates/ruff_python_parser/src/function.rs
+++ b/crates/ruff_python_parser/src/function.rs
@@ -39,10 +39,10 @@ pub(crate) fn validate_arguments(arguments: &ast::Parameters) -> Result<(), Lexi
         let range = arg.range;
         let arg_name = arg.name.as_str();
         if !all_arg_names.insert(arg_name) {
-            return Err(LexicalError {
-                error: LexicalErrorType::DuplicateArgumentError(arg_name.to_string()),
-                location: range.start(),
-            });
+            return Err(LexicalError::new(
+                LexicalErrorType::DuplicateArgumentError(arg_name.to_string()),
+                range.start(),
+            ));
         }
     }
 
@@ -64,10 +64,10 @@ pub(crate) fn validate_pos_params(
         .skip_while(|arg| arg.default.is_some()) // and then args with default
         .next(); // there must not be any more args without default
     if let Some(invalid) = first_invalid {
-        return Err(LexicalError {
-            error: LexicalErrorType::DefaultArgumentError,
-            location: invalid.parameter.start(),
-        });
+        return Err(LexicalError::new(
+            LexicalErrorType::DefaultArgumentError,
+            invalid.parameter.start(),
+        ));
     }
     Ok(())
 }
@@ -94,12 +94,10 @@ pub(crate) fn parse_arguments(
             // Check for duplicate keyword arguments in the call.
             if let Some(keyword_name) = &name {
                 if !keyword_names.insert(keyword_name.to_string()) {
-                    return Err(LexicalError {
-                        error: LexicalErrorType::DuplicateKeywordArgumentError(
-                            keyword_name.to_string(),
-                        ),
-                        location: start,
-                    });
+                    return Err(LexicalError::new(
+                        LexicalErrorType::DuplicateKeywordArgumentError(keyword_name.to_string()),
+                        start,
+                    ));
                 }
             } else {
                 double_starred = true;
@@ -113,17 +111,17 @@ pub(crate) fn parse_arguments(
         } else {
             // Positional arguments mustn't follow keyword arguments.
             if !keywords.is_empty() && !is_starred(&value) {
-                return Err(LexicalError {
-                    error: LexicalErrorType::PositionalArgumentError,
-                    location: value.start(),
-                });
+                return Err(LexicalError::new(
+                    LexicalErrorType::PositionalArgumentError,
+                    value.start(),
+                ));
                 // Allow starred arguments after keyword arguments but
                 // not after double-starred arguments.
             } else if double_starred {
-                return Err(LexicalError {
-                    error: LexicalErrorType::UnpackedArgumentError,
-                    location: value.start(),
-                });
+                return Err(LexicalError::new(
+                    LexicalErrorType::UnpackedArgumentError,
+                    value.start(),
+                ));
             }
 
             args.push(value);

--- a/crates/ruff_python_parser/src/invalid.rs
+++ b/crates/ruff_python_parser/src/invalid.rs
@@ -39,7 +39,7 @@ pub(crate) fn assignment_target(target: &Expr) -> Result<(), LexicalError> {
 
     let err = |location: TextSize| -> LexicalError {
         let error = LexicalErrorType::AssignmentError;
-        LexicalError { error, location }
+        LexicalError::new(error, location)
     };
     match *target {
         BoolOp(ref e) => Err(err(e.range.start())),

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1297,15 +1297,27 @@ impl FusedIterator for Lexer<'_> {}
 #[derive(Debug, Clone, PartialEq)]
 pub struct LexicalError {
     /// The type of error that occurred.
-    pub error: LexicalErrorType,
+    error: LexicalErrorType,
     /// The location of the error.
-    pub location: TextSize,
+    location: TextSize,
 }
 
 impl LexicalError {
     /// Creates a new `LexicalError` with the given error type and location.
     pub fn new(error: LexicalErrorType, location: TextSize) -> Self {
         Self { error, location }
+    }
+
+    pub fn error(&self) -> &LexicalErrorType {
+        &self.error
+    }
+
+    pub fn into_error(self) -> LexicalErrorType {
+        self.error
+    }
+
+    pub fn location(&self) -> TextSize {
+        self.location
     }
 }
 

--- a/crates/ruff_python_parser/src/parser.rs
+++ b/crates/ruff_python_parser/src/parser.rs
@@ -285,8 +285,8 @@ fn parse_error_from_lalrpop(err: LalrpopError<TextSize, Tok, LexicalError>) -> P
             offset: token.0,
         },
         LalrpopError::User { error } => ParseError {
-            error: ParseErrorType::Lexical(error.error),
-            offset: error.location,
+            offset: error.location(),
+            error: ParseErrorType::Lexical(error.into_error()),
         },
         LalrpopError::UnrecognizedToken { token, expected } => {
             // Hacky, but it's how CPython does it. See PyParser_AddToken,
@@ -359,8 +359,8 @@ impl ParseErrorType {
 impl From<LexicalError> for ParseError {
     fn from(error: LexicalError) -> Self {
         ParseError {
-            error: ParseErrorType::Lexical(error.error),
-            offset: error.location,
+            offset: error.location(),
+            error: ParseErrorType::Lexical(error.into_error()),
         }
     }
 }

--- a/crates/ruff_python_parser/src/python.lalrpop
+++ b/crates/ruff_python_parser/src/python.lalrpop
@@ -337,10 +337,10 @@ IpyEscapeCommandStatement: ast::Stmt = {
                 }
             ))
         } else {
-            Err(LexicalError {
-                error: LexicalErrorType::OtherError("IPython escape commands are only allowed in `Mode::Ipython`".to_string()),
+            Err(LexicalError::new(
+                LexicalErrorType::OtherError("IPython escape commands are only allowed in `Mode::Ipython`".to_string()),
                 location,
-            })?
+            ))?
         }
     }
 }
@@ -350,10 +350,10 @@ IpyEscapeCommandExpr: crate::parser::ParenthesizedExpr = {
         if mode == Mode::Ipython {
             // This should never occur as the lexer won't allow it.
             if !matches!(c.0, IpyEscapeKind::Magic | IpyEscapeKind::Shell) {
-                return Err(LexicalError {
-                    error: LexicalErrorType::OtherError("IPython escape command expr is only allowed for % and !".to_string()),
+                return Err(LexicalError::new(
+                    LexicalErrorType::OtherError("IPython escape command expr is only allowed for % and !".to_string()),
                     location,
-                })?;
+                ))?;
             }
             Ok(ast::ExprIpyEscapeCommand {
                 kind: c.0,
@@ -361,10 +361,10 @@ IpyEscapeCommandExpr: crate::parser::ParenthesizedExpr = {
                 range: (location..end_location).into()
             }.into())
         } else {
-            Err(LexicalError {
-                error: LexicalErrorType::OtherError("IPython escape commands are only allowed in `Mode::Ipython`".to_string()),
+            Err(LexicalError::new(
+                LexicalErrorType::OtherError("IPython escape commands are only allowed in `Mode::Ipython`".to_string()),
                 location,
-            })?
+            ))?
         }
     }
 }
@@ -381,10 +381,10 @@ IpyHelpEndEscapeCommandStatement: ast::Stmt = {
                 },
                 ast::Expr::Subscript(ast::ExprSubscript { value, slice, range, .. }) => {
                     let ast::Expr::NumberLiteral(ast::ExprNumberLiteral { value: ast::Number::Int(integer), .. }) = slice.as_ref() else {
-                        return Err(LexicalError {
-                            error: LexicalErrorType::OtherError("only integer literals are allowed in Subscript expressions in help end escape command".to_string()),
-                            location: range.start(),
-                        });
+                        return Err(LexicalError::new(
+                            LexicalErrorType::OtherError("only integer literals are allowed in Subscript expressions in help end escape command".to_string()),
+                            range.start(),
+                        ));
                     };
                     unparse_expr(value, buffer)?;
                     buffer.push('[');
@@ -397,10 +397,10 @@ IpyHelpEndEscapeCommandStatement: ast::Stmt = {
                     buffer.push_str(attr.as_str());
                 },
                 _ => {
-                    return Err(LexicalError {
-                        error: LexicalErrorType::OtherError("only Name, Subscript and Attribute expressions are allowed in help end escape command".to_string()),
-                        location: expr.start(),
-                    });
+                    return Err(LexicalError::new(
+                        LexicalErrorType::OtherError("only Name, Subscript and Attribute expressions are allowed in help end escape command".to_string()),
+                        expr.start(),
+                    ));
                 }
             }
             Ok(())
@@ -408,10 +408,10 @@ IpyHelpEndEscapeCommandStatement: ast::Stmt = {
 
         if mode != Mode::Ipython {
             return Err(ParseError::User {
-                error: LexicalError {
-                    error: LexicalErrorType::OtherError("IPython escape commands are only allowed in `Mode::Ipython`".to_string()),
+                error: LexicalError::new(
+                    LexicalErrorType::OtherError("IPython escape commands are only allowed in `Mode::Ipython`".to_string()),
                     location,
-                },
+                ),
             });
         }
 
@@ -420,10 +420,10 @@ IpyHelpEndEscapeCommandStatement: ast::Stmt = {
             2 => IpyEscapeKind::Help2,
             _ => {
                 return Err(ParseError::User {
-                    error: LexicalError {
-                        error: LexicalErrorType::OtherError("maximum of 2 `?` tokens are allowed in help end escape command".to_string()),
+                    error: LexicalError::new(
+                        LexicalErrorType::OtherError("maximum of 2 `?` tokens are allowed in help end escape command".to_string()),
                         location,
-                    },
+                    ),
                 });
             }
         };
@@ -561,10 +561,10 @@ Pattern: ast::Pattern = {
 AsPattern: ast::Pattern = {
     <location:@L> <pattern:OrPattern> "as" <name:Identifier> <end_location:@R> =>? {
         if name.as_str() == "_" {
-            Err(LexicalError {
-                error: LexicalErrorType::OtherError("cannot use '_' as a target".to_string()),
+            Err(LexicalError::new(
+                LexicalErrorType::OtherError("cannot use '_' as a target".to_string()),
                 location,
-            })?
+            ))?
         } else {
             Ok(ast::Pattern::MatchAs(
                 ast::PatternMatchAs {
@@ -1247,10 +1247,10 @@ DoubleStarTypedParameter: ast::Parameter = {
 ParameterListStarArgs<ParameterType, StarParameterType, DoubleStarParameterType>: (Option<Box<ast::Parameter>>, Vec<ast::ParameterWithDefault>, Option<Box<ast::Parameter>>) = {
     <location:@L> "*" <va:StarParameterType?> <kwonlyargs:("," <ParameterDef<ParameterType>>)*> <kwarg:("," <KwargParameter<DoubleStarParameterType>>)?> =>? {
         if va.is_none() && kwonlyargs.is_empty() && kwarg.is_none() {
-            return Err(LexicalError {
-                error: LexicalErrorType::OtherError("named arguments must follow bare *".to_string()),
+            return Err(LexicalError::new(
+                LexicalErrorType::OtherError("named arguments must follow bare *".to_string()),
                 location,
-            })?;
+            ))?;
         }
 
         let kwarg = kwarg.flatten();
@@ -1364,10 +1364,10 @@ NamedExpression: crate::parser::ParenthesizedExpr = {
 LambdaDef: crate::parser::ParenthesizedExpr = {
     <location:@L> "lambda" <location_args:@L> <parameters:ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter>?> <end_location_args:@R> ":" <fstring_middle:fstring_middle?> <body:Test<"all">> <end_location:@R> =>? {
         if fstring_middle.is_some() {
-            return Err(LexicalError {
-                error: LexicalErrorType::FStringError(FStringErrorType::LambdaWithoutParentheses),
+            return Err(LexicalError::new(
+                LexicalErrorType::FStringError(FStringErrorType::LambdaWithoutParentheses),
                 location,
-            })?;
+            ))?;
         }
         parameters.as_ref().map(validate_arguments).transpose()?;
 
@@ -1630,10 +1630,10 @@ FStringMiddlePattern: ast::FStringElement = {
 FStringReplacementField: ast::FStringElement = {
     <location:@L> "{" <value:TestListOrYieldExpr> <debug:"="?> <conversion:FStringConversion?> <format_spec:FStringFormatSpecSuffix?> "}" <end_location:@R> =>? {
         if value.expr.is_lambda_expr() && !value.is_parenthesized() {
-            return Err(LexicalError {
-                error: LexicalErrorType::FStringError(FStringErrorType::LambdaWithoutParentheses),
-                location: value.start(),
-            })?;
+            return Err(LexicalError::new(
+                LexicalErrorType::FStringError(FStringErrorType::LambdaWithoutParentheses),
+                value.start(),
+            ))?;
         }
         let debug_text = debug.map(|_| {
             let start_offset = location + "{".text_len();
@@ -1681,10 +1681,10 @@ FStringConversion: (TextSize, ast::ConversionFlag) = {
             "s" => ast::ConversionFlag::Str,
             "r" => ast::ConversionFlag::Repr,
             "a" => ast::ConversionFlag::Ascii,
-            _ => Err(LexicalError {
-                error: LexicalErrorType::FStringError(FStringErrorType::InvalidConversionFlag),
-                location: name_location,
-            })?
+            _ => Err(LexicalError::new(
+                LexicalErrorType::FStringError(FStringErrorType::InvalidConversionFlag),
+                name_location,
+            ))?
         };
         Ok((location, conversion))
     }
@@ -1722,10 +1722,10 @@ Atom<Goal>: crate::parser::ParenthesizedExpr = {
     <location:@L> "(" <left:(<OneOrMore<Test<"all">>> ",")?> <mid:NamedOrStarExpr> <right:("," <TestOrStarNamedExpr>)*> <trailing_comma:","?> ")" <end_location:@R> =>? {
         if left.is_none() && right.is_empty() && trailing_comma.is_none() {
             if mid.expr.is_starred_expr() {
-                return Err(LexicalError{
-                    error: LexicalErrorType::OtherError("cannot use starred expression here".to_string()),
-                    location: mid.start(),
-                })?;
+                return Err(LexicalError::new(
+                    LexicalErrorType::OtherError("cannot use starred expression here".to_string()),
+                    mid.start(),
+                ))?;
             }
             Ok(crate::parser::ParenthesizedExpr {
                 expr: mid.into(),
@@ -1751,10 +1751,10 @@ Atom<Goal>: crate::parser::ParenthesizedExpr = {
         range: (location..end_location).into(),
     }.into(),
     "(" <location:@L> "**" <e:Expression<"all">> ")" <end_location:@R> =>? {
-        Err(LexicalError{
-            error : LexicalErrorType::OtherError("cannot use double starred expression here".to_string()),
+        Err(LexicalError::new(
+            LexicalErrorType::OtherError("cannot use double starred expression here".to_string()),
             location,
-        }.into())
+        ).into())
     },
     <location:@L> "{" <e:DictLiteralValues?> "}" <end_location:@R> => {
         let (keys, values) = e

--- a/crates/ruff_python_parser/src/python.rs
+++ b/crates/ruff_python_parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: aa0540221d25f4eadfc9e043fb4fc631d537b672b8a96785dfec2407e0524b79
+// sha3: 5d684f12592dfd246411a2ca5f6bbed7c1e8ff9dd4129eaba0a98beee6d21cf6
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use ruff_python_ast::{self as ast, Int, IpyEscapeKind};
 use crate::{
@@ -33653,10 +33653,10 @@ fn __action74<
                 }
             ))
         } else {
-            Err(LexicalError {
-                error: LexicalErrorType::OtherError("IPython escape commands are only allowed in `Mode::Ipython`".to_string()),
+            Err(LexicalError::new(
+                LexicalErrorType::OtherError("IPython escape commands are only allowed in `Mode::Ipython`".to_string()),
                 location,
-            })?
+            ))?
         }
     }
 }
@@ -33676,10 +33676,10 @@ fn __action75<
         if mode == Mode::Ipython {
             // This should never occur as the lexer won't allow it.
             if !matches!(c.0, IpyEscapeKind::Magic | IpyEscapeKind::Shell) {
-                return Err(LexicalError {
-                    error: LexicalErrorType::OtherError("IPython escape command expr is only allowed for % and !".to_string()),
+                return Err(LexicalError::new(
+                    LexicalErrorType::OtherError("IPython escape command expr is only allowed for % and !".to_string()),
                     location,
-                })?;
+                ))?;
             }
             Ok(ast::ExprIpyEscapeCommand {
                 kind: c.0,
@@ -33687,10 +33687,10 @@ fn __action75<
                 range: (location..end_location).into()
             }.into())
         } else {
-            Err(LexicalError {
-                error: LexicalErrorType::OtherError("IPython escape commands are only allowed in `Mode::Ipython`".to_string()),
+            Err(LexicalError::new(
+                LexicalErrorType::OtherError("IPython escape commands are only allowed in `Mode::Ipython`".to_string()),
                 location,
-            })?
+            ))?
         }
     }
 }
@@ -33715,10 +33715,10 @@ fn __action76<
                 },
                 ast::Expr::Subscript(ast::ExprSubscript { value, slice, range, .. }) => {
                     let ast::Expr::NumberLiteral(ast::ExprNumberLiteral { value: ast::Number::Int(integer), .. }) = slice.as_ref() else {
-                        return Err(LexicalError {
-                            error: LexicalErrorType::OtherError("only integer literals are allowed in Subscript expressions in help end escape command".to_string()),
-                            location: range.start(),
-                        });
+                        return Err(LexicalError::new(
+                            LexicalErrorType::OtherError("only integer literals are allowed in Subscript expressions in help end escape command".to_string()),
+                            range.start(),
+                        ));
                     };
                     unparse_expr(value, buffer)?;
                     buffer.push('[');
@@ -33731,10 +33731,10 @@ fn __action76<
                     buffer.push_str(attr.as_str());
                 },
                 _ => {
-                    return Err(LexicalError {
-                        error: LexicalErrorType::OtherError("only Name, Subscript and Attribute expressions are allowed in help end escape command".to_string()),
-                        location: expr.start(),
-                    });
+                    return Err(LexicalError::new(
+                        LexicalErrorType::OtherError("only Name, Subscript and Attribute expressions are allowed in help end escape command".to_string()),
+                        expr.start(),
+                    ));
                 }
             }
             Ok(())
@@ -33742,10 +33742,10 @@ fn __action76<
 
         if mode != Mode::Ipython {
             return Err(ParseError::User {
-                error: LexicalError {
-                    error: LexicalErrorType::OtherError("IPython escape commands are only allowed in `Mode::Ipython`".to_string()),
+                error: LexicalError::new(
+                    LexicalErrorType::OtherError("IPython escape commands are only allowed in `Mode::Ipython`".to_string()),
                     location,
-                },
+                ),
             });
         }
 
@@ -33754,10 +33754,10 @@ fn __action76<
             2 => IpyEscapeKind::Help2,
             _ => {
                 return Err(ParseError::User {
-                    error: LexicalError {
-                        error: LexicalErrorType::OtherError("maximum of 2 `?` tokens are allowed in help end escape command".to_string()),
+                    error: LexicalError::new(
+                        LexicalErrorType::OtherError("maximum of 2 `?` tokens are allowed in help end escape command".to_string()),
                         location,
-                    },
+                    ),
                 });
             }
         };
@@ -34126,10 +34126,10 @@ fn __action95<
 {
     {
         if name.as_str() == "_" {
-            Err(LexicalError {
-                error: LexicalErrorType::OtherError("cannot use '_' as a target".to_string()),
+            Err(LexicalError::new(
+                LexicalErrorType::OtherError("cannot use '_' as a target".to_string()),
                 location,
-            })?
+            ))?
         } else {
             Ok(ast::Pattern::MatchAs(
                 ast::PatternMatchAs {
@@ -35917,10 +35917,10 @@ fn __action184<
 {
     {
         if fstring_middle.is_some() {
-            return Err(LexicalError {
-                error: LexicalErrorType::FStringError(FStringErrorType::LambdaWithoutParentheses),
+            return Err(LexicalError::new(
+                LexicalErrorType::FStringError(FStringErrorType::LambdaWithoutParentheses),
                 location,
-            })?;
+            ))?;
         }
         parameters.as_ref().map(validate_arguments).transpose()?;
 
@@ -36441,10 +36441,10 @@ fn __action221<
 {
     {
         if value.expr.is_lambda_expr() && !value.is_parenthesized() {
-            return Err(LexicalError {
-                error: LexicalErrorType::FStringError(FStringErrorType::LambdaWithoutParentheses),
-                location: value.start(),
-            })?;
+            return Err(LexicalError::new(
+                LexicalErrorType::FStringError(FStringErrorType::LambdaWithoutParentheses),
+                value.start(),
+            ))?;
         }
         let debug_text = debug.map(|_| {
             let start_offset = location + "{".text_len();
@@ -36522,10 +36522,10 @@ fn __action224<
             "s" => ast::ConversionFlag::Str,
             "r" => ast::ConversionFlag::Repr,
             "a" => ast::ConversionFlag::Ascii,
-            _ => Err(LexicalError {
-                error: LexicalErrorType::FStringError(FStringErrorType::InvalidConversionFlag),
-                location: name_location,
-            })?
+            _ => Err(LexicalError::new(
+                LexicalErrorType::FStringError(FStringErrorType::InvalidConversionFlag),
+                name_location,
+            ))?
         };
         Ok((location, conversion))
     }
@@ -39668,10 +39668,10 @@ fn __action445<
 {
     {
         if va.is_none() && kwonlyargs.is_empty() && kwarg.is_none() {
-            return Err(LexicalError {
-                error: LexicalErrorType::OtherError("named arguments must follow bare *".to_string()),
+            return Err(LexicalError::new(
+                LexicalErrorType::OtherError("named arguments must follow bare *".to_string()),
                 location,
-            })?;
+            ))?;
         }
 
         let kwarg = kwarg.flatten();
@@ -39793,10 +39793,10 @@ fn __action453<
 {
     {
         if va.is_none() && kwonlyargs.is_empty() && kwarg.is_none() {
-            return Err(LexicalError {
-                error: LexicalErrorType::OtherError("named arguments must follow bare *".to_string()),
+            return Err(LexicalError::new(
+                LexicalErrorType::OtherError("named arguments must follow bare *".to_string()),
                 location,
-            })?;
+            ))?;
         }
 
         let kwarg = kwarg.flatten();
@@ -41296,10 +41296,10 @@ fn __action554<
     {
         if left.is_none() && right.is_empty() && trailing_comma.is_none() {
             if mid.expr.is_starred_expr() {
-                return Err(LexicalError{
-                    error: LexicalErrorType::OtherError("cannot use starred expression here".to_string()),
-                    location: mid.start(),
-                })?;
+                return Err(LexicalError::new(
+                    LexicalErrorType::OtherError("cannot use starred expression here".to_string()),
+                    mid.start(),
+                ))?;
             }
             Ok(crate::parser::ParenthesizedExpr {
                 expr: mid.into(),
@@ -41386,10 +41386,10 @@ fn __action558<
 ) -> Result<crate::parser::ParenthesizedExpr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     {
-        Err(LexicalError{
-            error : LexicalErrorType::OtherError("cannot use double starred expression here".to_string()),
+        Err(LexicalError::new(
+            LexicalErrorType::OtherError("cannot use double starred expression here".to_string()),
             location,
-        }.into())
+        ).into())
     }
 }
 
@@ -41994,10 +41994,10 @@ fn __action596<
     {
         if left.is_none() && right.is_empty() && trailing_comma.is_none() {
             if mid.expr.is_starred_expr() {
-                return Err(LexicalError{
-                    error: LexicalErrorType::OtherError("cannot use starred expression here".to_string()),
-                    location: mid.start(),
-                })?;
+                return Err(LexicalError::new(
+                    LexicalErrorType::OtherError("cannot use starred expression here".to_string()),
+                    mid.start(),
+                ))?;
             }
             Ok(crate::parser::ParenthesizedExpr {
                 expr: mid.into(),
@@ -42084,10 +42084,10 @@ fn __action600<
 ) -> Result<crate::parser::ParenthesizedExpr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     {
-        Err(LexicalError{
-            error : LexicalErrorType::OtherError("cannot use double starred expression here".to_string()),
+        Err(LexicalError::new(
+            LexicalErrorType::OtherError("cannot use double starred expression here".to_string()),
             location,
-        }.into())
+        ).into())
     }
 }
 

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__invalid_leading_zero_big.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__invalid_leading_zero_big.snap
@@ -3,10 +3,12 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: tokens
 ---
 Err(
-    LexicalError {
-        error: OtherError(
-            "Invalid Token",
-        ),
-        location: 0,
-    },
+    LexicalError(
+        LexicalErrorInner {
+            error: OtherError(
+                "Invalid Token",
+            ),
+            location: 0,
+        },
+    ),
 )

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__invalid_leading_zero_small.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__invalid_leading_zero_small.snap
@@ -3,10 +3,12 @@ source: crates/ruff_python_parser/src/lexer.rs
 expression: tokens
 ---
 Err(
-    LexicalError {
-        error: OtherError(
-            "Invalid Token",
-        ),
-        location: 0,
-    },
+    LexicalError(
+        LexicalErrorInner {
+            error: OtherError(
+                "Invalid Token",
+            ),
+            location: 0,
+        },
+    ),
 )

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__tet_too_low_dedent.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__tet_too_low_dedent.snap
@@ -46,10 +46,12 @@ expression: tokens
         ),
     ),
     Err(
-        LexicalError {
-            error: IndentationError,
-            location: 20,
-        },
+        LexicalError(
+            LexicalErrorInner {
+                error: IndentationError,
+                location: 20,
+            },
+        ),
     ),
     Ok(
         (

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -8,6 +8,7 @@ use crate::Mode;
 
 use ruff_python_ast::{Int, IpyEscapeKind};
 use ruff_text_size::TextSize;
+use static_assertions::assert_eq_size;
 use std::fmt;
 
 /// The set of tokens the Python source code can be tokenized in.
@@ -912,3 +913,5 @@ impl From<&Tok> for TokenKind {
         Self::from_token(value)
     }
 }
+
+assert_eq_size!(Tok, [u8; 32]);

--- a/crates/ruff_python_parser/src/token.rs
+++ b/crates/ruff_python_parser/src/token.rs
@@ -8,7 +8,6 @@ use crate::Mode;
 
 use ruff_python_ast::{Int, IpyEscapeKind};
 use ruff_text_size::TextSize;
-use static_assertions::assert_eq_size;
 use std::fmt;
 
 /// The set of tokens the Python source code can be tokenized in.
@@ -914,4 +913,12 @@ impl From<&Tok> for TokenKind {
     }
 }
 
-assert_eq_size!(Tok, [u8; 32]);
+#[cfg(target_pointer_width = "64")]
+mod sizes {
+    use crate::lexer::LexicalError;
+    use crate::Tok;
+    use static_assertions::assert_eq_size;
+
+    assert_eq_size!(Tok, [u8; 32]);
+    assert_eq_size!(Result<Tok, LexicalError>, [u8; 32]);
+}

--- a/fuzz/fuzz_targets/ruff_parse_simple.rs
+++ b/fuzz/fuzz_targets/ruff_parse_simple.rs
@@ -47,7 +47,7 @@ fn do_fuzz(case: &[u8]) -> Corpus {
                 );
             }
             Err(err) => {
-                let offset = err.location.to_usize();
+                let offset = err.location().to_usize();
                 assert!(
                     code.is_char_boundary(offset),
                     "Invalid error location {} (not at char boundary)",


### PR DESCRIPTION
- Make `LexicalError` fields private
- Box `LexicalError` to reduce Result size
