### PR TITLE
[`pylint`] Avoid false-positive slot non-assignment for `__dict__` (`PLE0237`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/non_slot_assignment.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/non_slot_assignment.py
@@ -54,3 +54,15 @@ class StudentE(StudentD):
 
     def setup(self):
         pass
+
+
+class StudentF(object):
+    __slots__ = ("name", "__dict__")
+
+    def __init__(self, name, middle_name):
+        self.name = name
+        self.middle_name = middle_name  # [assigning-non-slot]
+        self.setup()
+
+    def setup(self):
+        pass

--- a/crates/ruff_linter/src/rules/pylint/rules/non_slot_assignment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/non_slot_assignment.rs
@@ -142,7 +142,7 @@ fn is_attributes_not_in_slots(body: &[Stmt]) -> Vec<AttributeAssignment> {
         }
     }
 
-    if slots.is_empty() {
+    if slots.is_empty() || slots.contains("__dict__") {
         return vec![];
     }
 


### PR DESCRIPTION
Closes https://github.com/astral-sh/ruff/issues/10306.