### PR TITLE
Corrected Path symlink method name (PTH114)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/violations.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/violations.rs
@@ -610,7 +610,7 @@ impl Violation for OsPathIsfile {
 /// ## Why is this bad?
 /// `pathlib` offers a high-level API for path manipulation, as compared to
 /// the lower-level API offered by `os`. When possible, using `Path` object
-/// methods such as `Path.is_link()` can improve readability over the `os`
+/// methods such as `Path.is_symlink()` can improve readability over the `os`
 /// module's counterparts (e.g., `os.path.islink()`).
 ///
 /// Note that `os` functions may be preferable if performance is a concern,
@@ -627,11 +627,11 @@ impl Violation for OsPathIsfile {
 /// ```python
 /// from pathlib import Path
 ///
-/// Path("docs").is_link()
+/// Path("docs").is_symlink()
 /// ```
 ///
 /// ## References
-/// - [Python documentation: `Path.is_link`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.is_link)
+/// - [Python documentation: `Path.is_symlink`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.is_symlink)
 /// - [Python documentation: `os.path.islink`](https://docs.python.org/3/library/os.path.html#os.path.islink)
 /// - [PEP 428](https://peps.python.org/pep-0428/)
 /// - [Correspondence between `os` and `pathlib`](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)


### PR DESCRIPTION
## Summary
Corrects mentions of `Path.is_link` to `Path.is_symlink` (the former doesn't exist).

## Test Plan
```sh
python scripts/generate_mkdocs.py && mkdocs serve -f mkdocs.public.yml
```
