### PR TITLE
`ruff server` default to current working directory in environments without any root directories or workspaces

### DIFF
--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -1,6 +1,5 @@
 //! Scheduling, I/O, and API endpoints.
 
-use anyhow::anyhow;
 use lsp::Connection;
 use lsp_server as lsp;
 use lsp_types as types;
@@ -46,9 +45,7 @@ impl Server {
             .workspace_folders
             .map(|folders| folders.into_iter().map(|folder| folder.uri).collect())
             .or_else(|| init_params.root_uri.map(|u| vec![u]))
-            .ok_or_else(|| {
-                anyhow!("No workspace or root URI was given in the LSP initialization parameters. The server cannot start.")
-            })?;
+            .unwrap_or_default();
 
         let initialize_data = serde_json::json!({
             "capabilities": server_capabilities,


### PR DESCRIPTION
## Summary

Fixes #10324

This removes an overeager failure case where we would exit early if no root directory or workspace folders were provided on server initialization. We now fall-back to the current working directory as a workspace for that file.

## Test Plan
N/A
