### PR TITLE
Avoid dropping node from `as` pattern

### DIFF
--- a/crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_0.py
+++ b/crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_0.py
@@ -1,0 +1,8 @@
+match subject:
+    #            Parser shouldn't confuse this as being a
+    #            class pattern
+    #            v
+    case (x as y)(a, b):
+    #     ^^^^^^
+    #    as-pattern
+        pass

--- a/crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_1.py
+++ b/crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_1.py
@@ -1,0 +1,8 @@
+match subject:
+    #             Parser shouldn't confuse this as being a
+    #             complex literal pattern
+    #             v
+    case (x as y) + 1j:
+    #     ^^^^^^
+    #    as-pattern
+        pass

--- a/crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_2.py
+++ b/crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_2.py
@@ -1,0 +1,5 @@
+match subject:
+    # This `as` pattern is unparenthesied so the parser never takes the path
+    # where it might be confused as a complex literal pattern.
+    case x as y + 1j:
+        pass

--- a/crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_3.py
+++ b/crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_3.py
@@ -1,0 +1,5 @@
+match subject:
+    #     Not in the mapping start token set, so the list parsing bails
+    #     v
+    case {(x as y): 1}:
+        pass

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_0.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_0.py.snap
@@ -1,0 +1,139 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_0.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..197,
+        body: [
+            Match(
+                StmtMatch {
+                    range: 0..147,
+                    subject: Name(
+                        ExprName {
+                            range: 6..13,
+                            id: "subject",
+                            ctx: Load,
+                        },
+                    ),
+                    cases: [
+                        MatchCase {
+                            range: 127..147,
+                            pattern: MatchAs(
+                                PatternMatchAs {
+                                    range: 133..139,
+                                    pattern: Some(
+                                        MatchAs(
+                                            PatternMatchAs {
+                                                range: 133..134,
+                                                pattern: None,
+                                                name: Some(
+                                                    Identifier {
+                                                        id: "x",
+                                                        range: 133..134,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: "y",
+                                            range: 138..139,
+                                        },
+                                    ),
+                                },
+                            ),
+                            guard: None,
+                            body: [
+                                AnnAssign(
+                                    StmtAnnAssign {
+                                        range: 140..147,
+                                        target: Tuple(
+                                            ExprTuple {
+                                                range: 140..146,
+                                                elts: [
+                                                    Name(
+                                                        ExprName {
+                                                            range: 141..142,
+                                                            id: "a",
+                                                            ctx: Store,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            range: 144..145,
+                                                            id: "b",
+                                                            ctx: Store,
+                                                        },
+                                                    ),
+                                                ],
+                                                ctx: Store,
+                                                parenthesized: true,
+                                            },
+                                        ),
+                                        annotation: Name(
+                                            ExprName {
+                                                range: 147..147,
+                                                id: "",
+                                                ctx: Invalid,
+                                            },
+                                        ),
+                                        value: None,
+                                        simple: false,
+                                    },
+                                ),
+                            ],
+                        },
+                    ],
+                },
+            ),
+            Pass(
+                StmtPass {
+                    range: 193..197,
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+3 |     #            class pattern
+4 |     #            v
+5 |     case (x as y)(a, b):
+  |                  ^ Syntax Error: expected Colon, found Lpar
+6 |     #     ^^^^^^
+7 |     #    as-pattern
+  |
+
+
+  |
+3 |     #            class pattern
+4 |     #            v
+5 |     case (x as y)(a, b):
+  |                         ^ Syntax Error: Expected an expression
+6 |     #     ^^^^^^
+7 |     #    as-pattern
+8 |         pass
+  |
+
+
+  |
+6 |     #     ^^^^^^
+7 |     #    as-pattern
+8 |         pass
+  | ^^^^^^^^ Syntax Error: unexpected indentation
+  |
+
+
+  |
+6 |     #     ^^^^^^
+7 |     #    as-pattern
+8 |         pass
+  |              Syntax Error: Expected a statement
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_1.py.snap
@@ -1,0 +1,131 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_1.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..209,
+        body: [
+            Match(
+                StmtMatch {
+                    range: 0..159,
+                    subject: Name(
+                        ExprName {
+                            range: 6..13,
+                            id: "subject",
+                            ctx: Load,
+                        },
+                    ),
+                    cases: [
+                        MatchCase {
+                            range: 140..159,
+                            pattern: MatchAs(
+                                PatternMatchAs {
+                                    range: 146..152,
+                                    pattern: Some(
+                                        MatchAs(
+                                            PatternMatchAs {
+                                                range: 146..147,
+                                                pattern: None,
+                                                name: Some(
+                                                    Identifier {
+                                                        id: "x",
+                                                        range: 146..147,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: "y",
+                                            range: 151..152,
+                                        },
+                                    ),
+                                },
+                            ),
+                            guard: None,
+                            body: [
+                                AnnAssign(
+                                    StmtAnnAssign {
+                                        range: 154..159,
+                                        target: UnaryOp(
+                                            ExprUnaryOp {
+                                                range: 154..158,
+                                                op: UAdd,
+                                                operand: NumberLiteral(
+                                                    ExprNumberLiteral {
+                                                        range: 156..158,
+                                                        value: Complex {
+                                                            real: 0.0,
+                                                            imag: 1.0,
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        annotation: Name(
+                                            ExprName {
+                                                range: 159..159,
+                                                id: "",
+                                                ctx: Invalid,
+                                            },
+                                        ),
+                                        value: None,
+                                        simple: false,
+                                    },
+                                ),
+                            ],
+                        },
+                    ],
+                },
+            ),
+            Pass(
+                StmtPass {
+                    range: 205..209,
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+3 |     #             complex literal pattern
+4 |     #             v
+5 |     case (x as y) + 1j:
+  |                   ^ Syntax Error: expected Colon, found Plus
+6 |     #     ^^^^^^
+7 |     #    as-pattern
+  |
+
+
+  |
+3 |     #             complex literal pattern
+4 |     #             v
+5 |     case (x as y) + 1j:
+  |                        ^ Syntax Error: Expected an expression
+6 |     #     ^^^^^^
+7 |     #    as-pattern
+8 |         pass
+  |
+
+
+  |
+6 |     #     ^^^^^^
+7 |     #    as-pattern
+8 |         pass
+  | ^^^^^^^^ Syntax Error: unexpected indentation
+  |
+
+
+  |
+6 |     #     ^^^^^^
+7 |     #    as-pattern
+8 |         pass
+  |              Syntax Error: Expected a statement
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_2.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_2.py.snap
@@ -1,0 +1,128 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_2.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..189,
+        body: [
+            Match(
+                StmtMatch {
+                    range: 0..176,
+                    subject: Name(
+                        ExprName {
+                            range: 6..13,
+                            id: "subject",
+                            ctx: Load,
+                        },
+                    ),
+                    cases: [
+                        MatchCase {
+                            range: 159..176,
+                            pattern: MatchAs(
+                                PatternMatchAs {
+                                    range: 164..170,
+                                    pattern: Some(
+                                        MatchAs(
+                                            PatternMatchAs {
+                                                range: 164..165,
+                                                pattern: None,
+                                                name: Some(
+                                                    Identifier {
+                                                        id: "x",
+                                                        range: 164..165,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: "y",
+                                            range: 169..170,
+                                        },
+                                    ),
+                                },
+                            ),
+                            guard: None,
+                            body: [
+                                AnnAssign(
+                                    StmtAnnAssign {
+                                        range: 171..176,
+                                        target: UnaryOp(
+                                            ExprUnaryOp {
+                                                range: 171..175,
+                                                op: UAdd,
+                                                operand: NumberLiteral(
+                                                    ExprNumberLiteral {
+                                                        range: 173..175,
+                                                        value: Complex {
+                                                            real: 0.0,
+                                                            imag: 1.0,
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        annotation: Name(
+                                            ExprName {
+                                                range: 176..176,
+                                                id: "",
+                                                ctx: Invalid,
+                                            },
+                                        ),
+                                        value: None,
+                                        simple: false,
+                                    },
+                                ),
+                            ],
+                        },
+                    ],
+                },
+            ),
+            Pass(
+                StmtPass {
+                    range: 185..189,
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+2 |     # This `as` pattern is unparenthesied so the parser never takes the path
+3 |     # where it might be confused as a complex literal pattern.
+4 |     case x as y + 1j:
+  |                 ^ Syntax Error: expected Colon, found Plus
+5 |         pass
+  |
+
+
+  |
+2 |     # This `as` pattern is unparenthesied so the parser never takes the path
+3 |     # where it might be confused as a complex literal pattern.
+4 |     case x as y + 1j:
+  |                      ^ Syntax Error: Expected an expression
+5 |         pass
+  |
+
+
+  |
+3 |     # where it might be confused as a complex literal pattern.
+4 |     case x as y + 1j:
+5 |         pass
+  | ^^^^^^^^ Syntax Error: unexpected indentation
+  |
+
+
+  |
+3 |     # where it might be confused as a complex literal pattern.
+4 |     case x as y + 1j:
+5 |         pass
+  |              Syntax Error: Expected a statement
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_3.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_3.py.snap
@@ -1,0 +1,157 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_3.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..135,
+        body: [
+            Match(
+                StmtMatch {
+                    range: 0..120,
+                    subject: Name(
+                        ExprName {
+                            range: 6..13,
+                            id: "subject",
+                            ctx: Load,
+                        },
+                    ),
+                    cases: [
+                        MatchCase {
+                            range: 103..120,
+                            pattern: MatchClass(
+                                PatternMatchClass {
+                                    range: 108..117,
+                                    cls: Dict(
+                                        ExprDict {
+                                            range: 108..109,
+                                            keys: [],
+                                            values: [],
+                                        },
+                                    ),
+                                    arguments: PatternArguments {
+                                        range: 109..117,
+                                        patterns: [
+                                            MatchAs(
+                                                PatternMatchAs {
+                                                    range: 110..116,
+                                                    pattern: Some(
+                                                        MatchAs(
+                                                            PatternMatchAs {
+                                                                range: 110..111,
+                                                                pattern: None,
+                                                                name: Some(
+                                                                    Identifier {
+                                                                        id: "x",
+                                                                        range: 110..111,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                    name: Some(
+                                                        Identifier {
+                                                            id: "y",
+                                                            range: 115..116,
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        keywords: [],
+                                    },
+                                },
+                            ),
+                            guard: None,
+                            body: [
+                                Expr(
+                                    StmtExpr {
+                                        range: 119..120,
+                                        value: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                range: 119..120,
+                                                value: Int(
+                                                    1,
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ],
+                },
+            ),
+            Pass(
+                StmtPass {
+                    range: 131..135,
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+2 |     #     Not in the mapping start token set, so the list parsing bails
+3 |     #     v
+4 |     case {(x as y): 1}:
+  |           ^ Syntax Error: Expected a mapping pattern or the end of the mapping pattern
+5 |         pass
+  |
+
+
+  |
+2 |     #     Not in the mapping start token set, so the list parsing bails
+3 |     #     v
+4 |     case {(x as y): 1}:
+  |          ^ Syntax Error: invalid value for a class pattern
+5 |         pass
+  |
+
+
+  |
+2 |     #     Not in the mapping start token set, so the list parsing bails
+3 |     #     v
+4 |     case {(x as y): 1}:
+  |                      ^ Syntax Error: Expected a statement
+5 |         pass
+  |
+
+
+  |
+2 |     #     Not in the mapping start token set, so the list parsing bails
+3 |     #     v
+4 |     case {(x as y): 1}:
+  |                       ^ Syntax Error: Expected a statement
+5 |         pass
+  |
+
+
+  |
+2 |     #     Not in the mapping start token set, so the list parsing bails
+3 |     #     v
+4 |     case {(x as y): 1}:
+  |                        ^ Syntax Error: Expected a statement
+5 |         pass
+  |
+
+
+  |
+3 |     #     v
+4 |     case {(x as y): 1}:
+5 |         pass
+  | ^^^^^^^^ Syntax Error: unexpected indentation
+  |
+
+
+  |
+3 |     #     v
+4 |     case {(x as y): 1}:
+5 |         pass
+  |              Syntax Error: Expected a statement
+  |


### PR DESCRIPTION
## Summary

This PR addresses the feedback given here: https://github.com/astral-sh/ruff/pull/10477#discussion_r1533540673

**Problem:** The `as` pattern containing both the pattern and name (`foo as bar`) cannot be converted to an expression as there's no AST node to represent that.

The solution for now is to not drop any nodes, panic in the conversion if the parser is doing so, and make sure the calling code is avoiding the panic.

There are 3 places where the conversion happens:
1. Mapping pattern
2. Class pattern
3. Complex literal pattern

Another thing to keep in mind is that the `parse_match_pattern_lhs` method only parses the `as` pattern if it's parenthesized. The reason being that the `(` is ambiguous as to whether it's a parenthesized pattern or the start of a sequence pattern.

Now, the mapping items are parsed using list parsing and it's only called if the start token is in the FIRST set which the `(` token isn't. This avoids the panic in mapping pattern.

For the class and complex literal pattern, the starting point is `parse_match_pattern_lhs` method. It then checks if the parser is at `(` (as in `Foo(x, y)`) or `+`/`-` (as in `1 + 1j`) and continues with the respective parsing methods. We want to avoid going further in case we have an `as` pattern to avoid the panic. This means we'll exit early in that case.

## Test Plan

Added a few test cases, updated the snapshots.

Note that this PR isn't focused on error recovery, it's to avoid dropping any potential node which is the case when converting from an `as` pattern to an expression.

Another thing to note is that the following test case fails (not added) because the error recovery is bad and the node ranges aren't in order:

```python
match subject:
    case {x as y: 1}:
        pass
```

<details><summary>Click here to view the AST and errors for the above code:</summary>
<p>

```rs
Module(
    ModModule {
        range: 0..50,
        body: [
            Match(
                StmtMatch {
                    range: 0..49,
                    subject: Name(
                        ExprName {
                            range: 6..13,
                            id: "subject",
                            ctx: Load,
                        },
                    ),
                    cases: [
                        MatchCase {
                            range: 19..49,
                            pattern: MatchMapping(
                                PatternMatchMapping {
                                    range: 24..35,
                                    keys: [
                                        Name(
                                            ExprName {
                                                range: 25..26,
                                                id: "x",
                                                ctx: Store,
                                            },
                                        ),
                                        Name(
                                            ExprName {
                                                range: 30..31,
                                                id: "y",
                                                ctx: Store,
                                            },
                                        ),
                                    ],
                                    patterns: [
                                        MatchValue(
                                            PatternMatchValue {
                                                range: 29..29,
                                                value: Name(
                                                    ExprName {
                                                        range: 27..29,
                                                        id: "as",
                                                        ctx: Load,
                                                    },
                                                ),
                                            },
                                        ),
                                        MatchValue(
                                            PatternMatchValue {
                                                range: 33..34,
                                                value: NumberLiteral(
                                                    ExprNumberLiteral {
                                                        range: 33..34,
                                                        value: Int(
                                                            1,
                                                        ),
                                                    },
                                                ),
                                            },
                                        ),
                                    ],
                                    rest: None,
                                },
                            ),
                            guard: None,
                            body: [
                                Pass(
                                    StmtPass {
                                        range: 45..49,
                                    },
                                ),
                            ],
                        },
                    ],
                },
            ),
        ],
    },
)
```

Errors:
```
Syntax Error: invalid mapping pattern key at byte range 25..26
  |
1 | match subject:
2 |     case {x as y: 1}:
  |           ^ Syntax Error: invalid mapping pattern key
3 |         pass
  |


Syntax Error: expected Colon, found As at byte range 27..29
  |
1 | match subject:
2 |     case {x as y: 1}:
  |             ^^ Syntax Error: expected Colon, found As
3 |         pass
  |


Syntax Error: expected Comma, found Name at byte range 30..31
  |
1 | match subject:
2 |     case {x as y: 1}:
  |                ^ Syntax Error: expected Comma, found Name
3 |         pass
  |
```

</p>
</details> 
