### PR TITLE
Add Alex Waygood as a CODEOWNER for flake8-pyi

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,6 @@
 /crates/ruff_formatter/ @MichaReiser
 /crates/ruff_python_formatter/ @MichaReiser
 /crates/ruff_python_parser/ @MichaReiser
+
+# flake8-pyi
+/crates/ruff_linter/src/rules/flake8_pyi/ @AlexWaygood


### PR DESCRIPTION
## Summary

Adds me as a codeowner for the flake8-pyi rules. I help maintain the original flake8 plugin these rules are derived from, and wrote the original versions of a bunch of these rules, so I think it makes sense for me to be pinged on PRs touching these files
