### PR TITLE
Remove `skip_until` parser method

### DIFF
--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -428,16 +428,6 @@ impl<'src> Parser<'src> {
         inner(&mut self.errors, error, ranged.range());
     }
 
-    /// Skip tokens until [`TokenSet`]. Returns the range of the skipped tokens.
-    #[deprecated(note = "We should not perform error recovery outside of lists. Remove")]
-    fn skip_until(&mut self, token_set: TokenSet) {
-        let mut progress = ParserProgress::default();
-        while !self.at_ts(token_set) {
-            progress.assert_progressing(self);
-            self.next_token();
-        }
-    }
-
     /// Returns `true` if the current token is of the given kind.
     fn at(&self, kind: TokenKind) -> bool {
         self.current_token_kind() == kind

--- a/crates/ruff_python_parser/src/parser/pattern.rs
+++ b/crates/ruff_python_parser/src/parser/pattern.rs
@@ -514,7 +514,7 @@ impl<'src> Parser<'src> {
                     Expr::Name(self.parse_name())
                 } else {
                     self.add_error(
-                        ParseErrorType::OtherError("Expression expected.".to_string()),
+                        ParseErrorType::OtherError("Expected a pattern".to_string()),
                         self.current_token_range(),
                     );
                     Expr::Name(ast::ExprName {
@@ -573,22 +573,22 @@ impl<'src> Parser<'src> {
                     has_seen_pattern = false;
                     has_seen_keyword_pattern = true;
 
+                    // Even in case the key pattern is invalid, we still need to parse
+                    // the value pattern to move the parser forward.
+                    let value_pattern = parser.parse_match_pattern();
+
                     if let Pattern::MatchAs(ast::PatternMatchAs {
                         name: Some(attr), ..
                     }) = pattern
                     {
-                        let pattern = parser.parse_match_pattern();
-
                         keywords.push(ast::PatternKeyword {
                             attr,
-                            pattern,
+                            pattern: value_pattern,
                             range: parser.node_range(pattern_start),
                         });
                     } else {
-                        #[allow(deprecated)]
-                        parser.skip_until(super::expression::END_EXPR_SET);
                         parser.add_error(
-                            ParseErrorType::OtherError("`not valid keyword pattern".to_string()),
+                            ParseErrorType::OtherError("Invalid keyword pattern".to_string()),
                             parser.node_range(pattern_start),
                         );
                     }

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -1436,12 +1436,6 @@ impl<'src> Parser<'src> {
         let mut has_seen_vararg = false;
         let mut has_seen_default_param = false;
 
-        let ending = match function_kind {
-            FunctionKind::Lambda => TokenKind::Colon,
-            FunctionKind::FunctionDef => TokenKind::Rpar,
-        };
-
-        let ending_set = TokenSet::new([TokenKind::Rarrow, ending]).union(COMPOUND_STMT_SET);
         let start = self.node_start();
 
         self.parse_comma_separated_list(
@@ -1494,20 +1488,6 @@ impl<'src> Parser<'src> {
                     } else {
                         args.push(param);
                     }
-                } else {
-                    if parser.at_ts(SIMPLE_STMT_SET) {
-                        return;
-                    }
-
-                    let range = parser.current_token_range();
-                    #[allow(deprecated)]
-                    parser.skip_until(
-                        ending_set.union(TokenSet::new([TokenKind::Comma, TokenKind::Colon])),
-                    );
-                    parser.add_error(
-                        ParseErrorType::OtherError("expected parameter".to_string()),
-                        range.cover(parser.current_token_range()), // TODO(micha): This goes one token too far?
-                    );
                 }
             },
             true,


### PR DESCRIPTION
## Summary

This PR removes the `skip_until` parser method. The main use case for it was for error recovery which we want to isolate only in list parsing.

There are two references which are removed:
1. Parsing a list of match arguments in a class pattern. Take the following code snippet as an example:

	```python
	match foo:
		case Foo(bar.z=1, baz):
			pass
	```
	This is a syntax error as the keyword argument pattern can only have an identifier but here it's an attribute node. Now, to move on to the next argument (`baz`), the parser would skip until the end of the argument to recover. What we will do now is to parse the value as a pattern (per spec) thus moving the parser ahead and add the node with an empty identifier.

	The above code will produce the following AST:

	<details><summary><b>AST</b></summary>
	<p>
	
	```rs
	Module(
	    ModModule {
	        range: 0..52,
	        body: [
	            Match(
	                StmtMatch {
	                    range: 0..51,
	                    subject: Name(
	                        ExprName {
	                            range: 6..9,
	                            id: "foo",
	                            ctx: Load,
	                        },
	                    ),
	                    cases: [
	                        MatchCase {
	                            range: 15..51,
	                            pattern: MatchClass(
	                                PatternMatchClass {
	                                    range: 20..37,
	                                    cls: Name(
	                                        ExprName {
	                                            range: 20..23,
	                                            id: "Foo",
	                                            ctx: Load,
	                                        },
	                                    ),
	                                    arguments: PatternArguments {
	                                        range: 24..37,
	                                        patterns: [
	                                            MatchAs(
	                                                PatternMatchAs {
	                                                    range: 33..36,
	                                                    pattern: None,
	                                                    name: Some(
	                                                        Identifier {
	                                                            id: "baz",
	                                                            range: 33..36,
	                                                        },
	                                                    ),
	                                                },
	                                            ),
	                                        ],
	                                        keywords: [
	                                            PatternKeyword {
	                                                range: 24..31,
	                                                attr: Identifier {
	                                                    id: "",
	                                                    range: 31..31,
	                                                },
	                                                pattern: MatchValue(
	                                                    PatternMatchValue {
	                                                        range: 30..31,
	                                                        value: NumberLiteral(
	                                                            ExprNumberLiteral {
	                                                                range: 30..31,
	                                                                value: Int(
	                                                                    1,
	                                                                ),
	                                                            },
	                                                        ),
	                                                    },
	                                                ),
	                                            },
	                                        ],
	                                    },
	                                },
	                            ),
	                            guard: None,
	                            body: [
	                                Pass(
	                                    StmtPass {
	                                        range: 47..51,
	                                    },
	                                ),
	                            ],
	                        },
	                    ],
	                },
	            ),
	        ],
	    },
	)
	```
	
	</p>
	</details> 

2. Parsing a list of parameters. Here, our list parsing method makes sure to only call the parse element function when it's a valid list element. A parameter can start either with a `Star`, `DoubleStar`, or `Name` token which corresponds to the 3 `if` conditions. Thus, the `else` block is not required as the list parsing will recover without it.

