### PR TITLE
CLI: Color entire line in Diffs

### DIFF
--- a/crates/ruff_linter/src/source_kind.rs
+++ b/crates/ruff_linter/src/source_kind.rs
@@ -235,8 +235,8 @@ impl std::fmt::Display for CodeDiff<'_> {
             for change in hunk.iter_changes() {
                 match change.tag() {
                     ChangeTag::Equal => write!(f, " {}", change.value())?,
-                    ChangeTag::Delete => write!(f, "{}{}", "-".red(), change.value())?,
-                    ChangeTag::Insert => write!(f, "{}{}", "+".green(), change.value())?,
+                    ChangeTag::Delete => write!(f, "{}{}", "-".red(), change.value().red())?,
+                    ChangeTag::Insert => write!(f, "{}{}", "+".green(), change.value().green())?,
                 }
 
                 if !self.diff.newline_terminated() {


### PR DESCRIPTION
## Summary

Quick fix applying color to entire line rather than just symbols. 

Changes this

![image](https://github.com/astral-sh/ruff/assets/101792782/ebe7150b-0c2d-451e-8d08-3f84d46a8952)

to this

![image](https://github.com/astral-sh/ruff/assets/101792782/3d304db9-bb31-488d-8d0c-978bd1e9731f)

## Test Plan

Tested on files that had full text lines changes and not just new lines/white space removed/added.

Follow up PR from #10110 