### PR TITLE
Respect Unicode characters in import sorting

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/isort/unicode.py
+++ b/crates/ruff_linter/resources/test/fixtures/isort/unicode.py
@@ -1,0 +1,6 @@
+from astropy.constants import hbar as ℏ
+from numpy import pi as π
+import numpy as ℂℇℊℋℌℍℎℐℑℒℓℕℤΩℨKÅℬℭℯℰℱℹℴ
+import numpy as CƐgHHHhIILlNZΩZKÅBCeEFio
+
+h = 2 * π * ℏ

--- a/crates/ruff_linter/src/rules/isort/annotate.rs
+++ b/crates/ruff_linter/src/rules/isort/annotate.rs
@@ -11,7 +11,7 @@ use super::{AnnotatedAliasData, AnnotatedImport};
 pub(crate) fn annotate_imports<'a>(
     imports: &'a [&'a Stmt],
     comments: Vec<Comment<'a>>,
-    locator: &Locator,
+    locator: &Locator<'a>,
     split_on_trailing_comma: bool,
     source_type: PySourceType,
 ) -> Vec<AnnotatedImport<'a>> {
@@ -44,8 +44,8 @@ pub(crate) fn annotate_imports<'a>(
                         names: names
                             .iter()
                             .map(|alias| AliasData {
-                                name: &alias.name,
-                                asname: alias.asname.as_deref(),
+                                name: locator.slice(&alias.name),
+                                asname: alias.asname.as_ref().map(|asname| locator.slice(asname)),
                             })
                             .collect(),
                         atop,
@@ -107,8 +107,8 @@ pub(crate) fn annotate_imports<'a>(
                             }
 
                             AnnotatedAliasData {
-                                name: &alias.name,
-                                asname: alias.asname.as_deref(),
+                                name: locator.slice(&alias.name),
+                                asname: alias.asname.as_ref().map(|asname| locator.slice(asname)),
                                 atop: alias_atop,
                                 inline: alias_inline,
                             }
@@ -116,7 +116,7 @@ pub(crate) fn annotate_imports<'a>(
                         .collect();
 
                     AnnotatedImport::ImportFrom {
-                        module: module.as_deref(),
+                        module: module.as_ref().map(|module| locator.slice(module)),
                         names: aliases,
                         level: *level,
                         trailing_comma: if split_on_trailing_comma {

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -342,6 +342,7 @@ mod tests {
     #[test_case(Path::new("star_before_others.py"))]
     #[test_case(Path::new("trailing_suffix.py"))]
     #[test_case(Path::new("type_comments.py"))]
+    #[test_case(Path::new("unicode.py"))]
     fn default(path: &Path) -> Result<()> {
         let snapshot = format!("{}", path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__unicode.py.snap
+++ b/crates/ruff_linter/src/rules/isort/snapshots/ruff_linter__rules__isort__tests__unicode.py.snap
@@ -1,0 +1,24 @@
+---
+source: crates/ruff_linter/src/rules/isort/mod.rs
+---
+unicode.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+  |
+1 | / from astropy.constants import hbar as ℏ
+2 | | from numpy import pi as π
+3 | | import numpy as ℂℇℊℋℌℍℎℐℑℒℓℕℤΩℨKÅℬℭℯℰℱℹℴ
+4 | | import numpy as CƐgHHHhIILlNZΩZKÅBCeEFio
+5 | | 
+6 | | h = 2 * π * ℏ
+  | |_^ I001
+  |
+  = help: Organize imports
+
+ℹ Safe fix
+  1 |+import numpy as CƐgHHHhIILlNZΩZKÅBCeEFio
+  2 |+import numpy as ℂℇℊℋℌℍℎℐℑℒℓℕℤΩℨKÅℬℭℯℰℱℹℴ
+1 3 | from astropy.constants import hbar as ℏ
+2 4 | from numpy import pi as π
+3   |-import numpy as ℂℇℊℋℌℍℎℐℑℒℓℕℤΩℨKÅℬℭℯℰℱℹℴ
+4   |-import numpy as CƐgHHHhIILlNZΩZKÅBCeEFio
+5 5 | 
+6 6 | h = 2 * π * ℏ


### PR DESCRIPTION
## Summary

Ensures that we use the raw identifier as provided in the source code, rather than the normalized Unicode identifier.

This _does_ mean that we treat these as two separate identifiers, and _don't_ merge them, even though Python will treat them as the same symbol:

```python
import numpy as ℂℇℊℋℌℍℎℐℑℒℓℕℤΩℨKÅℬℭℯℰℱℹℴ
import numpy as CƐgHHHhIILlNZΩZKÅBCeEFio
```

I think that's fine, this is super rare anyway and would likely be confusing for users.

Closes https://github.com/astral-sh/ruff/issues/10528.

## Test Plan

`cargo test`
