### PR TITLE
Set PowerPC Page Size to 64KB

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -251,8 +251,12 @@ jobs:
             arch: s390x
           - target: powerpc64le-unknown-linux-gnu
             arch: ppc64le
+            # see https://github.com/astral-sh/ruff/issues/10073
+            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: powerpc64-unknown-linux-gnu
             arch: ppc64
+            # see https://github.com/astral-sh/ruff/issues/10073
+            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/10073

We had a similar issue with aarch64 and the fix was to increase the page size to 64KB: https://github.com/astral-sh/ruff/issues/3791#issuecomment-1488100121

> The issue seems to be that jemalloc is compiled with fixed page sizes and using a larger page size than what it is compiled for segfaults. But jemalloc supports running on systems with smaller page sizes then configured at compile time. 
  Sources: [[1](https://github.com/jemalloc/jemalloc/issues/467), [2](https://gitlab.com/gitlab-org/omnibus-gitlab/-/merge_requests/4800)]


This PR does the same for PowerPC because widely used PowerPC systems use a default page size of 64KB [source](https://www.talospace.com/2020/10/where-did-64k-page-size-come-from.html)


## Test Plan
@nwf tested the built binary on their power pc

