### PR TITLE
Merge maps when combining options

### DIFF
--- a/crates/ruff_macros/src/combine_options.rs
+++ b/crates/ruff_macros/src/combine_options.rs
@@ -48,13 +48,53 @@ fn handle_field(field: &Field) -> syn::Result<proc_macro2::TokenStream> {
             ..
         }) => match segments.first() {
             Some(PathSegment {
-                ident: type_ident, ..
-            }) if type_ident == "Option" => Ok(quote_spanned!(
-                ident.span() => #ident: self.#ident.or(other.#ident)
-            )),
+                ident: type_ident,
+                arguments,
+            }) if type_ident == "Option" => {
+                // Given `Option<FxHashMap<_>>`, combine the maps by merging. In TOML, a hash map is
+                // represented as a table, so merging the maps is the correct behavior.
+                if let syn::PathArguments::AngleBracketed(args) = arguments {
+                    let inner_type_ident = args
+                        .args
+                        .first()
+                        .and_then(|arg| match arg {
+                            syn::GenericArgument::Type(Type::Path(TypePath {
+                                path: Path { segments, .. },
+                                ..
+                            })) => segments.first().map(|seg| &seg.ident),
+                            _ => None,
+                        })
+                        .ok_or_else(|| {
+                            syn::Error::new(
+                                ident.span(),
+                                "Expected `Option<_>` with a single type argument.",
+                            )
+                        })?;
+                    if inner_type_ident == "HashMap"
+                        || inner_type_ident == "BTreeMap"
+                        || inner_type_ident == "FxHashMap"
+                    {
+                        return Ok(quote_spanned!(
+                            ident.span() => #ident: match (self.#ident, other.#ident) {
+                                (Some(mut m1), Some(m2)) => {
+                                    m1.extend(m2);
+                                    Some(m1)
+                                },
+                                (None, Some(m)) | (Some(m), None) => Some(m),
+                                (None, None) => None,
+                            }
+                        ));
+                    }
+                }
+
+                Ok(quote_spanned!(
+                    ident.span() => #ident: self.#ident.or(other.#ident)
+                ))
+            }
+
             _ => Err(syn::Error::new(
                 ident.span(),
-                "Expected `Option<_>` or `Vec<_>` as type.",
+                "Expected `Option<_>` as type.",
             )),
         },
         _ => Err(syn::Error::new(ident.span(), "Expected type.")),

--- a/crates/ruff_macros/src/combine_options.rs
+++ b/crates/ruff_macros/src/combine_options.rs
@@ -1,5 +1,5 @@
 use quote::{quote, quote_spanned};
-use syn::{Data, DataStruct, DeriveInput, Field, Fields, Path, PathSegment, Type, TypePath};
+use syn::{Data, DataStruct, DeriveInput, Fields};
 
 pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let DeriveInput { ident, data, .. } = input;
@@ -9,15 +9,24 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
             fields: Fields::Named(fields),
             ..
         }) => {
-            let output = fields
+            let output: Vec<_> = fields
                 .named
                 .iter()
-                .map(handle_field)
-                .collect::<Result<Vec<_>, _>>()?;
+                .map(|field| {
+                    let ident = field
+                        .ident
+                        .as_ref()
+                        .expect("Expected to handle named fields");
+
+                    quote_spanned!(
+                        ident.span() => #ident: crate::configuration::CombineOptions::combine(self.#ident, other.#ident)
+                    )
+                })
+                .collect();
 
             Ok(quote! {
                 #[automatically_derived]
-                impl crate::configuration::CombinePluginOptions for #ident {
+                impl crate::configuration::CombineOptions for #ident {
                     fn combine(self, other: Self) -> Self {
                         #[allow(deprecated)]
                         Self {
@@ -33,70 +42,5 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
             ident.span(),
             "Can only derive CombineOptions from structs with named fields.",
         )),
-    }
-}
-
-fn handle_field(field: &Field) -> syn::Result<proc_macro2::TokenStream> {
-    let ident = field
-        .ident
-        .as_ref()
-        .expect("Expected to handle named fields");
-
-    match &field.ty {
-        Type::Path(TypePath {
-            path: Path { segments, .. },
-            ..
-        }) => match segments.first() {
-            Some(PathSegment {
-                ident: type_ident,
-                arguments,
-            }) if type_ident == "Option" => {
-                // Given `Option<FxHashMap<_>>`, combine the maps by merging. In TOML, a hash map is
-                // represented as a table, so merging the maps is the correct behavior.
-                if let syn::PathArguments::AngleBracketed(args) = arguments {
-                    let inner_type_ident = args
-                        .args
-                        .first()
-                        .and_then(|arg| match arg {
-                            syn::GenericArgument::Type(Type::Path(TypePath {
-                                path: Path { segments, .. },
-                                ..
-                            })) => segments.first().map(|seg| &seg.ident),
-                            _ => None,
-                        })
-                        .ok_or_else(|| {
-                            syn::Error::new(
-                                ident.span(),
-                                "Expected `Option<_>` with a single type argument.",
-                            )
-                        })?;
-                    if inner_type_ident == "HashMap"
-                        || inner_type_ident == "BTreeMap"
-                        || inner_type_ident == "FxHashMap"
-                    {
-                        return Ok(quote_spanned!(
-                            ident.span() => #ident: match (self.#ident, other.#ident) {
-                                (Some(mut m1), Some(m2)) => {
-                                    m1.extend(m2);
-                                    Some(m1)
-                                },
-                                (None, Some(m)) | (Some(m), None) => Some(m),
-                                (None, None) => None,
-                            }
-                        ));
-                    }
-                }
-
-                Ok(quote_spanned!(
-                    ident.span() => #ident: self.#ident.or(other.#ident)
-                ))
-            }
-
-            _ => Err(syn::Error::new(
-                ident.span(),
-                "Expected `Option<_>` as type.",
-            )),
-        },
-        _ => Err(syn::Error::new(ident.span(), "Expected type.")),
     }
 }

--- a/crates/ruff_macros/src/lib.rs
+++ b/crates/ruff_macros/src/lib.rs
@@ -24,6 +24,10 @@ pub fn derive_options_metadata(input: TokenStream) -> TokenStream {
         .into()
 }
 
+/// Automatically derives a `ruff_workspace::configuration::CombineOptions` implementation for the attributed type
+/// that calls `ruff_workspace::configuration::CombineOptions::combine` for each field.
+///
+/// The derive macro can only be used on structs with named fields.
 #[proc_macro_derive(CombineOptions)]
 pub fn derive_combine_options(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);


### PR DESCRIPTION
## Summary

If a user provides a value via a sub-table in a configuration file, we should combine that table when extending, rather than overwriting it.

Closes https://github.com/astral-sh/ruff/issues/9872.

## Test Plan

Creating a directory following the structure in #9872. Verified that `--show-settings` showed the custom section as a known package.
