### PR TITLE
Improve error message, recover from unary add

### DIFF
--- a/crates/ruff_python_parser/resources/invalid/statements/match/unary_add_usage.py
+++ b/crates/ruff_python_parser/resources/invalid/statements/match/unary_add_usage.py
@@ -1,0 +1,12 @@
+# Unary addition isn't allowed but we parse it for better error recovery.
+match subject:
+    case +1:
+        pass
+    case 1 | +2 | -3:
+        pass
+    case [1, +2, -3]:
+        pass
+    case Foo(x=+1, y=-2):
+        pass
+    case {True: +1, False: -2}:
+        pass

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -117,10 +117,16 @@ pub enum ParseErrorType {
     DefaultArgumentError,
     /// A simple statement and a compound statement was found in the same line.
     SimpleStmtAndCompoundStmtInSameLine,
+
     /// An invalid `match` case pattern was found.
     InvalidMatchPatternLiteral { pattern: TokenKind },
     /// A star pattern was found outside a sequence pattern.
     StarPatternUsageError,
+    /// Expected a real number for a complex literal pattern.
+    ExpectedRealNumber,
+    /// Expected an imaginary number for a complex literal pattern.
+    ExpectedImaginaryNumber,
+
     /// The parser expected a specific token that was not found.
     ExpectedToken {
         expected: TokenKind,
@@ -187,6 +193,12 @@ impl std::fmt::Display for ParseErrorType {
             }
             ParseErrorType::StarPatternUsageError => {
                 write!(f, "Star pattern cannot be used here")
+            }
+            ParseErrorType::ExpectedRealNumber => {
+                write!(f, "Expected a real number in complex literal pattern")
+            }
+            ParseErrorType::ExpectedImaginaryNumber => {
+                write!(f, "Expected an imaginary number in complex literal pattern")
             }
             ParseErrorType::UnexpectedIndentation => write!(f, "unexpected indentation"),
             ParseErrorType::InvalidAssignmentTarget => write!(f, "invalid assignment target"),

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -658,7 +658,7 @@ impl<'src> Parser<'src> {
         })
     }
 
