### PR TITLE
Fix subscript comment placement with parenthesized value

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/subscript.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/subscript.py
@@ -4,7 +4,6 @@ result = (
     + 1
 )[0]
 
-
 # Regression tests for: https://github.com/astral-sh/ruff/issues/10355
 repro(
     "some long string that takes up some space"
@@ -14,7 +13,7 @@ repro(
 
 repro(
     "some long string that takes up some space"
-)[0 # some long comment also taking up space
+)[0  # some long comment also taking up space
 ]
 
 repro(
@@ -23,9 +22,20 @@ repro(
 
 repro("some long string that takes up some space")[0]  # some long comment also taking up space
 
-
 repro(
     "some long string that takes up some space"
 )[  # some long comment also taking up space
 0:-1
+]
+
+(
+    repro
+)[  # some long comment also taking up space
+    0
+]
+
+(
+    repro  # some long comment also taking up space
+)[
+    0
 ]

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__subscript.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__subscript.py.snap
@@ -10,7 +10,6 @@ result = (
     + 1
 )[0]
 
-
 # Regression tests for: https://github.com/astral-sh/ruff/issues/10355
 repro(
     "some long string that takes up some space"
@@ -20,7 +19,7 @@ repro(
 
 repro(
     "some long string that takes up some space"
-)[0 # some long comment also taking up space
+)[0  # some long comment also taking up space
 ]
 
 repro(
@@ -29,11 +28,22 @@ repro(
 
 repro("some long string that takes up some space")[0]  # some long comment also taking up space
 
-
 repro(
     "some long string that takes up some space"
 )[  # some long comment also taking up space
 0:-1
+]
+
+(
+    repro
+)[  # some long comment also taking up space
+    0
+]
+
+(
+    repro  # some long comment also taking up space
+)[
+    0
 ]
 ```
 
@@ -44,7 +54,6 @@ result = (
     f(111111111111111111111111111111111111111111111111111111111111111111111111111111111)
     + 1
 )[0]
-
 
 # Regression tests for: https://github.com/astral-sh/ruff/issues/10355
 repro(
@@ -65,10 +74,17 @@ repro("some long string that takes up some space")[
     0
 ]  # some long comment also taking up space
 
-
 repro(
     "some long string that takes up some space"
 )[  # some long comment also taking up space
     0:-1
 ]
+
+(repro)[  # some long comment also taking up space
+    0
+]
+
+(
+    repro  # some long comment also taking up space
+)[0]
 ```


### PR DESCRIPTION
## Summary

This is a follow up on https://github.com/astral-sh/ruff/pull/10492 

I incorrectly assumed that `subscript.value.end()` always points past the value. However, this isn't the case for parenthesized values where the end "ends" before the parentheses. 

## Test Plan

I added new tests for the parenthesized case.
