### PR TITLE
Detect `mark_safe` usages in decorators

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S308.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S308.py
@@ -1,0 +1,22 @@
+from django.utils.safestring import mark_safe
+
+
+def some_func():
+    return mark_safe('<script>alert("evil!")</script>')
+
+
+@mark_safe
+def some_func():
+    return '<script>alert("evil!")</script>'
+
+
+from django.utils.html import mark_safe
+
+
+def some_func():
+    return mark_safe('<script>alert("evil!")</script>')
+
+
+@mark_safe
+def some_func():
+    return '<script>alert("evil!")</script>'

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -247,6 +247,11 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             if checker.enabled(Rule::HardcodedPasswordDefault) {
                 flake8_bandit::rules::hardcoded_password_default(checker, parameters);
             }
+            if checker.enabled(Rule::SuspiciousMarkSafeUsage) {
+                for decorator in decorator_list {
+                    flake8_bandit::rules::suspicious_function_decorator(checker, decorator);
+                }
+            }
             if checker.enabled(Rule::PropertyWithParameters) {
                 pylint::rules::property_with_parameters(checker, stmt, decorator_list, parameters);
             }

--- a/crates/ruff_linter/src/rules/flake8_bandit/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/mod.rs
@@ -46,6 +46,7 @@ mod tests {
     #[test_case(Rule::SubprocessWithoutShellEqualsTrue, Path::new("S603.py"))]
     #[test_case(Rule::SuspiciousPickleUsage, Path::new("S301.py"))]
     #[test_case(Rule::SuspiciousEvalUsage, Path::new("S307.py"))]
+    #[test_case(Rule::SuspiciousMarkSafeUsage, Path::new("S308.py"))]
     #[test_case(Rule::SuspiciousURLOpenUsage, Path::new("S310.py"))]
     #[test_case(Rule::SuspiciousTelnetUsage, Path::new("S312.py"))]
     #[test_case(Rule::SuspiciousTelnetlibImport, Path::new("S401.py"))]

--- a/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S308_S308.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bandit/snapshots/ruff_linter__rules__flake8_bandit__tests__S308_S308.py.snap
@@ -1,0 +1,34 @@
+---
+source: crates/ruff_linter/src/rules/flake8_bandit/mod.rs
+---
+S308.py:5:12: S308 Use of `mark_safe` may expose cross-site scripting vulnerabilities
+  |
+4 | def some_func():
+5 |     return mark_safe('<script>alert("evil!")</script>')
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S308
+  |
+
+S308.py:8:1: S308 Use of `mark_safe` may expose cross-site scripting vulnerabilities
+   |
+ 8 | @mark_safe
+   | ^^^^^^^^^^ S308
+ 9 | def some_func():
+10 |     return '<script>alert("evil!")</script>'
+   |
+
+S308.py:17:12: S308 Use of `mark_safe` may expose cross-site scripting vulnerabilities
+   |
+16 | def some_func():
+17 |     return mark_safe('<script>alert("evil!")</script>')
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S308
+   |
+
+S308.py:20:1: S308 Use of `mark_safe` may expose cross-site scripting vulnerabilities
+   |
+20 | @mark_safe
+   | ^^^^^^^^^^ S308
+21 | def some_func():
+22 |     return '<script>alert("evil!")</script>'
+   |
+
+


### PR DESCRIPTION
## Summary

Django's `mark_safe` can also be used as a decorator, so we should detect usages of `@mark_safe` for the purpose of the relevant Bandit rule.

Closes https://github.com/astral-sh/ruff/issues/9780.
