### PR TITLE
Add encoding when opening files in generate_mkdocs.py

### DIFF
--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -108,7 +108,7 @@ def main() -> None:
         if not generated:
             continue
 
-        with Path(f"docs/{filename}").open("w+") as f:
+        with Path(f"docs/{filename}").open("w+", encoding="utf8") as f:
             if filename == "contributing.md":
                 # Copy the CONTRIBUTING.md.
                 shutil.copy("CONTRIBUTING.md", "docs/contributing.md")
@@ -173,7 +173,7 @@ def main() -> None:
     # Add the nav section to mkdocs.yml.
     config["nav"] = [{section.title: section.filename} for section in SECTIONS]
 
-    with Path("mkdocs.generated.yml").open("w+") as fp:
+    with Path("mkdocs.generated.yml").open("w+", encoding="utf8") as fp:
         yaml.safe_dump(config, fp)
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Open files with utf8 encoding when writing files in generate_mkdocs.py.

The following can happen otherwise.
```
../ruff> python scripts/generate_mkdocs.py
    Finished dev [unoptimized + debuginfo] target(s) in 0.25s
     Running `target\debug\ruff_dev.exe generate-docs`
Traceback (most recent call last):
  File "C:\..\ruff\scripts\generate_mkdocs.py", line 185, in <module>
    main()
  File "C:\..\scripts\generate_mkdocs.py", line 141, in main
    f.write(clean_file_content(file_content, title))
  File "C:\..\AppData\Local\Programs\Python\Python310\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 1396-1397: character maps to <undefined>
```

I could not determine which character was causing the issue, but opening with utf8 encoding fixed it.

## Test Plan

Condering the change is small, I simply ran the file and confirmed it worked, but opened to suggestion on more robust testing.
