### PR TITLE
Fix `ruff-action` documentation to consistently use `args` instead of `options`

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -417,7 +417,7 @@ Alternatively, you can include `ruff-action` as a step in any other workflow fil
 `ruff-action` accepts optional configuration parameters via `with:`, including:
 
 - `version`: The Ruff version to install (default: latest).
-- `options`: The command-line arguments to pass to Ruff (default: `"check"`).
+- `args`: The command-line arguments to pass to Ruff (default: `"check"`).
 - `src`: The source paths to pass to Ruff (default: `"."`).
 
 For example, to run `ruff check --select B ./src` using Ruff version `0.0.259`:
@@ -425,7 +425,7 @@ For example, to run `ruff check --select B ./src` using Ruff version `0.0.259`:
 ```yaml
 - uses: chartboost/ruff-action@v1
   with:
-    src: "./src"
     version: 0.0.259
-    args: --select B
+    args: check --select B
+    src: "./src"
 ```


### PR DESCRIPTION
## Summary
Fixes https://github.com/astral-sh/ruff/issues/10246

I also fixed the `args` in the example to include `check` because setting `args` replaces the default `check` args.



