### PR TITLE
Run isort CRLF tests

### DIFF
--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -419,23 +419,20 @@ mod tests {
         Ok(())
     }
 
-    // Test currently disabled as line endings are automatically converted to
-    // platform-appropriate ones in CI/CD #[test_case(Path::new("
-    // line_ending_crlf.py"))] #[test_case(Path::new("line_ending_lf.py"))]
-    // fn source_code_style(path: &Path) -> Result<()> {
-    //     let snapshot = format!("{}", path.to_string_lossy());
-    //     let diagnostics = test_path(
-    //         Path::new("isort")
-    //             .join(path)
-    //             .as_path(),
-    //         &LinterSettings {
-    //             src: vec![test_resource_path("fixtures/isort")],
-    //             ..LinterSettings::for_rule(Rule::UnsortedImports)
-    //         },
-    //     )?;
-    //     crate::assert_messages!(snapshot, diagnostics);
-    //     Ok(())
-    // }
+    #[test_case(Path::new("line_ending_crlf.py"))]
+    #[test_case(Path::new("line_ending_lf.py"))]
+    fn source_code_style(path: &Path) -> Result<()> {
+        let snapshot = format!("{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("isort").join(path).as_path(),
+            &LinterSettings {
+                src: vec![test_resource_path("fixtures/isort")],
+                ..LinterSettings::for_rule(Rule::UnsortedImports)
+            },
+        )?;
+        crate::assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
 
     #[test_case(Path::new("separate_local_folder_imports.py"))]
     fn known_local_folder(path: &Path) -> Result<()> {

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__line_ending_crlf.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__line_ending_crlf.py.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+line_ending_crlf.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+  |
+1 | / from long_module_name import member_one, member_two, member_three, member_four, member_five
+2 | | 
+  | |_^ I001
+  |
+  = help: Organize imports
+
+ℹ Safe fix
+1   |-from long_module_name import member_one, member_two, member_three, member_four, member_five
+  1 |+from long_module_name import (
+  2 |+    member_five,
+  3 |+    member_four,
+  4 |+    member_one,
+  5 |+    member_three,
+  6 |+    member_two,
+  7 |+)
+2 8 | 
+
+

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__line_ending_lf.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__line_ending_lf.py.snap
@@ -1,0 +1,23 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+line_ending_lf.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+  |
+1 | / from long_module_name import member_one, member_two, member_three, member_four, member_five
+2 | | 
+  | |_^ I001
+  |
+  = help: Organize imports
+
+ℹ Safe fix
+1   |-from long_module_name import member_one, member_two, member_three, member_four, member_five
+  1 |+from long_module_name import (
+  2 |+    member_five,
+  3 |+    member_four,
+  4 |+    member_one,
+  5 |+    member_three,
+  6 |+    member_two,
+  7 |+)
+2 8 | 
+
+


### PR DESCRIPTION
## Summary

Re-enable the isort `crlf` and `lf` tests. They were commented out because git automatically converted their line endings on check out. This is no longer the case because the files are explicitly listed in our `.gitattributes` file. 

## Test Plan

`cargo test` and CI
