### PR TITLE
`docs`: update docker release version

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,7 +59,7 @@ the latest release.
 
 ```shell
 docker run -v .:/io --rm ghcr.io/astral-sh/ruff check .
-docker run -v .:/io --rm ghcr.io/astral-sh/ruff:0.1.3 check .
+docker run -v .:/io --rm ghcr.io/astral-sh/ruff:0.2.2 check .
 ```
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/ruff-python-linter.svg?exclude_unsupported=1)](https://repology.org/project/ruff-python-linter/versions)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,7 +59,7 @@ the latest release.
 
 ```shell
 docker run -v .:/io --rm ghcr.io/astral-sh/ruff check .
-docker run -v .:/io --rm ghcr.io/astral-sh/ruff:0.2.2 check .
+docker run -v .:/io --rm ghcr.io/astral-sh/ruff:0.3.0 check .
 ```
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/ruff-python-linter.svg?exclude_unsupported=1)](https://repology.org/project/ruff-python-linter/versions)


### PR DESCRIPTION
## Summary

This PR updates the docker release version from `0.1.3` to `0.3.0` (latest), since `0.1.3` does not seem to exist anymore.