### PR TITLE
Use string flags to mark it as invalid

### DIFF
--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -971,10 +971,17 @@ impl Ranged for FStringExpressionElement {
     }
 }
 
+/// A `FStringLiteralElement` with an empty `value` is an invalid f-string element.
 #[derive(Clone, Debug, PartialEq)]
 pub struct FStringLiteralElement {
     pub range: TextRange,
     pub value: Box<str>,
+}
+
+impl FStringLiteralElement {
+    pub fn is_valid(&self) -> bool {
+        !self.value.is_empty()
+    }
 }
 
 impl Ranged for FStringLiteralElement {
@@ -1516,6 +1523,9 @@ bitflags! {
         /// The string has an `r` or `R` prefix, meaning it is a raw string.
         /// It is invalid to set this flag if `U_PREFIX` is also set.
         const R_PREFIX = 1 << 3;
+
+        /// The string is invalid.
+        const INVALID = 1 << 4;
     }
 }
 
@@ -1544,6 +1554,12 @@ impl StringLiteralFlags {
             StringLiteralPrefix::RString => self.0 |= StringLiteralFlagsInner::R_PREFIX,
             StringLiteralPrefix::UString => self.0 |= StringLiteralFlagsInner::U_PREFIX,
         };
+        self
+    }
+
+    #[must_use]
+    pub fn with_invalid(mut self) -> Self {
+        self.0 |= StringLiteralFlagsInner::INVALID;
         self
     }
 
@@ -1849,6 +1865,9 @@ bitflags! {
 
         /// The bytestring has an `r` or `R` prefix, meaning it is a raw bytestring.
         const R_PREFIX = 1 << 3;
+
+        /// The bytestring is invalid.
+        const INVALID = 1 << 4;
     }
 }
 
@@ -1873,6 +1892,12 @@ impl BytesLiteralFlags {
     #[must_use]
     pub fn with_r_prefix(mut self) -> Self {
         self.0 |= BytesLiteralFlagsInner::R_PREFIX;
+        self
+    }
+
+    #[must_use]
+    pub fn with_invalid(mut self) -> Self {
+        self.0 |= BytesLiteralFlagsInner::INVALID;
         self
     }
 

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -971,7 +971,7 @@ impl Ranged for FStringExpressionElement {
     }
 }
 
-/// A `FStringLiteralElement` with an empty `value` is an invalid f-string element.
+/// An `FStringLiteralElement` with an empty `value` is an invalid f-string element.
 #[derive(Clone, Debug, PartialEq)]
 pub struct FStringLiteralElement {
     pub range: TextRange,
@@ -1524,7 +1524,7 @@ bitflags! {
         /// It is invalid to set this flag if `U_PREFIX` is also set.
         const R_PREFIX = 1 << 3;
 
-        /// The string is invalid.
+        /// The string was deemed invalid by the parser.
         const INVALID = 1 << 4;
     }
 }
@@ -1875,7 +1875,7 @@ bitflags! {
         /// The bytestring has an `r` or `R` prefix, meaning it is a raw bytestring.
         const R_PREFIX = 1 << 3;
 
-        /// The bytestring is invalid.
+        /// The bytestring was deemed invalid by the parser.
         const INVALID = 1 << 4;
     }
 }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1657,6 +1657,15 @@ impl StringLiteral {
     pub fn as_str(&self) -> &str {
         self
     }
+
+    /// Creates an invalid string literal with the given range.
+    pub fn invalid(range: TextRange) -> Self {
+        Self {
+            range,
+            value: "".into(),
+            flags: StringLiteralFlags::default().with_invalid(),
+        }
+    }
 }
 
 impl From<StringLiteral> for Expr {
@@ -1959,6 +1968,15 @@ impl BytesLiteral {
     /// Extracts a byte slice containing the entire [`BytesLiteral`].
     pub fn as_slice(&self) -> &[u8] {
         self
+    }
+
+    /// Creates a new invalid bytes literal with the given range.
+    pub fn invalid(range: TextRange) -> Self {
+        Self {
+            range,
+            value: Box::new([]),
+            flags: BytesLiteralFlags::default().with_invalid(),
+        }
     }
 }
 

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -866,7 +866,7 @@ impl<'src> Parser<'src> {
                         range,
                     });
                 }
-                Ordering::Greater => {}
+                Ordering::Greater => unreachable!(),
             }
         }
 

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::ops::Deref;
 
 use ruff_python_ast::{
@@ -9,9 +10,7 @@ use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use crate::parser::helpers::token_kind_to_cmp_op;
 use crate::parser::progress::ParserProgress;
 use crate::parser::{helpers, FunctionKind, Parser, ParserCtxFlags, EXPR_SET, NEWLINE_EOF_SET};
-use crate::string::{
-    concatenated_strings, parse_fstring_literal_element, parse_string_literal, StringType,
-};
+use crate::string::{parse_fstring_literal_element, parse_string_literal, StringType};
 use crate::token_set::TokenSet;
 use crate::{FStringErrorType, Mode, ParseErrorType, Tok, TokenKind};
 
@@ -818,17 +817,88 @@ impl<'src> Parser<'src> {
                     range,
                 }),
             },
