### PR TITLE
Fix `PT014` autofix for last item in list

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT014.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT014.py
@@ -51,3 +51,8 @@ def test_error_parentheses_trailing_comma(x):
 @pytest.mark.parametrize("x", [1, 2])
 def test_ok(x):
     ...
+
+
+@pytest.mark.parametrize('data, spec', [(1.0, 1.0), (1.0, 1.0)])
+def test_numbers(data, spec):
+    ...

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT014.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT014.snap
@@ -166,4 +166,20 @@ PT014.py:44:11: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.par
 46 45 | )
 47 46 | def test_error_parentheses_trailing_comma(x):
 
+PT014.py:56:53: PT014 [*] Duplicate of test case at index 0 in `@pytest_mark.parametrize`
+   |
+56 | @pytest.mark.parametrize('data, spec', [(1.0, 1.0), (1.0, 1.0)])
+   |                                                     ^^^^^^^^^^ PT014
+57 | def test_numbers(data, spec):
+58 |     ...
+   |
+   = help: Remove duplicate test case
 
+ℹ Unsafe fix
+53 53 |     ...
+54 54 | 
+55 55 | 
+56    |-@pytest.mark.parametrize('data, spec', [(1.0, 1.0), (1.0, 1.0)])
+   56 |+@pytest.mark.parametrize('data, spec', [(1.0, 1.0)])
+57 57 | def test_numbers(data, spec):
+58 58 |     ...


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This error was found browsing https://github.com/qarmin/Automated-Fuzzer/actions/runs/8396966850. Which failed when trying to autofix the PT014 violation in the following code:
```python
@pytest.mark.parametrize('data, spec', [(1.0, 1.0), (1.0, 1.0)])
def test_numbers(data, spec):
    ...
```

Investigation revealed that the implementation was not properly tested, when the duplicate value was also the last in the list. In particular the following function, which is in charge of finding the comma following an element to create the suggested fix,
https://github.com/astral-sh/ruff/blob/0a99bd84ce90564b10dbb7c3cf51c70922f4daed/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs#L647-L651
would find the next comma even if it was outside the list itself leading to a lot of code being deleted.

This PR fixes that.

## Test Plan

Added misbehaving code to the test fixture.
