### PR TITLE
Fix F821 false negatives when `from __future__ import annotations` is active (attempt 2)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_27.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_27.py
@@ -33,3 +33,16 @@ class MyClass:
 baz: MyClass
 eggs = baz  # Still invalid even when `__future__.annotations` are enabled
 eggs = "baz"  # always okay
+
+# Forward references:
+MaybeDStr: TypeAlias = Optional[DStr]  # Still invalid even when `__future__.annotations` are enabled
+MaybeDStr2: TypeAlias = Optional["DStr"]  # always okay
+DStr: TypeAlias = Union[D, str]  # Still invalid even when `__future__.annotations` are enabled
+DStr2: TypeAlias = Union["D", str]  # always okay
+
+class D: ...
+
+# More circular references
+class Leaf: ...
+class Tree(list[Tree | Leaf]): ...  # Still invalid even when `__future__.annotations` are enabled
+class Tree2(list["Tree | Leaf"]): ...  # always okay

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -937,6 +937,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
             && !self.semantic.in_deferred_type_definition()
             && self.semantic.in_type_definition()
             && self.semantic.future_annotations()
+            && (self.semantic.in_annotation() || self.source_type.is_stub())
         {
             if let Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) = expr {
                 self.visit.string_type_definitions.push((

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_27.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_27.py.snap
@@ -17,3 +17,30 @@ F821_27.py:34:8: F821 Undefined name `baz`
    |        ^^^ F821
 35 | eggs = "baz"  # always okay
    |
+
+F821_27.py:38:33: F821 Undefined name `DStr`
+   |
+37 | # Forward references:
+38 | MaybeDStr: TypeAlias = Optional[DStr]  # Still invalid even when `__future__.annotations` are enabled
+   |                                 ^^^^ F821
+39 | MaybeDStr2: TypeAlias = Optional["DStr"]  # always okay
+40 | DStr: TypeAlias = Union[D, str]  # Still invalid even when `__future__.annotations` are enabled
+   |
+
+F821_27.py:40:25: F821 Undefined name `D`
+   |
+38 | MaybeDStr: TypeAlias = Optional[DStr]  # Still invalid even when `__future__.annotations` are enabled
+39 | MaybeDStr2: TypeAlias = Optional["DStr"]  # always okay
+40 | DStr: TypeAlias = Union[D, str]  # Still invalid even when `__future__.annotations` are enabled
+   |                         ^ F821
+41 | DStr2: TypeAlias = Union["D", str]  # always okay
+   |
+
+F821_27.py:47:17: F821 Undefined name `Tree`
+   |
+45 | # More circular references
+46 | class Leaf: ...
+47 | class Tree(list[Tree | Leaf]): ...  # Still invalid even when `__future__.annotations` are enabled
+   |                 ^^^^ F821
+48 | class Tree2(list["Tree | Leaf"]): ...  # always okay
+   |


### PR DESCRIPTION
A second attempt to fix https://github.com/astral-sh/ruff/issues/10340. The earlier attempt was https://github.com/astral-sh/ruff/pull/10362, which was reverted in https://github.com/astral-sh/ruff/pull/10513.

https://github.com/astral-sh/ruff/pull/10362 incorrectly only allowed forward references in annotations if we were in a "typing-only annotation". But forward references are allowed in all type annotations, not just typing-only annotations, iff `from __future__ import annotations` is at the top of the file.

## Test plan

`cargo test`. The tests added in https://github.com/astral-sh/ruff/pull/10513 should prevent a repeat of the earlier regression that https://github.com/astral-sh/ruff/pull/10362 caused.