### PR TITLE
[`E402`] Allow cell magics before an import

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E402.ipynb
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E402.ipynb
@@ -87,6 +87,37 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a51463ee-091c-44b4-9069-c03bf7e3bf83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "import pathlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ddc937e-6c19-475f-b108-9405aa1af4f1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "285041d2-a76c-4ff3-8ff2-0131bbf66016",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "%%time\n",
+    "import pathlib"
+   ]
   }
  ],
  "metadata": {

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -365,6 +365,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
                 self.semantic.flags |= SemanticModelFlags::MODULE_DOCSTRING_BOUNDARY;
                 self.semantic.flags |= SemanticModelFlags::FUTURES_BOUNDARY;
                 if !(self.semantic.seen_import_boundary()
+                    || stmt.is_ipy_escape_command_stmt()
                     || helpers::is_assignment_to_a_dunder(stmt)
                     || helpers::in_nested_block(self.semantic.current_statements())
                     || imports::is_matplotlib_activation(stmt, self.semantic())

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E402_E402.ipynb.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__E402_E402.ipynb.snap
@@ -24,6 +24,6 @@ E402.ipynb:30:1: E402 Module level import not at top of cell
    |
 30 | import no_ok
    | ^^^^^^^^^^^^ E402
+31 | 
+32 | %%time
    |
-
-


### PR DESCRIPTION
## Summary

This PR fixes the bug to allow Ipython escape commands to be present before an import statement and avoid raising `E402`.

fixes: #10357 

## Test Plan

Add test case and make sure they don't raise the `E402` violation.

On `main`, we get the following:

```
crates/ruff_linter/resources/test/fixtures/pycodestyle/E402.ipynb:cell 8:2:1: E402 Module level import not at top of cell
  |
1 | %%time
2 | import pathlib
  | ^^^^^^^^^^^^^^ E402
  |

crates/ruff_linter/resources/test/fixtures/pycodestyle/E402.ipynb:cell 10:3:1: E402 Module level import not at top of cell
  |
1 | %%time
2 | %%time
3 | import pathlib
  | ^^^^^^^^^^^^^^ E402
```
