### PR TITLE
Omit repeated equality comparison for sys

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/repeated_equality_comparison.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/repeated_equality_comparison.py
@@ -52,4 +52,6 @@ foo[0] == "a" or foo[0] == "b"  # Subscripts.
 
 foo() == "a" or foo() == "b"  # Calls.
 
-sys.platform == "win32" or sys.platform == "emscripten" # sys attributes
+import sys
+
+sys.platform == "win32" or sys.platform == "emscripten"  # sys attributes

--- a/crates/ruff_linter/resources/test/fixtures/pylint/repeated_equality_comparison.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/repeated_equality_comparison.py
@@ -51,3 +51,5 @@ foo == foo or foo == bar  # Self-comparison.
 foo[0] == "a" or foo[0] == "b"  # Subscripts.
 
 foo() == "a" or foo() == "b"  # Calls.
+
+sys.platform == "win32" or sys.platform == "emscripten" # sys attributes

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
@@ -196,6 +196,14 @@ fn is_allowed_value(bool_op: BoolOp, value: &Expr) -> bool {
         return false;
     }
 
+    for comparator in comparators.iter() {
+        if let Some(expr_str) = comparator.to_str() {
+            if expr_str.starts_with("sys.platform") || expr_str.starts_with("sys.version") {
+                return false;
+            }
+        }
+    }
+
     true
 }
 


### PR DESCRIPTION
## Summary
Update PLR1714 to ignore `sys.platform` and `sys.version` checks. 
I'm not sure if these checks or if we need to add more. Please advise.

Fixes #10017

## Test Plan
Added a new test case and ran `cargo nextest run`