### PR TITLE
Fix `E30X` panics on blank lines with trailing white spaces

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.py
@@ -436,6 +436,15 @@ class Test:
 # end
 
 
+# no error
+def test():
+    pass
+  
+  # Wrongly indented comment
+    pass
+# end
+
+
 # E301
 class Class(object):
 
@@ -531,6 +540,20 @@ def f():
 @decorator
 def g():
     pass
+# end
+
+
+# E302
+class Test:
+	
+	pass
+	
+	def method1():
+		return 1
+		
+		
+	def method2():
+		return 22
 # end
 
 
@@ -645,6 +668,15 @@ class Test:
 
     def b(self):
         pass
+# end
+
+
+# E303
+def fn():
+    pass
+
+ 
+    pass
 # end
 
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/blank_lines.rs
@@ -501,7 +501,6 @@ impl BlankLines {
                 }
             }
             BlankLines::Many { count, range } => {
-                assert_eq!(range.end(), line_range.start());
                 *count = count.saturating_add(1);
                 *range = TextRange::new(range.start(), line_range.end());
             }

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E301_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E301_E30.py.snap
@@ -1,44 +1,44 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:444:5: E301 [*] Expected 1 blank line, found 0
+E30.py:453:5: E301 [*] Expected 1 blank line, found 0
     |
-442 |     def func1():
-443 |         pass
-444 |     def func2():
+451 |     def func1():
+452 |         pass
+453 |     def func2():
     |     ^^^ E301
-445 |         pass
-446 | # end
+454 |         pass
+455 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-441 441 | 
-442 442 |     def func1():
-443 443 |         pass
-    444 |+
-444 445 |     def func2():
-445 446 |         pass
-446 447 | # end
+450 450 | 
+451 451 |     def func1():
+452 452 |         pass
+    453 |+
+453 454 |     def func2():
+454 455 |         pass
+455 456 | # end
 
-E30.py:455:5: E301 [*] Expected 1 blank line, found 0
+E30.py:464:5: E301 [*] Expected 1 blank line, found 0
     |
-453 |         pass
-454 |     # comment
-455 |     def fn2():
+462 |         pass
+463 |     # comment
+464 |     def fn2():
     |     ^^^ E301
-456 |         pass
-457 | # end
+465 |         pass
+466 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-451 451 | 
-452 452 |     def fn1():
-453 453 |         pass
-    454 |+
-454 455 |     # comment
-455 456 |     def fn2():
-456 457 |         pass
+460 460 | 
+461 461 |     def fn1():
+462 462 |         pass
+    463 |+
+463 464 |     # comment
+464 465 |     def fn2():
+465 466 |         pass
 
 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E302_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E302_E30.py.snap
@@ -1,105 +1,85 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:462:1: E302 [*] Expected 2 blank lines, found 0
+E30.py:471:1: E302 [*] Expected 2 blank lines, found 0
     |
-460 | # E302
-461 | """Main module."""
-462 | def fn():
+469 | # E302
+470 | """Main module."""
+471 | def fn():
     | ^^^ E302
-463 |     pass
-464 | # end
+472 |     pass
+473 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-459 459 | 
-460 460 | # E302
-461 461 | """Main module."""
-    462 |+
-    463 |+
-462 464 | def fn():
-463 465 |     pass
-464 466 | # end
+468 468 | 
+469 469 | # E302
+470 470 | """Main module."""
+    471 |+
+    472 |+
+471 473 | def fn():
+472 474 |     pass
+473 475 | # end
 
-E30.py:469:1: E302 [*] Expected 2 blank lines, found 0
+E30.py:478:1: E302 [*] Expected 2 blank lines, found 0
     |
-467 | # E302
-468 | import sys
-469 | def get_sys_path():
+476 | # E302
+477 | import sys
+478 | def get_sys_path():
     | ^^^ E302
