### PR TITLE
Use Rust 1.76

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,7 +2277,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "smallvec",
- "static_assertions",
 ]
 
 [[package]]

--- a/crates/ruff_formatter/src/printer/line_suffixes.rs
+++ b/crates/ruff_formatter/src/printer/line_suffixes.rs
@@ -21,8 +21,7 @@ impl<'a> LineSuffixes<'a> {
     /// Takes all the pending line suffixes.
     pub(super) fn take_pending<'l>(
         &'l mut self,
-    ) -> impl Iterator<Item = LineSuffixEntry<'a>> + DoubleEndedIterator + 'l + ExactSizeIterator
-    {
+    ) -> impl DoubleEndedIterator<Item = LineSuffixEntry<'a>> + 'l + ExactSizeIterator {
         self.suffixes.drain(..)
     }
 

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -25,7 +25,6 @@ once_cell = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
 smallvec = { workspace = true }
-static_assertions = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3892,8 +3892,10 @@ mod tests {
         assert!(std::mem::size_of::<StmtFunctionDef>() <= 144);
         assert!(std::mem::size_of::<StmtClassDef>() <= 104);
         assert!(std::mem::size_of::<StmtTry>() <= 112);
-        assert!(std::mem::size_of::<Expr>() <= 72);
-        assert!(std::mem::size_of::<Pattern>() <= 88);
+        // 80 for Rustc < 1.76
+        assert!(matches!(std::mem::size_of::<Expr>(), 72 | 80));
+        // 96 for Rustc < 1.76
+        assert!(matches!(std::mem::size_of::<Pattern>(), 88 | 96));
         assert!(std::mem::size_of::<Mod>() <= 32);
     }
 }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3880,18 +3880,20 @@ impl Ranged for crate::nodes::ParameterWithDefault {
     }
 }
 
-#[cfg(target_pointer_width = "64")]
-mod size_assertions {
-    use static_assertions::assert_eq_size;
-
+#[cfg(test)]
+mod tests {
     #[allow(clippy::wildcard_imports)]
     use super::*;
 
-    assert_eq_size!(Stmt, [u8; 144]);
-    assert_eq_size!(StmtFunctionDef, [u8; 144]);
-    assert_eq_size!(StmtClassDef, [u8; 104]);
-    assert_eq_size!(StmtTry, [u8; 112]);
-    assert_eq_size!(Expr, [u8; 80]);
-    assert_eq_size!(Pattern, [u8; 96]);
-    assert_eq_size!(Mod, [u8; 32]);
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn size() {
+        assert!(std::mem::size_of::<Stmt>() <= 144);
+        assert!(std::mem::size_of::<StmtFunctionDef>() <= 144);
+        assert!(std::mem::size_of::<StmtClassDef>() <= 104);
+        assert!(std::mem::size_of::<StmtTry>() <= 112);
+        assert!(std::mem::size_of::<Expr>() <= 72);
+        assert!(std::mem::size_of::<Pattern>() <= 88);
+        assert!(std::mem::size_of::<Mod>() <= 32);
+    }
 }

--- a/crates/ruff_python_parser/src/parser.rs
+++ b/crates/ruff_python_parser/src/parser.rs
@@ -569,7 +569,8 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     #[test]
     fn size_assertions() {
-        assert!(std::mem::size_of::<ParenthesizedExpr>() <= 80);
+        // 80 with Rustc >= 1.76, 88 with Rustc < 1.76
+        assert!(matches!(std::mem::size_of::<ParenthesizedExpr>(), 80 | 88));
     }
 
     #[test]

--- a/crates/ruff_python_parser/src/parser.rs
+++ b/crates/ruff_python_parser/src/parser.rs
@@ -560,20 +560,17 @@ impl From<ExprSlice> for ParenthesizedExpr {
     }
 }
 
-#[cfg(target_pointer_width = "64")]
-mod size_assertions {
-    use static_assertions::assert_eq_size;
-
-    use crate::parser::ParenthesizedExpr;
-
-    assert_eq_size!(ParenthesizedExpr, [u8; 88]);
-}
-
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;
 
     use super::*;
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn size_assertions() {
+        assert!(std::mem::size_of::<ParenthesizedExpr>() <= 80);
+    }
 
     #[test]
     fn test_parse_empty() {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.75"
+channel = "1.76"


### PR DESCRIPTION
## Summary

This PR upgrades our default toolchain to 1.76. It does not change the minimal required rust version.

This new version of Rust is now able to better optimise our enums which shrinked the size of some AST nodes. 

## Test Plan

`cargo test` and `cargo +1.75 test`
