### PR TITLE
Require --preview for `ruff server`

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -497,7 +497,11 @@ pub struct FormatCommand {
 }
 
 #[derive(Clone, Debug, clap::Parser)]
-pub struct ServerCommand;
+pub struct ServerCommand {
+    /// Enable preview mode; required for regular operation
+    #[arg(long)]
+    pub(crate) preview: bool,
+}
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 pub enum HelpFormat {

--- a/crates/ruff/src/commands/server.rs
+++ b/crates/ruff/src/commands/server.rs
@@ -9,7 +9,11 @@ use tracing_subscriber::{
 };
 use tracing_tree::time::Uptime;
 
-pub(crate) fn run_server(log_level: LogLevel) -> Result<ExitStatus> {
+pub(crate) fn run_server(preview: bool, log_level: LogLevel) -> Result<ExitStatus> {
+    if !preview {
+        tracing::error!("--preview needs to be provided as a command line argument while the server is still unstable.\nFor example: `ruff server --preview`");
+        return Ok(ExitStatus::Error);
+    }
     let trace_level = if log_level == LogLevel::Verbose {
         Level::TRACE
     } else {

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -206,8 +206,8 @@ fn format(args: FormatCommand, global_options: GlobalConfigArgs) -> Result<ExitS
 
 #[allow(clippy::needless_pass_by_value)] // TODO: remove once we start taking arguments from here
 fn server(args: ServerCommand, log_level: LogLevel) -> Result<ExitStatus> {
-    let ServerCommand {} = args;
-    commands::server::run_server(log_level)
+    let ServerCommand { preview } = args;
+    commands::server::run_server(preview, log_level)
 }
 
 pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<ExitStatus> {


### PR DESCRIPTION
## Summary

Fixes #10367.

While the server is still in an unstable state, requiring a `--preview` flag would be a good way to indicate this to end users. 
