### PR TITLE
Fix E203 false positive for slices in format strings

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/extraneous_whitespace.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/extraneous_whitespace.rs
@@ -137,16 +137,16 @@ pub(crate) fn extraneous_whitespace(line: &LogicalLine, context: &mut LogicalLin
         match kind {
             TokenKind::FStringStart => fstrings += 1,
             TokenKind::FStringEnd => fstrings = fstrings.saturating_sub(1),
-            TokenKind::Lsqb if fstrings == 0 => {
+            TokenKind::Lsqb => {
                 brackets.push(kind);
             }
-            TokenKind::Rsqb if fstrings == 0 => {
+            TokenKind::Rsqb => {
                 brackets.pop();
             }
-            TokenKind::Lbrace if fstrings == 0 => {
+            TokenKind::Lbrace => {
                 brackets.push(kind);
             }
-            TokenKind::Rbrace if fstrings == 0 => {
+            TokenKind::Rbrace => {
                 brackets.pop();
             }
             _ => {}


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The code later in this file that checks for slices relies on the stack of brackets to determine the position. I'm not sure why format strings were being excluded from this, but the tests still pass with these match guards removed.

Closes #10278

## Test Plan

Still needs a test.