### PR TITLE
docs: fix a rustdoc typo in C409 rule

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
@@ -17,7 +17,7 @@ use super::helpers;
 ///
 /// If a list literal was passed, then it should be rewritten as a `tuple`
 /// literal. Otherwise, if a tuple literal was passed, then the outer call
-/// to `list()` should be removed.
+/// to `tuple()` should be removed.
 ///
 /// ## Examples
 /// ```python


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
fix a rustdoc typo in C409 rule.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
