### PR TITLE
Error recovery for unparenthesized gen expr in with item

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -475,8 +475,7 @@ impl<'src> Parser<'src> {
                     TokenKind::Async | TokenKind::For => {
                         parsed_expr = Expr::Generator(parser.parse_generator_expression(
                             parsed_expr.expr,
-                            start,
-                            false,
+                            GeneratorExpressionInParentheses::No(start),
                         ))
                         .into();
                     }
@@ -1238,8 +1237,10 @@ impl<'src> Parser<'src> {
                 }
             }
             TokenKind::Async | TokenKind::For => {
-                let generator =
-                    Expr::Generator(self.parse_generator_expression(parsed_expr.expr, start, true));
+                let generator = Expr::Generator(self.parse_generator_expression(
+                    parsed_expr.expr,
+                    GeneratorExpressionInParentheses::Yes(start),
+                ));
 
                 ParsedExpr {
                     expr: generator,
@@ -1424,24 +1425,48 @@ impl<'src> Parser<'src> {
         generators
     }
 
+    /// Parses a generator expression.
+    ///
+    /// The given `in_parentheses` parameter is used to determine whether the generator
+    /// expression is enclosed in parentheses or not:
+    /// - `Yes`, expect the `)` token after the generator expression.
+    /// - `No`, no parentheses are expected.
+    /// - `Maybe`, consume the `)` token if it's present.
+    ///
+    /// The contained start position in each variant is used to determine the range
+    /// of the generator expression.
+    ///
     /// See: <https://docs.python.org/3/reference/expressions.html#generator-expressions>
     pub(super) fn parse_generator_expression(
         &mut self,
         element: Expr,
-        start: TextSize,
-        in_parentheses: bool,
+        in_parentheses: GeneratorExpressionInParentheses,
     ) -> ast::ExprGenerator {
         let generators = self.parse_generators();
 
-        if in_parentheses {
-            self.expect(TokenKind::Rpar);
-        }
+        let (parenthesized, start) = match in_parentheses {
+            GeneratorExpressionInParentheses::Yes(lpar_start) => {
+                self.expect(TokenKind::Rpar);
+                (true, lpar_start)
+            }
+            GeneratorExpressionInParentheses::No(expr_start) => (false, expr_start),
+            GeneratorExpressionInParentheses::Maybe {
+                lpar_start,
+                expr_start,
+            } => {
+                if self.eat(TokenKind::Rpar) {
+                    (true, lpar_start)
+                } else {
+                    (false, expr_start)
+                }
+            }
+        };
 
         ast::ExprGenerator {
             elt: Box::new(element),
             generators,
             range: self.node_range(start),
-            parenthesized: in_parentheses,
+            parenthesized,
         }
     }
 
@@ -1780,4 +1805,24 @@ impl Precedence {
             Precedence::Unknown | Precedence::Initial => unreachable!(),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GeneratorExpressionInParentheses {
+    /// The generator expression is in parentheses. The given [`TextSize`] is the
+    /// start of the left parenthesis. E.g., `(x for x in range(10))`.
+    Yes(TextSize),
+
+    /// The generator expression is not in parentheses. The given [`TextSize`] is the
+    /// start of the expression. E.g., `x for x in range(10)`.
+    No(TextSize),
+
+    /// The generator expression may or may not be in parentheses. The given [`TextSize`]s
+    /// are the start of the left parenthesis and the start of the expression, respectively.
+    Maybe {
+        /// The start of the left parenthesis.
+        lpar_start: TextSize,
+        /// The start of the expression.
+        expr_start: TextSize,
+    },
 }

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__with__ambiguous_lpar_with_items.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__with__ambiguous_lpar_with_items.py.snap
@@ -319,10 +319,10 @@ Module(
                     is_async: false,
                     items: [
                         WithItem {
-                            range: 340..361,
+                            range: 341..361,
                             context_expr: Generator(
                                 ExprGenerator {
-                                    range: 340..361,
+                                    range: 341..361,
                                     elt: Name(
                                         ExprName {
                                             range: 341..342,
@@ -370,7 +370,7 @@ Module(
                                             is_async: false,
                                         },
                                     ],
-                                    parenthesized: true,
+                                    parenthesized: false,
                                 },
                             ),
                             optional_vars: None,
@@ -558,16 +558,7 @@ Module(
  8 | with (item := 10 as f): ...
  9 | with (item1, item2 := 10 as f): ...
 10 | with (x for x in range(10), item): ...
-   |                           ^ Syntax Error: expected Rpar, found Comma
-11 | with (item, x for x in range(10)): ...
-   |
-
-
-   |
- 8 | with (item := 10 as f): ...
- 9 | with (item1, item2 := 10 as f): ...
-10 | with (x for x in range(10), item): ...
-   |                                 ^ Syntax Error: expected Comma, found Rpar
+   |       ^^^^^^^^^^^^^^^^^^^^ Syntax Error: unparenthesized generator expression cannot be used here
 11 | with (item, x for x in range(10)): ...
    |
 


### PR DESCRIPTION
## Summary

This PR updates the generator expression parsing to facilitate better error recovery in case of unparenthesized generator expression as the first with item.

Refer: https://github.com/astral-sh/ruff/pull/10418#discussion_r1532162064

## Test Plan

Update the existing test snapshot.