-470 |     return sys.path
-471 | # end
-    |
-    = help: Add missing blank line(s)
-
-ℹ Safe fix
-466 466 | 
-467 467 | # E302
-468 468 | import sys
-    469 |+
-    470 |+
-469 471 | def get_sys_path():
-470 472 |     return sys.path
-471 473 | # end
-
-E30.py:478:1: E302 [*] Expected 2 blank lines, found 1
-    |
-476 |     pass
-477 | 
-478 | def b():
-    | ^^^ E302
-479 |     pass
+479 |     return sys.path
 480 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-475 475 | def a():
-476 476 |     pass
-477 477 | 
+475 475 | 
+476 476 | # E302
+477 477 | import sys
     478 |+
-478 479 | def b():
-479 480 |     pass
-480 481 | # end
+    479 |+
+478 480 | def get_sys_path():
+479 481 |     return sys.path
+480 482 | # end
 
-E30.py:489:1: E302 [*] Expected 2 blank lines, found 1
+E30.py:487:1: E302 [*] Expected 2 blank lines, found 1
     |
-487 | # comment
-488 | 
-489 | def b():
+485 |     pass
+486 | 
+487 | def b():
     | ^^^ E302
-490 |     pass
-491 | # end
+488 |     pass
+489 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
+484 484 | def a():
+485 485 |     pass
 486 486 | 
-487 487 | # comment
-488 488 | 
-    489 |+
-489 490 | def b():
-490 491 |     pass
-491 492 | # end
+    487 |+
+487 488 | def b():
+488 489 |     pass
+489 490 | # end
 
 E30.py:498:1: E302 [*] Expected 2 blank lines, found 1
     |
-496 |     pass
+496 | # comment
 497 | 
-498 | async def b():
-    | ^^^^^ E302
+498 | def b():
+    | ^^^ E302
 499 |     pass
 500 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-495 495 | def a():
-496 496 |     pass
+495 495 | 
+496 496 | # comment
 497 497 | 
     498 |+
-498 499 | async def b():
+498 499 | def b():
 499 500 |     pass
 500 501 | # end
 
@@ -107,7 +87,7 @@ E30.py:507:1: E302 [*] Expected 2 blank lines, found 1
     |
 505 |     pass
 506 | 
-507 | async  def x(y: int = 1):
+507 | async def b():
     | ^^^^^ E302
 508 |     pass
 509 | # end
@@ -115,73 +95,93 @@ E30.py:507:1: E302 [*] Expected 2 blank lines, found 1
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-504 504 | async  def x():
+504 504 | def a():
 505 505 |     pass
 506 506 | 
     507 |+
-507 508 | async  def x(y: int = 1):
+507 508 | async def b():
 508 509 |     pass
 509 510 | # end
 
-E30.py:515:1: E302 [*] Expected 2 blank lines, found 0
+E30.py:516:1: E302 [*] Expected 2 blank lines, found 1
     |
-513 | def bar():
 514 |     pass
-515 | def baz(): pass
-    | ^^^ E302
-516 | # end
+515 | 
+516 | async  def x(y: int = 1):
+    | ^^^^^ E302
+517 |     pass
+518 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-512 512 | # E302
-513 513 | def bar():
+513 513 | async  def x():
 514 514 |     pass
-    515 |+
+515 515 | 
     516 |+
-515 517 | def baz(): pass
-516 518 | # end
-517 519 | 
+516 517 | async  def x(y: int = 1):
+517 518 |     pass
+518 519 | # end
 
-E30.py:521:1: E302 [*] Expected 2 blank lines, found 0
+E30.py:524:1: E302 [*] Expected 2 blank lines, found 0
     |
-519 | # E302
-520 | def bar(): pass
-521 | def baz():
+522 | def bar():
+523 |     pass
+524 | def baz(): pass
     | ^^^ E302
-522 |     pass
-523 | # end
+525 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-518 518 | 
-519 519 | # E302
-520 520 | def bar(): pass
-    521 |+
-    522 |+
-521 523 | def baz():
-522 524 |     pass
-523 525 | # end
+521 521 | # E302
+522 522 | def bar():
+523 523 |     pass
+    524 |+
+    525 |+
+524 526 | def baz(): pass
+525 527 | # end
+526 528 | 
 
-E30.py:531:1: E302 [*] Expected 2 blank lines, found 1
+E30.py:530:1: E302 [*] Expected 2 blank lines, found 0
     |
