### PR TITLE
Complete end expression token set

### DIFF
--- a/crates/ruff_python_parser/resources/valid/expressions/name.py
+++ b/crates/ruff_python_parser/resources/valid/expressions/name.py
@@ -1,0 +1,11 @@
+_
+(_)
+__
+__init__
+name
+(name)
+
+# Soft keywords used as name
+match
+case
+type

--- a/crates/ruff_python_parser/resources/valid/expressions/number_literal.py
+++ b/crates/ruff_python_parser/resources/valid/expressions/number_literal.py
@@ -35,5 +35,6 @@ x = -100.0000J
 if 10 .real:
     ...
 
+# This is a type error, not a syntax error
 y = 100[no]
 y = 100(no)

--- a/crates/ruff_python_parser/resources/valid/other/atom.py
+++ b/crates/ruff_python_parser/resources/valid/other/atom.py
@@ -1,0 +1,6 @@
+...
+True
+False
+None
+
+# Other atoms are tested in their respective files.

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -176,7 +176,7 @@ impl<'src> Parser<'src> {
     pub(crate) fn parse_program(mut self) -> Program {
         let ast = if self.mode == Mode::Expression {
             let start = self.node_start();
-            let parsed_expr = self.parse_expression();
+            let parsed_expr = self.parse_expressions();
             let mut progress = ParserProgress::default();
 
             // TODO: How should error recovery work here? Just truncate after the expression?

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -195,7 +195,7 @@ impl<'src> Parser<'src> {
             }
             _ => {
                 let start = self.node_start();
-                let parsed_expr = self.parse_expression();
+                let parsed_expr = self.parse_expressions();
 
                 if self.eat(TokenKind::Equal) {
                     Stmt::Assign(self.parse_assign_statement(parsed_expr, start))
@@ -271,7 +271,7 @@ impl<'src> Parser<'src> {
 
         let value = self
             .at_expr()
-            .then(|| Box::new(self.parse_expression().expr));
+            .then(|| Box::new(self.parse_expressions().expr));
 
         ast::StmtReturn {
             range: self.node_range(start),
@@ -287,7 +287,7 @@ impl<'src> Parser<'src> {
         let exc = if self.at(TokenKind::Newline) {
             None
         } else {
-            let exc = self.parse_expression();
+            let exc = self.parse_expressions();
 
             if let Expr::Tuple(node) = &exc.expr {
                 if !node.parenthesized {
@@ -304,7 +304,7 @@ impl<'src> Parser<'src> {
         };
 
         let cause = (exc.is_some() && self.eat(TokenKind::From)).then(|| {
-            let cause = self.parse_expression();
+            let cause = self.parse_expressions();
 
             if let Expr::Tuple(ast::ExprTuple {
                 parenthesized: false,
@@ -569,13 +569,13 @@ impl<'src> Parser<'src> {
     /// See: <https://docs.python.org/3/reference/simple_stmts.html#grammar-token-python-grammar-assignment_stmt>
     fn parse_assign_statement(&mut self, target: ParsedExpr, start: TextSize) -> ast::StmtAssign {
         let mut targets = vec![target.expr];
-        let mut value = self.parse_expression();
+        let mut value = self.parse_expressions();
 
         if self.at(TokenKind::Equal) {
             self.parse_list(RecoveryContextKind::AssignmentTargets, |parser| {
                 parser.bump(TokenKind::Equal);
 
-                let mut parsed_expr = parser.parse_expression();
+                let mut parsed_expr = parser.parse_expressions();
 
                 std::mem::swap(&mut value, &mut parsed_expr);
 
@@ -625,7 +625,7 @@ impl<'src> Parser<'src> {
         helpers::set_expr_ctx(&mut target.expr, ExprContext::Store);
 
         let simple = target.expr.is_name_expr() && !target.is_parenthesized;
-        let annotation = self.parse_expression();
+        let annotation = self.parse_expressions();
 
         if matches!(
             annotation.expr,
@@ -642,7 +642,7 @@ impl<'src> Parser<'src> {
 
         let value = self
             .eat(TokenKind::Equal)
-            .then(|| Box::new(self.parse_expression().expr));
+            .then(|| Box::new(self.parse_expressions().expr));
 
         ast::StmtAnnAssign {
             target: Box::new(target.expr),
@@ -678,7 +678,7 @@ impl<'src> Parser<'src> {
 
         helpers::set_expr_ctx(&mut target.expr, ExprContext::Store);
 
-        let value = self.parse_expression();
+        let value = self.parse_expressions();
 
         ast::StmtAugAssign {
             target: Box::new(target.expr),
@@ -766,7 +766,7 @@ impl<'src> Parser<'src> {
             let type_ = if p.at(TokenKind::Colon) && !is_star {
                 None
             } else {
-                let parsed_expr = p.parse_expression();
+                let parsed_expr = p.parse_expressions();
                 if matches!(
                     parsed_expr.expr,
                     Expr::Tuple(ast::ExprTuple {
@@ -839,14 +839,14 @@ impl<'src> Parser<'src> {
         self.bump(TokenKind::For);
 
         let saved_context = self.set_ctx(ParserCtxFlags::FOR_TARGET);
-        let mut target = self.parse_expression();
+        let mut target = self.parse_expressions();
         self.restore_ctx(ParserCtxFlags::FOR_TARGET, saved_context);
 
         helpers::set_expr_ctx(&mut target.expr, ExprContext::Store);
 
         self.expect(TokenKind::In);
 
-        let iter = self.parse_expression();
+        let iter = self.parse_expressions();
 
         self.expect(TokenKind::Colon);
 
@@ -911,7 +911,7 @@ impl<'src> Parser<'src> {
         parameters.range = self.node_range(parameters_start);
 
         let returns = self.eat(TokenKind::Rarrow).then(|| {
-            let returns = self.parse_expression();
+            let returns = self.parse_expressions();
             if !returns.is_parenthesized && matches!(returns.expr, Expr::Tuple(_)) {
                 self.add_error(
                     ParseErrorType::OtherError(

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__assignment_keyword_target.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__assignment_keyword_target.py.snap
@@ -130,7 +130,7 @@ Module(
 
   |
 1 | a = pass = c
-  |     ^^^^ Syntax Error: Identifier expected. 'pass' is a keyword that cannot be used here.
+  |     ^^^^ Syntax Error: Expected an identifier, but found a keyword 'pass' that cannot be used here
 2 | 
 3 | a + b
   |
@@ -140,7 +140,7 @@ Module(
 3 | a + b
 4 | 
 5 | a = b = pass = c
-  |         ^^^^ Syntax Error: Identifier expected. 'pass' is a keyword that cannot be used here.
+  |         ^^^^ Syntax Error: Expected an identifier, but found a keyword 'pass' that cannot be used here
 6 | 
 7 | a + b
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__function_type_parameters.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__function_type_parameters.py.snap
@@ -434,7 +434,7 @@ Module(
 14 |     a + b
 15 | 
 16 | def keyword[A, await](): ...
-   |                ^^^^^ Syntax Error: Identifier expected. 'await' is a keyword that cannot be used here.
+   |                ^^^^^ Syntax Error: Expected an identifier, but found a keyword 'await' that cannot be used here
 17 | 
 18 | def not_a_type_param[A, |, B](): ...
    |

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__name.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__name.py.snap
@@ -1,0 +1,123 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/valid/expressions/name.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..76,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 0..1,
+                    value: Name(
+                        ExprName {
+                            range: 0..1,
+                            id: "_",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 2..5,
+                    value: Name(
+                        ExprName {
+                            range: 3..4,
+                            id: "_",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 6..8,
+                    value: Name(
+                        ExprName {
+                            range: 6..8,
+                            id: "__",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 9..17,
+                    value: Name(
+                        ExprName {
+                            range: 9..17,
+                            id: "__init__",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 18..22,
+                    value: Name(
+                        ExprName {
+                            range: 18..22,
+                            id: "name",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 23..29,
+                    value: Name(
+                        ExprName {
+                            range: 24..28,
+                            id: "name",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 60..65,
+                    value: Name(
+                        ExprName {
+                            range: 60..65,
+                            id: "match",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 66..70,
+                    value: Name(
+                        ExprName {
+                            range: 66..70,
+                            id: "case",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 71..75,
+                    value: Name(
+                        ExprName {
+                            range: 71..75,
+                            id: "type",
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__number_literal.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__number_literal.py.snap
@@ -7,7 +7,7 @@ input_file: crates/ruff_python_parser/resources/valid/expressions/number_literal
 ```
 Module(
     ModModule {
-        range: 0..657,
+        range: 0..700,
         body: [
             Assign(
                 StmtAssign {
@@ -949,11 +949,11 @@ Module(
             ),
             Assign(
                 StmtAssign {
-                    range: 634..645,
+                    range: 677..688,
                     targets: [
                         Name(
                             ExprName {
-                                range: 634..635,
+                                range: 677..678,
                                 id: "y",
                                 ctx: Store,
                             },
@@ -961,10 +961,10 @@ Module(
                     ],
                     value: Subscript(
                         ExprSubscript {
-                            range: 638..645,
+                            range: 681..688,
                             value: NumberLiteral(
                                 ExprNumberLiteral {
-                                    range: 638..641,
+                                    range: 681..684,
                                     value: Int(
                                         100,
                                     ),
@@ -972,7 +972,7 @@ Module(
                             ),
                             slice: Name(
                                 ExprName {
-                                    range: 642..644,
+                                    range: 685..687,
                                     id: "no",
                                     ctx: Load,
                                 },
@@ -984,11 +984,11 @@ Module(
             ),
             Assign(
                 StmtAssign {
-                    range: 646..657,
+                    range: 689..700,
                     targets: [
                         Name(
                             ExprName {
-                                range: 646..647,
+                                range: 689..690,
                                 id: "y",
                                 ctx: Store,
                             },
@@ -996,21 +996,21 @@ Module(
                     ],
                     value: Call(
                         ExprCall {
-                            range: 650..657,
+                            range: 693..700,
                             func: NumberLiteral(
                                 ExprNumberLiteral {
-                                    range: 650..653,
+                                    range: 693..696,
                                     value: Int(
                                         100,
                                     ),
                                 },
                             ),
                             arguments: Arguments {
-                                range: 653..657,
+                                range: 696..700,
                                 args: [
                                     Name(
                                         ExprName {
-                                            range: 654..656,
+                                            range: 697..699,
                                             id: "no",
                                             ctx: Load,
                                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@other__atom.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@other__atom.py.snap
@@ -1,0 +1,57 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/valid/other/atom.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..73,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 0..3,
+                    value: EllipsisLiteral(
+                        ExprEllipsisLiteral {
+                            range: 0..3,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 4..8,
+                    value: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 4..8,
+                            value: true,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 9..14,
+                    value: BooleanLiteral(
+                        ExprBooleanLiteral {
+                            range: 9..14,
+                            value: false,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 15..19,
+                    value: NoneLiteral(
+                        ExprNoneLiteral {
+                            range: 15..19,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```


### PR DESCRIPTION
## Summary

This PR completes the end expression set which is a set of tokens that can come after an expression. These were taken from the [Python Grammar] searching for the `expression` and looking at the kind of tokens after that.

It also renames the `parse_expression` to `parse_expressions` as the corresponding grammar is called "expressions".

