### PR TITLE
Remove long `Iterator::chain` sequence in `RuleCodePrefix::iter`

### DIFF
--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -391,8 +391,10 @@ fn generate_iter_impl(
             pub fn iter() -> impl Iterator<Item = RuleCodePrefix> {
                 use strum::IntoEnumIterator;
 
-                std::iter::empty()
-                    #(.chain(#linter_idents::iter().map(|x| Self::#linter_idents(x))))*
+                let mut prefixes = Vec::new();
+
+                #(prefixes.extend(#linter_idents::iter().map(|x| Self::#linter_idents(x)));)*
+                prefixes.into_iter()
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR removes the `Iterator::chain(...)` sequence in `RuleCodePrefix::iter()` with `Vec::expand` to avoid an overlong-recursive types. 

The existing `RuleCodePrefix::iter` method chains all rule group iterators together. This leads to very long recursive types `Chain<Map<Chain<Map<Chain<Map.....>>>>` (proportional to the number of rule groups). 

This PR rewrites the macro to use `Vec::extend` instead, which removes the long recursive type (at the cost of introducing a potential allocation). 

## Alternatives

An alternative would be to use a stack allocated array by unrolling the `Linter::iter` methods (generated by `EnumIter`). 
I don't think it's worth the extra complexity, considering that `RuleCodePrefix::iter` isn't a hot function.

## Test Plan

`cargo test`
