### PR TITLE
Avoid `TRIO115` if the argument is a variable

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_trio/TRIO115.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_trio/TRIO115.py
@@ -10,7 +10,7 @@ async def func():
 
     trio.sleep(0)  # TRIO115
     foo = 0
-    trio.sleep(foo)  # TRIO115
+    trio.sleep(foo)  # OK
     trio.sleep(1)  # OK
     time.sleep(0)  # OK
 
@@ -20,26 +20,26 @@ async def func():
     trio.sleep(bar)
 
     x, y = 0, 2000
-    trio.sleep(x)  # TRIO115
+    trio.sleep(x)  # OK
     trio.sleep(y)  # OK
 
     (a, b, [c, (d, e)]) = (1, 2, (0, [4, 0]))
-    trio.sleep(c)  # TRIO115
+    trio.sleep(c)  # OK
     trio.sleep(d)  # OK
-    trio.sleep(e)  # TRIO115
+    trio.sleep(e)  # OK
 
     m_x, m_y = 0
     trio.sleep(m_y)  # OK
     trio.sleep(m_x)  # OK
 
     m_a = m_b = 0
-    trio.sleep(m_a)  # TRIO115
-    trio.sleep(m_b)  # TRIO115
+    trio.sleep(m_a)  # OK
+    trio.sleep(m_b)  # OK
 
     m_c = (m_d, m_e) = (0, 0)
     trio.sleep(m_c)  # OK
-    trio.sleep(m_d)  # TRIO115
-    trio.sleep(m_e)  # TRIO115
+    trio.sleep(m_d)  # OK
+    trio.sleep(m_e)  # OK
 
 
 def func():
@@ -63,4 +63,16 @@ def func():
     import trio
 
     if (walrus := 0) == 0:
-        trio.sleep(walrus)  # TRIO115
+        trio.sleep(walrus)  # OK
+
+
+def func():
+    import trio
+
+    async def main() -> None:
+        sleep = 0
+        for _ in range(2):
+            await trio.sleep(sleep)  # OK
+            sleep = 10
+
+    trio.run(main)

