### PR TITLE
Fix string parsing error ranges

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1439,7 +1439,7 @@ impl std::fmt::Display for LexicalErrorType {
             LexicalErrorType::InvalidByteLiteral => {
                 write!(f, "bytes can only contain ASCII literal characters")
             }
-            LexicalErrorType::UnicodeError => write!(f, "Got unexpected unicode name"),
+            LexicalErrorType::UnicodeError => write!(f, "Got unexpected unicode"),
             LexicalErrorType::NestingError => write!(f, "Got unexpected nesting"),
             LexicalErrorType::IndentationError => {
                 write!(f, "unindent does not match any outer indentation level")

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1439,7 +1439,7 @@ impl std::fmt::Display for LexicalErrorType {
             LexicalErrorType::InvalidByteLiteral => {
                 write!(f, "bytes can only contain ASCII literal characters")
             }
-            LexicalErrorType::UnicodeError => write!(f, "Got unexpected unicode"),
+            LexicalErrorType::UnicodeError => write!(f, "Got unexpected unicode name"),
             LexicalErrorType::NestingError => write!(f, "Got unexpected nesting"),
             LexicalErrorType::IndentationError => {
                 write!(f, "unindent does not match any outer indentation level")

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__invalid_byte_literal_error.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__invalid_byte_literal_error.snap
@@ -1,0 +1,10 @@
+---
+source: crates/ruff_python_parser/src/string.rs
+expression: error
+---
+ParseError {
+    error: Lexical(
+        InvalidByteLiteral,
+    ),
+    location: 6..6,
+}

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__invalid_unicode_literal.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__invalid_unicode_literal.snap
@@ -4,7 +4,7 @@ expression: error
 ---
 ParseError {
     error: Lexical(
-        InvalidByteLiteral,
+        UnicodeError,
     ),
-    location: 6..10,
+    location: 4..6,
 }

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__invalid_unicode_name_error.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__invalid_unicode_name_error.snap
@@ -1,0 +1,10 @@
+---
+source: crates/ruff_python_parser/src/string.rs
+expression: error
+---
+ParseError {
+    error: Lexical(
+        UnicodeError,
+    ),
+    location: 4..11,
+}

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__missing_unicode_lbrace_error.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__missing_unicode_lbrace_error.snap
@@ -1,0 +1,10 @@
+---
+source: crates/ruff_python_parser/src/string.rs
+expression: error
+---
+ParseError {
+    error: Lexical(
+        MissingUnicodeLbrace,
+    ),
+    location: 3..3,
+}

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__missing_unicode_rbrace_error.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__missing_unicode_rbrace_error.snap
@@ -1,0 +1,10 @@
+---
+source: crates/ruff_python_parser/src/string.rs
+expression: error
+---
+ParseError {
+    error: Lexical(
+        MissingUnicodeRbrace,
+    ),
+    location: 9..9,
+}

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -171,7 +171,7 @@ impl StringParser {
         let Some(close_idx) = self.source[self.cursor..].find('}') else {
             return Err(LexicalError::new(
                 LexicalErrorType::MissingUnicodeRbrace,
-                TextRange::empty(start_pos),
+                TextRange::empty(self.compute_position(self.source.len())),
             ));
         };
 
@@ -881,6 +881,38 @@ mod tests {
         let parse_ast = parse_suite(source).unwrap();
 
         insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_missing_unicode_lbrace_error() {
+        let source = r"'\N '";
+        let error = parse_suite(source).unwrap_err();
+
+        insta::assert_debug_snapshot!(error);
+    }
+
+    #[test]
+    fn test_missing_unicode_rbrace_error() {
+        let source = r"'\N{SPACE'";
+        let error = parse_suite(source).unwrap_err();
+
+        insta::assert_debug_snapshot!(error);
+    }
+
+    #[test]
+    fn test_invalid_unicode_name_error() {
+        let source = r"'\N{INVALID}'";
+        let error = parse_suite(source).unwrap_err();
+
+        insta::assert_debug_snapshot!(error);
+    }
+
+    #[test]
+    fn test_invalid_byte_literal_error() {
+        let source = r"b'123a𝐁c'";
+        let error = parse_suite(source).unwrap_err();
+
+        insta::assert_debug_snapshot!(error);
     }
 
     macro_rules! test_aliases_parse {


### PR DESCRIPTION
## Summary

This PR fixes the error location report for string parsing.

In a lot of places we need to use an empty range because otherwise it could panic when trying to index a multibyte unicode characters.

## Test Plan

Add test cases and update the snapshots.
