### PR TITLE
F821: Fix false negatives in `.py` files when `from __future__ import annotations` is active

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_27.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_27.py
@@ -33,3 +33,16 @@ class MyClass:
 baz: MyClass
 eggs = baz  # Still invalid even when `__future__.annotations` are enabled
 eggs = "baz"  # always okay
+
+# Forward references:
+MaybeDStr: TypeAlias = Optional[DStr]  # Still invalid even when `__future__.annotations` are enabled
+MaybeDStr2: TypeAlias = Optional["DStr"]  # always okay
+DStr: TypeAlias = Union[D, str]  # Still invalid even when `__future__.annotations` are enabled
+DStr2: TypeAlias = Union["D", str]  # always okay
+
+class D: ...
+
+# More circular references
+class Leaf: ...
+class Tree(list[Tree | Leaf]): ...  # Still invalid even when `__future__.annotations` are enabled
+class Tree2(list["Tree | Leaf"]): ...  # always okay

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -938,6 +938,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
             && !self.semantic.in_deferred_type_definition()
             && self.semantic.in_type_definition()
             && self.semantic.future_annotations()
+            && (self.semantic.in_typing_only_annotation() || self.source_type.is_stub())
         {
             if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = expr {
                 self.visit.string_type_definitions.push((

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_27.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_27.py.snap
@@ -17,3 +17,30 @@ F821_27.py:34:8: F821 Undefined name `baz`
    |        ^^^ F821
 35 | eggs = "baz"  # always okay
    |
+
+F821_27.py:38:33: F821 Undefined name `DStr`
+   |
+37 | # Forward references:
+38 | MaybeDStr: TypeAlias = Optional[DStr]  # Still invalid even when `__future__.annotations` are enabled
+   |                                 ^^^^ F821
+39 | MaybeDStr2: TypeAlias = Optional["DStr"]  # always okay
+40 | DStr: TypeAlias = Union[D, str]  # Still invalid even when `__future__.annotations` are enabled
+   |
+
+F821_27.py:40:25: F821 Undefined name `D`
+   |
+38 | MaybeDStr: TypeAlias = Optional[DStr]  # Still invalid even when `__future__.annotations` are enabled
+39 | MaybeDStr2: TypeAlias = Optional["DStr"]  # always okay
+40 | DStr: TypeAlias = Union[D, str]  # Still invalid even when `__future__.annotations` are enabled
+   |                         ^ F821
+41 | DStr2: TypeAlias = Union["D", str]  # always okay
+   |
+
+F821_27.py:47:17: F821 Undefined name `Tree`
+   |
+45 | # More circular references
+46 | class Leaf: ...
+47 | class Tree(list[Tree | Leaf]): ...  # Still invalid even when `__future__.annotations` are enabled
+   |                 ^^^^ F821
+48 | class Tree2(list["Tree | Leaf"]): ...  # always okay
+   |


### PR DESCRIPTION
## Summary

Fixes #10340.

Currently, ruff emits no F821 rules on the following `.py` file, but the lines marked with XXX all fail at runtime due to undefined names, despite `from __future__ import annotations` being active:

```py
from __future__ import annotations

from typing import TypeAlias, Optional, Union

MaybeCStr: TypeAlias = Optional[CStr]  # XXX
MaybeCStr2: TypeAlias = Optional["CStr"]  # always okay
CStr: TypeAlias = Union[C, str]  # XXX
CStr2: TypeAlias = Union["C", str]  # always okay

class C: ...

class Leaf: ...
class Tree(list[Tree | Leaf]): ...  # XXX
class Tree2(list["Tree | Leaf"]): ...  # always okay
```

This PR fixes that.

Much like #10341, it took me an annoying amount of time to figure out how to fix this, but it turned out to be hilariously easy to fix once I saw where to make the change 🙃

## Test Plan

`cargo test`