-530 | # comment
-531 | @decorator
-    | ^ E302
-532 | def g():
-533 |     pass
+528 | # E302
+529 | def bar(): pass
+530 | def baz():
+    | ^^^ E302
+531 |     pass
+532 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-527 527 | def f():
-528 528 |     pass
-529 529 | 
+527 527 | 
+528 528 | # E302
+529 529 | def bar(): pass
     530 |+
     531 |+
-530 532 | # comment
-531 533 | @decorator
-532 534 | def g():
+530 532 | def baz():
+531 533 |     pass
+532 534 | # end
+
+E30.py:540:1: E302 [*] Expected 2 blank lines, found 1
+    |
+539 | # comment
+540 | @decorator
+    | ^ E302
+541 | def g():
+542 |     pass
+    |
+    = help: Add missing blank line(s)
+
+ℹ Safe fix
+536 536 | def f():
+537 537 |     pass
+538 538 | 
+    539 |+
+    540 |+
+539 541 | # comment
+540 542 | @decorator
+541 543 | def g():
 
 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E303_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E303_E30.py.snap
@@ -1,215 +1,250 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:542:5: E303 [*] Too many blank lines (2)
+E30.py:555:2: E303 [*] Too many blank lines (2)
     |
-542 |     # arbitrary comment
+555 |     def method2():
+    |     ^^^ E303
+556 |         return 22
+557 | # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+551 551 | 	def method1():
+552 552 | 		return 1
+553 553 | 		
+554     |-		
+555 554 | 	def method2():
+556 555 | 		return 22
+557 556 | # end
+
+E30.py:565:5: E303 [*] Too many blank lines (2)
+    |
+565 |     # arbitrary comment
     |     ^^^^^^^^^^^^^^^^^^^ E303
-543 | 
-544 |     def inner():  # E306 not expected (pycodestyle detects E306)
+566 | 
+567 |     def inner():  # E306 not expected (pycodestyle detects E306)
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-538 538 | def fn():
-539 539 |     _ = None
-540 540 | 
-541     |-
-542 541 |     # arbitrary comment
-543 542 | 
-544 543 |     def inner():  # E306 not expected (pycodestyle detects E306)
-
-E30.py:554:5: E303 [*] Too many blank lines (2)
-    |
-554 |     # arbitrary comment
-    |     ^^^^^^^^^^^^^^^^^^^ E303
-555 |     def inner():  # E306 not expected (pycodestyle detects E306)
-556 |         pass
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-550 550 | def fn():
-551 551 |     _ = None
-552 552 | 
-553     |-
-554 553 |     # arbitrary comment
-555 554 |     def inner():  # E306 not expected (pycodestyle detects E306)
-556 555 |         pass
-
-E30.py:565:1: E303 [*] Too many blank lines (3)
-    |
-565 | print()
-    | ^^^^^ E303
-566 | # end
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-561 561 | print()
-562 562 | 
+561 561 | def fn():
+562 562 |     _ = None
 563 563 | 
 564     |-
-565 564 | print()
-566 565 | # end
-567 566 | 
+565 564 |     # arbitrary comment
+566 565 | 
+567 566 |     def inner():  # E306 not expected (pycodestyle detects E306)
 
-E30.py:574:1: E303 [*] Too many blank lines (3)
+E30.py:577:5: E303 [*] Too many blank lines (2)
     |
-574 | # comment
-    | ^^^^^^^^^ E303
-575 | 
-576 | print()
+577 |     # arbitrary comment
+    |     ^^^^^^^^^^^^^^^^^^^ E303
+578 |     def inner():  # E306 not expected (pycodestyle detects E306)
+579 |         pass
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-570 570 | print()
-571 571 | 
-572 572 | 
-573     |-
-574 573 | # comment
-575 574 | 
-576 575 | print()
+573 573 | def fn():
+574 574 |     _ = None
+575 575 | 
+576     |-
+577 576 |     # arbitrary comment
+578 577 |     def inner():  # E306 not expected (pycodestyle detects E306)
+579 578 |         pass
 
