### PR TITLE
FString formatting: remove fstring handling in `normalize_string`

### DIFF
--- a/crates/ruff_python_formatter/src/other/f_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_element.rs
@@ -62,6 +62,7 @@ impl Format<PyFormatContext<'_>> for FormatFStringLiteralElement<'_> {
             self.context.quotes(),
             self.context.prefix(),
             is_hex_codes_in_unicode_sequences_enabled(f.context()),
+            true,
         );
         match &normalized {
             Cow::Borrowed(_) => source_text_slice(self.element.range()).fmt(f),


### PR DESCRIPTION
## Summary

The fstring handling inside of `normalize_string` is no longer needed with the new fstring formatting. 
Gate it so that we don't forget to remove it when we promote f-string formating to stable.

## Test Plan

`cargo test`
