### PR TITLE
Remove `peek_nth`, only allow 1 lookahead

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -140,7 +140,7 @@ impl<'src> Parser<'src> {
         match kind {
             TokenKind::Or => (Precedence::Or, kind, Associativity::Left),
             TokenKind::And => (Precedence::And, kind, Associativity::Left),
-            TokenKind::Not if self.peek_nth(1) == TokenKind::In => (
+            TokenKind::Not if self.peek() == TokenKind::In => (
                 Precedence::ComparisonsMembershipIdentity,
                 kind,
                 Associativity::Left,
@@ -749,7 +749,7 @@ impl<'src> Parser<'src> {
             let parsed_expr = self.parse_expression_with_precedence(op_bp);
             comparators.push(parsed_expr.expr);
 
-            if let Ok(op) = token_kind_to_cmp_op([self.current_token_kind(), self.peek_nth(1)]) {
+            if let Ok(op) = token_kind_to_cmp_op([self.current_token_kind(), self.peek()]) {
                 if matches!(op, CmpOp::IsNot | CmpOp::NotIn) {
                     self.next_token();
                 }

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -332,19 +332,11 @@ impl<'src> Parser<'src> {
         current
     }
 
-    fn peek_nth(&self, offset: usize) -> TokenKind {
-        if offset == 0 {
-            self.current_token_kind()
-        } else {
-            self.tokens
-                .peek_nth(offset - 1)
-                .map_or(TokenKind::EndOfFile, |spanned| spanned.0)
-        }
-    }
-
     /// Returns the next token kind without consuming it.
     fn peek(&self) -> TokenKind {
-        self.peek_nth(1)
+        self.tokens
+            .peek()
+            .map_or(TokenKind::EndOfFile, |spanned| spanned.0)
     }
 
     /// Returns the current token kind along with its range.

--- a/crates/ruff_python_parser/src/parser/pattern.rs
+++ b/crates/ruff_python_parser/src/parser/pattern.rs
@@ -357,7 +357,7 @@ impl<'src> Parser<'src> {
         parentheses: Option<SequenceMatchPatternParentheses>,
     ) -> ast::PatternMatchSequence {
         if parentheses.is_some_and(|parentheses| {
-            self.at(parentheses.closing_kind()) || self.peek_nth(1) == parentheses.closing_kind()
+            self.at(parentheses.closing_kind()) || self.peek() == parentheses.closing_kind()
         }) {
             // The comma is optional if it is a single-element sequence
             self.eat(TokenKind::Comma);
@@ -459,7 +459,7 @@ impl<'src> Parser<'src> {
                     range,
                 })
             }
-            TokenKind::Name if self.peek_nth(1) == TokenKind::Dot => {
+            TokenKind::Name if self.peek() == TokenKind::Dot => {
                 let (Tok::Name { name }, _) = self.bump(TokenKind::Name) else {
                     unreachable!()
                 };
@@ -497,7 +497,7 @@ impl<'src> Parser<'src> {
             }
             TokenKind::Minus
                 if matches!(
-                    self.peek_nth(1),
+                    self.peek(),
                     TokenKind::Int | TokenKind::Float | TokenKind::Complex
                 ) =>
             {

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -1568,7 +1568,7 @@ impl<'src> Parser<'src> {
             TokenKind::Class => {
                 Stmt::ClassDef(self.parse_class_definition(decorators, start_offset))
             }
-            TokenKind::Async if self.peek_nth(1) == TokenKind::Def => {
+            TokenKind::Async if self.peek() == TokenKind::Def => {
                 self.bump(TokenKind::Async);
 
                 Stmt::FunctionDef(ast::StmtFunctionDef {

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -1,7 +1,9 @@
+use std::iter::FusedIterator;
+
+use ruff_text_size::{TextRange, TextSize};
+
 use crate::lexer::{LexResult, LexicalError, Spanned};
 use crate::{Tok, TokenKind};
-use ruff_text_size::{TextRange, TextSize};
-use std::iter::FusedIterator;
 
 #[derive(Clone, Debug)]
 pub(crate) struct TokenSource {
@@ -43,7 +45,8 @@ impl TokenSource {
         Some(range.end())
     }
 
-    pub(crate) fn peek_nth(&self, mut n: usize) -> Option<(TokenKind, TextRange)> {
+    /// Returns the next token kind and its range without consuming it.
+    pub(crate) fn peek(&self) -> Option<(TokenKind, TextRange)> {
         let mut iter = self.tokens.as_slice().iter();
 
         loop {
@@ -53,14 +56,10 @@ impl TokenSource {
                 continue;
             }
 
-            if n == 0 {
-                break Some(match next {
-                    Ok((token, range)) => (TokenKind::from_token(token), *range),
-                    Err(error) => (TokenKind::Unknown, error.location()),
-                });
-            }
-
-            n -= 1;
+            break Some(match next {
+                Ok((token, range)) => (TokenKind::from_token(token), *range),
+                Err(error) => (TokenKind::Unknown, error.location()),
+            });
         }
     }
 


### PR DESCRIPTION
## Summary

This PR updates the parser to avoid having the ability to do infinite lookaheads. We replace this with a new `peek` method introduced in #10418. The `peek_nth` method was only used in the old with item parsing logic which used this to determine the with item kind without consuming the tokens and only then perform the actual parsing.
