### PR TITLE
Add cold attribute to less likely printer queue branches

### DIFF
--- a/crates/ruff_formatter/src/buffer.rs
+++ b/crates/ruff_formatter/src/buffer.rs
@@ -218,6 +218,7 @@ impl<Context> DerefMut for VecBuffer<'_, Context> {
 impl<Context> Buffer for VecBuffer<'_, Context> {
     type Context = Context;
 
+    #[inline]
     fn write_element(&mut self, element: FormatElement) {
         self.elements.push(element);
     }

--- a/crates/ruff_formatter/src/buffer.rs
+++ b/crates/ruff_formatter/src/buffer.rs
@@ -218,7 +218,6 @@ impl<Context> DerefMut for VecBuffer<'_, Context> {
 impl<Context> Buffer for VecBuffer<'_, Context> {
     type Context = Context;
 
-    #[inline]
     fn write_element(&mut self, element: FormatElement) {
         self.elements.push(element);
     }

--- a/crates/ruff_formatter/src/printer/queue.rs
+++ b/crates/ruff_formatter/src/printer/queue.rs
@@ -78,27 +78,28 @@ impl<'a> PrintQueue<'a> {
 impl<'a> Queue<'a> for PrintQueue<'a> {
     fn pop(&mut self) -> Option<&'a FormatElement> {
         let elements = self.element_slices.last_mut()?;
-        elements.next().or_else(|| {
-            self.element_slices.pop();
-            let elements = self.element_slices.last_mut()?;
-            elements.next()
-        })
+        elements.next().or_else(
+            #[cold]
+            || {
+                self.element_slices.pop();
+                let elements = self.element_slices.last_mut()?;
+                elements.next()
+            },
+        )
     }
 
     fn top_with_interned(&self) -> Option<&'a FormatElement> {
         let mut slices = self.element_slices.iter().rev();
         let slice = slices.next()?;
 
-        match slice.as_slice().first() {
-            Some(element) => Some(element),
-            None => {
-                if let Some(next_elements) = slices.next() {
-                    next_elements.as_slice().first()
-                } else {
-                    None
-                }
-            }
-        }
+        slice.as_slice().first().or_else(
+            #[cold]
+            || {
+                slices
+                    .next()
+                    .and_then(|next_elements| next_elements.as_slice().first())
+            },
+        )
     }
 
     fn extend_back(&mut self, elements: &'a [FormatElement]) {
@@ -146,24 +147,30 @@ impl<'a, 'print> FitsQueue<'a, 'print> {
 
 impl<'a, 'print> Queue<'a> for FitsQueue<'a, 'print> {
     fn pop(&mut self) -> Option<&'a FormatElement> {
-        self.queue.pop().or_else(|| {
-            if let Some(next_slice) = self.rest_elements.next_back() {
-                self.queue.extend_back(next_slice.as_slice());
-                self.queue.pop()
-            } else {
-                None
-            }
-        })
+        self.queue.pop().or_else(
+            #[cold]
+            || {
+                if let Some(next_slice) = self.rest_elements.next_back() {
+                    self.queue.extend_back(next_slice.as_slice());
+                    self.queue.pop()
+                } else {
+                    None
+                }
+            },
+        )
     }
 
     fn top_with_interned(&self) -> Option<&'a FormatElement> {
-        self.queue.top_with_interned().or_else(|| {
-            if let Some(next_elements) = self.rest_elements.as_slice().last() {
-                next_elements.as_slice().first()
-            } else {
-                None
-            }
-        })
+        self.queue.top_with_interned().or_else(
+            #[cold]
+            || {
+                if let Some(next_elements) = self.rest_elements.as_slice().last() {
+                    next_elements.as_slice().first()
+                } else {
+                    None
+                }
+            },
+        )
     }
 
     fn extend_back(&mut self, elements: &'a [FormatElement]) {


### PR DESCRIPTION
## Summary

The formatter writes most elements to a single `Vec<FormatElement>` except for: 

* Memoized content: It's sometimes necessary to emit the same content but using two different layouts. The formatter memoizes/interns the content's IR to avoid formatting it twice. The internet content stores the elements in its own `Vec`
* `BestFitting` layout: The `BestFitting` IR allows multiple different layouts for the same content. It stores the IR elements of the variants in a dedicated `Vec`

The fact that the Printer must support multiple `Vec`s add complexity to its queue because the queue needs to support a stack of slices where it pops elements from the top slice but takes the next slice if the top slice is empty. 

This PR adds a few `#[cold]` attributes signaling that it's unlikely that the top slice is empty because a) the printer takes elements from the main top-level `Vec` most of the time and b) most slices contain many elements, but have only one end ;)

This gives us a solid 2-3% performance improvement in the printer (I no longer see `FitsQueue::pop` in the top methods when profiling the large dataset)

![image](https://github.com/astral-sh/ruff/assets/1203881/8d793fba-47df-4127-88b1-b35699f50d6a)


@BurntSushi won't believe this

## Test

`cargo test`

