### PR TITLE
Fix ecosystem

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -250,6 +250,7 @@ jobs:
         with:
           name: ruff
           branch: ${{ github.event.pull_request.base.ref }}
+          workflow: "ci.yaml"
           check_artifacts: true
 
       - name: Install ruff-ecosystem


### PR DESCRIPTION

## Summary

I don't understand why our ecosystem check suddenly started failing but the reason is that the `dawidd6/action-download-artifact` action now uses the release workflow instead of the `CI` workflow. I've honestly been too lazy to debug what happened and hardcoding the workflow works as expected.

## Test Plan

The ecosystem checks on this branch are passing
