### PR TITLE
Allow trailing ellipsis in `typing.TYPE_CHECKING`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE790.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE790.py
@@ -227,3 +227,11 @@ class Repro[int](Protocol):
     def impl(self) -> str:
         """Docstring"""
         return self.func()
+
+
+import typing
+
+if typing.TYPE_CHECKING:
+    def contains_meaningful_ellipsis() -> list[int]:
+        """Allow this in a TYPE_CHECKING block."""
+        ...

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_placeholder.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_placeholder.rs
@@ -83,6 +83,12 @@ pub(crate) fn unnecessary_placeholder(checker: &mut Checker, body: &[Stmt]) {
         return;
     }
 
+    // In a type-checking block, a trailing ellipsis might be meaningful. A
+    // user might be using the type-checking context to declare a stub.
+    if checker.semantic().in_type_checking_block() {
+        return;
+    }
+
     for stmt in body {
         let kind = match stmt {
             Stmt::Pass(_) => Placeholder::Pass,

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_placeholder.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/unnecessary_placeholder.rs
@@ -83,16 +83,16 @@ pub(crate) fn unnecessary_placeholder(checker: &mut Checker, body: &[Stmt]) {
         return;
     }
 
-    // In a type-checking block, a trailing ellipsis might be meaningful. A
-    // user might be using the type-checking context to declare a stub.
-    if checker.semantic().in_type_checking_block() {
-        return;
-    }
-
     for stmt in body {
         let kind = match stmt {
             Stmt::Pass(_) => Placeholder::Pass,
             Stmt::Expr(expr) if expr.value.is_ellipsis_literal_expr() => {
+                // In a type-checking block, a trailing ellipsis might be meaningful. A
+                // user might be using the type-checking context to declare a stub.
+                if checker.semantic().in_type_checking_block() {
+                    return;
+                }
+
                 // Ellipses are significant in protocol methods and abstract methods. Specifically,
                 // Pyright uses the presence of an ellipsis to indicate that a method is a stub,
                 // rather than a default implementation.


### PR DESCRIPTION
## Summary

Trailing ellipses in objects defined in `typing.TYPE_CHECKING` might be meaningful (it might be declaring a stub). Thus, we should skip the `unnecessary-placeholder` (`PIE970`) rule in such contexts.

Closes #10358.

## Test Plan

`cargo nextest run`
