### PR TITLE
Apply NFKC normalization to unicode identifiers when storing bindings in the semantic model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,6 +2394,7 @@ dependencies = [
  "ruff_source_file",
  "ruff_text_size",
  "rustc-hash",
+ "unicode-normalization",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ tracing-tree = { version = "0.2.4" }
 typed-arena = { version = "2.0.2" }
 unic-ucd-category = { version = "0.9" }
 unicode-ident = { version = "1.0.12" }
+unicode-normalization = { version = "0.1.23" }
 unicode-width = { version = "0.1.11" }
 unicode_names2 = { version = "1.2.2" }
 ureq = { version = "2.9.6" }

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_28.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_28.py
@@ -1,0 +1,9 @@
+"""Test that unicode identifiers are NFKC-normalised"""
+
+𝒞 = 500
+print(𝒞)
+print(C + 𝒞)  # 2 references to the same variable due to NFKC normalization
+print(C / 𝒞)
+print(C == 𝑪 == 𝒞 == 𝓒 == 𝕮)
+
+print(𝒟)  # F821

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -156,6 +156,7 @@ mod tests {
     #[test_case(Rule::UndefinedName, Path::new("F821_26.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_26.pyi"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_27.py"))]
+    #[test_case(Rule::UndefinedName, Path::new("F821_28.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.pyi"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_1.py"))]

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_28.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_28.py.snap
@@ -1,0 +1,10 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+F821_28.py:9:7: F821 Undefined name `𝒟`
+  |
+7 | print(C == 𝑪 == 𝒞 == 𝓒 == 𝕮)
+8 | 
+9 | print(𝒟)  # F821
+  |       ^ F821
+  |

--- a/crates/ruff_python_semantic/Cargo.toml
+++ b/crates/ruff_python_semantic/Cargo.toml
@@ -23,6 +23,7 @@ ruff_text_size = { path = "../ruff_text_size" }
 bitflags = { workspace = true }
 is-macro = { workspace = true }
 rustc-hash = { workspace = true }
+unicode-normalization = { workspace = true }
 
 [dev-dependencies]
 ruff_python_parser = { path = "../ruff_python_parser" }

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -4,7 +4,7 @@ use std::ops::{Deref, DerefMut};
 use bitflags::bitflags;
 use ruff_python_ast as ast;
 use rustc_hash::FxHashMap;
-use unicode_normalization::{is_nfkc_quick, IsNormalized, UnicodeNormalization};
+use unicode_normalization::UnicodeNormalization;
 
 use ruff_index::{newtype_index, Idx, IndexSlice, IndexVec};
 
@@ -22,7 +22,7 @@ struct Bindings<'a>(FxHashMap<Cow<'a, str>, BindingId>);
 impl<'a> Bindings<'a> {
     #[inline]
     fn get(&self, name: &str) -> Option<&BindingId> {
-        if matches!(is_nfkc_quick(name.chars()), IsNormalized::Yes) {
+        if name.is_ascii() {
             self.0.get(name)
         } else {
             self.0.get(&*name.nfkc().collect::<String>())
@@ -31,7 +31,7 @@ impl<'a> Bindings<'a> {
 
     #[inline]
     fn insert(&mut self, name: &'a str, value: BindingId) -> Option<BindingId> {
-        if matches!(is_nfkc_quick(name.chars()), IsNormalized::Yes) {
+        if name.is_ascii() {
             self.0.insert(Cow::Borrowed(name), value)
         } else {
             self.0.insert(Cow::Owned(name.nfkc().collect()), value)
@@ -40,7 +40,7 @@ impl<'a> Bindings<'a> {
 
     #[inline]
     fn contains_key(&self, key: &str) -> bool {
-        if matches!(is_nfkc_quick(key.chars()), IsNormalized::Yes) {
+        if key.is_ascii() {
             self.0.contains_key(key)
         } else {
             self.0.contains_key(&*key.nfkc().collect::<String>())

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -22,31 +22,29 @@ struct Bindings<'a>(FxHashMap<Cow<'a, str>, BindingId>);
 impl<'a> Bindings<'a> {
     #[inline]
     fn get(&self, name: &str) -> Option<&BindingId> {
-        self.0.get(name).or({
-            if name.is_ascii() {
-                None
-            } else {
-                self.0.get(&*name.nfkc().collect::<String>())
-            }
-        })
+        if name.is_ascii() {
+            self.0.get(name)
+        } else {
+            self.0.get(&*name.nfkc().collect::<String>())
+        }
     }
 
     #[inline]
     fn insert(&mut self, name: &'a str, value: BindingId) -> Option<BindingId> {
-        let name = {
-            if name.is_ascii() {
-                Cow::Borrowed(name)
-            } else {
-                Cow::Owned(name.nfkc().collect())
-            }
-        };
-        self.0.insert(name, value)
+        if name.is_ascii() {
+            self.0.insert(Cow::Borrowed(name), value)
+        } else {
+            self.0.insert(Cow::Owned(name.nfkc().collect()), value)
+        }
     }
 
     #[inline]
     fn contains_key(&self, key: &str) -> bool {
-        self.0.contains_key(key)
-            || (!key.is_ascii() && self.0.contains_key(&*key.nfkc().collect::<String>()))
+        if key.is_ascii() {
+            self.0.contains_key(key)
+        } else {
+            self.0.contains_key(&*key.nfkc().collect::<String>())
+        }
     }
 
     #[inline]

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -20,34 +20,41 @@ use crate::star_import::StarImport;
 struct Bindings<'a>(FxHashMap<Cow<'a, str>, BindingId>);
 
 impl<'a> Bindings<'a> {
+    #[inline]
     fn get(&self, name: &str) -> Option<&BindingId> {
-        if name.is_ascii() {
-            self.0.get(name)
-        } else {
-            self.0.get(&*name.nfkc().collect::<String>())
-        }
+        self.0.get(name).or({
+            if name.is_ascii() {
+                None
+            } else {
+                self.0.get(&*name.nfkc().collect::<String>())
+            }
+        })
     }
 
+    #[inline]
     fn insert(&mut self, name: &'a str, value: BindingId) -> Option<BindingId> {
-        if name.is_ascii() {
-            self.0.insert(Cow::Borrowed(name), value)
-        } else {
-            self.0.insert(Cow::Owned(name.nfkc().collect()), value)
-        }
+        let name = {
+            if name.is_ascii() {
+                Cow::Borrowed(name)
+            } else {
+                Cow::Owned(name.nfkc().collect())
+            }
+        };
+        self.0.insert(name, value)
     }
 
+    #[inline]
     fn contains_key(&self, key: &str) -> bool {
-        if key.is_ascii() {
-            self.0.contains_key(key)
-        } else {
-            self.0.contains_key(&*key.nfkc().collect::<String>())
-        }
+        self.0.contains_key(key)
+            || (!key.is_ascii() && self.0.contains_key(&*key.nfkc().collect::<String>()))
     }
 
+    #[inline]
     fn values(&self) -> impl Iterator<Item = &BindingId> {
         self.0.values()
     }
 
+    #[inline]
     fn iter(&self) -> impl Iterator<Item = (&Cow<'a, str>, &BindingId)> {
         self.0.iter()
     }

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -4,7 +4,7 @@ use std::ops::{Deref, DerefMut};
 use bitflags::bitflags;
 use ruff_python_ast as ast;
 use rustc_hash::FxHashMap;
-use unicode_normalization::UnicodeNormalization;
+use unicode_normalization::{is_nfkc_quick, IsNormalized, UnicodeNormalization};
 
 use ruff_index::{newtype_index, Idx, IndexSlice, IndexVec};
 
@@ -22,7 +22,7 @@ struct Bindings<'a>(FxHashMap<Cow<'a, str>, BindingId>);
 impl<'a> Bindings<'a> {
     #[inline]
     fn get(&self, name: &str) -> Option<&BindingId> {
-        if name.is_ascii() {
+        if matches!(is_nfkc_quick(name.chars()), IsNormalized::Yes) {
             self.0.get(name)
         } else {
             self.0.get(&*name.nfkc().collect::<String>())
@@ -31,7 +31,7 @@ impl<'a> Bindings<'a> {
 
     #[inline]
     fn insert(&mut self, name: &'a str, value: BindingId) -> Option<BindingId> {
-        if name.is_ascii() {
+        if matches!(is_nfkc_quick(name.chars()), IsNormalized::Yes) {
             self.0.insert(Cow::Borrowed(name), value)
         } else {
             self.0.insert(Cow::Owned(name.nfkc().collect()), value)
@@ -40,7 +40,7 @@ impl<'a> Bindings<'a> {
 
     #[inline]
     fn contains_key(&self, key: &str) -> bool {
-        if key.is_ascii() {
+        if matches!(is_nfkc_quick(key.chars()), IsNormalized::Yes) {
             self.0.contains_key(key)
         } else {
             self.0.contains_key(&*key.nfkc().collect::<String>())


### PR DESCRIPTION
## Summary

Fixes #5003.

Python [applies NFKC normalization to identifiers that use unicode characters](https://docs.python.org/3/reference/lexical_analysis.html#identifiers). That means that F821 should not be emitted if ruff encounters the following snippet (but on `main`, it is), as from Python's perspective, these are all the same identifier:

```py
𝒞 = 500
print(𝒞)
print(C + 𝒞)  # ruff says `C` isn't defined
print(C / 𝒞)
print(C == 𝑪 == 𝒞 == 𝓒 == 𝕮)  # ruff says `C`, `𝑪`, ... isn't defined
```

I fixed this false positive by changing the `bindings` field in `ruff_python_semantic/scope.rs` so that identifiers are always unicode-normalized according to NFKC before being stored in the hashmap. An alternative approach I played around with was to unicode-normalize identifiers in the AST itself. However, this would have had undesirable consequences: the formatter would have started eagerly normalizing unicode characters in identifiers when it reformatted a Python file.

## Test Plan

`cargo test`
