### PR TITLE
Remove symbol from type-matching API

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_async/rules/open_sleep_or_subprocess_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/open_sleep_or_subprocess_call.rs
@@ -118,8 +118,7 @@ fn is_open_call_from_pathlib(func: &Expr, semantic: &SemanticModel) -> bool {
 
     let binding = semantic.binding(binding_id);
 
-    let Some(Expr::Call(call)) = analyze::typing::find_binding_value(&name.id, binding, semantic)
-    else {
+    let Some(Expr::Call(call)) = analyze::typing::find_binding_value(binding, semantic) else {
         return false;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/enumerate_for_loop.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/enumerate_for_loop.rs
@@ -76,8 +76,7 @@ pub(crate) fn enumerate_for_loop(checker: &mut Checker, for_stmt: &ast::StmtFor)
             }
 
             // Ensure that the index variable was initialized to 0.
-            let Some(value) = typing::find_binding_value(&index.id, binding, checker.semantic())
-            else {
+            let Some(value) = typing::find_binding_value(binding, checker.semantic()) else {
                 continue;
             };
             if !matches!(


### PR DESCRIPTION
## Summary

These should be no-op refactors to remove some redundant data from the type analysis APIs.