### PR TITLE
Bug fix: Prevent fully defined links [``name``](link) from being reformatted

### DIFF
--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -102,16 +102,15 @@ fn process_documentation(documentation: &str, out: &mut String, rule_name: &str)
     // a non-CommonMark-compliant Markdown parser, which doesn't support code
     // tags in link definitions
     // (see https://github.com/Python-Markdown/markdown/issues/280).
-    let documentation = Regex::new(r"\[`([^`]*?)`]($|[^\[])").unwrap().replace_all(
-        documentation,
-        |caps: &Captures| {
+    let documentation = Regex::new(r"\[`([^`]*?)`]($|[^\[\(])")
+        .unwrap()
+        .replace_all(documentation, |caps: &Captures| {
             format!(
                 "[`{option}`][{option}]{sep}",
                 option = &caps[1],
                 sep = &caps[2]
             )
-        },
-    );
+        });
 
     for line in documentation.split_inclusive('\n') {
         if line.starts_with("## ") {
@@ -159,7 +158,7 @@ mod tests {
         process_documentation(
             "
 See also [`lint.mccabe.max-complexity`] and [`lint.task-tags`].
-Something [`else`][other].
+Something [`else`][other]. Some [link](https://example.com).
 
 ## Options
 
@@ -174,7 +173,7 @@ Something [`else`][other].
             output,
             "
 See also [`lint.mccabe.max-complexity`][lint.mccabe.max-complexity] and [`lint.task-tags`][lint.task-tags].
-Something [`else`][other].
+Something [`else`][other]. Some [link](https://example.com).
 
 ## Options
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Currently fully define markdown links which include ticks are being reformatted by 
https://github.com/astral-sh/ruff/blob/861998612300520f2c18dbc7b8a6226300ceb508/crates/ruff_dev/src/generate_docs.rs#L105-L114

```[`name`](link)``` -> ```[`name`][name](link)```

For example: https://docs.astral.sh/ruff/rules/typed-argument-default-in-stub/

This PR excludes the open parentheses from the regex, so that these types of links won't be reformatted.

## Test Plan

Extended the regression test.