### PR TITLE
Skip another invalid notebook in the OpenAI repository

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -110,7 +110,8 @@ DEFAULT_TARGETS = [
             "include": ["*.ipynb"],
             # TODO(charlie): Re-enable after fixing typo.
             "exclude": [
-                "examples/dalle/Image_generations_edits_and_variations_with_DALL-E.ipynb"
+                "examples/dalle/Image_generations_edits_and_variations_with_DALL-E.ipynb",
+                "examples/How_to_handle_rate_limits.ipynb",
             ],
         },
     ),


### PR DESCRIPTION
We should consider another source for notebook ecosystem checks, these constantly have syntax errors
