### PR TITLE
Remove unneeded lifetime bounds

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -320,11 +320,8 @@ impl<'a> Checker<'a> {
     }
 }
 
-impl<'a, 'b> Visitor<'b> for Checker<'a>
-where
-    'b: 'a,
-{
-    fn visit_stmt(&mut self, stmt: &'b Stmt) {
+impl<'a> Visitor<'a> for Checker<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
         // Step 0: Pre-processing
         self.semantic.push_node(stmt);
 
@@ -922,14 +919,14 @@ where
         self.last_stmt_end = stmt.end();
     }
 
-    fn visit_annotation(&mut self, expr: &'b Expr) {
+    fn visit_annotation(&mut self, expr: &'a Expr) {
         let flags_snapshot = self.semantic.flags;
         self.semantic.flags |= SemanticModelFlags::TYPING_ONLY_ANNOTATION;
         self.visit_type_definition(expr);
         self.semantic.flags = flags_snapshot;
     }
 
-    fn visit_expr(&mut self, expr: &'b Expr) {
+    fn visit_expr(&mut self, expr: &'a Expr) {
         // Step 0: Pre-processing
         if !self.semantic.in_typing_literal()
             && !self.semantic.in_deferred_type_definition()
@@ -1403,7 +1400,7 @@ where
         self.semantic.pop_node();
     }
 
-    fn visit_except_handler(&mut self, except_handler: &'b ExceptHandler) {
+    fn visit_except_handler(&mut self, except_handler: &'a ExceptHandler) {
         let flags_snapshot = self.semantic.flags;
         self.semantic.flags |= SemanticModelFlags::EXCEPTION_HANDLER;
 
@@ -1453,7 +1450,7 @@ where
         self.semantic.flags = flags_snapshot;
     }
 
-    fn visit_parameters(&mut self, parameters: &'b Parameters) {
+    fn visit_parameters(&mut self, parameters: &'a Parameters) {
         // Step 1: Binding.
         // Bind, but intentionally avoid walking default expressions, as we handle them
         // upstream.
@@ -1477,7 +1474,7 @@ where
         analyze::parameters(parameters, self);
     }
 
-    fn visit_parameter(&mut self, parameter: &'b Parameter) {
+    fn visit_parameter(&mut self, parameter: &'a Parameter) {
         // Step 1: Binding.
         // Bind, but intentionally avoid walking the annotation, as we handle it
         // upstream.
@@ -1492,7 +1489,7 @@ where
         analyze::parameter(parameter, self);
     }
 
-    fn visit_pattern(&mut self, pattern: &'b Pattern) {
+    fn visit_pattern(&mut self, pattern: &'a Pattern) {
         // Step 1: Binding
         if let Pattern::MatchAs(ast::PatternMatchAs {
             name: Some(name), ..
@@ -1517,7 +1514,7 @@ where
         walk_pattern(self, pattern);
     }
 
-    fn visit_body(&mut self, body: &'b [Stmt]) {
+    fn visit_body(&mut self, body: &'a [Stmt]) {
         // Step 4: Analysis
         analyze::suite(body, self);
 
@@ -1527,7 +1524,7 @@ where
         }
     }
 
-    fn visit_match_case(&mut self, match_case: &'b MatchCase) {
+    fn visit_match_case(&mut self, match_case: &'a MatchCase) {
         self.visit_pattern(&match_case.pattern);
         if let Some(expr) = &match_case.guard {
             self.visit_boolean_test(expr);
@@ -1538,7 +1535,7 @@ where
         self.semantic.pop_branch();
     }
 
-    fn visit_type_param(&mut self, type_param: &'b ast::TypeParam) {
+    fn visit_type_param(&mut self, type_param: &'a ast::TypeParam) {
         // Step 1: Binding
         match type_param {
             ast::TypeParam::TypeVar(ast::TypeParamTypeVar { name, range, .. })
@@ -1563,7 +1560,7 @@ where
         }
     }
 
-    fn visit_f_string_element(&mut self, f_string_element: &'b ast::FStringElement) {
+    fn visit_f_string_element(&mut self, f_string_element: &'a ast::FStringElement) {
         // Step 2: Traversal
         walk_f_string_element(self, f_string_element);
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
@@ -79,11 +79,8 @@ struct NameFinder<'a> {
     names: FxHashMap<&'a str, &'a Expr>,
 }
 
-impl<'a, 'b> Visitor<'b> for NameFinder<'a>
-where
-    'b: 'a,
-{
-    fn visit_expr(&mut self, expr: &'b Expr) {
+impl<'a> Visitor<'a> for NameFinder<'a> {
+    fn visit_expr(&mut self, expr: &'a Expr) {
         match expr {
             Expr::Name(ast::ExprName { id, .. }) => {
                 self.names.insert(id, expr);

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
@@ -102,10 +102,7 @@ impl<'a> GroupNameFinder<'a> {
     }
 }
 
-impl<'a, 'b> Visitor<'b> for GroupNameFinder<'a>
-where
-    'b: 'a,
-{
+impl<'a> Visitor<'a> for GroupNameFinder<'a> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         if self.overridden {
             return;

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -223,10 +223,7 @@ impl<'a> ExceptionHandlerVisitor<'a> {
     }
 }
 
-impl<'a, 'b> Visitor<'b> for ExceptionHandlerVisitor<'a>
-where
-    'b: 'a,
-{
+impl<'a> Visitor<'a> for ExceptionHandlerVisitor<'a> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
             Stmt::Assert(_) => {

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -621,11 +621,8 @@ struct SkipFunctionsVisitor<'a> {
     addfinalizer_call: Option<&'a Expr>,
 }
 
-impl<'a, 'b> Visitor<'b> for SkipFunctionsVisitor<'a>
-where
-    'b: 'a,
-{
-    fn visit_stmt(&mut self, stmt: &'b Stmt) {
+impl<'a> Visitor<'a> for SkipFunctionsVisitor<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
             Stmt::Return(ast::StmtReturn { value, range: _ }) => {
                 if value.is_some() {
@@ -637,7 +634,7 @@ where
         }
     }
 
-    fn visit_expr(&mut self, expr: &'b Expr) {
+    fn visit_expr(&mut self, expr: &'a Expr) {
         match expr {
             Expr::YieldFrom(_) => {
                 self.has_yield_from = true;

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/patch.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/patch.rs
@@ -56,11 +56,8 @@ struct LambdaBodyVisitor<'a> {
     uses_args: bool,
 }
 
-impl<'a, 'b> Visitor<'b> for LambdaBodyVisitor<'a>
-where
-    'b: 'a,
-{
-    fn visit_expr(&mut self, expr: &'b Expr) {
+impl<'a> Visitor<'a> for LambdaBodyVisitor<'a> {
+    fn visit_expr(&mut self, expr: &'a Expr) {
         match expr {
             Expr::Name(ast::ExprName { id, .. }) => {
                 if self.parameters.includes(id) {

--- a/crates/ruff_linter/src/rules/isort/block.rs
+++ b/crates/ruff_linter/src/rules/isort/block.rs
@@ -120,11 +120,8 @@ impl<'a> BlockBuilder<'a> {
     }
 }
 
-impl<'a, 'b> StatementVisitor<'b> for BlockBuilder<'a>
-where
-    'b: 'a,
-{
-    fn visit_stmt(&mut self, stmt: &'b Stmt) {
+impl<'a> StatementVisitor<'a> for BlockBuilder<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
         // Track manual splits (e.g., `# isort: split`).
         if self
             .splits
@@ -276,7 +273,7 @@ where
         self.nested = prev_nested;
     }
 
-    fn visit_except_handler(&mut self, except_handler: &'b ExceptHandler) {
+    fn visit_except_handler(&mut self, except_handler: &'a ExceptHandler) {
         let prev_nested = self.nested;
         self.nested = true;
 
@@ -290,14 +287,14 @@ where
         self.nested = prev_nested;
     }
 
-    fn visit_match_case(&mut self, match_case: &'b MatchCase) {
+    fn visit_match_case(&mut self, match_case: &'a MatchCase) {
         for stmt in &match_case.body {
             self.visit_stmt(stmt);
         }
         self.finalize(None);
     }
 
-    fn visit_elif_else_clause(&mut self, elif_else_clause: &'b ElifElseClause) {
+    fn visit_elif_else_clause(&mut self, elif_else_clause: &'a ElifElseClause) {
         for stmt in &elif_else_clause.body {
             self.visit_stmt(stmt);
         }

--- a/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
@@ -151,11 +151,8 @@ impl<'a> MutationVisitor<'a> {
     }
 }
 
-impl<'a, 'b> StatementVisitor<'b> for MutationVisitor<'a>
-where
-    'b: 'a,
-{
-    fn visit_stmt(&mut self, stmt: &'b Stmt) {
+impl<'a> StatementVisitor<'a> for MutationVisitor<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
         if match_mutation(stmt, self.target) {
             self.is_mutated = true;
         } else {

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
@@ -222,10 +222,7 @@ struct NameFinder<'a> {
     names: Vec<&'a ast::ExprName>,
 }
 
-impl<'a, 'b> Visitor<'b> for NameFinder<'a>
-where
-    'b: 'a,
-{
+impl<'a> Visitor<'a> for NameFinder<'a> {
     fn visit_expr(&mut self, expr: &'a Expr) {
         if let Expr::Name(expr_name) = expr {
             self.names.push(expr_name);

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_within_try.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_within_try.rs
@@ -64,11 +64,8 @@ struct RaiseStatementVisitor<'a> {
     raises: Vec<&'a Stmt>,
 }
 
-impl<'a, 'b> StatementVisitor<'b> for RaiseStatementVisitor<'a>
-where
-    'b: 'a,
-{
-    fn visit_stmt(&mut self, stmt: &'b Stmt) {
+impl<'a> StatementVisitor<'a> for RaiseStatementVisitor<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
             Stmt::Raise(_) => self.raises.push(stmt),
             Stmt::Try(_) => (),

--- a/crates/ruff_linter/src/rules/tryceratops/rules/type_check_without_type_error.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/type_check_without_type_error.rs
@@ -50,11 +50,8 @@ struct ControlFlowVisitor<'a> {
     continues: Vec<&'a Stmt>,
 }
 
-impl<'a, 'b> StatementVisitor<'b> for ControlFlowVisitor<'a>
-where
-    'b: 'a,
-{
-    fn visit_stmt(&mut self, stmt: &'b Stmt) {
+impl<'a> StatementVisitor<'a> for ControlFlowVisitor<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
             Stmt::FunctionDef(_) | Stmt::ClassDef(_) => {
                 // Don't recurse.

--- a/crates/ruff_linter/src/rules/tryceratops/rules/verbose_raise.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/verbose_raise.rs
@@ -54,11 +54,8 @@ struct RaiseStatementVisitor<'a> {
     raises: Vec<&'a ast::StmtRaise>,
 }
 
-impl<'a, 'b> StatementVisitor<'b> for RaiseStatementVisitor<'a>
-where
-    'b: 'a,
-{
-    fn visit_stmt(&mut self, stmt: &'b Stmt) {
+impl<'a> StatementVisitor<'a> for RaiseStatementVisitor<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
             Stmt::Raise(raise @ ast::StmtRaise { .. }) => {
                 self.raises.push(raise);

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -903,10 +903,7 @@ pub struct NameFinder<'a> {
     pub names: FxHashMap<&'a str, &'a ast::ExprName>,
 }
 
-impl<'a, 'b> Visitor<'b> for NameFinder<'a>
-where
-    'b: 'a,
-{
+impl<'a> Visitor<'a> for NameFinder<'a> {
     fn visit_expr(&mut self, expr: &'a Expr) {
         if let Expr::Name(name) = expr {
             self.names.insert(&name.id, name);
@@ -922,10 +919,7 @@ pub struct StoredNameFinder<'a> {
     pub names: FxHashMap<&'a str, &'a ast::ExprName>,
 }
 
-impl<'a, 'b> Visitor<'b> for StoredNameFinder<'a>
-where
-    'b: 'a,
-{
+impl<'a> Visitor<'a> for StoredNameFinder<'a> {
     fn visit_expr(&mut self, expr: &'a Expr) {
         if let Expr::Name(name) = expr {
             if name.ctx.is_store() {
@@ -943,11 +937,8 @@ pub struct ReturnStatementVisitor<'a> {
     pub is_generator: bool,
 }
 
-impl<'a, 'b> Visitor<'b> for ReturnStatementVisitor<'a>
-where
-    'b: 'a,
-{
-    fn visit_stmt(&mut self, stmt: &'b Stmt) {
+impl<'a> Visitor<'a> for ReturnStatementVisitor<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
             Stmt::FunctionDef(_) | Stmt::ClassDef(_) => {
                 // Don't recurse.
@@ -957,7 +948,7 @@ where
         }
     }
 
-    fn visit_expr(&mut self, expr: &'b Expr) {
+    fn visit_expr(&mut self, expr: &'a Expr) {
         if let Expr::Yield(_) | Expr::YieldFrom(_) = expr {
             self.is_generator = true;
         } else {
@@ -972,11 +963,8 @@ pub struct RaiseStatementVisitor<'a> {
     pub raises: Vec<(TextRange, Option<&'a Expr>, Option<&'a Expr>)>,
 }
 
-impl<'a, 'b> StatementVisitor<'b> for RaiseStatementVisitor<'b>
-where
-    'b: 'a,
-{
-    fn visit_stmt(&mut self, stmt: &'b Stmt) {
+impl<'a> StatementVisitor<'a> for RaiseStatementVisitor<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
             Stmt::Raise(ast::StmtRaise {
                 exc,


### PR DESCRIPTION
## Summary

This PR removes the unneeded lifetime `'b` from many of our `Visitor` implementations. 

The lifetime is unneeded because it is only constraint by `'a`, so we can use `'a` directly.

## Test Plan

`cargo build`
