### PR TITLE
Fix error message for rule C400

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
@@ -46,7 +46,7 @@ impl AlwaysFixableViolation for UnnecessaryGeneratorList {
     #[derive_message_formats]
     fn message(&self) -> String {
         if self.short_circuit {
-            format!("Unnecessary generator (rewrite using `list()`")
+            format!("Unnecessary generator (rewrite using `list()`)")
         } else {
             format!("Unnecessary generator (rewrite as a `list` comprehension)")
         }

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C400_C400.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C400_C400.py.snap
@@ -43,7 +43,7 @@ C400.py:3:12: C400 [*] Unnecessary generator (rewrite as a `list` comprehension)
 7 7 | 
 8 8 | # Short-circuit case, combine with C416 and should produce x = list(range(3))
 
-C400.py:9:5: C400 [*] Unnecessary generator (rewrite using `list()`
+C400.py:9:5: C400 [*] Unnecessary generator (rewrite using `list()`)
    |
  8 | # Short-circuit case, combine with C416 and should produce x = list(range(3))
  9 | x = list(x for x in range(3))
@@ -63,7 +63,7 @@ C400.py:9:5: C400 [*] Unnecessary generator (rewrite using `list()`
 11 11 |     x for x in range(3)
 12 12 | )
 
-C400.py:10:5: C400 [*] Unnecessary generator (rewrite using `list()`
+C400.py:10:5: C400 [*] Unnecessary generator (rewrite using `list()`)
    |
  8 |   # Short-circuit case, combine with C416 and should produce x = list(range(3))
  9 |   x = list(x for x in range(3))


### PR DESCRIPTION
Fix a typos in the error message of rule C400

With the latest version of Ruff (0.3.3) if I have a `scratch.py` script like that:

```python
from typing import Dict, List, Tuple


def generate_samples(test_cases: Dict) -> List[Tuple]:
    return list(
        (input, expected)
        for input, expected in zip(test_cases["input_value"], test_cases["expected_value"])
    )
```

and I run ruff

```shell
>>> ruff check scratch.py --select C400
>>> scratch.py:5:12: C400 Unnecessary generator (rewrite using `list()`
```

This PR fixes the error message from _"(rewrite using `list()`"_ to _"(rewrite using `list()`)"_, and it fixes also the doc.

Related question: why I have this error message? The rule is not correct in this case. Should I open an issue for that?