### PR TITLE
[`pycodestyle`]: Make blank lines in typing stub files optional (`E3*`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30.pyi
@@ -1,0 +1,50 @@
+import json
+
+from typing import Any, Sequence
+
+class MissingCommand(TypeError): ...
+class AnoherClass: ...
+
+def a(): ...
+
+@overload
+def a(arg: int): ...
+ 
+@overload
+def a(arg: int, name: str): ...
+
+
+def grouped1(): ...
+def grouped2(): ...
+def grouped3( ): ...
+
+
+class BackendProxy:
+    backend_module: str
+    backend_object: str | None
+    backend: Any
+    
+    def grouped1(): ...
+    def grouped2(): ...
+    def grouped3( ): ...
+    @decorated
+    
+    def with_blank_line(): ...
+    
+    
+    def ungrouped(): ...
+a = "test"
+
+def function_def():
+    pass
+b = "test"
+
+
+def outer():
+     def inner():
+         pass
+     def inner2():
+         pass
+         
+class Foo: ...
+class Bar: ... 

--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30_isort.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E30_isort.pyi
@@ -1,0 +1,62 @@
+import json
+
+
+
+from typing import Any, Sequence
+
+
+class MissingCommand(TypeError): ...  # noqa: N818
+
+
+class BackendProxy:
+    backend_module: str
+    backend_object: str | None
+    backend: Any
+
+
+if __name__ == "__main__":
+    import abcd
+
+
+    abcd.foo()
+
+def __init__(self, backend_module: str, backend_obj: str | None) -> None: ...
+
+if TYPE_CHECKING:
+    import os
+
+
+
+    from typing_extensions import TypeAlias
+
+
+    abcd.foo()
+
+def __call__(self, name: str, *args: Any, **kwargs: Any) -> Any:
+    ...
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+def __call__2(self, name: str, *args: Any, **kwargs: Any) -> Any:
+    ...
+
+
+def _exit(self) -> None: ...
+
+
+def _optional_commands(self) -> dict[str, bool]: ...
+
+
+def run(argv: Sequence[str]) -> int: ...
+
+
+def read_line(fd: int = 0) -> bytearray: ...
+
+
+def flush() -> None: ...
+
+
+from typing import Any, Sequence
+
+class MissingCommand(TypeError): ...  # noqa: N818

--- a/crates/ruff_linter/src/checkers/tokens.rs
+++ b/crates/ruff_linter/src/checkers/tokens.rs
@@ -41,7 +41,8 @@ pub(crate) fn check_tokens(
         Rule::BlankLinesAfterFunctionOrClass,
         Rule::BlankLinesBeforeNestedDefinition,
     ]) {
-        BlankLinesChecker::new(locator, stylist, settings).check_lines(tokens, &mut diagnostics);
+        BlankLinesChecker::new(locator, stylist, settings, source_type)
+            .check_lines(tokens, &mut diagnostics);
     }
 
     if settings.rules.enabled(Rule::BlanketNOQA) {

--- a/crates/ruff_linter/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/mod.rs
@@ -222,6 +222,38 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Rule::BlankLineBetweenMethods)]
+    #[test_case(Rule::BlankLinesTopLevel)]
+    #[test_case(Rule::TooManyBlankLines)]
+    #[test_case(Rule::BlankLineAfterDecorator)]
+    #[test_case(Rule::BlankLinesAfterFunctionOrClass)]
+    #[test_case(Rule::BlankLinesBeforeNestedDefinition)]
+    fn blank_lines_typing_stub(rule_code: Rule) -> Result<()> {
+        let snapshot = format!("blank_lines_{}_typing_stub", rule_code.noqa_code());
+        let diagnostics = test_path(
+            Path::new("pycodestyle").join("E30.pyi"),
+            &settings::LinterSettings::for_rule(rule_code),
+        )?;
+        assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn blank_lines_typing_stub_isort() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("pycodestyle").join("E30_isort.pyi"),
+            &settings::LinterSettings {
+                ..settings::LinterSettings::for_rules([
+                    Rule::TooManyBlankLines,
+                    Rule::BlankLinesTopLevel,
+                    Rule::UnsortedImports,
+                ])
+            },
+        )?;
+        assert_messages!(diagnostics);
+        Ok(())
+    }
+
     #[test]
     fn constant_literals() -> Result<()> {
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E301_typing_stub.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E301_typing_stub.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E302_typing_stub.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E302_typing_stub.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E303_typing_stub.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E303_typing_stub.snap
@@ -1,0 +1,73 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+E30.pyi:17:1: E303 [*] Too many blank lines (2)
+   |
+17 | def grouped1(): ...
+   | ^^^ E303
+18 | def grouped2(): ...
+19 | def grouped3( ): ...
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+13 13 | @overload
+14 14 | def a(arg: int, name: str): ...
+15 15 | 
+16    |-
+17 16 | def grouped1(): ...
+18 17 | def grouped2(): ...
+19 18 | def grouped3( ): ...
+
+E30.pyi:22:1: E303 [*] Too many blank lines (2)
+   |
+22 | class BackendProxy:
+   | ^^^^^ E303
+23 |     backend_module: str
+24 |     backend_object: str | None
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+18 18 | def grouped2(): ...
+19 19 | def grouped3( ): ...
+20 20 | 
+21    |-
+22 21 | class BackendProxy:
+23 22 |     backend_module: str
+24 23 |     backend_object: str | None
+
+E30.pyi:35:5: E303 [*] Too many blank lines (2)
+   |
+35 |     def ungrouped(): ...
+   |     ^^^ E303
+36 | a = "test"
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+31 31 |     
+32 32 |     def with_blank_line(): ...
+33 33 |     
+34    |-    
+35 34 |     def ungrouped(): ...
+36 35 | a = "test"
+37 36 | 
+
+E30.pyi:43:1: E303 [*] Too many blank lines (2)
+   |
+43 | def outer():
+   | ^^^ E303
+44 |      def inner():
+45 |          pass
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+39 39 |     pass
+40 40 | b = "test"
+41 41 | 
+42    |-
+43 42 | def outer():
+44 43 |      def inner():
+45 44 |          pass

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E304_typing_stub.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E304_typing_stub.snap
@@ -1,0 +1,20 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+E30.pyi:32:5: E304 [*] Blank lines found after function decorator (1)
+   |
+30 |     @decorated
+31 |     
+32 |     def with_blank_line(): ...
+   |     ^^^ E304
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+28 28 |     def grouped2(): ...
+29 29 |     def grouped3( ): ...
+30 30 |     @decorated
+31    |-    
+32 31 |     def with_blank_line(): ...
+33 32 |     
+34 33 |

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E305_typing_stub.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E305_typing_stub.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E306_typing_stub.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_E306_typing_stub.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_typing_stub_isort.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__blank_lines_typing_stub_isort.snap
@@ -1,0 +1,270 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+E30_isort.pyi:1:1: I001 [*] Import block is un-sorted or un-formatted
+  |
+1 | / import json
+2 | | 
+3 | | 
+4 | | 
+5 | | from typing import Any, Sequence
+6 | | 
+7 | | 
+8 | | class MissingCommand(TypeError): ...  # noqa: N818
+  | |_^ I001
+  |
+  = help: Organize imports
+
+ℹ Safe fix
+1 1 | import json
+2   |-
+3   |-
+4   |-
+5 2 | from typing import Any, Sequence
+6   |-
+7 3 | 
+8 4 | class MissingCommand(TypeError): ...  # noqa: N818
+9 5 | 
+
+E30_isort.pyi:5:1: E303 [*] Too many blank lines (3)
+  |
+5 | from typing import Any, Sequence
+  | ^^^^ E303
+  |
+  = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+1 1 | import json
+2 2 | 
+3   |-
+4   |-
+5 3 | from typing import Any, Sequence
+6 4 | 
+7 5 | 
+
+E30_isort.pyi:8:1: E303 [*] Too many blank lines (2)
+  |
+8 | class MissingCommand(TypeError): ...  # noqa: N818
+  | ^^^^^ E303
+  |
+  = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+4 4 | 
+5 5 | from typing import Any, Sequence
+6 6 | 
+7   |-
+8 7 | class MissingCommand(TypeError): ...  # noqa: N818
+9 8 | 
+10 9 | 
+
+E30_isort.pyi:11:1: E303 [*] Too many blank lines (2)
+   |
+11 | class BackendProxy:
+   | ^^^^^ E303
+12 |     backend_module: str
+13 |     backend_object: str | None
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+7  7  | 
+8  8  | class MissingCommand(TypeError): ...  # noqa: N818
+9  9  | 
+10    |-
+11 10 | class BackendProxy:
+12 11 |     backend_module: str
+13 12 |     backend_object: str | None
+
+E30_isort.pyi:17:1: E303 [*] Too many blank lines (2)
+   |
+17 | if __name__ == "__main__":
+   | ^^ E303
+18 |     import abcd
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+13 13 |     backend_object: str | None
+14 14 |     backend: Any
+15 15 | 
+16    |-
+17 16 | if __name__ == "__main__":
+18 17 |     import abcd
+19 18 | 
+
+E30_isort.pyi:21:5: E303 [*] Too many blank lines (2)
+   |
+21 |     abcd.foo()
+   |     ^^^^ E303
+22 | 
+23 | def __init__(self, backend_module: str, backend_obj: str | None) -> None: ...
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+17 17 | if __name__ == "__main__":
+18 18 |     import abcd
+19 19 | 
+20    |-
+21 20 |     abcd.foo()
+22 21 | 
+23 22 | def __init__(self, backend_module: str, backend_obj: str | None) -> None: ...
+
+E30_isort.pyi:26:1: I001 [*] Import block is un-sorted or un-formatted
+   |
+25 |   if TYPE_CHECKING:
+26 | /     import os
+27 | | 
+28 | | 
+29 | | 
+30 | |     from typing_extensions import TypeAlias
+31 | | 
+   | |_^ I001
+32 |   
+33 |       abcd.foo()
+   |
+   = help: Organize imports
+
+ℹ Safe fix
+25 25 | if TYPE_CHECKING:
+26 26 |     import os
+27 27 | 
+28    |-
+29    |-
+30 28 |     from typing_extensions import TypeAlias
+31 29 | 
+32 30 | 
+
+E30_isort.pyi:30:5: E303 [*] Too many blank lines (3)
+   |
+30 |     from typing_extensions import TypeAlias
+   |     ^^^^ E303
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+25 25 | if TYPE_CHECKING:
+26 26 |     import os
+27 27 | 
+28    |-
+29    |-
+30 28 |     from typing_extensions import TypeAlias
+31 29 | 
+32 30 | 
+
+E30_isort.pyi:33:5: E303 [*] Too many blank lines (2)
+   |
+33 |     abcd.foo()
+   |     ^^^^ E303
+34 | 
+35 | def __call__(self, name: str, *args: Any, **kwargs: Any) -> Any:
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+29 29 | 
+30 30 |     from typing_extensions import TypeAlias
+31 31 | 
+32    |-
+33 32 |     abcd.foo()
+34 33 | 
+35 34 | def __call__(self, name: str, *args: Any, **kwargs: Any) -> Any:
+
+E30_isort.pyi:45:1: E303 [*] Too many blank lines (2)
+   |
+45 | def _exit(self) -> None: ...
+   | ^^^ E303
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+41 41 | def __call__2(self, name: str, *args: Any, **kwargs: Any) -> Any:
+42 42 |     ...
+43 43 | 
+44    |-
+45 44 | def _exit(self) -> None: ...
+46 45 | 
+47 46 | 
+
+E30_isort.pyi:48:1: E303 [*] Too many blank lines (2)
+   |
+48 | def _optional_commands(self) -> dict[str, bool]: ...
+   | ^^^ E303
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+44 44 | 
+45 45 | def _exit(self) -> None: ...
+46 46 | 
+47    |-
+48 47 | def _optional_commands(self) -> dict[str, bool]: ...
+49 48 | 
+50 49 | 
+
+E30_isort.pyi:51:1: E303 [*] Too many blank lines (2)
+   |
+51 | def run(argv: Sequence[str]) -> int: ...
+   | ^^^ E303
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+47 47 | 
+48 48 | def _optional_commands(self) -> dict[str, bool]: ...
+49 49 | 
+50    |-
+51 50 | def run(argv: Sequence[str]) -> int: ...
+52 51 | 
+53 52 | 
+
+E30_isort.pyi:54:1: E303 [*] Too many blank lines (2)
+   |
+54 | def read_line(fd: int = 0) -> bytearray: ...
+   | ^^^ E303
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+50 50 | 
+51 51 | def run(argv: Sequence[str]) -> int: ...
+52 52 | 
+53    |-
+54 53 | def read_line(fd: int = 0) -> bytearray: ...
+55 54 | 
+56 55 | 
+
+E30_isort.pyi:57:1: E303 [*] Too many blank lines (2)
+   |
+57 | def flush() -> None: ...
+   | ^^^ E303
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+53 53 | 
+54 54 | def read_line(fd: int = 0) -> bytearray: ...
+55 55 | 
+56    |-
+57 56 | def flush() -> None: ...
+58 57 | 
+59 58 | 
+
+E30_isort.pyi:60:1: E303 [*] Too many blank lines (2)
+   |
+60 | from typing import Any, Sequence
+   | ^^^^ E303
+61 | 
+62 | class MissingCommand(TypeError): ...  # noqa: N818
+   |
+   = help: Remove extraneous blank line(s)
+
+ℹ Safe fix
+56 56 | 
+57 57 | def flush() -> None: ...
+58 58 | 
+59    |-
+60 59 | from typing import Any, Sequence
+61 60 | 
+62 61 | class MissingCommand(TypeError): ...  # noqa: N818


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/10039

The [recommendation for typing stub files](https://typing.readthedocs.io/en/latest/source/stubs.html#blank-lines) is to use **one** blank line to group related definitions and
otherwise omit blank lines. 

The newly added blank line rules (`E3*`) didn't account for typing stub files and enforced two empty lines at the top level and one empty line otherwise, making it impossible to group related definitions. 

This PR implements the `E3*` rules to:

* Not enforce blank lines. The use of blank lines in typing definitions is entirely up to the user. 
* Allow at most one empty line, including between top level statements. 

## Test Plan

Added unit tests (It may look odd that many snapshots are empty but the point is that the rule should no longer emit diagnostics)
