### PR TITLE
Remove shadowed import, rather than shadowing import, in F811

### DIFF
--- a/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
@@ -22,6 +22,18 @@ use ruff_source_file::SourceRow;
 /// import foo
 /// import bar
 /// ```
+///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe when the redefinition matches the
+/// same bound name as the original definition, but maps to a different
+/// symbol, as removing the redefinition could change behavior.
+///
+/// For example, removing either import definition in the following
+/// snippet would lead to a change in behavior:
+/// ```python
+/// import datetime
+/// from datetime import datetime
+/// ```
 #[violation]
 pub struct RedefinedWhileUnused {
     pub name: String,

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_1.py.snap
@@ -1,9 +1,13 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F811_1.py:1:25: F811 Redefinition of unused `FU` from line 1
+F811_1.py:1:25: F811 [*] Redefinition of unused `FU` from line 1
   |
 1 | import fu as FU, bar as FU
   |                         ^^ F811
   |
   = help: Remove definition: `FU`
+
+ℹ Unsafe fix
+1   |-import fu as FU, bar as FU
+  1 |+import bar as FU

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_12.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_12.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F811_12.py:6:20: F811 Redefinition of unused `mixer` from line 2
+F811_12.py:6:20: F811 [*] Redefinition of unused `mixer` from line 2
   |
 4 |     pass
 5 | else:
@@ -10,3 +10,11 @@ F811_12.py:6:20: F811 Redefinition of unused `mixer` from line 2
 7 | mixer(123)
   |
   = help: Remove definition: `mixer`
+
+ℹ Unsafe fix
+1 1 | try:
+2   |-    from aa import mixer
+  2 |+    pass
+3 3 | except ImportError:
+4 4 |     pass
+5 5 | else:

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_17.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_17.py.snap
@@ -12,13 +12,11 @@ F811_17.py:6:12: F811 [*] Redefinition of unused `fu` from line 2
   = help: Remove definition: `fu`
 
 ℹ Safe fix
-3 3 | 
-4 4 | 
-5 5 | def bar():
-6   |-    import fu
-7 6 | 
-8 7 |     def baz():
-9 8 |         def fu():
+1 1 | """Test that shadowing a global name with a nested function generates a warning."""
+2   |-import fu
+3 2 | 
+4 3 | 
+5 4 | def bar():
 
 F811_17.py:9:13: F811 Redefinition of unused `fu` from line 6
    |
@@ -28,5 +26,3 @@ F811_17.py:9:13: F811 Redefinition of unused `fu` from line 6
 10 |             pass
    |
    = help: Remove definition: `fu`
-
-

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_2.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_2.py.snap
@@ -1,9 +1,13 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F811_2.py:1:34: F811 Redefinition of unused `FU` from line 1
+F811_2.py:1:34: F811 [*] Redefinition of unused `FU` from line 1
   |
 1 | from moo import fu as FU, bar as FU
   |                                  ^^ F811
   |
   = help: Remove definition: `FU`
+
+ℹ Unsafe fix
+1   |-from moo import fu as FU, bar as FU
+  1 |+from moo import bar as FU

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_21.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_21.py.snap
@@ -12,14 +12,12 @@ F811_21.py:32:5: F811 [*] Redefinition of unused `Sequence` from line 26
    = help: Remove definition: `Sequence`
 
 ℹ Safe fix
-29 29 | # This should ignore the first error.
-30 30 | from typing import (
-31 31 |     List,  # noqa: F811
-32    |-    Sequence,
-33    |-)
-   32 |+    )
-34 33 | 
-35 34 | # This should ignore both errors.
-36 35 | from typing import (  # noqa
-
-
+23 23 | # This should ignore both errors.
+24 24 | from typing import (
+25 25 |     List,  # noqa
+26    |-    Sequence,  # noqa
+27    |-)
+   26 |+    )
+28 27 | 
+29 28 | # This should ignore the first error.
+30 29 | from typing import (

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_23.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_23.py.snap
@@ -1,10 +1,16 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F811_23.py:4:15: F811 Redefinition of unused `foo` from line 3
+F811_23.py:4:15: F811 [*] Redefinition of unused `foo` from line 3
   |
 3 | import foo as foo
 4 | import bar as foo
   |               ^^^ F811
   |
   = help: Remove definition: `foo`
+
+ℹ Unsafe fix
+1 1 | """Test that shadowing an explicit re-export produces a warning."""
+2 2 | 
+3   |-import foo as foo
+4 3 | import bar as foo

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_28.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F811_F811_28.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pyflakes/mod.rs
 ---
-F811_28.py:4:22: F811 Redefinition of unused `datetime` from line 3
+F811_28.py:4:22: F811 [*] Redefinition of unused `datetime` from line 3
   |
 3 | import datetime
 4 | from datetime import datetime
@@ -10,3 +10,11 @@ F811_28.py:4:22: F811 Redefinition of unused `datetime` from line 3
 6 | datetime(1, 2, 3)
   |
   = help: Remove definition: `datetime`
+
+ℹ Unsafe fix
+1 1 | """Regression test for: https://github.com/astral-sh/ruff/issues/10384"""
+2 2 | 
+3   |-import datetime
+4 3 | from datetime import datetime
+5 4 | 
+6 5 | datetime(1, 2, 3)

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_global_import_in_local_scope.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__del_shadowed_global_import_in_local_scope.snap
@@ -28,12 +28,8 @@ source: crates/ruff_linter/src/rules/pyflakes/mod.rs
   = help: Remove definition: `os`
 
 ℹ Safe fix
-2 2 | import os
-3 3 | 
-4 4 | def f():
-5   |-    import os
-6 5 | 
-7 6 |     # Despite this `del`, `import os` in `f` should still be flagged as shadowing an unused
-8 7 |     # import.
-
-
+1 1 | 
+2   |-import os
+3 2 | 
+4 3 | def f():
+5 4 |     import os


### PR DESCRIPTION
## Summary

Today, in F811, if you have code like:

```
import datetime
from datetime import datetime
```

We flag a violation on the second line (the line of the redefinition), and the fix we generate is a removal of the second import. In #10387, I removed the fix in these cases, when the imports map to different symbols.

It seems "more correct", though to remove the first import, since the second import is the one that will _actually_ be used in practice. This PR changes that behavior.

However, I'm sure if this is actually correct, because we're now changing code that's far away from the violation itself. There's an example in our test suite that shows why this isn't ideal:

```python
from typing import (
    Sequence  # noqa
)

from typing import (
    Sequence
)
```

In this case, we'd remove the `Sequence  # noqa` line, since the `# noqa` isn't on the line containing the F811 violation. (I'm not really interested in parsing out the `# noqa` violation from the `Sequence  # noqa` line, because it risks breaking a bunch of assumptions about how `# noqa` works.)

Anyway, interested in feedback.