-E30.py:585:5: E303 [*] Too many blank lines (2)
+E30.py:588:1: E303 [*] Too many blank lines (3)
     |
-585 |     # comment
+588 | print()
+    | ^^^^^ E303
+589 | # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+584 584 | print()
+585 585 | 
+586 586 | 
+587     |-
+588 587 | print()
+589 588 | # end
+590 589 | 
+
+E30.py:597:1: E303 [*] Too many blank lines (3)
+    |
+597 | # comment
+    | ^^^^^^^^^ E303
+598 | 
+599 | print()
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+593 593 | print()
+594 594 | 
+595 595 | 
+596     |-
+597 596 | # comment
+598 597 | 
+599 598 | print()
+
+E30.py:608:5: E303 [*] Too many blank lines (2)
+    |
+608 |     # comment
     |     ^^^^^^^^^ E303
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-581 581 | def a():
-582 582 |     print()
-583 583 | 
-584     |-
-585 584 |     # comment
-586 585 | 
-587 586 | 
-
-E30.py:588:5: E303 [*] Too many blank lines (2)
-    |
-588 |     # another comment
-    |     ^^^^^^^^^^^^^^^^^ E303
-589 | 
-590 |     print()
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-584 584 | 
-585 585 |     # comment
-586 586 | 
-587     |-
-588 587 |     # another comment
-589 588 | 
-590 589 |     print()
-
-E30.py:599:1: E303 [*] Too many blank lines (3)
-    |
-599 | / """This class docstring comes on line 5.
-600 | | It gives error E303: too many blank lines (3)
-601 | | """
-    | |___^ E303
-602 |   # end
-    |
-    = help: Remove extraneous blank line(s)
-
-ℹ Safe fix
-595 595 | #!python
-596 596 | 
-597 597 | 
-598     |-
-599 598 | """This class docstring comes on line 5.
-600 599 | It gives error E303: too many blank lines (3)
-601 600 | """
+604 604 | def a():
+605 605 |     print()
+606 606 | 
+607     |-
+608 607 |     # comment
+609 608 | 
+610 609 | 
 
 E30.py:611:5: E303 [*] Too many blank lines (2)
     |
-611 |     def b(self):
-    |     ^^^ E303
-612 |         pass
-613 | # end
+611 |     # another comment
+    |     ^^^^^^^^^^^^^^^^^ E303
+612 | 
+613 |     print()
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-607 607 |     def a(self):
-608 608 |         pass
+607 607 | 
+608 608 |     # comment
 609 609 | 
 610     |-
-611 610 |     def b(self):
-612 611 |         pass
-613 612 | # end
+611 610 |     # another comment
+612 611 | 
+613 612 |     print()
 
-E30.py:621:5: E303 [*] Too many blank lines (2)
+E30.py:622:1: E303 [*] Too many blank lines (3)
     |
-621 |     a = 2
-    |     ^ E303
-622 | # end
+622 | / """This class docstring comes on line 5.
+623 | | It gives error E303: too many blank lines (3)
+624 | | """
+    | |___^ E303
+625 |   # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-617 617 | if True:
-618 618 |     a = 1
+618 618 | #!python
 619 619 | 
-620     |-
-621 620 |     a = 2
-622 621 | # end
-623 622 | 
+620 620 | 
+621     |-
+622 621 | """This class docstring comes on line 5.
+623 622 | It gives error E303: too many blank lines (3)
+624 623 | """
 
-E30.py:629:5: E303 [*] Too many blank lines (2)
+E30.py:634:5: E303 [*] Too many blank lines (2)
     |
-629 |     # comment
+634 |     def b(self):
+    |     ^^^ E303
+635 |         pass
+636 | # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+630 630 |     def a(self):
+631 631 |         pass
+632 632 | 
+633     |-
+634 633 |     def b(self):
+635 634 |         pass
+636 635 | # end
+
+E30.py:644:5: E303 [*] Too many blank lines (2)
+    |
+644 |     a = 2
+    |     ^ E303
+645 | # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+640 640 | if True:
+641 641 |     a = 1
+642 642 | 
+643     |-
+644 643 |     a = 2
+645 644 | # end
+646 645 | 
+
+E30.py:652:5: E303 [*] Too many blank lines (2)
+    |
+652 |     # comment
     |     ^^^^^^^^^ E303
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-625 625 | # E303
-626 626 | class Test:
-627 627 | 
-628     |-
-629 628 |     # comment
-630 629 | 
-631 630 | 
+648 648 | # E303
+649 649 | class Test:
+650 650 | 
+651     |-
+652 651 |     # comment
+653 652 | 
+654 653 | 
 
