### PR TITLE
Fix mkdocs local link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,7 +316,7 @@ To preview any changes to the documentation locally:
     ```
 
 The documentation should then be available locally at
-[http://127.0.0.1:8000/docs/](http://127.0.0.1:8000/docs/).
+[http://127.0.0.1:8000/ruff/](http://127.0.0.1:8000/ruff/).
 
 ## Release Process
 


### PR DESCRIPTION
## Summary

After following the instructions in [CONTRIBUTING.md](https://github.com/astral-sh/ruff/blob/main/CONTRIBUTING.md#mkdocs), the documentation is served on `http://127.0.0.1:8000/ruff/` rather than `http://127.0.0.1:8000/docs/`. This PR fixes the link.