### PR TITLE
Avoid failures due to non-deterministic binding ordering

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_logging/LOG009.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_logging/LOG009.py
@@ -1,9 +1,12 @@
-import logging
+def func():
+    import logging
 
-logging.WARN  # LOG009
-logging.WARNING  # OK
+    logging.WARN  # LOG009
+    logging.WARNING  # OK
 
-from logging import WARN, WARNING
 
-WARN  # LOG009
-WARNING  # OK
+def func():
+    from logging import WARN, WARNING
+
+    WARN  # LOG009
+    WARNING  # OK

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP017.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP017.py
@@ -1,11 +1,28 @@
-import datetime
-import datetime as dt
-from datetime import timezone
-from datetime import timezone as tz
+def func():
+    import datetime
 
-print(datetime.timezone(-1))
-print(timezone.utc)
-print(tz.utc)
+    print(datetime.timezone(-1))
 
-print(datetime.timezone.utc)
-print(dt.timezone.utc)
+
+def func():
+    from datetime import timezone
+
+    print(timezone.utc)
+
+
+def func():
+    from datetime import timezone as tz
+
+    print(tz.utc)
+
+
+def func():
+    import datetime
+
+    print(datetime.timezone.utc)
+
+
+def func():
+    import datetime as dt
+
+    print(dt.timezone.utc)

--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB163.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB163.py
@@ -1,9 +1,6 @@
 import math
 
-from math import e as special_e
-from math import log as special_log
-
-# Errors.
+# Errors
 math.log(1, 2)
 math.log(1, 10)
 math.log(1, math.e)
@@ -11,15 +8,10 @@ foo = ...
 math.log(foo, 2)
 math.log(foo, 10)
 math.log(foo, math.e)
-math.log(1, special_e)
-special_log(1, 2)
-special_log(1, 10)
-special_log(1, math.e)
-special_log(1, special_e)
 math.log(1, 2.0)
 math.log(1, 10.0)
 
-# Ok.
+# OK
 math.log2(1)
 math.log10(1)
 math.log(1)
@@ -39,6 +31,7 @@ math.log2(1, 10)  # math.log2 takes only one argument.
 math.log10(1, 2)  # math.log10 takes only one argument.
 
 math.log(1, base=2)  # math.log does not accept keyword arguments.
+
 
 def log(*args):
     print(f"Logging: {args}")

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF013_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF013_0.py
@@ -1,4 +1,3 @@
-import typing
 from typing import Annotated, Any, Literal, Optional, Tuple, Union, Hashable
 
 
@@ -26,10 +25,6 @@ def f(arg: str = None):  # RUF013
     pass
 
 
-def f(arg: typing.List[str] = None):  # RUF013
-    pass
-
-
 def f(arg: Tuple[str] = None):  # RUF013
     pass
 
@@ -38,10 +33,6 @@ def f(arg: Tuple[str] = None):  # RUF013
 
 
 def f(arg: Optional[int] = None):
-    pass
-
-
-def f(arg: typing.Optional[int] = None):
     pass
 
 
@@ -60,10 +51,6 @@ def f(arg: Union[str, None] = None):
     pass
 
 
-def f(arg: typing.Union[int, str, None] = None):
-    pass
-
-
 def f(arg: Union[int, str, Any] = None):
     pass
 
@@ -77,10 +64,6 @@ def f(arg: Union[int] = None):  # RUF013
 
 
 def f(arg: Union[int, str] = None):  # RUF013
-    pass
-
-
-def f(arg: typing.Union[int, str] = None):  # RUF013
     pass
 
 
@@ -127,10 +110,6 @@ def f(arg: Literal[1] = None):  # RUF013
 
 
 def f(arg: Literal[1, "foo"] = None):  # RUF013
-    pass
-
-
-def f(arg: typing.Literal[1, "foo", True] = None):  # RUF013
     pass
 
 

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF013_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF013_1.py
@@ -1,5 +1,5 @@
 # No `typing.Optional` import
 
 
-def f(arg: int = None):  # RUF011
+def f(arg: int = None):  # RUF013
     pass

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF013_3.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF013_3.py
@@ -1,0 +1,30 @@
+import typing
+
+
+def f(arg: typing.List[str] = None):  # RUF013
+    pass
+
+
+# Optional
+
+
+def f(arg: typing.Optional[int] = None):
+    pass
+
+
+# Union
+
+
+def f(arg: typing.Union[int, str, None] = None):
+    pass
+
+
+def f(arg: typing.Union[int, str] = None):  # RUF013
+    pass
+
+
+# Literal
+
+
+def f(arg: typing.Literal[1, "foo", True] = None):  # RUF013
+    pass

