### PR TITLE
Fix SIM113 false positive with async for loops

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM113.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM113.py
@@ -193,3 +193,11 @@ def func():
         for y in range(5):
             g(x, idx)
             idx += 1
+
+async def func():
+    # OK (for loop is async)
+    idx = 0
+
+    async for x in async_gen():
+        g(x, idx)
+        idx += 1

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/enumerate_for_loop.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/enumerate_for_loop.rs
@@ -49,6 +49,11 @@ impl Violation for EnumerateForLoop {
 
 /// SIM113
 pub(crate) fn enumerate_for_loop(checker: &mut Checker, for_stmt: &ast::StmtFor) {
+    // If the loop is async, abort.
+    if for_stmt.is_async {
+        return;
+    }
+
     // If the loop contains a `continue`, abort.
     let mut visitor = LoopControlFlowVisitor::default();
     visitor.visit_body(&for_stmt.body);


### PR DESCRIPTION
## Summary
Ignore `async for` loops when checking the SIM113 rule.

Closes #9995 

## Test Plan
A new test case was added to SIM113.py with an async for loop.
