### PR TITLE
[`ruff`] Avoid f-string false positives in `gettext` calls (`RUF027`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_1.py
@@ -25,6 +25,9 @@ def negative_cases():
     json3 = "{ 'positive': 'false' }"
     alternative_formatter("{a}", a=5)
     formatted = "{a}".fmt(a=7)
+    partial = "partial sentence"
+    a = _("formatting of {partial} in a translation string is bad practice")
+    _("formatting of {partial} in a translation string is bad practice")
     print(do_nothing("{a}".format(a=3)))
     print(do_nothing(alternative_formatter("{a}", a=5)))
     print(format(do_nothing("{a}"), a=5))

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_1.py
@@ -28,6 +28,7 @@ def negative_cases():
     partial = "partial sentence"
     a = _("formatting of {partial} in a translation string is bad practice")
     _("formatting of {partial} in a translation string is bad practice")
+    print(_("formatting of {partial} in a translation string is bad practice"))
     print(do_nothing("{a}".format(a=3)))
     print(do_nothing(alternative_formatter("{a}", a=5)))
     print(format(do_nothing("{a}"), a=5))


### PR DESCRIPTION
## Summary

It is a convention to use the `_()` alias for `gettext()`. We want to avoid
statement expressions and assignments related to aliases of the gettext API.
See https://docs.python.org/3/library/gettext.html for details. When one
uses `_() to mark a string for translation, the tools look for these markers
and replace the original string with its translated counterpart. If the
string contains variable placeholders or formatting, it can complicate the
translation process, lead to errors or incorrect translations.

## Test Plan

* Test file `RUF027_1.py` was extended such that the test reproduces the false-positive 

Closes https://github.com/astral-sh/ruff/issues/10023.
