### PR TITLE
Upgrade upload/download artifact actions in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,9 +52,9 @@ jobs:
           ruff --help
           python -m ruff --help
       - name: "Upload sdist"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-sdist
           path: dist
 
   macos-x86_64:
@@ -80,9 +80,9 @@ jobs:
           ruff --help
           python -m ruff --help
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-macos-x86_64
           path: dist
       - name: "Archive binary"
         run: |
@@ -90,9 +90,9 @@ jobs:
           tar czvf $ARCHIVE_FILE -C target/x86_64-apple-darwin/release ruff
           shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
       - name: "Upload binary"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: binaries
+          name: binaries-macos-x86_64
           path: |
             *.tar.gz
             *.sha256
@@ -119,9 +119,9 @@ jobs:
           ruff --help
           python -m ruff --help
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-aarch64-apple-darwin
           path: dist
       - name: "Archive binary"
         run: |
@@ -129,9 +129,9 @@ jobs:
           tar czvf $ARCHIVE_FILE -C target/aarch64-apple-darwin/release ruff
           shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
       - name: "Upload binary"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: binaries
+          name: binaries-aarch64-apple-darwin
           path: |
             *.tar.gz
             *.sha256
@@ -170,9 +170,9 @@ jobs:
           ruff --help
           python -m ruff --help
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.platform.target }}
           path: dist
       - name: "Archive binary"
         shell: bash
@@ -181,9 +181,9 @@ jobs:
           7z a $ARCHIVE_FILE ./target/${{ matrix.platform.target }}/release/ruff.exe
           sha256sum $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
       - name: "Upload binary"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: binaries
+          name: binaries-${{ matrix.platform.target }}
           path: |
             *.zip
             *.sha256
@@ -218,9 +218,9 @@ jobs:
           ruff --help
           python -m ruff --help
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.target }}
           path: dist
       - name: "Archive binary"
         run: |
@@ -228,9 +228,9 @@ jobs:
           tar czvf $ARCHIVE_FILE -C target/${{ matrix.target }}/release ruff
           shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
       - name: "Upload binary"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: binaries
+          name: binaries-${{ matrix.target }}
           path: |
             *.tar.gz
             *.sha256
@@ -289,9 +289,9 @@ jobs:
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             ruff --help
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.platform.target }}
           path: dist
       - name: "Archive binary"
         run: |
@@ -299,9 +299,9 @@ jobs:
           tar czvf $ARCHIVE_FILE -C target/${{ matrix.platform.target }}/release ruff
           shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
       - name: "Upload binary"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: binaries
+          name: binaries-${{ matrix.platform.target }}
           path: |
             *.tar.gz
             *.sha256
@@ -341,9 +341,9 @@ jobs:
             .venv/bin/pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             .venv/bin/ruff check --help
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.target }}
           path: dist
       - name: "Archive binary"
         run: |
@@ -351,9 +351,9 @@ jobs:
           tar czvf $ARCHIVE_FILE -C target/${{ matrix.target }}/release ruff
           shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
       - name: "Upload binary"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: binaries
+          name: binaries-${{ matrix.target }}
           path: |
             *.tar.gz
             *.sha256
@@ -398,9 +398,9 @@ jobs:
             .venv/bin/pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             .venv/bin/ruff check --help
       - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.platform.target }}
           path: dist
       - name: "Archive binary"
         run: |
@@ -408,9 +408,9 @@ jobs:
           tar czvf $ARCHIVE_FILE -C target/${{ matrix.platform.target }}/release ruff
           shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
       - name: "Upload binary"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: binaries
+          name: binaries-${{ matrix.platform.target }}
           path: |
             *.tar.gz
             *.sha256
@@ -467,10 +467,11 @@ jobs:
       # For pypi trusted publishing
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-*
           path: wheels
+          merge-multiple: true
       - name: Publish to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -510,10 +511,11 @@ jobs:
       # For GitHub release publishing
       contents: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: binaries
+          pattern: binaries-*
           path: binaries
+          merge-multiple: true
       - name: "Publish to GitHub"
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
## Summary

This PR upgrades the upload and download artifact GitHub actions to v4 for the release workflow. 

Upgrading the release workflow isn't as straightforward because it relies on the fact that the v3 action automatically merges artifacts with the same name. 

The existing release workflow merges all `wheels` and `binaries` into two artifacts and downloads these in the publish step.  There are two ways of how we can implement this with the new actions where one is safer and the other avoids storing the artifacts twice:

We can either be bold and use 

```yaml
      - uses: actions/download-artifact@v4
        with:
          pattern: binaries-*
          path: binaries
          merge-multiple: true
```

This should download all `binaries` artifacts and merge them in the `binaries` path. See [the action example](https://github.com/actions/download-artifact/tree/main?tab=readme-ov-file#download-multiple-filtered-artifacts-to-the-same-directory). 

That's what the current implementation uses, but I can't test the workflow without shipping a release... 

The safer approach (testable) is to use one additional step that merges all artifacts and reuploads them as a single archive:

```yaml
  merge-artifact:
    name: Merge Wheel and Bianaries
    runs-on: ubuntu-latest
    needs:
      - macos-universal
      - macos-x86_64
      - windows
      - linux
      - linux-cross
      - musllinux
      - musllinux-cross
    steps:
      - name: Merge Wheels
        uses: actions/upload-artifact/merge@v4
        with:
          name: wheels
          pattern: wheels-*
      - name: Merge Binaries
        uses: actions/upload-artifact/merge@v4
        with:
          name: binaries
          pattern: binaries-*
```

I verified that the step produces the same artifact as the existing workflow. However, it means we upload each artifact twice: Once as its own archive and once as a merged archive. 


I went with the first approach.... With the risk that we have to fix it during the next release.


Closes of https://github.com/astral-sh/ruff/issues/9527

## Test Plan

