### PR TITLE
docs: Formatter compatibility warning for D207 and D300

### DIFF
--- a/crates/ruff_linter/src/rules/pydocstyle/rules/indent.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/indent.rs
@@ -87,12 +87,17 @@ impl Violation for IndentWithSpaces {
 ///     """
 /// ```
 ///
+/// ## Formatter compatibility
+/// We recommend against using this rule alongside the [formatter]. The
+/// formatter enforces consistent indentation, making the rule redundant.
+///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
 /// - [NumPy Style Guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 /// - [Google Python Style Guide - Docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
 ///
 /// [PEP 257]: https://peps.python.org/pep-0257/
+/// [formatter]: https://docs.astral.sh/ruff/formatter/
 #[violation]
 pub struct UnderIndentation;
 

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/triple_quotes.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/triple_quotes.rs
@@ -27,10 +27,16 @@ use crate::docstrings::Docstring;
 ///     """Return the pathname of the KOS root directory."""
 /// ```
 ///
+/// ## Formatter compatibility
+/// We recommend against using this rule alongside the [formatter]. The
+/// formatter enforces consistent quotes, making the rule redundant.
+///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
 /// - [NumPy Style Guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 /// - [Google Python Style Guide - Docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
+///
+/// [formatter]: https://docs.astral.sh/ruff/formatter/
 #[violation]
 pub struct TripleSingleQuotes {
     expected_quote: Quote,


### PR DESCRIPTION
- Update docs to mention formatter compatibility interactions for under-indentation (D207) and triple-single-quotes (D300)
- Changes verified locally with mkdocs
- Closes: https://github.com/astral-sh/ruff/issues/9675