-E30.py:632:5: E303 [*] Too many blank lines (2)
+E30.py:655:5: E303 [*] Too many blank lines (2)
     |
-632 |     # another comment
+655 |     # another comment
     |     ^^^^^^^^^^^^^^^^^ E303
-633 | 
-634 |     def test(self): pass
+656 | 
+657 |     def test(self): pass
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-628 628 | 
-629 629 |     # comment
-630 630 | 
-631     |-
-632 631 |     # another comment
-633 632 | 
-634 633 |     def test(self): pass
+651 651 | 
+652 652 |     # comment
+653 653 | 
+654     |-
+655 654 |     # another comment
+656 655 | 
+657 656 |     def test(self): pass
 
-E30.py:646:5: E303 [*] Too many blank lines (2)
+E30.py:669:5: E303 [*] Too many blank lines (2)
     |
-646 |     def b(self):
+669 |     def b(self):
     |     ^^^ E303
-647 |         pass
-648 | # end
+670 |         pass
+671 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-642 642 | 
-643 643 | # wrongly indented comment
-644 644 | 
-645     |-
-646 645 |     def b(self):
-647 646 |         pass
-648 647 | # end
+665 665 | 
+666 666 | # wrongly indented comment
+667 667 | 
+668     |-
+669 668 |     def b(self):
+670 669 |         pass
+671 670 | # end
+
+E30.py:679:5: E303 [*] Too many blank lines (2)
+    |
+679 |     pass
+    |     ^^^^ E303
+680 | # end
+    |
+    = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+675 675 | def fn():
+676 676 |     pass
+677 677 | 
+678     |- 
+679 678 |     pass
+680 679 | # end
+681 680 | 
 
 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E304_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E304_E30.py.snap
@@ -1,65 +1,65 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:654:1: E304 [*] Blank lines found after function decorator (1)
+E30.py:686:1: E304 [*] Blank lines found after function decorator (1)
     |
-652 | @decorator
-653 | 
-654 | def function():
+684 | @decorator
+685 | 
+686 | def function():
     | ^^^ E304
-655 |     pass
-656 | # end
+687 |     pass
+688 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-650 650 | 
-651 651 | # E304
-652 652 | @decorator
-653     |-
-654 653 | def function():
-655 654 |     pass
-656 655 | # end
+682 682 | 
+683 683 | # E304
+684 684 | @decorator
+685     |-
+686 685 | def function():
+687 686 |     pass
+688 687 | # end
 
-E30.py:663:1: E304 [*] Blank lines found after function decorator (1)
+E30.py:695:1: E304 [*] Blank lines found after function decorator (1)
     |
-662 | # comment    E304 not expected
-663 | def function():
+694 | # comment    E304 not expected
+695 | def function():
     | ^^^ E304
-664 |     pass
-665 | # end
+696 |     pass
+697 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-658 658 | 
-659 659 | # E304
-660 660 | @decorator
-661     |-
-662 661 | # comment    E304 not expected
-663 662 | def function():
-664 663 |     pass
+690 690 | 
+691 691 | # E304
+692 692 | @decorator
+693     |-
+694 693 | # comment    E304 not expected
+695 694 | def function():
+696 695 |     pass
 
-E30.py:675:1: E304 [*] Blank lines found after function decorator (2)
+E30.py:707:1: E304 [*] Blank lines found after function decorator (2)
     |
-674 | # second comment  E304 not expected
-675 | def function():
+706 | # second comment  E304 not expected
+707 | def function():
     | ^^^ E304
-676 |     pass
-677 | # end
+708 |     pass
+709 | # end
     |
     = help: Remove extraneous blank line(s)
 
 ℹ Safe fix
