### PR TITLE
[`flake8-quotes`] Deactivate `Q000` in `Q002`-tests

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_quotes/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/mod.rs
@@ -139,7 +139,6 @@ mod tests {
                     avoid_escape: true,
                 },
                 ..LinterSettings::for_rules(vec![
-                    Rule::BadQuotesInlineString,
                     Rule::BadQuotesMultilineString,
                     Rule::BadQuotesDocstring,
                     Rule::AvoidableEscapedQuote,
@@ -173,7 +172,6 @@ mod tests {
                     avoid_escape: true,
                 },
                 ..LinterSettings::for_rules(vec![
-                    Rule::BadQuotesInlineString,
                     Rule::BadQuotesMultilineString,
                     Rule::BadQuotesDocstring,
                     Rule::AvoidableEscapedQuote,


### PR DESCRIPTION
## Summary

During the work on https://github.com/astral-sh/ruff/pull/10199, I noticed that
the rule Q000 was used in tests that focus on
the behavior of docstring quotes (Q002). 
As deactivation leads to more granular tests, this 
change makes sure that the different test files 
keep their focus in the long term and do not
start to test something unrelated. Furthermore,
this keeps snap files to the bare minimum.

Opening this PR,as I do not want to have this 
changes in https://github.com/astral-sh/ruff/pull/10199, as both are logical unrelated 
to each other.

## Test Plan

Not needed. Will be implicitly tested.
