### PR TITLE
Do not emit `Unknown` token

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -977,12 +977,6 @@ impl<'src> Parser<'src> {
                         });
                     fstring_literal
                 }
-                // `Invalid` tokens are created when there's a lexical error, so
-                // we ignore it here to avoid creating unexpected token errors
-                TokenKind::Unknown => {
-                    self.next_token();
-                    continue;
-                }
                 // Handle an unexpected token
                 _ => {
                     let (tok, range) = self.next_token();

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -100,9 +100,7 @@ impl Iterator for TokenSource {
                 }
 
                 Err(error) => {
-                    let location = error.location();
                     self.errors.push(error);
-                    break Some((Tok::Unknown, location));
                 }
             }
         }


### PR DESCRIPTION
## Summary

This PR updates the `TokenSource` to not emit the `Unknown` token if there's a lexical error.

To understand the reasoning behind this, we'll use the following example:

```python
f'hello {x!

z = 1
```

Here, the lexer will emit two errors at the _same_ location as show in the following output:

```
...
13 Name {
    name: "z",
} 14
15 Equal 16
17 Int {
    value: 1,
} 18
18 NonLogicalNewline 19
Error: 19:19 unexpected EOF while parsing
Error: 19:19 f-string: unterminated string
19 Newline 19
```

1. The parser is trying to parse a list of module statements
2. Starts parsing f-string
3. The parser is trying to parse a list of f-string elements
4. It encounters `z` after `!` which is an invalid conversion flag.
5. Exit the list parsing logic as the recovery can be handled by the outer context (module statement)
6. ... _some more error handling_
7. Current token is `Unknown` because of the lexical error (unexpected EOF)
8. F-string parsing logic skips this
9. Current token is `Unknown` again because of the "unterminated string" error
10. Both the previous and current token are the same and at the same location which means that the parser didn't progress. Panic!

The parser will then emit 2 `Unknown` tokens in total for the errors. This creates a problem in the logic to make sure that the parser is progressing because the tokens are at the same location which will seem like the parser is stuck. The program then panics.

This token is only used as a placeholder when there's a lexical error. This means that the parser need to skip this token when `next_token` is called or it needs to be handled by the parsing logic whichever matches against the current token kind. The latter was done by the f-string parsing logic. But this seems redundant as we can just avoid emitting it which is what this PR does.
