### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,21 +153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_cmd"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
-dependencies = [
- "anstyle",
- "bstr",
- "doc-comment",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,12 +617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,12 +677,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "drop_bomb"
@@ -1776,33 +1749,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "predicates"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
-dependencies = [
- "anstyle",
- "difflib",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,7 +1969,6 @@ version = "0.3.3"
 dependencies = [
  "anyhow",
  "argfile",
- "assert_cmd",
  "bincode",
  "bitflags 2.4.2",
  "cachedir",
@@ -2118,7 +2063,6 @@ dependencies = [
  "indoc",
  "itertools 0.12.1",
  "libcst",
- "once_cell",
  "pretty_assertions",
  "rayon",
  "regex",
@@ -2162,7 +2106,6 @@ name = "ruff_formatter"
 version = "0.0.0"
 dependencies = [
  "drop_bomb",
- "insta",
  "ruff_cache",
  "ruff_macros",
  "ruff_text_size",
@@ -2209,14 +2152,12 @@ dependencies = [
  "path-absolutize",
  "pathdiff",
  "pep440_rs",
- "pretty_assertions",
  "pyproject-toml",
  "quick-junit",
  "regex",
  "result-like",
  "ruff_cache",
  "ruff_diagnostics",
- "ruff_index",
  "ruff_macros",
  "ruff_notebook",
  "ruff_python_ast",
@@ -2237,7 +2178,6 @@ dependencies = [
  "smallvec",
  "strum",
  "strum_macros",
- "tempfile",
  "test-case",
  "thiserror",
  "toml",
@@ -2263,7 +2203,6 @@ name = "ruff_notebook"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "insta",
  "itertools 0.12.1",
  "once_cell",
  "rand",
@@ -2358,10 +2297,8 @@ version = "0.0.0"
 dependencies = [
  "bitflags 2.4.2",
  "hexf-parse",
- "is-macro",
  "itertools 0.12.1",
  "lexical-parse-float",
- "rand",
  "ruff_python_ast",
  "unic-ucd-category",
 ]
@@ -2427,7 +2364,6 @@ version = "0.0.0"
 dependencies = [
  "insta",
  "itertools 0.12.1",
- "ruff_python_ast",
  "ruff_python_index",
  "ruff_python_parser",
  "ruff_source_file",
@@ -2460,7 +2396,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "similar",
  "tracing",
 ]
 
@@ -2484,7 +2419,6 @@ dependencies = [
 name = "ruff_source_file"
 version = "0.0.0"
 dependencies = [
- "insta",
  "memchr",
  "once_cell",
  "ruff_text_size",
@@ -2539,7 +2473,6 @@ dependencies = [
  "is-macro",
  "itertools 0.12.1",
  "log",
- "once_cell",
  "path-absolutize",
  "pep440_rs",
  "regex",
@@ -2979,12 +2912,6 @@ dependencies = [
  "phf",
  "phf_codegen",
 ]
-
-[[package]]
-name = "termtree"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-case"
@@ -3444,15 +3371,6 @@ checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
 dependencies = [
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ aho-corasick = { version = "1.1.2" }
 annotate-snippets = { version = "0.9.2", features = ["color"] }
 anyhow = { version = "1.0.80" }
 argfile = { version = "0.1.6" }
-assert_cmd = { version = "2.0.13" }
 bincode = { version = "1.3.3" }
 bitflags = { version = "2.4.1" }
 bstr = { version = "1.9.1" }
@@ -27,7 +26,6 @@ clap_complete_command = { version = "0.5.1" }
 clearscreen = { version = "2.0.0" }
 codspeed-criterion-compat = { version = "2.4.0", default-features = false }
 colored = { version = "2.1.0" }
-configparser = { version = "3.0.3" }
 console_error_panic_hook = { version = "0.1.7" }
 console_log = { version = "1.0.0" }
 countme = { version = "3.0.1" }

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -54,7 +54,7 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
-tracing-subscriber = { workspace = true, features = ["registry"]}
+tracing-subscriber = { workspace = true, features = ["registry"] }
 tracing-tree = { workspace = true }
 walkdir = { workspace = true }
 wild = { workspace = true }
@@ -62,9 +62,8 @@ wild = { workspace = true }
 [dev-dependencies]
 # Enable test rules during development
 ruff_linter = { path = "../ruff_linter", features = ["clap", "test-rules"] }
-assert_cmd = { workspace = true }
 # Avoid writing colored snapshots when running tests from the terminal
-colored = { workspace = true, features = ["no-color"]}
+colored = { workspace = true, features = ["no-color"] }
 insta = { workspace = true, features = ["filters", "json"] }
 insta-cmd = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -22,7 +22,7 @@ ruff_python_formatter = { path = "../ruff_python_formatter" }
 ruff_python_parser = { path = "../ruff_python_parser" }
 ruff_python_stdlib = { path = "../ruff_python_stdlib" }
 ruff_python_trivia = { path = "../ruff_python_trivia" }
-ruff_workspace = { path = "../ruff_workspace", features = ["schemars"]}
+ruff_workspace = { path = "../ruff_workspace", features = ["schemars"] }
 
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["wrap_help"] }
@@ -31,7 +31,6 @@ imara-diff = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }
 libcst = { workspace = true }
-once_cell = { workspace = true }
 pretty_assertions = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }

--- a/crates/ruff_formatter/Cargo.toml
+++ b/crates/ruff_formatter/Cargo.toml
@@ -24,7 +24,6 @@ tracing = { workspace = true }
 unicode-width = { workspace = true }
 
 [dev-dependencies]
-insta = { workspace = true }
 
 [features]
 serde = ["dep:serde", "ruff_text_size/serde"]

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -15,7 +15,6 @@ license = { workspace = true }
 [dependencies]
 ruff_cache = { path = "../ruff_cache" }
 ruff_diagnostics = { path = "../ruff_diagnostics", features = ["serde"] }
-ruff_index = { path = "../ruff_index" }
 ruff_notebook = { path = "../ruff_notebook" }
 ruff_macros = { path = "../ruff_macros" }
 ruff_python_ast = { path = "../ruff_python_ast", features = ["serde"] }
@@ -75,11 +74,9 @@ url = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-pretty_assertions = { workspace = true }
 test-case = { workspace = true }
 # Disable colored output in tests
 colored = { workspace = true, features = ["no-color"] }
-tempfile = { workspace = true }
 
 [features]
 default = []

--- a/crates/ruff_notebook/Cargo.toml
+++ b/crates/ruff_notebook/Cargo.toml
@@ -29,7 +29,6 @@ uuid = { workspace = true }
 rand = { workspace = true }
 
 [dev-dependencies]
-insta = { workspace = true }
 test-case = { workspace = true }
 
 [lints]

--- a/crates/ruff_python_literal/Cargo.toml
+++ b/crates/ruff_python_literal/Cargo.toml
@@ -19,13 +19,11 @@ ruff_python_ast = { path = "../ruff_python_ast" }
 
 bitflags = { workspace = true }
 hexf-parse = { workspace = true }
-is-macro = { workspace = true }
 itertools = { workspace = true }
 lexical-parse-float = { workspace = true, features = ["format"] }
 unic-ucd-category = { workspace = true }
 
 [dev-dependencies]
-rand = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ruff_python_trivia/Cargo.toml
+++ b/crates/ruff_python_trivia/Cargo.toml
@@ -21,7 +21,6 @@ unicode-ident = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-ruff_python_ast = { path = "../ruff_python_ast" }
 ruff_python_parser = { path = "../ruff_python_parser" }
 ruff_python_index = { path = "../ruff_python_index" }
 

--- a/crates/ruff_server/Cargo.toml
+++ b/crates/ruff_server/Cargo.toml
@@ -34,7 +34,6 @@ lsp-types = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-similar = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ruff_source_file/Cargo.toml
+++ b/crates/ruff_source_file/Cargo.toml
@@ -19,7 +19,6 @@ ruff_text_size = { path = "../ruff_text_size" }
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]
-insta = { workspace = true }
 
 [features]
 serde = ["dep:serde", "ruff_text_size/serde"]

--- a/crates/ruff_workspace/Cargo.toml
+++ b/crates/ruff_workspace/Cargo.toml
@@ -30,13 +30,12 @@ itertools = { workspace = true }
 log = { workspace = true }
 glob = { workspace = true }
 globset = { workspace = true }
-once_cell = { workspace = true }
 path-absolutize = { workspace = true }
 pep440_rs = { workspace = true, features = ["serde"] }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
-serde = { workspace = true}
+serde = { workspace = true }
 shellexpand = { workspace = true }
 strum = { workspace = true }
 toml = { workspace = true }
@@ -48,7 +47,7 @@ tempfile = { workspace = true }
 
 [features]
 default = []
-schemars = [ "dep:schemars", "ruff_formatter/schemars", "ruff_python_formatter/schemars" ]
+schemars = ["dep:schemars", "ruff_formatter/schemars", "ruff_python_formatter/schemars"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
I used `cargo-shear` (see [tweet](https://twitter.com/boshen_c/status/1770106165923586395)) to remove some unused dependencies that `cargo udeps` wasn't reporting.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test`
