### PR TITLE
Improve various assignment target error

### DIFF
--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -94,11 +94,13 @@ pub enum ParseErrorType {
     /// An empty slice was found during parsing, e.g `l[]`.
     EmptySlice,
     /// An invalid expression was found in the assignment `target`.
-    AssignmentError,
+    InvalidAssignmentTarget,
     /// An invalid expression was found in the named assignment `target`.
-    NamedAssignmentError,
+    InvalidNamedAssignmentTarget,
     /// An invalid expression was found in the augmented assignment `target`.
-    AugAssignmentError,
+    InvalidAugmentedAssignmentTarget,
+    /// An invalid expression was found in the delete `target`.
+    InvalidDeleteTarget,
     /// Multiple simple statements were found in the same line without a `;` separating them.
     SimpleStmtsInSameLine,
     /// An unexpected indentation was found during parsing.
@@ -182,9 +184,16 @@ impl std::fmt::Display for ParseErrorType {
                 write!(f, "invalid pattern `{pattern:?}`")
             }
             ParseErrorType::UnexpectedIndentation => write!(f, "unexpected indentation"),
-            ParseErrorType::AssignmentError => write!(f, "invalid assignment target"),
-            ParseErrorType::NamedAssignmentError => write!(f, "invalid assignment target"),
-            ParseErrorType::AugAssignmentError => write!(f, "invalid augmented assignment target"),
+            ParseErrorType::InvalidAssignmentTarget => write!(f, "invalid assignment target"),
+            ParseErrorType::InvalidNamedAssignmentTarget => {
+                write!(f, "invalid named assignment target")
+            }
+            ParseErrorType::InvalidAugmentedAssignmentTarget => {
+                write!(f, "invalid augmented assignment target")
+            }
+            ParseErrorType::InvalidDeleteTarget => {
+                write!(f, "invalid delete target")
+            }
             ParseErrorType::DuplicateArgumentError(arg_name) => {
                 write!(f, "duplicate argument '{arg_name}' in function definition")
             }

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1565,11 +1565,18 @@ impl<'src> Parser<'src> {
         })
     }
 
+    /// Parses a named expression (`:=`).
+    ///
+    /// # Panics
+    ///
+    /// If the parser isn't positioned at a `:=` token.
+    ///
+    /// See: <https://docs.python.org/3/reference/expressions.html#assignment-expressions>
     fn parse_named_expression(&mut self, mut target: Expr, start: TextSize) -> ast::ExprNamed {
         self.bump(TokenKind::ColonEqual);
 
-        if !helpers::is_valid_assignment_target(&target) {
-            self.add_error(ParseErrorType::NamedAssignmentError, target.range());
+        if !target.is_name_expr() {
+            self.add_error(ParseErrorType::InvalidNamedAssignmentTarget, target.range());
         }
         helpers::set_expr_ctx(&mut target, ExprContext::Store);
 

--- a/crates/ruff_python_parser/src/parser/helpers.rs
+++ b/crates/ruff_python_parser/src/parser/helpers.rs
@@ -56,6 +56,19 @@ pub(super) fn is_valid_aug_assignment_target(expr: &Expr) -> bool {
     )
 }
 
+/// Check if the given expression is itself or contains an expression that is
+/// valid as a target of a `del` statement.
+pub(super) fn is_valid_del_target(expr: &Expr) -> bool {
+    // https://github.com/python/cpython/blob/d864b0094f9875c5613cbb0b7f7f3ca8f1c6b606/Parser/action_helpers.c#L1150-L1180
+    match expr {
+        Expr::List(ast::ExprList { elts, .. }) | Expr::Tuple(ast::ExprTuple { elts, .. }) => {
+            elts.iter().all(is_valid_del_target)
+        }
+        Expr::Name(_) | Expr::Attribute(_) | Expr::Subscript(_) => true,
+        _ => false,
+    }
+}
+
 /// Converts a [`TokenKind`] array of size 2 to its correspondent [`CmpOp`].
 pub(super) fn token_kind_to_cmp_op(kind: [TokenKind; 2]) -> Result<CmpOp, ()> {
     Ok(match kind {

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -253,15 +253,8 @@ impl<'src> Parser<'src> {
                 let mut target = parser.parse_conditional_expression_or_higher();
                 helpers::set_expr_ctx(&mut target.expr, ExprContext::Del);
 
-                // TODO(dhruvmanila): There are more restrictions on the targets here.
-                if matches!(target.expr, Expr::BoolOp(_) | Expr::Compare(_)) {
-                    parser.add_error(
-                        ParseErrorType::OtherError(format!(
-                            "`{}` not allowed in `del` statement",
-                            parser.src_text(&target.expr)
-                        )),
-                        &target.expr,
-                    );
+                if !helpers::is_valid_del_target(&target.expr) {
+                    parser.add_error(ParseErrorType::InvalidDeleteTarget, &target.expr);
                 }
                 target.expr
             },

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -597,7 +597,9 @@ impl<'src> Parser<'src> {
             targets
                 .iter()
                 .filter(|target| !helpers::is_valid_assignment_target(target))
-                .for_each(|target| self.add_error(ParseErrorType::AssignmentError, target.range()));
+                .for_each(|target| {
+                    self.add_error(ParseErrorType::InvalidAssignmentTarget, target.range());
+                });
         }
 
         ast::StmtAssign {
@@ -614,7 +616,7 @@ impl<'src> Parser<'src> {
         start: TextSize,
     ) -> ast::StmtAnnAssign {
         if !helpers::is_valid_assignment_target(&target.expr) {
-            self.add_error(ParseErrorType::AssignmentError, target.range());
+            self.add_error(ParseErrorType::InvalidAssignmentTarget, target.range());
         }
 
         if matches!(target.expr, Expr::Tuple(_)) {
@@ -674,7 +676,10 @@ impl<'src> Parser<'src> {
         self.bump_ts(AUGMENTED_ASSIGN_SET);
 
         if !helpers::is_valid_aug_assignment_target(&target.expr) {
-            self.add_error(ParseErrorType::AugAssignmentError, target.range());
+            self.add_error(
+                ParseErrorType::InvalidAugmentedAssignmentTarget,
+                target.range(),
+            );
         }
 
         helpers::set_expr_ctx(&mut target.expr, ExprContext::Store);


### PR DESCRIPTION
## Summary

This PR improves error related things around assignment nodes, mainly the following:
1. Rename parse error variant:
	a. `AssignmentError` -> `InvalidAssignmentTarget`
	b. `NamedAssignmentError` -> `InvalidNamedAssignmentTarget`
	c. `AugAssignmentError` -> `InvalidAugmnetedAssignmentTarget`
2. Add `InvalidDeleteTarget` for invalid `del` targets
	a. Add helper function to check if it's a valid delete target similar to other target check functions.
4. Fix: named assignment target can only be a `Name` node

## Test Plan

Various test cases locally. As mentioned in my previous PR, I want to keep the testing part separate.
