### PR TITLE
Fix unstable with-items formatting

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with.py
@@ -304,6 +304,17 @@ if True:
     with anyio.CancelScope(shield=True) if get_running_loop() else contextlib.nullcontext():
         pass
 
+if True:
+    with anyio.CancelScope(shield=True) if get_running_loop() else contextlib.nullcontext() as c:
+        pass
 
 with Child(aaaaaaaaa, bbbbbbbbbbbbbbb, cccccc), Document(aaaaa, bbbbbbbbbb, ddddddddddddd):
+    pass
+
+# Regression test for https://github.com/astral-sh/ruff/issues/10267
+with (
+    open(
+        "/etc/hosts"  # This is an incredibly long comment that has been replaced for sanitization
+    )
+):
     pass

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with_39.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/with_39.py
@@ -85,4 +85,8 @@ if True:
 with (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as c):
     pass
 
-
+with (  # outer comment
+    CtxManager1(),
+    CtxManager2(),
+):
+    pass

--- a/crates/ruff_python_formatter/src/other/with_item.rs
+++ b/crates/ruff_python_formatter/src/other/with_item.rs
@@ -22,6 +22,23 @@ pub enum WithItemLayout {
     /// This layout is used independent of the target version.
     SingleParenthesizedContextManager,
 
+    /// A with item that is the `with`s only context manager and it has no `target`.
+    ///
+    /// ```python
+    /// with a + b:
+    ///     ...
+    /// ```
+    ///
+    /// In this case, use [`maybe_parenthesize_expression`] to get the same formatting as when
+    /// formatting any other statement with a clause header.
+    ///
+    /// This layout is only used for Python 3.9+.
+    ///
+    /// Be careful that [`Self::SingleParenthesizedContextManager`] and this layout are compatible because
+    /// removing optional parentheses or adding parentheses will make the formatter pick the opposite layout
+    /// the second time the file gets formatted.
+    SingleWithoutTarget,
+
     /// This layout is used when the target python version doesn't support parenthesized context managers and
     /// it's either a single, unparenthesized with item or multiple items.
     ///
@@ -106,7 +123,8 @@ impl FormatNodeRule<WithItem> for FormatWithItem {
                 }
             }
 
-            WithItemLayout::SingleParenthesizedContextManager => {
+            WithItemLayout::SingleParenthesizedContextManager
+            | WithItemLayout::SingleWithoutTarget => {
                 write!(
                     f,
                     [maybe_parenthesize_expression(

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with.py.snap
@@ -310,8 +310,19 @@ if True:
     with anyio.CancelScope(shield=True) if get_running_loop() else contextlib.nullcontext():
         pass
 
+if True:
+    with anyio.CancelScope(shield=True) if get_running_loop() else contextlib.nullcontext() as c:
+        pass
 
 with Child(aaaaaaaaa, bbbbbbbbbbbbbbb, cccccc), Document(aaaaa, bbbbbbbbbb, ddddddddddddd):
+    pass
+
+# Regression test for https://github.com/astral-sh/ruff/issues/10267
+with (
+    open(
+        "/etc/hosts"  # This is an incredibly long comment that has been replaced for sanitization
+    )
+):
     pass
 ```
 
@@ -661,9 +672,20 @@ if True:
     ) if get_running_loop() else contextlib.nullcontext():
         pass
 
+if True:
+    with anyio.CancelScope(
+        shield=True
+    ) if get_running_loop() else contextlib.nullcontext() as c:
+        pass
 
 with Child(aaaaaaaaa, bbbbbbbbbbbbbbb, cccccc), Document(
     aaaaa, bbbbbbbbbb, ddddddddddddd
+):
+    pass
+
+# Regression test for https://github.com/astral-sh/ruff/issues/10267
+with open(
+    "/etc/hosts"  # This is an incredibly long comment that has been replaced for sanitization
 ):
     pass
 ```
@@ -1052,13 +1074,23 @@ if True:
     ):
         pass
 
+if True:
+    with (
+        anyio.CancelScope(shield=True)
+        if get_running_loop()
+        else contextlib.nullcontext() as c
+    ):
+        pass
 
 with (
     Child(aaaaaaaaa, bbbbbbbbbbbbbbb, cccccc),
     Document(aaaaa, bbbbbbbbbb, ddddddddddddd),
 ):
     pass
+
+# Regression test for https://github.com/astral-sh/ruff/issues/10267
+with open(
+    "/etc/hosts"  # This is an incredibly long comment that has been replaced for sanitization
+):
+    pass
 ```
-
-
-

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__with_39.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__with_39.py.snap
@@ -91,7 +91,11 @@ if True:
 with (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as c):
     pass
 
-
+with (  # outer comment
+    CtxManager1(),
+    CtxManager2(),
+):
+    pass
 ```
 
 ## Outputs
@@ -217,7 +221,10 @@ with (
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb as c
 ):
     pass
+
+with (  # outer comment
+    CtxManager1(),
+    CtxManager2(),
+):
+    pass
 ```
-
-
-


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/10267

The issue with the current formatting is that the formatter flips between the `SingleParenthesizedContextManager`  and `ParenthesizeIfExpands` or `SingleWithTarget` because the layouts use incompatible formatting ( `SingleParenthesizedContextManager`: `maybe_parenthesize_expression(context)` vs `ParenthesizeIfExpands`: `parenthesize_if_expands(item)`, `SingleWithTarget`: `optional_parentheses(item)`. 

The fix is to ensure that the layouts between which the formatter flips when adding or removing parentheses are the same. I do this by introducing a new `SingleWithoutTarget` layout that uses the same formatting as `SingleParenthesizedContextManager` if it has no target and prefer `SingleWithoutTarget` over using `ParenthesizeIfExpands` or `SingleWithTarget`. 

## Formatting change

The downside is that we now use `maybe_parenthesize_expression` over `parenthesize_if_expands` for expressions where `can_omit_optional_parentheses` returns `false`. This can lead to stable formatting changes. I only found one formatting change in our ecosystem check and, unfortunately, this is necessary to fix the instability (and instability fixes are okay to have as part of minor changes according to our versioning policy)

The benefit of the change is that `with` items with a single context manager and without a target are now formatted identically to how the same expression would be formatted in other clause headers.

## Test Plan

I ran the ecosystem check locally