### PR TITLE
Use ruff.toml format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,9 @@ Ruff can be configured through a `pyproject.toml`, `ruff.toml`, or `.ruff.toml` 
 [_Configuration_](https://docs.astral.sh/ruff/configuration/), or [_Settings_](https://docs.astral.sh/ruff/settings/)
 for a complete list of all configuration options).
 
-If left unspecified, Ruff's default configuration is equivalent to:
+If left unspecified, Ruff's default configuration is equivalent to the following `ruff.toml` file:
 
 ```toml
-[tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [
     ".bzr",
@@ -224,7 +223,7 @@ indent-width = 4
 # Assume Python 3.8
 target-version = "py38"
 
-[tool.ruff.lint]
+[lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 select = ["E4", "E7", "E9", "F"]
 ignore = []
@@ -236,7 +235,7 @@ unfixable = []
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-[tool.ruff.format]
+[format]
 # Like Black, use double quotes for strings.
 quote-style = "double"
 
@@ -250,11 +249,20 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 ```
 
-Some configuration options can be provided via the command-line, such as those related to
-rule enablement and disablement, file discovery, and logging level:
+Note that, in a `pyproject.toml`, each section header should be prefixed with `tool.ruff`. For
+example, `[lint]` should be replaced with `[tool.ruff.lint]`.
+
+Some configuration options can be provided via dedicated command-line arguments, such as those
+related to rule enablement and disablement, file discovery, and logging level:
 
 ```shell
-ruff check path/to/code/ --select F401 --select F403 --quiet
+ruff check --select F401 --select F403 --quiet
+```
+
+The remaining configuration options can be provided through a catch-all `--config` argument:
+
+```shell
+ruff check --config "lint.per-file-ignores = {'some_file.py' = ['F841']}"
 ```
 
 See `ruff help` for more on Ruff's top-level commands, or `ruff help check` and `ruff help format`


### PR DESCRIPTION
## Summary

See feedback in https://github.com/astral-sh/ruff/issues/4725#issuecomment-1994615409.

In the docs, we use a tabbed interface for express `ruff.toml` vs. `pyproject.toml`. Here, it might be clearer to default to `ruff.toml`, since it's more obviously _not_ `pyproject.toml`. But either way, this PR attempts to clarify that there's a difference.
