### PR TITLE
Removed unused variable in `TRY300`'s example

### DIFF
--- a/crates/ruff_linter/src/rules/tryceratops/rules/try_consider_else.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/try_consider_else.rs
@@ -25,7 +25,7 @@ use crate::checkers::ast::Checker;
 ///         rec = 1 / n
 ///         print(f"reciprocal of {n} is {rec}")
 ///         return rec
-///     except ZeroDivisionError as exc:
+///     except ZeroDivisionError:
 ///         logging.exception("Exception occurred")
 /// ```
 ///
@@ -37,7 +37,7 @@ use crate::checkers::ast::Checker;
 /// def reciprocal(n):
 ///     try:
 ///         rec = 1 / n
-///     except ZeroDivisionError as exc:
+///     except ZeroDivisionError:
 ///         logging.exception("Exception occurred")
 ///     else:
 ///         print(f"reciprocal of {n} is {rec}")


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Removes the unnecessary `exc` variable in `TRY300`'s docs example.

## Test Plan
```
python scripts/generate_mkdocs.py; mkdocs serve -f mkdocs.public.yml
```