### PR TITLE
Deprecate `ruff <path>` `ruff --explain`, `ruff --clean` and `ruff --generate-shell-completion`

### DIFF
--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -128,6 +128,7 @@ pub fn run(
         command,
         log_level_args,
     }: Args,
+    deprecated_alias_warning: Option<&'static str>,
 ) -> Result<ExitStatus> {
     {
         let default_panic_hook = std::panic::take_hook();
@@ -157,6 +158,10 @@ pub fn run(
 
     let log_level = LogLevel::from(&log_level_args);
     set_up_logging(&log_level)?;
+
+    if let Some(deprecated_alias_warning) = deprecated_alias_warning {
+        warn_user!("{}", deprecated_alias_warning);
+    }
 
     match command {
         Command::Version { output_format } => {

--- a/crates/ruff/tests/deprecation.rs
+++ b/crates/ruff/tests/deprecation.rs
@@ -12,9 +12,10 @@ const STDIN: &str = "l = 1";
 fn ruff_check(show_source: Option<bool>, output_format: Option<String>) -> Command {
     let mut cmd = Command::new(get_cargo_bin(BIN_NAME));
     let output_format = output_format.unwrap_or(format!("{}", SerializationFormat::default(false)));
-    cmd.arg("--output-format");
-    cmd.arg(output_format);
-    cmd.arg("--no-cache");
+    cmd.arg("check")
+        .arg("--output-format")
+        .arg(output_format)
+        .arg("--no-cache");
     match show_source {
         Some(true) => {
             cmd.arg("--show-source");

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -71,6 +71,7 @@ impl<'a> RuffCheck<'a> {
     /// Generate a [`Command`] for the `ruff check` command.
     fn build(self) -> Command {
         let mut cmd = ruff_cmd();
+        cmd.arg("check");
         if let Some(output_format) = self.output_format {
             cmd.args(["--output-format", output_format]);
         }
@@ -805,13 +806,13 @@ fn full_output_format() {
 }
 
 #[test]
-fn explain_status_codes_f401() {
-    assert_cmd_snapshot!(ruff_cmd().args(["--explain", "F401"]));
+fn rule_f401() {
+    assert_cmd_snapshot!(ruff_cmd().args(["rule", "F401"]));
 }
 
 #[test]
-fn explain_status_codes_ruf404() {
-    assert_cmd_snapshot!(ruff_cmd().args(["--explain", "RUF404"]), @r###"
+fn rule_invalid_rule_name() {
+    assert_cmd_snapshot!(ruff_cmd().args(["rule", "RUF404"]), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -1348,7 +1349,7 @@ fn unreadable_pyproject_toml() -> Result<()> {
 
     // Don't `--isolated` since the configuration discovery is where the error happens
     let args = Args::parse_from(["", "check", "--no-cache", tempdir.path().to_str().unwrap()]);
-    let err = run(args).err().context("Unexpected success")?;
+    let err = run(args, None).err().context("Unexpected success")?;
     assert_eq!(
         err.chain()
             .map(std::string::ToString::to_string)

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -12,7 +12,7 @@ use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
 use tempfile::TempDir;
 
 const BIN_NAME: &str = "ruff";
-const STDIN_BASE_OPTIONS: &[&str] = &["--no-cache", "--output-format", "concise"];
+const STDIN_BASE_OPTIONS: &[&str] = &["check", "--no-cache", "--output-format", "concise"];
 
 fn tempdir_filter(tempdir: &TempDir) -> String {
     format!(r"{}\\?/?", escape(tempdir.path().to_str().unwrap()))
@@ -246,7 +246,6 @@ OTHER = "OTHER"
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())
-        .arg("check")
         .args(STDIN_BASE_OPTIONS)
         .args(["--config", &ruff_toml.file_name().unwrap().to_string_lossy()])
         // Explicitly pass test.py, should be linted regardless of it being excluded by lint.exclude
@@ -293,7 +292,6 @@ inline-quotes = "single"
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())
-        .arg("check")
         .args(STDIN_BASE_OPTIONS)
         .args(["--config", &ruff_toml.file_name().unwrap().to_string_lossy()])
         .args(["--stdin-filename", "generated.py"])
@@ -386,7 +384,6 @@ inline-quotes = "single"
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())
-        .arg("check")
         .args(STDIN_BASE_OPTIONS)
         .args(["--config", &ruff_toml.file_name().unwrap().to_string_lossy()])
         .args(["--stdin-filename", "generated.py"])
@@ -435,7 +432,6 @@ inline-quotes = "single"
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())
-        .arg("check")
         .args(STDIN_BASE_OPTIONS)
         .args(["--config", &ruff_toml.file_name().unwrap().to_string_lossy()])
         .args(["--stdin-filename", "generated.py"])
@@ -495,7 +491,6 @@ ignore = ["D203", "D212"]
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(sub_dir)
-        .arg("check")
         .args(STDIN_BASE_OPTIONS)
         , @r###"
     success: true
@@ -921,7 +916,6 @@ include = ["*.ipy"]
     }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .current_dir(tempdir.path())
-        .arg("check")
         .args(STDIN_BASE_OPTIONS)
         .args(["--config", &ruff_toml.file_name().unwrap().to_string_lossy()])
         .args(["--extension", "ipy:ipynb"])

--- a/crates/ruff/tests/snapshots/integration_test__rule_f401.snap
+++ b/crates/ruff/tests/snapshots/integration_test__rule_f401.snap
@@ -3,7 +3,7 @@ source: crates/ruff/tests/integration_test.rs
 info:
   program: ruff
   args:
-    - "--explain"
+    - rule
     - F401
 ---
 success: true
@@ -68,4 +68,3 @@ else:
 - [Typing documentation: interface conventions](https://typing.readthedocs.io/en/latest/source/libraries.html#library-interface-public-and-private-symbols)
 
 ----- stderr -----
-


### PR DESCRIPTION
## Summary

Deprecate `ruff <path>` `ruff --explain`, `ruff --clean` and `ruff --generate-shell-completion` in favor of `ruff check <path>`, `ruff rule`, `ruff clean` and `ruff generate-shell-completion`.

Closes https://github.com/astral-sh/ruff/issues/9692

## Test Plan

**`--clean`**

```shell
./target/debug/ruff --clean
warning: `ruff --clean` is deprecated. Use `ruff clean` instead.
Removing cache at: .ruff_cache

❯ ./target/debug/ruff clean

```

**`--generate-shell-completion`**

```shell
❯ ./target/debug/ruff --generate-shell-completion fish > /dev/null
warning: `ruff --generate-shell-completion <SHELL>` is deprecated. Use `ruff generate-shell-completion <SHELL>` instead.


❯ ./target/debug/ruff generate-shell-completion fish > /dev/null


```

**`ruff --explain`**

```shell
❯ ./target/debug/ruff --explain RUF001
warning: `ruff --explain <RULE>` is deprecated. Use `ruff rule <RULE>` instead.
# ambiguous-unicode-character-string (RUF001)

Derived from the **Ruff-specific rules** linter.

...

❯ ./target/debug/ruff rule RUF001
# ambiguous-unicode-character-string (RUF001)
```

**`ruff`**

```shell
❯ ./target/debug/ruff .
warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.
warning: Detected debug build without --no-cache.
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `crates/ruff/resources/test/fixtures/include-test/nested-project/pyproject.toml`:
  - 'select' -> 'lint.select'

❯ ./target/debug/ruff check  .
warning: Detected debug build without --no-cache.
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `crates/ruff/resources/test/fixtures/include-test/nested-project/pyproject.toml`:
  - 'select' -> 'lint.select'

```
