### PR TITLE
Track conditional deletions in the semantic model

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/global_variable_not_assigned.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/global_variable_not_assigned.py
@@ -11,6 +11,13 @@ def f():
     print(X)
 
 
+def f():
+    global X
+
+    if X > 0:
+        del X
+
+
 ###
 # Non-errors.
 ###

--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{Diagnostic, Fix};
 use ruff_python_semantic::analyze::visibility;
-use ruff_python_semantic::{Binding, BindingKind, Imported, ScopeKind};
+use ruff_python_semantic::{Binding, BindingKind, Imported, ResolvedReference, ScopeKind};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -91,13 +91,29 @@ pub(crate) fn deferred_scopes(checker: &mut Checker) {
         if checker.enabled(Rule::GlobalVariableNotAssigned) {
             for (name, binding_id) in scope.bindings() {
                 let binding = checker.semantic.binding(binding_id);
+                // If the binding is a `global`, then it's a top-level `global` that was never
+                // assigned in the current scope. If it were assigned, the `global` would be
+                // shadowed by the assignment.
                 if binding.kind.is_global() {
-                    diagnostics.push(Diagnostic::new(
-                        pylint::rules::GlobalVariableNotAssigned {
-                            name: (*name).to_string(),
-                        },
-                        binding.range(),
-                    ));
+                    // If the binding was conditionally deleted, it will include a reference within
+                    // a `Del` context, but won't be shadowed by a `BindingKind::Deletion`, as in:
+                    // ```python
+                    // if condition:
+                    //     del var
+                    // ```
+                    if binding
+                        .references
+                        .iter()
+                        .map(|id| checker.semantic.reference(*id))
+                        .all(ResolvedReference::is_load)
+                    {
+                        diagnostics.push(Diagnostic::new(
+                            pylint::rules::GlobalVariableNotAssigned {
+                                name: (*name).to_string(),
+                            },
+                            binding.range(),
+                        ));
+                    }
                 }
             }
         }

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -540,7 +540,11 @@ impl<'a> Visitor<'a> for Checker<'a> {
                     for name in names {
                         if let Some((scope_id, binding_id)) = self.semantic.nonlocal(name) {
                             // Mark the binding as "used".
-                            self.semantic.add_local_reference(binding_id, name.range());
+                            self.semantic.add_local_reference(
+                                binding_id,
+                                ExprContext::Load,
+                                name.range(),
+                            );
 
                             // Mark the binding in the enclosing scope as "rebound" in the current
                             // scope.
@@ -2113,7 +2117,8 @@ impl<'a> Checker<'a> {
                 // Mark anything referenced in `__all__` as used.
                 // TODO(charlie): `range` here should be the range of the name in `__all__`, not
                 // the range of `__all__` itself.
-                self.semantic.add_global_reference(binding_id, range);
+                self.semantic
+                    .add_global_reference(binding_id, ExprContext::Load, range);
             } else {
                 if self.semantic.global_scope().uses_star_imports() {
                     if self.enabled(Rule::UndefinedLocalWithImportStarUsage) {

--- a/crates/ruff_linter/src/renamer.rs
+++ b/crates/ruff_linter/src/renamer.rs
@@ -255,6 +255,7 @@ impl Renamer {
             | BindingKind::ClassDefinition(_)
             | BindingKind::FunctionDefinition(_)
             | BindingKind::Deletion
+            | BindingKind::ConditionalDeletion(_)
             | BindingKind::UnboundException(_) => {
                 Some(Edit::range_replacement(target.to_string(), binding.range()))
             }

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -121,8 +121,7 @@ pub(crate) fn runtime_import_in_type_checking_block(
                 checker
                     .semantic()
                     .reference(reference_id)
-                    .context()
-                    .is_runtime()
+                    .in_runtime_context()
             })
         {
             let Some(node_id) = binding.source else {
@@ -155,8 +154,7 @@ pub(crate) fn runtime_import_in_type_checking_block(
                 if checker.settings.flake8_type_checking.quote_annotations
                     && binding.references().all(|reference_id| {
                         let reference = checker.semantic().reference(reference_id);
-                        reference.context().is_typing()
-                            || reference.in_runtime_evaluated_annotation()
+                        reference.in_typing_context() || reference.in_runtime_evaluated_annotation()
                     })
                 {
                     actions
@@ -268,7 +266,7 @@ fn quote_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) 
             .flat_map(|ImportBinding { binding, .. }| {
                 binding.references.iter().filter_map(|reference_id| {
                     let reference = checker.semantic().reference(*reference_id);
-                    if reference.context().is_runtime() {
+                    if reference.in_runtime_context() {
                         Some(quote_annotation(
                             reference.expression_id()?,
                             checker.semantic(),

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -499,7 +499,7 @@ fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) ->
             .flat_map(|ImportBinding { binding, .. }| {
                 binding.references.iter().filter_map(|reference_id| {
                     let reference = checker.semantic().reference(*reference_id);
-                    if reference.context().is_runtime() {
+                    if reference.in_runtime_context() {
                         Some(quote_annotation(
                             reference.expression_id()?,
                             checker.semantic(),

--- a/crates/ruff_linter/src/rules/pylint/rules/non_ascii_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/non_ascii_name.rs
@@ -67,6 +67,7 @@ pub(crate) fn non_ascii_name(binding: &Binding, locator: &Locator) -> Option<Dia
         | BindingKind::FromImport(_)
         | BindingKind::SubmoduleImport(_)
         | BindingKind::Deletion
+        | BindingKind::ConditionalDeletion(_)
         | BindingKind::UnboundException(_) => {
             return None;
         }

--- a/crates/ruff_python_semantic/src/reference.rs
+++ b/crates/ruff_python_semantic/src/reference.rs
@@ -3,10 +3,10 @@ use std::ops::Deref;
 use bitflags::bitflags;
 
 use ruff_index::{newtype_index, IndexSlice, IndexVec};
+use ruff_python_ast::ExprContext;
 use ruff_source_file::Locator;
 use ruff_text_size::{Ranged, TextRange};
 
-use crate::context::ExecutionContext;
 use crate::scope::ScopeId;
 use crate::{Exceptions, NodeId, SemanticModelFlags};
 
@@ -18,10 +18,12 @@ pub struct ResolvedReference {
     node_id: Option<NodeId>,
     /// The scope in which the reference is defined.
     scope_id: ScopeId,
-    /// The range of the reference in the source code.
-    range: TextRange,
+    /// The expression context in which the reference occurs (e.g., `Load`, `Store`, `Del`).
+    ctx: ExprContext,
     /// The model state in which the reference occurs.
     flags: SemanticModelFlags,
+    /// The range of the reference in the source code.
+    range: TextRange,
 }
 
 impl ResolvedReference {
@@ -35,13 +37,19 @@ impl ResolvedReference {
         self.scope_id
     }
 
-    /// The [`ExecutionContext`] of the reference.
-    pub const fn context(&self) -> ExecutionContext {
-        if self.flags.intersects(SemanticModelFlags::TYPING_CONTEXT) {
-            ExecutionContext::Typing
-        } else {
-            ExecutionContext::Runtime
-        }
+    /// Return `true` if the reference occurred in a `Load` operation.
+    pub const fn is_load(&self) -> bool {
+        self.ctx.is_load()
+    }
+
+    /// Return `true` if the context is in a typing context.
+    pub const fn in_typing_context(&self) -> bool {
+        self.flags.intersects(SemanticModelFlags::TYPING_CONTEXT)
+    }
+
+    /// Return `true` if the context is in a runtime context.
+    pub const fn in_runtime_context(&self) -> bool {
+        !self.flags.intersects(SemanticModelFlags::TYPING_CONTEXT)
     }
 
     /// Return `true` if the context is in a typing-only type annotation.
@@ -108,14 +116,16 @@ impl ResolvedReferences {
         &mut self,
         scope_id: ScopeId,
         node_id: Option<NodeId>,
-        range: TextRange,
+        ctx: ExprContext,
         flags: SemanticModelFlags,
+        range: TextRange,
     ) -> ResolvedReferenceId {
         self.0.push(ResolvedReference {
             node_id,
             scope_id,
-            range,
+            ctx,
             flags,
+            range,
         })
     }
 }


### PR DESCRIPTION
## Summary

Given `del X`, we'll typically add a `BindingKind::Deletion` to `X` to shadow the current binding. However, if the deletion is inside of a conditional operation, we _won't_, as in:

```python
def f():
    global X

    if X > 0:
        del X
```

We will, however, track it as a reference to the binding. This PR adds the expression context to those resolved references, so that we can detect that the `X` in `global X` was "assigned to".

Closes https://github.com/astral-sh/ruff/issues/10397.
