### PR TITLE
Remove deprecated parsing list functions

### DIFF
--- a/crates/ruff_python_formatter/src/other/f_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/f_string_element.rs
@@ -37,7 +37,6 @@ impl Format<PyFormatContext<'_>> for FormatFStringElement<'_> {
             FStringElement::Expression(expression) => {
                 FormatFStringExpressionElement::new(expression, self.context).fmt(f)
             }
-            #[allow(deprecated)]
             FStringElement::Invalid(_) => unreachable!(),
         }
     }

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -15,30 +15,56 @@ use crate::string::{
 use crate::token_set::TokenSet;
 use crate::{FStringErrorType, Mode, ParseErrorType, Tok, TokenKind};
 
+use super::RecoveryContextKind;
+
 /// Tokens that can appear after an expression.
 /// FIXME: this isn't exhaustive.
-const END_EXPR_SET: TokenSet = TokenSet::new([
+pub(super) const END_EXPR_SET: TokenSet = TokenSet::new([
+    // Ex) `expr`
     TokenKind::Newline,
+    // Ex) `expr;`
     TokenKind::Semi,
+    // Ex) `data[expr:]`
     TokenKind::Colon,
+    // Ex) `expr` (without a newline)
     TokenKind::EndOfFile,
+    // Ex) `{expr}`
     TokenKind::Rbrace,
+    // Ex) `[expr]`
     TokenKind::Rsqb,
+    // Ex) `(expr)`
     TokenKind::Rpar,
+    // Ex) `expr,`
     TokenKind::Comma,
+    // Ex) ??
     TokenKind::Dedent,
+    // Ex) `expr if expr else expr`
+    TokenKind::If,
     TokenKind::Else,
     TokenKind::As,
     TokenKind::From,
     TokenKind::For,
     TokenKind::Async,
     TokenKind::In,
+    // Ex) `f"{expr=}"`
     TokenKind::Equal,
+    // Ex) `f"{expr!s}"`
+    TokenKind::Exclamation,
 ]);
 
+const END_SEQUENCE_SET: TokenSet = END_EXPR_SET.remove(TokenKind::Comma);
+
 impl<'src> Parser<'src> {
-    pub(super) fn at_expr(&mut self) -> bool {
+    pub(super) fn at_expr(&self) -> bool {
         self.at_ts(EXPR_SET)
+    }
+
+    pub(super) fn at_expr_end(&self) -> bool {
+        self.at_ts(END_EXPR_SET)
+    }
+
+    pub(super) fn at_sequence_end(&self) -> bool {
+        self.at_ts(END_SEQUENCE_SET)
     }
 
     /// Parses every Python expression.
@@ -411,8 +437,16 @@ impl<'src> Parser<'src> {
         }
     }
 
+    /// Parses an argument list.
+    ///
+    /// # Panics
+    ///
+    /// If the parser isn't positioned at a `(` token.
+    ///
+    /// See: <https://docs.python.org/3/reference/expressions.html#grammar-token-python-grammar-argument_list>
     pub(super) fn parse_arguments(&mut self) -> ast::Arguments {
         let start = self.node_start();
+        self.bump(TokenKind::Lpar);
 
         let saved_context = self.set_ctx(ParserCtxFlags::ARGUMENTS);
 
@@ -421,12 +455,8 @@ impl<'src> Parser<'src> {
         let mut has_seen_kw_arg = false;
         let mut has_seen_kw_unpack = false;
 
-        #[allow(deprecated)]
-        self.parse_delimited(
-            true,
-            TokenKind::Lpar,
-            TokenKind::Comma,
-            TokenKind::Rpar,
+        self.parse_comma_separated_list(
+            RecoveryContextKind::Arguments,
             |parser| {
                 let argument_start = parser.node_start();
                 if parser.at(TokenKind::DoubleStar) {
@@ -498,8 +528,12 @@ impl<'src> Parser<'src> {
                     }
                 }
             },
+            true,
         );
+
         self.restore_ctx(ParserCtxFlags::ARGUMENTS, saved_context);
+
+        self.expect(TokenKind::Rpar);
 
         let arguments = ast::Arguments {
             range: self.node_range(start),
@@ -514,6 +548,12 @@ impl<'src> Parser<'src> {
         arguments
     }
 
+    /// Parses a subscript expression.
+    ///
+    /// # Panics
+    ///
+    /// If the parser isn't positioned at a `[` token.
+    ///
     /// See: <https://docs.python.org/3/reference/expressions.html#subscriptions>
     fn parse_subscript_expression(
         &mut self,
@@ -548,17 +588,16 @@ impl<'src> Parser<'src> {
         let slice_start = self.node_start();
         let mut slice = self.parse_slice();
 
+        // If there are more than one element in the slice, we need to create a tuple
+        // expression to represent it.
         if self.eat(TokenKind::Comma) {
             let mut slices = vec![slice];
-            #[allow(deprecated)]
-            self.parse_separated(
+
+            slices.extend_from_slice(&self.parse_comma_separated_list_into_vec(
+                RecoveryContextKind::Slices,
+                Parser::parse_slice,
                 true,
-                TokenKind::Comma,
-                TokenSet::new([TokenKind::Rsqb]),
-                |parser| {
-                    slices.push(parser.parse_slice());
-                },
-            );
+            ));
 
             slice = Expr::Tuple(ast::ExprTuple {
                 elts: slices,
@@ -1032,6 +1071,10 @@ impl<'src> Parser<'src> {
     }
 
     /// Parses a list or a list comprehension expression.
+    ///
+    /// # Panics
+    ///
+    /// If the parser isn't positioned at a `[` token.
     fn parse_list_like_expression(&mut self) -> Expr {
         let start = self.node_start();
 
@@ -1054,17 +1097,21 @@ impl<'src> Parser<'src> {
             });
         }
 
-        let parsed_expr = self.parse_named_expression_or_higher();
+        let first_element = self.parse_named_expression_or_higher();
 
         match self.current_token_kind() {
             TokenKind::Async | TokenKind::For => {
-                Expr::ListComp(self.parse_list_comprehension_expression(parsed_expr.expr, start))
+                Expr::ListComp(self.parse_list_comprehension_expression(first_element.expr, start))
             }
-            _ => Expr::List(self.parse_list_expression(parsed_expr.expr, start)),
+            _ => Expr::List(self.parse_list_expression(first_element.expr, start)),
         }
     }
 
     /// Parses a set, dict, set comprehension, or dict comprehension.
+    ///
+    /// # Panics
+    ///
+    /// If the parser isn't positioned at a `{` token.
     fn parse_set_or_dict_like_expression(&mut self) -> Expr {
         let start = self.node_start();
         self.bump(TokenKind::Lbrace);
@@ -1186,7 +1233,6 @@ impl<'src> Parser<'src> {
 
         parsed
     }
-    const END_SEQUENCE_SET: TokenSet = END_EXPR_SET.remove(TokenKind::Comma);
 
     /// Parses multiple items separated by a comma into a `TupleExpr` node.
     /// Uses `parse_func` to parse each item.
@@ -1201,16 +1247,17 @@ impl<'src> Parser<'src> {
     ) -> ast::ExprTuple {
         // In case of the tuple only having one element, we need to cover the
         // range of the comma.
-        if !self.at_ts(Self::END_SEQUENCE_SET) {
+        if !self.at_sequence_end() {
             self.expect(TokenKind::Comma);
         }
 
         let mut elts = vec![first_element];
 
-        #[allow(deprecated)]
-        self.parse_separated(true, TokenKind::Comma, Self::END_SEQUENCE_SET, |parser| {
-            elts.push(parse_func(parser).expr);
-        });
+        self.parse_comma_separated_list(
+            RecoveryContextKind::TupleElements,
+            |p| elts.push(parse_func(p).expr),
+            true,
+        );
 
         if parenthesized {
             self.expect(TokenKind::Rpar);
@@ -1224,18 +1271,21 @@ impl<'src> Parser<'src> {
         }
     }
 
+    /// Parses a list expression.
+    ///
     /// See: <https://docs.python.org/3/reference/expressions.html#list-displays>
     fn parse_list_expression(&mut self, first_element: Expr, start: TextSize) -> ast::ExprList {
-        if !self.at_ts(Self::END_SEQUENCE_SET) {
+        if !self.at_sequence_end() {
             self.expect(TokenKind::Comma);
         }
 
         let mut elts = vec![first_element];
 
-        #[allow(deprecated)]
-        self.parse_separated(true, TokenKind::Comma, Self::END_SEQUENCE_SET, |parser| {
-            elts.push(parser.parse_named_expression_or_higher().expr);
-        });
+        elts.extend_from_slice(&self.parse_comma_separated_list_into_vec(
+            RecoveryContextKind::ListElements,
+            |parser| parser.parse_named_expression_or_higher().expr,
+            true,
+        ));
 
         self.expect(TokenKind::Rsqb);
 
@@ -1246,18 +1296,21 @@ impl<'src> Parser<'src> {
         }
     }
 
+    /// Parses a set expression.
+    ///
     /// See: <https://docs.python.org/3/reference/expressions.html#set-displays>
     fn parse_set_expression(&mut self, first_element: Expr, start: TextSize) -> ast::ExprSet {
-        if !self.at_ts(Self::END_SEQUENCE_SET) {
+        if !self.at_sequence_end() {
             self.expect(TokenKind::Comma);
         }
 
         let mut elts = vec![first_element];
 
-        #[allow(deprecated)]
-        self.parse_separated(true, TokenKind::Comma, Self::END_SEQUENCE_SET, |parser| {
-            elts.push(parser.parse_named_expression_or_higher().expr);
-        });
+        elts.extend_from_slice(&self.parse_comma_separated_list_into_vec(
+            RecoveryContextKind::SetElements,
+            |parser| parser.parse_named_expression_or_higher().expr,
+            true,
+        ));
 
         self.expect(TokenKind::Rbrace);
 
@@ -1267,6 +1320,8 @@ impl<'src> Parser<'src> {
         }
     }
 
+    /// Parses a dictionary expression.
+    ///
     /// See: <https://docs.python.org/3/reference/expressions.html#dictionary-displays>
     fn parse_dictionary_expression(
         &mut self,
@@ -1274,24 +1329,27 @@ impl<'src> Parser<'src> {
         value: Expr,
         start: TextSize,
     ) -> ast::ExprDict {
-        if !self.at_ts(Self::END_SEQUENCE_SET) {
+        if !self.at_sequence_end() {
             self.expect(TokenKind::Comma);
         }
 
         let mut keys = vec![key];
         let mut values = vec![value];
 
-        #[allow(deprecated)]
-        self.parse_separated(true, TokenKind::Comma, Self::END_SEQUENCE_SET, |parser| {
-            if parser.eat(TokenKind::DoubleStar) {
-                keys.push(None);
-            } else {
-                keys.push(Some(parser.parse_conditional_expression_or_higher().expr));
+        self.parse_comma_separated_list(
+            RecoveryContextKind::DictElements,
+            |parser| {
+                if parser.eat(TokenKind::DoubleStar) {
+                    keys.push(None);
+                } else {
+                    keys.push(Some(parser.parse_conditional_expression_or_higher().expr));
 
-                parser.expect(TokenKind::Colon);
-            }
-            values.push(parser.parse_conditional_expression_or_higher().expr);
-        });
+                    parser.expect(TokenKind::Colon);
+                }
+                values.push(parser.parse_conditional_expression_or_higher().expr);
+            },
+            true,
+        );
 
         self.expect(TokenKind::Rbrace);
 

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -593,11 +593,11 @@ impl<'src> Parser<'src> {
         if self.eat(TokenKind::Comma) {
             let mut slices = vec![slice];
 
-            slices.extend_from_slice(&self.parse_comma_separated_list_into_vec(
+            self.parse_comma_separated_list(
                 RecoveryContextKind::Slices,
-                Parser::parse_slice,
+                |parser| slices.push(parser.parse_slice()),
                 true,
-            ));
+            );
 
             slice = Expr::Tuple(ast::ExprTuple {
                 elts: slices,
@@ -1281,11 +1281,11 @@ impl<'src> Parser<'src> {
 
         let mut elts = vec![first_element];
 
-        elts.extend_from_slice(&self.parse_comma_separated_list_into_vec(
+        self.parse_comma_separated_list(
             RecoveryContextKind::ListElements,
-            |parser| parser.parse_named_expression_or_higher().expr,
+            |parser| elts.push(parser.parse_named_expression_or_higher().expr),
             true,
-        ));
+        );
 
         self.expect(TokenKind::Rsqb);
 
@@ -1306,11 +1306,11 @@ impl<'src> Parser<'src> {
 
         let mut elts = vec![first_element];
 
-        elts.extend_from_slice(&self.parse_comma_separated_list_into_vec(
+        self.parse_comma_separated_list(
             RecoveryContextKind::SetElements,
-            |parser| parser.parse_named_expression_or_higher().expr,
+            |parser| elts.push(parser.parse_named_expression_or_higher().expr),
             true,
-        ));
+        );
 
         self.expect(TokenKind::Rbrace);
 

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -187,7 +187,7 @@ impl<'src> Parser<'src> {
                 range: self.node_range(start),
             })
         } else {
-            let body = self.parse_list(
+            let body = self.parse_list_into_vec(
                 RecoveryContextKind::ModuleStatements,
                 Parser::parse_statement,
             );
@@ -429,7 +429,6 @@ impl<'src> Parser<'src> {
     }
 
     /// Skip tokens until [`TokenSet`]. Returns the range of the skipped tokens.
-
     #[deprecated(note = "We should not perform error recovery outside of lists. Remove")]
     fn skip_until(&mut self, token_set: TokenSet) {
         let mut progress = ParserProgress::default();
@@ -439,10 +438,12 @@ impl<'src> Parser<'src> {
         }
     }
 
+    /// Returns `true` if the current token is of the given kind.
     fn at(&self, kind: TokenKind) -> bool {
         self.current_token_kind() == kind
     }
 
+    /// Returns `true` if the current token is found in the given token set.
     fn at_ts(&self, ts: TokenSet) -> bool {
         ts.contains(self.current_token_kind())
     }
@@ -457,21 +458,28 @@ impl<'src> Parser<'src> {
         &self.source[range - self.tokens_range.start()]
     }
 
-    fn parse_list<T>(
+    /// Parses a list of elements into a vector where each element is parsed using
+    /// the given `parse_element` function.
+    fn parse_list_into_vec<T>(
         &mut self,
-        kind: RecoveryContextKind,
+        recovery_context_kind: RecoveryContextKind,
         parse_element: impl Fn(&mut Parser<'src>) -> T,
     ) -> Vec<T> {
         let mut elements = Vec::new();
-
-        self.parse_sequence(kind, |p| elements.push(parse_element(p)));
-
+        self.parse_list(recovery_context_kind, |p| elements.push(parse_element(p)));
         elements
     }
 
-    fn parse_sequence(
+    /// Parses a list of elements where each element is parsed using the given
+    /// `parse_element` function.
+    ///
+    /// The difference between this function and `parse_list_into_vec` is that
+    /// this function does not return the parsed elements. Instead, it is the
+    /// caller's responsibility to handle the parsed elements. This is the reason
+    /// that the `parse_element` parameter is bound to [`FnMut`] instead of [`Fn`].
+    fn parse_list(
         &mut self,
-        kind: RecoveryContextKind,
+        recovery_context_kind: RecoveryContextKind,
         mut parse_element: impl FnMut(&mut Parser<'src>),
     ) {
         let mut progress = ParserProgress::default();
@@ -479,9 +487,9 @@ impl<'src> Parser<'src> {
         let saved_context = self.recovery_context;
         self.recovery_context = self
             .recovery_context
-            .union(RecoveryContext::from_kind(kind));
+            .union(RecoveryContext::from_kind(recovery_context_kind));
 
-        while !kind.is_list_terminator(self) {
+        while !recovery_context_kind.is_list_terminator(self) {
             progress.assert_progressing(self);
 
             // The end of file marker ends all lists.
@@ -489,14 +497,14 @@ impl<'src> Parser<'src> {
                 break;
             }
 
-            if kind.is_list_element(self) {
+            if recovery_context_kind.is_list_element(self) {
                 parse_element(self);
             } else {
                 let should_recover = self.is_enclosing_list_element_or_terminator();
 
                 // Not a recognised element. Add an error and either skip the token or break parsing the list
                 // if the token is recognised as an element or terminator of an enclosing list.
-                let error = kind.create_error(self);
+                let error = recovery_context_kind.create_error(self);
                 self.add_error(error, self.current_token_range());
 
                 if should_recover {
@@ -509,29 +517,60 @@ impl<'src> Parser<'src> {
         self.recovery_context = saved_context;
     }
 
-    fn parse_delimited_list<T>(
+    /// Parses a comma separated list of elements into a vector where each element
+    /// is parsed using the given `parse_element` function.
+    fn parse_comma_separated_list_into_vec<T>(
         &mut self,
-        kind: RecoveryContextKind,
+        recovery_context_kind: RecoveryContextKind,
         parse_element: impl Fn(&mut Parser<'src>) -> T,
         allow_trailing_comma: bool,
     ) -> Vec<T> {
-        let mut progress = ParserProgress::default();
         let mut elements = Vec::new();
+        self.parse_comma_separated_list(
+            recovery_context_kind,
+            |p| elements.push(parse_element(p)),
+            allow_trailing_comma,
+        );
+        elements
+    }
+
+    /// Parses a comma separated list of elements where each element is parsed
+    /// sing the given `parse_element` function.
+    ///
+    /// The difference between this function and `parse_comma_separated_list_into_vec`
+    /// is that this function does not return the parsed elements. Instead, it is the
+    /// caller's responsibility to handle the parsed elements. This is the reason
+    /// that the `parse_element` parameter is bound to [`FnMut`] instead of [`Fn`].
+    ///
+    /// If `allow_trailing_comma` is `true`, the function will allow a trailing
+    /// comma at the end of the list, otherwise it will add an error.
+    fn parse_comma_separated_list(
+        &mut self,
+        recovery_context_kind: RecoveryContextKind,
+        mut parse_element: impl FnMut(&mut Parser<'src>),
+        allow_trailing_comma: bool,
+    ) {
+        let mut progress = ParserProgress::default();
 
         let saved_context = self.recovery_context;
         self.recovery_context = self
             .recovery_context
-            .union(RecoveryContext::from_kind(kind));
+            .union(RecoveryContext::from_kind(recovery_context_kind));
 
         let mut trailing_comma_range: Option<TextRange> = None;
 
+        // TODO(dhruvmanila): I think this `loop` can be converted into a `while` loop
+        // similar to the one in the `parse_list` function above.
         loop {
             progress.assert_progressing(self);
 
-            self.current_token_kind();
+            // The end of file marker ends all lists.
+            if self.at(TokenKind::EndOfFile) {
+                break;
+            }
 
-            if kind.is_list_element(self) {
-                elements.push(parse_element(self));
+            if recovery_context_kind.is_list_element(self) {
+                parse_element(self);
 
                 let maybe_comma_range = self.current_token_range();
                 if self.eat(TokenKind::Comma) {
@@ -540,12 +579,12 @@ impl<'src> Parser<'src> {
                 }
                 trailing_comma_range = None;
 
-                if kind.is_list_terminator(self) {
+                if recovery_context_kind.is_list_terminator(self) {
                     break;
                 }
 
                 self.expect(TokenKind::Comma);
-            } else if kind.is_list_terminator(self) {
+            } else if recovery_context_kind.is_list_terminator(self) {
                 break;
             } else {
                 // Run the error recovery: This also handles the case when an element is missing between two commas: `a,,b`
@@ -553,7 +592,7 @@ impl<'src> Parser<'src> {
 
                 // Not a recognised element. Add an error and either skip the token or break parsing the list
                 // if the token is recognised as an element or terminator of an enclosing list.
-                let error = kind.create_error(self);
+                let error = recovery_context_kind.create_error(self);
                 self.add_error(error, self.current_token_range());
 
                 if should_recover {
@@ -570,18 +609,16 @@ impl<'src> Parser<'src> {
             }
         }
 
-        if let Some(trailing_comma) = trailing_comma_range {
+        if let Some(trailing_comma_range) = trailing_comma_range {
             if !allow_trailing_comma {
                 self.add_error(
                     ParseErrorType::OtherError("Trailing comma not allowed".to_string()),
-                    trailing_comma,
+                    trailing_comma_range,
                 );
             }
         }
 
         self.recovery_context = saved_context;
-
-        elements
     }
 
     #[cold]
@@ -593,59 +630,6 @@ impl<'src> Parser<'src> {
         }
 
         false
-    }
-
-    /// Parses elements enclosed within a delimiter pair, such as parentheses, brackets,
-    /// or braces.
-    #[deprecated(note = "Use `parse_delimited_list` instead.")]
-    fn parse_delimited(
-        &mut self,
-        allow_trailing_delim: bool,
-        opening: TokenKind,
-        delim: TokenKind,
-        closing: TokenKind,
-        func: impl FnMut(&mut Parser<'src>),
-    ) {
-        self.bump(opening);
-
-        #[allow(deprecated)]
-        self.parse_separated(allow_trailing_delim, delim, [closing], func);
-
-        self.expect(closing);
-    }
-
-    /// Parses a sequence of elements separated by a delimiter. This function stops
-    /// parsing upon encountering any of the tokens in `ending_set`, if it doesn't
-    /// encounter the tokens in `ending_set` it stops parsing when seeing the `EOF`
-    /// or `Newline` token.
-    #[deprecated(note = "Use `parse_delimited_list` instead.")]
-    fn parse_separated(
-        &mut self,
-        allow_trailing_delim: bool,
-        delim: TokenKind,
-        ending_set: impl Into<TokenSet>,
-        mut func: impl FnMut(&mut Parser<'src>),
-    ) {
-        let ending_set = NEWLINE_EOF_SET.union(ending_set.into());
-        let mut progress = ParserProgress::default();
-
-        while !self.at_ts(ending_set) {
-            progress.assert_progressing(self);
-            func(self);
-
-            // exit the loop if a trailing `delim` is not allowed
-            if !allow_trailing_delim && ending_set.contains(self.peek_nth(1)) {
-                break;
-            }
-
-            if !self.eat(delim) {
-                if self.at_expr() {
-                    self.expect(delim);
-                } else {
-                    break;
-                }
-            }
-        }
     }
 
     fn is_current_token_postfix(&self) -> bool {
@@ -663,13 +647,15 @@ enum SequenceMatchPatternParentheses {
 }
 
 impl SequenceMatchPatternParentheses {
-    fn closing_kind(self) -> TokenKind {
+    /// Returns the token kind that closes the parentheses.
+    const fn closing_kind(self) -> TokenKind {
         match self {
             SequenceMatchPatternParentheses::Tuple => TokenKind::Rpar,
             SequenceMatchPatternParentheses::List => TokenKind::Rsqb,
         }
     }
 
+    /// Returns `true` if the parentheses are for a list pattern e.g., `case [a, b]: ...`.
     const fn is_list(self) -> bool {
         matches!(self, SequenceMatchPatternParentheses::List)
     }
@@ -687,16 +673,53 @@ bitflags! {
     }
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 enum FunctionKind {
+    /// A lambda expression, e.g., `lambda x: x`
     Lambda,
+    /// A function definition, e.g., `def f(x): ...`
     FunctionDef,
+}
+
+impl FunctionKind {
+    /// Returns the token that terminates a list of parameters.
+    const fn list_terminator(self) -> TokenKind {
+        match self {
+            FunctionKind::Lambda => TokenKind::Colon,
+            FunctionKind::FunctionDef => TokenKind::Rpar,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+enum WithItemKind {
+    /// The `with` item is parenthesized, e.g., `with (a, b): ...`.
+    Parenthesized,
+    /// The `with` item has a parenthesized expression, e.g., `with (a) as b: ...`.
+    ParenthesizedExpression,
+    /// The `with` item isn't parenthesized in any way, e.g., `with a as b: ...`.
+    Unparenthesized,
+}
+
+impl WithItemKind {
+    /// Returns the token that terminates a list of `with` items.
+    const fn list_terminator(self) -> TokenKind {
+        match self {
+            WithItemKind::Parenthesized => TokenKind::Rpar,
+            WithItemKind::Unparenthesized | WithItemKind::ParenthesizedExpression => {
+                TokenKind::Colon
+            }
+        }
+    }
 }
 
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
 enum RecoveryContextKind {
+    /// When parsing a list of statements at the module level i.e., at the top level of a file.
     ModuleStatements,
+
+    /// When parsing a list of statements in a block e.g., the body of a function or a class.
     BlockStatements,
 
     /// The `elif` clauses of an `if` statement
@@ -708,9 +731,58 @@ enum RecoveryContextKind {
     /// When parsing a list of assignment targets
     AssignmentTargets,
 
+    /// When parsing a list of type parameters
     TypeParams,
 
+    /// When parsing a list of names in a `from ... import ...` statement
+    ImportFromAsNames,
+
+    /// When parsing a list of names in an `import` statement
     ImportNames,
+
+    /// When parsing a list of slice elements e.g., `data[1, 2]`.
+    ///
+    /// This is different from `ListElements` as the surrounding context is
+    /// different in that the list is part of a subscript expression.
+    Slices,
+
+    /// When parsing a list of elements in a list expression e.g., `[1, 2]`
+    ListElements,
+
+    /// When parsing a list of elements in a set expression e.g., `{1, 2}`
+    SetElements,
+
+    /// When parsing a list of elements in a dictionary expression e.g., `{1: "a", **data}`
+    DictElements,
+
+    /// When parsing a list of elements in a tuple expression e.g., `(1, 2)`
+    TupleElements,
+
+    /// When parsing a list of patterns in a match statement with an optional
+    /// parentheses, e.g., `case a, b: ...`, `case (a, b): ...`, `case [a, b]: ...`
+    SequenceMatchPattern(Option<SequenceMatchPatternParentheses>),
+
+    /// When parsing a mapping pattern in a match statement
+    MatchPatternMapping,
+
+    /// When parsing a list of arguments in a class pattern for the match statement
+    MatchPatternClassArguments,
+
+    /// When parsing a list of arguments in a function call or a class definition
+    Arguments,
+
+    /// When parsing a `del` statement
+    DeleteTargets,
+
+    /// When parsing a list of identifiers
+    Identifiers,
+
+    /// When parsing a list of parameters in a function definition which can be
+    /// either a function definition or a lambda expression.
+    Parameters(FunctionKind),
+
+    /// When parsing a list of items in a `with` statement
+    WithItems(WithItemKind),
 }
 
 impl RecoveryContextKind {
@@ -730,8 +802,8 @@ impl RecoveryContextKind {
                 matches!(p.current_token_kind(), TokenKind::Newline | TokenKind::Semi)
             }
 
-            // Tokens other than `]` are for better error recovery: For example, recover when we find the `:` of a clause header or
-            // the equal of a type assignment.
+            // Tokens other than `]` are for better error recovery. For example, recover when we
+            // find the `:` of a clause header or the equal of a type assignment.
             RecoveryContextKind::TypeParams => {
                 matches!(
                     p.current_token_kind(),
@@ -742,23 +814,78 @@ impl RecoveryContextKind {
                         | TokenKind::Lpar
                 )
             }
-            RecoveryContextKind::ImportNames => {
-                matches!(p.current_token_kind(), TokenKind::Rpar | TokenKind::Newline)
+            // The names of an import statement cannot be parenthesized, so it
+            // always ends with a newline.
+            RecoveryContextKind::ImportNames => p.at(TokenKind::Newline),
+            RecoveryContextKind::ImportFromAsNames => {
+                matches!(
+                    p.current_token_kind(),
+                    // `from a import (b, c)`
+                    TokenKind::Rpar
+                    // `from a import b, c`
+                    | TokenKind::Newline
+                )
+            }
+            // The elements in a container expression cannot end with a newline
+            // as all of them are actually non-logical newlines.
+            RecoveryContextKind::Slices | RecoveryContextKind::ListElements => {
+                p.at(TokenKind::Rsqb)
+            }
+            RecoveryContextKind::SetElements | RecoveryContextKind::DictElements => {
+                p.at(TokenKind::Rbrace)
+            }
+            RecoveryContextKind::TupleElements => p.at(TokenKind::Rpar),
+            RecoveryContextKind::SequenceMatchPattern(parentheses) => p.at(parentheses.map_or(
+                TokenKind::Colon,
+                SequenceMatchPatternParentheses::closing_kind,
+            )),
+            RecoveryContextKind::MatchPatternMapping => p.at(TokenKind::Rbrace),
+            RecoveryContextKind::MatchPatternClassArguments => p.at(TokenKind::Rpar),
+            RecoveryContextKind::Arguments => p.at(TokenKind::Rpar),
+            RecoveryContextKind::DeleteTargets | RecoveryContextKind::Identifiers => {
+                p.at(TokenKind::Newline)
+            }
+            RecoveryContextKind::Parameters(function_kind) => {
+                // `lambda x, y: ...` or `def f(x, y): ...`
+                p.at(function_kind.list_terminator())
+                    // To recover from missing closing parentheses
+                    || p.at(TokenKind::Rarrow)
+                    || p.at_compound_stmt()
+            }
+            RecoveryContextKind::WithItems(with_item_kind) => {
+                p.at(with_item_kind.list_terminator())
             }
         }
     }
 
     fn is_list_element(self, p: &Parser) -> bool {
         match self {
-            RecoveryContextKind::ModuleStatements => p.is_at_stmt(),
-            RecoveryContextKind::BlockStatements => p.is_at_stmt(),
+            RecoveryContextKind::ModuleStatements => p.at_stmt(),
+            RecoveryContextKind::BlockStatements => p.at_stmt(),
             RecoveryContextKind::Elif => p.at(TokenKind::Elif),
             RecoveryContextKind::Except => p.at(TokenKind::Except),
             RecoveryContextKind::AssignmentTargets => p.at(TokenKind::Equal),
-            RecoveryContextKind::TypeParams => p.is_at_type_param(),
-            RecoveryContextKind::ImportNames => {
+            RecoveryContextKind::TypeParams => p.at_type_param(),
+            RecoveryContextKind::ImportNames => p.at(TokenKind::Name),
+            RecoveryContextKind::ImportFromAsNames => {
                 matches!(p.current_token_kind(), TokenKind::Star | TokenKind::Name)
             }
+            RecoveryContextKind::Slices
+            | RecoveryContextKind::ListElements
+            | RecoveryContextKind::SetElements
+            | RecoveryContextKind::TupleElements => p.at_expr(),
+            RecoveryContextKind::DictElements => p.at(TokenKind::DoubleStar) || p.at_expr(),
+            RecoveryContextKind::SequenceMatchPattern(_) => p.at_pattern_start(),
+            RecoveryContextKind::MatchPatternMapping => p.at_mapping_pattern_start(),
+            RecoveryContextKind::MatchPatternClassArguments => p.at_pattern_start(),
+            RecoveryContextKind::Arguments => p.at_expr(),
+            RecoveryContextKind::DeleteTargets => p.at_expr(),
+            RecoveryContextKind::Identifiers => p.at(TokenKind::Name),
+            RecoveryContextKind::Parameters(_) => matches!(
+                p.current_token_kind(),
+                TokenKind::Name | TokenKind::Star | TokenKind::DoubleStar
+            ),
+            RecoveryContextKind::WithItems(_) => p.at_expr(),
         }
     }
 
@@ -776,7 +903,7 @@ impl RecoveryContextKind {
                     .to_string(),
             ),
             RecoveryContextKind::Except => ParseErrorType::OtherError(
-                "An `except` or `finally` clause or the end of the `try` statement expected."
+                "Expected an `except` or `finally` clause or the end of the `try` statement."
                     .to_string(),
             ),
             RecoveryContextKind::AssignmentTargets => {
@@ -785,33 +912,94 @@ impl RecoveryContextKind {
                         "The keyword is not allowed as a variable declaration name".to_string(),
                     )
                 } else {
-                    ParseErrorType::OtherError("Assignment target expected".to_string())
+                    ParseErrorType::OtherError("Expected an assignment target".to_string())
                 }
             }
             RecoveryContextKind::TypeParams => ParseErrorType::OtherError(
                 "Expected a type parameter or the end of the type parameter list".to_string(),
             ),
-            RecoveryContextKind::ImportNames => {
+            RecoveryContextKind::ImportFromAsNames => {
                 ParseErrorType::OtherError("Expected an import name or a ')'".to_string())
             }
+            RecoveryContextKind::ImportNames => {
+                ParseErrorType::OtherError("Expected an import name".to_string())
+            }
+            RecoveryContextKind::Slices => ParseErrorType::OtherError(
+                "Expected an expression or the end of the slice list".to_string(),
+            ),
+            RecoveryContextKind::ListElements => {
+                ParseErrorType::OtherError("Expected an expression or a ']'".to_string())
+            }
+            RecoveryContextKind::SetElements | RecoveryContextKind::DictElements => {
+                ParseErrorType::OtherError("Expected an expression or a '}'".to_string())
+            }
+            RecoveryContextKind::TupleElements => {
+                ParseErrorType::OtherError("Expected an expression or a ')'".to_string())
+            }
+            RecoveryContextKind::SequenceMatchPattern(_) => ParseErrorType::OtherError(
+                "Expected a pattern or the end of the sequence pattern".to_string(),
+            ),
+            RecoveryContextKind::MatchPatternMapping => ParseErrorType::OtherError(
+                "Expected a mapping pattern or the end of the mapping pattern".to_string(),
+            ),
+            RecoveryContextKind::MatchPatternClassArguments => {
+                ParseErrorType::OtherError("Expected a pattern or a ')'".to_string())
+            }
+            RecoveryContextKind::Arguments => {
+                ParseErrorType::OtherError("Expected an expression or a ')'".to_string())
+            }
+            RecoveryContextKind::DeleteTargets => {
+                ParseErrorType::OtherError("Expected a delete target".to_string())
+            }
+            RecoveryContextKind::Identifiers => {
+                ParseErrorType::OtherError("Expected an identifier".to_string())
+            }
+            RecoveryContextKind::Parameters(_) => ParseErrorType::OtherError(
+                "Expected a parameter or the end of the parameter list".to_string(),
+            ),
+            RecoveryContextKind::WithItems(with_item_kind) => match with_item_kind {
+                WithItemKind::Parenthesized => {
+                    ParseErrorType::OtherError("Expected an expression or a ')'".to_string())
+                }
+                _ => ParseErrorType::OtherError(
+                    "Expected an expression or the end of the with item list".to_string(),
+                ),
+            },
         }
     }
 }
 
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
-struct RecoveryContext(u8);
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+struct RecoveryContext(u32);
 
 bitflags! {
-    impl RecoveryContext: u8 {
+    impl RecoveryContext: u32 {
         const MODULE_STATEMENTS = 1 << 0;
         const BLOCK_STATEMENTS = 1 << 1;
         const ELIF = 1 << 2;
         const EXCEPT = 1 << 3;
-
         const ASSIGNMENT_TARGETS = 1 << 4;
         const TYPE_PARAMS = 1 << 5;
-
-        const IMPORT_NAMES = 1 << 6;
+        const IMPORT_FROM_AS_NAMES = 1 << 6;
+        const IMPORT_NAMES = 1 << 7;
+        const SLICES = 1 << 8;
+        const LIST_ELEMENTS = 1 << 9;
+        const SET_ELEMENTS = 1 << 10;
+        const DICT_ELEMENTS = 1 << 11;
+        const TUPLE_ELEMENTS = 1 << 12;
+        const SEQUENCE_MATCH_PATTERN = 1 << 13;
+        const SEQUENCE_MATCH_PATTERN_LIST = 1 << 14;
+        const SEQUENCE_MATCH_PATTERN_TUPLE = 1 << 15;
+        const MATCH_PATTERN_MAPPING = 1 << 16;
+        const MATCH_PATTERN_CLASS_ARGUMENTS = 1 << 17;
+        const ARGUMENTS = 1 << 18;
+        const DELETE = 1 << 19;
+        const IDENTIFIERS = 1 << 20;
+        const FUNCTION_PARAMETERS = 1 << 21;
+        const LAMBDA_PARAMETERS = 1 << 22;
+        const WITH_ITEMS_PARENTHESIZED = 1 << 23;
+        const WITH_ITEMS_PARENTHESIZED_EXPRESSION = 1 << 24;
+        const WITH_ITEMS_UNPARENTHESIZED = 1 << 25;
     }
 }
 
@@ -824,7 +1012,40 @@ impl RecoveryContext {
             RecoveryContextKind::Except => RecoveryContext::EXCEPT,
             RecoveryContextKind::AssignmentTargets => RecoveryContext::ASSIGNMENT_TARGETS,
             RecoveryContextKind::TypeParams => RecoveryContext::TYPE_PARAMS,
+            RecoveryContextKind::ImportFromAsNames => RecoveryContext::IMPORT_FROM_AS_NAMES,
             RecoveryContextKind::ImportNames => RecoveryContext::IMPORT_NAMES,
+            RecoveryContextKind::Slices => RecoveryContext::SLICES,
+            RecoveryContextKind::ListElements => RecoveryContext::LIST_ELEMENTS,
+            RecoveryContextKind::SetElements => RecoveryContext::SET_ELEMENTS,
+            RecoveryContextKind::DictElements => RecoveryContext::DICT_ELEMENTS,
+            RecoveryContextKind::TupleElements => RecoveryContext::TUPLE_ELEMENTS,
+            RecoveryContextKind::SequenceMatchPattern(parentheses) => match parentheses {
+                None => RecoveryContext::SEQUENCE_MATCH_PATTERN,
+                Some(SequenceMatchPatternParentheses::List) => {
+                    RecoveryContext::SEQUENCE_MATCH_PATTERN_LIST
+                }
+                Some(SequenceMatchPatternParentheses::Tuple) => {
+                    RecoveryContext::SEQUENCE_MATCH_PATTERN_TUPLE
+                }
+            },
+            RecoveryContextKind::MatchPatternMapping => RecoveryContext::MATCH_PATTERN_MAPPING,
+            RecoveryContextKind::MatchPatternClassArguments => {
+                RecoveryContext::MATCH_PATTERN_CLASS_ARGUMENTS
+            }
+            RecoveryContextKind::Arguments => RecoveryContext::ARGUMENTS,
+            RecoveryContextKind::DeleteTargets => RecoveryContext::DELETE,
+            RecoveryContextKind::Identifiers => RecoveryContext::IDENTIFIERS,
+            RecoveryContextKind::Parameters(function_kind) => match function_kind {
+                FunctionKind::Lambda => RecoveryContext::LAMBDA_PARAMETERS,
+                FunctionKind::FunctionDef => RecoveryContext::FUNCTION_PARAMETERS,
+            },
+            RecoveryContextKind::WithItems(with_item_kind) => match with_item_kind {
+                WithItemKind::Parenthesized => RecoveryContext::WITH_ITEMS_PARENTHESIZED,
+                WithItemKind::ParenthesizedExpression => {
+                    RecoveryContext::WITH_ITEMS_PARENTHESIZED_EXPRESSION
+                }
+                WithItemKind::Unparenthesized => RecoveryContext::WITH_ITEMS_UNPARENTHESIZED,
+            },
         }
     }
 
@@ -836,9 +1057,51 @@ impl RecoveryContext {
             RecoveryContext::MODULE_STATEMENTS => RecoveryContextKind::ModuleStatements,
             RecoveryContext::BLOCK_STATEMENTS => RecoveryContextKind::BlockStatements,
             RecoveryContext::ELIF => RecoveryContextKind::Elif,
+            RecoveryContext::EXCEPT => RecoveryContextKind::Except,
             RecoveryContext::ASSIGNMENT_TARGETS => RecoveryContextKind::AssignmentTargets,
             RecoveryContext::TYPE_PARAMS => RecoveryContextKind::TypeParams,
+            RecoveryContext::IMPORT_FROM_AS_NAMES => RecoveryContextKind::ImportFromAsNames,
             RecoveryContext::IMPORT_NAMES => RecoveryContextKind::ImportNames,
+            RecoveryContext::SLICES => RecoveryContextKind::Slices,
+            RecoveryContext::LIST_ELEMENTS => RecoveryContextKind::ListElements,
+            RecoveryContext::SET_ELEMENTS => RecoveryContextKind::SetElements,
+            RecoveryContext::DICT_ELEMENTS => RecoveryContextKind::DictElements,
+            RecoveryContext::TUPLE_ELEMENTS => RecoveryContextKind::TupleElements,
+            RecoveryContext::SEQUENCE_MATCH_PATTERN => {
+                RecoveryContextKind::SequenceMatchPattern(None)
+            }
+            RecoveryContext::SEQUENCE_MATCH_PATTERN_LIST => {
+                RecoveryContextKind::SequenceMatchPattern(Some(
+                    SequenceMatchPatternParentheses::List,
+                ))
+            }
+            RecoveryContext::SEQUENCE_MATCH_PATTERN_TUPLE => {
+                RecoveryContextKind::SequenceMatchPattern(Some(
+                    SequenceMatchPatternParentheses::Tuple,
+                ))
+            }
+            RecoveryContext::MATCH_PATTERN_MAPPING => RecoveryContextKind::MatchPatternMapping,
+            RecoveryContext::MATCH_PATTERN_CLASS_ARGUMENTS => {
+                RecoveryContextKind::MatchPatternClassArguments
+            }
+            RecoveryContext::ARGUMENTS => RecoveryContextKind::Arguments,
+            RecoveryContext::DELETE => RecoveryContextKind::DeleteTargets,
+            RecoveryContext::IDENTIFIERS => RecoveryContextKind::Identifiers,
+            RecoveryContext::FUNCTION_PARAMETERS => {
+                RecoveryContextKind::Parameters(FunctionKind::FunctionDef)
+            }
+            RecoveryContext::LAMBDA_PARAMETERS => {
+                RecoveryContextKind::Parameters(FunctionKind::Lambda)
+            }
+            RecoveryContext::WITH_ITEMS_PARENTHESIZED => {
+                RecoveryContextKind::WithItems(WithItemKind::Parenthesized)
+            }
+            RecoveryContext::WITH_ITEMS_PARENTHESIZED_EXPRESSION => {
+                RecoveryContextKind::WithItems(WithItemKind::ParenthesizedExpression)
+            }
+            RecoveryContext::WITH_ITEMS_UNPARENTHESIZED => {
+                RecoveryContextKind::WithItems(WithItemKind::Unparenthesized)
+            }
             _ => return None,
         })
     }

--- a/crates/ruff_python_parser/src/parser/pattern.rs
+++ b/crates/ruff_python_parser/src/parser/pattern.rs
@@ -218,16 +218,6 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         self.bump(TokenKind::Lbrace);
 
-        // Return an empty `PatternMatchMapping` when finding a `}` right after the `{`
-        if self.eat(TokenKind::Rbrace) {
-            return ast::PatternMatchMapping {
-                range: self.node_range(start),
-                keys: vec![],
-                patterns: vec![],
-                rest: None,
-            };
-        }
-
         let mut keys = vec![];
         let mut patterns = vec![];
         let mut rest = None;
@@ -377,11 +367,11 @@ impl<'src> Parser<'src> {
 
         let mut patterns = vec![first_element];
 
-        patterns.extend_from_slice(&self.parse_comma_separated_list_into_vec(
+        self.parse_comma_separated_list(
             RecoveryContextKind::SequenceMatchPattern(parentheses),
-            Parser::parse_match_pattern,
+            |parser| patterns.push(parser.parse_match_pattern()),
             true,
-        ));
+        );
 
         if let Some(parentheses) = parentheses {
             self.expect(parentheses.closing_kind());

--- a/crates/ruff_python_parser/src/parser/pattern.rs
+++ b/crates/ruff_python_parser/src/parser/pattern.rs
@@ -8,25 +8,57 @@ use crate::parser::{Parser, SequenceMatchPatternParentheses};
 use crate::token_set::TokenSet;
 use crate::{ParseErrorType, Tok, TokenKind};
 
-const END_EXPR_SET: TokenSet = TokenSet::new([
-    TokenKind::Newline,
-    TokenKind::Semi,
-    TokenKind::Colon,
-    TokenKind::EndOfFile,
-    TokenKind::Rbrace,
-    TokenKind::Rsqb,
-    TokenKind::Rpar,
-    TokenKind::Comma,
-    TokenKind::Dedent,
-    TokenKind::Else,
-    TokenKind::As,
-    TokenKind::From,
-    TokenKind::For,
-    TokenKind::Async,
-    TokenKind::In,
+use super::RecoveryContextKind;
+
+/// The set of tokens that can start a literal pattern.
+const LITERAL_PATTERN_START_SET: TokenSet = TokenSet::new([
+    TokenKind::None,
+    TokenKind::True,
+    TokenKind::False,
+    TokenKind::String,
+    TokenKind::Int,
+    TokenKind::Float,
+    TokenKind::Complex,
 ]);
 
+/// The set of tokens that can start a pattern.
+const PATTERN_START_SET: TokenSet = TokenSet::new([
+    // Star pattern
+    TokenKind::Star,
+    // Capture pattern
+    // Wildcard pattern ('_' is a name token)
+    // Value pattern (name or attribute)
+    // Class pattern
+    TokenKind::Name,
+    // Group pattern
+    TokenKind::Lpar,
+    // Sequence pattern
+    TokenKind::Lsqb,
+    // Mapping pattern
+    TokenKind::Lbrace,
+])
+.union(LITERAL_PATTERN_START_SET);
+
+/// The set of tokens that can start a mapping pattern.
+const MAPPING_PATTERN_START_SET: TokenSet = TokenSet::new([
+    // Double star pattern
+    TokenKind::DoubleStar,
+    // Value pattern
+    TokenKind::Name,
+])
+.union(LITERAL_PATTERN_START_SET);
+
 impl<'src> Parser<'src> {
+    /// Returns `true` if the current token is a valid start of a pattern.
+    pub(super) fn at_pattern_start(&self) -> bool {
+        self.at_ts(PATTERN_START_SET)
+    }
+
+    /// Returns `true` if the current token is a valid start of a mapping pattern.
+    pub(super) fn at_mapping_pattern_start(&self) -> bool {
+        self.at_ts(MAPPING_PATTERN_START_SET)
+    }
+
     pub(super) fn parse_match_patterns(&mut self) -> Pattern {
         let start = self.node_start();
         let pattern = self.parse_match_pattern();
@@ -85,6 +117,9 @@ impl<'src> Parser<'src> {
             lhs = Pattern::MatchClass(self.parse_match_pattern_class(lhs, start));
         }
 
+        // TODO(dhruvmanila): This error isn't being reported (`1 + 2` can't be used as a pattern)
+        // literal_pattern:
+        //     | signed_number !('+' | '-')
         if self.at(TokenKind::Plus) || self.at(TokenKind::Minus) {
             let (operator_token, _) = self.next_token();
             let operator = if matches!(operator_token, Tok::Plus) {
@@ -172,18 +207,33 @@ impl<'src> Parser<'src> {
         lhs
     }
 
+    /// Parses a mapping pattern.
+    ///
+    /// # Panics
+    ///
+    /// If the parser isn't positioned at a `{` token.
+    ///
+    /// See: <https://docs.python.org/3/reference/compound_stmts.html#mapping-patterns>
     fn parse_match_pattern_mapping(&mut self) -> ast::PatternMatchMapping {
         let start = self.node_start();
+        self.bump(TokenKind::Lbrace);
+
+        // Return an empty `PatternMatchMapping` when finding a `}` right after the `{`
+        if self.eat(TokenKind::Rbrace) {
+            return ast::PatternMatchMapping {
+                range: self.node_range(start),
+                keys: vec![],
+                patterns: vec![],
+                rest: None,
+            };
+        }
+
         let mut keys = vec![];
         let mut patterns = vec![];
         let mut rest = None;
 
-        #[allow(deprecated)]
-        self.parse_delimited(
-            true,
-            TokenKind::Lbrace,
-            TokenKind::Comma,
-            TokenKind::Rbrace,
+        self.parse_comma_separated_list(
+            RecoveryContextKind::MatchPatternMapping,
             |parser| {
                 if parser.eat(TokenKind::DoubleStar) {
                     rest = Some(parser.parse_identifier());
@@ -213,6 +263,7 @@ impl<'src> Parser<'src> {
                                 )),
                                 &pattern,
                             );
+                            #[allow(deprecated)]
                             Expr::Invalid(ast::ExprInvalid {
                                 value: parser.src_text(&pattern).into(),
                                 range: pattern.range(),
@@ -226,7 +277,13 @@ impl<'src> Parser<'src> {
                     patterns.push(parser.parse_match_pattern());
                 }
             },
+            true,
         );
+
+        // TODO(dhruvmanila): There can't be any other pattern after a `**` pattern.
+        // TODO(dhruvmanila): Duplicate literal keys should raise a SyntaxError.
+
+        self.expect(TokenKind::Rbrace);
 
         ast::PatternMatchMapping {
             range: self.node_range(start),
@@ -296,17 +353,19 @@ impl<'src> Parser<'src> {
         pattern
     }
 
+    /// Parses a sequence pattern.
+    ///
+    /// If the `parentheses` is `None`, it is an [open sequence pattern].
+    ///
+    /// See: <https://docs.python.org/3/reference/compound_stmts.html#sequence-patterns>
+    ///
+    /// [open sequence pattern]: https://docs.python.org/3/reference/compound_stmts.html#grammar-token-python-grammar-open_sequence_pattern
     fn parse_sequence_match_pattern(
         &mut self,
-        first_elt: Pattern,
+        first_element: Pattern,
         start: TextSize,
         parentheses: Option<SequenceMatchPatternParentheses>,
     ) -> ast::PatternMatchSequence {
-        let ending = parentheses.map_or(
-            TokenKind::Colon,
-            SequenceMatchPatternParentheses::closing_kind,
-        );
-
         if parentheses.is_some_and(|parentheses| {
             self.at(parentheses.closing_kind()) || self.peek_nth(1) == parentheses.closing_kind()
         }) {
@@ -316,19 +375,22 @@ impl<'src> Parser<'src> {
             self.expect(TokenKind::Comma);
         }
 
-        let mut patterns = vec![first_elt];
+        let mut patterns = vec![first_element];
 
-        #[allow(deprecated)]
-        self.parse_separated(true, TokenKind::Comma, [ending], |parser| {
-            patterns.push(parser.parse_match_pattern());
-        });
+        patterns.extend_from_slice(&self.parse_comma_separated_list_into_vec(
+            RecoveryContextKind::SequenceMatchPattern(parentheses),
+            Parser::parse_match_pattern,
+            true,
+        ));
 
         if let Some(parentheses) = parentheses {
             self.expect(parentheses.closing_kind());
         }
 
-        let range = self.node_range(start);
-        ast::PatternMatchSequence { range, patterns }
+        ast::PatternMatchSequence {
+            range: self.node_range(start),
+            patterns,
+        }
     }
 
     fn parse_match_pattern_literal(&mut self) -> Pattern {
@@ -488,23 +550,31 @@ impl<'src> Parser<'src> {
         lhs
     }
 
+    /// Parses the [pattern arguments] in a class pattern.
+    ///
+    /// # Panics
+    ///
+    /// If the parser isn't positioned at a `(` token.
+    ///
+    /// See: <https://docs.python.org/3/reference/compound_stmts.html#class-patterns>
+    ///
+    /// [pattern arguments]: https://docs.python.org/3/reference/compound_stmts.html#grammar-token-python-grammar-pattern_arguments
     fn parse_match_pattern_class(
         &mut self,
         cls: Pattern,
         start: TextSize,
     ) -> ast::PatternMatchClass {
+        self.bump(TokenKind::Lpar);
+
         let mut patterns = vec![];
         let mut keywords = vec![];
         let mut has_seen_pattern = false;
         let mut has_seen_keyword_pattern = false;
 
         let arguments_start = self.node_start();
-        #[allow(deprecated)]
-        self.parse_delimited(
-            true,
-            TokenKind::Lpar,
-            TokenKind::Comma,
-            TokenKind::Rpar,
+
+        self.parse_comma_separated_list(
+            RecoveryContextKind::MatchPatternClassArguments,
             |parser| {
                 let pattern_start = parser.node_start();
                 let pattern = parser.parse_match_pattern();
@@ -526,7 +596,7 @@ impl<'src> Parser<'src> {
                         });
                     } else {
                         #[allow(deprecated)]
-                        parser.skip_until(END_EXPR_SET);
+                        parser.skip_until(super::expression::END_EXPR_SET);
                         parser.add_error(
                             ParseErrorType::OtherError("`not valid keyword pattern".to_string()),
                             parser.node_range(pattern_start),
@@ -546,7 +616,10 @@ impl<'src> Parser<'src> {
                     );
                 }
             },
+            true,
         );
+
+        self.expect(TokenKind::Rpar);
 
         let arguments_range = self.node_range(arguments_start);
 


### PR DESCRIPTION
## Summary

This PR removes the deprecated parsing list functions and updates the references to use the new functions.

There are now 4 functions to accommodate this pattern. They are divided into 2 groups: one to parse a sequence of elements and the other to parse a sequence of elements _separated_ by a comma. In each of the groups, there are 2 functions: one collects and returns all the parsed elements as a vector and the other delegates the collection part to the user. This separation is achieved by using `Fn` and `FnMut` to allow mutation in the later case.

The error recovery context has been updated to accommodate the new sequence kind. Currently, the terminator token kinds only contain the necessary token to end the list and not necessarily the ones which might help in error recovery. This will be updated as I go through the testing phase. This phase is basically coming up with a bunch of invalid programs to check how the parser is acting and how can we help in the recovery phase.


## Test Plan

Currently, my plan is to keep the testing part separate than the actual update. This doesn't mean I'm not testing locally, but it's not thorough. The main reason is to keep the diffs to a minimal and writing test cases will require some effort which I want to decouple with the actual change. This is ok here as it's not getting merged into `main` but the parser PR.