-667 667 | 
-668 668 | # E304
-669 669 | @decorator
-670     |-
-671 670 | # comment  E304 not expected
-672     |-
-673     |-
-674 671 | # second comment  E304 not expected
-675 672 | def function():
-676 673 |     pass
+699 699 | 
+700 700 | # E304
+701 701 | @decorator
+702     |-
+703 702 | # comment  E304 not expected
+704     |-
+705     |-
+706 703 | # second comment  E304 not expected
+707 704 | def function():
+708 705 |     pass
 
 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E305_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E305_E30.py.snap
@@ -1,102 +1,102 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:687:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:719:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-686 |     # another comment
-687 | fn()
+718 |     # another comment
+719 | fn()
     | ^^ E305
-688 | # end
+720 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-684 684 |     # comment
-685 685 | 
-686 686 |     # another comment
-    687 |+
-    688 |+
-687 689 | fn()
-688 690 | # end
-689 691 | 
+716 716 |     # comment
+717 717 | 
+718 718 |     # another comment
+    719 |+
+    720 |+
+719 721 | fn()
+720 722 | # end
+721 723 | 
 
-E30.py:698:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:730:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-697 |     # another comment
-698 | a = 1
+729 |     # another comment
+730 | a = 1
     | ^ E305
-699 | # end
+731 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-695 695 |     # comment
-696 696 | 
-697 697 |     # another comment
-    698 |+
-    699 |+
-698 700 | a = 1
-699 701 | # end
-700 702 | 
+727 727 |     # comment
+728 728 | 
+729 729 |     # another comment
+    730 |+
+    731 |+
+730 732 | a = 1
+731 733 | # end
+732 734 | 
 
-E30.py:710:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:742:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-708 |     # another comment
-709 | 
-710 | try:
+740 |     # another comment
+741 | 
+742 | try:
     | ^^^ E305
-711 |     fn()
-712 | except Exception:
+743 |     fn()
+744 | except Exception:
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-707 707 | 
-708 708 |     # another comment
-709 709 | 
-    710 |+
-710 711 | try:
-711 712 |     fn()
-712 713 | except Exception:
+739 739 | 
+740 740 |     # another comment
+741 741 | 
+    742 |+
+742 743 | try:
+743 744 |     fn()
+744 745 | except Exception:
 
-E30.py:722:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:754:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-721 | # Two spaces before comments, too.
-722 | if a():
+753 | # Two spaces before comments, too.
+754 | if a():
     | ^^ E305
-723 |     a()
-724 | # end
+755 |     a()
+756 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-719 719 |     print()
-720 720 | 
-721 721 | # Two spaces before comments, too.
-    722 |+
-    723 |+
-722 724 | if a():
-723 725 |     a()
-724 726 | # end
+751 751 |     print()
+752 752 | 
+753 753 | # Two spaces before comments, too.
+    754 |+
+    755 |+
+754 756 | if a():
+755 757 |     a()
+756 758 | # end
 
-E30.py:735:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
+E30.py:767:1: E305 [*] Expected 2 blank lines after class or function definition, found (1)
     |
-733 |     blah, blah
-734 | 
-735 | if __name__ == '__main__':
+765 |     blah, blah
+766 | 
+767 | if __name__ == '__main__':
     | ^^ E305
-736 |     main()
-737 | # end
+768 |     main()
+769 | # end
     |
     = help: Add missing blank line(s)
 
 ℹ Safe fix
-732 732 | def main():
-733 733 |     blah, blah
-734 734 | 
-    735 |+
-735 736 | if __name__ == '__main__':
-736 737 |     main()
-737 738 | # end
+764 764 | def main():
+765 765 |     blah, blah
+766 766 | 
+    767 |+
+767 768 | if __name__ == '__main__':
+768 769 |     main()
+769 770 | # end
 
 

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E306_E30.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E306_E30.py.snap
@@ -1,223 +1,223 @@
 ---
 source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
 ---
-E30.py:743:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:775:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-741 | def a():
-742 |     x = 1
-743 |     def b():
+773 | def a():
+774 |     x = 1
+775 |     def b():
     |     ^^^ E306
