### PR TITLE
Disable top-level docstring formatting for notebooks

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.options.json
@@ -1,0 +1,5 @@
+[
+  {
+    "source_type": "Ipynb"
+  }
+]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.options.json
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.options.json
@@ -1,5 +1,8 @@
 [
   {
     "source_type": "Ipynb"
+  },
+  {
+    "source_type": "Python"
   }
 ]

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.py
@@ -1,0 +1,4 @@
+"""
+    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
+    Ruff should leave it as is
+""";

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.py
@@ -2,3 +2,5 @@
     This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
     Ruff should leave it as is
 """;
+
+"another normal string"

--- a/crates/ruff_python_formatter/src/range.rs
+++ b/crates/ruff_python_formatter/src/range.rs
@@ -214,9 +214,9 @@ impl<'ast> PreorderVisitor<'ast> for FindEnclosingNode<'_, 'ast> {
         // Don't pick potential docstrings as the closest enclosing node because `suite.rs` than fails to identify them as
         // docstrings and docstring formatting won't kick in.
         // Format the enclosing node instead and slice the formatted docstring from the result.
-        let is_maybe_docstring = node
-            .as_stmt_expr()
-            .is_some_and(|stmt| DocstringStmt::is_docstring_statement(stmt));
+        let is_maybe_docstring = node.as_stmt_expr().is_some_and(|stmt| {
+            DocstringStmt::is_docstring_statement(stmt, self.context.options().source_type())
+        });
 
         if is_maybe_docstring {
             return TraversalSignal::Skip;

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -746,7 +746,7 @@ impl<'a> DocstringStmt<'a> {
         suite_kind: SuiteKind,
         source_type: PySourceType,
     ) -> Option<DocstringStmt<'a>> {
-        // Notebooks don't have a concept of notebooks, never recognise them as docstrings.
+        // Notebooks don't have a concept of modules, therefore, don't recognise the first string as the module docstring.
         if source_type.is_ipynb() && suite_kind == SuiteKind::TopLevel {
             return None;
         }

--- a/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.py
+---
+## Input
+```python
+"""
+    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
+    Ruff should leave it as is
+""";
+```
+
+## Outputs
+### Output 1
+```
+indent-style               = space
+line-width                 = 88
+indent-width               = 4
+quote-style                = Double
+line-ending                = LineFeed
+magic-trailing-comma       = Respect
+docstring-code             = Disabled
+docstring-code-line-width  = "dynamic"
+preview                    = Disabled
+target_version             = Py38
+source_type                = Ipynb
+```
+
+```python
+"""
+    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
+    Ruff should leave it as is
+""";
+```
+
+
+

--- a/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
@@ -8,6 +8,8 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_d
     This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
     Ruff should leave it as is
 """;
+
+"another normal string"
 ```
 
 ## Outputs
@@ -30,7 +32,48 @@ source_type                = Ipynb
 """
     This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
     Ruff should leave it as is
-""";
+"""
+"another normal string"
+```
+
+
+### Output 2
+```
+indent-style               = space
+line-width                 = 88
+indent-width               = 4
+quote-style                = Double
+line-ending                = LineFeed
+magic-trailing-comma       = Respect
+docstring-code             = Disabled
+docstring-code-line-width  = "dynamic"
+preview                    = Disabled
+target_version             = Py38
+source_type                = Python
+```
+
+```python
+"""
+    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
+    Ruff should leave it as is
+"""
+"another normal string"
+```
+
+
+#### Preview changes
+```diff
+--- Stable
++++ Preview
+@@ -1,5 +1,6 @@
+ """
+-    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
+-    Ruff should leave it as is
++This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
++Ruff should leave it as is
+ """
++
+ "another normal string"
 ```
 
 


### PR DESCRIPTION
## Summary

> one can't access the module docstring for a notebook which makes a notebook not having a module level docstring. @dhruv

This PR handles strings at the top of a cell as non-docstrings. Handling them as docstrings has the undesired result that one might have multiple "docstrings" in a single notebook,
which is probably not what you want.

We don't need to gate this behind preview because it doesn't change any formatted code.

## Test Plan

Added tests
