### PR TITLE
Split `CallPath` into `QualifiedName` and `UnqualifiedName`

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -1071,27 +1071,27 @@ impl<'a> Visitor<'a> for Checker<'a> {
                         .and_then(|qualified_name| {
                             if self
                                 .semantic
-                                .match_typing_call_path(&qualified_name, "cast")
+                                .match_typing_qualified_name(&qualified_name, "cast")
                             {
                                 Some(typing::Callable::Cast)
                             } else if self
                                 .semantic
-                                .match_typing_call_path(&qualified_name, "NewType")
+                                .match_typing_qualified_name(&qualified_name, "NewType")
                             {
                                 Some(typing::Callable::NewType)
                             } else if self
                                 .semantic
-                                .match_typing_call_path(&qualified_name, "TypeVar")
+                                .match_typing_qualified_name(&qualified_name, "TypeVar")
                             {
                                 Some(typing::Callable::TypeVar)
                             } else if self
                                 .semantic
-                                .match_typing_call_path(&qualified_name, "NamedTuple")
+                                .match_typing_qualified_name(&qualified_name, "NamedTuple")
                             {
                                 Some(typing::Callable::NamedTuple)
                             } else if self
                                 .semantic
-                                .match_typing_call_path(&qualified_name, "TypedDict")
+                                .match_typing_qualified_name(&qualified_name, "TypedDict")
                             {
                                 Some(typing::Callable::TypedDict)
                             } else if matches!(

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -418,11 +418,11 @@ impl<'a> Visitor<'a> for Checker<'a> {
                     self.semantic.add_module(module);
 
                     if alias.asname.is_none() && alias.name.contains('.') {
-                        let call_path: Box<[&str]> = alias.name.split('.').collect();
+                        let qualified_name: Box<[&str]> = alias.name.split('.').collect();
                         self.add_binding(
                             module,
                             alias.identifier(),
-                            BindingKind::SubmoduleImport(SubmoduleImport { call_path }),
+                            BindingKind::SubmoduleImport(SubmoduleImport { qualified_name }),
                             BindingFlags::EXTERNAL,
                         );
                     } else {
@@ -439,11 +439,11 @@ impl<'a> Visitor<'a> for Checker<'a> {
                         }
 
                         let name = alias.asname.as_ref().unwrap_or(&alias.name);
-                        let call_path: Box<[&str]> = alias.name.split('.').collect();
+                        let qualified_name: Box<[&str]> = alias.name.split('.').collect();
                         self.add_binding(
                             name,
                             alias.identifier(),
-                            BindingKind::Import(Import { call_path }),
+                            BindingKind::Import(Import { qualified_name }),
                             flags,
                         );
                     }
@@ -503,12 +503,12 @@ impl<'a> Visitor<'a> for Checker<'a> {
                         // Attempt to resolve any relative imports; but if we don't know the current
                         // module path, or the relative import extends beyond the package root,
                         // fallback to a literal representation (e.g., `[".", "foo"]`).
-                        let call_path = collect_import_from_member(level, module, &alias.name)
+                        let qualified_name = collect_import_from_member(level, module, &alias.name)
                             .into_boxed_slice();
                         self.add_binding(
                             name,
                             alias.identifier(),
-                            BindingKind::FromImport(FromImport { call_path }),
+                            BindingKind::FromImport(FromImport { qualified_name }),
                             flags,
                         );
                     }
@@ -751,8 +751,8 @@ impl<'a> Visitor<'a> for Checker<'a> {
             }) => {
                 let mut handled_exceptions = Exceptions::empty();
                 for type_ in extract_handled_exceptions(handlers) {
-                    if let Some(call_path) = self.semantic.resolve_call_path(type_) {
-                        match call_path.segments() {
+                    if let Some(qualified_name) = self.semantic.resolve_qualified_name(type_) {
+                        match qualified_name.segments() {
                             ["", "NameError"] => {
                                 handled_exceptions |= Exceptions::NAME_ERROR;
                             }
@@ -1065,42 +1065,54 @@ impl<'a> Visitor<'a> for Checker<'a> {
             }) => {
                 self.visit_expr(func);
 
-                let callable = self.semantic.resolve_call_path(func).and_then(|call_path| {
-                    if self.semantic.match_typing_call_path(&call_path, "cast") {
-                        Some(typing::Callable::Cast)
-                    } else if self.semantic.match_typing_call_path(&call_path, "NewType") {
-                        Some(typing::Callable::NewType)
-                    } else if self.semantic.match_typing_call_path(&call_path, "TypeVar") {
-                        Some(typing::Callable::TypeVar)
-                    } else if self
-                        .semantic
-                        .match_typing_call_path(&call_path, "NamedTuple")
-                    {
-                        Some(typing::Callable::NamedTuple)
-                    } else if self
-                        .semantic
-                        .match_typing_call_path(&call_path, "TypedDict")
-                    {
-                        Some(typing::Callable::TypedDict)
-                    } else if matches!(
-                        call_path.segments(),
-                        [
-                            "mypy_extensions",
-                            "Arg"
-                                | "DefaultArg"
-                                | "NamedArg"
-                                | "DefaultNamedArg"
-                                | "VarArg"
-                                | "KwArg"
-                        ]
-                    ) {
-                        Some(typing::Callable::MypyExtension)
-                    } else if matches!(call_path.segments(), ["", "bool"]) {
-                        Some(typing::Callable::Bool)
-                    } else {
-                        None
-                    }
-                });
+                let callable =
+                    self.semantic
+                        .resolve_qualified_name(func)
+                        .and_then(|qualified_name| {
+                            if self
+                                .semantic
+                                .match_typing_call_path(&qualified_name, "cast")
+                            {
+                                Some(typing::Callable::Cast)
+                            } else if self
+                                .semantic
+                                .match_typing_call_path(&qualified_name, "NewType")
+                            {
+                                Some(typing::Callable::NewType)
+                            } else if self
+                                .semantic
+                                .match_typing_call_path(&qualified_name, "TypeVar")
+                            {
+                                Some(typing::Callable::TypeVar)
+                            } else if self
+                                .semantic
+                                .match_typing_call_path(&qualified_name, "NamedTuple")
+                            {
+                                Some(typing::Callable::NamedTuple)
+                            } else if self
+                                .semantic
+                                .match_typing_call_path(&qualified_name, "TypedDict")
+                            {
+                                Some(typing::Callable::TypedDict)
+                            } else if matches!(
+                                qualified_name.segments(),
+                                [
+                                    "mypy_extensions",
+                                    "Arg"
+                                        | "DefaultArg"
+                                        | "NamedArg"
+                                        | "DefaultNamedArg"
+                                        | "VarArg"
+                                        | "KwArg"
+                                ]
+                            ) {
+                                Some(typing::Callable::MypyExtension)
+                            } else if matches!(qualified_name.segments(), ["", "bool"]) {
+                                Some(typing::Callable::Bool)
+                            } else {
+                                None
+                            }
+                        });
                 match callable {
                     Some(typing::Callable::Bool) => {
                         let mut args = arguments.args.iter();

--- a/crates/ruff_linter/src/cst/helpers.rs
+++ b/crates/ruff_linter/src/cst/helpers.rs
@@ -1,43 +1,6 @@
 use libcst_native::{
-    Expression, Name, NameOrAttribute, ParenthesizableWhitespace, SimpleWhitespace, UnaryOperation,
+    Expression, Name, ParenthesizableWhitespace, SimpleWhitespace, UnaryOperation,
 };
-
-fn compose_call_path_inner<'a>(expr: &'a Expression, parts: &mut Vec<&'a str>) {
-    match expr {
-        Expression::Call(expr) => {
-            compose_call_path_inner(&expr.func, parts);
-        }
-        Expression::Attribute(expr) => {
-            compose_call_path_inner(&expr.value, parts);
-            parts.push(expr.attr.value);
-        }
-        Expression::Name(expr) => {
-            parts.push(expr.value);
-        }
-        _ => {}
-    }
-}
-
-pub(crate) fn compose_call_path(expr: &Expression) -> Option<String> {
-    let mut segments = vec![];
-    compose_call_path_inner(expr, &mut segments);
-    if segments.is_empty() {
-        None
-    } else {
-        Some(segments.join("."))
-    }
-}
-
-pub(crate) fn compose_module_path(module: &NameOrAttribute) -> String {
-    match module {
-        NameOrAttribute::N(name) => name.value.to_string(),
-        NameOrAttribute::A(attr) => {
-            let name = attr.attr.value;
-            let prefix = compose_call_path(&attr.value);
-            prefix.map_or_else(|| name.to_string(), |prefix| format!("{prefix}.{name}"))
-        }
-    }
-}
 
 /// Return a [`ParenthesizableWhitespace`] containing a single space.
 pub(crate) fn space() -> ParenthesizableWhitespace<'static> {

--- a/crates/ruff_linter/src/renamer.rs
+++ b/crates/ruff_linter/src/renamer.rs
@@ -232,7 +232,7 @@ impl Renamer {
             }
             BindingKind::SubmoduleImport(import) => {
                 // Ex) Rename `import pandas.core` to `import pandas as pd`.
-                let module_name = import.call_path.first().unwrap();
+                let module_name = import.qualified_name.first().unwrap();
                 Some(Edit::range_replacement(
                     format!("{module_name} as {target}"),
                     binding.range(),

--- a/crates/ruff_linter/src/rules/airflow/rules/task_variable_name.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/task_variable_name.rs
@@ -68,8 +68,8 @@ pub(crate) fn variable_name_task_id(
     // If the function doesn't come from Airflow, we can't do anything.
     if !checker
         .semantic()
-        .resolve_call_path(func)
-        .is_some_and(|call_path| matches!(call_path.segments()[0], "airflow"))
+        .resolve_qualified_name(func)
+        .is_some_and(|qualified_name| matches!(qualified_name.segments()[0], "airflow"))
     {
         return None;
     }

--- a/crates/ruff_linter/src/rules/flake8_2020/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_2020/helpers.rs
@@ -4,6 +4,6 @@ use ruff_python_semantic::SemanticModel;
 
 pub(super) fn is_sys(expr: &Expr, target: &str, semantic: &SemanticModel) -> bool {
     semantic
-        .resolve_call_path(expr)
+        .resolve_qualified_name(expr)
         .is_some_and(|call_path| call_path.segments() == ["sys", target])
 }

--- a/crates/ruff_linter/src/rules/flake8_2020/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_2020/helpers.rs
@@ -5,5 +5,5 @@ use ruff_python_semantic::SemanticModel;
 pub(super) fn is_sys(expr: &Expr, target: &str, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(expr)
-        .is_some_and(|call_path| call_path.segments() == ["sys", target])
+        .is_some_and(|qualified_name| qualified_name.segments() == ["sys", target])
 }

--- a/crates/ruff_linter/src/rules/flake8_2020/rules/name_or_attribute.rs
+++ b/crates/ruff_linter/src/rules/flake8_2020/rules/name_or_attribute.rs
@@ -54,7 +54,7 @@ pub(crate) fn name_or_attribute(checker: &mut Checker, expr: &Expr) {
     if checker
         .semantic()
         .resolve_qualified_name(expr)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["six", "PY3"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["six", "PY3"]))
     {
         checker
             .diagnostics

--- a/crates/ruff_linter/src/rules/flake8_2020/rules/name_or_attribute.rs
+++ b/crates/ruff_linter/src/rules/flake8_2020/rules/name_or_attribute.rs
@@ -53,7 +53,7 @@ pub(crate) fn name_or_attribute(checker: &mut Checker, expr: &Expr) {
 
     if checker
         .semantic()
-        .resolve_call_path(expr)
+        .resolve_qualified_name(expr)
         .is_some_and(|call_path| matches!(call_path.segments(), ["six", "PY3"]))
     {
         checker

--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call.rs
@@ -2,7 +2,7 @@ use ruff_python_ast::ExprCall;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::name::QualifiedName;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -41,7 +41,7 @@ impl Violation for BlockingHttpCallInAsyncFunction {
     }
 }
 
-fn is_blocking_http_call(call_path: &CallPath) -> bool {
+fn is_blocking_http_call(call_path: &QualifiedName) -> bool {
     matches!(
         call_path.segments(),
         ["urllib", "request", "urlopen"]
@@ -65,7 +65,7 @@ pub(crate) fn blocking_http_call(checker: &mut Checker, call: &ExprCall) {
     if checker.semantic().in_async_context() {
         if checker
             .semantic()
-            .resolve_call_path(call.func.as_ref())
+            .resolve_qualified_name(call.func.as_ref())
             .as_ref()
             .is_some_and(is_blocking_http_call)
         {

--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call.rs
@@ -41,9 +41,9 @@ impl Violation for BlockingHttpCallInAsyncFunction {
     }
 }
 
-fn is_blocking_http_call(call_path: &QualifiedName) -> bool {
+fn is_blocking_http_call(qualified_name: &QualifiedName) -> bool {
     matches!(
-        call_path.segments(),
+        qualified_name.segments(),
         ["urllib", "request", "urlopen"]
             | [
                 "httpx" | "requests",

--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_os_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_os_call.rs
@@ -60,9 +60,9 @@ pub(crate) fn blocking_os_call(checker: &mut Checker, call: &ExprCall) {
     }
 }
 
-fn is_unsafe_os_method(call_path: &QualifiedName) -> bool {
+fn is_unsafe_os_method(qualified_name: &QualifiedName) -> bool {
     matches!(
-        call_path.segments(),
+        qualified_name.segments(),
         [
             "os",
             "popen"

--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_os_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_os_call.rs
@@ -2,7 +2,7 @@ use ruff_python_ast::ExprCall;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::name::QualifiedName;
 use ruff_python_semantic::Modules;
 use ruff_text_size::Ranged;
 
@@ -47,7 +47,7 @@ pub(crate) fn blocking_os_call(checker: &mut Checker, call: &ExprCall) {
         if checker.semantic().in_async_context() {
             if checker
                 .semantic()
-                .resolve_call_path(call.func.as_ref())
+                .resolve_qualified_name(call.func.as_ref())
                 .as_ref()
                 .is_some_and(is_unsafe_os_method)
             {
@@ -60,7 +60,7 @@ pub(crate) fn blocking_os_call(checker: &mut Checker, call: &ExprCall) {
     }
 }
 
-fn is_unsafe_os_method(call_path: &CallPath) -> bool {
+fn is_unsafe_os_method(call_path: &QualifiedName) -> bool {
     matches!(
         call_path.segments(),
         [

--- a/crates/ruff_linter/src/rules/flake8_async/rules/open_sleep_or_subprocess_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/open_sleep_or_subprocess_call.rs
@@ -58,24 +58,26 @@ pub(crate) fn open_sleep_or_subprocess_call(checker: &mut Checker, call: &ast::E
 /// Returns `true` if the expression resolves to a blocking call, like `time.sleep` or
 /// `subprocess.run`.
 fn is_open_sleep_or_subprocess_call(func: &Expr, semantic: &SemanticModel) -> bool {
-    semantic.resolve_call_path(func).is_some_and(|call_path| {
-        matches!(
-            call_path.segments(),
-            ["", "open"]
-                | ["time", "sleep"]
-                | [
-                    "subprocess",
-                    "run"
-                        | "Popen"
-                        | "call"
-                        | "check_call"
-                        | "check_output"
-                        | "getoutput"
-                        | "getstatusoutput"
-                ]
-                | ["os", "wait" | "wait3" | "wait4" | "waitid" | "waitpid"]
-        )
-    })
+    semantic
+        .resolve_qualified_name(func)
+        .is_some_and(|call_path| {
+            matches!(
+                call_path.segments(),
+                ["", "open"]
+                    | ["time", "sleep"]
+                    | [
+                        "subprocess",
+                        "run"
+                            | "Popen"
+                            | "call"
+                            | "check_call"
+                            | "check_output"
+                            | "getoutput"
+                            | "getstatusoutput"
+                    ]
+                    | ["os", "wait" | "wait3" | "wait4" | "waitid" | "waitpid"]
+            )
+        })
 }
 
 /// Returns `true` if an expression resolves to a call to `pathlib.Path.open`.
@@ -94,7 +96,7 @@ fn is_open_call_from_pathlib(func: &Expr, semantic: &SemanticModel) -> bool {
     // Path("foo").open()
     // ```
     if let Expr::Call(call) = value.as_ref() {
-        let Some(call_path) = semantic.resolve_call_path(call.func.as_ref()) else {
+        let Some(call_path) = semantic.resolve_qualified_name(call.func.as_ref()) else {
             return false;
         };
         if call_path.segments() == ["pathlib", "Path"] {
@@ -123,6 +125,6 @@ fn is_open_call_from_pathlib(func: &Expr, semantic: &SemanticModel) -> bool {
     };
 
     semantic
-        .resolve_call_path(call.func.as_ref())
+        .resolve_qualified_name(call.func.as_ref())
         .is_some_and(|call_path| call_path.segments() == ["pathlib", "Path"])
 }

--- a/crates/ruff_linter/src/rules/flake8_async/rules/open_sleep_or_subprocess_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/open_sleep_or_subprocess_call.rs
@@ -60,9 +60,9 @@ pub(crate) fn open_sleep_or_subprocess_call(checker: &mut Checker, call: &ast::E
 fn is_open_sleep_or_subprocess_call(func: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["", "open"]
                     | ["time", "sleep"]
                     | [
@@ -96,10 +96,10 @@ fn is_open_call_from_pathlib(func: &Expr, semantic: &SemanticModel) -> bool {
     // Path("foo").open()
     // ```
     if let Expr::Call(call) = value.as_ref() {
-        let Some(call_path) = semantic.resolve_qualified_name(call.func.as_ref()) else {
+        let Some(qualified_name) = semantic.resolve_qualified_name(call.func.as_ref()) else {
             return false;
         };
-        if call_path.segments() == ["pathlib", "Path"] {
+        if qualified_name.segments() == ["pathlib", "Path"] {
             return true;
         }
     }
@@ -126,5 +126,5 @@ fn is_open_call_from_pathlib(func: &Expr, semantic: &SemanticModel) -> bool {
 
     semantic
         .resolve_qualified_name(call.func.as_ref())
-        .is_some_and(|call_path| call_path.segments() == ["pathlib", "Path"])
+        .is_some_and(|qualified_name| qualified_name.segments() == ["pathlib", "Path"])
 }

--- a/crates/ruff_linter/src/rules/flake8_bandit/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/helpers.rs
@@ -25,15 +25,21 @@ pub(super) fn is_untyped_exception(type_: Option<&Expr>, semantic: &SemanticMode
             elts.iter().any(|type_| {
                 semantic
                     .resolve_qualified_name(type_)
-                    .is_some_and(|call_path| {
-                        matches!(call_path.segments(), ["", "Exception" | "BaseException"])
+                    .is_some_and(|qualified_name| {
+                        matches!(
+                            qualified_name.segments(),
+                            ["", "Exception" | "BaseException"]
+                        )
                     })
             })
         } else {
             semantic
                 .resolve_qualified_name(type_)
-                .is_some_and(|call_path| {
-                    matches!(call_path.segments(), ["", "Exception" | "BaseException"])
+                .is_some_and(|qualified_name| {
+                    matches!(
+                        qualified_name.segments(),
+                        ["", "Exception" | "BaseException"]
+                    )
                 })
         }
     })

--- a/crates/ruff_linter/src/rules/flake8_bandit/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/helpers.rs
@@ -23,14 +23,18 @@ pub(super) fn is_untyped_exception(type_: Option<&Expr>, semantic: &SemanticMode
     type_.map_or(true, |type_| {
         if let Expr::Tuple(ast::ExprTuple { elts, .. }) = &type_ {
             elts.iter().any(|type_| {
-                semantic.resolve_call_path(type_).is_some_and(|call_path| {
-                    matches!(call_path.segments(), ["", "Exception" | "BaseException"])
-                })
+                semantic
+                    .resolve_qualified_name(type_)
+                    .is_some_and(|call_path| {
+                        matches!(call_path.segments(), ["", "Exception" | "BaseException"])
+                    })
             })
         } else {
-            semantic.resolve_call_path(type_).is_some_and(|call_path| {
-                matches!(call_path.segments(), ["", "Exception" | "BaseException"])
-            })
+            semantic
+                .resolve_qualified_name(type_)
+                .is_some_and(|call_path| {
+                    matches!(call_path.segments(), ["", "Exception" | "BaseException"])
+                })
         }
     })
 }

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/bad_file_permissions.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/bad_file_permissions.rs
@@ -67,7 +67,7 @@ pub(crate) fn bad_file_permissions(checker: &mut Checker, call: &ast::ExprCall) 
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["os", "chmod"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["os", "chmod"]))
     {
         if let Some(mode_arg) = call.arguments.find_argument("mode", 1) {
             match parse_mask(mode_arg, checker.semantic()) {
@@ -101,8 +101,8 @@ pub(crate) fn bad_file_permissions(checker: &mut Checker, call: &ast::ExprCall) 
 const WRITE_WORLD: u16 = 0o2;
 const EXECUTE_GROUP: u16 = 0o10;
 
-fn py_stat(call_path: &QualifiedName) -> Option<u16> {
-    match call_path.segments() {
+fn py_stat(qualified_name: &QualifiedName) -> Option<u16> {
+    match qualified_name.segments() {
         ["stat", "ST_MODE"] => Some(0o0),
         ["stat", "S_IFDOOR"] => Some(0o0),
         ["stat", "S_IFPORT"] => Some(0o0),

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/bad_file_permissions.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/bad_file_permissions.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::name::QualifiedName;
 use ruff_python_ast::{self as ast, Expr, Operator};
 use ruff_python_semantic::{Modules, SemanticModel};
 use ruff_text_size::Ranged;
@@ -66,7 +66,7 @@ pub(crate) fn bad_file_permissions(checker: &mut Checker, call: &ast::ExprCall) 
 
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["os", "chmod"]))
     {
         if let Some(mode_arg) = call.arguments.find_argument("mode", 1) {
@@ -101,7 +101,7 @@ pub(crate) fn bad_file_permissions(checker: &mut Checker, call: &ast::ExprCall) 
 const WRITE_WORLD: u16 = 0o2;
 const EXECUTE_GROUP: u16 = 0o10;
 
-fn py_stat(call_path: &CallPath) -> Option<u16> {
+fn py_stat(call_path: &QualifiedName) -> Option<u16> {
     match call_path.segments() {
         ["stat", "ST_MODE"] => Some(0o0),
         ["stat", "S_IFDOOR"] => Some(0o0),
@@ -155,7 +155,10 @@ fn parse_mask(expr: &Expr, semantic: &SemanticModel) -> Result<Option<u16>> {
             Some(value) => Ok(Some(value)),
             None => anyhow::bail!("int value out of range"),
         },
-        Expr::Attribute(_) => Ok(semantic.resolve_call_path(expr).as_ref().and_then(py_stat)),
+        Expr::Attribute(_) => Ok(semantic
+            .resolve_qualified_name(expr)
+            .as_ref()
+            .and_then(py_stat)),
         Expr::BinOp(ast::ExprBinOp {
             left,
             op,

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/django_raw_sql.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/django_raw_sql.rs
@@ -42,7 +42,7 @@ pub(crate) fn django_raw_sql(checker: &mut Checker, call: &ast::ExprCall) {
 
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| {
             matches!(
                 call_path.segments(),

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/django_raw_sql.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/django_raw_sql.rs
@@ -43,9 +43,9 @@ pub(crate) fn django_raw_sql(checker: &mut Checker, call: &ast::ExprCall) {
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["django", "db", "models", "expressions", "RawSQL"]
             )
         })

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/exec_used.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/exec_used.rs
@@ -35,7 +35,7 @@ impl Violation for ExecBuiltin {
 pub(crate) fn exec_used(checker: &mut Checker, func: &Expr) {
     if checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["" | "builtin", "exec"]))
     {
         checker

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/exec_used.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/exec_used.rs
@@ -36,7 +36,7 @@ pub(crate) fn exec_used(checker: &mut Checker, func: &Expr) {
     if checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["" | "builtin", "exec"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["" | "builtin", "exec"]))
     {
         checker
             .diagnostics

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/flask_debug_true.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/flask_debug_true.rs
@@ -65,7 +65,7 @@ pub(crate) fn flask_debug_true(checker: &mut Checker, call: &ExprCall) {
     }
 
     if typing::resolve_assignment(value, checker.semantic())
-        .is_some_and(|call_path| matches!(call_path.segments(), ["flask", "Flask"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["flask", "Flask"]))
     {
         checker
             .diagnostics

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
@@ -74,7 +74,7 @@ pub(crate) fn hardcoded_tmp_directory(checker: &mut Checker, string: StringLike)
     {
         if checker
             .semantic()
-            .resolve_call_path(func)
+            .resolve_qualified_name(func)
             .is_some_and(|call_path| matches!(call_path.segments(), ["tempfile", ..]))
         {
             return;

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
@@ -75,7 +75,7 @@ pub(crate) fn hardcoded_tmp_directory(checker: &mut Checker, string: StringLike)
         if checker
             .semantic()
             .resolve_qualified_name(func)
-            .is_some_and(|call_path| matches!(call_path.segments(), ["tempfile", ..]))
+            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["tempfile", ..]))
         {
             return;
         }

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
@@ -61,18 +61,17 @@ impl Violation for HashlibInsecureHashFunction {
 
 /// S324
 pub(crate) fn hashlib_insecure_hash_functions(checker: &mut Checker, call: &ast::ExprCall) {
-    if let Some(hashlib_call) =
-        checker
-            .semantic()
-            .resolve_call_path(&call.func)
-            .and_then(|call_path| match call_path.segments() {
-                ["hashlib", "new"] => Some(HashlibCall::New),
-                ["hashlib", "md4"] => Some(HashlibCall::WeakHash("md4")),
-                ["hashlib", "md5"] => Some(HashlibCall::WeakHash("md5")),
-                ["hashlib", "sha"] => Some(HashlibCall::WeakHash("sha")),
-                ["hashlib", "sha1"] => Some(HashlibCall::WeakHash("sha1")),
-                _ => None,
-            })
+    if let Some(hashlib_call) = checker
+        .semantic()
+        .resolve_qualified_name(&call.func)
+        .and_then(|call_path| match call_path.segments() {
+            ["hashlib", "new"] => Some(HashlibCall::New),
+            ["hashlib", "md4"] => Some(HashlibCall::WeakHash("md4")),
+            ["hashlib", "md5"] => Some(HashlibCall::WeakHash("md5")),
+            ["hashlib", "sha"] => Some(HashlibCall::WeakHash("sha")),
+            ["hashlib", "sha1"] => Some(HashlibCall::WeakHash("sha1")),
+            _ => None,
+        })
     {
         if !is_used_for_security(&call.arguments) {
             return;

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
@@ -64,7 +64,7 @@ pub(crate) fn hashlib_insecure_hash_functions(checker: &mut Checker, call: &ast:
     if let Some(hashlib_call) = checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .and_then(|call_path| match call_path.segments() {
+        .and_then(|qualified_name| match qualified_name.segments() {
             ["hashlib", "new"] => Some(HashlibCall::New),
             ["hashlib", "md4"] => Some(HashlibCall::WeakHash("md4")),
             ["hashlib", "md5"] => Some(HashlibCall::WeakHash("md5")),

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -61,7 +61,7 @@ impl Violation for Jinja2AutoescapeFalse {
 pub(crate) fn jinja2_autoescape_false(checker: &mut Checker, call: &ast::ExprCall) {
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["jinja2", "Environment"]))
     {
         if let Some(keyword) = call.arguments.find_keyword("autoescape") {

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -62,7 +62,9 @@ pub(crate) fn jinja2_autoescape_false(checker: &mut Checker, call: &ast::ExprCal
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["jinja2", "Environment"]))
+        .is_some_and(|qualifieed_name| {
+            matches!(qualifieed_name.segments(), ["jinja2", "Environment"])
+        })
     {
         if let Some(keyword) = call.arguments.find_keyword("autoescape") {
             match &keyword.value {

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
@@ -42,7 +42,7 @@ pub(crate) fn logging_config_insecure_listen(checker: &mut Checker, call: &ast::
 
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["logging", "config", "listen"]))
     {
         if call.arguments.find_keyword("verify").is_some() {

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
@@ -43,7 +43,9 @@ pub(crate) fn logging_config_insecure_listen(checker: &mut Checker, call: &ast::
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["logging", "config", "listen"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["logging", "config", "listen"])
+        })
     {
         if call.arguments.find_keyword("verify").is_some() {
             return;

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/mako_templates.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/mako_templates.rs
@@ -47,7 +47,7 @@ impl Violation for MakoTemplates {
 pub(crate) fn mako_templates(checker: &mut Checker, call: &ast::ExprCall) {
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["mako", "template", "Template"]))
     {
         checker

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/mako_templates.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/mako_templates.rs
@@ -48,7 +48,9 @@ pub(crate) fn mako_templates(checker: &mut Checker, call: &ast::ExprCall) {
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["mako", "template", "Template"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["mako", "template", "Template"])
+        })
     {
         checker
             .diagnostics

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/paramiko_calls.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/paramiko_calls.rs
@@ -39,7 +39,7 @@ impl Violation for ParamikoCall {
 pub(crate) fn paramiko_call(checker: &mut Checker, func: &Expr) {
     if checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["paramiko", "exec_command"]))
     {
         checker

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/paramiko_calls.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/paramiko_calls.rs
@@ -40,7 +40,9 @@ pub(crate) fn paramiko_call(checker: &mut Checker, func: &Expr) {
     if checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["paramiko", "exec_command"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["paramiko", "exec_command"])
+        })
     {
         checker
             .diagnostics

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
@@ -50,7 +50,7 @@ pub(crate) fn request_with_no_cert_validation(checker: &mut Checker, call: &ast:
     if let Some(target) = checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .and_then(|call_path| match call_path.segments() {
+        .and_then(|qualified_name| match qualified_name.segments() {
             ["requests", "get" | "options" | "head" | "post" | "put" | "patch" | "delete"] => {
                 Some("requests")
             }

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
@@ -49,7 +49,7 @@ impl Violation for RequestWithNoCertValidation {
 pub(crate) fn request_with_no_cert_validation(checker: &mut Checker, call: &ast::ExprCall) {
     if let Some(target) = checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .and_then(|call_path| match call_path.segments() {
             ["requests", "get" | "options" | "head" | "post" | "put" | "patch" | "delete"] => {
                 Some("requests")

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/request_without_timeout.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/request_without_timeout.rs
@@ -52,7 +52,7 @@ impl Violation for RequestWithoutTimeout {
 pub(crate) fn request_without_timeout(checker: &mut Checker, call: &ast::ExprCall) {
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| {
             matches!(
                 call_path.segments(),

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/request_without_timeout.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/request_without_timeout.rs
@@ -53,9 +53,9 @@ pub(crate) fn request_without_timeout(checker: &mut Checker, call: &ast::ExprCal
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 [
                     "requests",
                     "get" | "options" | "head" | "post" | "put" | "patch" | "delete"

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -419,7 +419,7 @@ enum CallKind {
 /// Return the [`CallKind`] of the given function call.
 fn get_call_kind(func: &Expr, semantic: &SemanticModel) -> Option<CallKind> {
     semantic
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .and_then(|call_path| match call_path.segments() {
             &[module, submodule] => match module {
                 "os" => match submodule {

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -420,7 +420,7 @@ enum CallKind {
 fn get_call_kind(func: &Expr, semantic: &SemanticModel) -> Option<CallKind> {
     semantic
         .resolve_qualified_name(func)
-        .and_then(|call_path| match call_path.segments() {
+        .and_then(|qualified_name| match qualified_name.segments() {
             &[module, submodule] => match module {
                 "os" => match submodule {
                     "execl" | "execle" | "execlp" | "execlpe" | "execv" | "execve" | "execvp"

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
@@ -44,7 +44,7 @@ impl Violation for SnmpInsecureVersion {
 pub(crate) fn snmp_insecure_version(checker: &mut Checker, call: &ast::ExprCall) {
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| {
             matches!(call_path.segments(), ["pysnmp", "hlapi", "CommunityData"])
         })

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
@@ -45,8 +45,11 @@ pub(crate) fn snmp_insecure_version(checker: &mut Checker, call: &ast::ExprCall)
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| {
-            matches!(call_path.segments(), ["pysnmp", "hlapi", "CommunityData"])
+        .is_some_and(|qualified_name| {
+            matches!(
+                qualified_name.segments(),
+                ["pysnmp", "hlapi", "CommunityData"]
+            )
         })
     {
         if let Some(keyword) = call.arguments.find_keyword("mpModel") {

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
@@ -45,7 +45,7 @@ pub(crate) fn snmp_weak_cryptography(checker: &mut Checker, call: &ast::ExprCall
     if call.arguments.len() < 3 {
         if checker
             .semantic()
-            .resolve_call_path(&call.func)
+            .resolve_qualified_name(&call.func)
             .is_some_and(|call_path| {
                 matches!(call_path.segments(), ["pysnmp", "hlapi", "UsmUserData"])
             })

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
@@ -46,8 +46,11 @@ pub(crate) fn snmp_weak_cryptography(checker: &mut Checker, call: &ast::ExprCall
         if checker
             .semantic()
             .resolve_qualified_name(&call.func)
-            .is_some_and(|call_path| {
-                matches!(call_path.segments(), ["pysnmp", "hlapi", "UsmUserData"])
+            .is_some_and(|qualified_name| {
+                matches!(
+                    qualified_name.segments(),
+                    ["pysnmp", "hlapi", "UsmUserData"]
+                )
             })
         {
             checker

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/ssh_no_host_key_verification.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/ssh_no_host_key_verification.rs
@@ -61,9 +61,9 @@ pub(crate) fn ssh_no_host_key_verification(checker: &mut Checker, call: &ExprCal
     if !checker
         .semantic()
         .resolve_qualified_name(map_callable(policy_argument))
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["paramiko", "client", "AutoAddPolicy" | "WarningPolicy"]
                     | ["paramiko", "AutoAddPolicy" | "WarningPolicy"]
             )
@@ -72,9 +72,9 @@ pub(crate) fn ssh_no_host_key_verification(checker: &mut Checker, call: &ExprCal
         return;
     }
 
-    if typing::resolve_assignment(value, checker.semantic()).is_some_and(|call_path| {
+    if typing::resolve_assignment(value, checker.semantic()).is_some_and(|qualified_name| {
         matches!(
-            call_path.segments(),
+            qualified_name.segments(),
             ["paramiko", "client", "SSHClient"] | ["paramiko", "SSHClient"]
         )
     }) {

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/ssh_no_host_key_verification.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/ssh_no_host_key_verification.rs
@@ -60,7 +60,7 @@ pub(crate) fn ssh_no_host_key_verification(checker: &mut Checker, call: &ExprCal
     // Detect either, e.g., `paramiko.client.AutoAddPolicy` or `paramiko.client.AutoAddPolicy()`.
     if !checker
         .semantic()
-        .resolve_call_path(map_callable(policy_argument))
+        .resolve_qualified_name(map_callable(policy_argument))
         .is_some_and(|call_path| {
             matches!(
                 call_path.segments(),

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/ssl_insecure_version.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/ssl_insecure_version.rs
@@ -51,7 +51,7 @@ impl Violation for SslInsecureVersion {
 pub(crate) fn ssl_insecure_version(checker: &mut Checker, call: &ExprCall) {
     let Some(keyword) = checker
         .semantic()
-        .resolve_call_path(call.func.as_ref())
+        .resolve_qualified_name(call.func.as_ref())
         .and_then(|call_path| match call_path.segments() {
             ["ssl", "wrap_socket"] => Some("ssl_version"),
             ["OpenSSL", "SSL", "Context"] => Some("method"),

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/ssl_insecure_version.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/ssl_insecure_version.rs
@@ -52,7 +52,7 @@ pub(crate) fn ssl_insecure_version(checker: &mut Checker, call: &ExprCall) {
     let Some(keyword) = checker
         .semantic()
         .resolve_qualified_name(call.func.as_ref())
-        .and_then(|call_path| match call_path.segments() {
+        .and_then(|qualified_name| match qualified_name.segments() {
             ["ssl", "wrap_socket"] => Some("ssl_version"),
             ["OpenSSL", "SSL", "Context"] => Some("method"),
             _ => None,

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/ssl_with_no_version.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/ssl_with_no_version.rs
@@ -39,7 +39,7 @@ impl Violation for SslWithNoVersion {
 pub(crate) fn ssl_with_no_version(checker: &mut Checker, call: &ExprCall) {
     if checker
         .semantic()
-        .resolve_call_path(call.func.as_ref())
+        .resolve_qualified_name(call.func.as_ref())
         .is_some_and(|call_path| matches!(call_path.segments(), ["ssl", "wrap_socket"]))
     {
         if call.arguments.find_keyword("ssl_version").is_none() {

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/ssl_with_no_version.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/ssl_with_no_version.rs
@@ -40,7 +40,7 @@ pub(crate) fn ssl_with_no_version(checker: &mut Checker, call: &ExprCall) {
     if checker
         .semantic()
         .resolve_qualified_name(call.func.as_ref())
-        .is_some_and(|call_path| matches!(call_path.segments(), ["ssl", "wrap_socket"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["ssl", "wrap_socket"]))
     {
         if call.arguments.find_keyword("ssl_version").is_none() {
             checker

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
@@ -825,8 +825,8 @@ impl Violation for SuspiciousFTPLibUsage {
 
 /// S301, S302, S303, S304, S305, S306, S307, S308, S310, S311, S312, S313, S314, S315, S316, S317, S318, S319, S320, S321, S323
 pub(crate) fn suspicious_function_call(checker: &mut Checker, call: &ExprCall) {
-    let Some(diagnostic_kind) = checker.semantic().resolve_qualified_name(call.func.as_ref()).and_then(|call_path| {
-        match call_path.segments() {
+    let Some(diagnostic_kind) = checker.semantic().resolve_qualified_name(call.func.as_ref()).and_then(|qualified_name| {
+        match qualified_name.segments() {
             // Pickle
             ["pickle" | "dill", "load" | "loads" | "Unpickler"] |
             ["shelve", "open" | "DbfilenameShelf"] |
@@ -907,8 +907,8 @@ pub(crate) fn suspicious_function_decorator(checker: &mut Checker, decorator: &D
     let Some(diagnostic_kind) = checker
         .semantic()
         .resolve_qualified_name(&decorator.expression)
-        .and_then(|call_path| {
-            match call_path.segments() {
+        .and_then(|qualified_name| {
+            match qualified_name.segments() {
                 // MarkSafe
                 ["django", "utils", "safestring" | "html", "mark_safe"] => {
                     Some(SuspiciousMarkSafeUsage.into())

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
@@ -825,7 +825,7 @@ impl Violation for SuspiciousFTPLibUsage {
 
 /// S301, S302, S303, S304, S305, S306, S307, S308, S310, S311, S312, S313, S314, S315, S316, S317, S318, S319, S320, S321, S323
 pub(crate) fn suspicious_function_call(checker: &mut Checker, call: &ExprCall) {
-    let Some(diagnostic_kind) = checker.semantic().resolve_call_path(call.func.as_ref()).and_then(|call_path| {
+    let Some(diagnostic_kind) = checker.semantic().resolve_qualified_name(call.func.as_ref()).and_then(|call_path| {
         match call_path.segments() {
             // Pickle
             ["pickle" | "dill", "load" | "loads" | "Unpickler"] |
@@ -906,7 +906,7 @@ pub(crate) fn suspicious_function_call(checker: &mut Checker, call: &ExprCall) {
 pub(crate) fn suspicious_function_decorator(checker: &mut Checker, decorator: &Decorator) {
     let Some(diagnostic_kind) = checker
         .semantic()
-        .resolve_call_path(&decorator.expression)
+        .resolve_qualified_name(&decorator.expression)
         .and_then(|call_path| {
             match call_path.segments() {
                 // MarkSafe

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
@@ -62,13 +62,13 @@ impl Violation for UnsafeYAMLLoad {
 pub(crate) fn unsafe_yaml_load(checker: &mut Checker, call: &ast::ExprCall) {
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["yaml", "load"]))
     {
         if let Some(loader_arg) = call.arguments.find_argument("Loader", 1) {
             if !checker
                 .semantic()
-                .resolve_call_path(loader_arg)
+                .resolve_qualified_name(loader_arg)
                 .is_some_and(|call_path| {
                     matches!(
                         call_path.segments(),

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
@@ -63,15 +63,15 @@ pub(crate) fn unsafe_yaml_load(checker: &mut Checker, call: &ast::ExprCall) {
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["yaml", "load"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["yaml", "load"]))
     {
         if let Some(loader_arg) = call.arguments.find_argument("Loader", 1) {
             if !checker
                 .semantic()
                 .resolve_qualified_name(loader_arg)
-                .is_some_and(|call_path| {
+                .is_some_and(|qualified_name| {
                     matches!(
-                        call_path.segments(),
+                        qualified_name.segments(),
                         ["yaml", "SafeLoader" | "CSafeLoader"]
                             | ["yaml", "loader", "SafeLoader" | "CSafeLoader"]
                     )

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/weak_cryptographic_key.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/weak_cryptographic_key.rs
@@ -101,8 +101,8 @@ fn extract_cryptographic_key(
     checker: &mut Checker,
     call: &ExprCall,
 ) -> Option<(CryptographicKey, TextRange)> {
-    let call_path = checker.semantic().resolve_qualified_name(&call.func)?;
-    match call_path.segments() {
+    let qualified_name = checker.semantic().resolve_qualified_name(&call.func)?;
+    match qualified_name.segments() {
         ["cryptography", "hazmat", "primitives", "asymmetric", function, "generate_private_key"] => {
             match *function {
                 "dsa" => {
@@ -116,9 +116,9 @@ fn extract_cryptographic_key(
                 "ec" => {
                     let argument = call.arguments.find_argument("curve", 0)?;
                     let ExprAttribute { attr, value, .. } = argument.as_attribute_expr()?;
-                    let call_path = checker.semantic().resolve_qualified_name(value)?;
+                    let qualified_name = checker.semantic().resolve_qualified_name(value)?;
                     if matches!(
-                        call_path.segments(),
+                        qualified_name.segments(),
                         ["cryptography", "hazmat", "primitives", "asymmetric", "ec"]
                     ) {
                         Some((

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/weak_cryptographic_key.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/weak_cryptographic_key.rs
@@ -101,7 +101,7 @@ fn extract_cryptographic_key(
     checker: &mut Checker,
     call: &ExprCall,
 ) -> Option<(CryptographicKey, TextRange)> {
-    let call_path = checker.semantic().resolve_call_path(&call.func)?;
+    let call_path = checker.semantic().resolve_qualified_name(&call.func)?;
     match call_path.segments() {
         ["cryptography", "hazmat", "primitives", "asymmetric", function, "generate_private_key"] => {
             match *function {
@@ -116,7 +116,7 @@ fn extract_cryptographic_key(
                 "ec" => {
                     let argument = call.arguments.find_argument("curve", 0)?;
                     let ExprAttribute { attr, value, .. } = argument.as_attribute_expr()?;
-                    let call_path = checker.semantic().resolve_call_path(value)?;
+                    let call_path = checker.semantic().resolve_qualified_name(value)?;
                     if matches!(
                         call_path.segments(),
                         ["cryptography", "hazmat", "primitives", "asymmetric", "ec"]

--- a/crates/ruff_linter/src/rules/flake8_blind_except/rules/blind_except.rs
+++ b/crates/ruff_linter/src/rules/flake8_blind_except/rules/blind_except.rs
@@ -141,7 +141,7 @@ pub(crate) fn blind_except(
                         if checker
                             .semantic()
                             .resolve_qualified_name(func.as_ref())
-                            .is_some_and(|call_path| match call_path.segments() {
+                            .is_some_and(|qualified_name| match qualified_name.segments() {
                                 ["logging", "exception"] => true,
                                 ["logging", "error"] => {
                                     if let Some(keyword) = arguments.find_keyword("exc_info") {

--- a/crates/ruff_linter/src/rules/flake8_blind_except/rules/blind_except.rs
+++ b/crates/ruff_linter/src/rules/flake8_blind_except/rules/blind_except.rs
@@ -140,7 +140,7 @@ pub(crate) fn blind_except(
                     Expr::Name(ast::ExprName { .. }) => {
                         if checker
                             .semantic()
-                            .resolve_call_path(func.as_ref())
+                            .resolve_qualified_name(func.as_ref())
                             .is_some_and(|call_path| match call_path.segments() {
                                 ["logging", "exception"] => true,
                                 ["logging", "error"] => {

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_default_value_positional_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_default_value_positional_argument.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::name::UnqualifiedName;
 use ruff_python_ast::{Decorator, ParameterWithDefault, Parameters};
 use ruff_python_semantic::analyze::visibility;
 use ruff_text_size::Ranged;
@@ -119,7 +119,7 @@ pub(crate) fn boolean_default_value_positional_argument(
         {
             // Allow Boolean defaults in setters.
             if decorator_list.iter().any(|decorator| {
-                CallPath::from_expr(&decorator.expression)
+                UnqualifiedName::from_expr(&decorator.expression)
                     .is_some_and(|call_path| call_path.segments() == [name, "setter"])
             }) {
                 return;

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_default_value_positional_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_default_value_positional_argument.rs
@@ -120,7 +120,7 @@ pub(crate) fn boolean_default_value_positional_argument(
             // Allow Boolean defaults in setters.
             if decorator_list.iter().any(|decorator| {
                 UnqualifiedName::from_expr(&decorator.expression)
-                    .is_some_and(|call_path| call_path.segments() == [name, "setter"])
+                    .is_some_and(|unqualified_name| unqualified_name.segments() == [name, "setter"])
             }) {
                 return;
             }

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_type_hint_positional_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_type_hint_positional_argument.rs
@@ -1,9 +1,8 @@
-use ruff_python_ast::{self as ast, Decorator, Expr, ParameterWithDefault, Parameters};
-
 use ruff_diagnostics::Diagnostic;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::name::UnqualifiedName;
+use ruff_python_ast::{self as ast, Decorator, Expr, ParameterWithDefault, Parameters};
 use ruff_python_semantic::analyze::visibility;
 use ruff_python_semantic::SemanticModel;
 use ruff_text_size::Ranged;
@@ -136,7 +135,7 @@ pub(crate) fn boolean_type_hint_positional_argument(
 
         // Allow Boolean type hints in setters.
         if decorator_list.iter().any(|decorator| {
-            CallPath::from_expr(&decorator.expression)
+            UnqualifiedName::from_expr(&decorator.expression)
                 .is_some_and(|call_path| call_path.segments() == [name, "setter"])
         }) {
             return;
@@ -196,7 +195,7 @@ fn match_annotation_to_complex_bool(annotation: &Expr, semantic: &SemanticModel)
                 return false;
             }
 
-            let call_path = semantic.resolve_call_path(value);
+            let call_path = semantic.resolve_qualified_name(value);
             if call_path
                 .as_ref()
                 .is_some_and(|call_path| semantic.match_typing_call_path(call_path, "Union"))

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -110,11 +110,13 @@ fn is_abc_class(bases: &[Expr], keywords: &[Keyword], semantic: &SemanticModel) 
         keyword.arg.as_ref().is_some_and(|arg| arg == "metaclass")
             && semantic
                 .resolve_qualified_name(&keyword.value)
-                .is_some_and(|call_path| matches!(call_path.segments(), ["abc", "ABCMeta"]))
+                .is_some_and(|qualified_name| {
+                    matches!(qualified_name.segments(), ["abc", "ABCMeta"])
+                })
     }) || bases.iter().any(|base| {
         semantic
             .resolve_qualified_name(base)
-            .is_some_and(|call_path| matches!(call_path.segments(), ["abc", "ABC"]))
+            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["abc", "ABC"]))
     })
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -109,11 +109,11 @@ fn is_abc_class(bases: &[Expr], keywords: &[Keyword], semantic: &SemanticModel) 
     keywords.iter().any(|keyword| {
         keyword.arg.as_ref().is_some_and(|arg| arg == "metaclass")
             && semantic
-                .resolve_call_path(&keyword.value)
+                .resolve_qualified_name(&keyword.value)
                 .is_some_and(|call_path| matches!(call_path.segments(), ["abc", "ABCMeta"]))
     }) || bases.iter().any(|base| {
         semantic
-            .resolve_call_path(base)
+            .resolve_qualified_name(base)
             .is_some_and(|call_path| matches!(call_path.segments(), ["abc", "ABC"]))
     })
 }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -95,14 +95,15 @@ pub(crate) fn assert_raises_exception(checker: &mut Checker, items: &[WithItem])
             return;
         };
 
-        let Some(exception) = checker
-            .semantic()
-            .resolve_call_path(arg)
-            .and_then(|call_path| match call_path.segments() {
-                ["", "Exception"] => Some(ExceptionKind::Exception),
-                ["", "BaseException"] => Some(ExceptionKind::BaseException),
-                _ => None,
-            })
+        let Some(exception) =
+            checker
+                .semantic()
+                .resolve_qualified_name(arg)
+                .and_then(|call_path| match call_path.segments() {
+                    ["", "Exception"] => Some(ExceptionKind::Exception),
+                    ["", "BaseException"] => Some(ExceptionKind::BaseException),
+                    _ => None,
+                })
         else {
             return;
         };
@@ -112,7 +113,7 @@ pub(crate) fn assert_raises_exception(checker: &mut Checker, items: &[WithItem])
             AssertionKind::AssertRaises
         } else if checker
             .semantic()
-            .resolve_call_path(func)
+            .resolve_qualified_name(func)
             .is_some_and(|call_path| matches!(call_path.segments(), ["pytest", "raises"]))
             && arguments.find_keyword("match").is_none()
         {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -99,7 +99,7 @@ pub(crate) fn assert_raises_exception(checker: &mut Checker, items: &[WithItem])
             checker
                 .semantic()
                 .resolve_qualified_name(arg)
-                .and_then(|call_path| match call_path.segments() {
+                .and_then(|qualified_name| match qualified_name.segments() {
                     ["", "Exception"] => Some(ExceptionKind::Exception),
                     ["", "BaseException"] => Some(ExceptionKind::BaseException),
                     _ => None,
@@ -114,7 +114,7 @@ pub(crate) fn assert_raises_exception(checker: &mut Checker, items: &[WithItem])
         } else if checker
             .semantic()
             .resolve_qualified_name(func)
-            .is_some_and(|call_path| matches!(call_path.segments(), ["pytest", "raises"]))
+            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["pytest", "raises"]))
             && arguments.find_keyword("match").is_none()
         {
             AssertionKind::PytestRaises

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -73,8 +73,11 @@ impl Violation for CachedInstanceMethod {
 fn is_cache_func(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(expr)
-        .is_some_and(|call_path| {
-            matches!(call_path.segments(), ["functools", "lru_cache" | "cache"])
+        .is_some_and(|qualified_name| {
+            matches!(
+                qualified_name.segments(),
+                ["functools", "lru_cache" | "cache"]
+            )
         })
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -71,9 +71,11 @@ impl Violation for CachedInstanceMethod {
 }
 
 fn is_cache_func(expr: &Expr, semantic: &SemanticModel) -> bool {
-    semantic.resolve_call_path(expr).is_some_and(|call_path| {
-        matches!(call_path.segments(), ["functools", "lru_cache" | "cache"])
-    })
+    semantic
+        .resolve_qualified_name(expr)
+        .is_some_and(|call_path| {
+            matches!(call_path.segments(), ["functools", "lru_cache" | "cache"])
+        })
 }
 
 /// B019

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -123,11 +123,11 @@ fn duplicate_handler_exceptions<'a>(
     let mut duplicates: FxHashSet<UnqualifiedName> = FxHashSet::default();
     let mut unique_elts: Vec<&Expr> = Vec::default();
     for type_ in elts {
-        if let Some(call_path) = UnqualifiedName::from_expr(type_) {
-            if seen.contains_key(&call_path) {
-                duplicates.insert(call_path);
+        if let Some(name) = UnqualifiedName::from_expr(type_) {
+            if seen.contains_key(&name) {
+                duplicates.insert(name);
             } else {
-                seen.entry(call_path).or_insert(type_);
+                seen.entry(name).or_insert(type_);
                 unique_elts.push(type_);
             }
         }
@@ -140,7 +140,7 @@ fn duplicate_handler_exceptions<'a>(
                 DuplicateHandlerException {
                     names: duplicates
                         .into_iter()
-                        .map(|call_path| call_path.segments().join("."))
+                        .map(|qualified_name| qualified_name.segments().join("."))
                         .sorted()
                         .collect::<Vec<String>>(),
                 },
@@ -183,11 +183,11 @@ pub(crate) fn duplicate_exceptions(checker: &mut Checker, handlers: &[ExceptHand
         };
         match type_.as_ref() {
             Expr::Attribute(_) | Expr::Name(_) => {
-                if let Some(call_path) = UnqualifiedName::from_expr(type_) {
-                    if seen.contains(&call_path) {
-                        duplicates.entry(call_path).or_default().push(type_);
+                if let Some(name) = UnqualifiedName::from_expr(type_) {
+                    if seen.contains(&name) {
+                        duplicates.entry(name).or_default().push(type_);
                     } else {
-                        seen.insert(call_path);
+                        seen.insert(name);
                     }
                 }
             }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -1,12 +1,12 @@
 use itertools::Itertools;
-use ruff_python_ast::{self as ast, ExceptHandler, Expr, ExprContext};
-use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use ruff_diagnostics::{AlwaysFixableViolation, Violation};
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::name::UnqualifiedName;
+use ruff_python_ast::{self as ast, ExceptHandler, Expr, ExprContext};
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
 use crate::fix::edits::pad;
@@ -118,12 +118,12 @@ fn duplicate_handler_exceptions<'a>(
     checker: &mut Checker,
     expr: &'a Expr,
     elts: &'a [Expr],
-) -> FxHashMap<CallPath<'a>, &'a Expr> {
-    let mut seen: FxHashMap<CallPath, &Expr> = FxHashMap::default();
-    let mut duplicates: FxHashSet<CallPath> = FxHashSet::default();
+) -> FxHashMap<UnqualifiedName<'a>, &'a Expr> {
+    let mut seen: FxHashMap<UnqualifiedName, &Expr> = FxHashMap::default();
+    let mut duplicates: FxHashSet<UnqualifiedName> = FxHashSet::default();
     let mut unique_elts: Vec<&Expr> = Vec::default();
     for type_ in elts {
-        if let Some(call_path) = CallPath::from_expr(type_) {
+        if let Some(call_path) = UnqualifiedName::from_expr(type_) {
             if seen.contains_key(&call_path) {
                 duplicates.insert(call_path);
             } else {
@@ -171,8 +171,8 @@ fn duplicate_handler_exceptions<'a>(
 
 /// B025
 pub(crate) fn duplicate_exceptions(checker: &mut Checker, handlers: &[ExceptHandler]) {
-    let mut seen: FxHashSet<CallPath> = FxHashSet::default();
-    let mut duplicates: FxHashMap<CallPath, Vec<&Expr>> = FxHashMap::default();
+    let mut seen: FxHashSet<UnqualifiedName> = FxHashSet::default();
+    let mut duplicates: FxHashMap<UnqualifiedName, Vec<&Expr>> = FxHashMap::default();
     for handler in handlers {
         let ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler {
             type_: Some(type_),
@@ -183,7 +183,7 @@ pub(crate) fn duplicate_exceptions(checker: &mut Checker, handlers: &[ExceptHand
         };
         match type_.as_ref() {
             Expr::Attribute(_) | Expr::Name(_) => {
-                if let Some(call_path) = CallPath::from_expr(type_) {
+                if let Some(call_path) = UnqualifiedName::from_expr(type_) {
                     if seen.contains(&call_path) {
                         duplicates.entry(call_path).or_default().push(type_);
                     } else {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
@@ -4,7 +4,7 @@ use ruff_text_size::{Ranged, TextRange};
 use ruff_diagnostics::Violation;
 use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::{compose_call_path, CallPath};
+use ruff_python_ast::name::{compose_call_path, QualifiedName};
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_semantic::analyze::typing::{
@@ -81,12 +81,15 @@ impl Violation for FunctionCallInDefaultArgument {
 
 struct ArgumentDefaultVisitor<'a, 'b> {
     semantic: &'a SemanticModel<'b>,
-    extend_immutable_calls: &'a [CallPath<'b>],
+    extend_immutable_calls: &'a [QualifiedName<'b>],
     diagnostics: Vec<(DiagnosticKind, TextRange)>,
 }
 
 impl<'a, 'b> ArgumentDefaultVisitor<'a, 'b> {
-    fn new(semantic: &'a SemanticModel<'b>, extend_immutable_calls: &'a [CallPath<'b>]) -> Self {
+    fn new(
+        semantic: &'a SemanticModel<'b>,
+        extend_immutable_calls: &'a [QualifiedName<'b>],
+    ) -> Self {
         Self {
             semantic,
             extend_immutable_calls,
@@ -123,12 +126,12 @@ impl Visitor<'_> for ArgumentDefaultVisitor<'_, '_> {
 /// B008
 pub(crate) fn function_call_in_argument_default(checker: &mut Checker, parameters: &Parameters) {
     // Map immutable calls to (module, member) format.
-    let extend_immutable_calls: Vec<CallPath> = checker
+    let extend_immutable_calls: Vec<QualifiedName> = checker
         .settings
         .flake8_bugbear
         .extend_immutable_calls
         .iter()
-        .map(|target| CallPath::from_qualified_name(target))
+        .map(|target| QualifiedName::from_dotted_name(target))
         .collect();
 
     let mut visitor = ArgumentDefaultVisitor::new(checker.semantic(), &extend_immutable_calls);

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_call_in_argument_default.rs
@@ -4,7 +4,7 @@ use ruff_text_size::{Ranged, TextRange};
 use ruff_diagnostics::Violation;
 use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::name::{compose_call_path, QualifiedName};
+use ruff_python_ast::name::{QualifiedName, UnqualifiedName};
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_semantic::analyze::typing::{
@@ -107,7 +107,7 @@ impl Visitor<'_> for ArgumentDefaultVisitor<'_, '_> {
                 {
                     self.diagnostics.push((
                         FunctionCallInDefaultArgument {
-                            name: compose_call_path(func),
+                            name: UnqualifiedName::from_expr(func).map(|name| name.to_string()),
                         }
                         .into(),
                         expr.range(),

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -1,7 +1,7 @@
-use ast::call_path::CallPath;
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::is_docstring_stmt;
+use ruff_python_ast::name::QualifiedName;
 use ruff_python_ast::{self as ast, Expr, Parameter, ParameterWithDefault, Stmt};
 use ruff_python_codegen::{Generator, Stylist};
 use ruff_python_index::Indexer;
@@ -98,12 +98,12 @@ pub(crate) fn mutable_argument_default(checker: &mut Checker, function_def: &ast
             continue;
         };
 
-        let extend_immutable_calls: Vec<CallPath> = checker
+        let extend_immutable_calls: Vec<QualifiedName> = checker
             .settings
             .flake8_bugbear
             .extend_immutable_calls
             .iter()
-            .map(|target| CallPath::from_qualified_name(target))
+            .map(|target| QualifiedName::from_dotted_name(target))
             .collect();
 
         if is_mutable_expr(default, checker.semantic())

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
@@ -40,7 +40,7 @@ impl Violation for NoExplicitStacklevel {
 pub(crate) fn no_explicit_stacklevel(checker: &mut Checker, call: &ast::ExprCall) {
     if !checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["warnings", "warn"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
@@ -41,7 +41,7 @@ pub(crate) fn no_explicit_stacklevel(checker: &mut Checker, call: &ast::ExprCall
     if !checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["warnings", "warn"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["warnings", "warn"]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/re_sub_positional_args.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/re_sub_positional_args.rs
@@ -63,7 +63,7 @@ pub(crate) fn re_sub_positional_args(checker: &mut Checker, call: &ast::ExprCall
 
     let Some(method) = checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .and_then(|call_path| match call_path.segments() {
             ["re", "sub"] => Some(Method::Sub),
             ["re", "subn"] => Some(Method::Subn),

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/re_sub_positional_args.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/re_sub_positional_args.rs
@@ -64,7 +64,7 @@ pub(crate) fn re_sub_positional_args(checker: &mut Checker, call: &ast::ExprCall
     let Some(method) = checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .and_then(|call_path| match call_path.segments() {
+        .and_then(|qualified_name| match qualified_name.segments() {
             ["re", "sub"] => Some(Method::Sub),
             ["re", "subn"] => Some(Method::Subn),
             ["re", "split"] => Some(Method::Split),

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
@@ -310,7 +310,7 @@ pub(crate) fn reuse_of_groupby_generator(
     // Check if the function call is `itertools.groupby`
     if !checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["itertools", "groupby"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
@@ -311,7 +311,7 @@ pub(crate) fn reuse_of_groupby_generator(
     if !checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["itertools", "groupby"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["itertools", "groupby"]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
@@ -60,7 +60,9 @@ pub(crate) fn useless_contextlib_suppress(
         && checker
             .semantic()
             .resolve_qualified_name(func)
-            .is_some_and(|call_path| matches!(call_path.segments(), ["contextlib", "suppress"]))
+            .is_some_and(|qualified_name| {
+                matches!(qualified_name.segments(), ["contextlib", "suppress"])
+            })
     {
         checker
             .diagnostics

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
@@ -59,7 +59,7 @@ pub(crate) fn useless_contextlib_suppress(
     if args.is_empty()
         && checker
             .semantic()
-            .resolve_call_path(func)
+            .resolve_qualified_name(func)
             .is_some_and(|call_path| matches!(call_path.segments(), ["contextlib", "suppress"]))
     {
         checker

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -99,32 +99,34 @@ fn is_infinite_iterator(arg: &Expr, semantic: &SemanticModel) -> bool {
         return false;
     };
 
-    semantic.resolve_call_path(func).is_some_and(|call_path| {
-        match call_path.segments() {
-            ["itertools", "cycle" | "count"] => true,
-            ["itertools", "repeat"] => {
-                // Ex) `itertools.repeat(1)`
-                if keywords.is_empty() && args.len() == 1 {
-                    return true;
-                }
+    semantic
+        .resolve_qualified_name(func)
+        .is_some_and(|call_path| {
+            match call_path.segments() {
+                ["itertools", "cycle" | "count"] => true,
+                ["itertools", "repeat"] => {
+                    // Ex) `itertools.repeat(1)`
+                    if keywords.is_empty() && args.len() == 1 {
+                        return true;
+                    }
 
-                // Ex) `itertools.repeat(1, None)`
-                if args.len() == 2 && args[1].is_none_literal_expr() {
-                    return true;
-                }
+                    // Ex) `itertools.repeat(1, None)`
+                    if args.len() == 2 && args[1].is_none_literal_expr() {
+                        return true;
+                    }
 
-                // Ex) `iterools.repeat(1, times=None)`
-                for keyword in keywords.iter() {
-                    if keyword.arg.as_ref().is_some_and(|name| name == "times") {
-                        if keyword.value.is_none_literal_expr() {
-                            return true;
+                    // Ex) `iterools.repeat(1, times=None)`
+                    for keyword in keywords.iter() {
+                        if keyword.arg.as_ref().is_some_and(|name| name == "times") {
+                            if keyword.value.is_none_literal_expr() {
+                                return true;
+                            }
                         }
                     }
-                }
 
-                false
+                    false
+                }
+                _ => false,
             }
-            _ => false,
-        }
-    })
+        })
 }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -101,8 +101,8 @@ fn is_infinite_iterator(arg: &Expr, semantic: &SemanticModel) -> bool {
 
     semantic
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| {
-            match call_path.segments() {
+        .is_some_and(|qualified_name| {
+            match qualified_name.segments() {
                 ["itertools", "cycle" | "count"] => true,
                 ["itertools", "repeat"] => {
                     // Ex) `itertools.repeat(1)`

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_fromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_fromtimestamp.rs
@@ -65,8 +65,11 @@ pub(crate) fn call_date_fromtimestamp(checker: &mut Checker, func: &Expr, locati
     if checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| {
-            matches!(call_path.segments(), ["datetime", "date", "fromtimestamp"])
+        .is_some_and(|qualified_name| {
+            matches!(
+                qualified_name.segments(),
+                ["datetime", "date", "fromtimestamp"]
+            )
         })
     {
         checker

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_fromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_fromtimestamp.rs
@@ -64,7 +64,7 @@ pub(crate) fn call_date_fromtimestamp(checker: &mut Checker, func: &Expr, locati
 
     if checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| {
             matches!(call_path.segments(), ["datetime", "date", "fromtimestamp"])
         })

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_today.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_today.rs
@@ -63,7 +63,7 @@ pub(crate) fn call_date_today(checker: &mut Checker, func: &Expr, location: Text
 
     if checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["datetime", "date", "today"]))
     {
         checker

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_today.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_today.rs
@@ -64,7 +64,9 @@ pub(crate) fn call_date_today(checker: &mut Checker, func: &Expr, location: Text
     if checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["datetime", "date", "today"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["datetime", "date", "today"])
+        })
     {
         checker
             .diagnostics

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
@@ -67,7 +67,7 @@ pub(crate) fn call_datetime_fromtimestamp(checker: &mut Checker, call: &ast::Exp
 
     if !checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| {
             matches!(
                 call_path.segments(),

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
@@ -68,9 +68,9 @@ pub(crate) fn call_datetime_fromtimestamp(checker: &mut Checker, call: &ast::Exp
     if !checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["datetime", "datetime", "fromtimestamp"]
             )
         })

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
@@ -63,7 +63,7 @@ pub(crate) fn call_datetime_now_without_tzinfo(checker: &mut Checker, call: &ast
 
     if !checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["datetime", "datetime", "now"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
@@ -64,7 +64,9 @@ pub(crate) fn call_datetime_now_without_tzinfo(checker: &mut Checker, call: &ast
     if !checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["datetime", "datetime", "now"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["datetime", "datetime", "now"])
+        })
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
@@ -71,7 +71,7 @@ pub(crate) fn call_datetime_strptime_without_zone(checker: &mut Checker, call: &
 
     if !checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| {
             matches!(call_path.segments(), ["datetime", "datetime", "strptime"])
         })

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
@@ -72,8 +72,11 @@ pub(crate) fn call_datetime_strptime_without_zone(checker: &mut Checker, call: &
     if !checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| {
-            matches!(call_path.segments(), ["datetime", "datetime", "strptime"])
+        .is_some_and(|qualified_name| {
+            matches!(
+                qualified_name.segments(),
+                ["datetime", "datetime", "strptime"]
+            )
         })
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
@@ -63,7 +63,9 @@ pub(crate) fn call_datetime_today(checker: &mut Checker, func: &Expr, location: 
     if !checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["datetime", "datetime", "today"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["datetime", "datetime", "today"])
+        })
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
@@ -62,7 +62,7 @@ pub(crate) fn call_datetime_today(checker: &mut Checker, func: &Expr, location: 
 
     if !checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["datetime", "datetime", "today"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
@@ -71,9 +71,9 @@ pub(crate) fn call_datetime_utcfromtimestamp(
     if !checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["datetime", "datetime", "utcfromtimestamp"]
             )
         })

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
@@ -70,7 +70,7 @@ pub(crate) fn call_datetime_utcfromtimestamp(
 
     if !checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| {
             matches!(
                 call_path.segments(),

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcnow.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcnow.rs
@@ -66,7 +66,7 @@ pub(crate) fn call_datetime_utcnow(checker: &mut Checker, func: &Expr, location:
 
     if !checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["datetime", "datetime", "utcnow"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcnow.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcnow.rs
@@ -67,7 +67,12 @@ pub(crate) fn call_datetime_utcnow(checker: &mut Checker, func: &Expr, location:
     if !checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["datetime", "datetime", "utcnow"]))
+        .is_some_and(|qualified_name| {
+            matches!(
+                qualified_name.segments(),
+                ["datetime", "datetime", "utcnow"]
+            )
+        })
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
@@ -59,7 +59,7 @@ pub(crate) fn call_datetime_without_tzinfo(checker: &mut Checker, call: &ast::Ex
 
     if !checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["datetime", "datetime"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
@@ -60,7 +60,7 @@ pub(crate) fn call_datetime_without_tzinfo(checker: &mut Checker, call: &ast::Ex
     if !checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["datetime", "datetime"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["datetime", "datetime"]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_django/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/helpers.rs
@@ -4,16 +4,19 @@ use ruff_python_semantic::{analyze, SemanticModel};
 
 /// Return `true` if a Python class appears to be a Django model, based on its base classes.
 pub(super) fn is_model(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> bool {
-    analyze::class::any_call_path(class_def, semantic, &|call_path| {
-        matches!(call_path.segments(), ["django", "db", "models", "Model"])
+    analyze::class::any_qualified_name(class_def, semantic, &|qualified_name| {
+        matches!(
+            qualified_name.segments(),
+            ["django", "db", "models", "Model"]
+        )
     })
 }
 
 /// Return `true` if a Python class appears to be a Django model form, based on its base classes.
 pub(super) fn is_model_form(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> bool {
-    analyze::class::any_call_path(class_def, semantic, &|call_path| {
+    analyze::class::any_qualified_name(class_def, semantic, &|qualified_name| {
         matches!(
-            call_path.segments(),
+            qualified_name.segments(),
             ["django", "forms", "ModelForm"] | ["django", "forms", "models", "ModelForm"]
         )
     })
@@ -23,8 +26,8 @@ pub(super) fn is_model_form(class_def: &ast::StmtClassDef, semantic: &SemanticMo
 pub(super) fn is_model_field(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(expr)
-        .is_some_and(|call_path| {
-            call_path
+        .is_some_and(|qualified_name| {
+            qualified_name
                 .segments()
                 .starts_with(&["django", "db", "models"])
         })
@@ -35,11 +38,13 @@ pub(super) fn get_model_field_name<'a>(
     expr: &'a Expr,
     semantic: &'a SemanticModel,
 ) -> Option<&'a str> {
-    semantic.resolve_qualified_name(expr).and_then(|call_path| {
-        let call_path = call_path.segments();
-        if !call_path.starts_with(&["django", "db", "models"]) {
-            return None;
-        }
-        call_path.last().copied()
-    })
+    semantic
+        .resolve_qualified_name(expr)
+        .and_then(|qualified_name| {
+            let qualified_name = qualified_name.segments();
+            if !qualified_name.starts_with(&["django", "db", "models"]) {
+                return None;
+            }
+            qualified_name.last().copied()
+        })
 }

--- a/crates/ruff_linter/src/rules/flake8_django/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/helpers.rs
@@ -21,11 +21,13 @@ pub(super) fn is_model_form(class_def: &ast::StmtClassDef, semantic: &SemanticMo
 
 /// Return `true` if the expression is constructor for a Django model field.
 pub(super) fn is_model_field(expr: &Expr, semantic: &SemanticModel) -> bool {
-    semantic.resolve_call_path(expr).is_some_and(|call_path| {
-        call_path
-            .segments()
-            .starts_with(&["django", "db", "models"])
-    })
+    semantic
+        .resolve_qualified_name(expr)
+        .is_some_and(|call_path| {
+            call_path
+                .segments()
+                .starts_with(&["django", "db", "models"])
+        })
 }
 
 /// Return the name of the field type, if the expression is constructor for a Django model field.
@@ -33,7 +35,7 @@ pub(super) fn get_model_field_name<'a>(
     expr: &'a Expr,
     semantic: &'a SemanticModel,
 ) -> Option<&'a str> {
-    semantic.resolve_call_path(expr).and_then(|call_path| {
+    semantic.resolve_qualified_name(expr).and_then(|call_path| {
         let call_path = call_path.segments();
         if !call_path.starts_with(&["django", "db", "models"]) {
             return None;

--- a/crates/ruff_linter/src/rules/flake8_django/rules/locals_in_render_function.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/locals_in_render_function.rs
@@ -52,7 +52,9 @@ pub(crate) fn locals_in_render_function(checker: &mut Checker, call: &ast::ExprC
     if !checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["django", "shortcuts", "render"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["django", "shortcuts", "render"])
+        })
     {
         return;
     }
@@ -73,5 +75,5 @@ fn is_locals_call(expr: &Expr, semantic: &SemanticModel) -> bool {
     };
     semantic
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["", "locals"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["", "locals"]))
 }

--- a/crates/ruff_linter/src/rules/flake8_django/rules/locals_in_render_function.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/locals_in_render_function.rs
@@ -51,7 +51,7 @@ pub(crate) fn locals_in_render_function(checker: &mut Checker, call: &ast::ExprC
 
     if !checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["django", "shortcuts", "render"]))
     {
         return;
@@ -72,6 +72,6 @@ fn is_locals_call(expr: &Expr, semantic: &SemanticModel) -> bool {
         return false;
     };
     semantic
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["", "locals"]))
 }

--- a/crates/ruff_linter/src/rules/flake8_django/rules/non_leading_receiver_decorator.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/non_leading_receiver_decorator.rs
@@ -62,8 +62,11 @@ pub(crate) fn non_leading_receiver_decorator(checker: &mut Checker, decorator_li
             checker
                 .semantic()
                 .resolve_qualified_name(&call.func)
-                .is_some_and(|call_path| {
-                    matches!(call_path.segments(), ["django", "dispatch", "receiver"])
+                .is_some_and(|qualified_name| {
+                    matches!(
+                        qualified_name.segments(),
+                        ["django", "dispatch", "receiver"]
+                    )
                 })
         });
         if i > 0 && is_receiver && !seen_receiver {

--- a/crates/ruff_linter/src/rules/flake8_django/rules/non_leading_receiver_decorator.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/non_leading_receiver_decorator.rs
@@ -61,7 +61,7 @@ pub(crate) fn non_leading_receiver_decorator(checker: &mut Checker, decorator_li
         let is_receiver = decorator.expression.as_call_expr().is_some_and(|call| {
             checker
                 .semantic()
-                .resolve_call_path(&call.func)
+                .resolve_qualified_name(&call.func)
                 .is_some_and(|call_path| {
                     matches!(call_path.segments(), ["django", "dispatch", "receiver"])
                 })

--- a/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
+++ b/crates/ruff_linter/src/rules/flake8_future_annotations/rules/future_rewritable_type_annotation.rs
@@ -80,7 +80,7 @@ impl Violation for FutureRewritableTypeAnnotation {
 pub(crate) fn future_rewritable_type_annotation(checker: &mut Checker, expr: &Expr) {
     let name = checker
         .semantic()
-        .resolve_call_path(expr)
+        .resolve_qualified_name(expr)
         .map(|binding| binding.to_string());
 
     if let Some(name) = name {

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/direct_logger_instantiation.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/direct_logger_instantiation.rs
@@ -62,7 +62,7 @@ pub(crate) fn direct_logger_instantiation(checker: &mut Checker, call: &ast::Exp
     if checker
         .semantic()
         .resolve_qualified_name(call.func.as_ref())
-        .is_some_and(|call_path| matches!(call_path.segments(), ["logging", "Logger"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["logging", "Logger"]))
     {
         let mut diagnostic = Diagnostic::new(DirectLoggerInstantiation, call.func.range());
         diagnostic.try_set_fix(|| {

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/direct_logger_instantiation.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/direct_logger_instantiation.rs
@@ -61,7 +61,7 @@ pub(crate) fn direct_logger_instantiation(checker: &mut Checker, call: &ast::Exp
 
     if checker
         .semantic()
-        .resolve_call_path(call.func.as_ref())
+        .resolve_qualified_name(call.func.as_ref())
         .is_some_and(|call_path| matches!(call_path.segments(), ["logging", "Logger"]))
     {
         let mut diagnostic = Diagnostic::new(DirectLoggerInstantiation, call.func.range());

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/exception_without_exc_info.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/exception_without_exc_info.rs
@@ -63,7 +63,9 @@ pub(crate) fn exception_without_exc_info(checker: &mut Checker, call: &ExprCall)
             if !checker
                 .semantic()
                 .resolve_qualified_name(call.func.as_ref())
-                .is_some_and(|call_path| matches!(call_path.segments(), ["logging", "exception"]))
+                .is_some_and(|qualified_name| {
+                    matches!(qualified_name.segments(), ["logging", "exception"])
+                })
             {
                 return;
             }

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/exception_without_exc_info.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/exception_without_exc_info.rs
@@ -62,7 +62,7 @@ pub(crate) fn exception_without_exc_info(checker: &mut Checker, call: &ExprCall)
         Expr::Name(_) => {
             if !checker
                 .semantic()
-                .resolve_call_path(call.func.as_ref())
+                .resolve_qualified_name(call.func.as_ref())
                 .is_some_and(|call_path| matches!(call_path.segments(), ["logging", "exception"]))
             {
                 return;

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/invalid_get_logger_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/invalid_get_logger_argument.rs
@@ -77,7 +77,7 @@ pub(crate) fn invalid_get_logger_argument(checker: &mut Checker, call: &ast::Exp
 
     if !checker
         .semantic()
-        .resolve_call_path(call.func.as_ref())
+        .resolve_qualified_name(call.func.as_ref())
         .is_some_and(|call_path| matches!(call_path.segments(), ["logging", "getLogger"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/invalid_get_logger_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/invalid_get_logger_argument.rs
@@ -78,7 +78,7 @@ pub(crate) fn invalid_get_logger_argument(checker: &mut Checker, call: &ast::Exp
     if !checker
         .semantic()
         .resolve_qualified_name(call.func.as_ref())
-        .is_some_and(|call_path| matches!(call_path.segments(), ["logging", "getLogger"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["logging", "getLogger"]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/undocumented_warn.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/undocumented_warn.rs
@@ -55,7 +55,7 @@ pub(crate) fn undocumented_warn(checker: &mut Checker, expr: &Expr) {
 
     if checker
         .semantic()
-        .resolve_call_path(expr)
+        .resolve_qualified_name(expr)
         .is_some_and(|call_path| matches!(call_path.segments(), ["logging", "WARN"]))
     {
         let mut diagnostic = Diagnostic::new(UndocumentedWarn, expr.range());

--- a/crates/ruff_linter/src/rules/flake8_logging/rules/undocumented_warn.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/rules/undocumented_warn.rs
@@ -56,7 +56,7 @@ pub(crate) fn undocumented_warn(checker: &mut Checker, expr: &Expr) {
     if checker
         .semantic()
         .resolve_qualified_name(expr)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["logging", "WARN"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["logging", "WARN"]))
     {
         let mut diagnostic = Diagnostic::new(UndocumentedWarn, expr.range());
         diagnostic.try_set_fix(|| {

--- a/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -111,7 +111,7 @@ fn check_log_record_attr_clash(checker: &mut Checker, extra: &Keyword) {
             if checker
                 .semantic()
                 .resolve_qualified_name(func)
-                .is_some_and(|call_path| matches!(call_path.segments(), ["", "dict"]))
+                .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["", "dict"]))
             {
                 for keyword in keywords.iter() {
                     if let Some(attr) = &keyword.arg {
@@ -165,13 +165,13 @@ pub(crate) fn logging_call(checker: &mut Checker, call: &ast::ExprCall) {
             (call_type, attr.range())
         }
         Expr::Name(_) => {
-            let Some(call_path) = checker
+            let Some(qualified_name) = checker
                 .semantic()
                 .resolve_qualified_name(call.func.as_ref())
             else {
                 return;
             };
-            let ["logging", attribute] = call_path.segments() else {
+            let ["logging", attribute] = qualified_name.segments() else {
                 return;
             };
             let Some(call_type) = LoggingCallType::from_attribute(attribute) else {

--- a/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -110,7 +110,7 @@ fn check_log_record_attr_clash(checker: &mut Checker, extra: &Keyword) {
         }) => {
             if checker
                 .semantic()
-                .resolve_call_path(func)
+                .resolve_qualified_name(func)
                 .is_some_and(|call_path| matches!(call_path.segments(), ["", "dict"]))
             {
                 for keyword in keywords.iter() {
@@ -165,7 +165,10 @@ pub(crate) fn logging_call(checker: &mut Checker, call: &ast::ExprCall) {
             (call_type, attr.range())
         }
         Expr::Name(_) => {
-            let Some(call_path) = checker.semantic().resolve_call_path(call.func.as_ref()) else {
+            let Some(call_path) = checker
+                .semantic()
+                .resolve_qualified_name(call.func.as_ref())
+            else {
                 return;
             };
             let ["logging", attribute] = call_path.segments() else {

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/non_unique_enums.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/non_unique_enums.rs
@@ -62,7 +62,7 @@ pub(crate) fn non_unique_enums(checker: &mut Checker, parent: &Stmt, body: &[Stm
     if !parent.bases().iter().any(|expr| {
         checker
             .semantic()
-            .resolve_call_path(expr)
+            .resolve_qualified_name(expr)
             .is_some_and(|call_path| matches!(call_path.segments(), ["enum", "Enum"]))
     }) {
         return;
@@ -77,7 +77,7 @@ pub(crate) fn non_unique_enums(checker: &mut Checker, parent: &Stmt, body: &[Stm
         if let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() {
             if checker
                 .semantic()
-                .resolve_call_path(func)
+                .resolve_qualified_name(func)
                 .is_some_and(|call_path| matches!(call_path.segments(), ["enum", "auto"]))
             {
                 continue;

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/non_unique_enums.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/non_unique_enums.rs
@@ -63,7 +63,7 @@ pub(crate) fn non_unique_enums(checker: &mut Checker, parent: &Stmt, body: &[Stm
         checker
             .semantic()
             .resolve_qualified_name(expr)
-            .is_some_and(|call_path| matches!(call_path.segments(), ["enum", "Enum"]))
+            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["enum", "Enum"]))
     }) {
         return;
     }
@@ -78,7 +78,7 @@ pub(crate) fn non_unique_enums(checker: &mut Checker, parent: &Stmt, body: &[Stm
             if checker
                 .semantic()
                 .resolve_qualified_name(func)
-                .is_some_and(|call_path| matches!(call_path.segments(), ["enum", "auto"]))
+                .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["enum", "auto"]))
             {
                 continue;
             }

--- a/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
@@ -98,10 +98,10 @@ impl Violation for PPrint {
 /// T201, T203
 pub(crate) fn print_call(checker: &mut Checker, call: &ast::ExprCall) {
     let mut diagnostic = {
-        let call_path = checker.semantic().resolve_qualified_name(&call.func);
-        if call_path
+        let qualified_name = checker.semantic().resolve_qualified_name(&call.func);
+        if qualified_name
             .as_ref()
-            .is_some_and(|call_path| matches!(call_path.segments(), ["", "print"]))
+            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["", "print"]))
         {
             // If the print call has a `file=` argument (that isn't `None`, `"sys.stdout"`,
             // or `"sys.stderr"`), don't trigger T201.
@@ -110,9 +110,9 @@ pub(crate) fn print_call(checker: &mut Checker, call: &ast::ExprCall) {
                     if checker
                         .semantic()
                         .resolve_qualified_name(&keyword.value)
-                        .map_or(true, |call_path| {
-                            call_path.segments() != ["sys", "stdout"]
-                                && call_path.segments() != ["sys", "stderr"]
+                        .map_or(true, |qualified_name| {
+                            qualified_name.segments() != ["sys", "stdout"]
+                                && qualified_name.segments() != ["sys", "stderr"]
                         })
                     {
                         return;
@@ -120,9 +120,9 @@ pub(crate) fn print_call(checker: &mut Checker, call: &ast::ExprCall) {
                 }
             }
             Diagnostic::new(Print, call.func.range())
-        } else if call_path
+        } else if qualified_name
             .as_ref()
-            .is_some_and(|call_path| matches!(call_path.segments(), ["pprint", "pprint"]))
+            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["pprint", "pprint"]))
         {
             Diagnostic::new(PPrint, call.func.range())
         } else {

--- a/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
@@ -98,7 +98,7 @@ impl Violation for PPrint {
 /// T201, T203
 pub(crate) fn print_call(checker: &mut Checker, call: &ast::ExprCall) {
     let mut diagnostic = {
-        let call_path = checker.semantic().resolve_call_path(&call.func);
+        let call_path = checker.semantic().resolve_qualified_name(&call.func);
         if call_path
             .as_ref()
             .is_some_and(|call_path| matches!(call_path.segments(), ["", "print"]))
@@ -107,13 +107,14 @@ pub(crate) fn print_call(checker: &mut Checker, call: &ast::ExprCall) {
             // or `"sys.stderr"`), don't trigger T201.
             if let Some(keyword) = call.arguments.find_keyword("file") {
                 if !keyword.value.is_none_literal_expr() {
-                    if checker.semantic().resolve_call_path(&keyword.value).map_or(
-                        true,
-                        |call_path| {
+                    if checker
+                        .semantic()
+                        .resolve_qualified_name(&keyword.value)
+                        .map_or(true, |call_path| {
                             call_path.segments() != ["sys", "stdout"]
                                 && call_path.segments() != ["sys", "stderr"]
-                        },
-                    ) {
+                        })
+                    {
                         return;
                     }
                 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_generator_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_generator_return_type.rs
@@ -125,10 +125,10 @@ pub(crate) fn bad_generator_return_type(
     // Determine the module from which the existing annotation is imported (e.g., `typing` or
     // `collections.abc`)
     let (method, module, member) = {
-        let Some(call_path) = semantic.resolve_qualified_name(map_subscript(returns)) else {
+        let Some(qualified_name) = semantic.resolve_qualified_name(map_subscript(returns)) else {
             return;
         };
-        match (name, call_path.segments()) {
+        match (name, qualified_name.segments()) {
             ("__iter__", ["typing", "Generator"]) => {
                 (Method::Iter, Module::Typing, Generator::Generator)
             }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_generator_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_generator_return_type.rs
@@ -125,7 +125,7 @@ pub(crate) fn bad_generator_return_type(
     // Determine the module from which the existing annotation is imported (e.g., `typing` or
     // `collections.abc`)
     let (method, module, member) = {
-        let Some(call_path) = semantic.resolve_call_path(map_subscript(returns)) else {
+        let Some(call_path) = semantic.resolve_qualified_name(map_subscript(returns)) else {
             return;
         };
         match (name, call_path.segments()) {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
@@ -75,7 +75,7 @@ pub(crate) fn bad_version_info_comparison(checker: &mut Checker, test: &Expr) {
 
     if !checker
         .semantic()
-        .resolve_call_path(left)
+        .resolve_qualified_name(left)
         .is_some_and(|call_path| matches!(call_path.segments(), ["sys", "version_info"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
@@ -76,7 +76,7 @@ pub(crate) fn bad_version_info_comparison(checker: &mut Checker, test: &Expr) {
     if !checker
         .semantic()
         .resolve_qualified_name(left)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["sys", "version_info"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["sys", "version_info"]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/collections_named_tuple.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/collections_named_tuple.rs
@@ -57,7 +57,7 @@ pub(crate) fn collections_named_tuple(checker: &mut Checker, expr: &Expr) {
 
     if checker
         .semantic()
-        .resolve_call_path(expr)
+        .resolve_qualified_name(expr)
         .is_some_and(|call_path| matches!(call_path.segments(), ["collections", "namedtuple"]))
     {
         checker

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/collections_named_tuple.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/collections_named_tuple.rs
@@ -58,7 +58,9 @@ pub(crate) fn collections_named_tuple(checker: &mut Checker, expr: &Expr) {
     if checker
         .semantic()
         .resolve_qualified_name(expr)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["collections", "namedtuple"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["collections", "namedtuple"])
+        })
     {
         checker
             .diagnostics

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
@@ -67,7 +67,7 @@ pub(crate) fn complex_if_statement_in_stub(checker: &mut Checker, test: &Expr) {
 
     if checker
         .semantic()
-        .resolve_call_path(left)
+        .resolve_qualified_name(left)
         .is_some_and(|call_path| {
             matches!(call_path.segments(), ["sys", "version_info" | "platform"])
         })

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
@@ -68,8 +68,11 @@ pub(crate) fn complex_if_statement_in_stub(checker: &mut Checker, test: &Expr) {
     if checker
         .semantic()
         .resolve_qualified_name(left)
-        .is_some_and(|call_path| {
-            matches!(call_path.segments(), ["sys", "version_info" | "platform"])
+        .is_some_and(|qualified_name| {
+            matches!(
+                qualified_name.segments(),
+                ["sys", "version_info" | "platform"]
+            )
         })
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
@@ -244,11 +244,11 @@ fn non_none_annotation_element<'a>(
 ) -> Option<&'a Expr> {
     // E.g., `typing.Union` or `typing.Optional`
     if let Expr::Subscript(ExprSubscript { value, slice, .. }) = annotation {
-        let call_path = semantic.resolve_qualified_name(value);
+        let qualified_name = semantic.resolve_qualified_name(value);
 
-        if call_path
+        if qualified_name
             .as_ref()
-            .is_some_and(|value| semantic.match_typing_call_path(value, "Optional"))
+            .is_some_and(|value| semantic.match_typing_qualified_name(value, "Optional"))
         {
             return if slice.is_none_literal_expr() {
                 None
@@ -257,9 +257,9 @@ fn non_none_annotation_element<'a>(
             };
         }
 
-        if !call_path
+        if !qualified_name
             .as_ref()
-            .is_some_and(|value| semantic.match_typing_call_path(value, "Union"))
+            .is_some_and(|value| semantic.match_typing_qualified_name(value, "Union"))
         {
             return None;
         }
@@ -307,9 +307,9 @@ fn is_object_or_unused(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(expr)
         .as_ref()
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["" | "builtins", "object"] | ["_typeshed", "Unused"]
             )
         })
@@ -320,7 +320,12 @@ fn is_base_exception(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(expr)
         .as_ref()
-        .is_some_and(|call_path| matches!(call_path.segments(), ["" | "builtins", "BaseException"]))
+        .is_some_and(|qualified_name| {
+            matches!(
+                qualified_name.segments(),
+                ["" | "builtins", "BaseException"]
+            )
+        })
 }
 
 /// Return `true` if the [`Expr`] is the `types.TracebackType` type.
@@ -328,7 +333,9 @@ fn is_traceback_type(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(expr)
         .as_ref()
-        .is_some_and(|call_path| matches!(call_path.segments(), ["types", "TracebackType"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["types", "TracebackType"])
+        })
 }
 
 /// Return `true` if the [`Expr`] is, e.g., `Type[BaseException]`.
@@ -341,7 +348,9 @@ fn is_base_exception_type(expr: &Expr, semantic: &SemanticModel) -> bool {
         || semantic
             .resolve_qualified_name(value)
             .as_ref()
-            .is_some_and(|call_path| matches!(call_path.segments(), ["" | "builtins", "type"]))
+            .is_some_and(|qualified_name| {
+                matches!(qualified_name.segments(), ["" | "builtins", "type"])
+            })
     {
         is_base_exception(slice, semantic)
     } else {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
@@ -244,7 +244,7 @@ fn non_none_annotation_element<'a>(
 ) -> Option<&'a Expr> {
     // E.g., `typing.Union` or `typing.Optional`
     if let Expr::Subscript(ExprSubscript { value, slice, .. }) = annotation {
-        let call_path = semantic.resolve_call_path(value);
+        let call_path = semantic.resolve_qualified_name(value);
 
         if call_path
             .as_ref()
@@ -305,7 +305,7 @@ fn non_none_annotation_element<'a>(
 /// Return `true` if the [`Expr`] is the `object` builtin or the `_typeshed.Unused` type.
 fn is_object_or_unused(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
-        .resolve_call_path(expr)
+        .resolve_qualified_name(expr)
         .as_ref()
         .is_some_and(|call_path| {
             matches!(
@@ -318,7 +318,7 @@ fn is_object_or_unused(expr: &Expr, semantic: &SemanticModel) -> bool {
 /// Return `true` if the [`Expr`] is `BaseException`.
 fn is_base_exception(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
-        .resolve_call_path(expr)
+        .resolve_qualified_name(expr)
         .as_ref()
         .is_some_and(|call_path| matches!(call_path.segments(), ["" | "builtins", "BaseException"]))
 }
@@ -326,7 +326,7 @@ fn is_base_exception(expr: &Expr, semantic: &SemanticModel) -> bool {
 /// Return `true` if the [`Expr`] is the `types.TracebackType` type.
 fn is_traceback_type(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
-        .resolve_call_path(expr)
+        .resolve_qualified_name(expr)
         .as_ref()
         .is_some_and(|call_path| matches!(call_path.segments(), ["types", "TracebackType"]))
 }
@@ -339,7 +339,7 @@ fn is_base_exception_type(expr: &Expr, semantic: &SemanticModel) -> bool {
 
     if semantic.match_typing_expr(value, "Type")
         || semantic
-            .resolve_call_path(value)
+            .resolve_qualified_name(value)
             .as_ref()
             .is_some_and(|call_path| matches!(call_path.segments(), ["" | "builtins", "type"]))
     {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/iter_method_return_iterable.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/iter_method_return_iterable.rs
@@ -88,7 +88,7 @@ pub(crate) fn iter_method_return_iterable(checker: &mut Checker, definition: &De
 
     if checker
         .semantic()
-        .resolve_call_path(map_subscript(annotation))
+        .resolve_qualified_name(map_subscript(annotation))
         .is_some_and(|call_path| {
             if is_async {
                 matches!(

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/iter_method_return_iterable.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/iter_method_return_iterable.rs
@@ -89,15 +89,15 @@ pub(crate) fn iter_method_return_iterable(checker: &mut Checker, definition: &De
     if checker
         .semantic()
         .resolve_qualified_name(map_subscript(annotation))
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             if is_async {
                 matches!(
-                    call_path.segments(),
+                    qualified_name.segments(),
                     ["typing", "AsyncIterable"] | ["collections", "abc", "AsyncIterable"]
                 )
             } else {
                 matches!(
-                    call_path.segments(),
+                    qualified_name.segments(),
                     ["typing", "Iterable"] | ["collections", "abc", "Iterable"]
                 )
             }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -231,12 +231,14 @@ fn is_metaclass(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> bool
 
 /// Returns `true` if the given expression resolves to a metaclass.
 fn is_metaclass_base(base: &Expr, semantic: &SemanticModel) -> bool {
-    semantic.resolve_call_path(base).is_some_and(|call_path| {
-        matches!(
-            call_path.segments(),
-            ["" | "builtins", "type"] | ["abc", "ABCMeta"] | ["enum", "EnumMeta" | "EnumType"]
-        )
-    })
+    semantic
+        .resolve_qualified_name(base)
+        .is_some_and(|call_path| {
+            matches!(
+                call_path.segments(),
+                ["" | "builtins", "type"] | ["abc", "ABCMeta"] | ["enum", "EnumMeta" | "EnumType"]
+            )
+        })
 }
 
 /// Returns `true` if the method is an in-place binary operator.
@@ -279,7 +281,7 @@ fn is_iterator(arguments: Option<&Arguments>, semantic: &SemanticModel) -> bool 
     };
     bases.iter().any(|expr| {
         semantic
-            .resolve_call_path(map_subscript(expr))
+            .resolve_qualified_name(map_subscript(expr))
             .is_some_and(|call_path| {
                 matches!(
                     call_path.segments(),
@@ -292,7 +294,7 @@ fn is_iterator(arguments: Option<&Arguments>, semantic: &SemanticModel) -> bool 
 /// Return `true` if the given expression resolves to `collections.abc.Iterable`.
 fn is_iterable(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
-        .resolve_call_path(map_subscript(expr))
+        .resolve_qualified_name(map_subscript(expr))
         .is_some_and(|call_path| {
             matches!(
                 call_path.segments(),
@@ -309,7 +311,7 @@ fn is_async_iterator(arguments: Option<&Arguments>, semantic: &SemanticModel) ->
     };
     bases.iter().any(|expr| {
         semantic
-            .resolve_call_path(map_subscript(expr))
+            .resolve_qualified_name(map_subscript(expr))
             .is_some_and(|call_path| {
                 matches!(
                     call_path.segments(),
@@ -322,7 +324,7 @@ fn is_async_iterator(arguments: Option<&Arguments>, semantic: &SemanticModel) ->
 /// Return `true` if the given expression resolves to `collections.abc.AsyncIterable`.
 fn is_async_iterable(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
-        .resolve_call_path(map_subscript(expr))
+        .resolve_qualified_name(map_subscript(expr))
         .is_some_and(|call_path| {
             matches!(
                 call_path.segments(),

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/non_self_return_type.rs
@@ -233,9 +233,9 @@ fn is_metaclass(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> bool
 fn is_metaclass_base(base: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(base)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["" | "builtins", "type"] | ["abc", "ABCMeta"] | ["enum", "EnumMeta" | "EnumType"]
             )
         })
@@ -282,9 +282,9 @@ fn is_iterator(arguments: Option<&Arguments>, semantic: &SemanticModel) -> bool 
     bases.iter().any(|expr| {
         semantic
             .resolve_qualified_name(map_subscript(expr))
-            .is_some_and(|call_path| {
+            .is_some_and(|qualified_name| {
                 matches!(
-                    call_path.segments(),
+                    qualified_name.segments(),
                     ["typing", "Iterator"] | ["collections", "abc", "Iterator"]
                 )
             })
@@ -295,9 +295,9 @@ fn is_iterator(arguments: Option<&Arguments>, semantic: &SemanticModel) -> bool 
 fn is_iterable(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(map_subscript(expr))
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["typing", "Iterable" | "Iterator"]
                     | ["collections", "abc", "Iterable" | "Iterator"]
             )
@@ -312,9 +312,9 @@ fn is_async_iterator(arguments: Option<&Arguments>, semantic: &SemanticModel) ->
     bases.iter().any(|expr| {
         semantic
             .resolve_qualified_name(map_subscript(expr))
-            .is_some_and(|call_path| {
+            .is_some_and(|qualified_name| {
                 matches!(
-                    call_path.segments(),
+                    qualified_name.segments(),
                     ["typing", "AsyncIterator"] | ["collections", "abc", "AsyncIterator"]
                 )
             })
@@ -325,9 +325,9 @@ fn is_async_iterator(arguments: Option<&Arguments>, semantic: &SemanticModel) ->
 fn is_async_iterable(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(map_subscript(expr))
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["typing", "AsyncIterable" | "AsyncIterator"]
                     | ["collections", "abc", "AsyncIterable" | "AsyncIterator"]
             )

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/prefix_type_params.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/prefix_type_params.rs
@@ -82,20 +82,20 @@ pub(crate) fn prefix_type_params(checker: &mut Checker, value: &Expr, targets: &
     let Some(kind) = checker
         .semantic()
         .resolve_qualified_name(func)
-        .and_then(|call_path| {
+        .and_then(|qualified_name| {
             if checker
                 .semantic()
-                .match_typing_call_path(&call_path, "ParamSpec")
+                .match_typing_qualified_name(&qualified_name, "ParamSpec")
             {
                 Some(VarKind::ParamSpec)
             } else if checker
                 .semantic()
-                .match_typing_call_path(&call_path, "TypeVar")
+                .match_typing_qualified_name(&qualified_name, "TypeVar")
             {
                 Some(VarKind::TypeVar)
             } else if checker
                 .semantic()
-                .match_typing_call_path(&call_path, "TypeVarTuple")
+                .match_typing_qualified_name(&qualified_name, "TypeVarTuple")
             {
                 Some(VarKind::TypeVarTuple)
             } else {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/prefix_type_params.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/prefix_type_params.rs
@@ -81,7 +81,7 @@ pub(crate) fn prefix_type_params(checker: &mut Checker, value: &Expr, targets: &
 
     let Some(kind) = checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .and_then(|call_path| {
             if checker
                 .semantic()

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
@@ -90,11 +90,11 @@ fn check_annotation(checker: &mut Checker, annotation: &Expr) {
     let mut has_int = false;
 
     let mut func = |expr: &Expr, _parent: &Expr| {
-        let Some(call_path) = checker.semantic().resolve_qualified_name(expr) else {
+        let Some(qualified_name) = checker.semantic().resolve_qualified_name(expr) else {
             return;
         };
 
-        match call_path.segments() {
+        match qualified_name.segments() {
             ["" | "builtins", "int"] => has_int = true,
             ["" | "builtins", "float"] => has_float = true,
             ["" | "builtins", "complex"] => has_complex = true,

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_numeric_union.rs
@@ -90,7 +90,7 @@ fn check_annotation(checker: &mut Checker, annotation: &Expr) {
     let mut has_int = false;
 
     let mut func = |expr: &Expr, _parent: &Expr| {
-        let Some(call_path) = checker.semantic().resolve_call_path(expr) else {
+        let Some(call_path) = checker.semantic().resolve_qualified_name(expr) else {
             return;
         };
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -248,13 +248,16 @@ impl AlwaysFixableViolation for TypeAliasWithoutAnnotation {
     }
 }
 
-fn is_allowed_negated_math_attribute(call_path: &QualifiedName) -> bool {
-    matches!(call_path.segments(), ["math", "inf" | "e" | "pi" | "tau"])
+fn is_allowed_negated_math_attribute(qualified_name: &QualifiedName) -> bool {
+    matches!(
+        qualified_name.segments(),
+        ["math", "inf" | "e" | "pi" | "tau"]
+    )
 }
 
-fn is_allowed_math_attribute(call_path: &QualifiedName) -> bool {
+fn is_allowed_math_attribute(qualified_name: &QualifiedName) -> bool {
     matches!(
-        call_path.segments(),
+        qualified_name.segments(),
         ["math", "inf" | "nan" | "e" | "pi" | "tau"]
             | [
                 "sys",
@@ -437,9 +440,9 @@ fn is_type_var_like_call(expr: &Expr, semantic: &SemanticModel) -> bool {
     };
     semantic
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 [
                     "typing" | "typing_extensions",
                     "TypeVar" | "TypeVarTuple" | "NewType" | "ParamSpec"
@@ -483,9 +486,9 @@ fn is_enum(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> bool {
             // If the base class is `enum.Enum`, `enum.Flag`, etc., then this is an enum.
             if semantic
                 .resolve_qualified_name(map_subscript(expr))
-                .is_some_and(|call_path| {
+                .is_some_and(|qualified_name| {
                     matches!(
-                        call_path.segments(),
+                        qualified_name.segments(),
                         [
                             "enum",
                             "Enum" | "Flag" | "IntEnum" | "IntFlag" | "StrEnum" | "ReprEnum"

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -2,8 +2,8 @@ use rustc_hash::FxHashSet;
 
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::CallPath;
 use ruff_python_ast::helpers::map_subscript;
+use ruff_python_ast::name::QualifiedName;
 use ruff_python_ast::{
     self as ast, Expr, Operator, ParameterWithDefault, Parameters, Stmt, UnaryOp,
 };
@@ -248,11 +248,11 @@ impl AlwaysFixableViolation for TypeAliasWithoutAnnotation {
     }
 }
 
-fn is_allowed_negated_math_attribute(call_path: &CallPath) -> bool {
+fn is_allowed_negated_math_attribute(call_path: &QualifiedName) -> bool {
     matches!(call_path.segments(), ["math", "inf" | "e" | "pi" | "tau"])
 }
 
-fn is_allowed_math_attribute(call_path: &CallPath) -> bool {
+fn is_allowed_math_attribute(call_path: &QualifiedName) -> bool {
     matches!(
         call_path.segments(),
         ["math", "inf" | "nan" | "e" | "pi" | "tau"]
@@ -324,7 +324,7 @@ fn is_valid_default_value_with_annotation(
                 // Ex) `-math.inf`, `-math.pi`, etc.
                 Expr::Attribute(_) => {
                     if semantic
-                        .resolve_call_path(operand)
+                        .resolve_qualified_name(operand)
                         .as_ref()
                         .is_some_and(is_allowed_negated_math_attribute)
                     {
@@ -373,7 +373,7 @@ fn is_valid_default_value_with_annotation(
         // Ex) `math.inf`, `sys.stdin`, etc.
         Expr::Attribute(_) => {
             if semantic
-                .resolve_call_path(default)
+                .resolve_qualified_name(default)
                 .as_ref()
                 .is_some_and(is_allowed_math_attribute)
             {
@@ -435,15 +435,17 @@ fn is_type_var_like_call(expr: &Expr, semantic: &SemanticModel) -> bool {
     let Expr::Call(ast::ExprCall { func, .. }) = expr else {
         return false;
     };
-    semantic.resolve_call_path(func).is_some_and(|call_path| {
-        matches!(
-            call_path.segments(),
-            [
-                "typing" | "typing_extensions",
-                "TypeVar" | "TypeVarTuple" | "NewType" | "ParamSpec"
-            ]
-        )
-    })
+    semantic
+        .resolve_qualified_name(func)
+        .is_some_and(|call_path| {
+            matches!(
+                call_path.segments(),
+                [
+                    "typing" | "typing_extensions",
+                    "TypeVar" | "TypeVarTuple" | "NewType" | "ParamSpec"
+                ]
+            )
+        })
 }
 
 /// Returns `true` if this is a "special" assignment which must have a value (e.g., an assignment to
@@ -480,7 +482,7 @@ fn is_enum(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> bool {
         class_def.bases().iter().any(|expr| {
             // If the base class is `enum.Enum`, `enum.Flag`, etc., then this is an enum.
             if semantic
-                .resolve_call_path(map_subscript(expr))
+                .resolve_qualified_name(map_subscript(expr))
                 .is_some_and(|call_path| {
                     matches!(
                         call_path.segments(),

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/str_or_repr_defined_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/str_or_repr_defined_in_stub.rs
@@ -80,7 +80,7 @@ pub(crate) fn str_or_repr_defined_in_stub(checker: &mut Checker, stmt: &Stmt) {
 
     if checker
         .semantic()
-        .resolve_call_path(returns)
+        .resolve_qualified_name(returns)
         .map_or(true, |call_path| {
             !matches!(call_path.segments(), ["" | "builtins", "str"])
         })

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/str_or_repr_defined_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/str_or_repr_defined_in_stub.rs
@@ -81,8 +81,8 @@ pub(crate) fn str_or_repr_defined_in_stub(checker: &mut Checker, stmt: &Stmt) {
     if checker
         .semantic()
         .resolve_qualified_name(returns)
-        .map_or(true, |call_path| {
-            !matches!(call_path.segments(), ["" | "builtins", "str"])
+        .map_or(true, |qualified_name| {
+            !matches!(qualified_name.segments(), ["" | "builtins", "str"])
         })
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
@@ -84,7 +84,7 @@ fn is_warnings_dot_deprecated(expr: Option<&ast::Expr>, semantic: &SemanticModel
         return false;
     };
     semantic
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| {
             matches!(
                 call_path.segments(),

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
@@ -85,9 +85,9 @@ fn is_warnings_dot_deprecated(expr: Option<&ast::Expr>, semantic: &SemanticModel
     };
     semantic
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["warnings" | "typing_extensions", "deprecated"]
             )
         })

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
@@ -81,7 +81,9 @@ pub(crate) fn unnecessary_type_union<'a>(checker: &mut Checker, union: &'a Expr)
             if checker
                 .semantic()
                 .resolve_qualified_name(unwrapped.value.as_ref())
-                .is_some_and(|call_path| matches!(call_path.segments(), ["" | "builtins", "type"]))
+                .is_some_and(|qualified_name| {
+                    matches!(qualified_name.segments(), ["" | "builtins", "type"])
+                })
             {
                 type_exprs.push(unwrapped.slice.as_ref());
             } else {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_type_union.rs
@@ -80,7 +80,7 @@ pub(crate) fn unnecessary_type_union<'a>(checker: &mut Checker, union: &'a Expr)
             let unwrapped = subscript.unwrap();
             if checker
                 .semantic()
-                .resolve_call_path(unwrapped.value.as_ref())
+                .resolve_qualified_name(unwrapped.value.as_ref())
                 .is_some_and(|call_path| matches!(call_path.segments(), ["" | "builtins", "type"]))
             {
                 type_exprs.push(unwrapped.slice.as_ref());

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -108,7 +108,7 @@ pub(crate) fn unrecognized_platform(checker: &mut Checker, test: &Expr) {
     if !checker
         .semantic()
         .resolve_qualified_name(left)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["sys", "platform"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["sys", "platform"]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -107,7 +107,7 @@ pub(crate) fn unrecognized_platform(checker: &mut Checker, test: &Expr) {
 
     if !checker
         .semantic()
-        .resolve_call_path(left)
+        .resolve_qualified_name(left)
         .is_some_and(|call_path| matches!(call_path.segments(), ["sys", "platform"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
@@ -136,7 +136,7 @@ pub(crate) fn unrecognized_version_info(checker: &mut Checker, test: &Expr) {
     if !checker
         .semantic()
         .resolve_qualified_name(map_subscript(left))
-        .is_some_and(|call_path| matches!(call_path.segments(), ["sys", "version_info"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["sys", "version_info"]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
@@ -135,7 +135,7 @@ pub(crate) fn unrecognized_version_info(checker: &mut Checker, test: &Expr) {
 
     if !checker
         .semantic()
-        .resolve_call_path(map_subscript(left))
+        .resolve_qualified_name(map_subscript(left))
         .is_some_and(|call_path| matches!(call_path.segments(), ["sys", "version_info"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unused_private_type_definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unused_private_type_definition.rs
@@ -195,17 +195,19 @@ pub(crate) fn unused_private_type_var(
         };
 
         let semantic = checker.semantic();
-        let Some(type_var_like_kind) = semantic.resolve_call_path(func).and_then(|call_path| {
-            if semantic.match_typing_call_path(&call_path, "TypeVar") {
-                Some("TypeVar")
-            } else if semantic.match_typing_call_path(&call_path, "ParamSpec") {
-                Some("ParamSpec")
-            } else if semantic.match_typing_call_path(&call_path, "TypeVarTuple") {
-                Some("TypeVarTuple")
-            } else {
-                None
-            }
-        }) else {
+        let Some(type_var_like_kind) =
+            semantic.resolve_qualified_name(func).and_then(|call_path| {
+                if semantic.match_typing_call_path(&call_path, "TypeVar") {
+                    Some("TypeVar")
+                } else if semantic.match_typing_call_path(&call_path, "ParamSpec") {
+                    Some("ParamSpec")
+                } else if semantic.match_typing_call_path(&call_path, "TypeVarTuple") {
+                    Some("TypeVarTuple")
+                } else {
+                    None
+                }
+            })
+        else {
             continue;
         };
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unused_private_type_definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unused_private_type_definition.rs
@@ -196,17 +196,20 @@ pub(crate) fn unused_private_type_var(
 
         let semantic = checker.semantic();
         let Some(type_var_like_kind) =
-            semantic.resolve_qualified_name(func).and_then(|call_path| {
-                if semantic.match_typing_call_path(&call_path, "TypeVar") {
-                    Some("TypeVar")
-                } else if semantic.match_typing_call_path(&call_path, "ParamSpec") {
-                    Some("ParamSpec")
-                } else if semantic.match_typing_call_path(&call_path, "TypeVarTuple") {
-                    Some("TypeVarTuple")
-                } else {
-                    None
-                }
-            })
+            semantic
+                .resolve_qualified_name(func)
+                .and_then(|qualified_name| {
+                    if semantic.match_typing_qualified_name(&qualified_name, "TypeVar") {
+                        Some("TypeVar")
+                    } else if semantic.match_typing_qualified_name(&qualified_name, "ParamSpec") {
+                        Some("ParamSpec")
+                    } else if semantic.match_typing_qualified_name(&qualified_name, "TypeVarTuple")
+                    {
+                        Some("TypeVarTuple")
+                    } else {
+                        None
+                    }
+                })
         else {
             continue;
         };

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -646,9 +646,9 @@ impl<'a> Visitor<'a> for SkipFunctionsVisitor<'a> {
                 }
             }
             Expr::Call(ast::ExprCall { func, .. }) => {
-                if UnqualifiedName::from_expr(func).is_some_and(|call_path| {
-                    matches!(call_path.segments(), ["request", "addfinalizer"])
-                }) {
+                if UnqualifiedName::from_expr(func)
+                    .is_some_and(|name| matches!(name.segments(), ["request", "addfinalizer"]))
+                {
                     self.addfinalizer_call = Some(expr);
                 };
                 visitor::walk_expr(self, expr);

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use ruff_diagnostics::{AlwaysFixableViolation, Violation};
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::CallPath;
 use ruff_python_ast::identifier::Identifier;
+use ruff_python_ast::name::UnqualifiedName;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::Decorator;
@@ -646,7 +646,7 @@ impl<'a> Visitor<'a> for SkipFunctionsVisitor<'a> {
                 }
             }
             Expr::Call(ast::ExprCall { func, .. }) => {
-                if CallPath::from_expr(func).is_some_and(|call_path| {
+                if UnqualifiedName::from_expr(func).is_some_and(|call_path| {
                     matches!(call_path.segments(), ["request", "addfinalizer"])
                 }) {
                     self.addfinalizer_call = Some(expr);

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -1,7 +1,6 @@
-use ruff_python_ast::call_path::CallPath;
-use ruff_python_ast::{self as ast, Decorator, Expr, Keyword};
-
 use ruff_python_ast::helpers::map_callable;
+use ruff_python_ast::name::UnqualifiedName;
+use ruff_python_ast::{self as ast, Decorator, Expr, Keyword};
 use ruff_python_semantic::SemanticModel;
 use ruff_python_trivia::PythonWhitespace;
 
@@ -9,7 +8,8 @@ pub(super) fn get_mark_decorators(
     decorators: &[Decorator],
 ) -> impl Iterator<Item = (&Decorator, &str)> {
     decorators.iter().filter_map(|decorator| {
-        let Some(call_path) = CallPath::from_expr(map_callable(&decorator.expression)) else {
+        let Some(call_path) = UnqualifiedName::from_expr(map_callable(&decorator.expression))
+        else {
             return None;
         };
         let ["pytest", "mark", marker] = call_path.segments() else {
@@ -21,25 +21,25 @@ pub(super) fn get_mark_decorators(
 
 pub(super) fn is_pytest_fail(call: &Expr, semantic: &SemanticModel) -> bool {
     semantic
-        .resolve_call_path(call)
+        .resolve_qualified_name(call)
         .is_some_and(|call_path| matches!(call_path.segments(), ["pytest", "fail"]))
 }
 
 pub(super) fn is_pytest_fixture(decorator: &Decorator, semantic: &SemanticModel) -> bool {
     semantic
-        .resolve_call_path(map_callable(&decorator.expression))
+        .resolve_qualified_name(map_callable(&decorator.expression))
         .is_some_and(|call_path| matches!(call_path.segments(), ["pytest", "fixture"]))
 }
 
 pub(super) fn is_pytest_yield_fixture(decorator: &Decorator, semantic: &SemanticModel) -> bool {
     semantic
-        .resolve_call_path(map_callable(&decorator.expression))
+        .resolve_qualified_name(map_callable(&decorator.expression))
         .is_some_and(|call_path| matches!(call_path.segments(), ["pytest", "yield_fixture"]))
 }
 
 pub(super) fn is_pytest_parametrize(decorator: &Decorator, semantic: &SemanticModel) -> bool {
     semantic
-        .resolve_call_path(map_callable(&decorator.expression))
+        .resolve_qualified_name(map_callable(&decorator.expression))
         .is_some_and(|call_path| matches!(call_path.segments(), ["pytest", "mark", "parametrize"]))
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -8,11 +8,10 @@ pub(super) fn get_mark_decorators(
     decorators: &[Decorator],
 ) -> impl Iterator<Item = (&Decorator, &str)> {
     decorators.iter().filter_map(|decorator| {
-        let Some(call_path) = UnqualifiedName::from_expr(map_callable(&decorator.expression))
-        else {
+        let Some(name) = UnqualifiedName::from_expr(map_callable(&decorator.expression)) else {
             return None;
         };
-        let ["pytest", "mark", marker] = call_path.segments() else {
+        let ["pytest", "mark", marker] = name.segments() else {
             return None;
         };
         Some((decorator, *marker))
@@ -22,25 +21,29 @@ pub(super) fn get_mark_decorators(
 pub(super) fn is_pytest_fail(call: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(call)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["pytest", "fail"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["pytest", "fail"]))
 }
 
 pub(super) fn is_pytest_fixture(decorator: &Decorator, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(map_callable(&decorator.expression))
-        .is_some_and(|call_path| matches!(call_path.segments(), ["pytest", "fixture"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["pytest", "fixture"]))
 }
 
 pub(super) fn is_pytest_yield_fixture(decorator: &Decorator, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(map_callable(&decorator.expression))
-        .is_some_and(|call_path| matches!(call_path.segments(), ["pytest", "yield_fixture"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["pytest", "yield_fixture"])
+        })
 }
 
 pub(super) fn is_pytest_parametrize(decorator: &Decorator, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(map_callable(&decorator.expression))
-        .is_some_and(|call_path| matches!(call_path.segments(), ["pytest", "mark", "parametrize"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["pytest", "mark", "parametrize"])
+        })
 }
 
 pub(super) fn keyword_is_literal(keyword: &Keyword, literal: &str) -> bool {

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/patch.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/patch.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::name::UnqualifiedName;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{self as ast, Expr, Parameters};
@@ -104,7 +104,7 @@ fn check_patch_call(call: &ast::ExprCall, index: usize) -> Option<Diagnostic> {
 
 /// PT008
 pub(crate) fn patch_with_lambda(call: &ast::ExprCall) -> Option<Diagnostic> {
-    let call_path = CallPath::from_expr(&call.func)?;
+    let call_path = UnqualifiedName::from_expr(&call.func)?;
 
     if matches!(
         call_path.segments(),

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/patch.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/patch.rs
@@ -104,10 +104,10 @@ fn check_patch_call(call: &ast::ExprCall, index: usize) -> Option<Diagnostic> {
 
 /// PT008
 pub(crate) fn patch_with_lambda(call: &ast::ExprCall) -> Option<Diagnostic> {
-    let call_path = UnqualifiedName::from_expr(&call.func)?;
+    let name = UnqualifiedName::from_expr(&call.func)?;
 
     if matches!(
-        call_path.segments(),
+        name.segments(),
         [
             "mocker"
                 | "class_mocker"
@@ -120,7 +120,7 @@ pub(crate) fn patch_with_lambda(call: &ast::ExprCall) -> Option<Diagnostic> {
     ) {
         check_patch_call(call, 1)
     } else if matches!(
-        call_path.segments(),
+        name.segments(),
         [
             "mocker"
                 | "class_mocker"

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/raises.rs
@@ -154,7 +154,7 @@ impl Violation for PytestRaisesWithoutException {
 fn is_pytest_raises(func: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["pytest", "raises"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["pytest", "raises"]))
 }
 
 const fn is_non_trivial_with_body(body: &[Stmt]) -> bool {
@@ -226,11 +226,11 @@ pub(crate) fn complex_raises(
 
 /// PT011
 fn exception_needs_match(checker: &mut Checker, exception: &Expr) {
-    if let Some(call_path) = checker
+    if let Some(qualified_name) = checker
         .semantic()
         .resolve_qualified_name(exception)
-        .and_then(|call_path| {
-            let call_path = call_path.to_string();
+        .and_then(|qualified_name| {
+            let qualified_name = qualified_name.to_string();
             checker
                 .settings
                 .flake8_pytest_style
@@ -242,13 +242,13 @@ fn exception_needs_match(checker: &mut Checker, exception: &Expr) {
                         .flake8_pytest_style
                         .raises_extend_require_match_for,
                 )
-                .any(|pattern| pattern.matches(&call_path))
-                .then_some(call_path)
+                .any(|pattern| pattern.matches(&qualified_name))
+                .then_some(qualified_name)
         })
     {
         checker.diagnostics.push(Diagnostic::new(
             PytestRaisesTooBroad {
-                exception: call_path,
+                exception: qualified_name,
             },
             exception.range(),
         ));

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/raises.rs
@@ -153,7 +153,7 @@ impl Violation for PytestRaisesWithoutException {
 
 fn is_pytest_raises(func: &Expr, semantic: &SemanticModel) -> bool {
     semantic
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["pytest", "raises"]))
 }
 
@@ -228,7 +228,7 @@ pub(crate) fn complex_raises(
 fn exception_needs_match(checker: &mut Checker, exception: &Expr) {
     if let Some(call_path) = checker
         .semantic()
-        .resolve_call_path(exception)
+        .resolve_qualified_name(exception)
         .and_then(|call_path| {
             let call_path = call_path.to_string();
             checker

--- a/crates/ruff_linter/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -100,7 +100,9 @@ pub(crate) fn unnecessary_paren_on_raise_exception(checker: &mut Checker, expr: 
             if checker
                 .semantic()
                 .resolve_qualified_name(func)
-                .is_some_and(|call_path| matches!(call_path.segments(), ["ctypes", "WinError"]))
+                .is_some_and(|qualified_name| {
+                    matches!(qualified_name.segments(), ["ctypes", "WinError"])
+                })
             {
                 return;
             }

--- a/crates/ruff_linter/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -99,7 +99,7 @@ pub(crate) fn unnecessary_paren_on_raise_exception(checker: &mut Checker, expr: 
             // we might as well get it right.
             if checker
                 .semantic()
-                .resolve_call_path(func)
+                .resolve_qualified_name(func)
                 .is_some_and(|call_path| matches!(call_path.segments(), ["ctypes", "WinError"]))
             {
                 return;

--- a/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
@@ -400,16 +400,19 @@ fn implicit_return_value(checker: &mut Checker, stack: &Stack) {
 fn is_noreturn_func(func: &Expr, semantic: &SemanticModel) -> bool {
     // First, look for known functions that never return from the standard library and popular
     // libraries.
-    if semantic.resolve_call_path(func).is_some_and(|call_path| {
-        matches!(
-            call_path.segments(),
-            ["" | "builtins" | "sys" | "_thread" | "pytest", "exit"]
-                | ["" | "builtins", "quit"]
-                | ["os" | "posix", "_exit" | "abort"]
-                | ["_winapi", "ExitProcess"]
-                | ["pytest", "fail" | "skip" | "xfail"]
-        ) || semantic.match_typing_call_path(&call_path, "assert_never")
-    }) {
+    if semantic
+        .resolve_qualified_name(func)
+        .is_some_and(|call_path| {
+            matches!(
+                call_path.segments(),
+                ["" | "builtins" | "sys" | "_thread" | "pytest", "exit"]
+                    | ["" | "builtins", "quit"]
+                    | ["os" | "posix", "_exit" | "abort"]
+                    | ["_winapi", "ExitProcess"]
+                    | ["pytest", "fail" | "skip" | "xfail"]
+            ) || semantic.match_typing_call_path(&call_path, "assert_never")
+        })
+    {
         return true;
     }
 
@@ -430,7 +433,7 @@ fn is_noreturn_func(func: &Expr, semantic: &SemanticModel) -> bool {
         return false;
     };
 
-    let Some(call_path) = semantic.resolve_call_path(returns) else {
+    let Some(call_path) = semantic.resolve_qualified_name(returns) else {
         return false;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/rules/function.rs
@@ -402,15 +402,15 @@ fn is_noreturn_func(func: &Expr, semantic: &SemanticModel) -> bool {
     // libraries.
     if semantic
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["" | "builtins" | "sys" | "_thread" | "pytest", "exit"]
                     | ["" | "builtins", "quit"]
                     | ["os" | "posix", "_exit" | "abort"]
                     | ["_winapi", "ExitProcess"]
                     | ["pytest", "fail" | "skip" | "xfail"]
-            ) || semantic.match_typing_call_path(&call_path, "assert_never")
+            ) || semantic.match_typing_qualified_name(&qualified_name, "assert_never")
         })
     {
         return true;
@@ -433,11 +433,11 @@ fn is_noreturn_func(func: &Expr, semantic: &SemanticModel) -> bool {
         return false;
     };
 
-    let Some(call_path) = semantic.resolve_qualified_name(returns) else {
+    let Some(qualified_name) = semantic.resolve_qualified_name(returns) else {
         return false;
     };
 
-    semantic.match_typing_call_path(&call_path, "NoReturn")
+    semantic.match_typing_qualified_name(&qualified_name, "NoReturn")
 }
 
 /// RET503

--- a/crates/ruff_linter/src/rules/flake8_return/visitor.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/visitor.rs
@@ -198,7 +198,7 @@ fn has_conditional_body(with: &ast::StmtWith, semantic: &SemanticModel) -> bool 
         else {
             return false;
         };
-        if let Some(call_path) = semantic.resolve_call_path(func) {
+        if let Some(call_path) = semantic.resolve_qualified_name(func) {
             if call_path.segments() == ["contextlib", "suppress"] {
                 return true;
             }

--- a/crates/ruff_linter/src/rules/flake8_return/visitor.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/visitor.rs
@@ -198,8 +198,8 @@ fn has_conditional_body(with: &ast::StmtWith, semantic: &SemanticModel) -> bool 
         else {
             return false;
         };
-        if let Some(call_path) = semantic.resolve_qualified_name(func) {
-            if call_path.segments() == ["contextlib", "suppress"] {
+        if let Some(qualified_name) = semantic.resolve_qualified_name(func) {
+            if qualified_name.segments() == ["contextlib", "suppress"] {
                 return true;
             }
         }

--- a/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
@@ -141,24 +141,24 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
         }
 
         // Allow some documented private methods, like `os._exit()`.
-        if let Some(call_path) = checker.semantic().resolve_qualified_name(expr) {
-            if matches!(call_path.segments(), ["os", "_exit"]) {
+        if let Some(qualified_name) = checker.semantic().resolve_qualified_name(expr) {
+            if matches!(qualified_name.segments(), ["os", "_exit"]) {
                 return;
             }
         }
 
         if let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() {
             // Ignore `super()` calls.
-            if let Some(call_path) = UnqualifiedName::from_expr(func) {
-                if matches!(call_path.segments(), ["super"]) {
+            if let Some(name) = UnqualifiedName::from_expr(func) {
+                if matches!(name.segments(), ["super"]) {
                     return;
                 }
             }
         }
 
-        if let Some(call_path) = UnqualifiedName::from_expr(value) {
+        if let Some(name) = UnqualifiedName::from_expr(value) {
             // Ignore `self` and `cls` accesses.
-            if matches!(call_path.segments(), ["self" | "cls" | "mcs"]) {
+            if matches!(name.segments(), ["self" | "cls" | "mcs"]) {
                 return;
             }
         }

--- a/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff_linter/src/rules/flake8_self/rules/private_member_access.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::name::UnqualifiedName;
 use ruff_python_ast::{self as ast, Expr};
 use ruff_python_semantic::{BindingKind, ScopeKind};
 use ruff_text_size::Ranged;
@@ -141,7 +141,7 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
         }
 
         // Allow some documented private methods, like `os._exit()`.
-        if let Some(call_path) = checker.semantic().resolve_call_path(expr) {
+        if let Some(call_path) = checker.semantic().resolve_qualified_name(expr) {
             if matches!(call_path.segments(), ["os", "_exit"]) {
                 return;
             }
@@ -149,14 +149,14 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
 
         if let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() {
             // Ignore `super()` calls.
-            if let Some(call_path) = CallPath::from_expr(func) {
+            if let Some(call_path) = UnqualifiedName::from_expr(func) {
                 if matches!(call_path.segments(), ["super"]) {
                     return;
                 }
             }
         }
 
-        if let Some(call_path) = CallPath::from_expr(value) {
+        if let Some(call_path) = UnqualifiedName::from_expr(value) {
             // Ignore `self` and `cls` accesses.
             if matches!(call_path.segments(), ["self" | "cls" | "mcs"]) {
                 return;

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -150,9 +150,9 @@ pub(crate) fn use_capital_environment_variables(checker: &mut Checker, expr: &Ex
     if !checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["os", "environ", "get"] | ["os", "getenv"]
             )
         })

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -149,7 +149,7 @@ pub(crate) fn use_capital_environment_variables(checker: &mut Checker, expr: &Ex
     };
     if !checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| {
             matches!(
                 call_path.segments(),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
@@ -100,9 +100,9 @@ fn explicit_with_items(checker: &mut Checker, with_items: &[WithItem]) -> bool {
     checker
         .semantic()
         .resolve_qualified_name(&expr_call.func)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["asyncio", "timeout" | "timeout_at"]
                     | ["anyio", "CancelScope" | "fail_after" | "move_on_after"]
                     | [

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_with.rs
@@ -99,7 +99,7 @@ fn explicit_with_items(checker: &mut Checker, with_items: &[WithItem]) -> bool {
     };
     checker
         .semantic()
-        .resolve_call_path(&expr_call.func)
+        .resolve_qualified_name(&expr_call.func)
         .is_some_and(|call_path| {
             matches!(
                 call_path.segments(),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -65,8 +65,8 @@ fn match_async_exit_stack(semantic: &SemanticModel) -> bool {
                 if let Expr::Call(ast::ExprCall { func, .. }) = &item.context_expr {
                     if semantic
                         .resolve_qualified_name(func)
-                        .is_some_and(|call_path| {
-                            matches!(call_path.segments(), ["contextlib", "AsyncExitStack"])
+                        .is_some_and(|qualified_name| {
+                            matches!(qualified_name.segments(), ["contextlib", "AsyncExitStack"])
                         })
                     {
                         return true;
@@ -99,8 +99,8 @@ fn match_exit_stack(semantic: &SemanticModel) -> bool {
                 if let Expr::Call(ast::ExprCall { func, .. }) = &item.context_expr {
                     if semantic
                         .resolve_qualified_name(func)
-                        .is_some_and(|call_path| {
-                            matches!(call_path.segments(), ["contextlib", "ExitStack"])
+                        .is_some_and(|qualified_name| {
+                            matches!(qualified_name.segments(), ["contextlib", "ExitStack"])
                         })
                     {
                         return true;
@@ -121,7 +121,9 @@ fn is_open(checker: &mut Checker, func: &Expr) -> bool {
                 Expr::Call(ast::ExprCall { func, .. }) => checker
                     .semantic()
                     .resolve_qualified_name(func)
-                    .is_some_and(|call_path| matches!(call_path.segments(), ["pathlib", "Path"])),
+                    .is_some_and(|qualified_name| {
+                        matches!(qualified_name.segments(), ["pathlib", "Path"])
+                    }),
                 _ => false,
             }
         }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -63,9 +63,12 @@ fn match_async_exit_stack(semantic: &SemanticModel) -> bool {
         if let Stmt::With(ast::StmtWith { items, .. }) = parent {
             for item in items {
                 if let Expr::Call(ast::ExprCall { func, .. }) = &item.context_expr {
-                    if semantic.resolve_call_path(func).is_some_and(|call_path| {
-                        matches!(call_path.segments(), ["contextlib", "AsyncExitStack"])
-                    }) {
+                    if semantic
+                        .resolve_qualified_name(func)
+                        .is_some_and(|call_path| {
+                            matches!(call_path.segments(), ["contextlib", "AsyncExitStack"])
+                        })
+                    {
                         return true;
                     }
                 }
@@ -94,9 +97,12 @@ fn match_exit_stack(semantic: &SemanticModel) -> bool {
         if let Stmt::With(ast::StmtWith { items, .. }) = parent {
             for item in items {
                 if let Expr::Call(ast::ExprCall { func, .. }) = &item.context_expr {
-                    if semantic.resolve_call_path(func).is_some_and(|call_path| {
-                        matches!(call_path.segments(), ["contextlib", "ExitStack"])
-                    }) {
+                    if semantic
+                        .resolve_qualified_name(func)
+                        .is_some_and(|call_path| {
+                            matches!(call_path.segments(), ["contextlib", "ExitStack"])
+                        })
+                    {
                         return true;
                     }
                 }
@@ -114,7 +120,7 @@ fn is_open(checker: &mut Checker, func: &Expr) -> bool {
             match value.as_ref() {
                 Expr::Call(ast::ExprCall { func, .. }) => checker
                     .semantic()
-                    .resolve_call_path(func)
+                    .resolve_qualified_name(func)
                     .is_some_and(|call_path| matches!(call_path.segments(), ["pathlib", "Path"])),
                 _ => false,
             }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/suppressible_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/suppressible_exception.rs
@@ -1,7 +1,7 @@
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers;
-use ruff_python_ast::name::compose_call_path;
+use ruff_python_ast::name::UnqualifiedName;
 use ruff_python_ast::{self as ast, ExceptHandler, Stmt};
 use ruff_text_size::Ranged;
 use ruff_text_size::{TextLen, TextRange};
@@ -107,7 +107,7 @@ pub(crate) fn suppressible_exception(
 
     let Some(handler_names) = helpers::extract_handled_exceptions(handlers)
         .into_iter()
-        .map(compose_call_path)
+        .map(|expr| UnqualifiedName::from_expr(expr).map(|name| name.to_string()))
         .collect::<Option<Vec<String>>>()
     else {
         return;

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/suppressible_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/suppressible_exception.rs
@@ -1,7 +1,7 @@
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::compose_call_path;
 use ruff_python_ast::helpers;
+use ruff_python_ast::name::compose_call_path;
 use ruff_python_ast::{self as ast, ExceptHandler, Stmt};
 use ruff_text_size::Ranged;
 use ruff_text_size::{TextLen, TextRange};

--- a/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_namedtuple_subclass.rs
+++ b/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_namedtuple_subclass.rs
@@ -73,7 +73,7 @@ pub(crate) fn no_slots_in_namedtuple_subclass(
         };
         checker
             .semantic()
-            .resolve_call_path(func)
+            .resolve_qualified_name(func)
             .is_some_and(|call_path| matches!(call_path.segments(), ["collections", "namedtuple"]))
     }) {
         if !has_slots(&class.body) {

--- a/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_namedtuple_subclass.rs
+++ b/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_namedtuple_subclass.rs
@@ -74,7 +74,9 @@ pub(crate) fn no_slots_in_namedtuple_subclass(
         checker
             .semantic()
             .resolve_qualified_name(func)
-            .is_some_and(|call_path| matches!(call_path.segments(), ["collections", "namedtuple"]))
+            .is_some_and(|qualified_name| {
+                matches!(qualified_name.segments(), ["collections", "namedtuple"])
+            })
     }) {
         if !has_slots(&class.body) {
             checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_str_subclass.rs
+++ b/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_str_subclass.rs
@@ -69,7 +69,7 @@ pub(crate) fn no_slots_in_str_subclass(checker: &mut Checker, stmt: &Stmt, class
 fn is_str_subclass(bases: &[Expr], semantic: &SemanticModel) -> bool {
     let mut is_str_subclass = false;
     for base in bases {
-        if let Some(call_path) = semantic.resolve_call_path(base) {
+        if let Some(call_path) = semantic.resolve_qualified_name(base) {
             match call_path.segments() {
                 ["" | "builtins", "str"] => {
                     is_str_subclass = true;

--- a/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_str_subclass.rs
+++ b/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_str_subclass.rs
@@ -69,8 +69,8 @@ pub(crate) fn no_slots_in_str_subclass(checker: &mut Checker, stmt: &Stmt, class
 fn is_str_subclass(bases: &[Expr], semantic: &SemanticModel) -> bool {
     let mut is_str_subclass = false;
     for base in bases {
-        if let Some(call_path) = semantic.resolve_qualified_name(base) {
-            match call_path.segments() {
+        if let Some(qualified_name) = semantic.resolve_qualified_name(base) {
+            match qualified_name.segments() {
                 ["" | "builtins", "str"] => {
                     is_str_subclass = true;
                 }

--- a/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_tuple_subclass.rs
+++ b/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_tuple_subclass.rs
@@ -59,11 +59,11 @@ pub(crate) fn no_slots_in_tuple_subclass(checker: &mut Checker, stmt: &Stmt, cla
         checker
             .semantic()
             .resolve_qualified_name(map_subscript(base))
-            .is_some_and(|call_path| {
-                matches!(call_path.segments(), ["" | "builtins", "tuple"])
+            .is_some_and(|qualified_name| {
+                matches!(qualified_name.segments(), ["" | "builtins", "tuple"])
                     || checker
                         .semantic()
-                        .match_typing_call_path(&call_path, "Tuple")
+                        .match_typing_qualified_name(&qualified_name, "Tuple")
             })
     }) {
         if !has_slots(&class.body) {

--- a/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_tuple_subclass.rs
+++ b/crates/ruff_linter/src/rules/flake8_slots/rules/no_slots_in_tuple_subclass.rs
@@ -58,7 +58,7 @@ pub(crate) fn no_slots_in_tuple_subclass(checker: &mut Checker, stmt: &Stmt, cla
     if bases.iter().any(|base| {
         checker
             .semantic()
-            .resolve_call_path(map_subscript(base))
+            .resolve_qualified_name(map_subscript(base))
             .is_some_and(|call_path| {
                 matches!(call_path.segments(), ["" | "builtins", "tuple"])
                     || checker

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/banned_api.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/banned_api.rs
@@ -66,9 +66,9 @@ pub(crate) fn banned_attribute_access(checker: &mut Checker, expr: &Expr) {
         checker
             .semantic()
             .resolve_qualified_name(expr)
-            .and_then(|call_path| {
+            .and_then(|qualified_name| {
                 banned_api.iter().find(|(banned_path, ..)| {
-                    call_path == QualifiedName::from_dotted_name(banned_path)
+                    qualified_name == QualifiedName::from_dotted_name(banned_path)
                 })
             })
     {

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/banned_api.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/banned_api.rs
@@ -2,7 +2,7 @@ use ruff_python_ast::Expr;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::name::QualifiedName;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -65,10 +65,10 @@ pub(crate) fn banned_attribute_access(checker: &mut Checker, expr: &Expr) {
     if let Some((banned_path, ban)) =
         checker
             .semantic()
-            .resolve_call_path(expr)
+            .resolve_qualified_name(expr)
             .and_then(|call_path| {
                 banned_api.iter().find(|(banned_path, ..)| {
-                    call_path == CallPath::from_qualified_name(banned_path)
+                    call_path == QualifiedName::from_dotted_name(banned_path)
                 })
             })
     {

--- a/crates/ruff_linter/src/rules/flake8_trio/method_name.rs
+++ b/crates/ruff_linter/src/rules/flake8_trio/method_name.rs
@@ -1,4 +1,4 @@
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::name::QualifiedName;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(super) enum MethodName {
@@ -70,8 +70,8 @@ impl MethodName {
 }
 
 impl MethodName {
-    pub(super) fn try_from(call_path: &CallPath<'_>) -> Option<Self> {
-        match call_path.segments() {
+    pub(super) fn try_from(qualified_name: &QualifiedName<'_>) -> Option<Self> {
+        match qualified_name.segments() {
             ["trio", "CancelScope"] => Some(Self::CancelScope),
             ["trio", "aclose_forcefully"] => Some(Self::AcloseForcefully),
             ["trio", "fail_after"] => Some(Self::FailAfter),

--- a/crates/ruff_linter/src/rules/flake8_trio/rules/sync_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_trio/rules/sync_call.rs
@@ -57,13 +57,13 @@ pub(crate) fn sync_call(checker: &mut Checker, call: &ExprCall) {
     }
 
     let Some(method_name) = ({
-        let Some(call_path) = checker
+        let Some(qualified_name) = checker
             .semantic()
             .resolve_qualified_name(call.func.as_ref())
         else {
             return;
         };
-        MethodName::try_from(&call_path)
+        MethodName::try_from(&qualified_name)
     }) else {
         return;
     };

--- a/crates/ruff_linter/src/rules/flake8_trio/rules/sync_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_trio/rules/sync_call.rs
@@ -57,7 +57,10 @@ pub(crate) fn sync_call(checker: &mut Checker, call: &ExprCall) {
     }
 
     let Some(method_name) = ({
-        let Some(call_path) = checker.semantic().resolve_call_path(call.func.as_ref()) else {
+        let Some(call_path) = checker
+            .semantic()
+            .resolve_qualified_name(call.func.as_ref())
+        else {
             return;
         };
         MethodName::try_from(&call_path)

--- a/crates/ruff_linter/src/rules/flake8_trio/rules/timeout_without_await.rs
+++ b/crates/ruff_linter/src/rules/flake8_trio/rules/timeout_without_await.rs
@@ -56,7 +56,9 @@ pub(crate) fn timeout_without_await(
 
     let Some(method_name) = with_items.iter().find_map(|item| {
         let call = item.context_expr.as_call_expr()?;
-        let call_path = checker.semantic().resolve_call_path(call.func.as_ref())?;
+        let call_path = checker
+            .semantic()
+            .resolve_qualified_name(call.func.as_ref())?;
         MethodName::try_from(&call_path)
     }) else {
         return;

--- a/crates/ruff_linter/src/rules/flake8_trio/rules/timeout_without_await.rs
+++ b/crates/ruff_linter/src/rules/flake8_trio/rules/timeout_without_await.rs
@@ -56,10 +56,10 @@ pub(crate) fn timeout_without_await(
 
     let Some(method_name) = with_items.iter().find_map(|item| {
         let call = item.context_expr.as_call_expr()?;
-        let call_path = checker
+        let qualified_name = checker
             .semantic()
             .resolve_qualified_name(call.func.as_ref())?;
-        MethodName::try_from(&call_path)
+        MethodName::try_from(&qualified_name)
     }) else {
         return;
     };

--- a/crates/ruff_linter/src/rules/flake8_trio/rules/unneeded_sleep.rs
+++ b/crates/ruff_linter/src/rules/flake8_trio/rules/unneeded_sleep.rs
@@ -63,7 +63,7 @@ pub(crate) fn unneeded_sleep(checker: &mut Checker, while_stmt: &ast::StmtWhile)
 
     if checker
         .semantic()
-        .resolve_call_path(func.as_ref())
+        .resolve_qualified_name(func.as_ref())
         .is_some_and(|path| matches!(path.segments(), ["trio", "sleep" | "sleep_until"]))
     {
         checker

--- a/crates/ruff_linter/src/rules/flake8_trio/rules/zero_sleep_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_trio/rules/zero_sleep_call.rs
@@ -62,7 +62,7 @@ pub(crate) fn zero_sleep_call(checker: &mut Checker, call: &ExprCall) {
 
     if !checker
         .semantic()
-        .resolve_call_path(call.func.as_ref())
+        .resolve_qualified_name(call.func.as_ref())
         .is_some_and(|call_path| matches!(call_path.segments(), ["trio", "sleep"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_trio/rules/zero_sleep_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_trio/rules/zero_sleep_call.rs
@@ -63,7 +63,7 @@ pub(crate) fn zero_sleep_call(checker: &mut Checker, call: &ExprCall) {
     if !checker
         .semantic()
         .resolve_qualified_name(call.func.as_ref())
-        .is_some_and(|call_path| matches!(call_path.segments(), ["trio", "sleep"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["trio", "sleep"]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
@@ -77,10 +77,10 @@ fn runtime_required_base_class(
     base_classes: &[String],
     semantic: &SemanticModel,
 ) -> bool {
-    analyze::class::any_call_path(class_def, semantic, &|call_path| {
+    analyze::class::any_qualified_name(class_def, semantic, &|qualified_name| {
         base_classes
             .iter()
-            .any(|base_class| QualifiedName::from_dotted_name(base_class) == call_path)
+            .any(|base_class| QualifiedName::from_dotted_name(base_class) == qualified_name)
     })
 }
 
@@ -96,10 +96,10 @@ fn runtime_required_decorators(
     decorator_list.iter().any(|decorator| {
         semantic
             .resolve_qualified_name(map_callable(&decorator.expression))
-            .is_some_and(|call_path| {
+            .is_some_and(|qualified_name| {
                 decorators
                     .iter()
-                    .any(|base_class| QualifiedName::from_dotted_name(base_class) == call_path)
+                    .any(|base_class| QualifiedName::from_dotted_name(base_class) == qualified_name)
             })
     })
 }
@@ -120,16 +120,16 @@ pub(crate) fn is_dataclass_meta_annotation(annotation: &Expr, semantic: &Semanti
         if class_def.decorator_list.iter().any(|decorator| {
             semantic
                 .resolve_qualified_name(map_callable(&decorator.expression))
-                .is_some_and(|call_path| {
-                    matches!(call_path.segments(), ["dataclasses", "dataclass"])
+                .is_some_and(|qualified_name| {
+                    matches!(qualified_name.segments(), ["dataclasses", "dataclass"])
                 })
         }) {
             // Determine whether the annotation is `typing.ClassVar` or `dataclasses.InitVar`.
             return semantic
                 .resolve_qualified_name(map_subscript(annotation))
-                .is_some_and(|call_path| {
-                    matches!(call_path.segments(), ["dataclasses", "InitVar"])
-                        || semantic.match_typing_call_path(&call_path, "ClassVar")
+                .is_some_and(|qualified_name| {
+                    matches!(qualified_name.segments(), ["dataclasses", "InitVar"])
+                        || semantic.match_typing_qualified_name(&qualified_name, "ClassVar")
                 });
         }
     }
@@ -155,8 +155,8 @@ pub(crate) fn is_singledispatch_interface(
     function_def.decorator_list.iter().any(|decorator| {
         semantic
             .resolve_qualified_name(&decorator.expression)
-            .is_some_and(|call_path| {
-                matches!(call_path.segments(), ["functools", "singledispatch"])
+            .is_some_and(|qualified_name| {
+                matches!(qualified_name.segments(), ["functools", "singledispatch"])
             })
     })
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_sep_split.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_sep_split.rs
@@ -79,7 +79,7 @@ pub(crate) fn os_sep_split(checker: &mut Checker, call: &ast::ExprCall) {
     if !checker
         .semantic()
         .resolve_qualified_name(sep)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["os", "sep"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["os", "sep"]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_sep_split.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_sep_split.rs
@@ -78,7 +78,7 @@ pub(crate) fn os_sep_split(checker: &mut Checker, call: &ast::ExprCall) {
 
     if !checker
         .semantic()
-        .resolve_call_path(sep)
+        .resolve_qualified_name(sep)
         .is_some_and(|call_path| matches!(call_path.segments(), ["os", "sep"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
@@ -47,7 +47,9 @@ pub(crate) fn path_constructor_current_directory(checker: &mut Checker, expr: &E
     if !checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["pathlib", "Path" | "PurePath"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["pathlib", "Path" | "PurePath"])
+        })
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/path_constructor_current_directory.rs
@@ -46,7 +46,7 @@ impl AlwaysFixableViolation for PathConstructorCurrentDirectory {
 pub(crate) fn path_constructor_current_directory(checker: &mut Checker, expr: &Expr, func: &Expr) {
     if !checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["pathlib", "Path" | "PurePath"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
@@ -16,142 +16,141 @@ use crate::rules::flake8_use_pathlib::violations::{
 use crate::settings::types::PythonVersion;
 
 pub(crate) fn replaceable_by_pathlib(checker: &mut Checker, call: &ExprCall) {
-    if let Some(diagnostic_kind) =
-        checker
-            .semantic()
-            .resolve_call_path(&call.func)
-            .and_then(|call_path| match call_path.segments() {
-                // PTH100
-                ["os", "path", "abspath"] => Some(OsPathAbspath.into()),
-                // PTH101
-                ["os", "chmod"] => Some(OsChmod.into()),
-                // PTH102
-                ["os", "makedirs"] => Some(OsMakedirs.into()),
-                // PTH103
-                ["os", "mkdir"] => Some(OsMkdir.into()),
-                // PTH104
-                ["os", "rename"] => Some(OsRename.into()),
-                // PTH105
-                ["os", "replace"] => Some(OsReplace.into()),
-                // PTH106
-                ["os", "rmdir"] => Some(OsRmdir.into()),
-                // PTH107
-                ["os", "remove"] => Some(OsRemove.into()),
-                // PTH108
-                ["os", "unlink"] => Some(OsUnlink.into()),
-                // PTH109
-                ["os", "getcwd"] => Some(OsGetcwd.into()),
-                ["os", "getcwdb"] => Some(OsGetcwd.into()),
-                // PTH110
-                ["os", "path", "exists"] => Some(OsPathExists.into()),
-                // PTH111
-                ["os", "path", "expanduser"] => Some(OsPathExpanduser.into()),
-                // PTH112
-                ["os", "path", "isdir"] => Some(OsPathIsdir.into()),
-                // PTH113
-                ["os", "path", "isfile"] => Some(OsPathIsfile.into()),
-                // PTH114
-                ["os", "path", "islink"] => Some(OsPathIslink.into()),
-                // PTH116
-                ["os", "stat"] => Some(OsStat.into()),
-                // PTH117
-                ["os", "path", "isabs"] => Some(OsPathIsabs.into()),
-                // PTH118
-                ["os", "path", "join"] => Some(
-                    OsPathJoin {
-                        module: "path".to_string(),
-                        joiner: if call.arguments.args.iter().any(Expr::is_starred_expr) {
-                            Joiner::Joinpath
-                        } else {
-                            Joiner::Slash
-                        },
-                    }
-                    .into(),
-                ),
-                ["os", "sep", "join"] => Some(
-                    OsPathJoin {
-                        module: "sep".to_string(),
-                        joiner: if call.arguments.args.iter().any(Expr::is_starred_expr) {
-                            Joiner::Joinpath
-                        } else {
-                            Joiner::Slash
-                        },
-                    }
-                    .into(),
-                ),
-                // PTH119
-                ["os", "path", "basename"] => Some(OsPathBasename.into()),
-                // PTH120
-                ["os", "path", "dirname"] => Some(OsPathDirname.into()),
-                // PTH121
-                ["os", "path", "samefile"] => Some(OsPathSamefile.into()),
-                // PTH122
-                ["os", "path", "splitext"] => Some(OsPathSplitext.into()),
-                // PTH202
-                ["os", "path", "getsize"] => Some(OsPathGetsize.into()),
-                // PTH203
-                ["os", "path", "getatime"] => Some(OsPathGetatime.into()),
-                // PTH204
-                ["os", "path", "getmtime"] => Some(OsPathGetmtime.into()),
-                // PTH205
-                ["os", "path", "getctime"] => Some(OsPathGetctime.into()),
-                // PTH123
-                ["" | "builtin", "open"] => {
-                    // `closefd` and `openener` are not supported by pathlib, so check if they are
-                    // are set to non-default values.
-                    // https://github.com/astral-sh/ruff/issues/7620
-                    // Signature as of Python 3.11 (https://docs.python.org/3/library/functions.html#open):
-                    // ```text
-                    //      0     1         2             3              4            5
-                    // open(file, mode='r', buffering=-1, encoding=None, errors=None, newline=None,
-                    //      6             7
-                    //      closefd=True, opener=None)
-                    //              ^^^^         ^^^^
-                    // ```
-                    // For `pathlib` (https://docs.python.org/3/library/pathlib.html#pathlib.Path.open):
-                    // ```text
-                    // Path.open(mode='r', buffering=-1, encoding=None, errors=None, newline=None)
-                    // ```
-                    if call
+    if let Some(diagnostic_kind) = checker
+        .semantic()
+        .resolve_qualified_name(&call.func)
+        .and_then(|call_path| match call_path.segments() {
+            // PTH100
+            ["os", "path", "abspath"] => Some(OsPathAbspath.into()),
+            // PTH101
+            ["os", "chmod"] => Some(OsChmod.into()),
+            // PTH102
+            ["os", "makedirs"] => Some(OsMakedirs.into()),
+            // PTH103
+            ["os", "mkdir"] => Some(OsMkdir.into()),
+            // PTH104
+            ["os", "rename"] => Some(OsRename.into()),
+            // PTH105
+            ["os", "replace"] => Some(OsReplace.into()),
+            // PTH106
+            ["os", "rmdir"] => Some(OsRmdir.into()),
+            // PTH107
+            ["os", "remove"] => Some(OsRemove.into()),
+            // PTH108
+            ["os", "unlink"] => Some(OsUnlink.into()),
+            // PTH109
+            ["os", "getcwd"] => Some(OsGetcwd.into()),
+            ["os", "getcwdb"] => Some(OsGetcwd.into()),
+            // PTH110
+            ["os", "path", "exists"] => Some(OsPathExists.into()),
+            // PTH111
+            ["os", "path", "expanduser"] => Some(OsPathExpanduser.into()),
+            // PTH112
+            ["os", "path", "isdir"] => Some(OsPathIsdir.into()),
+            // PTH113
+            ["os", "path", "isfile"] => Some(OsPathIsfile.into()),
+            // PTH114
+            ["os", "path", "islink"] => Some(OsPathIslink.into()),
+            // PTH116
+            ["os", "stat"] => Some(OsStat.into()),
+            // PTH117
+            ["os", "path", "isabs"] => Some(OsPathIsabs.into()),
+            // PTH118
+            ["os", "path", "join"] => Some(
+                OsPathJoin {
+                    module: "path".to_string(),
+                    joiner: if call.arguments.args.iter().any(Expr::is_starred_expr) {
+                        Joiner::Joinpath
+                    } else {
+                        Joiner::Slash
+                    },
+                }
+                .into(),
+            ),
+            ["os", "sep", "join"] => Some(
+                OsPathJoin {
+                    module: "sep".to_string(),
+                    joiner: if call.arguments.args.iter().any(Expr::is_starred_expr) {
+                        Joiner::Joinpath
+                    } else {
+                        Joiner::Slash
+                    },
+                }
+                .into(),
+            ),
+            // PTH119
+            ["os", "path", "basename"] => Some(OsPathBasename.into()),
+            // PTH120
+            ["os", "path", "dirname"] => Some(OsPathDirname.into()),
+            // PTH121
+            ["os", "path", "samefile"] => Some(OsPathSamefile.into()),
+            // PTH122
+            ["os", "path", "splitext"] => Some(OsPathSplitext.into()),
+            // PTH202
+            ["os", "path", "getsize"] => Some(OsPathGetsize.into()),
+            // PTH203
+            ["os", "path", "getatime"] => Some(OsPathGetatime.into()),
+            // PTH204
+            ["os", "path", "getmtime"] => Some(OsPathGetmtime.into()),
+            // PTH205
+            ["os", "path", "getctime"] => Some(OsPathGetctime.into()),
+            // PTH123
+            ["" | "builtin", "open"] => {
+                // `closefd` and `openener` are not supported by pathlib, so check if they are
+                // are set to non-default values.
+                // https://github.com/astral-sh/ruff/issues/7620
+                // Signature as of Python 3.11 (https://docs.python.org/3/library/functions.html#open):
+                // ```text
+                //      0     1         2             3              4            5
+                // open(file, mode='r', buffering=-1, encoding=None, errors=None, newline=None,
+                //      6             7
+                //      closefd=True, opener=None)
+                //              ^^^^         ^^^^
+                // ```
+                // For `pathlib` (https://docs.python.org/3/library/pathlib.html#pathlib.Path.open):
+                // ```text
+                // Path.open(mode='r', buffering=-1, encoding=None, errors=None, newline=None)
+                // ```
+                if call
+                    .arguments
+                    .find_argument("closefd", 6)
+                    .is_some_and(|expr| {
+                        !matches!(
+                            expr,
+                            Expr::BooleanLiteral(ExprBooleanLiteral { value: true, .. })
+                        )
+                    })
+                    || call
                         .arguments
-                        .find_argument("closefd", 6)
-                        .is_some_and(|expr| {
-                            !matches!(
-                                expr,
-                                Expr::BooleanLiteral(ExprBooleanLiteral { value: true, .. })
-                            )
-                        })
-                        || call
-                            .arguments
-                            .find_argument("opener", 7)
-                            .is_some_and(|expr| !expr.is_none_literal_expr())
-                    {
-                        return None;
-                    }
-                    Some(BuiltinOpen.into())
+                        .find_argument("opener", 7)
+                        .is_some_and(|expr| !expr.is_none_literal_expr())
+                {
+                    return None;
                 }
-                // PTH124
-                ["py", "path", "local"] => Some(PyPath.into()),
-                // PTH207
-                ["glob", "glob"] => Some(
-                    Glob {
-                        function: "glob".to_string(),
-                    }
-                    .into(),
-                ),
-                ["glob", "iglob"] => Some(
-                    Glob {
-                        function: "iglob".to_string(),
-                    }
-                    .into(),
-                ),
-                // PTH115
-                // Python 3.9+
-                ["os", "readlink"] if checker.settings.target_version >= PythonVersion::Py39 => {
-                    Some(OsReadlink.into())
+                Some(BuiltinOpen.into())
+            }
+            // PTH124
+            ["py", "path", "local"] => Some(PyPath.into()),
+            // PTH207
+            ["glob", "glob"] => Some(
+                Glob {
+                    function: "glob".to_string(),
                 }
-                _ => None,
-            })
+                .into(),
+            ),
+            ["glob", "iglob"] => Some(
+                Glob {
+                    function: "iglob".to_string(),
+                }
+                .into(),
+            ),
+            // PTH115
+            // Python 3.9+
+            ["os", "readlink"] if checker.settings.target_version >= PythonVersion::Py39 => {
+                Some(OsReadlink.into())
+            }
+            _ => None,
+        })
     {
         let diagnostic = Diagnostic::new::<DiagnosticKind>(diagnostic_kind, call.func.range());
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/replaceable_by_pathlib.rs
@@ -19,7 +19,7 @@ pub(crate) fn replaceable_by_pathlib(checker: &mut Checker, call: &ExprCall) {
     if let Some(diagnostic_kind) = checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .and_then(|call_path| match call_path.segments() {
+        .and_then(|qualified_name| match qualified_name.segments() {
             // PTH100
             ["os", "path", "abspath"] => Some(OsPathAbspath.into()),
             // PTH101

--- a/crates/ruff_linter/src/rules/numpy/rules/deprecated_function.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/deprecated_function.rs
@@ -63,7 +63,7 @@ pub(crate) fn deprecated_function(checker: &mut Checker, expr: &Expr) {
     if let Some((existing, replacement)) =
         checker
             .semantic()
-            .resolve_call_path(expr)
+            .resolve_qualified_name(expr)
             .and_then(|call_path| match call_path.segments() {
                 ["numpy", "round_"] => Some(("round_", "round")),
                 ["numpy", "product"] => Some(("product", "prod")),

--- a/crates/ruff_linter/src/rules/numpy/rules/deprecated_function.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/deprecated_function.rs
@@ -64,7 +64,7 @@ pub(crate) fn deprecated_function(checker: &mut Checker, expr: &Expr) {
         checker
             .semantic()
             .resolve_qualified_name(expr)
-            .and_then(|call_path| match call_path.segments() {
+            .and_then(|qualified_name| match qualified_name.segments() {
                 ["numpy", "round_"] => Some(("round_", "round")),
                 ["numpy", "product"] => Some(("product", "prod")),
                 ["numpy", "cumproduct"] => Some(("cumproduct", "cumprod")),

--- a/crates/ruff_linter/src/rules/numpy/rules/deprecated_type_alias.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/deprecated_type_alias.rs
@@ -56,7 +56,7 @@ pub(crate) fn deprecated_type_alias(checker: &mut Checker, expr: &Expr) {
 
     if let Some(type_name) = checker
         .semantic()
-        .resolve_call_path(expr)
+        .resolve_qualified_name(expr)
         .and_then(|call_path| {
             if matches!(
                 call_path.segments(),

--- a/crates/ruff_linter/src/rules/numpy/rules/deprecated_type_alias.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/deprecated_type_alias.rs
@@ -54,22 +54,30 @@ pub(crate) fn deprecated_type_alias(checker: &mut Checker, expr: &Expr) {
         return;
     }
 
-    if let Some(type_name) = checker
-        .semantic()
-        .resolve_qualified_name(expr)
-        .and_then(|call_path| {
-            if matches!(
-                call_path.segments(),
-                [
-                    "numpy",
-                    "bool" | "int" | "float" | "complex" | "object" | "str" | "long" | "unicode"
-                ]
-            ) {
-                Some(call_path.segments()[1])
-            } else {
-                None
-            }
-        })
+    if let Some(type_name) =
+        checker
+            .semantic()
+            .resolve_qualified_name(expr)
+            .and_then(|qualified_name| {
+                if matches!(
+                    qualified_name.segments(),
+                    [
+                        "numpy",
+                        "bool"
+                            | "int"
+                            | "float"
+                            | "complex"
+                            | "object"
+                            | "str"
+                            | "long"
+                            | "unicode"
+                    ]
+                ) {
+                    Some(qualified_name.segments()[1])
+                } else {
+                    None
+                }
+            })
     {
         let mut diagnostic = Diagnostic::new(
             NumpyDeprecatedTypeAlias {

--- a/crates/ruff_linter/src/rules/numpy/rules/legacy_random.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/legacy_random.rs
@@ -64,18 +64,19 @@ pub(crate) fn legacy_random(checker: &mut Checker, expr: &Expr) {
         return;
     }
 
-    if let Some(method_name) = checker
-        .semantic()
-        .resolve_call_path(expr)
-        .and_then(|call_path| {
-            // seeding state
-            if matches!(
-                call_path.segments(),
-                [
-                    "numpy",
-                    "random",
-                    // Seeds
-                    "seed" |
+    if let Some(method_name) =
+        checker
+            .semantic()
+            .resolve_qualified_name(expr)
+            .and_then(|call_path| {
+                // seeding state
+                if matches!(
+                    call_path.segments(),
+                    [
+                        "numpy",
+                        "random",
+                        // Seeds
+                        "seed" |
                     "get_state" |
                     "set_state" |
                     // Simple random data
@@ -128,13 +129,13 @@ pub(crate) fn legacy_random(checker: &mut Checker, expr: &Expr) {
                     "wald" |
                     "weibull" |
                     "zipf"
-                ]
-            ) {
-                Some(call_path.segments()[2])
-            } else {
-                None
-            }
-        })
+                    ]
+                ) {
+                    Some(call_path.segments()[2])
+                } else {
+                    None
+                }
+            })
     {
         checker.diagnostics.push(Diagnostic::new(
             NumpyLegacyRandom {

--- a/crates/ruff_linter/src/rules/numpy/rules/legacy_random.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/legacy_random.rs
@@ -68,10 +68,10 @@ pub(crate) fn legacy_random(checker: &mut Checker, expr: &Expr) {
         checker
             .semantic()
             .resolve_qualified_name(expr)
-            .and_then(|call_path| {
+            .and_then(|qualified_name| {
                 // seeding state
                 if matches!(
-                    call_path.segments(),
+                    qualified_name.segments(),
                     [
                         "numpy",
                         "random",
@@ -131,7 +131,7 @@ pub(crate) fn legacy_random(checker: &mut Checker, expr: &Expr) {
                     "zipf"
                     ]
                 ) {
-                    Some(call_path.segments()[2])
+                    Some(qualified_name.segments()[2])
                 } else {
                     None
                 }

--- a/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
@@ -159,7 +159,7 @@ pub(crate) fn numpy_2_0_deprecation(checker: &mut Checker, expr: &Expr) {
 
     let maybe_replacement = checker
         .semantic()
-        .resolve_call_path(expr)
+        .resolve_qualified_name(expr)
         .and_then(|call_path| match call_path.segments() {
             // NumPy's main namespace np.* members removed in 2.0
             ["numpy", "add_docstring"] => Some(Replacement {

--- a/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
@@ -160,7 +160,7 @@ pub(crate) fn numpy_2_0_deprecation(checker: &mut Checker, expr: &Expr) {
     let maybe_replacement = checker
         .semantic()
         .resolve_qualified_name(expr)
-        .and_then(|call_path| match call_path.segments() {
+        .and_then(|qualified_name| match qualified_name.segments() {
             // NumPy's main namespace np.* members removed in 2.0
             ["numpy", "add_docstring"] => Some(Replacement {
                 existing: "add_docstring",

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -56,7 +56,7 @@ pub(crate) fn inplace_argument(checker: &mut Checker, call: &ast::ExprCall) {
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| !matches!(call_path.segments(), ["pandas", ..]))
+        .is_some_and(|qualified_name| !matches!(qualified_name.segments(), ["pandas", ..]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -55,7 +55,7 @@ pub(crate) fn inplace_argument(checker: &mut Checker, call: &ast::ExprCall) {
     // If the function was imported from another module, and it's _not_ Pandas, abort.
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| !matches!(call_path.segments(), ["pandas", ..]))
     {
         return;

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/read_table.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/read_table.rs
@@ -54,7 +54,7 @@ pub(crate) fn use_of_read_table(checker: &mut Checker, call: &ast::ExprCall) {
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["pandas", "read_table"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["pandas", "read_table"]))
     {
         if let Some(Expr::StringLiteral(ast::ExprStringLiteral { value, .. })) = call
             .arguments

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/read_table.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/read_table.rs
@@ -53,7 +53,7 @@ pub(crate) fn use_of_read_table(checker: &mut Checker, call: &ast::ExprCall) {
 
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["pandas", "read_table"]))
     {
         if let Some(Expr::StringLiteral(ast::ExprStringLiteral { value, .. })) = call

--- a/crates/ruff_linter/src/rules/pep8_naming/helpers.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/helpers.rs
@@ -33,9 +33,9 @@ pub(super) fn is_named_tuple_assignment(stmt: &Stmt, semantic: &SemanticModel) -
     };
     semantic
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| {
-            matches!(call_path.segments(), ["collections", "namedtuple"])
-                || semantic.match_typing_call_path(&call_path, "NamedTuple")
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["collections", "namedtuple"])
+                || semantic.match_typing_qualified_name(&qualified_name, "NamedTuple")
         })
 }
 
@@ -68,9 +68,9 @@ pub(super) fn is_type_var_assignment(stmt: &Stmt, semantic: &SemanticModel) -> b
     };
     semantic
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| {
-            semantic.match_typing_call_path(&call_path, "TypeVar")
-                || semantic.match_typing_call_path(&call_path, "NewType")
+        .is_some_and(|qualified_name| {
+            semantic.match_typing_qualified_name(&qualified_name, "TypeVar")
+                || semantic.match_typing_qualified_name(&qualified_name, "NewType")
         })
 }
 
@@ -122,8 +122,8 @@ pub(super) fn is_django_model_import(name: &str, stmt: &Stmt, semantic: &Semanti
         }
 
         // Match against, e.g., `apps.get_model("zerver", "Attachment")`.
-        if let Some(call_path) = UnqualifiedName::from_expr(func.as_ref()) {
-            if matches!(call_path.segments(), [.., "get_model"]) {
+        if let Some(unqualified_name) = UnqualifiedName::from_expr(func.as_ref()) {
+            if matches!(unqualified_name.segments(), [.., "get_model"]) {
                 if let Some(argument) =
                     arguments.find_argument("model_name", arguments.args.len().saturating_sub(1))
                 {
@@ -139,9 +139,9 @@ pub(super) fn is_django_model_import(name: &str, stmt: &Stmt, semantic: &Semanti
         }
 
         // Match against, e.g., `import_string("zerver.models.Attachment")`.
-        if let Some(call_path) = semantic.resolve_qualified_name(func.as_ref()) {
+        if let Some(qualified_name) = semantic.resolve_qualified_name(func.as_ref()) {
             if matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["django", "utils", "module_loading", "import_string"]
             ) {
                 if let Some(argument) = arguments.find_argument("dotted_path", 0) {

--- a/crates/ruff_linter/src/rules/pep8_naming/helpers.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/helpers.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
-use ruff_python_ast::call_path::CallPath;
-use ruff_python_ast::{self as ast, Arguments, Expr, Stmt};
 
+use ruff_python_ast::name::UnqualifiedName;
+use ruff_python_ast::{self as ast, Arguments, Expr, Stmt};
 use ruff_python_semantic::SemanticModel;
 use ruff_python_stdlib::str::{is_cased_lowercase, is_cased_uppercase};
 
@@ -31,10 +31,12 @@ pub(super) fn is_named_tuple_assignment(stmt: &Stmt, semantic: &SemanticModel) -
     let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() else {
         return false;
     };
-    semantic.resolve_call_path(func).is_some_and(|call_path| {
-        matches!(call_path.segments(), ["collections", "namedtuple"])
-            || semantic.match_typing_call_path(&call_path, "NamedTuple")
-    })
+    semantic
+        .resolve_qualified_name(func)
+        .is_some_and(|call_path| {
+            matches!(call_path.segments(), ["collections", "namedtuple"])
+                || semantic.match_typing_call_path(&call_path, "NamedTuple")
+        })
 }
 
 /// Returns `true` if the statement is an assignment to a `TypedDict`.
@@ -64,10 +66,12 @@ pub(super) fn is_type_var_assignment(stmt: &Stmt, semantic: &SemanticModel) -> b
     let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() else {
         return false;
     };
-    semantic.resolve_call_path(func).is_some_and(|call_path| {
-        semantic.match_typing_call_path(&call_path, "TypeVar")
-            || semantic.match_typing_call_path(&call_path, "NewType")
-    })
+    semantic
+        .resolve_qualified_name(func)
+        .is_some_and(|call_path| {
+            semantic.match_typing_call_path(&call_path, "TypeVar")
+                || semantic.match_typing_call_path(&call_path, "NewType")
+        })
 }
 
 /// Returns `true` if the statement is an assignment to a `TypeAlias`.
@@ -118,7 +122,7 @@ pub(super) fn is_django_model_import(name: &str, stmt: &Stmt, semantic: &Semanti
         }
 
         // Match against, e.g., `apps.get_model("zerver", "Attachment")`.
-        if let Some(call_path) = CallPath::from_expr(func.as_ref()) {
+        if let Some(call_path) = UnqualifiedName::from_expr(func.as_ref()) {
             if matches!(call_path.segments(), [.., "get_model"]) {
                 if let Some(argument) =
                     arguments.find_argument("model_name", arguments.args.len().saturating_sub(1))
@@ -135,7 +139,7 @@ pub(super) fn is_django_model_import(name: &str, stmt: &Stmt, semantic: &Semanti
         }
 
         // Match against, e.g., `import_string("zerver.models.Attachment")`.
-        if let Some(call_path) = semantic.resolve_call_path(func.as_ref()) {
+        if let Some(call_path) = semantic.resolve_qualified_name(func.as_ref()) {
             if matches!(
                 call_path.segments(),
                 ["django", "utils", "module_loading", "import_string"]

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -153,10 +153,13 @@ fn extract_types(annotation: &Expr, semantic: &SemanticModel) -> Option<(Vec<Exp
         return None;
     };
 
-    if !semantic.resolve_call_path(value).is_some_and(|call_path| {
-        matches!(call_path.segments(), ["collections", "abc", "Callable"])
-            || semantic.match_typing_call_path(&call_path, "Callable")
-    }) {
+    if !semantic
+        .resolve_qualified_name(value)
+        .is_some_and(|call_path| {
+            matches!(call_path.segments(), ["collections", "abc", "Callable"])
+                || semantic.match_typing_call_path(&call_path, "Callable")
+        })
+    {
         return None;
     }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -155,9 +155,11 @@ fn extract_types(annotation: &Expr, semantic: &SemanticModel) -> Option<(Vec<Exp
 
     if !semantic
         .resolve_qualified_name(value)
-        .is_some_and(|call_path| {
-            matches!(call_path.segments(), ["collections", "abc", "Callable"])
-                || semantic.match_typing_call_path(&call_path, "Callable")
+        .is_some_and(|qualified_name| {
+            matches!(
+                qualified_name.segments(),
+                ["collections", "abc", "Callable"]
+            ) || semantic.match_typing_qualified_name(&qualified_name, "Callable")
         })
     {
         return None;

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
@@ -114,7 +114,7 @@ fn deprecated_type_comparison(checker: &mut Checker, compare: &ast::ExprCompare)
                 // Ex) `type(obj) is types.NoneType`
                 if checker
                     .semantic()
-                    .resolve_call_path(value.as_ref())
+                    .resolve_qualified_name(value.as_ref())
                     .is_some_and(|call_path| matches!(call_path.segments(), ["types", ..]))
                 {
                     checker.diagnostics.push(Diagnostic::new(
@@ -312,7 +312,7 @@ fn is_dtype(expr: &Expr, semantic: &SemanticModel) -> bool {
     match expr {
         // Ex) `np.dtype(obj)`
         Expr::Call(ast::ExprCall { func, .. }) => semantic
-            .resolve_call_path(func)
+            .resolve_qualified_name(func)
             .is_some_and(|call_path| matches!(call_path.segments(), ["numpy", "dtype"])),
         // Ex) `obj.dtype`
         Expr::Attribute(ast::ExprAttribute { attr, .. }) => {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
@@ -115,7 +115,9 @@ fn deprecated_type_comparison(checker: &mut Checker, compare: &ast::ExprCompare)
                 if checker
                     .semantic()
                     .resolve_qualified_name(value.as_ref())
-                    .is_some_and(|call_path| matches!(call_path.segments(), ["types", ..]))
+                    .is_some_and(|qualified_name| {
+                        matches!(qualified_name.segments(), ["types", ..])
+                    })
                 {
                     checker.diagnostics.push(Diagnostic::new(
                         TypeComparison {
@@ -313,7 +315,7 @@ fn is_dtype(expr: &Expr, semantic: &SemanticModel) -> bool {
         // Ex) `np.dtype(obj)`
         Expr::Call(ast::ExprCall { func, .. }) => semantic
             .resolve_qualified_name(func)
-            .is_some_and(|call_path| matches!(call_path.segments(), ["numpy", "dtype"])),
+            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["numpy", "dtype"])),
         // Ex) `obj.dtype`
         Expr::Attribute(ast::ExprAttribute { attr, .. }) => {
             // Ex) `obj.dtype`

--- a/crates/ruff_linter/src/rules/pydocstyle/helpers.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/helpers.rs
@@ -54,10 +54,10 @@ pub(crate) fn should_ignore_definition(
     function.decorator_list.iter().any(|decorator| {
         semantic
             .resolve_qualified_name(map_callable(&decorator.expression))
-            .is_some_and(|call_path| {
+            .is_some_and(|qualified_name| {
                 ignore_decorators
                     .iter()
-                    .any(|decorator| QualifiedName::from_dotted_name(decorator) == call_path)
+                    .any(|decorator| QualifiedName::from_dotted_name(decorator) == qualified_name)
             })
     })
 }

--- a/crates/ruff_linter/src/rules/pydocstyle/helpers.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/helpers.rs
@@ -1,7 +1,7 @@
-use ruff_python_ast::call_path::CallPath;
 use std::collections::BTreeSet;
 
 use ruff_python_ast::helpers::map_callable;
+use ruff_python_ast::name::QualifiedName;
 use ruff_python_semantic::{Definition, SemanticModel};
 use ruff_source_file::UniversalNewlines;
 
@@ -53,11 +53,11 @@ pub(crate) fn should_ignore_definition(
 
     function.decorator_list.iter().any(|decorator| {
         semantic
-            .resolve_call_path(map_callable(&decorator.expression))
+            .resolve_qualified_name(map_callable(&decorator.expression))
             .is_some_and(|call_path| {
                 ignore_decorators
                     .iter()
-                    .any(|decorator| CallPath::from_qualified_name(decorator) == call_path)
+                    .any(|decorator| QualifiedName::from_dotted_name(decorator) == call_path)
             })
     })
 }

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/non_imperative_mood.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/non_imperative_mood.rs
@@ -5,7 +5,7 @@ use once_cell::sync::Lazy;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::name::QualifiedName;
 use ruff_python_semantic::analyze::visibility::{is_property, is_test};
 use ruff_source_file::UniversalNewlines;
 use ruff_text_size::Ranged;
@@ -74,8 +74,8 @@ pub(crate) fn non_imperative_mood(
 
     let property_decorators = property_decorators
         .iter()
-        .map(|decorator| CallPath::from_qualified_name(decorator))
-        .collect::<Vec<CallPath>>();
+        .map(|decorator| QualifiedName::from_dotted_name(decorator))
+        .collect::<Vec<QualifiedName>>();
 
     if is_test(&function.name)
         || is_property(

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_open_mode.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_open_mode.rs
@@ -91,7 +91,9 @@ fn is_open(func: &Expr, semantic: &SemanticModel) -> Option<Kind> {
             match value.as_ref() {
                 Expr::Call(ast::ExprCall { func, .. }) => semantic
                     .resolve_qualified_name(func)
-                    .is_some_and(|call_path| matches!(call_path.segments(), ["pathlib", "Path"]))
+                    .is_some_and(|qualified_name| {
+                        matches!(qualified_name.segments(), ["pathlib", "Path"])
+                    })
                     .then_some(Kind::Pathlib),
                 _ => None,
             }

--- a/crates/ruff_linter/src/rules/pylint/rules/bad_open_mode.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_open_mode.rs
@@ -90,7 +90,7 @@ fn is_open(func: &Expr, semantic: &SemanticModel) -> Option<Kind> {
         Expr::Attribute(ast::ExprAttribute { attr, value, .. }) if attr.as_str() == "open" => {
             match value.as_ref() {
                 Expr::Call(ast::ExprCall { func, .. }) => semantic
-                    .resolve_call_path(func)
+                    .resolve_qualified_name(func)
                     .is_some_and(|call_path| matches!(call_path.segments(), ["pathlib", "Path"]))
                     .then_some(Kind::Pathlib),
                 _ => None,

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
@@ -50,7 +50,7 @@ pub(crate) fn invalid_envvar_default(checker: &mut Checker, call: &ast::ExprCall
 
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["os", "getenv"]))
     {
         // Find the `default` argument, if it exists.

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_default.rs
@@ -51,7 +51,7 @@ pub(crate) fn invalid_envvar_default(checker: &mut Checker, call: &ast::ExprCall
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["os", "getenv"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["os", "getenv"]))
     {
         // Find the `default` argument, if it exists.
         let Some(expr) = call.arguments.find_argument("default", 1) else {

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_value.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_value.rs
@@ -43,7 +43,7 @@ pub(crate) fn invalid_envvar_value(checker: &mut Checker, call: &ast::ExprCall) 
 
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["os", "getenv"]))
     {
         // Find the `key` argument, if it exists.

--- a/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_value.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/invalid_envvar_value.rs
@@ -44,7 +44,7 @@ pub(crate) fn invalid_envvar_value(checker: &mut Checker, call: &ast::ExprCall) 
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["os", "getenv"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["os", "getenv"]))
     {
         // Find the `key` argument, if it exists.
         let Some(expr) = call.arguments.find_argument("key", 0) else {

--- a/crates/ruff_linter/src/rules/pylint/rules/logging.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/logging.rs
@@ -115,7 +115,10 @@ pub(crate) fn logging_call(checker: &mut Checker, call: &ast::ExprCall) {
             }
         }
         Expr::Name(_) => {
-            let Some(call_path) = checker.semantic().resolve_call_path(call.func.as_ref()) else {
+            let Some(call_path) = checker
+                .semantic()
+                .resolve_qualified_name(call.func.as_ref())
+            else {
                 return;
             };
             let ["logging", attribute] = call_path.segments() else {

--- a/crates/ruff_linter/src/rules/pylint/rules/logging.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/logging.rs
@@ -115,13 +115,13 @@ pub(crate) fn logging_call(checker: &mut Checker, call: &ast::ExprCall) {
             }
         }
         Expr::Name(_) => {
-            let Some(call_path) = checker
+            let Some(qualified_name) = checker
                 .semantic()
                 .resolve_qualified_name(call.func.as_ref())
             else {
                 return;
             };
-            let ["logging", attribute] = call_path.segments() else {
+            let ["logging", attribute] = qualified_name.segments() else {
                 return;
             };
             if LoggingLevel::from_attribute(attribute).is_none() {

--- a/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_self_use.rs
@@ -1,7 +1,7 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::CallPath;
 use ruff_python_ast::identifier::Identifier;
+use ruff_python_ast::name::QualifiedName;
 use ruff_python_ast::{self as ast, ParameterWithDefault};
 use ruff_python_semantic::{
     analyze::{function_type, visibility},
@@ -84,8 +84,8 @@ pub(crate) fn no_self_use(
         .pydocstyle
         .property_decorators
         .iter()
-        .map(|decorator| CallPath::from_qualified_name(decorator))
-        .collect::<Vec<CallPath>>();
+        .map(|decorator| QualifiedName::from_dotted_name(decorator))
+        .collect::<Vec<QualifiedName>>();
 
     if helpers::is_empty(body)
         || visibility::is_magic(name)

--- a/crates/ruff_linter/src/rules/pylint/rules/non_slot_assignment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/non_slot_assignment.rs
@@ -67,7 +67,7 @@ pub(crate) fn non_slot_assignment(checker: &mut Checker, class_def: &ast::StmtCl
         checker
             .semantic()
             .resolve_qualified_name(base)
-            .is_some_and(|call_path| matches!(call_path.segments(), ["", "object"]))
+            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["", "object"]))
     }) {
         return;
     }

--- a/crates/ruff_linter/src/rules/pylint/rules/non_slot_assignment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/non_slot_assignment.rs
@@ -66,7 +66,7 @@ pub(crate) fn non_slot_assignment(checker: &mut Checker, class_def: &ast::StmtCl
     if !class_def.bases().iter().all(|base| {
         checker
             .semantic()
-            .resolve_call_path(base)
+            .resolve_qualified_name(base)
             .is_some_and(|call_path| matches!(call_path.segments(), ["", "object"]))
     }) {
         return;

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
@@ -202,9 +202,11 @@ fn is_allowed_value(bool_op: BoolOp, value: &Expr, semantic: &SemanticModel) -> 
     // Ignore `sys.version_info` and `sys.platform` comparisons, which are only
     // respected by type checkers when enforced via equality.
     if any_over_expr(value, &|expr| {
-        semantic.resolve_call_path(expr).is_some_and(|call_path| {
-            matches!(call_path.segments(), ["sys", "version_info" | "platform"])
-        })
+        semantic
+            .resolve_qualified_name(expr)
+            .is_some_and(|call_path| {
+                matches!(call_path.segments(), ["sys", "version_info" | "platform"])
+            })
     }) {
         return false;
     }

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
@@ -204,8 +204,11 @@ fn is_allowed_value(bool_op: BoolOp, value: &Expr, semantic: &SemanticModel) -> 
     if any_over_expr(value, &|expr| {
         semantic
             .resolve_qualified_name(expr)
-            .is_some_and(|call_path| {
-                matches!(call_path.segments(), ["sys", "version_info" | "platform"])
+            .is_some_and(|qualified_name| {
+                matches!(
+                    qualified_name.segments(),
+                    ["sys", "version_info" | "platform"]
+                )
             })
     }) {
         return false;

--- a/crates/ruff_linter/src/rules/pylint/rules/singledispatch_method.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/singledispatch_method.rs
@@ -97,8 +97,8 @@ pub(crate) fn singledispatch_method(
         if checker
             .semantic()
             .resolve_qualified_name(&decorator.expression)
-            .is_some_and(|call_path| {
-                matches!(call_path.segments(), ["functools", "singledispatch"])
+            .is_some_and(|qualified_name| {
+                matches!(qualified_name.segments(), ["functools", "singledispatch"])
             })
         {
             let mut diagnostic = Diagnostic::new(SingledispatchMethod, decorator.range());

--- a/crates/ruff_linter/src/rules/pylint/rules/singledispatch_method.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/singledispatch_method.rs
@@ -96,7 +96,7 @@ pub(crate) fn singledispatch_method(
     for decorator in decorator_list {
         if checker
             .semantic()
-            .resolve_call_path(&decorator.expression)
+            .resolve_qualified_name(&decorator.expression)
             .is_some_and(|call_path| {
                 matches!(call_path.segments(), ["functools", "singledispatch"])
             })

--- a/crates/ruff_linter/src/rules/pylint/rules/subprocess_popen_preexec_fn.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/subprocess_popen_preexec_fn.rs
@@ -57,7 +57,7 @@ pub(crate) fn subprocess_popen_preexec_fn(checker: &mut Checker, call: &ast::Exp
 
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["subprocess", "Popen"]))
     {
         if let Some(keyword) = call

--- a/crates/ruff_linter/src/rules/pylint/rules/subprocess_popen_preexec_fn.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/subprocess_popen_preexec_fn.rs
@@ -58,7 +58,7 @@ pub(crate) fn subprocess_popen_preexec_fn(checker: &mut Checker, call: &ast::Exp
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["subprocess", "Popen"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["subprocess", "Popen"]))
     {
         if let Some(keyword) = call
             .arguments

--- a/crates/ruff_linter/src/rules/pylint/rules/subprocess_run_without_check.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/subprocess_run_without_check.rs
@@ -67,7 +67,7 @@ pub(crate) fn subprocess_run_without_check(checker: &mut Checker, call: &ast::Ex
 
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["subprocess", "run"]))
     {
         if call.arguments.find_keyword("check").is_none() {

--- a/crates/ruff_linter/src/rules/pylint/rules/subprocess_run_without_check.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/subprocess_run_without_check.rs
@@ -68,7 +68,7 @@ pub(crate) fn subprocess_run_without_check(checker: &mut Checker, call: &ast::Ex
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["subprocess", "run"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["subprocess", "run"]))
     {
         if call.arguments.find_keyword("check").is_none() {
             let mut diagnostic = Diagnostic::new(SubprocessRunWithoutCheck, call.func.range());

--- a/crates/ruff_linter/src/rules/pylint/rules/type_bivariance.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/type_bivariance.rs
@@ -103,7 +103,7 @@ pub(crate) fn type_bivariance(checker: &mut Checker, value: &Expr) {
     if is_const_true(covariant) && is_const_true(contravariant) {
         let Some(kind) = checker
             .semantic()
-            .resolve_call_path(func)
+            .resolve_qualified_name(func)
             .and_then(|call_path| {
                 if checker
                     .semantic()

--- a/crates/ruff_linter/src/rules/pylint/rules/type_bivariance.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/type_bivariance.rs
@@ -101,24 +101,25 @@ pub(crate) fn type_bivariance(checker: &mut Checker, value: &Expr) {
     };
 
     if is_const_true(covariant) && is_const_true(contravariant) {
-        let Some(kind) = checker
-            .semantic()
-            .resolve_qualified_name(func)
-            .and_then(|call_path| {
-                if checker
-                    .semantic()
-                    .match_typing_call_path(&call_path, "ParamSpec")
-                {
-                    Some(VarKind::ParamSpec)
-                } else if checker
-                    .semantic()
-                    .match_typing_call_path(&call_path, "TypeVar")
-                {
-                    Some(VarKind::TypeVar)
-                } else {
-                    None
-                }
-            })
+        let Some(kind) =
+            checker
+                .semantic()
+                .resolve_qualified_name(func)
+                .and_then(|qualified_name| {
+                    if checker
+                        .semantic()
+                        .match_typing_qualified_name(&qualified_name, "ParamSpec")
+                    {
+                        Some(VarKind::ParamSpec)
+                    } else if checker
+                        .semantic()
+                        .match_typing_qualified_name(&qualified_name, "TypeVar")
+                    {
+                        Some(VarKind::TypeVar)
+                    } else {
+                        None
+                    }
+                })
         else {
             return;
         };

--- a/crates/ruff_linter/src/rules/pylint/rules/type_name_incorrect_variance.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/type_name_incorrect_variance.rs
@@ -95,7 +95,7 @@ pub(crate) fn type_name_incorrect_variance(checker: &mut Checker, value: &Expr) 
 
     let Some(kind) = checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .and_then(|call_path| {
             if checker
                 .semantic()

--- a/crates/ruff_linter/src/rules/pylint/rules/type_name_incorrect_variance.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/type_name_incorrect_variance.rs
@@ -96,15 +96,15 @@ pub(crate) fn type_name_incorrect_variance(checker: &mut Checker, value: &Expr) 
     let Some(kind) = checker
         .semantic()
         .resolve_qualified_name(func)
-        .and_then(|call_path| {
+        .and_then(|qualified_name| {
             if checker
                 .semantic()
-                .match_typing_call_path(&call_path, "ParamSpec")
+                .match_typing_qualified_name(&qualified_name, "ParamSpec")
             {
                 Some(VarKind::ParamSpec)
             } else if checker
                 .semantic()
-                .match_typing_call_path(&call_path, "TypeVar")
+                .match_typing_qualified_name(&qualified_name, "TypeVar")
             {
                 Some(VarKind::TypeVar)
             } else {

--- a/crates/ruff_linter/src/rules/pylint/rules/type_param_name_mismatch.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/type_param_name_mismatch.rs
@@ -89,7 +89,7 @@ pub(crate) fn type_param_name_mismatch(checker: &mut Checker, value: &Expr, targ
 
     let Some(kind) = checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .and_then(|call_path| {
             if checker
                 .semantic()

--- a/crates/ruff_linter/src/rules/pylint/rules/type_param_name_mismatch.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/type_param_name_mismatch.rs
@@ -90,25 +90,25 @@ pub(crate) fn type_param_name_mismatch(checker: &mut Checker, value: &Expr, targ
     let Some(kind) = checker
         .semantic()
         .resolve_qualified_name(func)
-        .and_then(|call_path| {
+        .and_then(|qualified_name| {
             if checker
                 .semantic()
-                .match_typing_call_path(&call_path, "ParamSpec")
+                .match_typing_qualified_name(&qualified_name, "ParamSpec")
             {
                 Some(VarKind::ParamSpec)
             } else if checker
                 .semantic()
-                .match_typing_call_path(&call_path, "TypeVar")
+                .match_typing_qualified_name(&qualified_name, "TypeVar")
             {
                 Some(VarKind::TypeVar)
             } else if checker
                 .semantic()
-                .match_typing_call_path(&call_path, "TypeVarTuple")
+                .match_typing_qualified_name(&qualified_name, "TypeVarTuple")
             {
                 Some(VarKind::TypeVarTuple)
             } else if checker
                 .semantic()
-                .match_typing_call_path(&call_path, "NewType")
+                .match_typing_qualified_name(&qualified_name, "NewType")
             {
                 Some(VarKind::NewType)
             } else {

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
@@ -127,7 +127,9 @@ fn enumerate_items<'a>(
     // Check that the function is the `enumerate` builtin.
     if !semantic
         .resolve_qualified_name(func.as_ref())
-        .is_some_and(|call_path| matches!(call_path.segments(), ["builtins" | "", "enumerate"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["builtins" | "", "enumerate"])
+        })
     {
         return None;
     }

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
@@ -126,7 +126,7 @@ fn enumerate_items<'a>(
 
     // Check that the function is the `enumerate` builtin.
     if !semantic
-        .resolve_call_path(func.as_ref())
+        .resolve_qualified_name(func.as_ref())
         .is_some_and(|call_path| matches!(call_path.segments(), ["builtins" | "", "enumerate"]))
     {
         return None;

--- a/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
@@ -73,8 +73,8 @@ pub(crate) fn unspecified_encoding(checker: &mut Checker, call: &ast::ExprCall) 
     let Some((function_name, mode)) = checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .filter(|call_path| is_violation(call, call_path))
-        .map(|call_path| (call_path.to_string(), Mode::from(&call_path)))
+        .filter(|qualified_name| is_violation(call, qualified_name))
+        .map(|qualified_name| (qualified_name.to_string(), Mode::from(&qualified_name)))
     else {
         return;
     };

--- a/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast as ast;
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::name::QualifiedName;
 use ruff_python_ast::Expr;
 use ruff_text_size::{Ranged, TextRange};
 
@@ -72,7 +72,7 @@ impl AlwaysFixableViolation for UnspecifiedEncoding {
 pub(crate) fn unspecified_encoding(checker: &mut Checker, call: &ast::ExprCall) {
     let Some((function_name, mode)) = checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .filter(|call_path| is_violation(call, call_path))
         .map(|call_path| (call_path.to_string(), Mode::from(&call_path)))
     else {
@@ -145,7 +145,7 @@ fn is_binary_mode(expr: &Expr) -> Option<bool> {
 }
 
 /// Returns `true` if the given call lacks an explicit `encoding`.
-fn is_violation(call: &ast::ExprCall, call_path: &CallPath) -> bool {
+fn is_violation(call: &ast::ExprCall, qualified_name: &QualifiedName) -> bool {
     // If we have something like `*args`, which might contain the encoding argument, abort.
     if call.arguments.args.iter().any(Expr::is_starred_expr) {
         return false;
@@ -159,7 +159,7 @@ fn is_violation(call: &ast::ExprCall, call_path: &CallPath) -> bool {
     {
         return false;
     }
-    match call_path.segments() {
+    match qualified_name.segments() {
         ["" | "codecs" | "_io", "open"] => {
             if let Some(mode_arg) = call.arguments.find_argument("mode", 1) {
                 if is_binary_mode(mode_arg).unwrap_or(true) {
@@ -171,7 +171,7 @@ fn is_violation(call: &ast::ExprCall, call_path: &CallPath) -> bool {
             call.arguments.find_argument("encoding", 3).is_none()
         }
         ["tempfile", "TemporaryFile" | "NamedTemporaryFile" | "SpooledTemporaryFile"] => {
-            let mode_pos = usize::from(call_path.segments()[1] == "SpooledTemporaryFile");
+            let mode_pos = usize::from(qualified_name.segments()[1] == "SpooledTemporaryFile");
             if let Some(mode_arg) = call.arguments.find_argument("mode", mode_pos) {
                 if is_binary_mode(mode_arg).unwrap_or(true) {
                     // binary mode or unknown mode is no violation
@@ -198,8 +198,8 @@ enum Mode {
     Unsupported,
 }
 
-impl From<&CallPath<'_>> for Mode {
-    fn from(value: &CallPath<'_>) -> Self {
+impl From<&QualifiedName<'_>> for Mode {
+    fn from(value: &QualifiedName<'_>) -> Self {
         match value.segments() {
             ["" | "codecs" | "_io", "open"] => Mode::Supported,
             ["tempfile", "TemporaryFile" | "NamedTemporaryFile" | "SpooledTemporaryFile"] => {

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_exception_statement.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_exception_statement.rs
@@ -65,9 +65,9 @@ pub(crate) fn useless_exception_statement(checker: &mut Checker, expr: &ast::Stm
 fn is_builtin_exception(expr: &Expr, semantic: &SemanticModel) -> bool {
     return semantic
         .resolve_qualified_name(expr)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 [
                     "",
                     "SystemExit"

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_exception_statement.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_exception_statement.rs
@@ -63,33 +63,35 @@ pub(crate) fn useless_exception_statement(checker: &mut Checker, expr: &ast::Stm
 ///
 /// See: <https://docs.python.org/3/library/exceptions.html#exception-hierarchy>
 fn is_builtin_exception(expr: &Expr, semantic: &SemanticModel) -> bool {
-    return semantic.resolve_call_path(expr).is_some_and(|call_path| {
-        matches!(
-            call_path.segments(),
-            [
-                "",
-                "SystemExit"
-                    | "Exception"
-                    | "ArithmeticError"
-                    | "AssertionError"
-                    | "AttributeError"
-                    | "BufferError"
-                    | "EOFError"
-                    | "ImportError"
-                    | "LookupError"
-                    | "IndexError"
-                    | "KeyError"
-                    | "MemoryError"
-                    | "NameError"
-                    | "ReferenceError"
-                    | "RuntimeError"
-                    | "NotImplementedError"
-                    | "StopIteration"
-                    | "SyntaxError"
-                    | "SystemError"
-                    | "TypeError"
-                    | "ValueError"
-            ]
-        )
-    });
+    return semantic
+        .resolve_qualified_name(expr)
+        .is_some_and(|call_path| {
+            matches!(
+                call_path.segments(),
+                [
+                    "",
+                    "SystemExit"
+                        | "Exception"
+                        | "ArithmeticError"
+                        | "AssertionError"
+                        | "AttributeError"
+                        | "BufferError"
+                        | "EOFError"
+                        | "ImportError"
+                        | "LookupError"
+                        | "IndexError"
+                        | "KeyError"
+                        | "MemoryError"
+                        | "NameError"
+                        | "ReferenceError"
+                        | "RuntimeError"
+                        | "NotImplementedError"
+                        | "StopIteration"
+                        | "SyntaxError"
+                        | "SystemError"
+                        | "TypeError"
+                        | "ValueError"
+                ]
+            )
+        });
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_with_lock.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_with_lock.rs
@@ -66,9 +66,9 @@ pub(crate) fn useless_with_lock(checker: &mut Checker, with: &ast::StmtWith) {
         if !checker
             .semantic()
             .resolve_qualified_name(call.func.as_ref())
-            .is_some_and(|call_path| {
+            .is_some_and(|qualified_name| {
                 matches!(
-                    call_path.segments(),
+                    qualified_name.segments(),
                     [
                         "threading",
                         "Lock" | "RLock" | "Condition" | "Semaphore" | "BoundedSemaphore"

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_with_lock.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_with_lock.rs
@@ -65,7 +65,7 @@ pub(crate) fn useless_with_lock(checker: &mut Checker, with: &ast::StmtWith) {
 
         if !checker
             .semantic()
-            .resolve_call_path(call.func.as_ref())
+            .resolve_qualified_name(call.func.as_ref())
             .is_some_and(|call_path| {
                 matches!(
                     call_path.segments(),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -53,7 +53,7 @@ impl Violation for DatetimeTimezoneUTC {
 pub(crate) fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
     if checker
         .semantic()
-        .resolve_call_path(expr)
+        .resolve_qualified_name(expr)
         .is_some_and(|call_path| matches!(call_path.segments(), ["datetime", "timezone", "utc"]))
     {
         let mut diagnostic = Diagnostic::new(DatetimeTimezoneUTC, expr.range());

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -54,7 +54,9 @@ pub(crate) fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
     if checker
         .semantic()
         .resolve_qualified_name(expr)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["datetime", "timezone", "utc"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["datetime", "timezone", "utc"])
+        })
     {
         let mut diagnostic = Diagnostic::new(DatetimeTimezoneUTC, expr.range());
         diagnostic.try_set_fix(|| {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -256,7 +256,7 @@ pub(crate) fn deprecated_mock_attribute(checker: &mut Checker, attribute: &ast::
     }
 
     if UnqualifiedName::from_expr(&attribute.value)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["mock", "mock"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["mock", "mock"]))
     {
         let mut diagnostic = Diagnostic::new(
             DeprecatedMockImport {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -7,7 +7,7 @@ use log::error;
 
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::name::UnqualifiedName;
 use ruff_python_ast::whitespace::indentation;
 use ruff_python_ast::{self as ast, Stmt};
 use ruff_python_codegen::Stylist;
@@ -255,7 +255,7 @@ pub(crate) fn deprecated_mock_attribute(checker: &mut Checker, attribute: &ast::
         return;
     }
 
-    if CallPath::from_expr(&attribute.value)
+    if UnqualifiedName::from_expr(&attribute.value)
         .is_some_and(|call_path| matches!(call_path.segments(), ["mock", "mock"]))
     {
         let mut diagnostic = Diagnostic::new(

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -466,9 +466,9 @@ pub(crate) fn f_strings(
             checker
                 .semantic()
                 .resolve_qualified_name(call.func.as_ref())
-                .map_or(false, |call_path| {
+                .map_or(false, |qualified_name| {
                     matches!(
-                        call_path.segments(),
+                        qualified_name.segments(),
                         ["django", "utils", "translation", "gettext" | "gettext_lazy"]
                     )
                 })

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -465,7 +465,7 @@ pub(crate) fn f_strings(
         expr.as_call_expr().is_some_and(|call| {
             checker
                 .semantic()
-                .resolve_call_path(call.func.as_ref())
+                .resolve_qualified_name(call.func.as_ref())
                 .map_or(false, |call_path| {
                     matches!(
                         call_path.segments(),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -76,7 +76,7 @@ pub(crate) fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list:
             && keywords.len() == 1
             && checker
                 .semantic()
-                .resolve_call_path(func)
+                .resolve_qualified_name(func)
                 .is_some_and(|call_path| matches!(call_path.segments(), ["functools", "lru_cache"]))
         {
             let Keyword {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -77,7 +77,9 @@ pub(crate) fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list:
             && checker
                 .semantic()
                 .resolve_qualified_name(func)
-                .is_some_and(|call_path| matches!(call_path.segments(), ["functools", "lru_cache"]))
+                .is_some_and(|qualified_name| {
+                    matches!(qualified_name.segments(), ["functools", "lru_cache"])
+                })
         {
             let Keyword {
                 arg,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -70,7 +70,9 @@ pub(crate) fn lru_cache_without_parameters(checker: &mut Checker, decorator_list
             && checker
                 .semantic()
                 .resolve_qualified_name(func)
-                .is_some_and(|call_path| matches!(call_path.segments(), ["functools", "lru_cache"]))
+                .is_some_and(|qualified_name| {
+                    matches!(qualified_name.segments(), ["functools", "lru_cache"])
+                })
         {
             let mut diagnostic = Diagnostic::new(
                 LRUCacheWithoutParameters,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -69,7 +69,7 @@ pub(crate) fn lru_cache_without_parameters(checker: &mut Checker, decorator_list
             && arguments.keywords.is_empty()
             && checker
                 .semantic()
-                .resolve_call_path(func)
+                .resolve_qualified_name(func)
                 .is_some_and(|call_path| matches!(call_path.segments(), ["functools", "lru_cache"]))
         {
             let mut diagnostic = Diagnostic::new(

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/open_alias.rs
@@ -49,7 +49,7 @@ impl Violation for OpenAlias {
 pub(crate) fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
     if checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["io", "open"]))
     {
         let mut diagnostic = Diagnostic::new(OpenAlias, expr.range());

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/open_alias.rs
@@ -50,7 +50,7 @@ pub(crate) fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
     if checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["io", "open"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["io", "open"]))
     {
         let mut diagnostic = Diagnostic::new(OpenAlias, expr.range());
         if checker.semantic().is_builtin("open") {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -4,7 +4,7 @@ use ruff_text_size::{Ranged, TextRange};
 use crate::fix::edits::pad;
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::compose_call_path;
+use ruff_python_ast::name::compose_call_path;
 use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
@@ -56,19 +56,21 @@ impl AlwaysFixableViolation for OSErrorAlias {
 
 /// Return `true` if an [`Expr`] is an alias of `OSError`.
 fn is_alias(expr: &Expr, semantic: &SemanticModel) -> bool {
-    semantic.resolve_call_path(expr).is_some_and(|call_path| {
-        matches!(
-            call_path.segments(),
-            ["", "EnvironmentError" | "IOError" | "WindowsError"]
-                | ["mmap" | "select" | "socket" | "os", "error"]
-        )
-    })
+    semantic
+        .resolve_qualified_name(expr)
+        .is_some_and(|call_path| {
+            matches!(
+                call_path.segments(),
+                ["", "EnvironmentError" | "IOError" | "WindowsError"]
+                    | ["mmap" | "select" | "socket" | "os", "error"]
+            )
+        })
 }
 
 /// Return `true` if an [`Expr`] is `OSError`.
 fn is_os_error(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
-        .resolve_call_path(expr)
+        .resolve_qualified_name(expr)
         .is_some_and(|call_path| matches!(call_path.segments(), ["", "OSError"]))
 }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -97,7 +97,7 @@ pub(crate) fn outdated_version_block(checker: &mut Checker, stmt_if: &StmtIf) {
         // Detect `sys.version_info`, along with slices (like `sys.version_info[:2]`).
         if !checker
             .semantic()
-            .resolve_call_path(map_subscript(left))
+            .resolve_qualified_name(map_subscript(left))
             .is_some_and(|call_path| matches!(call_path.segments(), ["sys", "version_info"]))
         {
             continue;

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -98,7 +98,9 @@ pub(crate) fn outdated_version_block(checker: &mut Checker, stmt_if: &StmtIf) {
         if !checker
             .semantic()
             .resolve_qualified_name(map_subscript(left))
-            .is_some_and(|call_path| matches!(call_path.segments(), ["sys", "version_info"]))
+            .is_some_and(|qualified_name| {
+                matches!(qualified_name.segments(), ["sys", "version_info"])
+            })
         {
             continue;
         }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -61,7 +61,7 @@ pub(crate) fn replace_stdout_stderr(checker: &mut Checker, call: &ast::ExprCall)
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["subprocess", "run"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["subprocess", "run"]))
     {
         // Find `stdout` and `stderr` kwargs.
         let Some(stdout) = call.arguments.find_keyword("stdout") else {
@@ -75,11 +75,15 @@ pub(crate) fn replace_stdout_stderr(checker: &mut Checker, call: &ast::ExprCall)
         if !checker
             .semantic()
             .resolve_qualified_name(&stdout.value)
-            .is_some_and(|call_path| matches!(call_path.segments(), ["subprocess", "PIPE"]))
+            .is_some_and(|qualified_name| {
+                matches!(qualified_name.segments(), ["subprocess", "PIPE"])
+            })
             || !checker
                 .semantic()
                 .resolve_qualified_name(&stderr.value)
-                .is_some_and(|call_path| matches!(call_path.segments(), ["subprocess", "PIPE"]))
+                .is_some_and(|qualified_name| {
+                    matches!(qualified_name.segments(), ["subprocess", "PIPE"])
+                })
         {
             return;
         }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -60,7 +60,7 @@ pub(crate) fn replace_stdout_stderr(checker: &mut Checker, call: &ast::ExprCall)
 
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["subprocess", "run"]))
     {
         // Find `stdout` and `stderr` kwargs.
@@ -74,11 +74,11 @@ pub(crate) fn replace_stdout_stderr(checker: &mut Checker, call: &ast::ExprCall)
         // Verify that they're both set to `subprocess.PIPE`.
         if !checker
             .semantic()
-            .resolve_call_path(&stdout.value)
+            .resolve_qualified_name(&stdout.value)
             .is_some_and(|call_path| matches!(call_path.segments(), ["subprocess", "PIPE"]))
             || !checker
                 .semantic()
-                .resolve_call_path(&stderr.value)
+                .resolve_qualified_name(&stderr.value)
                 .is_some_and(|call_path| matches!(call_path.segments(), ["subprocess", "PIPE"]))
         {
             return;

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -56,7 +56,7 @@ pub(crate) fn replace_universal_newlines(checker: &mut Checker, call: &ast::Expr
 
     if checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["subprocess", "run"]))
     {
         let Some(kwarg) = call.arguments.find_keyword("universal_newlines") else {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -57,7 +57,7 @@ pub(crate) fn replace_universal_newlines(checker: &mut Checker, call: &ast::Expr
     if checker
         .semantic()
         .resolve_qualified_name(&call.func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["subprocess", "run"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["subprocess", "run"]))
     {
         let Some(kwarg) = call.arguments.find_keyword("universal_newlines") else {
             return;

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/timeout_error_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/timeout_error_alias.rs
@@ -4,7 +4,7 @@ use ruff_text_size::{Ranged, TextRange};
 use crate::fix::edits::pad;
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::compose_call_path;
+use ruff_python_ast::name::compose_call_path;
 use ruff_python_semantic::SemanticModel;
 
 use crate::checkers::ast::Checker;
@@ -59,30 +59,32 @@ impl AlwaysFixableViolation for TimeoutErrorAlias {
 
 /// Return `true` if an [`Expr`] is an alias of `TimeoutError`.
 fn is_alias(expr: &Expr, semantic: &SemanticModel, target_version: PythonVersion) -> bool {
-    semantic.resolve_call_path(expr).is_some_and(|call_path| {
-        if target_version >= PythonVersion::Py311 {
-            matches!(
-                call_path.segments(),
-                ["socket", "timeout"] | ["asyncio", "TimeoutError"]
-            )
-        } else {
-            // N.B. This lint is only invoked for Python 3.10+. We assume
-            // as much here since otherwise socket.timeout would be an unsafe
-            // fix in Python <3.10. We add an assert to make this assumption
-            // explicit.
-            assert!(
-                target_version >= PythonVersion::Py310,
-                "lint should only be used for Python 3.10+",
-            );
-            matches!(call_path.segments(), ["socket", "timeout"])
-        }
-    })
+    semantic
+        .resolve_qualified_name(expr)
+        .is_some_and(|call_path| {
+            if target_version >= PythonVersion::Py311 {
+                matches!(
+                    call_path.segments(),
+                    ["socket", "timeout"] | ["asyncio", "TimeoutError"]
+                )
+            } else {
+                // N.B. This lint is only invoked for Python 3.10+. We assume
+                // as much here since otherwise socket.timeout would be an unsafe
+                // fix in Python <3.10. We add an assert to make this assumption
+                // explicit.
+                assert!(
+                    target_version >= PythonVersion::Py310,
+                    "lint should only be used for Python 3.10+",
+                );
+                matches!(call_path.segments(), ["socket", "timeout"])
+            }
+        })
 }
 
 /// Return `true` if an [`Expr`] is `TimeoutError`.
 fn is_timeout_error(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
-        .resolve_call_path(expr)
+        .resolve_qualified_name(expr)
         .is_some_and(|call_path| matches!(call_path.segments(), ["", "TimeoutError"]))
 }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/type_of_primitive.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/type_of_primitive.rs
@@ -61,7 +61,7 @@ pub(crate) fn type_of_primitive(checker: &mut Checker, expr: &Expr, func: &Expr,
     if !checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["", "type"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["", "type"]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/type_of_primitive.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/type_of_primitive.rs
@@ -60,7 +60,7 @@ pub(crate) fn type_of_primitive(checker: &mut Checker, expr: &Expr, func: &Expr,
     };
     if !checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["", "type"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -53,7 +53,7 @@ pub(crate) fn typing_text_str_alias(checker: &mut Checker, expr: &Expr) {
 
     if checker
         .semantic()
-        .resolve_call_path(expr)
+        .resolve_qualified_name(expr)
         .is_some_and(|call_path| matches!(call_path.segments(), ["typing", "Text"]))
     {
         let mut diagnostic = Diagnostic::new(TypingTextStrAlias, expr.range());

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -54,7 +54,7 @@ pub(crate) fn typing_text_str_alias(checker: &mut Checker, expr: &Expr) {
     if checker
         .semantic()
         .resolve_qualified_name(expr)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["typing", "Text"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["typing", "Text"]))
     {
         let mut diagnostic = Diagnostic::new(TypingTextStrAlias, expr.range());
         if checker.semantic().is_builtin("str") {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -2,7 +2,7 @@ use ruff_python_ast::Expr;
 
 use ruff_diagnostics::{Applicability, Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::compose_call_path;
+use ruff_python_ast::name::compose_call_path;
 use ruff_python_semantic::analyze::typing::ModuleMember;
 use ruff_text_size::Ranged;
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -2,7 +2,7 @@ use ruff_python_ast::Expr;
 
 use ruff_diagnostics::{Applicability, Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::name::compose_call_path;
+use ruff_python_ast::name::UnqualifiedName;
 use ruff_python_semantic::analyze::typing::ModuleMember;
 use ruff_text_size::Ranged;
 
@@ -81,12 +81,12 @@ pub(crate) fn use_pep585_annotation(
     expr: &Expr,
     replacement: &ModuleMember,
 ) {
-    let Some(from) = compose_call_path(expr) else {
+    let Some(from) = UnqualifiedName::from_expr(expr) else {
         return;
     };
     let mut diagnostic = Diagnostic::new(
         NonPEP585Annotation {
-            from,
+            from: from.to_string(),
             to: replacement.to_string(),
         },
         expr.range(),

--- a/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
@@ -100,7 +100,7 @@ pub(crate) fn bit_count(checker: &mut Checker, call: &ExprCall) {
     // Ensure that we're performing a `bin(...)`.
     if !checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["" | "builtins", "bin"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
@@ -101,7 +101,7 @@ pub(crate) fn bit_count(checker: &mut Checker, call: &ExprCall) {
     if !checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["" | "builtins", "bin"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["" | "builtins", "bin"]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/refurb/rules/hashlib_digest_hex.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/hashlib_digest_hex.rs
@@ -85,7 +85,7 @@ pub(crate) fn hashlib_digest_hex(checker: &mut Checker, call: &ExprCall) {
 
     if checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| {
             matches!(
                 call_path.segments(),

--- a/crates/ruff_linter/src/rules/refurb/rules/hashlib_digest_hex.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/hashlib_digest_hex.rs
@@ -86,9 +86,9 @@ pub(crate) fn hashlib_digest_hex(checker: &mut Checker, call: &ExprCall) {
     if checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 [
                     "hashlib",
                     "md5"

--- a/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
@@ -77,7 +77,7 @@ pub(crate) fn no_implicit_cwd(checker: &mut Checker, call: &ExprCall) {
     if !checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["pathlib", "Path"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["pathlib", "Path"]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
@@ -76,7 +76,7 @@ pub(crate) fn no_implicit_cwd(checker: &mut Checker, call: &ExprCall) {
 
     if !checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["pathlib", "Path"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/refurb/rules/metaclass_abcmeta.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/metaclass_abcmeta.rs
@@ -64,7 +64,7 @@ pub(crate) fn metaclass_abcmeta(checker: &mut Checker, class_def: &StmtClassDef)
     if !checker
         .semantic()
         .resolve_qualified_name(&keyword.value)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["abc", "ABCMeta"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["abc", "ABCMeta"]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/refurb/rules/metaclass_abcmeta.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/metaclass_abcmeta.rs
@@ -63,7 +63,7 @@ pub(crate) fn metaclass_abcmeta(checker: &mut Checker, class_def: &StmtClassDef)
     // Determine whether it's assigned to `abc.ABCMeta`.
     if !checker
         .semantic()
-        .resolve_call_path(&keyword.value)
+        .resolve_qualified_name(&keyword.value)
         .is_some_and(|call_path| matches!(call_path.segments(), ["abc", "ABCMeta"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
@@ -72,7 +72,7 @@ impl Violation for PrintEmptyString {
 pub(crate) fn print_empty_string(checker: &mut Checker, call: &ast::ExprCall) {
     if !checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .as_ref()
         .is_some_and(|call_path| matches!(call_path.segments(), ["", "print"]))
     {

--- a/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
@@ -74,7 +74,7 @@ pub(crate) fn print_empty_string(checker: &mut Checker, call: &ast::ExprCall) {
         .semantic()
         .resolve_qualified_name(&call.func)
         .as_ref()
-        .is_some_and(|call_path| matches!(call_path.segments(), ["", "print"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["", "print"]))
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/refurb/rules/redundant_log_base.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/redundant_log_base.rs
@@ -76,7 +76,7 @@ pub(crate) fn redundant_log_base(checker: &mut Checker, call: &ast::ExprCall) {
 
     if !checker
         .semantic()
-        .resolve_call_path(&call.func)
+        .resolve_qualified_name(&call.func)
         .as_ref()
         .is_some_and(|call_path| matches!(call_path.segments(), ["math", "log"]))
     {
@@ -89,7 +89,7 @@ pub(crate) fn redundant_log_base(checker: &mut Checker, call: &ast::ExprCall) {
         Base::Ten
     } else if checker
         .semantic()
-        .resolve_call_path(base)
+        .resolve_qualified_name(base)
         .as_ref()
         .is_some_and(|call_path| matches!(call_path.segments(), ["math", "e"]))
     {

--- a/crates/ruff_linter/src/rules/refurb/rules/redundant_log_base.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/redundant_log_base.rs
@@ -78,7 +78,7 @@ pub(crate) fn redundant_log_base(checker: &mut Checker, call: &ast::ExprCall) {
         .semantic()
         .resolve_qualified_name(&call.func)
         .as_ref()
-        .is_some_and(|call_path| matches!(call_path.segments(), ["math", "log"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["math", "log"]))
     {
         return;
     }
@@ -91,7 +91,7 @@ pub(crate) fn redundant_log_base(checker: &mut Checker, call: &ast::ExprCall) {
         .semantic()
         .resolve_qualified_name(base)
         .as_ref()
-        .is_some_and(|call_path| matches!(call_path.segments(), ["math", "e"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["math", "e"]))
     {
         Base::E
     } else {

--- a/crates/ruff_linter/src/rules/refurb/rules/regex_flag_alias.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/regex_flag_alias.rs
@@ -60,7 +60,7 @@ pub(crate) fn regex_flag_alias(checker: &mut Checker, expr: &Expr) {
     let Some(flag) = checker
         .semantic()
         .resolve_qualified_name(expr)
-        .and_then(|call_path| match call_path.segments() {
+        .and_then(|qualified_name| match qualified_name.segments() {
             ["re", "A"] => Some(RegexFlag::Ascii),
             ["re", "I"] => Some(RegexFlag::IgnoreCase),
             ["re", "L"] => Some(RegexFlag::Locale),

--- a/crates/ruff_linter/src/rules/refurb/rules/regex_flag_alias.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/regex_flag_alias.rs
@@ -57,21 +57,20 @@ pub(crate) fn regex_flag_alias(checker: &mut Checker, expr: &Expr) {
         return;
     }
 
-    let Some(flag) =
-        checker
-            .semantic()
-            .resolve_call_path(expr)
-            .and_then(|call_path| match call_path.segments() {
-                ["re", "A"] => Some(RegexFlag::Ascii),
-                ["re", "I"] => Some(RegexFlag::IgnoreCase),
-                ["re", "L"] => Some(RegexFlag::Locale),
-                ["re", "M"] => Some(RegexFlag::Multiline),
-                ["re", "S"] => Some(RegexFlag::DotAll),
-                ["re", "T"] => Some(RegexFlag::Template),
-                ["re", "U"] => Some(RegexFlag::Unicode),
-                ["re", "X"] => Some(RegexFlag::Verbose),
-                _ => None,
-            })
+    let Some(flag) = checker
+        .semantic()
+        .resolve_qualified_name(expr)
+        .and_then(|call_path| match call_path.segments() {
+            ["re", "A"] => Some(RegexFlag::Ascii),
+            ["re", "I"] => Some(RegexFlag::IgnoreCase),
+            ["re", "L"] => Some(RegexFlag::Locale),
+            ["re", "M"] => Some(RegexFlag::Multiline),
+            ["re", "S"] => Some(RegexFlag::DotAll),
+            ["re", "T"] => Some(RegexFlag::Template),
+            ["re", "U"] => Some(RegexFlag::Unicode),
+            ["re", "X"] => Some(RegexFlag::Verbose),
+            _ => None,
+        })
     else {
         return;
     };

--- a/crates/ruff_linter/src/rules/ruff/rules/asyncio_dangling_task.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/asyncio_dangling_task.rs
@@ -73,7 +73,7 @@ pub(crate) fn asyncio_dangling_task(expr: &Expr, semantic: &SemanticModel) -> Op
     // Ex) `asyncio.create_task(...)`
     if let Some(method) =
         semantic
-            .resolve_call_path(func)
+            .resolve_qualified_name(func)
             .and_then(|call_path| match call_path.segments() {
                 ["asyncio", "create_task"] => Some(Method::CreateTask),
                 ["asyncio", "ensure_future"] => Some(Method::EnsureFuture),

--- a/crates/ruff_linter/src/rules/ruff/rules/asyncio_dangling_task.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/asyncio_dangling_task.rs
@@ -71,14 +71,13 @@ pub(crate) fn asyncio_dangling_task(expr: &Expr, semantic: &SemanticModel) -> Op
     };
 
     // Ex) `asyncio.create_task(...)`
-    if let Some(method) =
-        semantic
-            .resolve_qualified_name(func)
-            .and_then(|call_path| match call_path.segments() {
-                ["asyncio", "create_task"] => Some(Method::CreateTask),
-                ["asyncio", "ensure_future"] => Some(Method::EnsureFuture),
-                _ => None,
-            })
+    if let Some(method) = semantic
+        .resolve_qualified_name(func)
+        .and_then(|qualified_name| match qualified_name.segments() {
+            ["asyncio", "create_task"] => Some(Method::CreateTask),
+            ["asyncio", "ensure_future"] => Some(Method::EnsureFuture),
+            _ => None,
+        })
     {
         return Some(Diagnostic::new(
             AsyncioDanglingTask {
@@ -93,9 +92,9 @@ pub(crate) fn asyncio_dangling_task(expr: &Expr, semantic: &SemanticModel) -> Op
     if let Expr::Attribute(ast::ExprAttribute { attr, value, .. }) = func.as_ref() {
         if attr == "create_task" {
             if let Expr::Name(name) = value.as_ref() {
-                if typing::resolve_assignment(value, semantic).is_some_and(|call_path| {
+                if typing::resolve_assignment(value, semantic).is_some_and(|qualified_name| {
                     matches!(
-                        call_path.segments(),
+                        qualified_name.segments(),
                         [
                             "asyncio",
                             "get_event_loop" | "get_running_loop" | "new_event_loop"

--- a/crates/ruff_linter/src/rules/ruff/rules/default_factory_kwarg.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/default_factory_kwarg.rs
@@ -77,7 +77,7 @@ pub(crate) fn default_factory_kwarg(checker: &mut Checker, call: &ast::ExprCall)
     // If the call isn't a `defaultdict` constructor, return.
     if !checker
         .semantic()
-        .resolve_call_path(call.func.as_ref())
+        .resolve_qualified_name(call.func.as_ref())
         .is_some_and(|call_path| matches!(call_path.segments(), ["collections", "defaultdict"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/ruff/rules/default_factory_kwarg.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/default_factory_kwarg.rs
@@ -78,7 +78,9 @@ pub(crate) fn default_factory_kwarg(checker: &mut Checker, call: &ast::ExprCall)
     if !checker
         .semantic()
         .resolve_qualified_name(call.func.as_ref())
-        .is_some_and(|call_path| matches!(call_path.segments(), ["collections", "defaultdict"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["collections", "defaultdict"])
+        })
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
@@ -2,8 +2,7 @@ use ruff_python_ast::{self as ast, Expr, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::name::compose_call_path;
-use ruff_python_ast::name::QualifiedName;
+use ruff_python_ast::name::{QualifiedName, UnqualifiedName};
 use ruff_python_semantic::analyze::typing::is_immutable_func;
 use ruff_text_size::Ranged;
 
@@ -103,7 +102,7 @@ pub(crate) fn function_call_in_dataclass_default(
                 {
                     checker.diagnostics.push(Diagnostic::new(
                         FunctionCallInDataclassDefaultArgument {
-                            name: compose_call_path(func),
+                            name: UnqualifiedName::from_expr(func).map(|name| name.to_string()),
                         },
                         expr.range(),
                     ));

--- a/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/function_call_in_dataclass_default.rs
@@ -2,8 +2,8 @@ use ruff_python_ast::{self as ast, Expr, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::compose_call_path;
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::name::compose_call_path;
+use ruff_python_ast::name::QualifiedName;
 use ruff_python_semantic::analyze::typing::is_immutable_func;
 use ruff_text_size::Ranged;
 
@@ -80,12 +80,12 @@ pub(crate) fn function_call_in_dataclass_default(
         return;
     }
 
-    let extend_immutable_calls: Vec<CallPath> = checker
+    let extend_immutable_calls: Vec<QualifiedName> = checker
         .settings
         .flake8_bugbear
         .extend_immutable_calls
         .iter()
-        .map(|target| CallPath::from_qualified_name(target))
+        .map(|target| QualifiedName::from_dotted_name(target))
         .collect();
 
     for statement in &class_def.body {

--- a/crates/ruff_linter/src/rules/ruff/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/helpers.rs
@@ -25,7 +25,7 @@ pub(super) fn is_dataclass_field(func: &Expr, semantic: &SemanticModel) -> bool 
     }
 
     semantic
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["dataclasses", "field"]))
 }
 
@@ -59,7 +59,7 @@ pub(super) fn is_dataclass(class_def: &ast::StmtClassDef, semantic: &SemanticMod
 
     class_def.decorator_list.iter().any(|decorator| {
         semantic
-            .resolve_call_path(map_callable(&decorator.expression))
+            .resolve_qualified_name(map_callable(&decorator.expression))
             .is_some_and(|call_path| matches!(call_path.segments(), ["dataclasses", "dataclass"]))
     })
 }

--- a/crates/ruff_linter/src/rules/ruff/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/helpers.rs
@@ -26,7 +26,7 @@ pub(super) fn is_dataclass_field(func: &Expr, semantic: &SemanticModel) -> bool 
 
     semantic
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["dataclasses", "field"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["dataclasses", "field"]))
 }
 
 /// Returns `true` if the given [`Expr`] is a `typing.ClassVar` annotation.
@@ -60,7 +60,9 @@ pub(super) fn is_dataclass(class_def: &ast::StmtClassDef, semantic: &SemanticMod
     class_def.decorator_list.iter().any(|decorator| {
         semantic
             .resolve_qualified_name(map_callable(&decorator.expression))
-            .is_some_and(|call_path| matches!(call_path.segments(), ["dataclasses", "dataclass"]))
+            .is_some_and(|qualified_name| {
+                matches!(qualified_name.segments(), ["dataclasses", "dataclass"])
+            })
     })
 }
 
@@ -72,9 +74,9 @@ pub(super) fn has_default_copy_semantics(
     class_def: &ast::StmtClassDef,
     semantic: &SemanticModel,
 ) -> bool {
-    analyze::class::any_call_path(class_def, semantic, &|call_path| {
+    analyze::class::any_qualified_name(class_def, semantic, &|qualified_name| {
         matches!(
-            call_path.segments(),
+            qualified_name.segments(),
             ["pydantic", "BaseModel" | "BaseSettings" | "BaseConfig"]
                 | ["pydantic_settings", "BaseSettings"]
                 | ["msgspec", "Struct"]

--- a/crates/ruff_linter/src/rules/ruff/rules/never_union.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/never_union.rs
@@ -193,10 +193,10 @@ enum NeverLike {
 
 impl NeverLike {
     fn from_expr(expr: &Expr, semantic: &ruff_python_semantic::SemanticModel) -> Option<Self> {
-        let call_path = semantic.resolve_qualified_name(expr)?;
-        if semantic.match_typing_call_path(&call_path, "NoReturn") {
+        let qualified_name = semantic.resolve_qualified_name(expr)?;
+        if semantic.match_typing_qualified_name(&qualified_name, "NoReturn") {
             Some(NeverLike::NoReturn)
-        } else if semantic.match_typing_call_path(&call_path, "Never") {
+        } else if semantic.match_typing_qualified_name(&qualified_name, "Never") {
             Some(NeverLike::Never)
         } else {
             None

--- a/crates/ruff_linter/src/rules/ruff/rules/never_union.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/never_union.rs
@@ -193,7 +193,7 @@ enum NeverLike {
 
 impl NeverLike {
     fn from_expr(expr: &Expr, semantic: &ruff_python_semantic::SemanticModel) -> Option<Self> {
-        let call_path = semantic.resolve_call_path(expr)?;
+        let call_path = semantic.resolve_qualified_name(expr)?;
         if semantic.match_typing_call_path(&call_path, "NoReturn") {
             Some(NeverLike::NoReturn)
         } else if semantic.match_typing_call_path(&call_path, "Never") {

--- a/crates/ruff_linter/src/rules/ruff/typing.rs
+++ b/crates/ruff_linter/src/rules/ruff/typing.rs
@@ -83,19 +83,20 @@ impl<'a> TypingTarget<'a> {
                     // If we can't resolve the call path, it must be defined
                     // in the same file and could be a type alias.
                     Some(TypingTarget::Unknown),
-                    |call_path| {
-                        if semantic.match_typing_call_path(&call_path, "Optional") {
+                    |qualified_name| {
+                        if semantic.match_typing_qualified_name(&qualified_name, "Optional") {
                             Some(TypingTarget::Optional(slice.as_ref()))
-                        } else if semantic.match_typing_call_path(&call_path, "Literal") {
+                        } else if semantic.match_typing_qualified_name(&qualified_name, "Literal") {
                             Some(TypingTarget::Literal(slice.as_ref()))
-                        } else if semantic.match_typing_call_path(&call_path, "Union") {
+                        } else if semantic.match_typing_qualified_name(&qualified_name, "Union") {
                             Some(TypingTarget::Union(slice.as_ref()))
-                        } else if semantic.match_typing_call_path(&call_path, "Annotated") {
+                        } else if semantic.match_typing_qualified_name(&qualified_name, "Annotated")
+                        {
                             resolve_slice_value(slice.as_ref())
                                 .next()
                                 .map(TypingTarget::Annotated)
                         } else {
-                            if is_known_type(&call_path, minor_version) {
+                            if is_known_type(&qualified_name, minor_version) {
                                 Some(TypingTarget::Known)
                             } else {
                                 Some(TypingTarget::Unknown)
@@ -119,16 +120,19 @@ impl<'a> TypingTarget<'a> {
                 // If we can't resolve the call path, it must be defined in the
                 // same file, so we assume it's `Any` as it could be a type alias.
                 Some(TypingTarget::Unknown),
-                |call_path| {
-                    if semantic.match_typing_call_path(&call_path, "Any") {
+                |qualified_name| {
+                    if semantic.match_typing_qualified_name(&qualified_name, "Any") {
                         Some(TypingTarget::Any)
-                    } else if matches!(call_path.segments(), ["" | "builtins", "object"]) {
+                    } else if matches!(qualified_name.segments(), ["" | "builtins", "object"]) {
                         Some(TypingTarget::Object)
-                    } else if semantic.match_typing_call_path(&call_path, "Hashable")
-                        || matches!(call_path.segments(), ["collections", "abc", "Hashable"])
+                    } else if semantic.match_typing_qualified_name(&qualified_name, "Hashable")
+                        || matches!(
+                            qualified_name.segments(),
+                            ["collections", "abc", "Hashable"]
+                        )
                     {
                         Some(TypingTarget::Hashable)
-                    } else if !is_known_type(&call_path, minor_version) {
+                    } else if !is_known_type(&qualified_name, minor_version) {
                         // If it's not a known type, we assume it's `Any`.
                         Some(TypingTarget::Unknown)
                     } else {

--- a/crates/ruff_linter/src/rules/tryceratops/helpers.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/helpers.rs
@@ -35,7 +35,9 @@ impl<'a, 'b> Visitor<'b> for LoggerCandidateVisitor<'a, 'b> {
                     }
                 }
                 Expr::Name(_) => {
-                    if let Some(call_path) = self.semantic.resolve_call_path(call.func.as_ref()) {
+                    if let Some(call_path) =
+                        self.semantic.resolve_qualified_name(call.func.as_ref())
+                    {
                         if let ["logging", attribute] = call_path.segments() {
                             if let Some(logging_level) = LoggingLevel::from_attribute(attribute) {
                                 {

--- a/crates/ruff_linter/src/rules/tryceratops/helpers.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/helpers.rs
@@ -35,10 +35,10 @@ impl<'a, 'b> Visitor<'b> for LoggerCandidateVisitor<'a, 'b> {
                     }
                 }
                 Expr::Name(_) => {
-                    if let Some(call_path) =
+                    if let Some(qualified_name) =
                         self.semantic.resolve_qualified_name(call.func.as_ref())
                     {
-                        if let ["logging", attribute] = call_path.segments() {
+                        if let ["logging", attribute] = qualified_name.segments() {
                             if let Some(logging_level) = LoggingLevel::from_attribute(attribute) {
                                 {
                                     self.calls.push((call, logging_level));

--- a/crates/ruff_linter/src/rules/tryceratops/rules/error_instead_of_exception.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/error_instead_of_exception.rs
@@ -91,8 +91,8 @@ pub(crate) fn error_instead_of_exception(checker: &mut Checker, handlers: &[Exce
                                 if checker
                                     .semantic()
                                     .resolve_qualified_name(expr.func.as_ref())
-                                    .is_some_and(|call_path| {
-                                        matches!(call_path.segments(), ["logging", "error"])
+                                    .is_some_and(|qualified_name| {
+                                        matches!(qualified_name.segments(), ["logging", "error"])
                                     })
                                 {
                                     Applicability::Safe
@@ -118,8 +118,11 @@ pub(crate) fn error_instead_of_exception(checker: &mut Checker, handlers: &[Exce
                                     if checker
                                         .semantic()
                                         .resolve_qualified_name(expr.func.as_ref())
-                                        .is_some_and(|call_path| {
-                                            matches!(call_path.segments(), ["logging", "error"])
+                                        .is_some_and(|qualified_name| {
+                                            matches!(
+                                                qualified_name.segments(),
+                                                ["logging", "error"]
+                                            )
                                         })
                                     {
                                         Applicability::Safe

--- a/crates/ruff_linter/src/rules/tryceratops/rules/error_instead_of_exception.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/error_instead_of_exception.rs
@@ -90,7 +90,7 @@ pub(crate) fn error_instead_of_exception(checker: &mut Checker, handlers: &[Exce
                                 // the object _may_ not be a logger.
                                 if checker
                                     .semantic()
-                                    .resolve_call_path(expr.func.as_ref())
+                                    .resolve_qualified_name(expr.func.as_ref())
                                     .is_some_and(|call_path| {
                                         matches!(call_path.segments(), ["logging", "error"])
                                     })
@@ -117,7 +117,7 @@ pub(crate) fn error_instead_of_exception(checker: &mut Checker, handlers: &[Exce
                                     // the object _may_ not be a logger.
                                     if checker
                                         .semantic()
-                                        .resolve_call_path(expr.func.as_ref())
+                                        .resolve_qualified_name(expr.func.as_ref())
                                         .is_some_and(|call_path| {
                                             matches!(call_path.segments(), ["logging", "error"])
                                         })

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
@@ -73,7 +73,9 @@ pub(crate) fn raise_vanilla_args(checker: &mut Checker, expr: &Expr) {
     if checker
         .semantic()
         .resolve_qualified_name(func)
-        .is_some_and(|call_path| matches!(call_path.segments(), ["", "NotImplementedError"]))
+        .is_some_and(|qualified_name| {
+            matches!(qualified_name.segments(), ["", "NotImplementedError"])
+        })
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
@@ -72,7 +72,7 @@ pub(crate) fn raise_vanilla_args(checker: &mut Checker, expr: &Expr) {
     // `NotImplementedError`.
     if checker
         .semantic()
-        .resolve_call_path(func)
+        .resolve_qualified_name(func)
         .is_some_and(|call_path| matches!(call_path.segments(), ["", "NotImplementedError"]))
     {
         return;

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_class.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_class.rs
@@ -65,7 +65,7 @@ impl Violation for RaiseVanillaClass {
 pub(crate) fn raise_vanilla_class(checker: &mut Checker, expr: &Expr) {
     if checker
         .semantic()
-        .resolve_call_path(if let Expr::Call(ast::ExprCall { func, .. }) = expr {
+        .resolve_qualified_name(if let Expr::Call(ast::ExprCall { func, .. }) = expr {
             func
         } else {
             expr

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_class.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_class.rs
@@ -70,7 +70,7 @@ pub(crate) fn raise_vanilla_class(checker: &mut Checker, expr: &Expr) {
         } else {
             expr
         })
-        .is_some_and(|call_path| matches!(call_path.segments(), ["", "Exception"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["", "Exception"]))
     {
         checker
             .diagnostics

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_within_try.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_within_try.rs
@@ -112,8 +112,11 @@ pub(crate) fn raise_within_try(checker: &mut Checker, body: &[Stmt], handlers: &
                 checker
                     .semantic()
                     .resolve_qualified_name(expr)
-                    .is_some_and(|call_path| {
-                        matches!(call_path.segments(), ["", "Exception" | "BaseException"])
+                    .is_some_and(|qualified_name| {
+                        matches!(
+                            qualified_name.segments(),
+                            ["", "Exception" | "BaseException"]
+                        )
                     })
             })
         {

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_within_try.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_within_try.rs
@@ -111,7 +111,7 @@ pub(crate) fn raise_within_try(checker: &mut Checker, body: &[Stmt], handlers: &
             || handled_exceptions.iter().any(|expr| {
                 checker
                     .semantic()
-                    .resolve_call_path(expr)
+                    .resolve_qualified_name(expr)
                     .is_some_and(|call_path| {
                         matches!(call_path.segments(), ["", "Exception" | "BaseException"])
                     })

--- a/crates/ruff_linter/src/rules/tryceratops/rules/type_check_without_type_error.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/type_check_without_type_error.rs
@@ -76,9 +76,9 @@ fn check_type_check_call(checker: &mut Checker, call: &Expr) -> bool {
     checker
         .semantic()
         .resolve_qualified_name(call)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["", "isinstance" | "issubclass" | "callable"]
             )
         })
@@ -101,9 +101,9 @@ fn is_builtin_exception(checker: &mut Checker, exc: &Expr) -> bool {
     return checker
         .semantic()
         .resolve_qualified_name(exc)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 [
                     "",
                     "ArithmeticError"

--- a/crates/ruff_linter/src/rules/tryceratops/rules/type_check_without_type_error.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/type_check_without_type_error.rs
@@ -75,7 +75,7 @@ fn has_control_flow(stmt: &Stmt) -> bool {
 fn check_type_check_call(checker: &mut Checker, call: &Expr) -> bool {
     checker
         .semantic()
-        .resolve_call_path(call)
+        .resolve_qualified_name(call)
         .is_some_and(|call_path| {
             matches!(
                 call_path.segments(),
@@ -100,7 +100,7 @@ fn check_type_check_test(checker: &mut Checker, test: &Expr) -> bool {
 fn is_builtin_exception(checker: &mut Checker, exc: &Expr) -> bool {
     return checker
         .semantic()
-        .resolve_call_path(exc)
+        .resolve_qualified_name(exc)
         .is_some_and(|call_path| {
             matches!(
                 call_path.segments(),

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -7,7 +7,7 @@ use ruff_python_trivia::{indentation_at_offset, CommentRanges, SimpleTokenKind, 
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
-use crate::call_path::{CallPath, CallPathBuilder};
+use crate::name::{QualifiedName, QualifiedNameBuilder};
 use crate::parenthesize::parenthesized_range;
 use crate::statement_visitor::StatementVisitor;
 use crate::visitor::Visitor;
@@ -800,8 +800,8 @@ pub fn collect_import_from_member<'a>(
     level: Option<u32>,
     module: Option<&'a str>,
     member: &'a str,
-) -> CallPath<'a> {
-    let mut call_path_builder = CallPathBuilder::with_capacity(
+) -> QualifiedName<'a> {
+    let mut call_path_builder = QualifiedNameBuilder::with_capacity(
         level.unwrap_or_default() as usize
             + module
                 .map(|module| module.split('.').count())
@@ -838,9 +838,9 @@ pub fn from_relative_import<'a>(
     import: &[&'a str],
     // The remaining segments to the call path (e.g., given `bar.baz`, `["baz"]`).
     tail: &[&'a str],
-) -> Option<CallPath<'a>> {
+) -> Option<QualifiedName<'a>> {
     let mut call_path_builder =
-        CallPathBuilder::with_capacity(module.len() + import.len() + tail.len());
+        QualifiedNameBuilder::with_capacity(module.len() + import.len() + tail.len());
 
     // Start with the module path.
     call_path_builder.extend(module.iter().map(String::as_str));

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -801,7 +801,7 @@ pub fn collect_import_from_member<'a>(
     module: Option<&'a str>,
     member: &'a str,
 ) -> QualifiedName<'a> {
-    let mut call_path_builder = QualifiedNameBuilder::with_capacity(
+    let mut qualified_name_builder = QualifiedNameBuilder::with_capacity(
         level.unwrap_or_default() as usize
             + module
                 .map(|module| module.split('.').count())
@@ -813,20 +813,20 @@ pub fn collect_import_from_member<'a>(
     if let Some(level) = level {
         if level > 0 {
             for _ in 0..level {
-                call_path_builder.push(".");
+                qualified_name_builder.push(".");
             }
         }
     }
 
     // Add the remaining segments.
     if let Some(module) = module {
-        call_path_builder.extend(module.split('.'));
+        qualified_name_builder.extend(module.split('.'));
     }
 
     // Add the member.
-    call_path_builder.push(member);
+    qualified_name_builder.push(member);
 
-    call_path_builder.build()
+    qualified_name_builder.build()
 }
 
 /// Format the call path for a relative import, or `None` if the relative import extends beyond
@@ -839,28 +839,28 @@ pub fn from_relative_import<'a>(
     // The remaining segments to the call path (e.g., given `bar.baz`, `["baz"]`).
     tail: &[&'a str],
 ) -> Option<QualifiedName<'a>> {
-    let mut call_path_builder =
+    let mut qualified_name_builder =
         QualifiedNameBuilder::with_capacity(module.len() + import.len() + tail.len());
 
     // Start with the module path.
-    call_path_builder.extend(module.iter().map(String::as_str));
+    qualified_name_builder.extend(module.iter().map(String::as_str));
 
     // Remove segments based on the number of dots.
     for segment in import {
         if *segment == "." {
-            if call_path_builder.is_empty() {
+            if qualified_name_builder.is_empty() {
                 return None;
             }
-            call_path_builder.pop();
+            qualified_name_builder.pop();
         } else {
-            call_path_builder.push(segment);
+            qualified_name_builder.push(segment);
         }
     }
 
     // Add the remaining segments.
-    call_path_builder.extend_from_slice(tail);
+    qualified_name_builder.extend_from_slice(tail);
 
-    Some(call_path_builder.build())
+    Some(qualified_name_builder.build())
 }
 
 /// Given an imported module (based on its relative import level and module name), return the

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -6,7 +6,6 @@ pub use node::{AnyNode, AnyNodeRef, AstNode, NodeKind};
 pub use nodes::*;
 
 pub mod all;
-pub mod call_path;
 pub mod comparable;
 pub mod docstrings;
 mod expression;
@@ -15,6 +14,7 @@ pub mod helpers;
 pub mod identifier;
 pub mod imports;
 mod int;
+pub mod name;
 mod node;
 mod nodes;
 pub mod parenthesize;

--- a/crates/ruff_python_semantic/src/analyze/class.rs
+++ b/crates/ruff_python_semantic/src/analyze/class.rs
@@ -1,28 +1,28 @@
 use rustc_hash::FxHashSet;
 
 use ruff_python_ast as ast;
-use ruff_python_ast::call_path::CallPath;
 use ruff_python_ast::helpers::map_subscript;
+use ruff_python_ast::name::QualifiedName;
 
 use crate::{BindingId, SemanticModel};
 
-/// Return `true` if any base class matches a [`CallPath`] predicate.
+/// Return `true` if any base class matches a [`QualifiedName`] predicate.
 pub fn any_call_path(
     class_def: &ast::StmtClassDef,
     semantic: &SemanticModel,
-    func: &dyn Fn(CallPath) -> bool,
+    func: &dyn Fn(QualifiedName) -> bool,
 ) -> bool {
     fn inner(
         class_def: &ast::StmtClassDef,
         semantic: &SemanticModel,
-        func: &dyn Fn(CallPath) -> bool,
+        func: &dyn Fn(QualifiedName) -> bool,
         seen: &mut FxHashSet<BindingId>,
     ) -> bool {
         class_def.bases().iter().any(|expr| {
             // If the base class itself matches the pattern, then this does too.
             // Ex) `class Foo(BaseModel): ...`
             if semantic
-                .resolve_call_path(map_subscript(expr))
+                .resolve_qualified_name(map_subscript(expr))
                 .is_some_and(func)
             {
                 return true;

--- a/crates/ruff_python_semantic/src/analyze/class.rs
+++ b/crates/ruff_python_semantic/src/analyze/class.rs
@@ -7,7 +7,7 @@ use ruff_python_ast::name::QualifiedName;
 use crate::{BindingId, SemanticModel};
 
 /// Return `true` if any base class matches a [`QualifiedName`] predicate.
-pub fn any_call_path(
+pub fn any_qualified_name(
     class_def: &ast::StmtClassDef,
     semantic: &SemanticModel,
     func: &dyn Fn(QualifiedName) -> bool,

--- a/crates/ruff_python_semantic/src/analyze/function_type.rs
+++ b/crates/ruff_python_semantic/src/analyze/function_type.rs
@@ -36,8 +36,8 @@ pub fn classify(
             // The class itself extends a known metaclass, so all methods are class methods.
             semantic
                 .resolve_qualified_name(map_callable(expr))
-                .is_some_and( |call_path| {
-                    matches!(call_path.segments(), ["", "type"] | ["abc", "ABCMeta"])
+                .is_some_and( |qualified_name| {
+                    matches!(qualified_name.segments(), ["", "type"] | ["abc", "ABCMeta"])
                 })
         })
         || decorator_list.iter().any(|decorator| is_class_method(decorator, semantic, classmethod_decorators))
@@ -60,13 +60,13 @@ fn is_static_method(
     // The decorator is an import, so should match against a qualified path.
     if semantic
         .resolve_qualified_name(decorator)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["", "staticmethod"] | ["abc", "abstractstaticmethod"]
             ) || staticmethod_decorators
                 .iter()
-                .any(|decorator| call_path == QualifiedName::from_dotted_name(decorator))
+                .any(|decorator| qualified_name == QualifiedName::from_dotted_name(decorator))
         })
     {
         return true;
@@ -75,8 +75,8 @@ fn is_static_method(
     // We do not have a resolvable call path, most likely from a decorator like
     // `@someproperty.setter`. Instead, match on the last element.
     if !staticmethod_decorators.is_empty() {
-        if UnqualifiedName::from_expr(decorator).is_some_and(|call_path| {
-            call_path.segments().last().is_some_and(|tail| {
+        if UnqualifiedName::from_expr(decorator).is_some_and(|name| {
+            name.segments().last().is_some_and(|tail| {
                 staticmethod_decorators
                     .iter()
                     .any(|decorator| tail == decorator)
@@ -100,13 +100,13 @@ fn is_class_method(
     // The decorator is an import, so should match against a qualified path.
     if semantic
         .resolve_qualified_name(decorator)
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 ["", "classmethod"] | ["abc", "abstractclassmethod"]
             ) || classmethod_decorators
                 .iter()
-                .any(|decorator| call_path == QualifiedName::from_dotted_name(decorator))
+                .any(|decorator| qualified_name == QualifiedName::from_dotted_name(decorator))
         })
     {
         return true;
@@ -115,8 +115,8 @@ fn is_class_method(
     // We do not have a resolvable call path, most likely from a decorator like
     // `@someproperty.setter`. Instead, match on the last element.
     if !classmethod_decorators.is_empty() {
-        if UnqualifiedName::from_expr(decorator).is_some_and(|call_path| {
-            call_path.segments().last().is_some_and(|tail| {
+        if UnqualifiedName::from_expr(decorator).is_some_and(|name| {
+            name.segments().last().is_some_and(|tail| {
                 classmethod_decorators
                     .iter()
                     .any(|decorator| tail == decorator)

--- a/crates/ruff_python_semantic/src/analyze/imports.rs
+++ b/crates/ruff_python_semantic/src/analyze/imports.rs
@@ -18,9 +18,9 @@ pub fn is_sys_path_modification(stmt: &Stmt, semantic: &SemanticModel) -> bool {
     };
     semantic
         .resolve_qualified_name(func.as_ref())
-        .is_some_and(|call_path| {
+        .is_some_and(|qualified_name| {
             matches!(
-                call_path.segments(),
+                qualified_name.segments(),
                 [
                     "sys",
                     "path",
@@ -48,9 +48,9 @@ pub fn is_os_environ_modification(stmt: &Stmt, semantic: &SemanticModel) -> bool
         Stmt::Expr(ast::StmtExpr { value, .. }) => match value.as_ref() {
             Expr::Call(ast::ExprCall { func, .. }) => semantic
                 .resolve_qualified_name(func.as_ref())
-                .is_some_and(|call_path| {
+                .is_some_and(|qualified_name| {
                     matches!(
-                        call_path.segments(),
+                        qualified_name.segments(),
                         ["os", "putenv" | "unsetenv"]
                             | [
                                 "os",
@@ -64,19 +64,23 @@ pub fn is_os_environ_modification(stmt: &Stmt, semantic: &SemanticModel) -> bool
         Stmt::Delete(ast::StmtDelete { targets, .. }) => targets.iter().any(|target| {
             semantic
                 .resolve_qualified_name(map_subscript(target))
-                .is_some_and(|call_path| matches!(call_path.segments(), ["os", "environ"]))
+                .is_some_and(|qualified_name| {
+                    matches!(qualified_name.segments(), ["os", "environ"])
+                })
         }),
         Stmt::Assign(ast::StmtAssign { targets, .. }) => targets.iter().any(|target| {
             semantic
                 .resolve_qualified_name(map_subscript(target))
-                .is_some_and(|call_path| matches!(call_path.segments(), ["os", "environ"]))
+                .is_some_and(|qualified_name| {
+                    matches!(qualified_name.segments(), ["os", "environ"])
+                })
         }),
         Stmt::AnnAssign(ast::StmtAnnAssign { target, .. }) => semantic
             .resolve_qualified_name(map_subscript(target))
-            .is_some_and(|call_path| matches!(call_path.segments(), ["os", "environ"])),
+            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["os", "environ"])),
         Stmt::AugAssign(ast::StmtAugAssign { target, .. }) => semantic
             .resolve_qualified_name(map_subscript(target))
-            .is_some_and(|call_path| matches!(call_path.segments(), ["os", "environ"])),
+            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["os", "environ"])),
         _ => false,
     }
 }
@@ -96,5 +100,5 @@ pub fn is_matplotlib_activation(stmt: &Stmt, semantic: &SemanticModel) -> bool {
     };
     semantic
         .resolve_qualified_name(func.as_ref())
-        .is_some_and(|call_path| matches!(call_path.segments(), ["matplotlib", "use"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["matplotlib", "use"]))
 }

--- a/crates/ruff_python_semantic/src/analyze/imports.rs
+++ b/crates/ruff_python_semantic/src/analyze/imports.rs
@@ -17,7 +17,7 @@ pub fn is_sys_path_modification(stmt: &Stmt, semantic: &SemanticModel) -> bool {
         return false;
     };
     semantic
-        .resolve_call_path(func.as_ref())
+        .resolve_qualified_name(func.as_ref())
         .is_some_and(|call_path| {
             matches!(
                 call_path.segments(),
@@ -47,7 +47,7 @@ pub fn is_os_environ_modification(stmt: &Stmt, semantic: &SemanticModel) -> bool
     match stmt {
         Stmt::Expr(ast::StmtExpr { value, .. }) => match value.as_ref() {
             Expr::Call(ast::ExprCall { func, .. }) => semantic
-                .resolve_call_path(func.as_ref())
+                .resolve_qualified_name(func.as_ref())
                 .is_some_and(|call_path| {
                     matches!(
                         call_path.segments(),
@@ -63,19 +63,19 @@ pub fn is_os_environ_modification(stmt: &Stmt, semantic: &SemanticModel) -> bool
         },
         Stmt::Delete(ast::StmtDelete { targets, .. }) => targets.iter().any(|target| {
             semantic
-                .resolve_call_path(map_subscript(target))
+                .resolve_qualified_name(map_subscript(target))
                 .is_some_and(|call_path| matches!(call_path.segments(), ["os", "environ"]))
         }),
         Stmt::Assign(ast::StmtAssign { targets, .. }) => targets.iter().any(|target| {
             semantic
-                .resolve_call_path(map_subscript(target))
+                .resolve_qualified_name(map_subscript(target))
                 .is_some_and(|call_path| matches!(call_path.segments(), ["os", "environ"]))
         }),
         Stmt::AnnAssign(ast::StmtAnnAssign { target, .. }) => semantic
-            .resolve_call_path(map_subscript(target))
+            .resolve_qualified_name(map_subscript(target))
             .is_some_and(|call_path| matches!(call_path.segments(), ["os", "environ"])),
         Stmt::AugAssign(ast::StmtAugAssign { target, .. }) => semantic
-            .resolve_call_path(map_subscript(target))
+            .resolve_qualified_name(map_subscript(target))
             .is_some_and(|call_path| matches!(call_path.segments(), ["os", "environ"])),
         _ => false,
     }
@@ -95,6 +95,6 @@ pub fn is_matplotlib_activation(stmt: &Stmt, semantic: &SemanticModel) -> bool {
         return false;
     };
     semantic
-        .resolve_call_path(func.as_ref())
+        .resolve_qualified_name(func.as_ref())
         .is_some_and(|call_path| matches!(call_path.segments(), ["matplotlib", "use"]))
 }

--- a/crates/ruff_python_semantic/src/analyze/logging.rs
+++ b/crates/ruff_python_semantic/src/analyze/logging.rs
@@ -27,9 +27,9 @@ pub fn is_logger_candidate(
 
     // If the symbol was imported from another module, ensure that it's either a user-specified
     // logger object, the `logging` module itself, or `flask.current_app.logger`.
-    if let Some(call_path) = semantic.resolve_qualified_name(value) {
+    if let Some(qualified_name) = semantic.resolve_qualified_name(value) {
         if matches!(
-            call_path.segments(),
+            qualified_name.segments(),
             ["logging"] | ["flask", "current_app", "logger"]
         ) {
             return true;
@@ -37,7 +37,7 @@ pub fn is_logger_candidate(
 
         if logger_objects
             .iter()
-            .any(|logger| QualifiedName::from_dotted_name(logger) == call_path)
+            .any(|logger| QualifiedName::from_dotted_name(logger) == qualified_name)
         {
             return true;
         }
@@ -47,8 +47,8 @@ pub fn is_logger_candidate(
 
     // Otherwise, if the symbol was defined in the current module, match against some common
     // logger names.
-    if let Some(call_path) = UnqualifiedName::from_expr(value) {
-        if let Some(tail) = call_path.segments().last() {
+    if let Some(name) = UnqualifiedName::from_expr(value) {
+        if let Some(tail) = name.segments().last() {
             if tail.starts_with("log")
                 || tail.ends_with("logger")
                 || tail.ends_with("logging")
@@ -79,7 +79,7 @@ pub fn exc_info<'a>(arguments: &'a Arguments, semantic: &SemanticModel) -> Optio
         .value
         .as_call_expr()
         .and_then(|call| semantic.resolve_qualified_name(&call.func))
-        .is_some_and(|call_path| matches!(call_path.segments(), ["sys", "exc_info"]))
+        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["sys", "exc_info"]))
     {
         return Some(exc_info);
     }

--- a/crates/ruff_python_semantic/src/analyze/visibility.rs
+++ b/crates/ruff_python_semantic/src/analyze/visibility.rs
@@ -18,7 +18,7 @@ pub fn is_staticmethod(decorator_list: &[Decorator], semantic: &SemanticModel) -
     decorator_list.iter().any(|decorator| {
         semantic
             .resolve_qualified_name(map_callable(&decorator.expression))
-            .is_some_and(|call_path| matches!(call_path.segments(), ["", "staticmethod"]))
+            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["", "staticmethod"]))
     })
 }
 
@@ -27,7 +27,7 @@ pub fn is_classmethod(decorator_list: &[Decorator], semantic: &SemanticModel) ->
     decorator_list.iter().any(|decorator| {
         semantic
             .resolve_qualified_name(map_callable(&decorator.expression))
-            .is_some_and(|call_path| matches!(call_path.segments(), ["", "classmethod"]))
+            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["", "classmethod"]))
     })
 }
 
@@ -50,9 +50,9 @@ pub fn is_abstract(decorator_list: &[Decorator], semantic: &SemanticModel) -> bo
     decorator_list.iter().any(|decorator| {
         semantic
             .resolve_qualified_name(map_callable(&decorator.expression))
-            .is_some_and(|call_path| {
+            .is_some_and(|qualified_name| {
                 matches!(
-                    call_path.segments(),
+                    qualified_name.segments(),
                     [
                         "abc",
                         "abstractmethod"
@@ -76,13 +76,13 @@ pub fn is_property(
     decorator_list.iter().any(|decorator| {
         semantic
             .resolve_qualified_name(map_callable(&decorator.expression))
-            .is_some_and(|call_path| {
+            .is_some_and(|qualified_name| {
                 matches!(
-                    call_path.segments(),
+                    qualified_name.segments(),
                     ["", "property"] | ["functools", "cached_property"]
                 ) || extra_properties
                     .iter()
-                    .any(|extra_property| extra_property.segments() == call_path.segments())
+                    .any(|extra_property| extra_property.segments() == qualified_name.segments())
             })
     })
 }
@@ -187,9 +187,9 @@ pub(crate) fn function_visibility(function: &ast::StmtFunctionDef) -> Visibility
 pub fn method_visibility(function: &ast::StmtFunctionDef) -> Visibility {
     // Is this a setter or deleter?
     if function.decorator_list.iter().any(|decorator| {
-        UnqualifiedName::from_expr(&decorator.expression).is_some_and(|call_path| {
-            call_path.segments() == [function.name.as_str(), "setter"]
-                || call_path.segments() == [function.name.as_str(), "deleter"]
+        UnqualifiedName::from_expr(&decorator.expression).is_some_and(|name| {
+            name.segments() == [function.name.as_str(), "setter"]
+                || name.segments() == [function.name.as_str(), "deleter"]
         })
     }) {
         return Visibility::Private;

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -4,7 +4,7 @@ use std::ops::{Deref, DerefMut};
 use bitflags::bitflags;
 
 use ruff_index::{newtype_index, IndexSlice, IndexVec};
-use ruff_python_ast::name::format_call_path_segments;
+use ruff_python_ast::name::format_qualified_name_segments;
 use ruff_python_ast::Stmt;
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
@@ -561,7 +561,7 @@ pub trait Imported<'a> {
     /// Returns the fully-qualified name of the imported symbol.
     fn qualified_name(&self) -> String {
         let mut output = String::new();
-        format_call_path_segments(self.call_path(), &mut output).unwrap();
+        format_qualified_name_segments(self.call_path(), &mut output).unwrap();
         output
     }
 }

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -4,7 +4,7 @@ use std::ops::{Deref, DerefMut};
 use bitflags::bitflags;
 
 use ruff_index::{newtype_index, IndexSlice, IndexVec};
-use ruff_python_ast::call_path::format_call_path_segments;
+use ruff_python_ast::name::format_call_path_segments;
 use ruff_python_ast::Stmt;
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
@@ -125,38 +125,38 @@ impl<'a> Binding<'a> {
             // import foo.baz
             // ```
             BindingKind::Import(Import {
-                call_path: redefinition,
+                qualified_name: redefinition,
             }) => {
                 if let BindingKind::SubmoduleImport(SubmoduleImport {
-                    call_path: definition,
+                    qualified_name: definition,
                 }) = &existing.kind
                 {
                     return redefinition == definition;
                 }
             }
             BindingKind::FromImport(FromImport {
-                call_path: redefinition,
+                qualified_name: redefinition,
             }) => {
                 if let BindingKind::SubmoduleImport(SubmoduleImport {
-                    call_path: definition,
+                    qualified_name: definition,
                 }) = &existing.kind
                 {
                     return redefinition == definition;
                 }
             }
             BindingKind::SubmoduleImport(SubmoduleImport {
-                call_path: redefinition,
+                qualified_name: redefinition,
             }) => match &existing.kind {
                 BindingKind::Import(Import {
-                    call_path: definition,
+                    qualified_name: definition,
                 })
                 | BindingKind::SubmoduleImport(SubmoduleImport {
-                    call_path: definition,
+                    qualified_name: definition,
                 }) => {
                     return redefinition == definition;
                 }
                 BindingKind::FromImport(FromImport {
-                    call_path: definition,
+                    qualified_name: definition,
                 }) => {
                     return redefinition == definition;
                 }
@@ -362,7 +362,7 @@ pub struct Import<'a> {
     /// The full name of the module being imported.
     /// Ex) Given `import foo`, `qualified_name` would be "foo".
     /// Ex) Given `import foo as bar`, `qualified_name` would be "foo".
-    pub call_path: Box<[&'a str]>,
+    pub qualified_name: Box<[&'a str]>,
 }
 
 /// A binding for a member imported from a module, keyed on the name to which the member is bound.
@@ -373,7 +373,7 @@ pub struct FromImport<'a> {
     /// The full name of the member being imported.
     /// Ex) Given `from foo import bar`, `qualified_name` would be "foo.bar".
     /// Ex) Given `from foo import bar as baz`, `qualified_name` would be "foo.bar".
-    pub call_path: Box<[&'a str]>,
+    pub qualified_name: Box<[&'a str]>,
 }
 
 /// A binding for a submodule imported from a module, keyed on the name of the parent module.
@@ -382,7 +382,7 @@ pub struct FromImport<'a> {
 pub struct SubmoduleImport<'a> {
     /// The full name of the submodule being imported.
     /// Ex) Given `import foo.bar`, `qualified_name` would be "foo.bar".
-    pub call_path: Box<[&'a str]>,
+    pub qualified_name: Box<[&'a str]>,
 }
 
 #[derive(Debug, Clone, is_macro::Is)]
@@ -569,12 +569,12 @@ pub trait Imported<'a> {
 impl<'a> Imported<'a> for Import<'a> {
     /// For example, given `import foo`, returns `["foo"]`.
     fn call_path(&self) -> &[&'a str] {
-        self.call_path.as_ref()
+        self.qualified_name.as_ref()
     }
 
     /// For example, given `import foo`, returns `["foo"]`.
     fn module_name(&self) -> &[&'a str] {
-        &self.call_path[..1]
+        &self.qualified_name[..1]
     }
 
     /// For example, given `import foo`, returns `"foo"`.
@@ -586,12 +586,12 @@ impl<'a> Imported<'a> for Import<'a> {
 impl<'a> Imported<'a> for SubmoduleImport<'a> {
     /// For example, given `import foo.bar`, returns `["foo", "bar"]`.
     fn call_path(&self) -> &[&'a str] {
-        self.call_path.as_ref()
+        self.qualified_name.as_ref()
     }
 
     /// For example, given `import foo.bar`, returns `["foo"]`.
     fn module_name(&self) -> &[&'a str] {
-        &self.call_path[..1]
+        &self.qualified_name[..1]
     }
 
     /// For example, given `import foo.bar`, returns `"foo.bar"`.
@@ -603,17 +603,17 @@ impl<'a> Imported<'a> for SubmoduleImport<'a> {
 impl<'a> Imported<'a> for FromImport<'a> {
     /// For example, given `from foo import bar`, returns `["foo", "bar"]`.
     fn call_path(&self) -> &[&'a str] {
-        &self.call_path
+        &self.qualified_name
     }
 
     /// For example, given `from foo import bar`, returns `["foo"]`.
     fn module_name(&self) -> &[&'a str] {
-        &self.call_path[..self.call_path.len() - 1]
+        &self.qualified_name[..self.qualified_name.len() - 1]
     }
 
     /// For example, given `from foo import bar`, returns `"bar"`.
     fn member_name(&self) -> Cow<'a, str> {
-        Cow::Borrowed(self.call_path[self.call_path.len() - 1])
+        Cow::Borrowed(self.qualified_name[self.qualified_name.len() - 1])
     }
 }
 

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use bitflags::bitflags;
 use rustc_hash::FxHashMap;
 
-use ruff_python_ast::call_path::{CallPath, CallPathBuilder};
 use ruff_python_ast::helpers::from_relative_import;
+use ruff_python_ast::name::{QualifiedName, QualifiedNameBuilder, UnqualifiedName};
 use ruff_python_ast::{self as ast, Expr, Operator, Stmt};
 use ruff_python_stdlib::path::is_python_stub_file;
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -173,12 +173,12 @@ impl<'a> SemanticModel<'a> {
     pub fn match_typing_expr(&self, expr: &Expr, target: &str) -> bool {
         self.seen_typing()
             && self
-                .resolve_call_path(expr)
+                .resolve_qualified_name(expr)
                 .is_some_and(|call_path| self.match_typing_call_path(&call_path, target))
     }
 
     /// Return `true` if the call path is a reference to `typing.${target}`.
-    pub fn match_typing_call_path(&self, call_path: &CallPath, target: &str) -> bool {
+    pub fn match_typing_call_path(&self, call_path: &QualifiedName, target: &str) -> bool {
         if matches!(
             call_path.segments(),
             ["typing" | "_typeshed" | "typing_extensions", member] if *member == target
@@ -187,8 +187,8 @@ impl<'a> SemanticModel<'a> {
         }
 
         if self.typing_modules.iter().any(|module| {
-            let module = CallPath::from_unqualified_name(module);
-            let mut builder = CallPathBuilder::from_path(module);
+            let module = QualifiedName::from_dotted_name(module);
+            let mut builder = QualifiedNameBuilder::from_qualified_name(module);
             builder.push(target);
             let target_path = builder.build();
             call_path == &target_path
@@ -568,7 +568,7 @@ impl<'a> SemanticModel<'a> {
     /// associated with `Class`, then the `BindingKind::FunctionDefinition` associated with
     /// `Class.method`.
     pub fn lookup_attribute(&self, value: &Expr) -> Option<BindingId> {
-        let call_path = CallPath::from_expr(value)?;
+        let call_path = UnqualifiedName::from_expr(value)?;
 
         // Find the symbol in the current scope.
         let (symbol, attribute) = call_path.segments().split_first()?;
@@ -659,10 +659,10 @@ impl<'a> SemanticModel<'a> {
     /// ```
     ///
     /// ...then `resolve_call_path(${python_version})` will resolve to `sys.version_info`.
-    pub fn resolve_call_path<'name, 'expr: 'name>(
+    pub fn resolve_qualified_name<'name, 'expr: 'name>(
         &self,
         value: &'expr Expr,
-    ) -> Option<CallPath<'name>>
+    ) -> Option<QualifiedName<'name>>
     where
         'a: 'name,
     {
@@ -683,25 +683,37 @@ impl<'a> SemanticModel<'a> {
             .map(|id| self.binding(id))?;
 
         match &binding.kind {
-            BindingKind::Import(Import { call_path }) => {
-                let value_path = CallPath::from_expr(value)?;
-                let (_, tail) = value_path.segments().split_first()?;
-                let resolved: CallPath = call_path.iter().chain(tail.iter()).copied().collect();
+            BindingKind::Import(Import {
+                qualified_name: call_path,
+            }) => {
+                let unqualified_name = UnqualifiedName::from_expr(value)?;
+                let (_, tail) = unqualified_name.segments().split_first()?;
+                let resolved: QualifiedName =
+                    call_path.iter().chain(tail.iter()).copied().collect();
                 Some(resolved)
             }
-            BindingKind::SubmoduleImport(SubmoduleImport { call_path }) => {
-                let value_path = CallPath::from_expr(value)?;
-                let (_, tail) = value_path.segments().split_first()?;
-                let mut builder = CallPathBuilder::with_capacity(1 + tail.len());
-                builder.extend(call_path.iter().copied().take(1));
-                builder.extend(tail.iter().copied());
-                Some(builder.build())
-            }
-            BindingKind::FromImport(FromImport { call_path }) => {
-                let value_path = CallPath::from_expr(value)?;
+            BindingKind::SubmoduleImport(SubmoduleImport {
+                qualified_name: call_path,
+            }) => {
+                let value_path = UnqualifiedName::from_expr(value)?;
                 let (_, tail) = value_path.segments().split_first()?;
 
-                let resolved: CallPath =
+                Some(
+                    call_path
+                        .iter()
+                        .take(1)
+                        .chain(tail.iter())
+                        .copied()
+                        .collect(),
+                )
+            }
+            BindingKind::FromImport(FromImport {
+                qualified_name: call_path,
+            }) => {
+                let value_path = UnqualifiedName::from_expr(value)?;
+                let (_, tail) = value_path.segments().split_first()?;
+
+                let resolved: QualifiedName =
                     if call_path.first().map_or(false, |segment| *segment == ".") {
                         from_relative_import(self.module_path?, call_path, tail)?
                     } else {
@@ -712,10 +724,10 @@ impl<'a> SemanticModel<'a> {
             BindingKind::Builtin => {
                 if value.is_name_expr() {
                     // Ex) `dict`
-                    Some(CallPath::from_slice(&["", head.id.as_str()]))
+                    Some(QualifiedName::from_slice(&["", head.id.as_str()]))
                 } else {
                     // Ex) `dict.__dict__`
-                    let value_path = CallPath::from_expr(value)?;
+                    let value_path = UnqualifiedName::from_expr(value)?;
                     Some(
                         std::iter::once("")
                             .chain(value_path.segments().iter().copied())
@@ -724,8 +736,8 @@ impl<'a> SemanticModel<'a> {
                 }
             }
             BindingKind::ClassDefinition(_) | BindingKind::FunctionDefinition(_) => {
-                let value_path = CallPath::from_expr(value)?;
-                let resolved: CallPath = self
+                let value_path = UnqualifiedName::from_expr(value)?;
+                let resolved: QualifiedName = self
                     .module_path?
                     .iter()
                     .map(String::as_str)
@@ -765,7 +777,9 @@ impl<'a> SemanticModel<'a> {
                         // Ex) Given `module="sys"` and `object="exit"`:
                         // `import sys`         -> `sys.exit`
                         // `import sys as sys2` -> `sys2.exit`
-                        BindingKind::Import(Import { call_path }) => {
+                        BindingKind::Import(Import {
+                            qualified_name: call_path,
+                        }) => {
                             if call_path.as_ref() == module_path.as_slice() {
                                 if let Some(source) = binding.source {
                                     // Verify that `sys` isn't bound in an inner scope.
@@ -787,7 +801,9 @@ impl<'a> SemanticModel<'a> {
                         // Ex) Given `module="os.path"` and `object="join"`:
                         // `from os.path import join`          -> `join`
                         // `from os.path import join as join2` -> `join2`
-                        BindingKind::FromImport(FromImport { call_path }) => {
+                        BindingKind::FromImport(FromImport {
+                            qualified_name: call_path,
+                        }) => {
                             if let Some((target_member, target_module)) = call_path.split_last() {
                                 if target_module == module_path.as_slice()
                                     && target_member == &member
@@ -814,7 +830,9 @@ impl<'a> SemanticModel<'a> {
                         // `import os.path ` -> `os.name`
                         // Ex) Given `module="os.path"` and `object="join"`:
                         // `import os.path ` -> `os.path.join`
-                        BindingKind::SubmoduleImport(SubmoduleImport { call_path }) => {
+                        BindingKind::SubmoduleImport(SubmoduleImport {
+                            qualified_name: call_path,
+                        }) => {
                             if call_path.starts_with(&module_path) {
                                 if let Some(source) = binding.source {
                                     // Verify that `os` isn't bound in an inner scope.

--- a/crates/ruff_python_stdlib/src/typing.rs
+++ b/crates/ruff_python_stdlib/src/typing.rs
@@ -2,9 +2,9 @@
 /// can be used as `list[int]`).
 ///
 /// See: <https://docs.python.org/3/library/typing.html>
-pub fn is_standard_library_generic(call_path: &[&str]) -> bool {
+pub fn is_standard_library_generic(qualified_name: &[&str]) -> bool {
     matches!(
-        call_path,
+        qualified_name,
         ["", "dict" | "frozenset" | "list" | "set" | "tuple" | "type"]
             | [
                 "collections" | "typing" | "typing_extensions",
@@ -118,13 +118,16 @@ pub fn is_standard_library_generic(call_path: &[&str]) -> bool {
 /// See: <https://docs.python.org/3/library/typing.html>
 ///
 /// [PEP 593]: https://peps.python.org/pep-0593/
-pub fn is_pep_593_generic_type(call_path: &[&str]) -> bool {
-    matches!(call_path, ["typing" | "typing_extensions", "Annotated"])
+pub fn is_pep_593_generic_type(qualified_name: &[&str]) -> bool {
+    matches!(
+        qualified_name,
+        ["typing" | "typing_extensions", "Annotated"]
+    )
 }
 
 /// Returns `true` if a call path is `Literal`.
-pub fn is_standard_library_literal(call_path: &[&str]) -> bool {
-    matches!(call_path, ["typing" | "typing_extensions", "Literal"])
+pub fn is_standard_library_literal(qualified_name: &[&str]) -> bool {
+    matches!(qualified_name, ["typing" | "typing_extensions", "Literal"])
 }
 
 /// Returns `true` if a name matches that of a generic from the Python standard library (e.g.
@@ -219,9 +222,9 @@ pub fn is_literal_member(member: &str) -> bool {
 
 /// Returns `true` if a call path represents that of an immutable, non-generic type from the Python
 /// standard library (e.g. `int` or `str`).
-pub fn is_immutable_non_generic_type(call_path: &[&str]) -> bool {
+pub fn is_immutable_non_generic_type(qualified_name: &[&str]) -> bool {
     matches!(
-        call_path,
+        qualified_name,
         ["collections", "abc", "Sized"]
             | ["typing", "LiteralString" | "Sized"]
             | [
@@ -241,9 +244,9 @@ pub fn is_immutable_non_generic_type(call_path: &[&str]) -> bool {
 
 /// Returns `true` if a call path represents that of an immutable, generic type from the Python
 /// standard library (e.g. `tuple`).
-pub fn is_immutable_generic_type(call_path: &[&str]) -> bool {
+pub fn is_immutable_generic_type(qualified_name: &[&str]) -> bool {
     matches!(
-        call_path,
+        qualified_name,
         ["", "tuple"]
             | [
                 "collections",
@@ -279,9 +282,9 @@ pub fn is_immutable_generic_type(call_path: &[&str]) -> bool {
 
 /// Returns `true` if a call path represents a function from the Python standard library that
 /// returns a mutable value (e.g., `dict`).
-pub fn is_mutable_return_type(call_path: &[&str]) -> bool {
+pub fn is_mutable_return_type(qualified_name: &[&str]) -> bool {
     matches!(
-        call_path,
+        qualified_name,
         ["", "dict" | "list" | "set"]
             | [
                 "collections",
@@ -292,9 +295,9 @@ pub fn is_mutable_return_type(call_path: &[&str]) -> bool {
 
 /// Returns `true` if a call path represents a function from the Python standard library that
 /// returns a immutable value (e.g., `bool`).
-pub fn is_immutable_return_type(call_path: &[&str]) -> bool {
+pub fn is_immutable_return_type(qualified_name: &[&str]) -> bool {
     matches!(
-        call_path,
+        qualified_name,
         ["datetime", "date" | "datetime" | "timedelta"]
             | ["decimal", "Decimal"]
             | ["fractions", "Fraction"]


### PR DESCRIPTION
## Summary

Charlie can probably explain this better than I but it turns out, `CallPath` is used for two different things:

* To represent unqualified names like `version` where `version` can be a local variable or imported (e.g. `from sys import version` where the full qualified name is `sys.version`)
* To represent resolved, full qualified names

This PR splits `CallPath` into two types to make this destinction clear. 

> Note: I haven't renamed all `call_path` variables to `qualified_name` or `unqualified_name`. I can do that if that's welcomed but I first want to get feedback on the approach and naming overall.

## Test Plan

`cargo test`
