### PR TITLE
Upgrade upload/download artifact actions in CI.yaml workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,7 +133,7 @@ jobs:
         env:
           # Setting RUSTDOCFLAGS because `cargo doc --check` isn't yet implemented (https://github.com/rust-lang/cargo/issues/10025).
           RUSTDOCFLAGS: "-D warnings"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ruff
           path: target/debug/ruff
@@ -238,7 +238,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         name: Download comparison Ruff binary
         id: ruff-target
         with:
@@ -325,13 +325,13 @@ jobs:
         run: |
           echo ${{ github.event.number }} > pr-number
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload PR Number
         with:
           name: pr-number
           path: pr-number
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload Results
         with:
           name: ecosystem-result
@@ -485,7 +485,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         name: Download development ruff binary
         id: ruff-target
         with:


### PR DESCRIPTION
## Summary

This PR upgrades the upload and download artifact GitHub actions to v4 for the CI.yaml workflow. 

Upgrading the CI.yaml workflow is straightforward because all our artifacts have unique names (multiple artifact with the same name are no longer supported)

Part of https://github.com/astral-sh/ruff/issues/9527

## Test Plan

See GitHub Actions outcome
