### PR TITLE
Automatic configuration reloading for `ruff server`

### DIFF
--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -69,7 +69,7 @@ impl Server {
 
         conn.initialize_finish(id, initialize_data)?;
 
-        // Register capabilites
+        // Register capabilities
         conn.sender
             .send(lsp_server::Message::Request(lsp_server::Request {
                 id: 1.into(),

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -117,7 +117,7 @@ impl Server {
                 tracing::error!("Timed out while waiting for client to acknowledge registration of dynamic capabilities");
             });
         } else {
-            tracing::warn!("LSP client does not support dynamic file watcher registration - automatic configuration reloading will not be available.")
+            tracing::warn!("LSP client does not support dynamic file watcher registration - automatic configuration reloading will not be available.");
         }
 
         Ok(Self {

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -118,6 +118,8 @@ impl Server {
             });
 
             next_request_id.fetch_add(1, Ordering::SeqCst);
+        } else {
+            tracing::warn!("LSP client does not support dynamic file watcher registration - automatic configuration reloading will not be available.")
         }
 
         Ok(Self {

--- a/crates/ruff_server/src/server.rs
+++ b/crates/ruff_server/src/server.rs
@@ -84,7 +84,7 @@ impl Server {
             // Register capabilities
             conn.sender
                 .send(lsp_server::Message::Request(lsp_server::Request {
-                    id: next_request_id.load(Ordering::Relaxed).into(),
+                    id: next_request_id.fetch_add(1, Ordering::Relaxed).into(),
                     method: "client/registerCapability".into(),
                     params: serde_json::to_value(lsp_types::RegistrationParams {
                         registrations: vec![lsp_types::Registration {
@@ -116,8 +116,6 @@ impl Server {
             let _ = conn.receiver.recv_timeout(Duration::from_secs(5)).map_err(|_| {
                 tracing::error!("Timed out while waiting for client to acknowledge registration of dynamic capabilities");
             });
-
-            next_request_id.fetch_add(1, Ordering::SeqCst);
         } else {
             tracing::warn!("LSP client does not support dynamic file watcher registration - automatic configuration reloading will not be available.")
         }

--- a/crates/ruff_server/src/server/api.rs
+++ b/crates/ruff_server/src/server/api.rs
@@ -65,6 +65,9 @@ pub(super) fn notification<'a>(notif: server::Notification) -> Task<'a> {
         notification::DidChangeConfiguration::METHOD => {
             local_notification_task::<notification::DidChangeConfiguration>(notif)
         }
+        notification::DidChangeWatchedFiles::METHOD => {
+            local_notification_task::<notification::DidChangeWatchedFiles>(notif)
+        }
         notification::DidChangeWorkspace::METHOD => {
             local_notification_task::<notification::DidChangeWorkspace>(notif)
         }

--- a/crates/ruff_server/src/server/api/notifications.rs
+++ b/crates/ruff_server/src/server/api/notifications.rs
@@ -1,6 +1,7 @@
 mod cancel;
 mod did_change;
 mod did_change_configuration;
+mod did_change_watched_files;
 mod did_change_workspace;
 mod did_close;
 mod did_open;
@@ -9,6 +10,7 @@ use super::traits::{NotificationHandler, SyncNotificationHandler};
 pub(super) use cancel::Cancel;
 pub(super) use did_change::DidChange;
 pub(super) use did_change_configuration::DidChangeConfiguration;
+pub(super) use did_change_watched_files::DidChangeWatchedFiles;
 pub(super) use did_change_workspace::DidChangeWorkspace;
 pub(super) use did_close::DidClose;
 pub(super) use did_open::DidOpen;

--- a/crates/ruff_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/ruff_server/src/server/api/notifications/did_change_watched_files.rs
@@ -1,0 +1,27 @@
+use crate::server::api::LSPResult;
+use crate::server::client::Notifier;
+use crate::server::Result;
+use crate::session::Session;
+use lsp_types as types;
+use lsp_types::notification as notif;
+
+pub(crate) struct DidChangeWatchedFiles;
+
+impl super::NotificationHandler for DidChangeWatchedFiles {
+    type NotificationType = notif::DidChangeWatchedFiles;
+}
+
+impl super::SyncNotificationHandler for DidChangeWatchedFiles {
+    fn run(
+        session: &mut Session,
+        _notifier: Notifier,
+        params: types::DidChangeWatchedFilesParams,
+    ) -> Result<()> {
+        for change in params.changes {
+            session
+                .reload_configuration(&change.uri)
+                .with_failure_code(lsp_server::ErrorCode::InternalError)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/ruff_server/src/session.rs
+++ b/crates/ruff_server/src/session.rs
@@ -111,6 +111,10 @@ impl Session {
             .ok_or_else(|| anyhow!("Tried to open unavailable document `{url}`"))
     }
 
+    pub(crate) fn reload_configuration(&mut self, url: &Url) -> crate::Result<()> {
+        self.workspaces.reload_configuration(url)
+    }
+
     pub(crate) fn open_workspace_folder(&mut self, url: &Url) -> crate::Result<()> {
         self.workspaces.open_workspace_folder(url)?;
         Ok(())
@@ -232,46 +236,55 @@ impl Workspaces {
 
     fn snapshot(&self, document_url: &Url) -> Option<DocumentRef> {
         self.workspace_for_url(document_url)
-            .and_then(|w| w.open_documents.snapshot(document_url))
+            .and_then(|(_, workspace)| workspace.open_documents.snapshot(document_url))
     }
 
     fn controller(&mut self, document_url: &Url) -> Option<&mut DocumentController> {
         self.workspace_for_url_mut(document_url)
-            .and_then(|w| w.open_documents.controller(document_url))
+            .and_then(|(_, workspace)| workspace.open_documents.controller(document_url))
     }
 
     fn configuration(&self, document_url: &Url) -> Option<&Arc<RuffConfiguration>> {
         self.workspace_for_url(document_url)
-            .map(|w| &w.configuration)
+            .map(|(_, workspace)| &workspace.configuration)
+    }
+
+    fn reload_configuration(&mut self, changed_url: &Url) -> crate::Result<()> {
+        let (path, workspace) = self
+            .workspace_for_url_mut(changed_url)
+            .ok_or_else(|| anyhow!("Workspace not found for {changed_url}"))?;
+        workspace.reload_configuration(path);
+        Ok(())
     }
 
     fn open(&mut self, url: &Url, contents: String, version: DocumentVersion) {
-        if let Some(w) = self.workspace_for_url_mut(url) {
-            w.open_documents.open(url, contents, version);
+        if let Some((_, workspace)) = self.workspace_for_url_mut(url) {
+            workspace.open_documents.open(url, contents, version);
         }
     }
 
     fn close(&mut self, url: &Url) -> crate::Result<()> {
         self.workspace_for_url_mut(url)
             .ok_or_else(|| anyhow!("Workspace not found for {url}"))?
+            .1
             .open_documents
             .close(url)
     }
 
-    fn workspace_for_url(&self, url: &Url) -> Option<&Workspace> {
+    fn workspace_for_url(&self, url: &Url) -> Option<(&Path, &Workspace)> {
         let path = url.to_file_path().ok()?;
         self.0
             .range(..path)
             .next_back()
-            .map(|(_, workspace)| workspace)
+            .map(|(path, workspace)| (path.as_path(), workspace))
     }
 
-    fn workspace_for_url_mut(&mut self, url: &Url) -> Option<&mut Workspace> {
+    fn workspace_for_url_mut(&mut self, url: &Url) -> Option<(&Path, &mut Workspace)> {
         let path = url.to_file_path().ok()?;
         self.0
             .range_mut(..path)
             .next_back()
-            .map(|(_, workspace)| workspace)
+            .map(|(path, workspace)| (path.as_path(), workspace))
     }
 }
 
@@ -290,6 +303,10 @@ impl Workspace {
                 configuration: Arc::new(configuration),
             },
         ))
+    }
+
+    fn reload_configuration(&mut self, path: &Path) {
+        self.configuration = Arc::new(Self::find_configuration_or_fallback(path));
     }
 
     fn find_configuration_or_fallback(root: &Path) -> RuffConfiguration {


### PR DESCRIPTION
## Summary

Fixes #10366.

`ruff server` now registers a file watcher on the client side using the LSP protocol, and listen for events on configuration files. On such an event, it reloads the configuration in the 'nearest' workspace to the file that was changed.

## Test Plan

N/A