--- a/crates/ruff_linter/resources/test/fixtures/tryceratops/TRY400.py
+++ b/crates/ruff_linter/resources/test/fixtures/tryceratops/TRY400.py
@@ -3,13 +3,10 @@ Violation:
 Use '.exception' over '.error' inside except blocks
 """
 
-import logging
-import sys
-
-logger = logging.getLogger(__name__)
-
 
 def bad():
+    import logging
+
     try:
         a = 1
     except Exception:
@@ -20,6 +17,10 @@ def bad():
 
 
 def bad():
+    import logging
+
+    logger = logging.getLogger(__name__)
+
     try:
         a = 1
     except Exception:
@@ -50,6 +51,10 @@ def bad():
 
 
 def good():
+    import logging
+
+    logger = logging.getLogger(__name__)
+
     try:
         a = 1
     except Exception:
@@ -64,6 +69,10 @@ def good():
 
 
 def fine():
+    import logging
+
+    logger = logging.getLogger(__name__)
+
     try:
         a = 1
     except Exception:
@@ -71,16 +80,20 @@ def fine():
 
 
 def fine():
+    import logging
+    import sys
+
+    logger = logging.getLogger(__name__)
+
     try:
         a = 1
     except Exception:
         logger.error("Context message here", exc_info=sys.exc_info())
 
 
-from logging import error, exception
-
-
 def bad():
+    from logging import error, exception
+
     try:
         a = 1
     except Exception:
@@ -91,6 +104,8 @@ def bad():
 
 
 def good():
+    from logging import error, exception
+
     try:
         a = 1
     except Exception:
@@ -98,6 +113,8 @@ def good():
 
 
 def fine():
+    from logging import error, exception
+
     try:
         a = 1
     except Exception:
@@ -105,6 +122,9 @@ def fine():
 
 
 def fine():
+    from logging import error, exception
+    import sys
+
     try:
         a = 1
     except Exception:
@@ -112,6 +132,8 @@ def fine():
 
 
 def nested():
+    from logging import error, exception
+
     try:
         a = 1
     except Exception:

--- a/crates/ruff_linter/src/rules/flake8_logging/snapshots/ruff_linter__rules__flake8_logging__tests__LOG009_LOG009.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_logging/snapshots/ruff_linter__rules__flake8_logging__tests__LOG009_LOG009.py.snap
@@ -1,41 +1,40 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_logging/mod.rs
 ---
-LOG009.py:3:1: LOG009 [*] Use of undocumented `logging.WARN` constant
+LOG009.py:4:5: LOG009 [*] Use of undocumented `logging.WARN` constant
   |
-1 | import logging
-2 | 
-3 | logging.WARN  # LOG009
-  | ^^^^^^^^^^^^ LOG009
-4 | logging.WARNING  # OK
-  |
-  = help: Replace `logging.WARN` with `logging.WARNING`
-
-ℹ Safe fix
-1 1 | import logging
-2 2 | 
-3   |-logging.WARN  # LOG009
-  3 |+logging.WARNING  # LOG009
-4 4 | logging.WARNING  # OK
-5 5 | 
-6 6 | from logging import WARN, WARNING
-
-LOG009.py:8:1: LOG009 [*] Use of undocumented `logging.WARN` constant
-  |
-6 | from logging import WARN, WARNING
-7 | 
-8 | WARN  # LOG009
-  | ^^^^ LOG009
-9 | WARNING  # OK
+2 |     import logging
+3 | 
+4 |     logging.WARN  # LOG009
+  |     ^^^^^^^^^^^^ LOG009
+5 |     logging.WARNING  # OK
   |
   = help: Replace `logging.WARN` with `logging.WARNING`
 
 ℹ Safe fix
-5 5 | 
-6 6 | from logging import WARN, WARNING
+1 1 | def func():
+2 2 |     import logging
+3 3 | 
+4   |-    logging.WARN  # LOG009
+  4 |+    logging.WARNING  # LOG009
+5 5 |     logging.WARNING  # OK
+6 6 | 
 7 7 | 
-8   |-WARN  # LOG009
-  8 |+logging.WARNING  # LOG009
-9 9 | WARNING  # OK
 
+LOG009.py:11:5: LOG009 [*] Use of undocumented `logging.WARN` constant
+   |
+ 9 |     from logging import WARN, WARNING
+10 | 
+11 |     WARN  # LOG009
+   |     ^^^^ LOG009
+12 |     WARNING  # OK
+   |
+   = help: Replace `logging.WARN` with `logging.WARNING`
 
+ℹ Safe fix
+8  8  | def func():
+9  9  |     from logging import WARN, WARNING
+10 10 | 
+11    |-    WARN  # LOG009
+   11 |+    WARNING  # LOG009
+12 12 |     WARNING  # OK

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__datetime_utc_alias_py311.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__datetime_utc_alias_py311.snap
@@ -1,77 +1,85 @@
 ---
 source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
 ---
-UP017.py:7:7: UP017 [*] Use `datetime.UTC` alias
-  |
-6 | print(datetime.timezone(-1))
-7 | print(timezone.utc)
-  |       ^^^^^^^^^^^^ UP017
-8 | print(tz.utc)
-  |
-  = help: Convert to `datetime.UTC` alias
-
-ℹ Safe fix
-4 4 | from datetime import timezone as tz
-5 5 | 
-6 6 | print(datetime.timezone(-1))
-7   |-print(timezone.utc)
-  7 |+print(datetime.UTC)
-8 8 | print(tz.utc)
-9 9 | 
-10 10 | print(datetime.timezone.utc)
-
-UP017.py:8:7: UP017 [*] Use `datetime.UTC` alias
+UP017.py:10:11: UP017 [*] Use `datetime.UTC` alias
    |
- 6 | print(datetime.timezone(-1))
- 7 | print(timezone.utc)
- 8 | print(tz.utc)
-   |       ^^^^^^ UP017
+ 8 |     from datetime import timezone
  9 | 
-10 | print(datetime.timezone.utc)
+10 |     print(timezone.utc)
+   |           ^^^^^^^^^^^^ UP017
    |
    = help: Convert to `datetime.UTC` alias
 
 ℹ Safe fix
-5 5 | 
-6 6 | print(datetime.timezone(-1))
-7 7 | print(timezone.utc)
-8   |-print(tz.utc)
-  8 |+print(datetime.UTC)
-9 9 | 
-10 10 | print(datetime.timezone.utc)
-11 11 | print(dt.timezone.utc)
+   1  |+from datetime import UTC
+1  2  | def func():
+2  3  |     import datetime
+3  4  | 
+--------------------------------------------------------------------------------
+7  8  | def func():
+8  9  |     from datetime import timezone
+9  10 | 
+10    |-    print(timezone.utc)
+   11 |+    print(UTC)
+11 12 | 
+12 13 | 
+13 14 | def func():
 
-UP017.py:10:7: UP017 [*] Use `datetime.UTC` alias
+UP017.py:16:11: UP017 [*] Use `datetime.UTC` alias
    |
- 8 | print(tz.utc)
- 9 | 
-10 | print(datetime.timezone.utc)
-   |       ^^^^^^^^^^^^^^^^^^^^^ UP017
-11 | print(dt.timezone.utc)
-   |
-   = help: Convert to `datetime.UTC` alias
-
-ℹ Safe fix
-7  7  | print(timezone.utc)
-8  8  | print(tz.utc)
-9  9  | 
-10    |-print(datetime.timezone.utc)
-   10 |+print(datetime.UTC)
-11 11 | print(dt.timezone.utc)
-
-UP017.py:11:7: UP017 [*] Use `datetime.UTC` alias
-   |
-10 | print(datetime.timezone.utc)
-11 | print(dt.timezone.utc)
-   |       ^^^^^^^^^^^^^^^ UP017
+14 |     from datetime import timezone as tz
+15 | 
+16 |     print(tz.utc)
+   |           ^^^^^^ UP017
    |
    = help: Convert to `datetime.UTC` alias
 
 ℹ Safe fix
-8  8  | print(tz.utc)
-9  9  | 
-10 10 | print(datetime.timezone.utc)
-11    |-print(dt.timezone.utc)
-   11 |+print(datetime.UTC)
+   1  |+from datetime import UTC
+1  2  | def func():
+2  3  |     import datetime
+3  4  | 
+--------------------------------------------------------------------------------
+13 14 | def func():
+14 15 |     from datetime import timezone as tz
+15 16 | 
+16    |-    print(tz.utc)
+   17 |+    print(UTC)
+17 18 | 
+18 19 | 
+19 20 | def func():
 
+UP017.py:22:11: UP017 [*] Use `datetime.UTC` alias
+   |
+20 |     import datetime
+21 | 
+22 |     print(datetime.timezone.utc)
+   |           ^^^^^^^^^^^^^^^^^^^^^ UP017
+   |
+   = help: Convert to `datetime.UTC` alias
 
+ℹ Safe fix
+19 19 | def func():
+20 20 |     import datetime
+21 21 | 
+22    |-    print(datetime.timezone.utc)
+   22 |+    print(datetime.UTC)
+23 23 | 
+24 24 | 
+25 25 | def func():
+
+UP017.py:28:11: UP017 [*] Use `datetime.UTC` alias
+   |
+26 |     import datetime as dt
+27 | 
+28 |     print(dt.timezone.utc)
+   |           ^^^^^^^^^^^^^^^ UP017
+   |
+   = help: Convert to `datetime.UTC` alias
+
+ℹ Safe fix
+25 25 | def func():
+26 26 |     import datetime as dt
+27 27 | 
+28    |-    print(dt.timezone.utc)
+   28 |+    print(dt.UTC)

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB163_FURB163.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB163_FURB163.py.snap
@@ -1,275 +1,168 @@
 ---
 source: crates/ruff_linter/src/rules/refurb/mod.rs
 ---
-FURB163.py:7:1: FURB163 [*] Prefer `math.log2(1)` over `math.log` with a redundant base
+FURB163.py:4:1: FURB163 [*] Prefer `math.log2(1)` over `math.log` with a redundant base
   |
-6 | # Errors.
-7 | math.log(1, 2)
+3 | # Errors
+4 | math.log(1, 2)
   | ^^^^^^^^^^^^^^ FURB163
-8 | math.log(1, 10)
-9 | math.log(1, math.e)
+5 | math.log(1, 10)
+6 | math.log(1, math.e)
   |
   = help: Replace with `math.log2(1)`
 
 ℹ Safe fix
-4 4 | from math import log as special_log
-5 5 | 
-6 6 | # Errors.
-7   |-math.log(1, 2)
-  7 |+math.log2(1)
-8 8 | math.log(1, 10)
-9 9 | math.log(1, math.e)
-10 10 | foo = ...
+1 1 | import math
+2 2 | 
+3 3 | # Errors
+4   |-math.log(1, 2)
+  4 |+math.log2(1)
+5 5 | math.log(1, 10)
+6 6 | math.log(1, math.e)
+7 7 | foo = ...
 
-FURB163.py:8:1: FURB163 [*] Prefer `math.log10(1)` over `math.log` with a redundant base
-   |
- 6 | # Errors.
- 7 | math.log(1, 2)
- 8 | math.log(1, 10)
-   | ^^^^^^^^^^^^^^^ FURB163
- 9 | math.log(1, math.e)
-10 | foo = ...
-   |
-   = help: Replace with `math.log10(1)`
-
-ℹ Safe fix
-5 5 | 
-6 6 | # Errors.
-7 7 | math.log(1, 2)
-8   |-math.log(1, 10)
-  8 |+math.log10(1)
-9 9 | math.log(1, math.e)
-10 10 | foo = ...
-11 11 | math.log(foo, 2)
-
-FURB163.py:9:1: FURB163 [*] Prefer `math.log(1)` over `math.log` with a redundant base
-   |
- 7 | math.log(1, 2)
- 8 | math.log(1, 10)
- 9 | math.log(1, math.e)
-   | ^^^^^^^^^^^^^^^^^^^ FURB163
-10 | foo = ...
-11 | math.log(foo, 2)
-   |
-   = help: Replace with `math.log(1)`
+FURB163.py:5:1: FURB163 [*] Prefer `math.log10(1)` over `math.log` with a redundant base
+  |
+3 | # Errors
+4 | math.log(1, 2)
+5 | math.log(1, 10)
+  | ^^^^^^^^^^^^^^^ FURB163
+6 | math.log(1, math.e)
+7 | foo = ...
+  |
+  = help: Replace with `math.log10(1)`
 
 ℹ Safe fix
-6  6  | # Errors.
-7  7  | math.log(1, 2)
-8  8  | math.log(1, 10)
-9     |-math.log(1, math.e)
-   9  |+math.log(1)
-10 10 | foo = ...
-11 11 | math.log(foo, 2)
-12 12 | math.log(foo, 10)
+2 2 | 
+3 3 | # Errors
+4 4 | math.log(1, 2)
+5   |-math.log(1, 10)
+  5 |+math.log10(1)
+6 6 | math.log(1, math.e)
+7 7 | foo = ...
+8 8 | math.log(foo, 2)
 
-FURB163.py:11:1: FURB163 [*] Prefer `math.log2(foo)` over `math.log` with a redundant base
+FURB163.py:6:1: FURB163 [*] Prefer `math.log(1)` over `math.log` with a redundant base
+  |
+4 | math.log(1, 2)
+5 | math.log(1, 10)
+6 | math.log(1, math.e)
+  | ^^^^^^^^^^^^^^^^^^^ FURB163
+7 | foo = ...
+8 | math.log(foo, 2)
+  |
+  = help: Replace with `math.log(1)`
+
+ℹ Safe fix
+3 3 | # Errors
+4 4 | math.log(1, 2)
+5 5 | math.log(1, 10)
+6   |-math.log(1, math.e)
+  6 |+math.log(1)
+7 7 | foo = ...
+8 8 | math.log(foo, 2)
+9 9 | math.log(foo, 10)
+
+FURB163.py:8:1: FURB163 [*] Prefer `math.log2(foo)` over `math.log` with a redundant base
    |
- 9 | math.log(1, math.e)
-10 | foo = ...
-11 | math.log(foo, 2)
+ 6 | math.log(1, math.e)
+ 7 | foo = ...
+ 8 | math.log(foo, 2)
    | ^^^^^^^^^^^^^^^^ FURB163
-12 | math.log(foo, 10)
-13 | math.log(foo, math.e)
+ 9 | math.log(foo, 10)
+10 | math.log(foo, math.e)
    |
    = help: Replace with `math.log2(foo)`
 
 ℹ Safe fix
-8  8  | math.log(1, 10)
-9  9  | math.log(1, math.e)
-10 10 | foo = ...
-11    |-math.log(foo, 2)
-   11 |+math.log2(foo)
-12 12 | math.log(foo, 10)
-13 13 | math.log(foo, math.e)
-14 14 | math.log(1, special_e)
+5 5 | math.log(1, 10)
+6 6 | math.log(1, math.e)
+7 7 | foo = ...
+8   |-math.log(foo, 2)
+  8 |+math.log2(foo)
+9 9 | math.log(foo, 10)
+10 10 | math.log(foo, math.e)
+11 11 | math.log(1, 2.0)
 
-FURB163.py:12:1: FURB163 [*] Prefer `math.log10(foo)` over `math.log` with a redundant base
+FURB163.py:9:1: FURB163 [*] Prefer `math.log10(foo)` over `math.log` with a redundant base
    |
-10 | foo = ...
-11 | math.log(foo, 2)
-12 | math.log(foo, 10)
+ 7 | foo = ...
+ 8 | math.log(foo, 2)
+ 9 | math.log(foo, 10)
    | ^^^^^^^^^^^^^^^^^ FURB163
-13 | math.log(foo, math.e)
-14 | math.log(1, special_e)
+10 | math.log(foo, math.e)
+11 | math.log(1, 2.0)
    |
    = help: Replace with `math.log10(foo)`
 
 ℹ Safe fix
-9  9  | math.log(1, math.e)
-10 10 | foo = ...
-11 11 | math.log(foo, 2)
-12    |-math.log(foo, 10)
-   12 |+math.log10(foo)
-13 13 | math.log(foo, math.e)
-14 14 | math.log(1, special_e)
-15 15 | special_log(1, 2)
+6  6  | math.log(1, math.e)
+7  7  | foo = ...
+8  8  | math.log(foo, 2)
+9     |-math.log(foo, 10)
+   9  |+math.log10(foo)
+10 10 | math.log(foo, math.e)
+11 11 | math.log(1, 2.0)
+12 12 | math.log(1, 10.0)
 
-FURB163.py:13:1: FURB163 [*] Prefer `math.log(foo)` over `math.log` with a redundant base
+FURB163.py:10:1: FURB163 [*] Prefer `math.log(foo)` over `math.log` with a redundant base
    |
-11 | math.log(foo, 2)
-12 | math.log(foo, 10)
-13 | math.log(foo, math.e)
+ 8 | math.log(foo, 2)
+ 9 | math.log(foo, 10)
+10 | math.log(foo, math.e)
    | ^^^^^^^^^^^^^^^^^^^^^ FURB163
-14 | math.log(1, special_e)
-15 | special_log(1, 2)
+11 | math.log(1, 2.0)
+12 | math.log(1, 10.0)
    |
    = help: Replace with `math.log(foo)`
 
 ℹ Safe fix
-10 10 | foo = ...
-11 11 | math.log(foo, 2)
-12 12 | math.log(foo, 10)
-13    |-math.log(foo, math.e)
-   13 |+math.log(foo)
-14 14 | math.log(1, special_e)
-15 15 | special_log(1, 2)
-16 16 | special_log(1, 10)
+7  7  | foo = ...
+8  8  | math.log(foo, 2)
+9  9  | math.log(foo, 10)
+10    |-math.log(foo, math.e)
+   10 |+math.log(foo)
+11 11 | math.log(1, 2.0)
+12 12 | math.log(1, 10.0)
+13 13 | 
 
-FURB163.py:14:1: FURB163 [*] Prefer `math.log(1)` over `math.log` with a redundant base
+FURB163.py:11:1: FURB163 [*] Prefer `math.log2(1)` over `math.log` with a redundant base
    |
-12 | math.log(foo, 10)
-13 | math.log(foo, math.e)
-14 | math.log(1, special_e)
-   | ^^^^^^^^^^^^^^^^^^^^^^ FURB163
-15 | special_log(1, 2)
-16 | special_log(1, 10)
-   |
-   = help: Replace with `math.log(1)`
-
-ℹ Safe fix
-11 11 | math.log(foo, 2)
-12 12 | math.log(foo, 10)
-13 13 | math.log(foo, math.e)
-14    |-math.log(1, special_e)
-   14 |+math.log(1)
-15 15 | special_log(1, 2)
-16 16 | special_log(1, 10)
-17 17 | special_log(1, math.e)
-
-FURB163.py:15:1: FURB163 [*] Prefer `math.log2(1)` over `math.log` with a redundant base
-   |
-13 | math.log(foo, math.e)
-14 | math.log(1, special_e)
-15 | special_log(1, 2)
-   | ^^^^^^^^^^^^^^^^^ FURB163
-16 | special_log(1, 10)
-17 | special_log(1, math.e)
-   |
-   = help: Replace with `math.log2(1)`
-
-ℹ Safe fix
-12 12 | math.log(foo, 10)
-13 13 | math.log(foo, math.e)
-14 14 | math.log(1, special_e)
-15    |-special_log(1, 2)
-   15 |+math.log2(1)
-16 16 | special_log(1, 10)
-17 17 | special_log(1, math.e)
-18 18 | special_log(1, special_e)
-
-FURB163.py:16:1: FURB163 [*] Prefer `math.log10(1)` over `math.log` with a redundant base
-   |
-14 | math.log(1, special_e)
-15 | special_log(1, 2)
-16 | special_log(1, 10)
-   | ^^^^^^^^^^^^^^^^^^ FURB163
-17 | special_log(1, math.e)
-18 | special_log(1, special_e)
-   |
-   = help: Replace with `math.log10(1)`
-
-ℹ Safe fix
-13 13 | math.log(foo, math.e)
-14 14 | math.log(1, special_e)
-15 15 | special_log(1, 2)
-16    |-special_log(1, 10)
-   16 |+math.log10(1)
-17 17 | special_log(1, math.e)
-18 18 | special_log(1, special_e)
-19 19 | math.log(1, 2.0)
-
-FURB163.py:17:1: FURB163 [*] Prefer `math.log(1)` over `math.log` with a redundant base
-   |
-15 | special_log(1, 2)
-16 | special_log(1, 10)
-17 | special_log(1, math.e)
-   | ^^^^^^^^^^^^^^^^^^^^^^ FURB163
-18 | special_log(1, special_e)
-19 | math.log(1, 2.0)
-   |
-   = help: Replace with `math.log(1)`
-
-ℹ Safe fix
-14 14 | math.log(1, special_e)
-15 15 | special_log(1, 2)
-16 16 | special_log(1, 10)
-17    |-special_log(1, math.e)
-   17 |+math.log(1)
-18 18 | special_log(1, special_e)
-19 19 | math.log(1, 2.0)
-20 20 | math.log(1, 10.0)
-
-FURB163.py:18:1: FURB163 [*] Prefer `math.log(1)` over `math.log` with a redundant base
-   |
-16 | special_log(1, 10)
-17 | special_log(1, math.e)
-18 | special_log(1, special_e)
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ FURB163
-19 | math.log(1, 2.0)
-20 | math.log(1, 10.0)
-   |
-   = help: Replace with `math.log(1)`
-
-ℹ Safe fix
-15 15 | special_log(1, 2)
-16 16 | special_log(1, 10)
-17 17 | special_log(1, math.e)
-18    |-special_log(1, special_e)
-   18 |+math.log(1)
-19 19 | math.log(1, 2.0)
-20 20 | math.log(1, 10.0)
-21 21 | 
-
-FURB163.py:19:1: FURB163 [*] Prefer `math.log2(1)` over `math.log` with a redundant base
-   |
-17 | special_log(1, math.e)
-18 | special_log(1, special_e)
-19 | math.log(1, 2.0)
+ 9 | math.log(foo, 10)
+10 | math.log(foo, math.e)
+11 | math.log(1, 2.0)
    | ^^^^^^^^^^^^^^^^ FURB163
-20 | math.log(1, 10.0)
+12 | math.log(1, 10.0)
    |
    = help: Replace with `math.log2(1)`
 
 ℹ Safe fix
-16 16 | special_log(1, 10)
-17 17 | special_log(1, math.e)
-18 18 | special_log(1, special_e)
-19    |-math.log(1, 2.0)
-   19 |+math.log2(1)
-20 20 | math.log(1, 10.0)
-21 21 | 
-22 22 | # Ok.
+8  8  | math.log(foo, 2)
+9  9  | math.log(foo, 10)
+10 10 | math.log(foo, math.e)
+11    |-math.log(1, 2.0)
+   11 |+math.log2(1)
+12 12 | math.log(1, 10.0)
+13 13 | 
+14 14 | # OK
 
-FURB163.py:20:1: FURB163 [*] Prefer `math.log10(1)` over `math.log` with a redundant base
+FURB163.py:12:1: FURB163 [*] Prefer `math.log10(1)` over `math.log` with a redundant base
    |
-18 | special_log(1, special_e)
-19 | math.log(1, 2.0)
-20 | math.log(1, 10.0)
+10 | math.log(foo, math.e)
+11 | math.log(1, 2.0)
+12 | math.log(1, 10.0)
    | ^^^^^^^^^^^^^^^^^ FURB163
-21 | 
-22 | # Ok.
+13 | 
+14 | # OK
    |
    = help: Replace with `math.log10(1)`
 
 ℹ Safe fix
-17 17 | special_log(1, math.e)
-18 18 | special_log(1, special_e)
-19 19 | math.log(1, 2.0)
-20    |-math.log(1, 10.0)
-   20 |+math.log10(1)
-21 21 | 
-22 22 | # Ok.
-23 23 | math.log2(1)
-
-
+9  9  | math.log(foo, 10)
+10 10 | math.log(foo, math.e)
+11 11 | math.log(1, 2.0)
+12    |-math.log(1, 10.0)
+   12 |+math.log10(1)
+13 13 | 
+14 14 | # OK
+15 15 | math.log2(1)

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -27,6 +27,7 @@ mod tests {
     #[test_case(Rule::ImplicitOptional, Path::new("RUF013_0.py"))]
     #[test_case(Rule::ImplicitOptional, Path::new("RUF013_1.py"))]
     #[test_case(Rule::ImplicitOptional, Path::new("RUF013_2.py"))]
+    #[test_case(Rule::ImplicitOptional, Path::new("RUF013_3.py"))]
     #[test_case(Rule::MutableClassDefault, Path::new("RUF012.py"))]
     #[test_case(Rule::MutableDataclassDefault, Path::new("RUF008.py"))]
     #[test_case(Rule::PairwiseOverZipped, Path::new("RUF007.py"))]

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__PY39_RUF013_RUF013_0.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__PY39_RUF013_RUF013_0.py.snap
@@ -1,416 +1,360 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
-RUF013_0.py:21:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:20:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
-21 | def f(arg: int = None):  # RUF013
+20 | def f(arg: int = None):  # RUF013
    |            ^^^ RUF013
-22 |     pass
+21 |     pass
    |
    = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-18 18 |     pass
+17 17 |     pass
+18 18 | 
 19 19 | 
-20 20 | 
-21    |-def f(arg: int = None):  # RUF013
-   21 |+def f(arg: Optional[int] = None):  # RUF013
-22 22 |     pass
+20    |-def f(arg: int = None):  # RUF013
+   20 |+def f(arg: Optional[int] = None):  # RUF013
+21 21 |     pass
+22 22 | 
 23 23 | 
-24 24 | 
 
-RUF013_0.py:25:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:24:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
-25 | def f(arg: str = None):  # RUF013
+24 | def f(arg: str = None):  # RUF013
    |            ^^^ RUF013
-26 |     pass
+25 |     pass
    |
    = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-22 22 |     pass
+21 21 |     pass
+22 22 | 
 23 23 | 
-24 24 | 
-25    |-def f(arg: str = None):  # RUF013
-   25 |+def f(arg: Optional[str] = None):  # RUF013
-26 26 |     pass
+24    |-def f(arg: str = None):  # RUF013
+   24 |+def f(arg: Optional[str] = None):  # RUF013
+25 25 |     pass
+26 26 | 
 27 27 | 
-28 28 | 
 
-RUF013_0.py:29:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:28:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
-29 | def f(arg: typing.List[str] = None):  # RUF013
-   |            ^^^^^^^^^^^^^^^^ RUF013
-30 |     pass
-   |
-   = help: Convert to `Optional[T]`
-
-ℹ Unsafe fix
-26 26 |     pass
-27 27 | 
-28 28 | 
-29    |-def f(arg: typing.List[str] = None):  # RUF013
-   29 |+def f(arg: Optional[typing.List[str]] = None):  # RUF013
-30 30 |     pass
-31 31 | 
-32 32 | 
-
-RUF013_0.py:33:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
-   |
-33 | def f(arg: Tuple[str] = None):  # RUF013
+28 | def f(arg: Tuple[str] = None):  # RUF013
    |            ^^^^^^^^^^ RUF013
-34 |     pass
+29 |     pass
    |
    = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-30 30 |     pass
+25 25 |     pass
+26 26 | 
+27 27 | 
+28    |-def f(arg: Tuple[str] = None):  # RUF013
+   28 |+def f(arg: Optional[Tuple[str]] = None):  # RUF013
+29 29 |     pass
+30 30 | 
 31 31 | 
-32 32 | 
-33    |-def f(arg: Tuple[str] = None):  # RUF013
-   33 |+def f(arg: Optional[Tuple[str]] = None):  # RUF013
-34 34 |     pass
-35 35 | 
-36 36 | 
 
-RUF013_0.py:71:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:58:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
-71 | def f(arg: Union = None):  # RUF013
+58 | def f(arg: Union = None):  # RUF013
    |            ^^^^^ RUF013
-72 |     pass
+59 |     pass
    |
    = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-68 68 |     pass
-69 69 | 
-70 70 | 
-71    |-def f(arg: Union = None):  # RUF013
-   71 |+def f(arg: Optional[Union] = None):  # RUF013
-72 72 |     pass
-73 73 | 
-74 74 | 
+55 55 |     pass
+56 56 | 
+57 57 | 
+58    |-def f(arg: Union = None):  # RUF013
+   58 |+def f(arg: Optional[Union] = None):  # RUF013
+59 59 |     pass
+60 60 | 
+61 61 | 
 
-RUF013_0.py:75:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:62:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
-75 | def f(arg: Union[int] = None):  # RUF013
+62 | def f(arg: Union[int] = None):  # RUF013
    |            ^^^^^^^^^^ RUF013
-76 |     pass
+63 |     pass
    |
    = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-72 72 |     pass
-73 73 | 
-74 74 | 
-75    |-def f(arg: Union[int] = None):  # RUF013
-   75 |+def f(arg: Optional[Union[int]] = None):  # RUF013
-76 76 |     pass
-77 77 | 
-78 78 | 
+59 59 |     pass
+60 60 | 
+61 61 | 
+62    |-def f(arg: Union[int] = None):  # RUF013
+   62 |+def f(arg: Optional[Union[int]] = None):  # RUF013
+63 63 |     pass
+64 64 | 
+65 65 | 
 
-RUF013_0.py:79:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:66:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
-79 | def f(arg: Union[int, str] = None):  # RUF013
+66 | def f(arg: Union[int, str] = None):  # RUF013
    |            ^^^^^^^^^^^^^^^ RUF013
-80 |     pass
+67 |     pass
    |
    = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-76 76 |     pass
-77 77 | 
-78 78 | 
-79    |-def f(arg: Union[int, str] = None):  # RUF013
-   79 |+def f(arg: Optional[Union[int, str]] = None):  # RUF013
-80 80 |     pass
-81 81 | 
-82 82 | 
+63 63 |     pass
+64 64 | 
+65 65 | 
+66    |-def f(arg: Union[int, str] = None):  # RUF013
+   66 |+def f(arg: Optional[Union[int, str]] = None):  # RUF013
+67 67 |     pass
+68 68 | 
+69 69 | 
 
-RUF013_0.py:83:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:85:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
-83 | def f(arg: typing.Union[int, str] = None):  # RUF013
-   |            ^^^^^^^^^^^^^^^^^^^^^^ RUF013
-84 |     pass
+85 | def f(arg: int | float = None):  # RUF013
+   |            ^^^^^^^^^^^ RUF013
+86 |     pass
    |
    = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-80 80 |     pass
-81 81 | 
-82 82 | 
-83    |-def f(arg: typing.Union[int, str] = None):  # RUF013
-   83 |+def f(arg: Optional[typing.Union[int, str]] = None):  # RUF013
-84 84 |     pass
-85 85 | 
-86 86 | 
+82 82 |     pass
+83 83 | 
+84 84 | 
+85    |-def f(arg: int | float = None):  # RUF013
+   85 |+def f(arg: Optional[int | float] = None):  # RUF013
+86 86 |     pass
+87 87 | 
+88 88 | 
 
-RUF013_0.py:102:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
-    |
-102 | def f(arg: int | float = None):  # RUF013
-    |            ^^^^^^^^^^^ RUF013
-103 |     pass
-    |
-    = help: Convert to `Optional[T]`
-
-ℹ Unsafe fix
-99  99  |     pass
-100 100 | 
-101 101 | 
-102     |-def f(arg: int | float = None):  # RUF013
-    102 |+def f(arg: Optional[int | float] = None):  # RUF013
-103 103 |     pass
-104 104 | 
-105 105 | 
-
-RUF013_0.py:106:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
-    |
-106 | def f(arg: int | float | str | bytes = None):  # RUF013
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^^ RUF013
-107 |     pass
-    |
-    = help: Convert to `Optional[T]`
+RUF013_0.py:89:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+   |
+89 | def f(arg: int | float | str | bytes = None):  # RUF013
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^ RUF013
+90 |     pass
+   |
+   = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-103 103 |     pass
-104 104 | 
-105 105 | 
-106     |-def f(arg: int | float | str | bytes = None):  # RUF013
-    106 |+def f(arg: Optional[int | float | str | bytes] = None):  # RUF013
-107 107 |     pass
-108 108 | 
-109 109 | 
+86 86 |     pass
+87 87 | 
+88 88 | 
+89    |-def f(arg: int | float | str | bytes = None):  # RUF013
+   89 |+def f(arg: Optional[int | float | str | bytes] = None):  # RUF013
+90 90 |     pass
+91 91 | 
+92 92 | 
 
-RUF013_0.py:125:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:108:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-125 | def f(arg: Literal[1] = None):  # RUF013
+108 | def f(arg: Literal[1] = None):  # RUF013
     |            ^^^^^^^^^^ RUF013
-126 |     pass
+109 |     pass
     |
     = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-122 122 |     pass
-123 123 | 
-124 124 | 
-125     |-def f(arg: Literal[1] = None):  # RUF013
-    125 |+def f(arg: Optional[Literal[1]] = None):  # RUF013
-126 126 |     pass
-127 127 | 
-128 128 | 
+105 105 |     pass
+106 106 | 
+107 107 | 
+108     |-def f(arg: Literal[1] = None):  # RUF013
+    108 |+def f(arg: Optional[Literal[1]] = None):  # RUF013
+109 109 |     pass
+110 110 | 
+111 111 | 
 
-RUF013_0.py:129:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:112:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-129 | def f(arg: Literal[1, "foo"] = None):  # RUF013
+112 | def f(arg: Literal[1, "foo"] = None):  # RUF013
     |            ^^^^^^^^^^^^^^^^^ RUF013
-130 |     pass
+113 |     pass
     |
     = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-126 126 |     pass
-127 127 | 
-128 128 | 
-129     |-def f(arg: Literal[1, "foo"] = None):  # RUF013
-    129 |+def f(arg: Optional[Literal[1, "foo"]] = None):  # RUF013
-130 130 |     pass
-131 131 | 
-132 132 | 
+109 109 |     pass
+110 110 | 
+111 111 | 
+112     |-def f(arg: Literal[1, "foo"] = None):  # RUF013
+    112 |+def f(arg: Optional[Literal[1, "foo"]] = None):  # RUF013
+113 113 |     pass
+114 114 | 
+115 115 | 
 
-RUF013_0.py:133:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:131:22: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-133 | def f(arg: typing.Literal[1, "foo", True] = None):  # RUF013
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF013
-134 |     pass
-    |
-    = help: Convert to `Optional[T]`
-
-ℹ Unsafe fix
-130 130 |     pass
-131 131 | 
-132 132 | 
-133     |-def f(arg: typing.Literal[1, "foo", True] = None):  # RUF013
-    133 |+def f(arg: Optional[typing.Literal[1, "foo", True]] = None):  # RUF013
-134 134 |     pass
-135 135 | 
-136 136 | 
-
-RUF013_0.py:152:22: RUF013 [*] PEP 484 prohibits implicit `Optional`
-    |
-152 | def f(arg: Annotated[int, ...] = None):  # RUF013
+131 | def f(arg: Annotated[int, ...] = None):  # RUF013
     |                      ^^^ RUF013
-153 |     pass
+132 |     pass
     |
     = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-149 149 |     pass
-150 150 | 
-151 151 | 
-152     |-def f(arg: Annotated[int, ...] = None):  # RUF013
-    152 |+def f(arg: Annotated[Optional[int], ...] = None):  # RUF013
-153 153 |     pass
-154 154 | 
-155 155 | 
+128 128 |     pass
+129 129 | 
+130 130 | 
+131     |-def f(arg: Annotated[int, ...] = None):  # RUF013
+    131 |+def f(arg: Annotated[Optional[int], ...] = None):  # RUF013
+132 132 |     pass
+133 133 | 
+134 134 | 
 
-RUF013_0.py:156:32: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:135:32: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-156 | def f(arg: Annotated[Annotated[int | str, ...], ...] = None):  # RUF013
+135 | def f(arg: Annotated[Annotated[int | str, ...], ...] = None):  # RUF013
     |                                ^^^^^^^^^ RUF013
-157 |     pass
+136 |     pass
     |
     = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-153 153 |     pass
-154 154 | 
-155 155 | 
-156     |-def f(arg: Annotated[Annotated[int | str, ...], ...] = None):  # RUF013
-    156 |+def f(arg: Annotated[Annotated[Optional[int | str], ...], ...] = None):  # RUF013
-157 157 |     pass
-158 158 | 
-159 159 | 
+132 132 |     pass
+133 133 | 
+134 134 | 
+135     |-def f(arg: Annotated[Annotated[int | str, ...], ...] = None):  # RUF013
+    135 |+def f(arg: Annotated[Annotated[Optional[int | str], ...], ...] = None):  # RUF013
+136 136 |     pass
+137 137 | 
+138 138 | 
 
-RUF013_0.py:172:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:151:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-171 | def f(
-172 |     arg1: int = None,  # RUF013
+150 | def f(
+151 |     arg1: int = None,  # RUF013
     |           ^^^ RUF013
-173 |     arg2: Union[int, float] = None,  # RUF013
-174 |     arg3: Literal[1, 2, 3] = None,  # RUF013
+152 |     arg2: Union[int, float] = None,  # RUF013
+153 |     arg3: Literal[1, 2, 3] = None,  # RUF013
     |
     = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-169 169 | 
-170 170 | 
-171 171 | def f(
-172     |-    arg1: int = None,  # RUF013
-    172 |+    arg1: Optional[int] = None,  # RUF013
-173 173 |     arg2: Union[int, float] = None,  # RUF013
-174 174 |     arg3: Literal[1, 2, 3] = None,  # RUF013
-175 175 | ):
+148 148 | 
+149 149 | 
+150 150 | def f(
+151     |-    arg1: int = None,  # RUF013
+    151 |+    arg1: Optional[int] = None,  # RUF013
+152 152 |     arg2: Union[int, float] = None,  # RUF013
+153 153 |     arg3: Literal[1, 2, 3] = None,  # RUF013
+154 154 | ):
 
-RUF013_0.py:173:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:152:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-171 | def f(
-172 |     arg1: int = None,  # RUF013
-173 |     arg2: Union[int, float] = None,  # RUF013
+150 | def f(
+151 |     arg1: int = None,  # RUF013
+152 |     arg2: Union[int, float] = None,  # RUF013
     |           ^^^^^^^^^^^^^^^^^ RUF013
-174 |     arg3: Literal[1, 2, 3] = None,  # RUF013
-175 | ):
+153 |     arg3: Literal[1, 2, 3] = None,  # RUF013
+154 | ):
     |
     = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-170 170 | 
-171 171 | def f(
-172 172 |     arg1: int = None,  # RUF013
-173     |-    arg2: Union[int, float] = None,  # RUF013
-    173 |+    arg2: Optional[Union[int, float]] = None,  # RUF013
-174 174 |     arg3: Literal[1, 2, 3] = None,  # RUF013
-175 175 | ):
-176 176 |     pass
+149 149 | 
+150 150 | def f(
+151 151 |     arg1: int = None,  # RUF013
+152     |-    arg2: Union[int, float] = None,  # RUF013
+    152 |+    arg2: Optional[Union[int, float]] = None,  # RUF013
+153 153 |     arg3: Literal[1, 2, 3] = None,  # RUF013
+154 154 | ):
+155 155 |     pass
 
-RUF013_0.py:174:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:153:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-172 |     arg1: int = None,  # RUF013
-173 |     arg2: Union[int, float] = None,  # RUF013
-174 |     arg3: Literal[1, 2, 3] = None,  # RUF013
+151 |     arg1: int = None,  # RUF013
+152 |     arg2: Union[int, float] = None,  # RUF013
+153 |     arg3: Literal[1, 2, 3] = None,  # RUF013
     |           ^^^^^^^^^^^^^^^^ RUF013
-175 | ):
-176 |     pass
+154 | ):
+155 |     pass
     |
     = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-171 171 | def f(
-172 172 |     arg1: int = None,  # RUF013
-173 173 |     arg2: Union[int, float] = None,  # RUF013
-174     |-    arg3: Literal[1, 2, 3] = None,  # RUF013
-    174 |+    arg3: Optional[Literal[1, 2, 3]] = None,  # RUF013
-175 175 | ):
-176 176 |     pass
-177 177 | 
+150 150 | def f(
+151 151 |     arg1: int = None,  # RUF013
+152 152 |     arg2: Union[int, float] = None,  # RUF013
+153     |-    arg3: Literal[1, 2, 3] = None,  # RUF013
+    153 |+    arg3: Optional[Literal[1, 2, 3]] = None,  # RUF013
+154 154 | ):
+155 155 |     pass
+156 156 | 
 
-RUF013_0.py:202:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:181:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-202 | def f(arg: Union[Annotated[int, ...], Union[str, bytes]] = None):  # RUF013
+181 | def f(arg: Union[Annotated[int, ...], Union[str, bytes]] = None):  # RUF013
     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF013
-203 |     pass
+182 |     pass
     |
     = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-199 199 |     pass
-200 200 | 
-201 201 | 
-202     |-def f(arg: Union[Annotated[int, ...], Union[str, bytes]] = None):  # RUF013
-    202 |+def f(arg: Optional[Union[Annotated[int, ...], Union[str, bytes]]] = None):  # RUF013
-203 203 |     pass
-204 204 | 
-205 205 | 
+178 178 |     pass
+179 179 | 
+180 180 | 
+181     |-def f(arg: Union[Annotated[int, ...], Union[str, bytes]] = None):  # RUF013
+    181 |+def f(arg: Optional[Union[Annotated[int, ...], Union[str, bytes]]] = None):  # RUF013
+182 182 |     pass
+183 183 | 
+184 184 | 
 
-RUF013_0.py:209:13: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:188:13: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-209 | def f(arg: "int" = None):  # RUF013
+188 | def f(arg: "int" = None):  # RUF013
     |             ^^^ RUF013
-210 |     pass
+189 |     pass
     |
     = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-206 206 | # Quoted
-207 207 | 
-208 208 | 
-209     |-def f(arg: "int" = None):  # RUF013
-    209 |+def f(arg: "Optional[int]" = None):  # RUF013
-210 210 |     pass
-211 211 | 
-212 212 | 
+185 185 | # Quoted
+186 186 | 
+187 187 | 
+188     |-def f(arg: "int" = None):  # RUF013
+    188 |+def f(arg: "Optional[int]" = None):  # RUF013
+189 189 |     pass
+190 190 | 
+191 191 | 
 
-RUF013_0.py:213:13: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:192:13: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-213 | def f(arg: "str" = None):  # RUF013
+192 | def f(arg: "str" = None):  # RUF013
     |             ^^^ RUF013
-214 |     pass
+193 |     pass
     |
     = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-210 210 |     pass
-211 211 | 
-212 212 | 
-213     |-def f(arg: "str" = None):  # RUF013
-    213 |+def f(arg: "Optional[str]" = None):  # RUF013
-214 214 |     pass
-215 215 | 
-216 216 | 
+189 189 |     pass
+190 190 | 
+191 191 | 
+192     |-def f(arg: "str" = None):  # RUF013
+    192 |+def f(arg: "Optional[str]" = None):  # RUF013
+193 193 |     pass
+194 194 | 
+195 195 | 
 
-RUF013_0.py:217:12: RUF013 PEP 484 prohibits implicit `Optional`
+RUF013_0.py:196:12: RUF013 PEP 484 prohibits implicit `Optional`
     |
-217 | def f(arg: "st" "r" = None):  # RUF013
+196 | def f(arg: "st" "r" = None):  # RUF013
     |            ^^^^^^^^ RUF013
-218 |     pass
+197 |     pass
     |
     = help: Convert to `Optional[T]`
 
-RUF013_0.py:225:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:204:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-225 | def f(arg: Union["int", "str"] = None):  # RUF013
+204 | def f(arg: Union["int", "str"] = None):  # RUF013
     |            ^^^^^^^^^^^^^^^^^^^ RUF013
-226 |     pass
+205 |     pass
     |
     = help: Convert to `Optional[T]`
 
 ℹ Unsafe fix
-222 222 |     pass
-223 223 | 
-224 224 | 
-225     |-def f(arg: Union["int", "str"] = None):  # RUF013
-    225 |+def f(arg: Optional[Union["int", "str"]] = None):  # RUF013
-226 226 |     pass
-227 227 | 
-228 228 | 
-
-
+201 201 |     pass
+202 202 | 
+203 203 | 
+204     |-def f(arg: Union["int", "str"] = None):  # RUF013
+    204 |+def f(arg: Optional[Union["int", "str"]] = None):  # RUF013
+205 205 |     pass
+206 206 | 
+207 207 |

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__PY39_RUF013_RUF013_1.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__PY39_RUF013_RUF013_1.py.snap
@@ -3,7 +3,7 @@ source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
 RUF013_1.py:4:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
   |
-4 | def f(arg: int = None):  # RUF011
+4 | def f(arg: int = None):  # RUF013
   |            ^^^ RUF013
 5 |     pass
   |
@@ -14,8 +14,6 @@ RUF013_1.py:4:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
   2 |+from typing import Optional
 2 3 | 
 3 4 | 
-4   |-def f(arg: int = None):  # RUF011
-  5 |+def f(arg: Optional[int] = None):  # RUF011
+4   |-def f(arg: int = None):  # RUF013
+  5 |+def f(arg: Optional[int] = None):  # RUF013
 5 6 |     pass
-
-

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF013_RUF013_0.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF013_RUF013_0.py.snap
@@ -1,416 +1,360 @@
 ---
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
-RUF013_0.py:21:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:20:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
-21 | def f(arg: int = None):  # RUF013
+20 | def f(arg: int = None):  # RUF013
    |            ^^^ RUF013
-22 |     pass
+21 |     pass
    |
    = help: Convert to `T | None`
 
 ℹ Unsafe fix
-18 18 |     pass
+17 17 |     pass
+18 18 | 
 19 19 | 
-20 20 | 
-21    |-def f(arg: int = None):  # RUF013
-   21 |+def f(arg: int | None = None):  # RUF013
-22 22 |     pass
+20    |-def f(arg: int = None):  # RUF013
+   20 |+def f(arg: int | None = None):  # RUF013
+21 21 |     pass
+22 22 | 
 23 23 | 
-24 24 | 
 
-RUF013_0.py:25:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:24:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
-25 | def f(arg: str = None):  # RUF013
+24 | def f(arg: str = None):  # RUF013
    |            ^^^ RUF013
-26 |     pass
+25 |     pass
    |
    = help: Convert to `T | None`
 
 ℹ Unsafe fix
-22 22 |     pass
+21 21 |     pass
+22 22 | 
 23 23 | 
-24 24 | 
-25    |-def f(arg: str = None):  # RUF013
-   25 |+def f(arg: str | None = None):  # RUF013
-26 26 |     pass
+24    |-def f(arg: str = None):  # RUF013
+   24 |+def f(arg: str | None = None):  # RUF013
+25 25 |     pass
+26 26 | 
 27 27 | 
-28 28 | 
 
-RUF013_0.py:29:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:28:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
-29 | def f(arg: typing.List[str] = None):  # RUF013
-   |            ^^^^^^^^^^^^^^^^ RUF013
-30 |     pass
-   |
-   = help: Convert to `T | None`
-
-ℹ Unsafe fix
-26 26 |     pass
-27 27 | 
-28 28 | 
-29    |-def f(arg: typing.List[str] = None):  # RUF013
-   29 |+def f(arg: typing.List[str] | None = None):  # RUF013
-30 30 |     pass
-31 31 | 
-32 32 | 
-
-RUF013_0.py:33:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
-   |
-33 | def f(arg: Tuple[str] = None):  # RUF013
+28 | def f(arg: Tuple[str] = None):  # RUF013
    |            ^^^^^^^^^^ RUF013
-34 |     pass
+29 |     pass
    |
    = help: Convert to `T | None`
 
 ℹ Unsafe fix
-30 30 |     pass
+25 25 |     pass
+26 26 | 
+27 27 | 
+28    |-def f(arg: Tuple[str] = None):  # RUF013
+   28 |+def f(arg: Tuple[str] | None = None):  # RUF013
+29 29 |     pass
+30 30 | 
 31 31 | 
-32 32 | 
-33    |-def f(arg: Tuple[str] = None):  # RUF013
-   33 |+def f(arg: Tuple[str] | None = None):  # RUF013
-34 34 |     pass
-35 35 | 
-36 36 | 
 
-RUF013_0.py:71:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:58:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
-71 | def f(arg: Union = None):  # RUF013
+58 | def f(arg: Union = None):  # RUF013
    |            ^^^^^ RUF013
-72 |     pass
+59 |     pass
    |
    = help: Convert to `T | None`
 
 ℹ Unsafe fix
-68 68 |     pass
-69 69 | 
-70 70 | 
-71    |-def f(arg: Union = None):  # RUF013
-   71 |+def f(arg: Union | None = None):  # RUF013
-72 72 |     pass
-73 73 | 
-74 74 | 
+55 55 |     pass
+56 56 | 
+57 57 | 
+58    |-def f(arg: Union = None):  # RUF013
+   58 |+def f(arg: Union | None = None):  # RUF013
+59 59 |     pass
+60 60 | 
+61 61 | 
 
-RUF013_0.py:75:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:62:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
-75 | def f(arg: Union[int] = None):  # RUF013
+62 | def f(arg: Union[int] = None):  # RUF013
    |            ^^^^^^^^^^ RUF013
-76 |     pass
+63 |     pass
    |
    = help: Convert to `T | None`
 
 ℹ Unsafe fix
-72 72 |     pass
-73 73 | 
-74 74 | 
-75    |-def f(arg: Union[int] = None):  # RUF013
-   75 |+def f(arg: Union[int] | None = None):  # RUF013
-76 76 |     pass
-77 77 | 
-78 78 | 
+59 59 |     pass
+60 60 | 
+61 61 | 
+62    |-def f(arg: Union[int] = None):  # RUF013
+   62 |+def f(arg: Union[int] | None = None):  # RUF013
+63 63 |     pass
+64 64 | 
+65 65 | 
 
-RUF013_0.py:79:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:66:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
-79 | def f(arg: Union[int, str] = None):  # RUF013
+66 | def f(arg: Union[int, str] = None):  # RUF013
    |            ^^^^^^^^^^^^^^^ RUF013
-80 |     pass
+67 |     pass
    |
    = help: Convert to `T | None`
 
 ℹ Unsafe fix
-76 76 |     pass
-77 77 | 
-78 78 | 
-79    |-def f(arg: Union[int, str] = None):  # RUF013
-   79 |+def f(arg: Union[int, str] | None = None):  # RUF013
-80 80 |     pass
-81 81 | 
-82 82 | 
+63 63 |     pass
+64 64 | 
+65 65 | 
+66    |-def f(arg: Union[int, str] = None):  # RUF013
+   66 |+def f(arg: Union[int, str] | None = None):  # RUF013
+67 67 |     pass
+68 68 | 
+69 69 | 
 
-RUF013_0.py:83:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:85:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
    |
-83 | def f(arg: typing.Union[int, str] = None):  # RUF013
-   |            ^^^^^^^^^^^^^^^^^^^^^^ RUF013
-84 |     pass
+85 | def f(arg: int | float = None):  # RUF013
+   |            ^^^^^^^^^^^ RUF013
+86 |     pass
    |
    = help: Convert to `T | None`
 
 ℹ Unsafe fix
-80 80 |     pass
-81 81 | 
-82 82 | 
-83    |-def f(arg: typing.Union[int, str] = None):  # RUF013
-   83 |+def f(arg: typing.Union[int, str] | None = None):  # RUF013
-84 84 |     pass
-85 85 | 
-86 86 | 
+82 82 |     pass
+83 83 | 
+84 84 | 
+85    |-def f(arg: int | float = None):  # RUF013
+   85 |+def f(arg: int | float | None = None):  # RUF013
+86 86 |     pass
+87 87 | 
+88 88 | 
 
-RUF013_0.py:102:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
-    |
-102 | def f(arg: int | float = None):  # RUF013
-    |            ^^^^^^^^^^^ RUF013
-103 |     pass
-    |
-    = help: Convert to `T | None`
-
-ℹ Unsafe fix
-99  99  |     pass
-100 100 | 
-101 101 | 
-102     |-def f(arg: int | float = None):  # RUF013
-    102 |+def f(arg: int | float | None = None):  # RUF013
-103 103 |     pass
-104 104 | 
-105 105 | 
-
-RUF013_0.py:106:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
-    |
-106 | def f(arg: int | float | str | bytes = None):  # RUF013
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^^ RUF013
-107 |     pass
-    |
-    = help: Convert to `T | None`
+RUF013_0.py:89:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+   |
+89 | def f(arg: int | float | str | bytes = None):  # RUF013
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^ RUF013
+90 |     pass
+   |
+   = help: Convert to `T | None`
 
 ℹ Unsafe fix
-103 103 |     pass
-104 104 | 
-105 105 | 
-106     |-def f(arg: int | float | str | bytes = None):  # RUF013
-    106 |+def f(arg: int | float | str | bytes | None = None):  # RUF013
-107 107 |     pass
-108 108 | 
-109 109 | 
+86 86 |     pass
+87 87 | 
+88 88 | 
+89    |-def f(arg: int | float | str | bytes = None):  # RUF013
+   89 |+def f(arg: int | float | str | bytes | None = None):  # RUF013
+90 90 |     pass
+91 91 | 
+92 92 | 
 
-RUF013_0.py:125:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:108:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-125 | def f(arg: Literal[1] = None):  # RUF013
+108 | def f(arg: Literal[1] = None):  # RUF013
     |            ^^^^^^^^^^ RUF013
-126 |     pass
+109 |     pass
     |
     = help: Convert to `T | None`
 
 ℹ Unsafe fix
-122 122 |     pass
-123 123 | 
-124 124 | 
-125     |-def f(arg: Literal[1] = None):  # RUF013
-    125 |+def f(arg: Literal[1] | None = None):  # RUF013
-126 126 |     pass
-127 127 | 
-128 128 | 
+105 105 |     pass
+106 106 | 
+107 107 | 
+108     |-def f(arg: Literal[1] = None):  # RUF013
+    108 |+def f(arg: Literal[1] | None = None):  # RUF013
+109 109 |     pass
+110 110 | 
+111 111 | 
 
-RUF013_0.py:129:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:112:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-129 | def f(arg: Literal[1, "foo"] = None):  # RUF013
+112 | def f(arg: Literal[1, "foo"] = None):  # RUF013
     |            ^^^^^^^^^^^^^^^^^ RUF013
-130 |     pass
+113 |     pass
     |
     = help: Convert to `T | None`
 
 ℹ Unsafe fix
-126 126 |     pass
-127 127 | 
-128 128 | 
-129     |-def f(arg: Literal[1, "foo"] = None):  # RUF013
-    129 |+def f(arg: Literal[1, "foo"] | None = None):  # RUF013
-130 130 |     pass
-131 131 | 
-132 132 | 
+109 109 |     pass
+110 110 | 
+111 111 | 
+112     |-def f(arg: Literal[1, "foo"] = None):  # RUF013
+    112 |+def f(arg: Literal[1, "foo"] | None = None):  # RUF013
+113 113 |     pass
+114 114 | 
+115 115 | 
 
-RUF013_0.py:133:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:131:22: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-133 | def f(arg: typing.Literal[1, "foo", True] = None):  # RUF013
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF013
-134 |     pass
-    |
-    = help: Convert to `T | None`
-
-ℹ Unsafe fix
-130 130 |     pass
-131 131 | 
-132 132 | 
-133     |-def f(arg: typing.Literal[1, "foo", True] = None):  # RUF013
-    133 |+def f(arg: typing.Literal[1, "foo", True] | None = None):  # RUF013
-134 134 |     pass
-135 135 | 
-136 136 | 
-
-RUF013_0.py:152:22: RUF013 [*] PEP 484 prohibits implicit `Optional`
-    |
-152 | def f(arg: Annotated[int, ...] = None):  # RUF013
+131 | def f(arg: Annotated[int, ...] = None):  # RUF013
     |                      ^^^ RUF013
-153 |     pass
+132 |     pass
     |
     = help: Convert to `T | None`
 
 ℹ Unsafe fix
-149 149 |     pass
-150 150 | 
-151 151 | 
-152     |-def f(arg: Annotated[int, ...] = None):  # RUF013
-    152 |+def f(arg: Annotated[int | None, ...] = None):  # RUF013
-153 153 |     pass
-154 154 | 
-155 155 | 
+128 128 |     pass
+129 129 | 
+130 130 | 
+131     |-def f(arg: Annotated[int, ...] = None):  # RUF013
+    131 |+def f(arg: Annotated[int | None, ...] = None):  # RUF013
+132 132 |     pass
+133 133 | 
+134 134 | 
 
-RUF013_0.py:156:32: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:135:32: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-156 | def f(arg: Annotated[Annotated[int | str, ...], ...] = None):  # RUF013
+135 | def f(arg: Annotated[Annotated[int | str, ...], ...] = None):  # RUF013
     |                                ^^^^^^^^^ RUF013
-157 |     pass
+136 |     pass
     |
     = help: Convert to `T | None`
 
 ℹ Unsafe fix
-153 153 |     pass
-154 154 | 
-155 155 | 
-156     |-def f(arg: Annotated[Annotated[int | str, ...], ...] = None):  # RUF013
-    156 |+def f(arg: Annotated[Annotated[int | str | None, ...], ...] = None):  # RUF013
-157 157 |     pass
-158 158 | 
-159 159 | 
+132 132 |     pass
+133 133 | 
+134 134 | 
+135     |-def f(arg: Annotated[Annotated[int | str, ...], ...] = None):  # RUF013
+    135 |+def f(arg: Annotated[Annotated[int | str | None, ...], ...] = None):  # RUF013
+136 136 |     pass
+137 137 | 
+138 138 | 
 
-RUF013_0.py:172:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:151:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-171 | def f(
-172 |     arg1: int = None,  # RUF013
+150 | def f(
+151 |     arg1: int = None,  # RUF013
     |           ^^^ RUF013
-173 |     arg2: Union[int, float] = None,  # RUF013
-174 |     arg3: Literal[1, 2, 3] = None,  # RUF013
+152 |     arg2: Union[int, float] = None,  # RUF013
+153 |     arg3: Literal[1, 2, 3] = None,  # RUF013
     |
     = help: Convert to `T | None`
 
 ℹ Unsafe fix
-169 169 | 
-170 170 | 
-171 171 | def f(
-172     |-    arg1: int = None,  # RUF013
-    172 |+    arg1: int | None = None,  # RUF013
-173 173 |     arg2: Union[int, float] = None,  # RUF013
-174 174 |     arg3: Literal[1, 2, 3] = None,  # RUF013
-175 175 | ):
+148 148 | 
+149 149 | 
+150 150 | def f(
+151     |-    arg1: int = None,  # RUF013
+    151 |+    arg1: int | None = None,  # RUF013
+152 152 |     arg2: Union[int, float] = None,  # RUF013
+153 153 |     arg3: Literal[1, 2, 3] = None,  # RUF013
+154 154 | ):
 
-RUF013_0.py:173:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:152:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-171 | def f(
-172 |     arg1: int = None,  # RUF013
-173 |     arg2: Union[int, float] = None,  # RUF013
+150 | def f(
+151 |     arg1: int = None,  # RUF013
+152 |     arg2: Union[int, float] = None,  # RUF013
     |           ^^^^^^^^^^^^^^^^^ RUF013
-174 |     arg3: Literal[1, 2, 3] = None,  # RUF013
-175 | ):
+153 |     arg3: Literal[1, 2, 3] = None,  # RUF013
+154 | ):
     |
     = help: Convert to `T | None`
 
 ℹ Unsafe fix
-170 170 | 
-171 171 | def f(
-172 172 |     arg1: int = None,  # RUF013
-173     |-    arg2: Union[int, float] = None,  # RUF013
-    173 |+    arg2: Union[int, float] | None = None,  # RUF013
-174 174 |     arg3: Literal[1, 2, 3] = None,  # RUF013
-175 175 | ):
-176 176 |     pass
+149 149 | 
+150 150 | def f(
+151 151 |     arg1: int = None,  # RUF013
+152     |-    arg2: Union[int, float] = None,  # RUF013
+    152 |+    arg2: Union[int, float] | None = None,  # RUF013
+153 153 |     arg3: Literal[1, 2, 3] = None,  # RUF013
+154 154 | ):
+155 155 |     pass
 
-RUF013_0.py:174:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:153:11: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-172 |     arg1: int = None,  # RUF013
-173 |     arg2: Union[int, float] = None,  # RUF013
-174 |     arg3: Literal[1, 2, 3] = None,  # RUF013
+151 |     arg1: int = None,  # RUF013
+152 |     arg2: Union[int, float] = None,  # RUF013
+153 |     arg3: Literal[1, 2, 3] = None,  # RUF013
     |           ^^^^^^^^^^^^^^^^ RUF013
-175 | ):
-176 |     pass
+154 | ):
+155 |     pass
     |
     = help: Convert to `T | None`
 
 ℹ Unsafe fix
-171 171 | def f(
-172 172 |     arg1: int = None,  # RUF013
-173 173 |     arg2: Union[int, float] = None,  # RUF013
-174     |-    arg3: Literal[1, 2, 3] = None,  # RUF013
-    174 |+    arg3: Literal[1, 2, 3] | None = None,  # RUF013
-175 175 | ):
-176 176 |     pass
-177 177 | 
+150 150 | def f(
+151 151 |     arg1: int = None,  # RUF013
+152 152 |     arg2: Union[int, float] = None,  # RUF013
+153     |-    arg3: Literal[1, 2, 3] = None,  # RUF013
+    153 |+    arg3: Literal[1, 2, 3] | None = None,  # RUF013
+154 154 | ):
+155 155 |     pass
+156 156 | 
 
-RUF013_0.py:202:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:181:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-202 | def f(arg: Union[Annotated[int, ...], Union[str, bytes]] = None):  # RUF013
+181 | def f(arg: Union[Annotated[int, ...], Union[str, bytes]] = None):  # RUF013
     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF013
-203 |     pass
+182 |     pass
     |
     = help: Convert to `T | None`
 
 ℹ Unsafe fix
-199 199 |     pass
-200 200 | 
-201 201 | 
-202     |-def f(arg: Union[Annotated[int, ...], Union[str, bytes]] = None):  # RUF013
-    202 |+def f(arg: Union[Annotated[int, ...], Union[str, bytes]] | None = None):  # RUF013
-203 203 |     pass
-204 204 | 
-205 205 | 
+178 178 |     pass
+179 179 | 
+180 180 | 
+181     |-def f(arg: Union[Annotated[int, ...], Union[str, bytes]] = None):  # RUF013
+    181 |+def f(arg: Union[Annotated[int, ...], Union[str, bytes]] | None = None):  # RUF013
+182 182 |     pass
+183 183 | 
+184 184 | 
 
-RUF013_0.py:209:13: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:188:13: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-209 | def f(arg: "int" = None):  # RUF013
+188 | def f(arg: "int" = None):  # RUF013
     |             ^^^ RUF013
-210 |     pass
+189 |     pass
     |
     = help: Convert to `T | None`
 
 ℹ Unsafe fix
-206 206 | # Quoted
-207 207 | 
-208 208 | 
-209     |-def f(arg: "int" = None):  # RUF013
-    209 |+def f(arg: "int | None" = None):  # RUF013
-210 210 |     pass
-211 211 | 
-212 212 | 
+185 185 | # Quoted
+186 186 | 
+187 187 | 
+188     |-def f(arg: "int" = None):  # RUF013
+    188 |+def f(arg: "int | None" = None):  # RUF013
+189 189 |     pass
+190 190 | 
+191 191 | 
 
-RUF013_0.py:213:13: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:192:13: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-213 | def f(arg: "str" = None):  # RUF013
+192 | def f(arg: "str" = None):  # RUF013
     |             ^^^ RUF013
-214 |     pass
+193 |     pass
     |
     = help: Convert to `T | None`
 
 ℹ Unsafe fix
-210 210 |     pass
-211 211 | 
-212 212 | 
-213     |-def f(arg: "str" = None):  # RUF013
-    213 |+def f(arg: "str | None" = None):  # RUF013
-214 214 |     pass
-215 215 | 
-216 216 | 
+189 189 |     pass
+190 190 | 
+191 191 | 
+192     |-def f(arg: "str" = None):  # RUF013
+    192 |+def f(arg: "str | None" = None):  # RUF013
+193 193 |     pass
+194 194 | 
+195 195 | 
 
-RUF013_0.py:217:12: RUF013 PEP 484 prohibits implicit `Optional`
+RUF013_0.py:196:12: RUF013 PEP 484 prohibits implicit `Optional`
     |
-217 | def f(arg: "st" "r" = None):  # RUF013
+196 | def f(arg: "st" "r" = None):  # RUF013
     |            ^^^^^^^^ RUF013
-218 |     pass
+197 |     pass
     |
     = help: Convert to `T | None`
 
-RUF013_0.py:225:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+RUF013_0.py:204:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
     |
-225 | def f(arg: Union["int", "str"] = None):  # RUF013
+204 | def f(arg: Union["int", "str"] = None):  # RUF013
     |            ^^^^^^^^^^^^^^^^^^^ RUF013
-226 |     pass
+205 |     pass
     |
     = help: Convert to `T | None`
 
 ℹ Unsafe fix
-222 222 |     pass
-223 223 | 
-224 224 | 
-225     |-def f(arg: Union["int", "str"] = None):  # RUF013
-    225 |+def f(arg: Union["int", "str"] | None = None):  # RUF013
-226 226 |     pass
-227 227 | 
-228 228 | 
-
-
+201 201 |     pass
+202 202 | 
+203 203 | 
+204     |-def f(arg: Union["int", "str"] = None):  # RUF013
+    204 |+def f(arg: Union["int", "str"] | None = None):  # RUF013
+205 205 |     pass
+206 206 | 
+207 207 |

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF013_RUF013_1.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF013_RUF013_1.py.snap
@@ -3,7 +3,7 @@ source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
 RUF013_1.py:4:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
   |
-4 | def f(arg: int = None):  # RUF011
+4 | def f(arg: int = None):  # RUF013
   |            ^^^ RUF013
 5 |     pass
   |
@@ -13,8 +13,6 @@ RUF013_1.py:4:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
 1 1 | # No `typing.Optional` import
 2 2 | 
 3 3 | 
-4   |-def f(arg: int = None):  # RUF011
-  4 |+def f(arg: int | None = None):  # RUF011
+4   |-def f(arg: int = None):  # RUF013
+  4 |+def f(arg: int | None = None):  # RUF013
 5 5 |     pass
-
-

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF013_RUF013_3.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF013_RUF013_3.py.snap
@@ -1,0 +1,54 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+RUF013_3.py:4:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+  |
+4 | def f(arg: typing.List[str] = None):  # RUF013
+  |            ^^^^^^^^^^^^^^^^ RUF013
+5 |     pass
+  |
+  = help: Convert to `T | None`
+
+ℹ Unsafe fix
+1 1 | import typing
+2 2 | 
+3 3 | 
+4   |-def f(arg: typing.List[str] = None):  # RUF013
+  4 |+def f(arg: typing.List[str] | None = None):  # RUF013
+5 5 |     pass
+6 6 | 
+7 7 | 
+
+RUF013_3.py:22:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+   |
+22 | def f(arg: typing.Union[int, str] = None):  # RUF013
+   |            ^^^^^^^^^^^^^^^^^^^^^^ RUF013
+23 |     pass
+   |
+   = help: Convert to `T | None`
+
+ℹ Unsafe fix
+19 19 |     pass
+20 20 | 
+21 21 | 
+22    |-def f(arg: typing.Union[int, str] = None):  # RUF013
+   22 |+def f(arg: typing.Union[int, str] | None = None):  # RUF013
+23 23 |     pass
+24 24 | 
+25 25 | 
+
+RUF013_3.py:29:12: RUF013 [*] PEP 484 prohibits implicit `Optional`
+   |
+29 | def f(arg: typing.Literal[1, "foo", True] = None):  # RUF013
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RUF013
+30 |     pass
+   |
+   = help: Convert to `T | None`
+
+ℹ Unsafe fix
+26 26 | # Literal
+27 27 | 
+28 28 | 
+29    |-def f(arg: typing.Literal[1, "foo", True] = None):  # RUF013
+   29 |+def f(arg: typing.Literal[1, "foo", True] | None = None):  # RUF013
+30 30 |     pass

--- a/crates/ruff_linter/src/rules/tryceratops/snapshots/ruff_linter__rules__tryceratops__tests__error-instead-of-exception_TRY400.py.snap
+++ b/crates/ruff_linter/src/rules/tryceratops/snapshots/ruff_linter__rules__tryceratops__tests__error-instead-of-exception_TRY400.py.snap
@@ -1,215 +1,213 @@
 ---
 source: crates/ruff_linter/src/rules/tryceratops/mod.rs
 ---
-TRY400.py:16:9: TRY400 [*] Use `logging.exception` instead of `logging.error`
+TRY400.py:13:9: TRY400 [*] Use `logging.exception` instead of `logging.error`
    |
-14 |         a = 1
-15 |     except Exception:
-16 |         logging.error("Context message here")
+11 |         a = 1
+12 |     except Exception:
+13 |         logging.error("Context message here")
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
-17 | 
-18 |         if True:
+14 | 
+15 |         if True:
    |
    = help: Replace with `exception`
 
 ℹ Safe fix
-13 13 |     try:
-14 14 |         a = 1
-15 15 |     except Exception:
-16    |-        logging.error("Context message here")
-   16 |+        logging.exception("Context message here")
-17 17 | 
-18 18 |         if True:
-19 19 |             logging.error("Context message here")
+10 10 |     try:
+11 11 |         a = 1
+12 12 |     except Exception:
+13    |-        logging.error("Context message here")
+   13 |+        logging.exception("Context message here")
+14 14 | 
+15 15 |         if True:
+16 16 |             logging.error("Context message here")
 
-TRY400.py:19:13: TRY400 [*] Use `logging.exception` instead of `logging.error`
+TRY400.py:16:13: TRY400 [*] Use `logging.exception` instead of `logging.error`
    |
-18 |         if True:
-19 |             logging.error("Context message here")
+15 |         if True:
+16 |             logging.error("Context message here")
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
    |
    = help: Replace with `exception`
 
 ℹ Safe fix
-16 16 |         logging.error("Context message here")
+13 13 |         logging.error("Context message here")
+14 14 | 
+15 15 |         if True:
+16    |-            logging.error("Context message here")
+   16 |+            logging.exception("Context message here")
 17 17 | 
-18 18 |         if True:
-19    |-            logging.error("Context message here")
-   19 |+            logging.exception("Context message here")
-20 20 | 
-21 21 | 
-22 22 | def bad():
+18 18 | 
+19 19 | def bad():
 
-TRY400.py:26:9: TRY400 [*] Use `logging.exception` instead of `logging.error`
+TRY400.py:27:9: TRY400 [*] Use `logging.exception` instead of `logging.error`
    |
-24 |         a = 1
-25 |     except Exception:
-26 |         logger.error("Context message here")
+25 |         a = 1
+26 |     except Exception:
+27 |         logger.error("Context message here")
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
-27 | 
-28 |         if True:
+28 | 
+29 |         if True:
    |
    = help: Replace with `exception`
 
 ℹ Unsafe fix
-23 23 |     try:
-24 24 |         a = 1
-25 25 |     except Exception:
-26    |-        logger.error("Context message here")
-   26 |+        logger.exception("Context message here")
-27 27 | 
-28 28 |         if True:
-29 29 |             logger.error("Context message here")
+24 24 |     try:
+25 25 |         a = 1
+26 26 |     except Exception:
+27    |-        logger.error("Context message here")
+   27 |+        logger.exception("Context message here")
+28 28 | 
+29 29 |         if True:
+30 30 |             logger.error("Context message here")
 
-TRY400.py:29:13: TRY400 [*] Use `logging.exception` instead of `logging.error`
+TRY400.py:30:13: TRY400 [*] Use `logging.exception` instead of `logging.error`
    |
-28 |         if True:
-29 |             logger.error("Context message here")
+29 |         if True:
+30 |             logger.error("Context message here")
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
    |
    = help: Replace with `exception`
 
 ℹ Unsafe fix
-26 26 |         logger.error("Context message here")
-27 27 | 
-28 28 |         if True:
-29    |-            logger.error("Context message here")
-   29 |+            logger.exception("Context message here")
-30 30 | 
+27 27 |         logger.error("Context message here")
+28 28 | 
+29 29 |         if True:
+30    |-            logger.error("Context message here")
+   30 |+            logger.exception("Context message here")
 31 31 | 
-32 32 | def bad():
+32 32 | 
+33 33 | def bad():
 
-TRY400.py:36:9: TRY400 [*] Use `logging.exception` instead of `logging.error`
+TRY400.py:37:9: TRY400 [*] Use `logging.exception` instead of `logging.error`
    |
-34 |         a = 1
-35 |     except Exception:
-36 |         log.error("Context message here")
+35 |         a = 1
+36 |     except Exception:
+37 |         log.error("Context message here")
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
-37 | 
-38 |         if True:
+38 | 
+39 |         if True:
    |
    = help: Replace with `exception`
 
 ℹ Unsafe fix
-33 33 |     try:
-34 34 |         a = 1
-35 35 |     except Exception:
-36    |-        log.error("Context message here")
-   36 |+        log.exception("Context message here")
-37 37 | 
-38 38 |         if True:
-39 39 |             log.error("Context message here")
+34 34 |     try:
+35 35 |         a = 1
+36 36 |     except Exception:
+37    |-        log.error("Context message here")
+   37 |+        log.exception("Context message here")
+38 38 | 
+39 39 |         if True:
+40 40 |             log.error("Context message here")
 
-TRY400.py:39:13: TRY400 [*] Use `logging.exception` instead of `logging.error`
+TRY400.py:40:13: TRY400 [*] Use `logging.exception` instead of `logging.error`
    |
-38 |         if True:
-39 |             log.error("Context message here")
+39 |         if True:
+40 |             log.error("Context message here")
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
    |
    = help: Replace with `exception`
 
 ℹ Unsafe fix
-36 36 |         log.error("Context message here")
-37 37 | 
-38 38 |         if True:
-39    |-            log.error("Context message here")
-   39 |+            log.exception("Context message here")
-40 40 | 
+37 37 |         log.error("Context message here")
+38 38 | 
+39 39 |         if True:
+40    |-            log.error("Context message here")
+   40 |+            log.exception("Context message here")
 41 41 | 
-42 42 | def bad():
+42 42 | 
+43 43 | def bad():
 
-TRY400.py:46:9: TRY400 [*] Use `logging.exception` instead of `logging.error`
+TRY400.py:47:9: TRY400 [*] Use `logging.exception` instead of `logging.error`
    |
-44 |         a = 1
-45 |     except Exception:
-46 |         self.logger.error("Context message here")
+45 |         a = 1
+46 |     except Exception:
+47 |         self.logger.error("Context message here")
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
-47 | 
-48 |         if True:
+48 | 
+49 |         if True:
    |
    = help: Replace with `exception`
 
 ℹ Unsafe fix
-43 43 |     try:
-44 44 |         a = 1
-45 45 |     except Exception:
-46    |-        self.logger.error("Context message here")
-   46 |+        self.logger.exception("Context message here")
-47 47 | 
-48 48 |         if True:
-49 49 |             self.logger.error("Context message here")
+44 44 |     try:
+45 45 |         a = 1
+46 46 |     except Exception:
+47    |-        self.logger.error("Context message here")
+   47 |+        self.logger.exception("Context message here")
+48 48 | 
+49 49 |         if True:
+50 50 |             self.logger.error("Context message here")
 
-TRY400.py:49:13: TRY400 [*] Use `logging.exception` instead of `logging.error`
+TRY400.py:50:13: TRY400 [*] Use `logging.exception` instead of `logging.error`
    |
-48 |         if True:
-49 |             self.logger.error("Context message here")
+49 |         if True:
+50 |             self.logger.error("Context message here")
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
    |
    = help: Replace with `exception`
 
 ℹ Unsafe fix
-46 46 |         self.logger.error("Context message here")
-47 47 | 
-48 48 |         if True:
-49    |-            self.logger.error("Context message here")
-   49 |+            self.logger.exception("Context message here")
-50 50 | 
+47 47 |         self.logger.error("Context message here")
+48 48 | 
+49 49 |         if True:
+50    |-            self.logger.error("Context message here")
+   50 |+            self.logger.exception("Context message here")
 51 51 | 
-52 52 | def good():
+52 52 | 
+53 53 | def good():
 
-TRY400.py:87:9: TRY400 [*] Use `logging.exception` instead of `logging.error`
-   |
-85 |         a = 1
-86 |     except Exception:
-87 |         error("Context message here")
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
-88 | 
-89 |         if True:
-   |
-   = help: Replace with `exception`
-
-ℹ Safe fix
-84 84 |     try:
-85 85 |         a = 1
-86 86 |     except Exception:
-87    |-        error("Context message here")
-   87 |+        exception("Context message here")
-88 88 | 
-89 89 |         if True:
-90 90 |             error("Context message here")
-
-TRY400.py:90:13: TRY400 [*] Use `logging.exception` instead of `logging.error`
-   |
-89 |         if True:
-90 |             error("Context message here")
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
-   |
-   = help: Replace with `exception`
-
-ℹ Safe fix
-87 87 |         error("Context message here")
-88 88 | 
-89 89 |         if True:
-90    |-            error("Context message here")
-   90 |+            exception("Context message here")
-91 91 | 
-92 92 | 
-93 93 | def good():
-
-TRY400.py:121:13: TRY400 [*] Use `logging.exception` instead of `logging.error`
+TRY400.py:100:9: TRY400 [*] Use `logging.exception` instead of `logging.error`
     |
-119 |             b = 2
-120 |         except Exception:
-121 |             error("Context message here")
+ 98 |         a = 1
+ 99 |     except Exception:
+100 |         error("Context message here")
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
+101 | 
+102 |         if True:
+    |
+    = help: Replace with `exception`
+
+ℹ Safe fix
+97  97  |     try:
+98  98  |         a = 1
+99  99  |     except Exception:
+100     |-        error("Context message here")
+    100 |+        exception("Context message here")
+101 101 | 
+102 102 |         if True:
+103 103 |             error("Context message here")
+
+TRY400.py:103:13: TRY400 [*] Use `logging.exception` instead of `logging.error`
+    |
+102 |         if True:
+103 |             error("Context message here")
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
     |
     = help: Replace with `exception`
 
 ℹ Safe fix
-118 118 |         try:
-119 119 |             b = 2
-120 120 |         except Exception:
-121     |-            error("Context message here")
-    121 |+            exception("Context message here")
+100 100 |         error("Context message here")
+101 101 | 
+102 102 |         if True:
+103     |-            error("Context message here")
+    103 |+            exception("Context message here")
+104 104 | 
+105 105 | 
+106 106 | def good():
 
+TRY400.py:143:13: TRY400 [*] Use `logging.exception` instead of `logging.error`
+    |
+141 |             b = 2
+142 |         except Exception:
+143 |             error("Context message here")
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
+    |
+    = help: Replace with `exception`
 
+ℹ Safe fix
+140 140 |         try:
+141 141 |             b = 2
+142 142 |         except Exception:
+143     |-            error("Context message here")
+    143 |+            exception("Context message here")


### PR DESCRIPTION
## Summary

We're seeing failures in https://github.com/astral-sh/ruff/issues/10470 because `resolve_qualified_import_name` isn't guaranteed to return a specific import if a symbol is accessible in two ways (e.g., you have both `import logging` and `from logging import error` in scope, and you want `logging.error`). This PR breaks up the failing tests such that the imports aren't in the same scope.

Closes https://github.com/astral-sh/ruff/issues/10470.

## Test Plan

I added a `bindings.reverse()` to `resolve_qualified_import_name` to ensure that the tests pass regardless of the binding order.
