### PR TITLE
COM812: Allow "single line" arguments without trailing comma

### DIFF
--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -791,14 +791,6 @@ pub(super) fn warn_incompatible_formatter_settings(resolver: &Resolver) {
         for rule in [
             // The formatter might collapse implicit string concatenation on a single line.
             Rule::SingleLineImplicitStringConcatenation,
-            // Flags missing trailing commas when all arguments are on its own line:
-            // ```python
-            // def args(
-            //     aaaaaaaa, bbbbbbbbb, cccccccccc, ddddddddd, eeeeeeee, ffffff, gggggggggggg, hhhh
-            // ):
-            //     pass
-            // ```
-            Rule::MissingTrailingComma,
         ] {
             if setting.linter.rules.enabled(rule) {
                 incompatible_rules.insert(rule);

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -783,7 +783,6 @@ if condition:
     	print('Should change quotes')
 
     ----- stderr -----
-    warning: The following rules may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
     "###);
     Ok(())
 }
@@ -912,7 +911,7 @@ def say_hy(name: str):
     1 file reformatted
 
     ----- stderr -----
-    warning: The following rules may cause conflicts when used with the formatter: `COM812`, `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
+    warning: The following rules may cause conflicts when used with the formatter: `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
     warning: The `format.indent-style="tab"` option is incompatible with `W191`, which lints against all uses of tabs. We recommend disabling these rules when using the formatter, which enforces a consistent indentation style. Alternatively, set the `format.indent-style` option to `"space"`.
     warning: The `format.indent-style="tab"` option is incompatible with `D206`, with requires space-based indentation. We recommend disabling these rules when using the formatter, which enforces a consistent indentation style. Alternatively, set the `format.indent-style` option to `"space"`.
     warning: The `flake8-quotes.inline-quotes="single"` option is incompatible with the formatter's `format.quote-style="double"`. We recommend disabling `Q000` and `Q003` when using the formatter, which enforces a consistent quote style. Alternatively, set both options to either `"single"` or `"double"`.
@@ -971,7 +970,7 @@ def say_hy(name: str):
     	print(f"Hy {name}")
 
     ----- stderr -----
-    warning: The following rules may cause conflicts when used with the formatter: `COM812`, `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
+    warning: The following rules may cause conflicts when used with the formatter: `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
     warning: The `format.indent-style="tab"` option is incompatible with `W191`, which lints against all uses of tabs. We recommend disabling these rules when using the formatter, which enforces a consistent indentation style. Alternatively, set the `format.indent-style` option to `"space"`.
     warning: The `format.indent-style="tab"` option is incompatible with `D206`, with requires space-based indentation. We recommend disabling these rules when using the formatter, which enforces a consistent indentation style. Alternatively, set the `format.indent-style` option to `"space"`.
     warning: The `flake8-quotes.inline-quotes="single"` option is incompatible with the formatter's `format.quote-style="double"`. We recommend disabling `Q000` and `Q003` when using the formatter, which enforces a consistent quote style. Alternatively, set both options to either `"single"` or `"double"`.
@@ -1069,7 +1068,7 @@ def say_hy(name: str):
     ----- stderr -----
     warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Ignoring `one-blank-line-before-class`.
     warning: `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Ignoring `multi-line-summary-second-line`.
-    warning: The following rules may cause conflicts when used with the formatter: `COM812`, `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
+    warning: The following rules may cause conflicts when used with the formatter: `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
     "###);
     Ok(())
 }

--- a/crates/ruff_linter/resources/test/fixtures/flake8_commas/COM81.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_commas/COM81.py
@@ -42,7 +42,7 @@ foo = (
 4,
 )
 
-foo = 3, 
+foo = 3,
 
 class A(object):
  foo = 3
@@ -654,3 +654,55 @@ f"""This is a test. {
     if True else
     "Don't add a trailing comma here ->"
 }"""
+
+
+def good_single(
+    a, bbbb, cccccccc, dddddddd, eeeeee
+):
+    ...
+
+def bad_single(
+    a, bbbb, cccccccc, dddddddd, eeeeee,
+):
+    ...
+
+def test(
+    a, b, c,
+):
+    ...
+
+def test(
+    a, b, c, d
+):
+    ...
+
+def single_line_argument_with_comma(
+    a=[bbbbbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccccccccccccccc],
+):
+    pass
+
+# A trailing comma is required
+def single_line_argument(
+    a=[bbbbbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccccccccccccccc]
+):
+    pass
+
+
+# The arguments and the inner list require a trailing comma
+def multiline_argument(
+    a=[
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+        ccccccccccccccccccccccccccccccccccc
+    ]
+):
+    pass
+
+# The arguments need a trailing comma, but not the list values.
+def multiline_argument_flat_single_line_list(
+    a = [
+        1, 2
+    ]
+): pass
+
+
+

--- a/crates/ruff_linter/src/rules/flake8_commas/snapshots/ruff_linter__rules__flake8_commas__tests__COM81.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_commas/snapshots/ruff_linter__rules__flake8_commas__tests__COM81.py.snap
@@ -106,7 +106,7 @@ COM81.py:45:8: COM818 Trailing comma on bare tuple prohibited
    |
 43 | )
 44 | 
-45 | foo = 3, 
+45 | foo = 3,
    |        ^ COM818
 46 | 
 47 | class A(object):
@@ -959,23 +959,85 @@ COM81.py:644:46: COM819 [*] Trailing comma prohibited
 646 646 | raise Exception(
 647 647 |     "first", extra=f"Add trailing comma here ->"
 
-COM81.py:647:49: COM812 [*] Trailing comma missing
+COM81.py:686:75: COM812 [*] Trailing comma missing
     |
-646 | raise Exception(
-647 |     "first", extra=f"Add trailing comma here ->"
-    |                                                  COM812
-648 | )
+684 | # A trailing comma is required
+685 | def single_line_argument(
+686 |     a=[bbbbbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccccccccccccccc]
+    |                                                                            COM812
+687 | ):
+688 |     pass
     |
     = help: Add trailing comma
 
 ℹ Safe fix
-644 644 | kwargs.pop("remove", f"this {trailing_comma}",)
-645 645 | 
-646 646 | raise Exception(
-647     |-    "first", extra=f"Add trailing comma here ->"
-    647 |+    "first", extra=f"Add trailing comma here ->",
-648 648 | )
-649 649 | 
-650 650 | assert False, f"<- This is not a trailing comma"
+683 683 | 
+684 684 | # A trailing comma is required
+685 685 | def single_line_argument(
+686     |-    a=[bbbbbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccccccccccccccc]
+    686 |+    a=[bbbbbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccccccccccccccc],
+687 687 | ):
+688 688 |     pass
+689 689 | 
 
+COM81.py:695:44: COM812 [*] Trailing comma missing
+    |
+693 |     a=[
+694 |         bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+695 |         ccccccccccccccccccccccccccccccccccc
+    |                                             COM812
+696 |     ]
+697 | ):
+    |
+    = help: Add trailing comma
 
+ℹ Safe fix
+692 692 | def multiline_argument(
+693 693 |     a=[
+694 694 |         bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+695     |-        ccccccccccccccccccccccccccccccccccc
+    695 |+        ccccccccccccccccccccccccccccccccccc,
+696 696 |     ]
+697 697 | ):
+698 698 |     pass
+
+COM81.py:696:6: COM812 [*] Trailing comma missing
+    |
+694 |         bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+695 |         ccccccccccccccccccccccccccccccccccc
+696 |     ]
+    |       COM812
+697 | ):
+698 |     pass
+    |
+    = help: Add trailing comma
+
+ℹ Safe fix
+693 693 |     a=[
+694 694 |         bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+695 695 |         ccccccccccccccccccccccccccccccccccc
+696     |-    ]
+    696 |+    ],
+697 697 | ):
+698 698 |     pass
+699 699 | 
+
+COM81.py:704:6: COM812 [*] Trailing comma missing
+    |
+702 |     a = [
+703 |         1, 2
+704 |     ]
+    |       COM812
+705 | ): pass
+    |
+    = help: Add trailing comma
+
+ℹ Safe fix
+701 701 | def multiline_argument_flat_single_line_list(
+702 702 |     a = [
+703 703 |         1, 2
+704     |-    ]
+    704 |+    ],
+705 705 | ): pass
+706 706 | 
+707 707 |


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/9216

This PR makes trailing commas after "single-line-arguments" optional so that the rule is compatible with the formatter:

```python
def test(
	a, b, c # no trailing comma required but permitted
): pass

def test(
	a, # requires a trailing comma
): pass

def test(
	a = [
		b, c # no trailing comma required
	], # trailing comma required
): pass
```

This is a breaking change because it makes the rule less strict. 

## Recommendation for not merging

The motivation of this change is to make COM812 compatible with the formatter (see https://github.com/astral-sh/ruff/issues/9216). There has been more discussion in that thread since I started implementing the change and I think we **should not** ship it. But I want to get more feedback before deciding. 

When I started working on the change, I assumed that the way the arguments would be expanded across multiple lines always is:

```python
def test(
	a, b, c
): ...

# After adding more arguments so that it now needs to be broken
def test(
	a,
	b,
	c,
): ...
```

For this formatting, adding a trailing comma after `a, b, c` doesn't help reduce the diff lines because every line is changed, so making the trailing comma optional is in the spirit of the lint rule. 

However, there are alternative formattings that I didn't consider: 

```python
def test(
	a, b, c,
	d): pass

def test(
	a, b, c,
	d,
): pass
```

In both cases, requiring a trailing comma after `c` is desired to minimize the diff. With this change, COM812 would no longer enforce the trailing comma after `c`. 

That means whether it is correct to enforce a trailing comma depends on the desired formatting, but this requires parametrizing the lint rule.

I'm **not** in favor of adding a new option for this because:

* If you use the formatter, the recommended solution is to disable `COM812` because the formatter properly formats the arguments.
* You can use the formatter and the linter together if you disagree with the formatter's single-line argument formatting and use the lint rule to catch and "fix" the formatting. However, it means that you're using an unsupported setup and you have to expect rough edges (warning) and that it won't be supported in the future. For example, ruff might automatically disable `COM812` in the future when it discovers that a project uses the formatter and linter together.
* The last option is to add a configuration option to COM812. I consider this a bad trade because it increases our configuration surface without solving the formatter incompatibility. `COM812`  remains incompatible, it's just that it now depends on the configuration setting. It also has the downside that we would need to change the setting's default, forcing everyone relying on today's COM812 behavior to change their configuration. 



## Test Plan

Added tests