-    fn parse_unary_expression(&mut self) -> ast::ExprUnaryOp {
+    pub(super) fn parse_unary_expression(&mut self) -> ast::ExprUnaryOp {
         let start = self.node_start();
 
         let op = UnaryOp::try_from(self.current_token_kind())

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -989,7 +989,10 @@ impl RecoveryContextKind {
             | RecoveryContextKind::SetElements
             | RecoveryContextKind::TupleElements(_) => p.at_expr(),
             RecoveryContextKind::DictElements => p.at(TokenKind::DoubleStar) || p.at_expr(),
-            RecoveryContextKind::SequenceMatchPattern(_) => p.at_pattern_start(),
+            RecoveryContextKind::SequenceMatchPattern(_) => {
+                // `+` doesn't start any pattern but is here for better error recovery.
+                p.at(TokenKind::Plus) || p.at_pattern_start()
+            }
             RecoveryContextKind::MatchPatternMapping => {
                 // A star pattern is invalid as a mapping key and is here only for
                 // better error recovery.

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__invalid_class_pattern.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__invalid_class_pattern.py.snap
@@ -40,7 +40,7 @@ Module(
                                                 range: 72..82,
                                                 attr: Identifier {
                                                     id: "",
-                                                    range: 82..82,
+                                                    range: 80..80,
                                                 },
                                                 pattern: MatchValue(
                                                     PatternMatchValue {
@@ -89,7 +89,7 @@ Module(
                                                 range: 111..120,
                                                 attr: Identifier {
                                                     id: "",
-                                                    range: 120..120,
+                                                    range: 118..118,
                                                 },
                                                 pattern: MatchValue(
                                                     PatternMatchValue {
@@ -138,7 +138,7 @@ Module(
                                                 range: 149..159,
                                                 attr: Identifier {
                                                     id: "",
-                                                    range: 159..159,
+                                                    range: 157..157,
                                                 },
                                                 pattern: MatchValue(
                                                     PatternMatchValue {
@@ -187,7 +187,7 @@ Module(
                                                 range: 188..202,
                                                 attr: Identifier {
                                                     id: "",
-                                                    range: 202..202,
+                                                    range: 200..200,
                                                 },
                                                 pattern: MatchValue(
                                                     PatternMatchValue {
@@ -236,7 +236,7 @@ Module(
                                                 range: 231..234,
                                                 attr: Identifier {
                                                     id: "",
-                                                    range: 234..234,
+                                                    range: 233..233,
                                                 },
                                                 pattern: MatchValue(
                                                     PatternMatchValue {
@@ -285,7 +285,7 @@ Module(
                                                 range: 263..270,
                                                 attr: Identifier {
                                                     id: "",
-                                                    range: 270..270,
+                                                    range: 269..269,
                                                 },
                                                 pattern: MatchValue(
                                                     PatternMatchValue {
@@ -327,7 +327,7 @@ Module(
 1 | # Invalid keyword pattern in class argument
 2 | match subject:
 3 |     case Foo(x as y = 1):
-  |              ^^^^^^^^^^ Syntax Error: Invalid keyword pattern
+  |              ^^^^^^ Syntax Error: Expected an identifier for the keyword pattern
 4 |         pass
 5 |     case Foo(x | y = 1):
   |
@@ -337,7 +337,7 @@ Module(
 3 |     case Foo(x as y = 1):
 4 |         pass
 5 |     case Foo(x | y = 1):
-  |              ^^^^^^^^^ Syntax Error: Invalid keyword pattern
+  |              ^^^^^ Syntax Error: Expected an identifier for the keyword pattern
 6 |         pass
 7 |     case Foo([x, y] = 1):
   |
@@ -347,7 +347,7 @@ Module(
 5 |     case Foo(x | y = 1):
 6 |         pass
 7 |     case Foo([x, y] = 1):
-  |              ^^^^^^^^^^ Syntax Error: Invalid keyword pattern
+  |              ^^^^^^ Syntax Error: Expected an identifier for the keyword pattern
 8 |         pass
 9 |     case Foo({False: 0} = 1):
   |
@@ -357,7 +357,7 @@ Module(
  7 |     case Foo([x, y] = 1):
  8 |         pass
  9 |     case Foo({False: 0} = 1):
-   |              ^^^^^^^^^^^^^^ Syntax Error: Invalid keyword pattern
+   |              ^^^^^^^^^^ Syntax Error: Expected an identifier for the keyword pattern
 10 |         pass
 11 |     case Foo(1=1):
    |
@@ -367,7 +367,7 @@ Module(
  9 |     case Foo({False: 0} = 1):
 10 |         pass
 11 |     case Foo(1=1):
-   |              ^^^ Syntax Error: Invalid keyword pattern
+   |              ^ Syntax Error: Expected an identifier for the keyword pattern
 12 |         pass
 13 |     case Foo(Bar()=1):
    |
@@ -377,7 +377,7 @@ Module(
 11 |     case Foo(1=1):
 12 |         pass
 13 |     case Foo(Bar()=1):
-   |              ^^^^^^^ Syntax Error: Invalid keyword pattern
+   |              ^^^^^ Syntax Error: Expected an identifier for the keyword pattern
 14 |         pass
 15 |     # Positional pattern cannot follow keyword pattern
    |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__invalid_lhs_or_rhs_pattern.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__invalid_lhs_or_rhs_pattern.py.snap
@@ -810,7 +810,7 @@ Module(
   |
 1 | match invalid_lhs_pattern:
 2 |     case Foo() + 1j:
-  |          ^^^^^ Syntax Error: invalid lhs pattern
+  |          ^^^^^ Syntax Error: Expected a real number in complex literal pattern
 3 |         pass
 4 |     case x + 2j:
   |
@@ -820,7 +820,7 @@ Module(
 2 |     case Foo() + 1j:
 3 |         pass
 4 |     case x + 2j:
-  |          ^ Syntax Error: invalid lhs pattern
+  |          ^ Syntax Error: Expected a real number in complex literal pattern
 5 |         pass
 6 |     case _ + 3j:
   |
@@ -830,7 +830,7 @@ Module(
 4 |     case x + 2j:
 5 |         pass
 6 |     case _ + 3j:
-  |          ^ Syntax Error: invalid lhs pattern
+  |          ^ Syntax Error: Expected a real number in complex literal pattern
 7 |         pass
 8 |     case (1 | 2) + 4j:
   |
@@ -840,7 +840,7 @@ Module(
  6 |     case _ + 3j:
  7 |         pass
  8 |     case (1 | 2) + 4j:
-   |           ^^^^^ Syntax Error: invalid lhs pattern
+   |           ^^^^^ Syntax Error: Expected a real number in complex literal pattern
  9 |         pass
 10 |     case [1, 2] + 5j:
    |
@@ -850,7 +850,7 @@ Module(
  8 |     case (1 | 2) + 4j:
  9 |         pass
 10 |     case [1, 2] + 5j:
-   |          ^^^^^^ Syntax Error: invalid lhs pattern
+   |          ^^^^^^ Syntax Error: Expected a real number in complex literal pattern
 11 |         pass
 12 |     case {True: 1} + 6j:
    |
@@ -860,7 +860,7 @@ Module(
 10 |     case [1, 2] + 5j:
 11 |         pass
 12 |     case {True: 1} + 6j:
-   |          ^^^^^^^^^ Syntax Error: invalid lhs pattern
+   |          ^^^^^^^^^ Syntax Error: Expected a real number in complex literal pattern
 13 |         pass
 14 |     case 1j + 2j:
    |
@@ -870,7 +870,7 @@ Module(
 12 |     case {True: 1} + 6j:
 13 |         pass
 14 |     case 1j + 2j:
-   |          ^^ Syntax Error: real number required in complex literal
+   |          ^^ Syntax Error: Expected a real number in complex literal pattern
 15 |         pass
 16 |     case -1j + 2j:
    |
@@ -880,7 +880,7 @@ Module(
 14 |     case 1j + 2j:
 15 |         pass
 16 |     case -1j + 2j:
-   |          ^^^ Syntax Error: real number required in complex literal
+   |          ^^^ Syntax Error: Expected a real number in complex literal pattern
 17 |         pass
    |
 
@@ -888,7 +888,7 @@ Module(
    |
 19 | match invalid_rhs_pattern:
 20 |     case 1 + Foo():
-   |              ^^^^^ Syntax Error: invalid rhs pattern
+   |              ^^^^^ Syntax Error: Expected an imaginary number in complex literal pattern
 21 |         pass
 22 |     case 2 + x:
    |
@@ -898,7 +898,7 @@ Module(
 20 |     case 1 + Foo():
 21 |         pass
 22 |     case 2 + x:
-   |              ^ Syntax Error: invalid rhs pattern
+   |              ^ Syntax Error: Expected an imaginary number in complex literal pattern
 23 |         pass
 24 |     case 3 + _:
    |
@@ -908,7 +908,7 @@ Module(
 22 |     case 2 + x:
 23 |         pass
 24 |     case 3 + _:
-   |              ^ Syntax Error: invalid rhs pattern
+   |              ^ Syntax Error: Expected an imaginary number in complex literal pattern
 25 |         pass
 26 |     case 4 + (1 | 2):
    |
@@ -918,7 +918,7 @@ Module(
 24 |     case 3 + _:
 25 |         pass
 26 |     case 4 + (1 | 2):
-   |               ^^^^^ Syntax Error: invalid rhs pattern
+   |               ^^^^^ Syntax Error: Expected an imaginary number in complex literal pattern
 27 |         pass
 28 |     case 5 + [1, 2]:
    |
@@ -928,7 +928,7 @@ Module(
 26 |     case 4 + (1 | 2):
 27 |         pass
 28 |     case 5 + [1, 2]:
-   |              ^^^^^^ Syntax Error: invalid rhs pattern
+   |              ^^^^^^ Syntax Error: Expected an imaginary number in complex literal pattern
 29 |         pass
 30 |     case 6 + {True: 1}:
    |
@@ -938,7 +938,7 @@ Module(
 28 |     case 5 + [1, 2]:
 29 |         pass
 30 |     case 6 + {True: 1}:
-   |              ^^^^^^^^^ Syntax Error: invalid rhs pattern
+   |              ^^^^^^^^^ Syntax Error: Expected an imaginary number in complex literal pattern
 31 |         pass
 32 |     case 1 + 2:
    |
@@ -948,7 +948,7 @@ Module(
 30 |     case 6 + {True: 1}:
 31 |         pass
 32 |     case 1 + 2:
-   |              ^ Syntax Error: imaginary number required in complex literal
+   |              ^ Syntax Error: Expected an imaginary number in complex literal pattern
 33 |         pass
    |
 
@@ -956,7 +956,7 @@ Module(
    |
 35 | match invalid_lhs_rhs_pattern:
 36 |     case Foo() + Bar():
-   |          ^^^^^ Syntax Error: invalid lhs pattern
+   |          ^^^^^ Syntax Error: Expected a real number in complex literal pattern
 37 |         pass
    |
 
@@ -964,6 +964,6 @@ Module(
    |
 35 | match invalid_lhs_rhs_pattern:
 36 |     case Foo() + Bar():
-   |                  ^^^^^ Syntax Error: invalid rhs pattern
+   |                  ^^^^^ Syntax Error: Expected an imaginary number in complex literal pattern
 37 |         pass
    |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__unary_add_usage.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__unary_add_usage.py.snap
@@ -1,0 +1,398 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/statements/match/unary_add_usage.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..269,
+        body: [
+            Match(
+                StmtMatch {
+                    range: 74..268,
+                    subject: Name(
+                        ExprName {
+                            range: 80..87,
+                            id: "subject",
+                            ctx: Load,
+                        },
+                    ),
+                    cases: [
+                        MatchCase {
+                            range: 93..114,
+                            pattern: MatchValue(
+                                PatternMatchValue {
+                                    range: 98..100,
+                                    value: UnaryOp(
+                                        ExprUnaryOp {
+                                            range: 98..100,
+                                            op: UAdd,
+                                            operand: NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 99..100,
+                                                    value: Int(
+                                                        1,
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ),
+                            guard: None,
+                            body: [
+                                Pass(
+                                    StmtPass {
+                                        range: 110..114,
+                                    },
+                                ),
+                            ],
+                        },
+                        MatchCase {
+                            range: 119..149,
+                            pattern: MatchOr(
+                                PatternMatchOr {
+                                    range: 124..135,
+                                    patterns: [
+                                        MatchValue(
+                                            PatternMatchValue {
+                                                range: 124..125,
+                                                value: NumberLiteral(
+                                                    ExprNumberLiteral {
+                                                        range: 124..125,
+                                                        value: Int(
+                                                            1,
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        MatchValue(
+                                            PatternMatchValue {
+                                                range: 128..130,
+                                                value: UnaryOp(
+                                                    ExprUnaryOp {
+                                                        range: 128..130,
+                                                        op: UAdd,
+                                                        operand: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                range: 129..130,
+                                                                value: Int(
+                                                                    2,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        MatchValue(
+                                            PatternMatchValue {
+                                                range: 133..135,
+                                                value: UnaryOp(
+                                                    ExprUnaryOp {
+                                                        range: 133..135,
+                                                        op: USub,
+                                                        operand: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                range: 134..135,
+                                                                value: Int(
+                                                                    3,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            guard: None,
+                            body: [
+                                Pass(
+                                    StmtPass {
+                                        range: 145..149,
+                                    },
+                                ),
+                            ],
+                        },
+                        MatchCase {
+                            range: 154..184,
+                            pattern: MatchSequence(
+                                PatternMatchSequence {
+                                    range: 159..170,
+                                    patterns: [
+                                        MatchValue(
+                                            PatternMatchValue {
+                                                range: 160..161,
+                                                value: NumberLiteral(
+                                                    ExprNumberLiteral {
+                                                        range: 160..161,
+                                                        value: Int(
+                                                            1,
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        MatchValue(
+                                            PatternMatchValue {
+                                                range: 163..165,
+                                                value: UnaryOp(
+                                                    ExprUnaryOp {
+                                                        range: 163..165,
+                                                        op: UAdd,
+                                                        operand: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                range: 164..165,
+                                                                value: Int(
+                                                                    2,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        MatchValue(
+                                            PatternMatchValue {
+                                                range: 167..169,
+                                                value: UnaryOp(
+                                                    ExprUnaryOp {
+                                                        range: 167..169,
+                                                        op: USub,
+                                                        operand: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                range: 168..169,
+                                                                value: Int(
+                                                                    3,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            guard: None,
+                            body: [
+                                Pass(
+                                    StmtPass {
+                                        range: 180..184,
+                                    },
+                                ),
+                            ],
+                        },
+                        MatchCase {
+                            range: 189..223,
+                            pattern: MatchClass(
+                                PatternMatchClass {
+                                    range: 194..209,
+                                    cls: Name(
+                                        ExprName {
+                                            range: 194..197,
+                                            id: "Foo",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    arguments: PatternArguments {
+                                        range: 197..209,
+                                        patterns: [],
+                                        keywords: [
+                                            PatternKeyword {
+                                                range: 198..202,
+                                                attr: Identifier {
+                                                    id: "x",
+                                                    range: 198..199,
+                                                },
+                                                pattern: MatchValue(
+                                                    PatternMatchValue {
+                                                        range: 200..202,
+                                                        value: UnaryOp(
+                                                            ExprUnaryOp {
+                                                                range: 200..202,
+                                                                op: UAdd,
+                                                                operand: NumberLiteral(
+                                                                    ExprNumberLiteral {
+                                                                        range: 201..202,
+                                                                        value: Int(
+                                                                            1,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                            PatternKeyword {
+                                                range: 204..208,
+                                                attr: Identifier {
+                                                    id: "y",
+                                                    range: 204..205,
+                                                },
+                                                pattern: MatchValue(
+                                                    PatternMatchValue {
+                                                        range: 206..208,
+                                                        value: UnaryOp(
+                                                            ExprUnaryOp {
+                                                                range: 206..208,
+                                                                op: USub,
+                                                                operand: NumberLiteral(
+                                                                    ExprNumberLiteral {
+                                                                        range: 207..208,
+                                                                        value: Int(
+                                                                            2,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                },
+                            ),
+                            guard: None,
+                            body: [
+                                Pass(
+                                    StmtPass {
+                                        range: 219..223,
+                                    },
+                                ),
+                            ],
+                        },
+                        MatchCase {
+                            range: 228..268,
+                            pattern: MatchMapping(
+                                PatternMatchMapping {
+                                    range: 233..254,
+                                    keys: [
+                                        BooleanLiteral(
+                                            ExprBooleanLiteral {
+                                                range: 234..238,
+                                                value: true,
+                                            },
+                                        ),
+                                        BooleanLiteral(
+                                            ExprBooleanLiteral {
+                                                range: 244..249,
+                                                value: false,
+                                            },
+                                        ),
+                                    ],
+                                    patterns: [
+                                        MatchValue(
+                                            PatternMatchValue {
+                                                range: 240..242,
+                                                value: UnaryOp(
+                                                    ExprUnaryOp {
+                                                        range: 240..242,
+                                                        op: UAdd,
+                                                        operand: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                range: 241..242,
+                                                                value: Int(
+                                                                    1,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        MatchValue(
+                                            PatternMatchValue {
+                                                range: 251..253,
+                                                value: UnaryOp(
+                                                    ExprUnaryOp {
+                                                        range: 251..253,
+                                                        op: USub,
+                                                        operand: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                range: 252..253,
+                                                                value: Int(
+                                                                    2,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    rest: None,
+                                },
+                            ),
+                            guard: None,
+                            body: [
+                                Pass(
+                                    StmtPass {
+                                        range: 264..268,
+                                    },
+                                ),
+                            ],
+                        },
+                    ],
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | # Unary addition isn't allowed but we parse it for better error recovery.
+2 | match subject:
+3 |     case +1:
+  |          ^^ Syntax Error: Unary plus is not allowed as a literal pattern
+4 |         pass
+5 |     case 1 | +2 | -3:
+  |
+
+
+  |
+3 |     case +1:
+4 |         pass
+5 |     case 1 | +2 | -3:
+  |              ^^ Syntax Error: Unary plus is not allowed as a literal pattern
+6 |         pass
+7 |     case [1, +2, -3]:
+  |
+
+
+  |
+5 |     case 1 | +2 | -3:
+6 |         pass
+7 |     case [1, +2, -3]:
+  |              ^^ Syntax Error: Unary plus is not allowed as a literal pattern
+8 |         pass
+9 |     case Foo(x=+1, y=-2):
+  |
+
+
+   |
+ 7 |     case [1, +2, -3]:
+ 8 |         pass
+ 9 |     case Foo(x=+1, y=-2):
+   |                ^^ Syntax Error: Unary plus is not allowed as a literal pattern
+10 |         pass
+11 |     case {True: +1, False: -2}:
+   |
+
+
+   |
+ 9 |     case Foo(x=+1, y=-2):
+10 |         pass
+11 |     case {True: +1, False: -2}:
+   |                 ^^ Syntax Error: Unary plus is not allowed as a literal pattern
+12 |         pass
+   |


### PR DESCRIPTION
## Summary

This PR is a follow-up to #10477 which does the following:
1. Improve error message around complex literal pattern. Remove usage of "lhs" and "rhs" term from user facing messages.
2. Better error recovery for unary plus. This isn't allowed in the literal pattern so we'll just parse it and throw an error directly.
3. Fix a bug where we disallowed a unary sub in sequence pattern
4. Reduce error range for invalid key value for a mapping pattern

## Test Plan

Add new test cases, update and review the snapshots