--- a/crates/ruff_linter/src/rules/flake8_trio/rules/zero_sleep_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_trio/rules/zero_sleep_call.rs
@@ -1,7 +1,6 @@
 use ruff_diagnostics::{AlwaysFixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::{self as ast, Expr, ExprCall, Int, Number};
-use ruff_python_semantic::analyze::typing::find_assigned_value;
 use ruff_python_semantic::Modules;
 use ruff_text_size::Ranged;
 
@@ -71,20 +70,6 @@ pub(crate) fn zero_sleep_call(checker: &mut Checker, call: &ExprCall) {
     match arg {
         Expr::NumberLiteral(ast::ExprNumberLiteral { value, .. }) => {
             if !matches!(value, Number::Int(Int::ZERO)) {
-                return;
-            }
-        }
-        Expr::Name(ast::ExprName { id, .. }) => {
-            let Some(value) = find_assigned_value(id, checker.semantic()) else {
-                return;
-            };
-            if !matches!(
-                value,
-                Expr::NumberLiteral(ast::ExprNumberLiteral {
-                    value: Number::Int(Int::ZERO),
-                    ..
-                })
-            ) {
                 return;
             }
         }

--- a/crates/ruff_linter/src/rules/flake8_trio/snapshots/ruff_linter__rules__flake8_trio__tests__TRIO115_TRIO115.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_trio/snapshots/ruff_linter__rules__flake8_trio__tests__TRIO115_TRIO115.py.snap
@@ -29,7 +29,7 @@ TRIO115.py:11:5: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.s
 11 |     trio.sleep(0)  # TRIO115
    |     ^^^^^^^^^^^^^ TRIO115
 12 |     foo = 0
-13 |     trio.sleep(foo)  # TRIO115
+13 |     trio.sleep(foo)  # OK
    |
    = help: Replace with `trio.lowlevel.checkpoint()`
 
@@ -40,29 +40,8 @@ TRIO115.py:11:5: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.s
 11    |-    trio.sleep(0)  # TRIO115
    11 |+    trio.lowlevel.checkpoint()  # TRIO115
 12 12 |     foo = 0
-13 13 |     trio.sleep(foo)  # TRIO115
+13 13 |     trio.sleep(foo)  # OK
 14 14 |     trio.sleep(1)  # OK
-
-TRIO115.py:13:5: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
-   |
-11 |     trio.sleep(0)  # TRIO115
-12 |     foo = 0
-13 |     trio.sleep(foo)  # TRIO115
-   |     ^^^^^^^^^^^^^^^ TRIO115
-14 |     trio.sleep(1)  # OK
-15 |     time.sleep(0)  # OK
-   |
-   = help: Replace with `trio.lowlevel.checkpoint()`
-
-ℹ Safe fix
-10 10 | 
-11 11 |     trio.sleep(0)  # TRIO115
-12 12 |     foo = 0
-13    |-    trio.sleep(foo)  # TRIO115
-   13 |+    trio.lowlevel.checkpoint()  # TRIO115
-14 14 |     trio.sleep(1)  # OK
-15 15 |     time.sleep(0)  # OK
-16 16 | 
 
 TRIO115.py:17:5: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
    |
@@ -84,145 +63,6 @@ TRIO115.py:17:5: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.s
 18 18 | 
 19 19 |     bar = "bar"
 20 20 |     trio.sleep(bar)
-
-TRIO115.py:23:5: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
-   |
-22 |     x, y = 0, 2000
-23 |     trio.sleep(x)  # TRIO115
-   |     ^^^^^^^^^^^^^ TRIO115
-24 |     trio.sleep(y)  # OK
-   |
-   = help: Replace with `trio.lowlevel.checkpoint()`
-
-ℹ Safe fix
-20 20 |     trio.sleep(bar)
-21 21 | 
-22 22 |     x, y = 0, 2000
-23    |-    trio.sleep(x)  # TRIO115
-   23 |+    trio.lowlevel.checkpoint()  # TRIO115
-24 24 |     trio.sleep(y)  # OK
-25 25 | 
-26 26 |     (a, b, [c, (d, e)]) = (1, 2, (0, [4, 0]))
-
-TRIO115.py:27:5: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
-   |
-26 |     (a, b, [c, (d, e)]) = (1, 2, (0, [4, 0]))
-27 |     trio.sleep(c)  # TRIO115
-   |     ^^^^^^^^^^^^^ TRIO115
-28 |     trio.sleep(d)  # OK
-29 |     trio.sleep(e)  # TRIO115
-   |
-   = help: Replace with `trio.lowlevel.checkpoint()`
-
-ℹ Safe fix
-24 24 |     trio.sleep(y)  # OK
-25 25 | 
-26 26 |     (a, b, [c, (d, e)]) = (1, 2, (0, [4, 0]))
-27    |-    trio.sleep(c)  # TRIO115
-   27 |+    trio.lowlevel.checkpoint()  # TRIO115
-28 28 |     trio.sleep(d)  # OK
-29 29 |     trio.sleep(e)  # TRIO115
-30 30 | 
-
-TRIO115.py:29:5: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
-   |
-27 |     trio.sleep(c)  # TRIO115
-28 |     trio.sleep(d)  # OK
-29 |     trio.sleep(e)  # TRIO115
-   |     ^^^^^^^^^^^^^ TRIO115
-30 | 
-31 |     m_x, m_y = 0
-   |
-   = help: Replace with `trio.lowlevel.checkpoint()`
-
-ℹ Safe fix
-26 26 |     (a, b, [c, (d, e)]) = (1, 2, (0, [4, 0]))
-27 27 |     trio.sleep(c)  # TRIO115
-28 28 |     trio.sleep(d)  # OK
-29    |-    trio.sleep(e)  # TRIO115
-   29 |+    trio.lowlevel.checkpoint()  # TRIO115
-30 30 | 
-31 31 |     m_x, m_y = 0
-32 32 |     trio.sleep(m_y)  # OK
-
-TRIO115.py:36:5: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
-   |
-35 |     m_a = m_b = 0
-36 |     trio.sleep(m_a)  # TRIO115
-   |     ^^^^^^^^^^^^^^^ TRIO115
-37 |     trio.sleep(m_b)  # TRIO115
-   |
-   = help: Replace with `trio.lowlevel.checkpoint()`
-
-ℹ Safe fix
-33 33 |     trio.sleep(m_x)  # OK
-34 34 | 
-35 35 |     m_a = m_b = 0
-36    |-    trio.sleep(m_a)  # TRIO115
-   36 |+    trio.lowlevel.checkpoint()  # TRIO115
-37 37 |     trio.sleep(m_b)  # TRIO115
-38 38 | 
-39 39 |     m_c = (m_d, m_e) = (0, 0)
-
-TRIO115.py:37:5: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
-   |
-35 |     m_a = m_b = 0
-36 |     trio.sleep(m_a)  # TRIO115
-37 |     trio.sleep(m_b)  # TRIO115
-   |     ^^^^^^^^^^^^^^^ TRIO115
-38 | 
-39 |     m_c = (m_d, m_e) = (0, 0)
-   |
-   = help: Replace with `trio.lowlevel.checkpoint()`
-
-ℹ Safe fix
-34 34 | 
-35 35 |     m_a = m_b = 0
-36 36 |     trio.sleep(m_a)  # TRIO115
-37    |-    trio.sleep(m_b)  # TRIO115
-   37 |+    trio.lowlevel.checkpoint()  # TRIO115
-38 38 | 
-39 39 |     m_c = (m_d, m_e) = (0, 0)
-40 40 |     trio.sleep(m_c)  # OK
-
-TRIO115.py:41:5: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
-   |
-39 |     m_c = (m_d, m_e) = (0, 0)
-40 |     trio.sleep(m_c)  # OK
-41 |     trio.sleep(m_d)  # TRIO115
-   |     ^^^^^^^^^^^^^^^ TRIO115
-42 |     trio.sleep(m_e)  # TRIO115
-   |
-   = help: Replace with `trio.lowlevel.checkpoint()`
-
-ℹ Safe fix
-38 38 | 
-39 39 |     m_c = (m_d, m_e) = (0, 0)
-40 40 |     trio.sleep(m_c)  # OK
-41    |-    trio.sleep(m_d)  # TRIO115
-   41 |+    trio.lowlevel.checkpoint()  # TRIO115
-42 42 |     trio.sleep(m_e)  # TRIO115
-43 43 | 
-44 44 | 
-
-TRIO115.py:42:5: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
-   |
-40 |     trio.sleep(m_c)  # OK
-41 |     trio.sleep(m_d)  # TRIO115
-42 |     trio.sleep(m_e)  # TRIO115
-   |     ^^^^^^^^^^^^^^^ TRIO115
-   |
-   = help: Replace with `trio.lowlevel.checkpoint()`
-
-ℹ Safe fix
-39 39 |     m_c = (m_d, m_e) = (0, 0)
-40 40 |     trio.sleep(m_c)  # OK
-41 41 |     trio.sleep(m_d)  # TRIO115
-42    |-    trio.sleep(m_e)  # TRIO115
-   42 |+    trio.lowlevel.checkpoint()  # TRIO115
-43 43 | 
-44 44 | 
-45 45 | def func():
 
 TRIO115.py:48:14: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
    |
@@ -292,20 +132,3 @@ TRIO115.py:59:11: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.
 60 60 | 
 61 61 | 
 62 62 | def func():
-
-TRIO115.py:66:9: TRIO115 [*] Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
-   |
-65 |     if (walrus := 0) == 0:
-66 |         trio.sleep(walrus)  # TRIO115
-   |         ^^^^^^^^^^^^^^^^^^ TRIO115
-   |
-   = help: Replace with `trio.lowlevel.checkpoint()`
-
-ℹ Safe fix
-63 63 |     import trio
-64 64 | 
-65 65 |     if (walrus := 0) == 0:
-66    |-        trio.sleep(walrus)  # TRIO115
-   66 |+        trio.lowlevel.checkpoint()  # TRIO115
-
-


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fix "TRIO115 false positive with with sleep(var) where var starts as 0" #9935 based on the discussion in the issue.

## Test Plan

Issue code added to fixture