-744 |         pass
-745 | # end
+776 |         pass
+777 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-740 740 | # E306:3:5
-741 741 | def a():
-742 742 |     x = 1
-    743 |+
-743 744 |     def b():
-744 745 |         pass
-745 746 | # end
+772 772 | # E306:3:5
+773 773 | def a():
+774 774 |     x = 1
+    775 |+
+775 776 |     def b():
+776 777 |         pass
+777 778 | # end
 
-E30.py:751:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:783:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-749 | async def a():
-750 |     x = 1
-751 |     def b():
+781 | async def a():
+782 |     x = 1
+783 |     def b():
     |     ^^^ E306
-752 |         pass
-753 | # end
+784 |         pass
+785 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-748 748 | #: E306:3:5
-749 749 | async def a():
-750 750 |     x = 1
-    751 |+
-751 752 |     def b():
-752 753 |         pass
-753 754 | # end
+780 780 | #: E306:3:5
+781 781 | async def a():
+782 782 |     x = 1
+    783 |+
+783 784 |     def b():
+784 785 |         pass
+785 786 | # end
 
-E30.py:759:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:791:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-757 | def a():
-758 |     x = 2
-759 |     def b():
+789 | def a():
+790 |     x = 2
+791 |     def b():
     |     ^^^ E306
-760 |         x = 1
-761 |         def c():
+792 |         x = 1
+793 |         def c():
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-756 756 | #: E306:3:5 E306:5:9
-757 757 | def a():
-758 758 |     x = 2
-    759 |+
-759 760 |     def b():
-760 761 |         x = 1
-761 762 |         def c():
+788 788 | #: E306:3:5 E306:5:9
+789 789 | def a():
+790 790 |     x = 2
+    791 |+
+791 792 |     def b():
+792 793 |         x = 1
+793 794 |         def c():
 
-E30.py:761:9: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:793:9: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-759 |     def b():
-760 |         x = 1
-761 |         def c():
+791 |     def b():
+792 |         x = 1
+793 |         def c():
     |         ^^^ E306
-762 |             pass
-763 | # end
+794 |             pass
+795 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-758 758 |     x = 2
-759 759 |     def b():
-760 760 |         x = 1
-    761 |+
-761 762 |         def c():
-762 763 |             pass
-763 764 | # end
+790 790 |     x = 2
+791 791 |     def b():
+792 792 |         x = 1
+    793 |+
+793 794 |         def c():
+794 795 |             pass
+795 796 | # end
 
-E30.py:769:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:801:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-767 | def a():
-768 |     x = 1
-769 |     class C:
+799 | def a():
+800 |     x = 1
+801 |     class C:
     |     ^^^^^ E306
-770 |         pass
-771 |     x = 2
+802 |         pass
+803 |     x = 2
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-766 766 | # E306:3:5 E306:6:5
-767 767 | def a():
-768 768 |     x = 1
-    769 |+
-769 770 |     class C:
-770 771 |         pass
-771 772 |     x = 2
+798 798 | # E306:3:5 E306:6:5
+799 799 | def a():
+800 800 |     x = 1
+    801 |+
+801 802 |     class C:
+802 803 |         pass
+803 804 |     x = 2
 
-E30.py:772:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:804:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-770 |         pass
-771 |     x = 2
-772 |     def b():
+802 |         pass
+803 |     x = 2
+804 |     def b():
     |     ^^^ E306
-773 |         pass
-774 | # end
+805 |         pass
+806 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-769 769 |     class C:
-770 770 |         pass
-771 771 |     x = 2
-    772 |+
-772 773 |     def b():
-773 774 |         pass
-774 775 | # end
+801 801 |     class C:
+802 802 |         pass
+803 803 |     x = 2
+    804 |+
+804 805 |     def b():
+805 806 |         pass
+806 807 | # end
 
-E30.py:781:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:813:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-779 |     def bar():
-780 |         pass
-781 |     def baz(): pass
+811 |     def bar():
+812 |         pass
+813 |     def baz(): pass
     |     ^^^ E306
