### PR TITLE
Move `RUF001`, `RUF002` to AST checker

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/string_like.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/string_like.rs
@@ -2,10 +2,16 @@ use ruff_python_ast::StringLike;
 
 use crate::checkers::ast::Checker;
 use crate::codes::Rule;
-use crate::rules::{flake8_bandit, flake8_pyi};
+use crate::rules::{flake8_bandit, flake8_pyi, ruff};
 
 /// Run lint rules over a [`StringLike`] syntax nodes.
 pub(crate) fn string_like(string_like: StringLike, checker: &mut Checker) {
+    if checker.any_enabled(&[
+        Rule::AmbiguousUnicodeCharacterString,
+        Rule::AmbiguousUnicodeCharacterDocstring,
+    ]) {
+        ruff::rules::ambiguous_unicode_character_string(checker, string_like);
+    }
     if checker.enabled(Rule::HardcodedBindAllInterfaces) {
         flake8_bandit::rules::hardcoded_bind_all_interfaces(checker, string_like);
     }

--- a/crates/ruff_linter/src/checkers/tokens.rs
+++ b/crates/ruff_linter/src/checkers/tokens.rs
@@ -67,11 +67,11 @@ pub(crate) fn check_tokens(
         .rules
         .enabled(Rule::AmbiguousUnicodeCharacterComment)
     {
-        for &(_, range) in tokens.iter().flatten().filter(|(tok, _)| tok.is_comment()) {
+        for range in indexer.comment_ranges() {
             ruff::rules::ambiguous_unicode_character_comment(
                 &mut diagnostics,
                 locator,
-                range,
+                *range,
                 settings,
             );
         }

--- a/crates/ruff_linter/src/registry.rs
+++ b/crates/ruff_linter/src/registry.rs
@@ -256,8 +256,6 @@ impl Rule {
             | Rule::MixedSpacesAndTabs
             | Rule::TrailingWhitespace => LintSource::PhysicalLines,
             Rule::AmbiguousUnicodeCharacterComment
-            | Rule::AmbiguousUnicodeCharacterDocstring
-            | Rule::AmbiguousUnicodeCharacterString
             | Rule::AvoidableEscapedQuote
             | Rule::BadQuotesDocstring
             | Rule::BadQuotesInlineString


### PR DESCRIPTION
## Summary

Part of #7595 

This PR moves the `RUF001` and `RUF002` rules to the AST checker. This removes the use of docstring detection from these rules.

## Test Plan

As this is just a refactor, make sure existing test cases pass.
