### PR TITLE
docs: update actions in documentation to recent versions without deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: chartboost/ruff-action@v1
 ```
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -370,9 +370,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -404,7 +404,7 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: chartboost/ruff-action@v1
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Update documentation to match current versions of default actions. The versions documented right now produce deprecation warnings on GitHub Action runners.

For the changed actions see:
- https://github.com/actions/checkout/releases
- https://github.com/actions/setup-python/releases

## Test Plan

<!-- How was it tested? -->
n/a