### PR TITLE
Filter out test rules in `RuleSelector` JSON schema

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,10 +117,7 @@ jobs:
           tool: cargo-insta
       - uses: Swatinem/rust-cache@v2
       - name: "Run tests"
-        run: cargo insta test --all --exclude ruff_dev --all-features --unreferenced reject
-      - name: "Run dev tests"
-        # e.g. generating the schema — these should not run with all features enabled
-        run: cargo insta test -p ruff_dev --unreferenced reject
+        run: cargo insta test --all --all-features --unreferenced reject
       # Check for broken links in the documentation.
       - run: cargo doc --all --no-deps
         env:

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -321,6 +321,15 @@ mod schema {
                             true
                         }
                     })
+                    .filter(|rule| {
+                        // Filter out all test-only rules
+                        #[cfg(feature = "test-rules")]
+                        if rule.starts_with("RUF9") {
+                            return false;
+                        }
+
+                        true
+                    })
                     .sorted()
                     .map(Value::String)
                     .collect(),


### PR DESCRIPTION
## Summary

Running `cargo test` fails today because `cargo dev generate-all` runs with the `test-rules` feature enabled (because `ruff` enables the feature), which results in the test rules showing up in the JSON schema. 

This PR fixes this by filtering out the test rules if the `test-rules` feature is enabled. I don't particularly like it but how it is today is very disruptive to the development workflow.

## Test Plan

`cargo test` no longer fails 
