### PR TITLE
Respect external codes in file-level exemptions

### DIFF
--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -29,7 +29,13 @@ pub(crate) fn check_noqa(
     settings: &LinterSettings,
 ) -> Vec<usize> {
     // Identify any codes that are globally exempted (within the current file).
-    let exemption = FileExemption::try_extract(locator.contents(), comment_ranges, path, locator);
+    let exemption = FileExemption::try_extract(
+        locator.contents(),
+        comment_ranges,
+        &settings.external,
+        path,
+        locator,
+    );
 
     // Extract all `noqa` directives.
     let mut noqa_directives = NoqaDirectives::from_commented_ranges(comment_ranges, path, locator);

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -407,6 +407,7 @@ pub fn add_noqa_to_path(
         &diagnostics.0,
         &locator,
         indexer.comment_ranges(),
+        &settings.external,
         &directives.noqa_line_for,
         stylist.line_ending(),
     )


### PR DESCRIPTION
We shouldn't warn when an "external" code is used in a file-level exemption.

Closes https://github.com/astral-sh/ruff/issues/10202.