### PR TITLE
Remove unreachable error case while f-string parsing

### DIFF
--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -282,24 +282,22 @@ impl StringParser {
                 // This is still an invalid escape sequence, but we don't want to
                 // raise a syntax error as is done by the CPython parser. It might
                 // be supported in the future, refer to point 3: https://peps.python.org/pep-0701/#rejected-ideas
-                b'\\' if !self.kind.is_raw_string() && self.peek_byte().is_some() => {
-                    match self.parse_escaped_char()? {
-                        None => {}
-                        Some(EscapedChar::Literal(c)) => value.push(c),
-                        Some(EscapedChar::Escape(c)) => {
-                            value.push('\\');
-                            value.push(c);
+                b'\\' => {
+                    if !self.kind.is_raw_string() && self.peek_byte().is_some() {
+                        match self.parse_escaped_char()? {
+                            None => {}
+                            Some(EscapedChar::Literal(c)) => value.push(c),
+                            Some(EscapedChar::Escape(c)) => {
+                                value.push('\\');
+                                value.push(c);
+                            }
                         }
+                    } else {
+                        value.push('\\');
                     }
                 }
                 ch => {
-                    if !ch.is_ascii() {
-                        return Err(LexicalError::new(
-                            LexicalErrorType::InvalidByteLiteral,
-                            TextRange::empty(self.position()),
-                        ));
-                    }
-                    value.push(char::from(*ch));
+                    unreachable!("Expected '{{', '}}', or '\\' but got {:?}", ch);
                 }
             }
 


### PR DESCRIPTION
## Summary

This PR updates the f-string literal parsing code to remove the unreachable error handling and make it explicit that this is an unreachable branch.

As mentioned in https://github.com/astral-sh/ruff/pull/10406#discussion_r1530373513:

> Correct me if I'm wrong but I don't think this branch is even reachable because the `memchr3` call only tries to find either `{`, `}`, or `\` which the match statement covers up.
>
> Ok, so this code _is_ reachable but still the `ch` will always be `\` because the previous match case is something like:
>
> ```rs
> 	'\\' if !self.kind.is_raw_string() && self.peek_byte().is_some() => ...
> 	ch => ...
> ```
>
> I can confirm that by running the entire test suite.

## Test Plan

`cargo test`
