### PR TITLE
unused_imports/F401: Explain when imports are preserved

### DIFF
--- a/crates/ruff/tests/snapshots/integration_test__explain_status_codes_f401.snap
+++ b/crates/ruff/tests/snapshots/integration_test__explain_status_codes_f401.snap
@@ -25,6 +25,15 @@ import cycles. They also increase the cognitive load of reading the code.
 If an import statement is used to check for the availability or existence
 of a module, consider using `importlib.util.find_spec` instead.
 
+If an import statement is used to re-export a symbol as part of a module's
+public interface, consider using a "redundant" import alias, which
+instructs Ruff (and other tools) to respect the re-export, and avoid
+marking it as unused, as in:
+
+```python
+from module import member as member
+```
+
 ## Example
 ```python
 import numpy as np  # unused import
@@ -48,13 +57,6 @@ if find_spec("numpy") is not None:
     print("numpy is installed")
 else:
     print("numpy is not installed")
-```
-
-Note that Ruff respects symbols used in a module's interface. So an unused
-import can be preserved with a 'redundant import alias':
-
-```python
-from other_module import reexported_fn as reexported_fn
 ```
 
 ## Options

--- a/crates/ruff/tests/snapshots/integration_test__explain_status_codes_f401.snap
+++ b/crates/ruff/tests/snapshots/integration_test__explain_status_codes_f401.snap
@@ -50,12 +50,20 @@ else:
     print("numpy is not installed")
 ```
 
+Note that Ruff respects symbols used in a module's interface. So an unused
+import can be preserved with a 'redundant import alias':
+
+```python
+from other_module import reexported_fn as reexported_fn
+```
+
 ## Options
-- `lint.pyflakes.extend-generics`
+- `lint.ignore-init-module-imports`
 
 ## References
 - [Python documentation: `import`](https://docs.python.org/3/reference/simple_stmts.html#the-import-statement)
 - [Python documentation: `importlib.util.find_spec`](https://docs.python.org/3/library/importlib.html#importlib.util.find_spec)
+- [Typing documentation: interface conventions](https://typing.readthedocs.io/en/latest/source/libraries.html#library-interface-public-and-private-symbols)
 
 ----- stderr -----
 

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -53,12 +53,20 @@ enum UnusedImportContext {
 ///     print("numpy is not installed")
 /// ```
 ///
+/// Note that Ruff respects symbols used in a module's interface. So an unused
+/// import can be preserved with a 'redundant import alias':
+///
+/// ```python
+/// from other_module import reexported_fn as reexported_fn
+/// ```
+///
 /// ## Options
-/// - `lint.pyflakes.extend-generics`
+/// - `lint.ignore-init-module-imports`
 ///
 /// ## References
 /// - [Python documentation: `import`](https://docs.python.org/3/reference/simple_stmts.html#the-import-statement)
 /// - [Python documentation: `importlib.util.find_spec`](https://docs.python.org/3/library/importlib.html#importlib.util.find_spec)
+/// - [Typing documentation: interface conventions](https://typing.readthedocs.io/en/latest/source/libraries.html#library-interface-public-and-private-symbols)
 #[violation]
 pub struct UnusedImport {
     name: String,

--- a/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/unused_import.rs
@@ -28,6 +28,15 @@ enum UnusedImportContext {
 /// If an import statement is used to check for the availability or existence
 /// of a module, consider using `importlib.util.find_spec` instead.
 ///
+/// If an import statement is used to re-export a symbol as part of a module's
+/// public interface, consider using a "redundant" import alias, which
+/// instructs Ruff (and other tools) to respect the re-export, and avoid
+/// marking it as unused, as in:
+///
+/// ```python
+/// from module import member as member
+/// ```
+///
 /// ## Example
 /// ```python
 /// import numpy as np  # unused import
@@ -51,13 +60,6 @@ enum UnusedImportContext {
 ///     print("numpy is installed")
 /// else:
 ///     print("numpy is not installed")
-/// ```
-///
-/// Note that Ruff respects symbols used in a module's interface. So an unused
-/// import can be preserved with a 'redundant import alias':
-///
-/// ```python
-/// from other_module import reexported_fn as reexported_fn
 /// ```
 ///
 /// ## Options


### PR DESCRIPTION
The docs previously mentioned an irrelevant config option, but were missing a link to the relevant `ignore-init-module-imports` config option which _is_ actually used.

Additionally, this commit adds a link to the documentation to explain the conventions around a module interface which includes using a redundant import alias to preserve an unused import.

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

(noticed this while filing  #9962)
