### PR TITLE
Add `repos/` to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+repos/
 
 # Translations
 *.mo


### PR DESCRIPTION
## Summary

I would like to add `repos/` to the gitignore since it is given as an example for the cache directory path in [the ecosystem check's README](https://github.com/astral-sh/ruff/tree/main/python/ruff-ecosystem#development):

```console
ruff-ecosystem check ruff "./target/debug/ruff" --cache ./repos
```