### PR TITLE
Remove "Beta" Label from formatter documentation

### DIFF
--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -23,7 +23,7 @@ For details, see [Black compatibility](#black-compatibility).
 
 ## Getting started
 
-The Ruff formatter is available in Beta as of Ruff v0.1.2.
+The Ruff formatter is available since Ruff v0.1.2.
 
 ### CLI
 

--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -23,7 +23,7 @@ For details, see [Black compatibility](#black-compatibility).
 
 ## Getting started
 
-The Ruff formatter is available since Ruff v0.1.2.
+The Ruff formatter is available as of Ruff v0.1.2.
 
 ### CLI
 

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -3,8 +3,7 @@
 The Ruff formatter is an extremely fast Python code formatter designed as a drop-in replacement for
 [Black](https://pypi.org/project/black/), available as part of the `ruff` CLI via `ruff format`.
 
-The Ruff formatter is available as a [production-ready Beta](https://astral.sh/blog/the-ruff-formatter)
-as of Ruff v0.1.2.
+The Ruff formatter is available since Ruff [v0.1.2](https://astral.sh/blog/the-ruff-formatter).
 
 ## `ruff format`
 

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -3,7 +3,7 @@
 The Ruff formatter is an extremely fast Python code formatter designed as a drop-in replacement for
 [Black](https://pypi.org/project/black/), available as part of the `ruff` CLI via `ruff format`.
 
-The Ruff formatter is available since Ruff [v0.1.2](https://astral.sh/blog/the-ruff-formatter).
+The Ruff formatter is available as of Ruff [v0.1.2](https://astral.sh/blog/the-ruff-formatter).
 
 ## `ruff format`
 

--- a/playground/src/Editor/SecondarySideBar.tsx
+++ b/playground/src/Editor/SecondarySideBar.tsx
@@ -20,7 +20,7 @@ export default function SecondarySideBar({
   return (
     <SideBar position="right">
       <SideBarEntry
-        title="Format (beta)"
+        title="Format"
         position={"right"}
         selected={selected === SecondaryTool.Format}
         onClick={() => onSelected(SecondaryTool.Format)}


### PR DESCRIPTION
## Summary

Remove the "Beta" label from the formatter documentation.


