### PR TITLE
Docstring formatting: Preserve tab indentation when using `indent-style=tabs`

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/.editorconfig
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/.editorconfig
@@ -5,3 +5,7 @@ ij_formatter_enabled = false
 ["range_formatting/*.py"]
 generated_code = true
 ij_formatter_enabled = false
+
+[docstring_tab_indentation.py]
+generated_code = true
+ij_formatter_enabled = false

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_tab_indentation.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_tab_indentation.options.json
@@ -1,0 +1,10 @@
+[
+  {
+    "indent_style": "tab",
+    "indent_width": 4
+  },
+  {
+    "indent_style": "tab",
+    "indent_width": 8
+  }
+]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_tab_indentation.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_tab_indentation.py
@@ -1,0 +1,67 @@
+# Tests the behavior of the formatter when it comes to tabs inside docstrings
+# when using `indent_style="tab`
+
+# The example below uses tabs exclusively. The formatter should preserve the tab indentation
+# of `arg1`.
+def tab_argument(arg1: str) -> None:
+	"""
+	Arguments:
+		arg1: super duper arg with 2 tabs in front
+	"""
+
+# The `arg1` is intended with spaces. The formatter should not change the spaces to a tab
+# because it must assume that the spaces are used for alignment and not indentation.
+def space_argument(arg1: str) -> None:
+	"""
+	Arguments:
+	        arg1: super duper arg with a tab and a space in front
+	"""
+
+def under_indented(arg1: str) -> None:
+	"""
+	Arguments:
+	        arg1: super duper arg with a tab and a space in front
+arg2: Not properly indented
+	"""
+
+def under_indented_tabs(arg1: str) -> None:
+	"""
+	Arguments:
+		arg1: super duper arg with a tab and a space in front
+arg2: Not properly indented
+	"""
+
+
+# The docstring itself is indented with spaces but the argument is indented by a tab.
+# Keep the tab indentation of the argument, convert th docstring indent to tabs.
+def space_indented_docstring_containing_tabs(arg1: str) -> None:
+    """
+    Arguments:
+    	arg1: super duper arg
+    """
+
+
+# The docstring uses tabs, spaces, tabs indentation.
+# Fallback to use space indentation
+def mixed_indentation(arg1: str) -> None:
+	"""
+	Arguments:
+	        	arg1: super duper arg with a tab and a space in front
+	"""
+
+
+# The example shows an ascii art. The formatter should not change the spaces
+# to tabs because it breaks the ASCII art when inspecting the docstring with `inspect.cleandoc(ascii_art.__doc__)`
+# when using an indent width other than 8.
+def ascii_art():
+	r"""
+	Look at this beautiful tree.
+
+	    a
+	   / \
+	  b   c
+	 / \
+	d   e
+	"""
+
+

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_tab_indentation.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_tab_indentation.py
@@ -31,6 +31,11 @@ def under_indented_tabs(arg1: str) -> None:
 arg2: Not properly indented
 	"""
 
+def spaces_tabs_over_indent(arg1: str) -> None:
+    """
+    Arguments:
+      	arg1: super duper arg with a tab and a space in front
+    """
 
 # The docstring itself is indented with spaces but the argument is indented by a tab.
 # Keep the tab indentation of the argument, convert th docstring indent to tabs.

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_tab_indentation.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_tab_indentation.py.snap
@@ -37,6 +37,11 @@ def under_indented_tabs(arg1: str) -> None:
 arg2: Not properly indented
 	"""
 
+def spaces_tabs_over_indent(arg1: str) -> None:
+    """
+    Arguments:
+      	arg1: super duper arg with a tab and a space in front
+    """
 
 # The docstring itself is indented with spaces but the argument is indented by a tab.
 # Keep the tab indentation of the argument, convert th docstring indent to tabs.
