### PR TITLE
[`flake8-boolean-trap`] Add setting for user defined allowed boolean trap

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_boolean_trap/FBT.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_boolean_trap/FBT.py
@@ -132,3 +132,26 @@ class Fit:
         print(force)
 
 Fit(force=True)
+
+
+# https://github.com/astral-sh/ruff/issues/10356
+from django.db.models import Case, Q, Value, When
+
+
+qs.annotate(
+    is_foo_or_bar=Case(
+        When(Q(is_foo=True) | Q(is_bar=True)),
+        then=Value(True),
+    ),
+    default=Value(False),
+)
+
+
+# https://github.com/astral-sh/ruff/issues/10485
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+
+    foo: bool = Field(True, exclude=True)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_boolean_trap/FBT.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_boolean_trap/FBT.py
@@ -31,8 +31,7 @@ def function(
     kwonly_nonboolvalued_boolhint: bool = 1,
     kwonly_nonboolvalued_boolstrhint: "bool" = 1,
     **kw,
-):
-    ...
+): ...
 
 
 def used(do):
@@ -131,6 +130,7 @@ class Fit:
     def __post_init__(self, force: bool) -> None:
         print(force)
 
+
 Fit(force=True)
 
 
@@ -153,5 +153,4 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-
     foo: bool = Field(True, exclude=True)

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/mod.rs
@@ -60,7 +60,6 @@ mod tests {
                         "deploy".to_string(),
                         "used".to_string(),
                     ],