-782 | # end
+814 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-778 778 | def foo():
-779 779 |     def bar():
-780 780 |         pass
-    781 |+
-781 782 |     def baz(): pass
-782 783 | # end
-783 784 | 
+810 810 | def foo():
+811 811 |     def bar():
+812 812 |         pass
+    813 |+
+813 814 |     def baz(): pass
+814 815 | # end
+815 816 | 
 
-E30.py:788:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:820:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-786 | def foo():
-787 |     def bar(): pass
-788 |     def baz():
+818 | def foo():
+819 |     def bar(): pass
+820 |     def baz():
     |     ^^^ E306
-789 |         pass
-790 | # end
+821 |         pass
+822 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-785 785 | # E306:3:5
-786 786 | def foo():
-787 787 |     def bar(): pass
-    788 |+
-788 789 |     def baz():
-789 790 |         pass
-790 791 | # end
+817 817 | # E306:3:5
+818 818 | def foo():
+819 819 |     def bar(): pass
+    820 |+
+820 821 |     def baz():
+821 822 |         pass
+822 823 | # end
 
-E30.py:796:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:828:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-794 | def a():
-795 |     x = 2
-796 |     @decorator
+826 | def a():
+827 |     x = 2
+828 |     @decorator
     |     ^ E306
-797 |     def b():
-798 |         pass
+829 |     def b():
+830 |         pass
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-793 793 | # E306
-794 794 | def a():
-795 795 |     x = 2
-    796 |+
-796 797 |     @decorator
-797 798 |     def b():
-798 799 |         pass
+825 825 | # E306
+826 826 | def a():
+827 827 |     x = 2
+    828 |+
+828 829 |     @decorator
+829 830 |     def b():
+830 831 |         pass
 
-E30.py:805:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:837:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-803 | def a():
-804 |     x = 2
-805 |     @decorator
+835 | def a():
+836 |     x = 2
+837 |     @decorator
     |     ^ E306
-806 |     async def b():
-807 |         pass
+838 |     async def b():
+839 |         pass
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-802 802 | # E306
-803 803 | def a():
-804 804 |     x = 2
-    805 |+
-805 806 |     @decorator
-806 807 |     async def b():
-807 808 |         pass
+834 834 | # E306
+835 835 | def a():
+836 836 |     x = 2
+    837 |+
+837 838 |     @decorator
+838 839 |     async def b():
+839 840 |         pass
 
-E30.py:814:5: E306 [*] Expected 1 blank line before a nested definition, found 0
+E30.py:846:5: E306 [*] Expected 1 blank line before a nested definition, found 0
     |
-812 | def a():
-813 |     x = 2
-814 |     async def b():
+844 | def a():
+845 |     x = 2
+846 |     async def b():
     |     ^^^^^ E306
-815 |         pass
-816 | # end
+847 |         pass
+848 | # end
     |
     = help: Add missing blank line
 
 ℹ Safe fix
-811 811 | # E306
-812 812 | def a():
-813 813 |     x = 2
-    814 |+
-814 815 |     async def b():
-815 816 |         pass
-816 817 | # end
+843 843 | # E306
+844 844 | def a():
+845 845 |     x = 2
+    846 |+
+846 847 |     async def b():
+847 848 |         pass
+848 849 | # end
 
 


### PR DESCRIPTION
## Summary

The #9906 issue is triggered by blank lines with trailing white spaces. The trailing spaces cause the  `assert_eq!` that was added in [this discussion](
https://github.com/astral-sh/ruff/pull/9266#discussion_r1452383949) to fail.

This PR removes the  `assert_eq!`.

## Test Plan

I tested the change on the python files provided in #9906 (on top of cargo test).
I also added a few fixtures with blank lines with trailing white spaces.

## Issue example/explaination
The issue is triggered by blank lines with trailing white spaces. 
For example, by creating a blank file with `echo "\n     \n" >> temp.py`, we get the snippet given in the issue:

```

     
```
Running ruff on this, we get the following tokens:
```
(NonLogicalNewline, 0..1)
(NonLogicalNewline, 6..7)
(NonLogicalNewline, 7..8)
```

We can see that the end of the first token range's end and the second token range's start do not match because of the 5 spaces.