### PR TITLE
Fix the sorting of the schema submited to schemastore

### DIFF
--- a/scripts/update_schemastore.py
+++ b/scripts/update_schemastore.py
@@ -55,9 +55,18 @@ def update_schemastore(schemastore: Path) -> None:
     schema = json.loads(root.joinpath("ruff.schema.json").read_text())
     schema["$id"] = "https://json.schemastore.org/ruff.json"
     src.joinpath(ruff_json).write_text(
-        json.dumps(dict(sorted(schema.items())), indent=2, ensure_ascii=False),
+        json.dumps(dict(schema.items()), indent=2, ensure_ascii=False),
     )
-    check_call(["node_modules/.bin/prettier", "--write", ruff_json], cwd=src)
+    check_call(
+        [
+            "node_modules/.bin/prettier",
+            "--plugin",
+            "prettier-plugin-sort-json",
+            "--write",
+            ruff_json,
+        ],
+        cwd=src,
+    )
 
     # Check if the schema has changed
     # https://stackoverflow.com/a/9393642/3549270


### PR DESCRIPTION
## Summary

Schemastore uses a prettier plugin to sort the properties. See https://github.com/astral-sh/schemastore/commit/734c0e50105228741c0b76853efdd81b5f93487c

This commit makes sure we use the same plugin when running `prettier`. 

## Test Plan

https://github.com/SchemaStore/schemastore/pull/3614
