### PR TITLE
Move shell expansion into `--config` lookup

### DIFF
--- a/crates/ruff/src/resolve.rs
+++ b/crates/ruff/src/resolve.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::Result;
 use log::debug;
@@ -34,13 +34,8 @@ pub fn resolve(
     // Second priority: the user specified a `pyproject.toml` file. Use that
     // `pyproject.toml` for _all_ configuration, and resolve paths relative to the
     // current working directory. (This matches ESLint's behavior.)
-    if let Some(pyproject) = config_arguments
-        .config_file()
-        .map(|config| config.display().to_string())
-        .map(|config| shellexpand::full(&config).map(|config| PathBuf::from(config.as_ref())))
-        .transpose()?
-    {
-        let settings = resolve_root_settings(&pyproject, Relativity::Cwd, config_arguments)?;
+    if let Some(pyproject) = config_arguments.config_file() {
+        let settings = resolve_root_settings(pyproject, Relativity::Cwd, config_arguments)?;
         debug!(
             "Using user-specified configuration file at: {}",
             pyproject.display()
@@ -48,7 +43,7 @@ pub fn resolve(
         return Ok(PyprojectConfig::new(
             PyprojectDiscoveryStrategy::Fixed,
             settings,
-            Some(pyproject),
+            Some(pyproject.to_path_buf()),
         ));
     }
 

--- a/crates/ruff/tests/format.rs
+++ b/crates/ruff/tests/format.rs
@@ -111,7 +111,7 @@ fn nonexistent_config_file() {
            option
 
     It looks like you were trying to pass a path to a configuration file.
-    The path `foo.toml` does not exist
+    The path `foo.toml` does not point to a configuration file
 
     For more information, try '--help'.
     "###);

--- a/crates/ruff/tests/lint.rs
+++ b/crates/ruff/tests/lint.rs
@@ -522,7 +522,7 @@ fn nonexistent_config_file() {
            option
 
     It looks like you were trying to pass a path to a configuration file.
-    The path `foo.toml` does not exist
+    The path `foo.toml` does not point to a configuration file
 
     For more information, try '--help'.
     "###);
@@ -1141,9 +1141,6 @@ ignore = ["F841"]
 "#,
     )?;
 
-    insta::with_settings!({
-        filters => vec![(tempdir_filter(&tempdir).as_str(), "[TMP]/")]
-    }, {
     assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
         .args(STDIN_BASE_OPTIONS)
         .arg("--config")
@@ -1166,7 +1163,6 @@ def func():
 
     ----- stderr -----
     "###);
-    });
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

When users provide configurations via `--config`, we use `shellexpand` to ensure that we expand signifiers like `~` and environment variables.

In https://github.com/astral-sh/ruff/pull/9599, we modified `--config` to accept either a path or an arbitrary setting. However, the detection (to determine whether the value is a path or a setting) was lacking the `shellexpand` behavior -- it was downstream. So we were always treating paths like `~/ruff.toml` as values, not paths.

Closes https://github.com/astral-sh/ruff-vscode/issues/413.
