### PR TITLE
Fix trailing kwargs end of line comment after slash

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/function.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/statement/function.py
@@ -278,6 +278,13 @@ def f42(
 ):
     pass
 
+# Regression test for https://github.com/astral-sh/ruff/issues/10281
+def f43(
+    __bar: str,
+    /,
+    **specifiers: typing.Any,  # noqa: ANN401
+) -> int:
+    return len(specifiers)
 
 # Check trailing commas are permitted in funcdef argument list.
 def f(a, ): pass

--- a/crates/ruff_python_formatter/src/other/parameters.rs
+++ b/crates/ruff_python_formatter/src/other/parameters.rs
@@ -457,6 +457,7 @@ pub(crate) fn find_parameter_separators(
         .map(Ranged::start)
         .or(parameters.vararg.as_ref().map(|first| first.start()))
         .or(star.as_ref().map(|star| star.separator.start()))
+        .or(parameters.kwarg.as_deref().map(Ranged::start))
         .unwrap_or(parameters.end());
     let slash = slash.map(|(preceding_end, slash)| ParameterSeparator {
         preceding_end,

--- a/crates/ruff_python_formatter/src/other/parameters.rs
+++ b/crates/ruff_python_formatter/src/other/parameters.rs
@@ -450,6 +450,7 @@ pub(crate) fn find_parameter_separators(
     // * `f(a, /, b)`
     // * `f(a, /, *b)`
     // * `f(a, /, *, b)`
+    // * `f(a, /, *, **b)`
     // * `f(a, /)`
     let slash_following_start = parameters
         .args

--- a/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@statement__function.py.snap
@@ -284,6 +284,13 @@ def f42(
 ):
     pass
 
+# Regression test for https://github.com/astral-sh/ruff/issues/10281
+def f43(
+    __bar: str,
+    /,
+    **specifiers: typing.Any,  # noqa: ANN401
+) -> int:
+    return len(specifiers)
 
 # Check trailing commas are permitted in funcdef argument list.
 def f(a, ): pass
@@ -760,6 +767,15 @@ def f42(
     pass
 
 
+# Regression test for https://github.com/astral-sh/ruff/issues/10281
+def f43(
+    __bar: str,
+    /,
+    **specifiers: typing.Any,  # noqa: ANN401
+) -> int:
+    return len(specifiers)
+
+
 # Check trailing commas are permitted in funcdef argument list.
 def f(
     a,
@@ -999,6 +1015,3 @@ def function_with_one_argument_and_a_keyword_separator(
 ) -> ReallyReallyReallyReallyReallyReallyReallyReallyLongName:
     pass
 ```
-
-
-


### PR DESCRIPTION
## Summary

Fixes the handling end of line comments that belong to `**kwargs` when the `**kwargs` come after a slash.

The issue was that we missed to include the `**kwargs` start position when determining the start of the next node coming after the `/`.

Fixes https://github.com/astral-sh/ruff/issues/10281

## Test Plan

Added test
