### PR TITLE
Added Image Augmentation library Albumentations (13k stars) to Readme to "Who is using Ruff" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ Ruff is released under the MIT license.
 
 Ruff is used by a number of major open-source projects and companies, including:
 
+- [Albumentations](https://github.com/albumentations-team/albumentations)
 - Amazon ([AWS SAM](https://github.com/aws/serverless-application-model))
 - Anthropic ([Python SDK](https://github.com/anthropics/anthropic-sdk-python))
 - [Apache Airflow](https://github.com/apache/airflow)


### PR DESCRIPTION
At [Albumentations](https://github.com/albumentations-team/albumentations) we used latest versions of isort, flake8 and pyupgrade, but after adding ruff, we encountered hundreds of issues that we needed to address.

Ruff is an extremely powerful linter and formatter.