-                    ..super::settings::Settings::default()
                 },
                 ..LinterSettings::for_rule(Rule::BooleanPositionalValueInCall)
             },

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/mod.rs
@@ -54,11 +54,8 @@ mod tests {
             &LinterSettings {
                 flake8_boolean_trap: super::settings::Settings {
                     extend_allowed_calls: vec![
-                        "Value".to_string(),
-                        "Field".to_string(),
-                        "settings".to_string(),
-                        "deploy".to_string(),
-                        "used".to_string(),
+                        "django.db.models.Value".to_string(),
+                        "pydantic.Field".to_string(),
                     ],
                 },
                 ..LinterSettings::for_rule(Rule::BooleanPositionalValueInCall)

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/mod.rs
@@ -1,6 +1,7 @@
 //! Rules from [flake8-boolean-trap](https://pypi.org/project/flake8-boolean-trap/).
 mod helpers;
 pub(crate) mod rules;
+pub mod settings;
 
 #[cfg(test)]
 mod tests {
@@ -11,6 +12,7 @@ mod tests {
 
     use crate::registry::Rule;
     use crate::settings::types::PreviewMode;
+    use crate::settings::LinterSettings;
     use crate::test::test_path;
     use crate::{assert_messages, settings};
 
@@ -42,6 +44,28 @@ mod tests {
             },
         )?;
         assert_messages!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn extend_allowed_callable() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("flake8_boolean_trap/FBT.py"),
+            &LinterSettings {
+                flake8_boolean_trap: super::settings::Settings {
+                    extend_allowed_calls: vec![
+                        "Value".to_string(),
+                        "Field".to_string(),
+                        "settings".to_string(),
+                        "deploy".to_string(),
+                        "used".to_string(),
+                    ],
+                    ..super::settings::Settings::default()
+                },
+                ..LinterSettings::for_rule(Rule::BooleanPositionalValueInCall)
+            },
+        )?;
+        assert_messages!(diagnostics);
         Ok(())
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_positional_value_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_positional_value_in_call.rs
@@ -46,7 +46,7 @@ impl Violation for BooleanPositionalValueInCall {
 }
 
 pub(crate) fn boolean_positional_value_in_call(checker: &mut Checker, call: &ast::ExprCall) {
-    if allow_boolean_trap(call) {
+    if allow_boolean_trap(call, checker.settings) {
         return;
     }
     for arg in call

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_positional_value_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_positional_value_in_call.rs
@@ -52,7 +52,7 @@ impl Violation for BooleanPositionalValueInCall {
 }
 
 pub(crate) fn boolean_positional_value_in_call(checker: &mut Checker, call: &ast::ExprCall) {
-    if allow_boolean_trap(call, checker.settings) {
+    if allow_boolean_trap(call, checker) {
         return;
     }
     for arg in call

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_positional_value_in_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/rules/boolean_positional_value_in_call.rs
@@ -9,6 +9,9 @@ use crate::rules::flake8_boolean_trap::helpers::allow_boolean_trap;
 /// ## What it does
 /// Checks for boolean positional arguments in function calls.
 ///
+/// Some functions are whitelisted by default. To extend the list of allowed calls
+/// configure the [`lint.flake8-boolean-trap.extend-allowed-calls`] option.
+///
 /// ## Why is this bad?
 /// Calling a function with boolean positional arguments is confusing as the
 /// meaning of the boolean value is not clear to the caller, and to future
@@ -31,6 +34,9 @@ use crate::rules::flake8_boolean_trap::helpers::allow_boolean_trap;
 ///
 /// func(flag=True)
 /// ```
+///
+/// ## Options
+/// - `lint.flake8-boolean-trap.extend-allowed-calls`
 ///
 /// ## References
 /// - [Python documentation: Calls](https://docs.python.org/3/reference/expressions.html#calls)

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/settings.rs
@@ -1,0 +1,31 @@
+//! Settings for the `flake8_boolean_trap` plugin.
+
+use crate::display_settings;
+use ruff_macros::CacheKey;
+use std::fmt;
+
+#[derive(Debug, CacheKey)]
+pub struct Settings {
+    pub extend_allowed_calls: Vec<String>,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            extend_allowed_calls: Vec::new(),
+        }
+    }
+}
+
+impl fmt::Display for Settings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        display_settings! {
+            formatter = f,
+            namespace = "linter.flake8_boolean_trap",
+            fields = [
+                self.extend_allowed_calls | array,
+            ]
+        }
+        Ok(())
+    }
+}

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/settings.rs
@@ -1,8 +1,10 @@
-//! Settings for the `flake8_boolean_trap` plugin.
+//! Settings for the `flake8-boolean-trap` plugin.
+
+use std::fmt;
+
+use ruff_macros::CacheKey;
 
 use crate::display_settings;
-use ruff_macros::CacheKey;
-use std::fmt;
 
 #[derive(Debug, CacheKey, Default)]
 pub struct Settings {

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/settings.rs
@@ -4,17 +4,9 @@ use crate::display_settings;
 use ruff_macros::CacheKey;
 use std::fmt;
 
-#[derive(Debug, CacheKey)]
+#[derive(Debug, CacheKey, Default)]
 pub struct Settings {
     pub extend_allowed_calls: Vec<String>,
-}
-
-impl Default for Settings {
-    fn default() -> Self {
-        Self {
-            extend_allowed_calls: Vec::new(),
-        }
-    }
 }
 
 impl fmt::Display for Settings {

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__FBT001_FBT.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__FBT001_FBT.py.snap
@@ -81,12 +81,10 @@ FBT.py:19:5: FBT001 Boolean-typed positional argument in function definition
 21 |     kwonly_nonvalued_nohint,
    |
 
-FBT.py:91:19: FBT001 Boolean-typed positional argument in function definition
+FBT.py:90:19: FBT001 Boolean-typed positional argument in function definition
    |
-90 |     # FBT001: Boolean positional arg in function definition
-91 |     def foo(self, value: bool) -> None:
+89 |     # FBT001: Boolean positional arg in function definition
+90 |     def foo(self, value: bool) -> None:
    |                   ^^^^^ FBT001
-92 |         pass
+91 |         pass
    |
-
-

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__FBT003_FBT.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__FBT003_FBT.py.snap
@@ -34,4 +34,29 @@ FBT.py:121:10: FBT003 Boolean positional value in function call
     |          ^^^^ FBT003
     |
 
+FBT.py:144:20: FBT003 Boolean positional value in function call
+    |
+142 |     is_foo_or_bar=Case(
+143 |         When(Q(is_foo=True) | Q(is_bar=True)),
+144 |         then=Value(True),
+    |                    ^^^^ FBT003
+145 |     ),
+146 |     default=Value(False),
+    |
 
+FBT.py:146:19: FBT003 Boolean positional value in function call
+    |
+144 |         then=Value(True),
+145 |     ),
+146 |     default=Value(False),
+    |                   ^^^^^ FBT003
+147 | )
+    |
+
+FBT.py:157:23: FBT003 Boolean positional value in function call
+    |
+155 | class Settings(BaseSettings):
+156 | 
+157 |     foo: bool = Field(True, exclude=True)
+    |                       ^^^^ FBT003
+    |

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__FBT003_FBT.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__FBT003_FBT.py.snap
@@ -1,36 +1,36 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_boolean_trap/mod.rs
 ---
-FBT.py:42:11: FBT003 Boolean positional value in function call
+FBT.py:41:11: FBT003 Boolean positional value in function call
    |
-42 | used("a", True)
+41 | used("a", True)
    |           ^^^^ FBT003
-43 | used(do=True)
+42 | used(do=True)
    |
 
-FBT.py:57:11: FBT003 Boolean positional value in function call
+FBT.py:56:11: FBT003 Boolean positional value in function call
    |
-55 | {}.pop(True, False)
-56 | dict.fromkeys(("world",), True)
-57 | {}.deploy(True, False)
+54 | {}.pop(True, False)
+55 | dict.fromkeys(("world",), True)
+56 | {}.deploy(True, False)
    |           ^^^^ FBT003
-58 | getattr(someobj, attrname, False)
-59 | mylist.index(True)
+57 | getattr(someobj, attrname, False)
+58 | mylist.index(True)
    |
 
-FBT.py:57:17: FBT003 Boolean positional value in function call
+FBT.py:56:17: FBT003 Boolean positional value in function call
    |
-55 | {}.pop(True, False)
-56 | dict.fromkeys(("world",), True)
-57 | {}.deploy(True, False)
+54 | {}.pop(True, False)
+55 | dict.fromkeys(("world",), True)
+56 | {}.deploy(True, False)
    |                 ^^^^^ FBT003
-58 | getattr(someobj, attrname, False)
-59 | mylist.index(True)
+57 | getattr(someobj, attrname, False)
+58 | mylist.index(True)
    |
 
-FBT.py:121:10: FBT003 Boolean positional value in function call
+FBT.py:120:10: FBT003 Boolean positional value in function call
     |
-121 | settings(True)
+120 | settings(True)
     |          ^^^^ FBT003
     |
 
@@ -53,10 +53,9 @@ FBT.py:146:19: FBT003 Boolean positional value in function call
 147 | )
     |
 
-FBT.py:157:23: FBT003 Boolean positional value in function call
+FBT.py:156:23: FBT003 Boolean positional value in function call
     |
 155 | class Settings(BaseSettings):
-156 | 
-157 |     foo: bool = Field(True, exclude=True)
+156 |     foo: bool = Field(True, exclude=True)
     |                       ^^^^ FBT003
     |

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__extend_allowed_callable.snap
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__extend_allowed_callable.snap
@@ -1,4 +1,35 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_boolean_trap/mod.rs
 ---
+FBT.py:42:11: FBT003 Boolean positional value in function call
+   |
+42 | used("a", True)
+   |           ^^^^ FBT003
+43 | used(do=True)
+   |
 
+FBT.py:57:11: FBT003 Boolean positional value in function call
+   |
+55 | {}.pop(True, False)
+56 | dict.fromkeys(("world",), True)
+57 | {}.deploy(True, False)
+   |           ^^^^ FBT003
+58 | getattr(someobj, attrname, False)
+59 | mylist.index(True)
+   |
+
+FBT.py:57:17: FBT003 Boolean positional value in function call
+   |
+55 | {}.pop(True, False)
+56 | dict.fromkeys(("world",), True)
+57 | {}.deploy(True, False)
+   |                 ^^^^^ FBT003
+58 | getattr(someobj, attrname, False)
+59 | mylist.index(True)
+   |
+
+FBT.py:121:10: FBT003 Boolean positional value in function call
+    |
+121 | settings(True)
+    |          ^^^^ FBT003
+    |

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__extend_allowed_callable.snap
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__extend_allowed_callable.snap
@@ -1,35 +1,35 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_boolean_trap/mod.rs
 ---
-FBT.py:42:11: FBT003 Boolean positional value in function call
+FBT.py:41:11: FBT003 Boolean positional value in function call
    |
-42 | used("a", True)
+41 | used("a", True)
    |           ^^^^ FBT003
-43 | used(do=True)
+42 | used(do=True)
    |
 
-FBT.py:57:11: FBT003 Boolean positional value in function call
+FBT.py:56:11: FBT003 Boolean positional value in function call
    |
-55 | {}.pop(True, False)
-56 | dict.fromkeys(("world",), True)
-57 | {}.deploy(True, False)
+54 | {}.pop(True, False)
+55 | dict.fromkeys(("world",), True)
+56 | {}.deploy(True, False)
    |           ^^^^ FBT003
-58 | getattr(someobj, attrname, False)
-59 | mylist.index(True)
+57 | getattr(someobj, attrname, False)
+58 | mylist.index(True)
    |
 
-FBT.py:57:17: FBT003 Boolean positional value in function call
+FBT.py:56:17: FBT003 Boolean positional value in function call
    |
-55 | {}.pop(True, False)
-56 | dict.fromkeys(("world",), True)
-57 | {}.deploy(True, False)
+54 | {}.pop(True, False)
+55 | dict.fromkeys(("world",), True)
+56 | {}.deploy(True, False)
    |                 ^^^^^ FBT003
-58 | getattr(someobj, attrname, False)
-59 | mylist.index(True)
+57 | getattr(someobj, attrname, False)
+58 | mylist.index(True)
    |
 
-FBT.py:121:10: FBT003 Boolean positional value in function call
+FBT.py:120:10: FBT003 Boolean positional value in function call
     |
-121 | settings(True)
+120 | settings(True)
     |          ^^^^ FBT003
     |

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__extend_allowed_callable.snap
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__extend_allowed_callable.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/flake8_boolean_trap/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__preview__FBT001_FBT.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_boolean_trap/snapshots/ruff_linter__rules__flake8_boolean_trap__tests__preview__FBT001_FBT.py.snap
@@ -81,26 +81,24 @@ FBT.py:19:5: FBT001 Boolean-typed positional argument in function definition
 21 |     kwonly_nonvalued_nohint,
    |
 
-FBT.py:91:19: FBT001 Boolean-typed positional argument in function definition
+FBT.py:90:19: FBT001 Boolean-typed positional argument in function definition
    |
-90 |     # FBT001: Boolean positional arg in function definition
-91 |     def foo(self, value: bool) -> None:
+89 |     # FBT001: Boolean positional arg in function definition
+90 |     def foo(self, value: bool) -> None:
    |                   ^^^^^ FBT001
-92 |         pass
+91 |         pass
    |
 
-FBT.py:101:10: FBT001 Boolean-typed positional argument in function definition
+FBT.py:100:10: FBT001 Boolean-typed positional argument in function definition
     |
-101 | def func(x: Union[list, Optional[int | str | float | bool]]):
+100 | def func(x: Union[list, Optional[int | str | float | bool]]):
     |          ^ FBT001
-102 |     pass
+101 |     pass
     |
 
-FBT.py:105:10: FBT001 Boolean-typed positional argument in function definition
+FBT.py:104:10: FBT001 Boolean-typed positional argument in function definition
     |
-105 | def func(x: bool | str):
+104 | def func(x: bool | str):
     |          ^ FBT001
-106 |     pass
+105 |     pass
     |
-
-

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -16,11 +16,11 @@ use ruff_macros::CacheKey;
 use crate::line_width::LineLength;
 use crate::registry::{Linter, Rule};
 use crate::rules::{
-    flake8_annotations, flake8_bandit, flake8_bugbear, flake8_builtins, flake8_comprehensions,
-    flake8_copyright, flake8_errmsg, flake8_gettext, flake8_implicit_str_concat,
-    flake8_import_conventions, flake8_pytest_style, flake8_quotes, flake8_self,
-    flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments, isort, mccabe, pep8_naming,
-    pycodestyle, pydocstyle, pyflakes, pylint, pyupgrade,
+    flake8_annotations, flake8_bandit, flake8_boolean_trap, flake8_bugbear, flake8_builtins,
+    flake8_comprehensions, flake8_copyright, flake8_errmsg, flake8_gettext,
+    flake8_implicit_str_concat, flake8_import_conventions, flake8_pytest_style, flake8_quotes,
+    flake8_self, flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments, isort, mccabe,
+    pep8_naming, pycodestyle, pydocstyle, pyflakes, pylint, pyupgrade,
 };
 use crate::settings::types::{ExtensionMapping, FilePatternSet, PerFileIgnores, PythonVersion};
 use crate::{codes, RuleSelector};
@@ -237,6 +237,7 @@ pub struct LinterSettings {
     // Plugins
     pub flake8_annotations: flake8_annotations::settings::Settings,
     pub flake8_bandit: flake8_bandit::settings::Settings,
+    pub flake8_boolean_trap: flake8_boolean_trap::settings::Settings,
     pub flake8_bugbear: flake8_bugbear::settings::Settings,
     pub flake8_builtins: flake8_builtins::settings::Settings,
     pub flake8_comprehensions: flake8_comprehensions::settings::Settings,
@@ -399,16 +400,17 @@ impl LinterSettings {
             typing_modules: vec![],
             flake8_annotations: flake8_annotations::settings::Settings::default(),
             flake8_bandit: flake8_bandit::settings::Settings::default(),
+            flake8_boolean_trap: flake8_boolean_trap::settings::Settings::default(),
             flake8_bugbear: flake8_bugbear::settings::Settings::default(),
             flake8_builtins: flake8_builtins::settings::Settings::default(),
             flake8_comprehensions: flake8_comprehensions::settings::Settings::default(),
             flake8_copyright: flake8_copyright::settings::Settings::default(),
             flake8_errmsg: flake8_errmsg::settings::Settings::default(),
+            flake8_gettext: flake8_gettext::settings::Settings::default(),
             flake8_implicit_str_concat: flake8_implicit_str_concat::settings::Settings::default(),
             flake8_import_conventions: flake8_import_conventions::settings::Settings::default(),
             flake8_pytest_style: flake8_pytest_style::settings::Settings::default(),
             flake8_quotes: flake8_quotes::settings::Settings::default(),
-            flake8_gettext: flake8_gettext::settings::Settings::default(),
             flake8_self: flake8_self::settings::Settings::default(),
             flake8_tidy_imports: flake8_tidy_imports::settings::Settings::default(),
             flake8_type_checking: flake8_type_checking::settings::Settings::default(),

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -40,10 +40,11 @@ use ruff_python_formatter::{
 };
 
 use crate::options::{
-    Flake8AnnotationsOptions, Flake8BanditOptions, Flake8BugbearOptions, Flake8BuiltinsOptions,
-    Flake8ComprehensionsOptions, Flake8CopyrightOptions, Flake8ErrMsgOptions, Flake8GetTextOptions,
-    Flake8ImplicitStrConcatOptions, Flake8ImportConventionsOptions, Flake8PytestStyleOptions,
-    Flake8QuotesOptions, Flake8SelfOptions, Flake8TidyImportsOptions, Flake8TypeCheckingOptions,
+    Flake8AnnotationsOptions, Flake8BanditOptions, Flake8BooleanTrapOptions, Flake8BugbearOptions,
+    Flake8BuiltinsOptions, Flake8ComprehensionsOptions, Flake8CopyrightOptions,
+    Flake8ErrMsgOptions, Flake8GetTextOptions, Flake8ImplicitStrConcatOptions,
+    Flake8ImportConventionsOptions, Flake8PytestStyleOptions, Flake8QuotesOptions,
+    Flake8SelfOptions, Flake8TidyImportsOptions, Flake8TypeCheckingOptions,
     Flake8UnusedArgumentsOptions, FormatOptions, IsortOptions, LintCommonOptions, LintOptions,
     McCabeOptions, Options, Pep8NamingOptions, PyUpgradeOptions, PycodestyleOptions,
     PydocstyleOptions, PyflakesOptions, PylintOptions,
@@ -291,6 +292,10 @@ impl Configuration {
                 flake8_bandit: lint
                     .flake8_bandit
                     .map(Flake8BanditOptions::into_settings)
+                    .unwrap_or_default(),
+                flake8_boolean_trap: lint
+                    .flake8_boolean_trap
+                    .map(Flake8BooleanTrapOptions::into_settings)
                     .unwrap_or_default(),
                 flake8_bugbear: lint
                     .flake8_bugbear
@@ -609,6 +614,7 @@ pub struct LintConfiguration {
     // Plugins
     pub flake8_annotations: Option<Flake8AnnotationsOptions>,
     pub flake8_bandit: Option<Flake8BanditOptions>,
+    pub flake8_boolean_trap: Option<Flake8BooleanTrapOptions>,
     pub flake8_bugbear: Option<Flake8BugbearOptions>,
     pub flake8_builtins: Option<Flake8BuiltinsOptions>,
     pub flake8_comprehensions: Option<Flake8ComprehensionsOptions>,
@@ -713,6 +719,7 @@ impl LintConfiguration {
             // Plugins
             flake8_annotations: options.common.flake8_annotations,
             flake8_bandit: options.common.flake8_bandit,
+            flake8_boolean_trap: options.common.flake8_boolean_trap,
             flake8_bugbear: options.common.flake8_bugbear,
             flake8_builtins: options.common.flake8_builtins,
             flake8_comprehensions: options.common.flake8_comprehensions,
@@ -1127,6 +1134,7 @@ impl LintConfiguration {
             // Plugins
             flake8_annotations: self.flake8_annotations.combine(config.flake8_annotations),
             flake8_bandit: self.flake8_bandit.combine(config.flake8_bandit),
+            flake8_boolean_trap: self.flake8_boolean_trap.combine(config.flake8_boolean_trap),
             flake8_bugbear: self.flake8_bugbear.combine(config.flake8_bugbear),
             flake8_builtins: self.flake8_builtins.combine(config.flake8_builtins),
             flake8_comprehensions: self
@@ -1356,6 +1364,10 @@ fn warn_about_deprecated_top_level_lint_options(
 
     if top_level_options.flake8_bandit.is_some() {
         used_options.push("flake8-bandit");
+    }
+
+    if top_level_options.flake8_boolean_trap.is_some() {
+        used_options.push("flake8-boolean-trap");
     }
 
     if top_level_options.flake8_bugbear.is_some() {

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1056,11 +1056,14 @@ impl Flake8BanditOptions {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Flake8BooleanTrapOptions {
-    /// A list of calls with which to allow a boolean trap.
+    /// Additional callable functions with which to allow boolean traps.
+    ///
+    /// Expects to receive a list of fully-qualified names (e.g., `pydantic.Field`, rather than
+    /// `Field`).
     #[option(
         default = "[]",
         value_type = "list[str]",
-        example = "extend-allowed-calls = [\"Field\", \"Value\"]"
+        example = "extend-allowed-calls = [\"pydantic.Field\", \"django.db.models.Value\"]"
     )]
     pub extend_allowed_calls: Option<Vec<String>>,
 }

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -809,6 +809,10 @@ pub struct LintCommonOptions {
     #[option_group]
     pub flake8_bandit: Option<Flake8BanditOptions>,
 
+    /// Options for the `flake8-boolean-trap` plugin.
+    #[option_group]
+    pub flake8_boolean_trap: Option<Flake8BooleanTrapOptions>,
+
     /// Options for the `flake8-bugbear` plugin.
     #[option_group]
     pub flake8_bugbear: Option<Flake8BugbearOptions>,
@@ -1042,6 +1046,29 @@ impl Flake8BanditOptions {
                 .chain(self.hardcoded_tmp_directory_extend.unwrap_or_default())
                 .collect(),
             check_typed_exception: self.check_typed_exception.unwrap_or(false),
+        }
+    }
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
+)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct Flake8BooleanTrapOptions {
+    /// A list of calls with which to allow a boolean trap.
+    #[option(
+        default = "[]",
+        value_type = "list[str]",
+        example = "extend-allowed-calls = [\"Field\", \"Value\"]"
+    )]
+    pub extend_allowed_calls: Option<Vec<String>>,
+}
+
+impl Flake8BooleanTrapOptions {
+    pub fn into_settings(self) -> ruff_linter::rules::flake8_boolean_trap::settings::Settings {
+        ruff_linter::rules::flake8_boolean_trap::settings::Settings {
+            extend_allowed_calls: self.extend_allowed_calls.unwrap_or_default(),
         }
     }
 }

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -910,7 +910,7 @@
       "type": "object",
       "properties": {
         "extend-allowed-calls": {
-          "description": "A list of calls with which to allow a boolean trap.",
+          "description": "Additional callable functions with which to allow boolean traps.\n\nExpects to receive a list of fully-qualified names (e.g., `pydantic.Field`, rather than `Field`).",
           "type": [
             "array",
             "null"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -226,6 +226,18 @@
         }
       ]
     },
+    "flake8-boolean-trap": {
+      "description": "Options for the `flake8-boolean-trap` plugin.",
+      "deprecated": true,
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8BooleanTrapOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "flake8-bugbear": {
       "description": "Options for the `flake8-bugbear` plugin.",
       "deprecated": true,
@@ -883,6 +895,22 @@
         },
         "hardcoded-tmp-directory-extend": {
           "description": "A list of directories to consider temporary, in addition to those specified by `hardcoded-tmp-directory`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Flake8BooleanTrapOptions": {
+      "type": "object",
+      "properties": {
+        "extend-allowed-calls": {
+          "description": "A list of calls with which to allow a boolean trap.",
           "type": [
             "array",
             "null"
@@ -1908,6 +1936,17 @@
           "anyOf": [
             {
               "$ref": "#/definitions/Flake8BanditOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-boolean-trap": {
+          "description": "Options for the `flake8-boolean-trap` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8BooleanTrapOptions"
             },
             {
               "type": "null"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Add a setting `extend-allowed-calls` to allow users to define their own list of calls which allow boolean traps.

Resolves #10485.
Resolves #10356.

## Test Plan

Extended text fixture and added setting test.
