### PR TITLE
Remove `build` from the default exclusion list

### DIFF
--- a/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/snapshots/show_settings__display_default_settings.snap
@@ -44,7 +44,6 @@ file_resolver.exclude = [
 	"__pypackages__",
 	"_build",
 	"buck-out",
-	"build",
 	"dist",
 	"node_modules",
 	"site-packages",
@@ -366,4 +365,3 @@ formatter.docstring_code_format = disabled
 formatter.docstring_code_line_width = dynamic
 
 ----- stderr -----
-

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -177,7 +177,7 @@ pub struct Options {
     /// Note that you'll typically want to use
     /// [`extend-exclude`](#extend-exclude) to modify the excluded paths.
     #[option(
-        default = r#"[".bzr", ".direnv", ".eggs", ".git", ".git-rewrite", ".hg", ".mypy_cache", ".nox", ".pants.d", ".pytype", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "buck-out", "build", "dist", "node_modules", "venv"]"#,
+        default = r#"[".bzr", ".direnv", ".eggs", ".git", ".git-rewrite", ".hg", ".mypy_cache", ".nox", ".pants.d", ".pytype", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "buck-out", "dist", "node_modules", "venv"]"#,
         value_type = "list[str]",
         example = r#"
             exclude = [".venv"]

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -128,7 +128,6 @@ pub(crate) static EXCLUDE: &[FilePattern] = &[
     FilePattern::Builtin("__pypackages__"),
     FilePattern::Builtin("_build"),
     FilePattern::Builtin("buck-out"),
-    FilePattern::Builtin("build"),
     FilePattern::Builtin("dist"),
     FilePattern::Builtin("node_modules"),
     FilePattern::Builtin("site-packages"),


### PR DESCRIPTION
## Summary

This is a not-unpopular directory name, and it's led to tons of issues and user confusion (most recently: https://github.com/astral-sh/ruff-pre-commit/issues/69). I've wanted to remove it for a long time, but we need to do so as part of a minor release.