### PR TITLE
Migrate to `nextest`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: "Run tests"
         shell: bash
-        run: cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 8
+        run: cargo nextest run --workspace --status-level skip --failure-output immediate-final --no-fail-fast -j 12
       # Check for broken links in the documentation.
       - run: cargo doc --all --no-deps
         env:
@@ -148,7 +148,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: "Run tests"
         shell: bash
-        run: cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 8
+        run: cargo nextest run --workspace --status-level skip --failure-output immediate-final --no-fail-fast -j 12
 
   cargo-test-wasm:
     name: "cargo test (wasm)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,13 +111,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Install Rust toolchain"
         run: rustup show
-      - name: "Install cargo insta"
+      - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-insta
+          tool: cargo-nextest
       - uses: Swatinem/rust-cache@v2
       - name: "Run tests"
-        run: cargo insta test --all --all-features --unreferenced reject
+        shell: bash
+        run: cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 12
       # Check for broken links in the documentation.
       - run: cargo doc --all --no-deps
         env:
@@ -138,15 +139,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Install Rust toolchain"
         run: rustup show
-      - name: "Install cargo insta"
+      - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-insta
+          tool: cargo-nextest
       - uses: Swatinem/rust-cache@v2
       - name: "Run tests"
         shell: bash
-        # We can't reject unreferenced snapshots on windows because flake8_executable can't run on windows
-        run: cargo insta test --all --exclude ruff_dev --all-features
+        run: cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 12
 
   cargo-test-wasm:
     name: "cargo test (wasm)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: "Run tests"
         shell: bash
-        run: cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 12
+        run: cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 4
       # Check for broken links in the documentation.
       - run: cargo doc --all --no-deps
         env:
@@ -148,7 +148,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: "Run tests"
         shell: bash
-        run: cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 12
+        run: cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 4
 
   cargo-test-wasm:
     name: "cargo test (wasm)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: "Run tests"
         shell: bash
-        run: cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 4
+        run: cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 8
       # Check for broken links in the documentation.
       - run: cargo doc --all --no-deps
         env:
@@ -148,7 +148,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: "Run tests"
         shell: bash
-        run: cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 4
+        run: cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 8
 
   cargo-test-wasm:
     name: "cargo test (wasm)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Install Rust toolchain"
         run: rustup show
+      - name: "Install mold"
+        uses: rui314/setup-mold@v1
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ You'll also need [Insta](https://insta.rs/docs/) to update snapshot tests:
 cargo install cargo-insta
 ```
 
-and pre-commit to run some validation checks:
+And you'll need pre-commit to run some validation checks:
 
 ```shell
 pipx install pre-commit  # or `pip install pre-commit` if you have a virtualenv
@@ -75,6 +75,16 @@ when making a commit:
 ```shell
 pre-commit install
 ```
+
+We recommend [nextest](https://nexte.st/) to run Ruff's test suite (via `cargo nextest run`),
+though it's not strictly necessary:
+
+```shell
+cargo install nextest
+```
+
+Throughout this guide, any usages of `cargo test` can be replaced with `cargo nextest run`,
+if you choose to install `nextest`.
 
 ### Development
 


### PR DESCRIPTION
## Summary

We've had success with `nextest` in other projects, so lets migrate Ruff.

The Linux tests look a little bit faster (from 2m32s down to 2m8s), the Windows tests look a little bit slower but not dramatically so.