### PR TITLE
[`pycodestyle`] Allow `os.environ` modifications between imports (`E402`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E402_2.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E402_2.py
@@ -1,0 +1,7 @@
+import os
+
+os.environ["WORLD_SIZE"] = "1"
+os.putenv("CUDA_VISIBLE_DEVICES", "4")
+del os.environ["WORLD_SIZE"]
+
+import torch

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -374,7 +374,9 @@ where
                     || helpers::is_assignment_to_a_dunder(stmt)
                     || helpers::in_nested_block(self.semantic.current_statements())
                     || imports::is_matplotlib_activation(stmt, self.semantic())
-                    || imports::is_sys_path_modification(stmt, self.semantic()))
+                    || imports::is_sys_path_modification(stmt, self.semantic())
+                    || (self.settings.preview.is_enabled()
+                        && imports::is_os_environ_modification(stmt, self.semantic())))
                 {
                     self.semantic.flags |= SemanticModelFlags::IMPORT_BOUNDARY;
                 }

--- a/crates/ruff_linter/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/mod.rs
@@ -38,6 +38,7 @@ mod tests {
     #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E40.py"))]
     #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E402_0.py"))]
     #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E402_1.py"))]
+    #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E402_2.py"))]
     #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E402.ipynb"))]
     #[test_case(Rule::MultipleImportsOnOneLine, Path::new("E40.py"))]
     #[test_case(Rule::MultipleStatementsOnOneLineColon, Path::new("E70.py"))]
@@ -69,6 +70,7 @@ mod tests {
 
     #[test_case(Rule::IsLiteral, Path::new("constant_literals.py"))]
     #[test_case(Rule::TypeComparison, Path::new("E721.py"))]
+    #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E402_2.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(
             "preview__{}_{}",

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/module_import_not_at_top_of_file.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/module_import_not_at_top_of_file.rs
@@ -17,6 +17,9 @@ use crate::checkers::ast::Checker;
 /// `sys.path.insert`, `sys.path.append`, and similar modifications between import
 /// statements.
 ///
+/// In [preview], this rule also allows `os.environ` modifications between import
+/// statements.
+///
 /// ## Example
 /// ```python
 /// "One string"
@@ -37,6 +40,7 @@ use crate::checkers::ast::Checker;
 /// ```
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#imports
+/// [preview]: https://docs.astral.sh/ruff/preview/
 #[violation]
 pub struct ModuleImportNotAtTopOfFile {
     source_type: PySourceType,

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E402_E402_2.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E402_E402_2.py.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+E402_2.py:7:1: E402 Module level import not at top of file
+  |
+5 | del os.environ["WORLD_SIZE"]
+6 | 
+7 | import torch
+  | ^^^^^^^^^^^^ E402
+  |
+
+

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__E402_E402_2.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__preview__E402_E402_2.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+


### PR DESCRIPTION
## Summary

Allows, e.g.:

```python
import os

os.environ["WORLD_SIZE"] = "1"
os.putenv("CUDA_VISIBLE_DEVICES", "4")

import torch
```

For now, this is only allowed in preview.

Closes https://github.com/astral-sh/ruff/issues/10059