@@ -127,6 +132,13 @@ def under_indented_tabs(arg1: str) -> None:
 	"""
 
 
+def spaces_tabs_over_indent(arg1: str) -> None:
+	"""
+	Arguments:
+	    arg1: super duper arg with a tab and a space in front
+	"""
+
+
 # The docstring itself is indented with spaces but the argument is indented by a tab.
 # Keep the tab indentation of the argument, convert th docstring indent to tabs.
 def space_indented_docstring_containing_tabs(arg1: str) -> None:
@@ -211,6 +223,13 @@ def under_indented_tabs(arg1: str) -> None:
 		Arguments:
 			arg1: super duper arg with a tab and a space in front
 	arg2: Not properly indented
+	"""
+
+
+def spaces_tabs_over_indent(arg1: str) -> None:
+	"""
+	Arguments:
+	    arg1: super duper arg with a tab and a space in front
 	"""
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring_tab_indentation.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring_tab_indentation.py.snap
@@ -1,0 +1,251 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring_tab_indentation.py
+---
+## Input
+```python
+# Tests the behavior of the formatter when it comes to tabs inside docstrings
+# when using `indent_style="tab`
+
+# The example below uses tabs exclusively. The formatter should preserve the tab indentation
+# of `arg1`.
+def tab_argument(arg1: str) -> None:
+	"""
+	Arguments:
+		arg1: super duper arg with 2 tabs in front
+	"""
+
+# The `arg1` is intended with spaces. The formatter should not change the spaces to a tab
+# because it must assume that the spaces are used for alignment and not indentation.
+def space_argument(arg1: str) -> None:
+	"""
+	Arguments:
+	        arg1: super duper arg with a tab and a space in front
+	"""
+
+def under_indented(arg1: str) -> None:
+	"""
+	Arguments:
+	        arg1: super duper arg with a tab and a space in front
+arg2: Not properly indented
+	"""
+
+def under_indented_tabs(arg1: str) -> None:
+	"""
+	Arguments:
+		arg1: super duper arg with a tab and a space in front
+arg2: Not properly indented
+	"""
+
+
+# The docstring itself is indented with spaces but the argument is indented by a tab.
+# Keep the tab indentation of the argument, convert th docstring indent to tabs.
+def space_indented_docstring_containing_tabs(arg1: str) -> None:
+    """
+    Arguments:
+    	arg1: super duper arg
+    """
+
+
+# The docstring uses tabs, spaces, tabs indentation.
+# Fallback to use space indentation
+def mixed_indentation(arg1: str) -> None:
+	"""
+	Arguments:
+	        	arg1: super duper arg with a tab and a space in front
+	"""
+
+
+# The example shows an ascii art. The formatter should not change the spaces
+# to tabs because it breaks the ASCII art when inspecting the docstring with `inspect.cleandoc(ascii_art.__doc__)`
+# when using an indent width other than 8.
+def ascii_art():
+	r"""
+	Look at this beautiful tree.
+
+	    a
+	   / \
+	  b   c
+	 / \
+	d   e
+	"""
+
+
+```
+
+## Outputs
+### Output 1
+```
+indent-style               = tab
+line-width                 = 88
+indent-width               = 4
+quote-style                = Double
+line-ending                = LineFeed
+magic-trailing-comma       = Respect
+docstring-code             = Disabled
+docstring-code-line-width  = "dynamic"
+preview                    = Disabled
+target_version             = Py38
+source_type                = Python
+```
+
+```python
+# Tests the behavior of the formatter when it comes to tabs inside docstrings
+# when using `indent_style="tab`
+
+# The example below uses tabs exclusively. The formatter should preserve the tab indentation
+# of `arg1`.
+def tab_argument(arg1: str) -> None:
+	"""
+	Arguments:
+		arg1: super duper arg with 2 tabs in front
+	"""
+
+
+# The `arg1` is intended with spaces. The formatter should not change the spaces to a tab
+# because it must assume that the spaces are used for alignment and not indentation.
+def space_argument(arg1: str) -> None:
+	"""
+	Arguments:
+	        arg1: super duper arg with a tab and a space in front
+	"""
+
+
+def under_indented(arg1: str) -> None:
+	"""
+		Arguments:
+		        arg1: super duper arg with a tab and a space in front
+	arg2: Not properly indented
+	"""
+
+
+def under_indented_tabs(arg1: str) -> None:
+	"""
+		Arguments:
+			arg1: super duper arg with a tab and a space in front
+	arg2: Not properly indented
+	"""
+
+
+# The docstring itself is indented with spaces but the argument is indented by a tab.
+# Keep the tab indentation of the argument, convert th docstring indent to tabs.
+def space_indented_docstring_containing_tabs(arg1: str) -> None:
+	"""
+	Arguments:
+		arg1: super duper arg
+	"""
+
+
+# The docstring uses tabs, spaces, tabs indentation.
+# Fallback to use space indentation
+def mixed_indentation(arg1: str) -> None:
+	"""
+	Arguments:
+	                arg1: super duper arg with a tab and a space in front
+	"""
+
+
+# The example shows an ascii art. The formatter should not change the spaces
+# to tabs because it breaks the ASCII art when inspecting the docstring with `inspect.cleandoc(ascii_art.__doc__)`
+# when using an indent width other than 8.
+def ascii_art():
+	r"""
+	Look at this beautiful tree.
+
+	    a
+	   / \
+	  b   c
+	 / \
+	d   e
+	"""
+```
+
+
+### Output 2
+```
+indent-style               = tab
+line-width                 = 88
+indent-width               = 8
+quote-style                = Double
+line-ending                = LineFeed
+magic-trailing-comma       = Respect
+docstring-code             = Disabled
+docstring-code-line-width  = "dynamic"
+preview                    = Disabled
+target_version             = Py38
+source_type                = Python
+```
+
+```python
+# Tests the behavior of the formatter when it comes to tabs inside docstrings
+# when using `indent_style="tab`
+
+# The example below uses tabs exclusively. The formatter should preserve the tab indentation
+# of `arg1`.
+def tab_argument(arg1: str) -> None:
+	"""
+	Arguments:
+		arg1: super duper arg with 2 tabs in front
+	"""
+
+
+# The `arg1` is intended with spaces. The formatter should not change the spaces to a tab
+# because it must assume that the spaces are used for alignment and not indentation.
+def space_argument(arg1: str) -> None:
+	"""
+	Arguments:
+	        arg1: super duper arg with a tab and a space in front
+	"""
+
+
+def under_indented(arg1: str) -> None:
+	"""
+		Arguments:
+		        arg1: super duper arg with a tab and a space in front
+	arg2: Not properly indented
+	"""
+
+
+def under_indented_tabs(arg1: str) -> None:
+	"""
+		Arguments:
+			arg1: super duper arg with a tab and a space in front
+	arg2: Not properly indented
+	"""
+
+
+# The docstring itself is indented with spaces but the argument is indented by a tab.
+# Keep the tab indentation of the argument, convert th docstring indent to tabs.
+def space_indented_docstring_containing_tabs(arg1: str) -> None:
+	"""
+	Arguments:
+		arg1: super duper arg
+	"""
+
+
+# The docstring uses tabs, spaces, tabs indentation.
+# Fallback to use space indentation
+def mixed_indentation(arg1: str) -> None:
+	"""
+	Arguments:
+	                arg1: super duper arg with a tab and a space in front
+	"""
+
+
+# The example shows an ascii art. The formatter should not change the spaces
+# to tabs because it breaks the ASCII art when inspecting the docstring with `inspect.cleandoc(ascii_art.__doc__)`
+# when using an indent width other than 8.
+def ascii_art():
+	r"""
+	Look at this beautiful tree.
+
+	    a
+	   / \
+	  b   c
+	 / \
+	d   e
+	"""
+```
+
+
+


### PR DESCRIPTION
## Summary

This PR ensures that the formatter preserves `tab`s inside of docstring when using `indent-style=tab`. 

Today, the formatter converts all docstring-indent to spaces, regardless of the configured indent-style.
This is unexpected for users and creates with `E101` (`mixed-spaces-and-tabs`). For example:

```python
def tab_argument(arg1: str) -> None:
	"""
	Arguments:
		arg1: super duper arg with 2 tabs in front
	"""
```

Gets reformatted to 

```python
def tab_argument(arg1: str) -> None:
	"""
	Arguments:
	        arg1: super duper arg with 2 tabs in front
	"""
```

Even though the user expliclty wants tab indentations. 

The formatter won't automatically convert multiples of `indent-width` spaces to tabs because it can break 
ASCII arts (and other formatting that use spaces for alignmen). 

The downside of this change is tha the formatter won't enforce a consistent indentation inside of docstrings when using `indent-style=tab`.

Fixes https://github.com/astral-sh/ruff/issues/8430


This PR does not yet address that our formatter always expands `tab` to 8 spaces (instead of the configured `indent-width`)

It's not necessary to gate this change behind preview because it doesn't change already formatted code.

## Test Plan

added tests, `cargo test`
