### PR TITLE
Fix typo in `string_token_flags.rs`

### DIFF
--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__raw_byte_literal_1.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__raw_byte_literal_1.snap
@@ -22,7 +22,7 @@ expression: parse_ast
                                 flags: BytesLiteralFlags {
                                     quote_style: Single,
                                     prefix: Raw {
-                                        uppercase_r: true,
+                                        uppercase_r: false,
                                     },
                                     triple_quoted: false,
                                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__raw_byte_literal_2.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__raw_byte_literal_2.snap
@@ -20,7 +20,7 @@ expression: parse_ast
                                 flags: BytesLiteralFlags {
                                     quote_style: Single,
                                     prefix: Raw {
-                                        uppercase_r: true,
+                                        uppercase_r: false,
                                     },
                                     triple_quoted: false,
                                 },

--- a/crates/ruff_python_parser/src/string_token_flags.rs
+++ b/crates/ruff_python_parser/src/string_token_flags.rs
@@ -168,10 +168,10 @@ impl StringPrefix {
         // bytestrings
         if flags.contains(StringFlags::B_PREFIX) {
             if flags.contains(StringFlags::R_PREFIX_LOWER) {
-                return Self::Bytes(ByteStringPrefix::Raw { uppercase_r: true });
-            }
-            if flags.contains(StringFlags::R_PREFIX_LOWER) {
                 return Self::Bytes(ByteStringPrefix::Raw { uppercase_r: false });
+            }
+            if flags.contains(StringFlags::R_PREFIX_UPPER) {
+                return Self::Bytes(ByteStringPrefix::Raw { uppercase_r: true });
             }
             return Self::Bytes(ByteStringPrefix::Regular);
         }


### PR DESCRIPTION
I ~~spent far too long trying to track this bug down~~ bumped into this while working on a separate PR trying to use these string flags
