### PR TITLE
Encapsulate `Program` fields

### DIFF
--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -39,11 +39,36 @@ pub(crate) fn parse_tokens(
 
 #[derive(Debug)]
 pub struct Program {
-    pub ast: ast::Mod,
-    pub parse_errors: Vec<ParseError>,
+    ast: ast::Mod,
+    parse_errors: Vec<ParseError>,
 }
 
 impl Program {
+    /// Returns the parsed AST.
+    pub fn ast(&self) -> &ast::Mod {
+        &self.ast
+    }
+
+    /// Returns a list of syntax errors found during parsing.
+    pub fn errors(&self) -> &[ParseError] {
+        &self.parse_errors
+    }
+
+    /// Consumes the `Program` and returns the parsed AST.
+    pub fn into_ast(self) -> ast::Mod {
+        self.ast
+    }
+
+    /// Consumes the `Program` and returns a list of syntax errors found during parsing.
+    pub fn into_errors(self) -> Vec<ParseError> {
+        self.parse_errors
+    }
+
+    /// Returns `true` if the program is valid i.e., it has no syntax errors.
+    pub fn is_valid(&self) -> bool {
+        self.parse_errors.is_empty()
+    }
+
     pub fn parse_str(source: &str, mode: Mode) -> Program {
         let tokens = lex(source, mode);
         Self::parse_tokens(source, tokens.collect(), mode)

--- a/crates/ruff_python_parser/tests/fixtures.rs
+++ b/crates/ruff_python_parser/tests/fixtures.rs
@@ -19,24 +19,23 @@ fn invalid_syntax() {
 
         let program = Program::parse_str(&source, Mode::Module);
 
-        assert_ne!(
-            &program.parse_errors,
-            &[],
+        assert!(
+            !program.is_valid(),
             "{input_path:?}: Expected parser to generate at least one syntax error for a program containing syntax errors."
         );
 
-        validate_ast(&program.ast, source.text_len(), input_path);
+        validate_ast(program.ast(), source.text_len(), input_path);
 
         let mut output = String::new();
         writeln!(&mut output, "## AST").unwrap();
-        writeln!(&mut output, "\n ```\n{:#?}\n```", &program.ast).unwrap();
+        writeln!(&mut output, "\n ```\n{:#?}\n```", program.ast()).unwrap();
 
         writeln!(&mut output, "## Errors\n").unwrap();
 
         let line_index = LineIndex::from_source_text(&source);
         let source_code = SourceCode::new(&source, &line_index);
 
-        for error in &program.parse_errors {
+        for error in program.errors() {
             writeln!(
                 &mut output,
                 "{}\n",
@@ -68,13 +67,13 @@ fn valid_syntax() {
 
         let program = Program::parse_str(&source, Mode::Module);
 
-        if !program.parse_errors.is_empty() {
+        if !program.is_valid() {
             let line_index = LineIndex::from_source_text(&source);
             let source_code = SourceCode::new(&source, &line_index);
 
             let mut message = "Expected no syntax errors for a valid program but the parser generated the following errors:\n".to_string();
 
-            for error in &program.parse_errors {
+            for error in program.errors() {
                 writeln!(
                     &mut message,
                     "{}\n",
@@ -90,11 +89,11 @@ fn valid_syntax() {
             panic!("{input_path:?}: {message}");
         }
 
-        validate_ast(&program.ast, source.text_len(), input_path);
+        validate_ast(program.ast(), source.text_len(), input_path);
 
         let mut output = String::new();
         writeln!(&mut output, "## AST").unwrap();
-        writeln!(&mut output, "\n ```\n{:#?}\n```", &program.ast).unwrap();
+        writeln!(&mut output, "\n ```\n{:#?}\n```", program.ast()).unwrap();
 
         insta::with_settings!({
             omit_expression => true,


### PR DESCRIPTION
## Summary

This PR updates the fields in `Program` struct to be private and exposes methods to get the values. The motivation behind this is to encapsulate the internal representation of the parsed program which we could alter in the future.
