### PR TITLE
fix(ERA001): detect commented out `case` statements, add more one-line support

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py
+++ b/crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py
@@ -28,3 +28,6 @@ dictionary = {
 }
 
 #import os  # noqa
+
+# case 1:
+# case "foo": print()

--- a/crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py
+++ b/crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py
@@ -31,3 +31,6 @@ dictionary = {
 
 # case 1:
 # case "foo": print()
+# try: A()
+# except Exception as e: print(e)
+# finally: print("done")

--- a/crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py
+++ b/crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py
@@ -30,7 +30,3 @@ dictionary = {
 #import os  # noqa
 
 # case 1:
-# case "foo": print()
-# try: A()
-# except Exception as e: print(e)
-# finally: print("done")

--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -26,7 +26,7 @@ static HASH_NUMBER: Lazy<Regex> = Lazy::new(|| Regex::new(r"#\d").unwrap());
 static POSITIVE_CASES: Lazy<RegexSet> = Lazy::new(|| {
     RegexSet::new([
         // Keywords
-        r"^(?:elif\s+.*\s*:|else\s*:|try\s*:|finally\s*:|except\s+.*\s*:|case\s+.*\s*:)$",
+        r"^(?:elif\s+.*\s*:|else\s*:|try\s*:|finally\s*:|except\s+.*\s*:|case\s+.*\s*:.*)$",
         // Partial dictionary
         r#"^['"]\w+['"]\s*:.+[,{]\s*(#.*)?$"#,
         // Multiline assignment
@@ -157,6 +157,7 @@ mod tests {
         assert!(comment_contains_code("#except Exception:", &[]));
         assert!(comment_contains_code("# case 1:", &[]));
         assert!(comment_contains_code("#case 1:", &[]));
+        assert!(comment_contains_code("#case 1: print()", &[]));
 
         assert!(!comment_contains_code("# this is = to that :(", &[]));
         assert!(!comment_contains_code("#else", &[]));

--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -26,7 +26,7 @@ static HASH_NUMBER: Lazy<Regex> = Lazy::new(|| Regex::new(r"#\d").unwrap());
 static POSITIVE_CASES: Lazy<RegexSet> = Lazy::new(|| {
     RegexSet::new([
         // Keywords
-        r"^(?:elif\s+.*\s*:|else\s*:|try\s*:|finally\s*:|except\s+.*\s*:|case\s+.*\s*:.*)$",
+        r"^(?:elif\s+.*\s*:.*|else\s*:.*|try\s*:.*|finally\s*:.*|except.*:.*|case\s+.*\s*:.*)$",
         // Partial dictionary
         r#"^['"]\w+['"]\s*:.+[,{]\s*(#.*)?$"#,
         // Multiline assignment
@@ -148,6 +148,27 @@ mod tests {
     }
 
     #[test]
+    fn comment_contains_code_single_line() {
+        assert!(comment_contains_code("# case 1: print()", &[]));
+        assert!(comment_contains_code("# try: get(1, 2, 3)", &[]));
+        assert!(comment_contains_code("# else: print()", &[]));
+        assert!(comment_contains_code("# elif x == 10: print()", &[]));
+        assert!(comment_contains_code(
+            "# except Exception as e: print(e)",
+            &[]
+        ));
+        assert!(comment_contains_code("# except: print()", &[]));
+        assert!(comment_contains_code("# finally: close_handle()", &[]));
+
+        assert!(!comment_contains_code("# try: use cache", &[]));
+        assert!(!comment_contains_code("# else: we should return", &[]));
+        assert!(!comment_contains_code(
+            "# call function except: without cache",
+            &[]
+        ));
+    }
+
+    #[test]
     fn comment_contains_code_with_multiline() {
         assert!(comment_contains_code("#else:", &[]));
         assert!(comment_contains_code("#  else  :  ", &[]));
@@ -157,7 +178,7 @@ mod tests {
         assert!(comment_contains_code("#except Exception:", &[]));
         assert!(comment_contains_code("# case 1:", &[]));
         assert!(comment_contains_code("#case 1:", &[]));
-        assert!(comment_contains_code("#case 1: print()", &[]));
+        assert!(comment_contains_code("# try:", &[]));
 
         assert!(!comment_contains_code("# this is = to that :(", &[]));
         assert!(!comment_contains_code("#else", &[]));

--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -26,7 +26,7 @@ static HASH_NUMBER: Lazy<Regex> = Lazy::new(|| Regex::new(r"#\d").unwrap());
 static POSITIVE_CASES: Lazy<RegexSet> = Lazy::new(|| {
     RegexSet::new([
         // Keywords
-        r"^(?:elif\s+.*\s*:|else\s*:|try\s*:|finally\s*:|except.*:|case\s+.*\s*:)$",
+        r"^(?:elif\s+.*\s*:|else\s*:|try\s*:|finally\s*:|except\s+.*\s*|case\s+.*\s*:)$",
         // Partial dictionary
         r#"^['"]\w+['"]\s*:.+[,{]\s*(#.*)?$"#,
         // Multiline assignment
@@ -157,7 +157,6 @@ mod tests {
         assert!(comment_contains_code("#except Exception:", &[]));
         assert!(comment_contains_code("# case 1:", &[]));
         assert!(comment_contains_code("#case 1:", &[]));
-        assert!(comment_contains_code("# try:", &[]));
 
         assert!(!comment_contains_code("# this is = to that :(", &[]));
         assert!(!comment_contains_code("#else", &[]));

--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -26,7 +26,7 @@ static HASH_NUMBER: Lazy<Regex> = Lazy::new(|| Regex::new(r"#\d").unwrap());
 static POSITIVE_CASES: Lazy<RegexSet> = Lazy::new(|| {
     RegexSet::new([
         // Keywords
-        r"^(?:elif\s+.*\s*:.*|else\s*:.*|try\s*:.*|finally\s*:.*|except.*:.*|case\s+.*\s*:.*)$",
+        r"^(?:elif\s+.*\s*:|else\s*:|try\s*:|finally\s*:|except.*:|case\s+.*\s*:)$",
         // Partial dictionary
         r#"^['"]\w+['"]\s*:.+[,{]\s*(#.*)?$"#,
         // Multiline assignment
@@ -145,27 +145,6 @@ mod tests {
         assert!(comment_contains_code("#return x", &[]));
 
         assert!(!comment_contains_code("#to print", &[]));
-    }
-
-    #[test]
-    fn comment_contains_code_single_line() {
-        assert!(comment_contains_code("# case 1: print()", &[]));
-        assert!(comment_contains_code("# try: get(1, 2, 3)", &[]));
-        assert!(comment_contains_code("# else: print()", &[]));
-        assert!(comment_contains_code("# elif x == 10: print()", &[]));
-        assert!(comment_contains_code(
-            "# except Exception as e: print(e)",
-            &[]
-        ));
-        assert!(comment_contains_code("# except: print()", &[]));
-        assert!(comment_contains_code("# finally: close_handle()", &[]));
-
-        assert!(!comment_contains_code("# try: use cache", &[]));
-        assert!(!comment_contains_code("# else: we should return", &[]));
-        assert!(!comment_contains_code(
-            "# call function except: without cache",
-            &[]
-        ));
     }
 
     #[test]

--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -26,7 +26,7 @@ static HASH_NUMBER: Lazy<Regex> = Lazy::new(|| Regex::new(r"#\d").unwrap());
 static POSITIVE_CASES: Lazy<RegexSet> = Lazy::new(|| {
     RegexSet::new([
         // Keywords
-        r"^(?:elif\s+.*\s*:|else\s*:|try\s*:|finally\s*:|except\s+.*\s*:)$",
+        r"^(?:elif\s+.*\s*:|else\s*:|try\s*:|finally\s*:|except\s+.*\s*:|case\s+.*\s*:)$",
         // Partial dictionary
         r#"^['"]\w+['"]\s*:.+[,{]\s*(#.*)?$"#,
         // Multiline assignment
@@ -155,11 +155,14 @@ mod tests {
         assert!(comment_contains_code("#elif True:", &[]));
         assert!(comment_contains_code("#x = foo(", &[]));
         assert!(comment_contains_code("#except Exception:", &[]));
+        assert!(comment_contains_code("# case 1:", &[]));
+        assert!(comment_contains_code("#case 1:", &[]));
 
         assert!(!comment_contains_code("# this is = to that :(", &[]));
         assert!(!comment_contains_code("#else", &[]));
         assert!(!comment_contains_code("#or else:", &[]));
         assert!(!comment_contains_code("#else True:", &[]));
+        assert!(!comment_contains_code("# in that case:", &[]));
 
         // Unpacking assignments
         assert!(comment_contains_code(

--- a/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
+++ b/crates/ruff_linter/src/rules/eradicate/rules/commented_out_code.rs
@@ -47,7 +47,8 @@ fn is_standalone_comment(line: &str) -> bool {
     for char in line.chars() {
         if char == '#' {
             return true;
-        } else if !char.is_whitespace() {
+        }
+        if !char.is_whitespace() {
             return false;
         }
     }

--- a/crates/ruff_linter/src/rules/eradicate/snapshots/ruff_linter__rules__eradicate__tests__ERA001_ERA001.py.snap
+++ b/crates/ruff_linter/src/rules/eradicate/snapshots/ruff_linter__rules__eradicate__tests__ERA001_ERA001.py.snap
@@ -148,4 +148,92 @@ ERA001.py:27:5: ERA001 Found commented-out code
 29 28 | 
 30 29 | #import os  # noqa
 
+ERA001.py:32:1: ERA001 Found commented-out code
+   |
+30 | #import os  # noqa
+31 | 
+32 | # case 1:
+   | ^^^^^^^^^ ERA001
+33 | # case "foo": print()
+34 | # try: A()
+   |
+   = help: Remove commented-out code
 
+ℹ Display-only fix
+29 29 | 
+30 30 | #import os  # noqa
+31 31 | 
+32    |-# case 1:
+33 32 | # case "foo": print()
+34 33 | # try: A()
+35 34 | # except Exception as e: print(e)
+
+ERA001.py:33:1: ERA001 Found commented-out code
+   |
+32 | # case 1:
+33 | # case "foo": print()
+   | ^^^^^^^^^^^^^^^^^^^^^ ERA001
+34 | # try: A()
+35 | # except Exception as e: print(e)
+   |
+   = help: Remove commented-out code
+
+ℹ Display-only fix
+30 30 | #import os  # noqa
+31 31 | 
+32 32 | # case 1:
+33    |-# case "foo": print()
+34 33 | # try: A()
+35 34 | # except Exception as e: print(e)
+36 35 | # finally: print("done")
+
+ERA001.py:34:1: ERA001 Found commented-out code
+   |
+32 | # case 1:
+33 | # case "foo": print()
+34 | # try: A()
+   | ^^^^^^^^^^ ERA001
+35 | # except Exception as e: print(e)
+36 | # finally: print("done")
+   |
+   = help: Remove commented-out code
+
+ℹ Display-only fix
+31 31 | 
+32 32 | # case 1:
+33 33 | # case "foo": print()
+34    |-# try: A()
+35 34 | # except Exception as e: print(e)
+36 35 | # finally: print("done")
+
+ERA001.py:35:1: ERA001 Found commented-out code
+   |
+33 | # case "foo": print()
+34 | # try: A()
+35 | # except Exception as e: print(e)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ERA001
+36 | # finally: print("done")
+   |
+   = help: Remove commented-out code
+
+ℹ Display-only fix
+32 32 | # case 1:
+33 33 | # case "foo": print()
+34 34 | # try: A()
+35    |-# except Exception as e: print(e)
+36 35 | # finally: print("done")
+
+ERA001.py:36:1: ERA001 Found commented-out code
+   |
+34 | # try: A()
+35 | # except Exception as e: print(e)
+36 | # finally: print("done")
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ ERA001
+   |
+   = help: Remove commented-out code
+
+ℹ Display-only fix
+33 33 | # case "foo": print()
+34 34 | # try: A()
+35 35 | # except Exception as e: print(e)
+36    |-# finally: print("done")

--- a/crates/ruff_linter/src/rules/eradicate/snapshots/ruff_linter__rules__eradicate__tests__ERA001_ERA001.py.snap
+++ b/crates/ruff_linter/src/rules/eradicate/snapshots/ruff_linter__rules__eradicate__tests__ERA001_ERA001.py.snap
@@ -154,8 +154,6 @@ ERA001.py:32:1: ERA001 Found commented-out code
 31 | 
 32 | # case 1:
    | ^^^^^^^^^ ERA001
-33 | # case "foo": print()
-34 | # try: A()
    |
    = help: Remove commented-out code
 
@@ -164,76 +162,3 @@ ERA001.py:32:1: ERA001 Found commented-out code
 30 30 | #import os  # noqa
 31 31 | 
 32    |-# case 1:
-33 32 | # case "foo": print()
-34 33 | # try: A()
-35 34 | # except Exception as e: print(e)
-
-ERA001.py:33:1: ERA001 Found commented-out code
-   |
-32 | # case 1:
-33 | # case "foo": print()
-   | ^^^^^^^^^^^^^^^^^^^^^ ERA001
-34 | # try: A()
-35 | # except Exception as e: print(e)
-   |
-   = help: Remove commented-out code
-
-ℹ Display-only fix
-30 30 | #import os  # noqa
-31 31 | 
-32 32 | # case 1:
-33    |-# case "foo": print()
-34 33 | # try: A()
-35 34 | # except Exception as e: print(e)
-36 35 | # finally: print("done")
-
-ERA001.py:34:1: ERA001 Found commented-out code
-   |
-32 | # case 1:
-33 | # case "foo": print()
-34 | # try: A()
-   | ^^^^^^^^^^ ERA001
-35 | # except Exception as e: print(e)
-36 | # finally: print("done")
-   |
-   = help: Remove commented-out code
-
-ℹ Display-only fix
-31 31 | 
-32 32 | # case 1:
-33 33 | # case "foo": print()
-34    |-# try: A()
-35 34 | # except Exception as e: print(e)
-36 35 | # finally: print("done")
-
-ERA001.py:35:1: ERA001 Found commented-out code
-   |
-33 | # case "foo": print()
-34 | # try: A()
-35 | # except Exception as e: print(e)
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ERA001
-36 | # finally: print("done")
-   |
-   = help: Remove commented-out code
-
-ℹ Display-only fix
-32 32 | # case 1:
-33 33 | # case "foo": print()
-34 34 | # try: A()
-35    |-# except Exception as e: print(e)
-36 35 | # finally: print("done")
-
-ERA001.py:36:1: ERA001 Found commented-out code
-   |
-34 | # try: A()
-35 | # except Exception as e: print(e)
-36 | # finally: print("done")
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ ERA001
-   |
-   = help: Remove commented-out code
-
-ℹ Display-only fix
-33 33 | # case "foo": print()
-34 34 | # try: A()
-35 35 | # except Exception as e: print(e)
-36    |-# finally: print("done")


### PR DESCRIPTION
## Summary

Closes #10031 

- Detect commented out `case` statements. Playground repro: https://play.ruff.rs/5a305aa9-6e5c-4fa4-999a-8fc427ab9a23
- Add more support for one-line commented out code.

## Test Plan

Unit tested and tested with
```sh
cargo run -p ruff -- check crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py --no-cache --preview --select ERA001
```

TODO:
- [x] `cargo insta test`