-            _ => concatenated_strings(strings, range).unwrap_or_else(|error| {
-                let location = error.location();
-                self.add_error(ParseErrorType::Lexical(error.into_error()), location);
-
-                #[allow(deprecated)]
-                Expr::Invalid(ast::ExprInvalid {
-                    value: self.src_text(location).into(),
-                    range: location,
-                })
-            }),
+            _ => self.handle_implicitly_concatenated_strings(strings, range),
         }
+    }
+
+    /// Handles implicitly concatenated strings.
+    fn handle_implicitly_concatenated_strings(
+        &mut self,
+        strings: Vec<StringType>,
+        range: TextRange,
+    ) -> Expr {
+        debug_assert!(strings.len() > 1);
+
+        let mut has_fstring = false;
+        let mut byte_literal_count = 0;
+        for string in &strings {
+            match string {
+                StringType::FString(_) => has_fstring = true,
+                StringType::Bytes(_) => byte_literal_count += 1,
+                StringType::Str(_) => {}
+            }
+        }
+        let has_bytes = byte_literal_count > 0;
+
+        if has_bytes {
+            match byte_literal_count.cmp(&strings.len()) {
+                Ordering::Less => {
+                    self.add_error(
+                        ParseErrorType::OtherError(
+                            "cannot mix bytes and non-bytes literals".to_string(),
+                        ),
+                        range,
+                    );
+                }
+                // Only construct a byte expression if all the literals are bytes
+                // otherwise, we'll try either string or f-string. This is to retain
+                // as much information as possible.
+                Ordering::Equal => {
+                    let mut values = Vec::with_capacity(strings.len());
+                    for string in strings {
+                        values.push(match string {
+                            StringType::Bytes(value) => value,
+                            _ => ast::BytesLiteral::invalid(string.range()),
+                        });
+                    }
+                    return Expr::from(ast::ExprBytesLiteral {
+                        value: ast::BytesLiteralValue::concatenated(values),
+                        range,
+                    });
+                }
+                Ordering::Greater => {}
+            }
+        }
+
+        if !has_fstring {
+            let mut values = Vec::with_capacity(strings.len());
+            for string in strings {
+                values.push(match string {
+                    StringType::Str(value) => value,
+                    _ => ast::StringLiteral::invalid(string.range()),
+                });
+            }
+            return Expr::from(ast::ExprStringLiteral {
+                value: ast::StringLiteralValue::concatenated(values),
+                range,
+            });
+        }
+
+        let mut parts = Vec::with_capacity(strings.len());
+        for string in strings {
+            match string {
+                StringType::FString(fstring) => parts.push(ast::FStringPart::FString(fstring)),
+                StringType::Str(string) => parts.push(ast::FStringPart::Literal(string)),
+                StringType::Bytes(bytes) => parts.push(ast::FStringPart::Literal(
+                    ast::StringLiteral::invalid(bytes.range()),
+                )),
+            }
+        }
+
+        Expr::from(ast::ExprFString {
+            value: ast::FStringValue::concatenated(parts),
+            range,
+        })
     }
 
     /// Parses a single string literal.
@@ -851,17 +921,13 @@ impl<'src> Parser<'src> {
 
                 if kind.is_byte_string() {
                     StringType::Bytes(ast::BytesLiteral {
-                        value: self
-                            .src_text(range)
-                            .to_string()
-                            .into_boxed_str()
-                            .into_boxed_bytes(),
+                        value: Box::new([]),
                         range,
                         flags: ast::BytesLiteralFlags::from(kind).with_invalid(),
                     })
                 } else {
                     StringType::Str(ast::StringLiteral {
-                        value: self.src_text(range).to_string().into_boxed_str(),
+                        value: "".into(),
                         range,
                         flags: ast::StringLiteralFlags::from(kind).with_invalid(),
                     })
@@ -923,7 +989,7 @@ impl<'src> Parser<'src> {
                                     location,
                                 );
                                 ast::FStringLiteralElement {
-                                    value: parser.src_text(range).to_string().into_boxed_str(),
+                                    value: "".into(),
                                     range,
                                 }
                             },


### PR DESCRIPTION
## Summary

This PR updates the string flags to include an `Invalid` variant for any invalid string nodes as deemed by the parser. This is to avoid dropping the nodes and instead just mark it as invalid. The nodes will be empty for now but we can discuss on whether to keep the raw source text or not. It's not really required because the range can be used to get the same.

It also adds a new `handle_implicitly_concatenated_strings` method which is similar to existing `concatenated_strings` function. The reason to have a separate method is to avoid dropping all strings if there's an error. The error being that it's concatenating bytes and non-bytes literal. Now, we need to decide which strings to retain. Currently, I've kept it simple to retain bytes literal _only_ if all of them are bytes otherwise we'll have string / f-string with invalid nodes instead of bytes literal.

This removes the need for having a `StringType::Invalid` variant.

## Test Plan

- [x] Existing test cases pass
- [x] No performance regression
