### PR TITLE
Consider raw source code for `W605`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/W605_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/W605_1.py
@@ -52,3 +52,8 @@ value = rf'\{{1}}'
 value = rf'\{1}'
 value = rf'{1:\}'
 value = f"{rf"\{1}"}"
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/10434
+f"{{}}+-\d"
+f"\n{{}}+-\d+"
+f"\n{{}}�+-\d+"

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -67,14 +67,15 @@ pub(crate) fn invalid_escape_sequence(
     token_range: TextRange,
 ) {
     let (token_source_code, string_start_location, kind) = match token {
-        Tok::FStringMiddle { value, kind } => {
+        Tok::FStringMiddle { kind, .. } => {
             if kind.is_raw_string() {
                 return;
             }
-            let Some(range) = indexer.fstring_ranges().innermost(token_range.start()) else {
+            let Some(f_string_range) = indexer.fstring_ranges().innermost(token_range.start())
+            else {
                 return;
             };
-            (&**value, range.start(), kind)
+            (locator.slice(token_range), f_string_range.start(), kind)
         }
         Tok::String { kind, .. } => {
             if kind.is_raw_string() {

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__W605_W605_1.py.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__W605_W605_1.py.snap
@@ -224,4 +224,55 @@ W605_1.py:48:15: W605 [*] Invalid escape sequence: `\{`
 50 50 | # Okay
 51 51 | value = rf'\{{1}}'
 
+W605_1.py:57:9: W605 [*] Invalid escape sequence: `\d`
+   |
+56 | # Regression tests for https://github.com/astral-sh/ruff/issues/10434
+57 | f"{{}}+-\d"
+   |         ^^ W605
+58 | f"\n{{}}+-\d+"
+59 | f"\n{{}}�+-\d+"
+   |
+   = help: Use a raw string literal
 
+ℹ Safe fix
+54 54 | value = f"{rf"\{1}"}"
+55 55 | 
+56 56 | # Regression tests for https://github.com/astral-sh/ruff/issues/10434
+57    |-f"{{}}+-\d"
+   57 |+rf"{{}}+-\d"
+58 58 | f"\n{{}}+-\d+"
+59 59 | f"\n{{}}�+-\d+"
+
+W605_1.py:58:11: W605 [*] Invalid escape sequence: `\d`
+   |
+56 | # Regression tests for https://github.com/astral-sh/ruff/issues/10434
+57 | f"{{}}+-\d"
+58 | f"\n{{}}+-\d+"
+   |           ^^ W605
+59 | f"\n{{}}�+-\d+"
+   |
+   = help: Add backslash to escape sequence
+
+ℹ Safe fix
+55 55 | 
+56 56 | # Regression tests for https://github.com/astral-sh/ruff/issues/10434
+57 57 | f"{{}}+-\d"
+58    |-f"\n{{}}+-\d+"
+   58 |+f"\n{{}}+-\\d+"
+59 59 | f"\n{{}}�+-\d+"
+
+W605_1.py:59:12: W605 [*] Invalid escape sequence: `\d`
+   |
+57 | f"{{}}+-\d"
+58 | f"\n{{}}+-\d+"
+59 | f"\n{{}}�+-\d+"
+   |            ^^ W605
+   |
+   = help: Add backslash to escape sequence
+
+ℹ Safe fix
+56 56 | # Regression tests for https://github.com/astral-sh/ruff/issues/10434
+57 57 | f"{{}}+-\d"
+58 58 | f"\n{{}}+-\d+"
+59    |-f"\n{{}}�+-\d+"
+   59 |+f"\n{{}}�+-\\d+"


### PR DESCRIPTION
## Summary

This PR fixes a panic in the linter for `W605`.

Consider the following f-string:
```python
f"{{}}ab"
```

The `FStringMiddle` token would contain `{}ab`. Notice that the escaped braces have _reduced_ the string. This means we cannot use the text value from the token to determine the location of the escape sequence but need to extract it from the source code.

fixes: #10434 

## Test Plan

Add new test cases and update the snapshots.
