### PR TITLE
Fix `PD002` autofix for chained calls

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pandas_vet/PD002.py
+++ b/crates/ruff_linter/resources/test/fixtures/pandas_vet/PD002.py
@@ -36,3 +36,5 @@ torch.m.ReLU(inplace=True)  # safe because this isn't a pandas call
 x.rotate_z(45, inplace=True)
 
 x.reorder_levels().sort_index(inplace=True)
+
+x.drop(["a"], axis=1, inplace=True).sort_index(inplace=True)

--- a/crates/ruff_linter/resources/test/fixtures/pandas_vet/PD002.py
+++ b/crates/ruff_linter/resources/test/fixtures/pandas_vet/PD002.py
@@ -34,3 +34,5 @@ torch.m.ReLU(inplace=True)  # safe because this isn't a pandas call
 
 # This method doesn't take exist in Pandas, so ignore it.
 x.rotate_z(45, inplace=True)
+
+x.reorder_levels().sort_index(inplace=True)

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -119,7 +119,8 @@ fn convert_inplace_argument_to_assignment(
     locator: &Locator,
 ) -> Option<Fix> {
     // Add the assignment.
-    let attr = call.func.as_attribute_expr()?;
+    // let attr = call.func.as_attribute_expr()?;
+    let attr = get_base_attribute(call)?;
     let insert_assignment = Edit::insertion(
         format!("{name} = ", name = locator.slice(attr.value.range())),
         parenthesized_range(
@@ -142,6 +143,14 @@ fn convert_inplace_argument_to_assignment(
     .ok()?;
 
     Some(Fix::unsafe_edits(insert_assignment, [remove_argument]))
+}
+
+fn get_base_attribute(call: &ast::ExprCall) -> Option<&ast::ExprAttribute> {
+    let mut attr = call.func.as_attribute_expr()?;
+    while let ast::Expr::Call(ast::ExprCall { func, .. }) = attr.value.as_ref() {
+        attr = func.as_attribute_expr()?;
+    }
+    return Some(attr);
 }
 
 /// Returns `true` if the given method accepts an `inplace` argument when used on a Pandas

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -150,7 +150,7 @@ fn get_base_attribute(call: &ast::ExprCall) -> Option<&ast::ExprAttribute> {
     while let ast::Expr::Call(ast::ExprCall { func, .. }) = attr.value.as_ref() {
         attr = func.as_attribute_expr()?;
     }
-    return Some(attr);
+    Some(attr)
 }
 
 /// Returns `true` if the given method accepts an `inplace` argument when used on a Pandas

--- a/crates/ruff_linter/src/rules/pandas_vet/snapshots/ruff_linter__rules__pandas_vet__tests__PD002_PD002.py.snap
+++ b/crates/ruff_linter/src/rules/pandas_vet/snapshots/ruff_linter__rules__pandas_vet__tests__PD002_PD002.py.snap
@@ -179,4 +179,18 @@ PD002.py:33:24: PD002 [*] `inplace=True` should be avoided; it has inconsistent 
 35 35 | # This method doesn't take exist in Pandas, so ignore it.
 36 36 | x.rotate_z(45, inplace=True)
 
+PD002.py:38:31: PD002 [*] `inplace=True` should be avoided; it has inconsistent behavior
+   |
+36 | x.rotate_z(45, inplace=True)
+37 | 
+38 | x.reorder_levels().sort_index(inplace=True)
+   |                               ^^^^^^^^^^^^ PD002
+   |
+   = help: Assign to variable; remove `inplace` arg
 
+ℹ Unsafe fix
+35 35 | # This method doesn't take exist in Pandas, so ignore it.
+36 36 | x.rotate_z(45, inplace=True)
+37 37 | 
+38    |-x.reorder_levels().sort_index(inplace=True)
+   38 |+x = x.reorder_levels().sort_index()


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This error was found browsing https://github.com/qarmin/Automated-Fuzzer/actions/runs/8396966850. Which failed when trying to autofix the PD002 violation in the following code:
```python
x.reorder_levels().sort_index(inplace=True)
```
the autofix transformed the code to
```python
x.reorder_levels() = x.reorder_levels().sort_index()
```
to address this I implemented a function to iterate down the list of chain calls and find the first attribute which is not a call and use that as the target. I'm guessing this is probably already implemented somewhere but I couldn't find it.

The new autofix is:
```python
x = x.reorder_levels().sort_index()
```

## Test Plan

Added misbehaving code to the test fixture.
