### PR TITLE
Fix broken documentation links affected by namespace changes in lint rules

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -83,7 +83,7 @@ impl Violation for AmbiguousUnicodeCharacterString {
 /// spec recommends `GREEK CAPITAL LETTER OMEGA` over `OHM SIGN`.
 ///
 /// You can omit characters from being flagged as ambiguous via the
-/// [`allowed-confusables`] setting.
+/// [`lint.allowed-confusables`] setting.
 ///
 /// ## Example
 /// ```python
@@ -136,7 +136,7 @@ impl Violation for AmbiguousUnicodeCharacterDocstring {
 /// spec recommends `GREEK CAPITAL LETTER OMEGA` over `OHM SIGN`.
 ///
 /// You can omit characters from being flagged as ambiguous via the
-/// [`allowed-confusables`] setting.
+/// [`lint.allowed-confusables`] setting.
 ///
 /// ## Example
 /// ```python

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -261,8 +261,8 @@ from numpy import tan, uint8, uint16, uint32, uint64
 Like isort, Ruff's import sorting is compatible with Black.
 
 Ruff does not yet support all of isort's configuration options, though it does support many of
-them. You can find the supported settings in the [API reference](settings.md#isort).
-For example, you can set [`known-first-party`](settings.md#isort-known-first-party)
+them. You can find the supported settings in the [API reference](settings.md#lintisort).
+For example, you can set [`known-first-party`](settings.md#lint_isort_known-first-party)
 like so:
 
 === "pyproject.toml"

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -426,7 +426,7 @@ Found 3 errors.
 
 ## Does Ruff support NumPy- or Google-style docstrings?
 
-Yes! To enforce a docstring convention, add a [`convention`](settings.md#pydocstyle-convention)
+Yes! To enforce a docstring convention, add a [`convention`](settings.md#lint_pydocstyle_convention)
 setting following to your configuration file:
 
 === "pyproject.toml"
@@ -447,7 +447,7 @@ For example, if you're coming from flake8-docstrings, and your originating confi
 `--docstring-convention=numpy`, you'd instead set `convention = "numpy"` in your `pyproject.toml`,
 as above.
 
-Alongside [`convention`](settings.md#pydocstyle-convention), you'll want to
+Alongside [`convention`](settings.md#lint_pydocstyle_convention), you'll want to
 explicitly enable the `D` rule code prefix, since the `D` rules are not enabled by default:
 
 === "pyproject.toml"
@@ -470,7 +470,7 @@ explicitly enable the `D` rule code prefix, since the `D` rules are not enabled 
     convention = "google"
     ```
 
-Enabling a [`convention`](settings.md#pydocstyle-convention) will disable any rules that are not
+Enabling a [`convention`](settings.md#lint_pydocstyle_convention) will disable any rules that are not
 included in the specified convention. As such, the intended workflow is to enable a convention and
 then selectively enable or disable any additional rules on top of it:
 
@@ -556,7 +556,7 @@ The Google convention includes all `D` errors apart from:
 [`D409`](rules/section-underline-matches-section-length.md), and
 [`D413`](rules/no-blank-line-after-section.md).
 
-By default, no [`convention`](settings.md#pydocstyle-convention) is set, and so the enabled rules
+By default, no [`convention`](settings.md#lint_pydocstyle_convention) is set, and so the enabled rules
 are determined by the [`select`](settings.md#select) setting alone.
 
 ## What is "preview"?

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -557,7 +557,7 @@ The Google convention includes all `D` errors apart from:
 [`D413`](rules/no-blank-line-after-section.md).
 
 By default, no [`convention`](settings.md#lint_pydocstyle_convention) is set, and so the enabled rules
-are determined by the [`select`](settings.md#select) setting alone.
+are determined by the [`select`](settings.md#lint_select) setting alone.
 
 ## What is "preview"?
 

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -206,7 +206,7 @@ ruff check . --fix --unsafe-fixes
 By default, Ruff will display a hint when unsafe fixes are available but not enabled. The suggestion can be silenced
 by setting the [`unsafe-fixes`](settings.md#unsafe-fixes) setting to `false` or using the `--no-unsafe-fixes` flag.
 
-The safety of fixes can be adjusted per rule using the [`extend-safe-fixes`](settings.md#extend-safe-fixes) and [`extend-unsafe-fixes`](settings.md#extend-unsafe-fixes) settings.
+The safety of fixes can be adjusted per rule using the [`lint.extend-safe-fixes`](settings.md#lint_extend-safe-fixes) and [`extend-unsafe-fixes`](settings.md#extend-unsafe-fixes) settings.
 
 For example, the following configuration would promote unsafe fixes for `F601` to safe fixes and demote safe fixes for `UP034` to unsafe fixes:
 

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -206,7 +206,7 @@ ruff check . --fix --unsafe-fixes
 By default, Ruff will display a hint when unsafe fixes are available but not enabled. The suggestion can be silenced
 by setting the [`unsafe-fixes`](settings.md#unsafe-fixes) setting to `false` or using the `--no-unsafe-fixes` flag.
 
-The safety of fixes can be adjusted per rule using the [`lint.extend-safe-fixes`](settings.md#lint_extend-safe-fixes) and [`extend-unsafe-fixes`](settings.md#extend-unsafe-fixes) settings.
+The safety of fixes can be adjusted per rule using the [`lint.extend-safe-fixes`](settings.md#lint_extend-safe-fixes) and [`lint.extend-unsafe-fixes`](settings.md#lint_extend-unsafe-fixes) settings.
 
 For example, the following configuration would promote unsafe fixes for `F601` to safe fixes and demote safe fixes for `UP034` to unsafe fixes:
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

- This PR addresses broken links in the documentation that resulted from namespace changes to `lint`, introduced in version `0.2.0`.
- Short backstory:
  - While setting up `pydocstyle` rules for our Python codebase, I noticed that the [related section in the FAQ page](https://docs.astral.sh/ruff/faq/#does-ruff-support-numpy-or-google-style-docstrings) contained broken links. Although this was a minor issue, I wanted to prevent others (especially those unfamiliar with Ruff) from encountering the same inconvenience.

## Test Plan

<!-- How was it tested? -->

```
mkdocs serve -f mkdocs.public.yml
```

- Changed pages
  - RUF002, RUF003
    - [ruff/rules/ambiguous-unicode-character-docstring/](https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-docstring/)
    - [ruff/rules/ambiguous-unicode-character-comment/](https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-comment/)
    
    Fixed broken links to match [ruff/rules/ambiguous-unicode-character-string/](https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-string/) (RUF001)
  - FAQ
    - [ruff/faq/#how-does-ruffs-import-sorting-compare-to-isort](https://docs.astral.sh/ruff/faq/#how-does-ruffs-import-sorting-compare-to-isort)
    - [ruff/faq/#does-ruff-support-numpy-or-google-style-docstrings](https://docs.astral.sh/ruff/faq/#does-ruff-support-numpy-or-google-style-docstrings)
  - The Ruff Linter
    - [ruff/linter/#fix-safety](https://docs.astral.sh/ruff/linter/#fix-safety)