### PR TITLE
Add tests for list expression parsing

### DIFF
--- a/crates/ruff_python_parser/resources/invalid/expressions/list/missing_closing_bracket_0.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/list/missing_closing_bracket_0.py
@@ -1,0 +1,3 @@
+# Missing closing bracket 0: No elements
+
+[

--- a/crates/ruff_python_parser/resources/invalid/expressions/list/missing_closing_bracket_1.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/list/missing_closing_bracket_1.py
@@ -1,0 +1,6 @@
+# Missing closing bracket 1: No elements on the same line, the one on the next line
+# is considered to be part of the list.
+
+[
+
+x + y

--- a/crates/ruff_python_parser/resources/invalid/expressions/list/missing_closing_bracket_2.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/list/missing_closing_bracket_2.py
@@ -1,0 +1,6 @@
+# Missing closing bracket 2: One element on the line, the other one on the next line
+# will be considered to be part of the list.
+
+[1,
+
+x + y

--- a/crates/ruff_python_parser/resources/invalid/expressions/list/missing_closing_bracket_3.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/list/missing_closing_bracket_3.py
@@ -1,0 +1,7 @@
+# Missing closing bracket 3: Multiple elements without a trailing comma and the next
+# token starts a statement.
+
+[1, 2
+
+def foo():
+    pass

--- a/crates/ruff_python_parser/resources/invalid/expressions/list/recover.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/list/recover.py
@@ -1,0 +1,20 @@
+# Test cases for list expressions where the parser recovers from a syntax error.
+
+[,]
+
+[1,,2]
+
+[1,,]
+
+# Missing comma
+[1 2]
+
+# Dictionary element in a list
+[1: 2]
+
+# Missing expression
+[1, x + ]
+
+[1; 2]
+
+[*]

--- a/crates/ruff_python_parser/resources/invalid/expressions/list/star_expression_precedence.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/list/star_expression_precedence.py
@@ -1,0 +1,10 @@
+# For list expression, the minimum binding power of star expression is bitwise or.
+
+[(*x), y]
+[*x in y, z]
+[*not x, z]
+[*x and y, z]
+[*x or y, z]
+[*x if True else y, z]
+[*lambda x: x, z]
+[*x := 2, z]

--- a/crates/ruff_python_parser/resources/valid/expressions/list.py
+++ b/crates/ruff_python_parser/resources/valid/expressions/list.py
@@ -1,5 +1,34 @@
-[1 + i, [1, 2, 3, 4], (a, i + x, y), {a, b, c}, {a: 1}]
-[1, 2, 3]
+# Simple lists
 []
 [1]
-[f(g(attr.H()) for c in l)]
+[1,]
+[1, 2, 3]
+[1, 2, 3,]
+
+# Mixed with indentations
+[
+]
+[
+        1
+]
+[
+    1,
+        2,
+]
+
+# Nested
+[[[1]]]
+[[1, 2], [3, 4]]
+
+# Named expression
+[x := 2]
+[x := 2,]
+[1, x := 2, 3]
+
+# Star expression
+[1, *x, 3]
+[1, *x | y, 3]
+
+# Random expressions
+[1 + 2, [1, 2, 3, 4], (a, b + c, d), {a, b, c}, {a: 1}, x := 2]
+[call1(call2(value.attr()) for element in iter)]

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -129,7 +129,6 @@ impl<'src> Parser<'src> {
     /// the [Python grammar] depending on whether named expressions are allowed.
     ///
     /// [Python grammar]: https://docs.python.org/3/reference/grammar.html
-    #[allow(dead_code)]
     pub(super) fn parse_star_expression_or_higher(
         &mut self,
         allow_named_expression: AllowNamedExpression,
@@ -1261,7 +1260,8 @@ impl<'src> Parser<'src> {
             });
         }
 
-        let first_element = self.parse_named_expression_or_higher();
+        // Parse the first element with a more general rule and limit it later.
+        let first_element = self.parse_star_expression_or_higher(AllowNamedExpression::Yes);
 
         match self.current_token_kind() {
             TokenKind::Async | TokenKind::For => {
@@ -1446,7 +1446,11 @@ impl<'src> Parser<'src> {
         let mut elts = vec![first_element];
 
         self.parse_comma_separated_list(RecoveryContextKind::ListElements, |parser| {
-            elts.push(parser.parse_named_expression_or_higher().expr);
+            elts.push(
+                parser
+                    .parse_star_expression_or_higher(AllowNamedExpression::Yes)
+                    .expr,
+            );
         });
 
         self.expect(TokenKind::Rsqb);
@@ -2002,7 +2006,6 @@ enum StarredExpressionPrecedence {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(super) enum AllowNamedExpression {
     Yes,
     No,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__missing_closing_bracket_0.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__missing_closing_bracket_0.py.snap
@@ -1,0 +1,43 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/list/missing_closing_bracket_0.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..43,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 42..43,
+                    value: List(
+                        ExprList {
+                            range: 42..43,
+                            elts: [
+                                Name(
+                                    ExprName {
+                                        range: 43..43,
+                                        id: "",
+                                        ctx: Invalid,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | # Missing closing bracket 0: No elements
+2 | 
+3 | [
+  |   Syntax Error: unexpected EOF while parsing
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__missing_closing_bracket_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__missing_closing_bracket_1.py.snap
@@ -1,0 +1,56 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/list/missing_closing_bracket_1.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..133,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 125..133,
+                    value: List(
+                        ExprList {
+                            range: 125..133,
+                            elts: [
+                                BinOp(
+                                    ExprBinOp {
+                                        range: 128..133,
+                                        left: Name(
+                                            ExprName {
+                                                range: 128..129,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        op: Add,
+                                        right: Name(
+                                            ExprName {
+                                                range: 132..133,
+                                                id: "y",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+4 | [
+5 | 
+6 | x + y
+  |       Syntax Error: unexpected EOF while parsing
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__missing_closing_bracket_2.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__missing_closing_bracket_2.py.snap
@@ -1,0 +1,64 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/list/missing_closing_bracket_2.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..141,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 131..141,
+                    value: List(
+                        ExprList {
+                            range: 131..141,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 132..133,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                BinOp(
+                                    ExprBinOp {
+                                        range: 136..141,
+                                        left: Name(
+                                            ExprName {
+                                                range: 136..137,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        op: Add,
+                                        right: Name(
+                                            ExprName {
+                                                range: 140..141,
+                                                id: "y",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+4 | [1,
+5 | 
+6 | x + y
+  |       Syntax Error: unexpected EOF while parsing
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__missing_closing_bracket_3.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__missing_closing_bracket_3.py.snap
@@ -1,0 +1,99 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/list/missing_closing_bracket_3.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..140,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 114..119,
+                    value: List(
+                        ExprList {
+                            range: 114..119,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 115..116,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 118..119,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            FunctionDef(
+                StmtFunctionDef {
+                    range: 121..140,
+                    is_async: false,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: "foo",
+                        range: 125..128,
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 128..130,
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 136..140,
+                            },
+                        ),
+                    ],
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+4 | [1, 2
+5 | 
+6 | def foo():
+  | ^^^ Syntax Error: expected Comma, found Def
+7 |     pass
+  |
+
+
+  |
+2 |   # token starts a statement.
+3 |   
+4 | / [1, 2
+5 | | 
+6 | | def foo():
+  | |___^ Syntax Error: compound statements not allowed in the same line as simple statements
+7 |       pass
+  |
+
+
+  |
+6 | def foo():
+7 |     pass
+  |          Syntax Error: unexpected EOF while parsing
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__recover.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__recover.py.snap
@@ -1,0 +1,314 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/list/recover.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..208,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 82..85,
+                    value: List(
+                        ExprList {
+                            range: 82..85,
+                            elts: [
+                                Name(
+                                    ExprName {
+                                        range: 83..83,
+                                        id: "",
+                                        ctx: Invalid,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 87..93,
+                    value: List(
+                        ExprList {
+                            range: 87..93,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 88..89,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 91..92,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 95..100,
+                    value: List(
+                        ExprList {
+                            range: 95..100,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 96..97,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 118..123,
+                    value: List(
+                        ExprList {
+                            range: 118..123,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 119..120,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 121..122,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 156..162,
+                    value: List(
+                        ExprList {
+                            range: 156..162,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 157..158,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 160..161,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 185..194,
+                    value: List(
+                        ExprList {
+                            range: 185..194,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 186..187,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                BinOp(
+                                    ExprBinOp {
+                                        range: 189..192,
+                                        left: Name(
+                                            ExprName {
+                                                range: 189..190,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        op: Add,
+                                        right: Name(
+                                            ExprName {
+                                                range: 192..192,
+                                                id: "",
+                                                ctx: Invalid,
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 196..202,
+                    value: List(
+                        ExprList {
+                            range: 196..202,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 197..198,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 200..201,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 204..207,
+                    value: List(
+                        ExprList {
+                            range: 204..207,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 205..206,
+                                        value: Name(
+                                            ExprName {
+                                                range: 206..206,
+                                                id: "",
+                                                ctx: Invalid,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | # Test cases for list expressions where the parser recovers from a syntax error.
+2 | 
+3 | [,]
+  |  ^ Syntax Error: Expected an expression
+4 | 
+5 | [1,,2]
+  |
+
+
+  |
+3 | [,]
+4 | 
+5 | [1,,2]
+  |    ^ Syntax Error: Expected an expression or a ']'
+6 | 
+7 | [1,,]
+  |
+
+
+  |
+5 | [1,,2]
+6 | 
+7 | [1,,]
+  |    ^ Syntax Error: Expected an expression or a ']'
+8 | 
+9 | # Missing comma
+  |
+
+
+   |
+ 9 | # Missing comma
+10 | [1 2]
+   |    ^ Syntax Error: expected Comma, found Int
+11 | 
+12 | # Dictionary element in a list
+   |
+
+
+   |
+12 | # Dictionary element in a list
+13 | [1: 2]
+   |   ^ Syntax Error: Expected an expression or a ']'
+14 | 
+15 | # Missing expression
+   |
+
+
+   |
+15 | # Missing expression
+16 | [1, x + ]
+   |         ^ Syntax Error: Expected an expression
+17 | 
+18 | [1; 2]
+   |
+
+
+   |
+16 | [1, x + ]
+17 | 
+18 | [1; 2]
+   |   ^ Syntax Error: Expected an expression or a ']'
+19 | 
+20 | [*]
+   |
+
+
+   |
+18 | [1; 2]
+19 | 
+20 | [*]
+   |   ^ Syntax Error: Expected an expression
+   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__star_expression_precedence.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__star_expression_precedence.py.snap
@@ -1,0 +1,455 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/list/star_expression_precedence.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..200,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 84..93,
+                    value: List(
+                        ExprList {
+                            range: 84..93,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 86..88,
+                                        value: Name(
+                                            ExprName {
+                                                range: 87..88,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 91..92,
+                                        id: "y",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 94..106,
+                    value: List(
+                        ExprList {
+                            range: 94..106,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 95..97,
+                                        value: Name(
+                                            ExprName {
+                                                range: 96..97,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 101..102,
+                                        id: "y",
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 104..105,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 107..118,
+                    value: List(
+                        ExprList {
+                            range: 107..118,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 108..114,
+                                        value: UnaryOp(
+                                            ExprUnaryOp {
+                                                range: 109..114,
+                                                op: Not,
+                                                operand: Name(
+                                                    ExprName {
+                                                        range: 113..114,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 116..117,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 119..132,
+                    value: List(
+                        ExprList {
+                            range: 119..132,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 120..122,
+                                        value: Name(
+                                            ExprName {
+                                                range: 121..122,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 127..128,
+                                        id: "y",
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 130..131,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 133..145,
+                    value: List(
+                        ExprList {
+                            range: 133..145,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 134..136,
+                                        value: Name(
+                                            ExprName {
+                                                range: 135..136,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 140..141,
+                                        id: "y",
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 143..144,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 146..167,
+                    value: Tuple(
+                        ExprTuple {
+                            range: 146..167,
+                            elts: [
+                                If(
+                                    ExprIf {
+                                        range: 146..164,
+                                        test: BooleanLiteral(
+                                            ExprBooleanLiteral {
+                                                range: 153..157,
+                                                value: true,
+                                            },
+                                        ),
+                                        body: List(
+                                            ExprList {
+                                                range: 146..149,
+                                                elts: [
+                                                    Starred(
+                                                        ExprStarred {
+                                                            range: 147..149,
+                                                            value: Name(
+                                                                ExprName {
+                                                                    range: 148..149,
+                                                                    id: "x",
+                                                                    ctx: Load,
+                                                                },
+                                                            ),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        orelse: Name(
+                                            ExprName {
+                                                range: 163..164,
+                                                id: "y",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 166..167,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                            parenthesized: false,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 169..186,
+                    value: List(
+                        ExprList {
+                            range: 169..186,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 170..182,
+                                        value: Lambda(
+                                            ExprLambda {
+                                                range: 171..182,
+                                                parameters: Some(
+                                                    Parameters {
+                                                        range: 178..179,
+                                                        posonlyargs: [],
+                                                        args: [
+                                                            ParameterWithDefault {
+                                                                range: 178..179,
+                                                                parameter: Parameter {
+                                                                    range: 178..179,
+                                                                    name: Identifier {
+                                                                        id: "x",
+                                                                        range: 178..179,
+                                                                    },
+                                                                    annotation: None,
+                                                                },
+                                                                default: None,
+                                                            },
+                                                        ],
+                                                        vararg: None,
+                                                        kwonlyargs: [],
+                                                        kwarg: None,
+                                                    },
+                                                ),
+                                                body: Name(
+                                                    ExprName {
+                                                        range: 181..182,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 184..185,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 187..199,
+                    value: List(
+                        ExprList {
+                            range: 187..199,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 188..190,
+                                        value: Name(
+                                            ExprName {
+                                                range: 189..190,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 194..195,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 197..198,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+3 | [(*x), y]
+4 | [*x in y, z]
+  |     ^^ Syntax Error: Expected an expression or a ']'
+5 | [*not x, z]
+6 | [*x and y, z]
+  |
+
+
+  |
+3 | [(*x), y]
+4 | [*x in y, z]
+5 | [*not x, z]
+  |   ^^^^^ Syntax Error: unary `not` expression cannot be used here
+6 | [*x and y, z]
+7 | [*x or y, z]
+  |
+
+
+  |
+4 | [*x in y, z]
+5 | [*not x, z]
+6 | [*x and y, z]
+  |     ^^^ Syntax Error: expected Comma, found And
+7 | [*x or y, z]
+8 | [*x if True else y, z]
+  |
+
+
+  |
+5 | [*not x, z]
+6 | [*x and y, z]
+7 | [*x or y, z]
+  |     ^^ Syntax Error: expected Comma, found Or
+8 | [*x if True else y, z]
+9 | [*lambda x: x, z]
+  |
+
+
+   |
+ 6 | [*x and y, z]
+ 7 | [*x or y, z]
+ 8 | [*x if True else y, z]
+   |     ^^ Syntax Error: Expected an expression or a ']'
+ 9 | [*lambda x: x, z]
+10 | [*x := 2, z]
+   |
+
+
+   |
+ 6 | [*x and y, z]
+ 7 | [*x or y, z]
+ 8 | [*x if True else y, z]
+   |                      ^ Syntax Error: Expected a statement
+ 9 | [*lambda x: x, z]
+10 | [*x := 2, z]
+   |
+
+
+   |
+ 6 | [*x and y, z]
+ 7 | [*x or y, z]
+ 8 | [*x if True else y, z]
+   |                       ^ Syntax Error: Expected a statement
+ 9 | [*lambda x: x, z]
+10 | [*x := 2, z]
+   |
+
+
+   |
+ 7 | [*x or y, z]
+ 8 | [*x if True else y, z]
+ 9 | [*lambda x: x, z]
+   |   ^^^^^^^^^^^ Syntax Error: lambda expression cannot be used here
+10 | [*x := 2, z]
+   |
+
+
+   |
+ 8 | [*x if True else y, z]
+ 9 | [*lambda x: x, z]
+10 | [*x := 2, z]
+   |     ^^ Syntax Error: expected Comma, found ColonEqual
+   |

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__list.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__list.py.snap
@@ -7,171 +7,33 @@ input_file: crates/ruff_python_parser/resources/valid/expressions/list.py
 ```
 Module(
     ModModule {
-        range: 0..101,
+        range: 0..384,
         body: [
             Expr(
                 StmtExpr {
-                    range: 0..55,
+                    range: 15..17,
                     value: List(
                         ExprList {
-                            range: 0..55,
+                            range: 15..17,
+                            elts: [],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 18..21,
+                    value: List(
+                        ExprList {
+                            range: 18..21,
                             elts: [
-                                BinOp(
-                                    ExprBinOp {
-                                        range: 1..6,
-                                        left: NumberLiteral(
-                                            ExprNumberLiteral {
-                                                range: 1..2,
-                                                value: Int(
-                                                    1,
-                                                ),
-                                            },
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 19..20,
+                                        value: Int(
+                                            1,
                                         ),
-                                        op: Add,
-                                        right: Name(
-                                            ExprName {
-                                                range: 5..6,
-                                                id: "i",
-                                                ctx: Load,
-                                            },
-                                        ),
-                                    },
-                                ),
-                                List(
-                                    ExprList {
-                                        range: 8..20,
-                                        elts: [
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    range: 9..10,
-                                                    value: Int(
-                                                        1,
-                                                    ),
-                                                },
-                                            ),
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    range: 12..13,
-                                                    value: Int(
-                                                        2,
-                                                    ),
-                                                },
-                                            ),
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    range: 15..16,
-                                                    value: Int(
-                                                        3,
-                                                    ),
-                                                },
-                                            ),
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    range: 18..19,
-                                                    value: Int(
-                                                        4,
-                                                    ),
-                                                },
-                                            ),
-                                        ],
-                                        ctx: Load,
-                                    },
-                                ),
-                                Tuple(
-                                    ExprTuple {
-                                        range: 22..35,
-                                        elts: [
-                                            Name(
-                                                ExprName {
-                                                    range: 23..24,
-                                                    id: "a",
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            BinOp(
-                                                ExprBinOp {
-                                                    range: 26..31,
-                                                    left: Name(
-                                                        ExprName {
-                                                            range: 26..27,
-                                                            id: "i",
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    op: Add,
-                                                    right: Name(
-                                                        ExprName {
-                                                            range: 30..31,
-                                                            id: "x",
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                            Name(
-                                                ExprName {
-                                                    range: 33..34,
-                                                    id: "y",
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        ],
-                                        ctx: Load,
-                                        parenthesized: true,
-                                    },
-                                ),
-                                Set(
-                                    ExprSet {
-                                        range: 37..46,
-                                        elts: [
-                                            Name(
-                                                ExprName {
-                                                    range: 38..39,
-                                                    id: "a",
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            Name(
-                                                ExprName {
-                                                    range: 41..42,
-                                                    id: "b",
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            Name(
-                                                ExprName {
-                                                    range: 44..45,
-                                                    id: "c",
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        ],
-                                    },
-                                ),
-                                Dict(
-                                    ExprDict {
-                                        range: 48..54,
-                                        keys: [
-                                            Some(
-                                                Name(
-                                                    ExprName {
-                                                        range: 49..50,
-                                                        id: "a",
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                            ),
-                                        ],
-                                        values: [
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    range: 52..53,
-                                                    value: Int(
-                                                        1,
-                                                    ),
-                                                },
-                                            ),
-                                        ],
                                     },
                                 ),
                             ],
@@ -182,14 +44,35 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 56..65,
+                    range: 22..26,
                     value: List(
                         ExprList {
-                            range: 56..65,
+                            range: 22..26,
                             elts: [
                                 NumberLiteral(
                                     ExprNumberLiteral {
-                                        range: 57..58,
+                                        range: 23..24,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 27..36,
+                    value: List(
+                        ExprList {
+                            range: 27..36,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 28..29,
                                         value: Int(
                                             1,
                                         ),
@@ -197,7 +80,7 @@ Module(
                                 ),
                                 NumberLiteral(
                                     ExprNumberLiteral {
-                                        range: 60..61,
+                                        range: 31..32,
                                         value: Int(
                                             2,
                                         ),
@@ -205,7 +88,7 @@ Module(
                                 ),
                                 NumberLiteral(
                                     ExprNumberLiteral {
-                                        range: 63..64,
+                                        range: 34..35,
                                         value: Int(
                                             3,
                                         ),
@@ -219,10 +102,47 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 66..68,
+                    range: 37..47,
                     value: List(
                         ExprList {
-                            range: 66..68,
+                            range: 37..47,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 38..39,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 41..42,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 44..45,
+                                        value: Int(
+                                            3,
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 75..78,
+                    value: List(
+                        ExprList {
+                            range: 75..78,
                             elts: [],
                             ctx: Load,
                         },
@@ -231,14 +151,14 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 69..72,
+                    range: 79..92,
                     value: List(
                         ExprList {
-                            range: 69..72,
+                            range: 79..92,
                             elts: [
                                 NumberLiteral(
                                     ExprNumberLiteral {
-                                        range: 70..71,
+                                        range: 89..90,
                                         value: Int(
                                             1,
                                         ),
@@ -252,62 +172,593 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 73..100,
+                    range: 93..114,
                     value: List(
                         ExprList {
-                            range: 73..100,
+                            range: 93..114,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 99..100,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 110..111,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 125..132,
+                    value: List(
+                        ExprList {
+                            range: 125..132,
+                            elts: [
+                                List(
+                                    ExprList {
+                                        range: 126..131,
+                                        elts: [
+                                            List(
+                                                ExprList {
+                                                    range: 127..130,
+                                                    elts: [
+                                                        NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                range: 128..129,
+                                                                value: Int(
+                                                                    1,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ],
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ],
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 133..149,
+                    value: List(
+                        ExprList {
+                            range: 133..149,
+                            elts: [
+                                List(
+                                    ExprList {
+                                        range: 134..140,
+                                        elts: [
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 135..136,
+                                                    value: Int(
+                                                        1,
+                                                    ),
+                                                },
+                                            ),
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 138..139,
+                                                    value: Int(
+                                                        2,
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        ctx: Load,
+                                    },
+                                ),
+                                List(
+                                    ExprList {
+                                        range: 142..148,
+                                        elts: [
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 143..144,
+                                                    value: Int(
+                                                        3,
+                                                    ),
+                                                },
+                                            ),
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 146..147,
+                                                    value: Int(
+                                                        4,
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 170..178,
+                    value: List(
+                        ExprList {
+                            range: 170..178,
+                            elts: [
+                                Named(
+                                    ExprNamed {
+                                        range: 171..177,
+                                        target: Name(
+                                            ExprName {
+                                                range: 171..172,
+                                                id: "x",
+                                                ctx: Store,
+                                            },
+                                        ),
+                                        value: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                range: 176..177,
+                                                value: Int(
+                                                    2,
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 179..188,
+                    value: List(
+                        ExprList {
+                            range: 179..188,
+                            elts: [
+                                Named(
+                                    ExprNamed {
+                                        range: 180..186,
+                                        target: Name(
+                                            ExprName {
+                                                range: 180..181,
+                                                id: "x",
+                                                ctx: Store,
+                                            },
+                                        ),
+                                        value: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                range: 185..186,
+                                                value: Int(
+                                                    2,
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 189..203,
+                    value: List(
+                        ExprList {
+                            range: 189..203,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 190..191,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                Named(
+                                    ExprNamed {
+                                        range: 193..199,
+                                        target: Name(
+                                            ExprName {
+                                                range: 193..194,
+                                                id: "x",
+                                                ctx: Store,
+                                            },
+                                        ),
+                                        value: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                range: 198..199,
+                                                value: Int(
+                                                    2,
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 201..202,
+                                        value: Int(
+                                            3,
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 223..233,
+                    value: List(
+                        ExprList {
+                            range: 223..233,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 224..225,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                Starred(
+                                    ExprStarred {
+                                        range: 227..229,
+                                        value: Name(
+                                            ExprName {
+                                                range: 228..229,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 231..232,
+                                        value: Int(
+                                            3,
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 234..248,
+                    value: List(
+                        ExprList {
+                            range: 234..248,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 235..236,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                Starred(
+                                    ExprStarred {
+                                        range: 238..244,
+                                        value: BinOp(
+                                            ExprBinOp {
+                                                range: 239..244,
+                                                left: Name(
+                                                    ExprName {
+                                                        range: 239..240,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                op: BitOr,
+                                                right: Name(
+                                                    ExprName {
+                                                        range: 243..244,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 246..247,
+                                        value: Int(
+                                            3,
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 271..334,
+                    value: List(
+                        ExprList {
+                            range: 271..334,
+                            elts: [
+                                BinOp(
+                                    ExprBinOp {
+                                        range: 272..277,
+                                        left: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                range: 272..273,
+                                                value: Int(
+                                                    1,
+                                                ),
+                                            },
+                                        ),
+                                        op: Add,
+                                        right: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                range: 276..277,
+                                                value: Int(
+                                                    2,
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                List(
+                                    ExprList {
+                                        range: 279..291,
+                                        elts: [
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 280..281,
+                                                    value: Int(
+                                                        1,
+                                                    ),
+                                                },
+                                            ),
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 283..284,
+                                                    value: Int(
+                                                        2,
+                                                    ),
+                                                },
+                                            ),
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 286..287,
+                                                    value: Int(
+                                                        3,
+                                                    ),
+                                                },
+                                            ),
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 289..290,
+                                                    value: Int(
+                                                        4,
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        ctx: Load,
+                                    },
+                                ),
+                                Tuple(
+                                    ExprTuple {
+                                        range: 293..306,
+                                        elts: [
+                                            Name(
+                                                ExprName {
+                                                    range: 294..295,
+                                                    id: "a",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            BinOp(
+                                                ExprBinOp {
+                                                    range: 297..302,
+                                                    left: Name(
+                                                        ExprName {
+                                                            range: 297..298,
+                                                            id: "b",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    op: Add,
+                                                    right: Name(
+                                                        ExprName {
+                                                            range: 301..302,
+                                                            id: "c",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                            Name(
+                                                ExprName {
+                                                    range: 304..305,
+                                                    id: "d",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ],
+                                        ctx: Load,
+                                        parenthesized: true,
+                                    },
+                                ),
+                                Set(
+                                    ExprSet {
+                                        range: 308..317,
+                                        elts: [
+                                            Name(
+                                                ExprName {
+                                                    range: 309..310,
+                                                    id: "a",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            Name(
+                                                ExprName {
+                                                    range: 312..313,
+                                                    id: "b",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            Name(
+                                                ExprName {
+                                                    range: 315..316,
+                                                    id: "c",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                ),
+                                Dict(
+                                    ExprDict {
+                                        range: 319..325,
+                                        keys: [
+                                            Some(
+                                                Name(
+                                                    ExprName {
+                                                        range: 320..321,
+                                                        id: "a",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            ),
+                                        ],
+                                        values: [
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 323..324,
+                                                    value: Int(
+                                                        1,
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                ),
+                                Named(
+                                    ExprNamed {
+                                        range: 327..333,
+                                        target: Name(
+                                            ExprName {
+                                                range: 327..328,
+                                                id: "x",
+                                                ctx: Store,
+                                            },
+                                        ),
+                                        value: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                range: 332..333,
+                                                value: Int(
+                                                    2,
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 335..383,
+                    value: List(
+                        ExprList {
+                            range: 335..383,
                             elts: [
                                 Call(
                                     ExprCall {
-                                        range: 74..99,
+                                        range: 336..382,
                                         func: Name(
                                             ExprName {
-                                                range: 74..75,
-                                                id: "f",
+                                                range: 336..341,
+                                                id: "call1",
                                                 ctx: Load,
                                             },
                                         ),
                                         arguments: Arguments {
-                                            range: 75..99,
+                                            range: 341..382,
                                             args: [
                                                 Generator(
                                                     ExprGenerator {
-                                                        range: 76..98,
+                                                        range: 342..381,
                                                         elt: Call(
                                                             ExprCall {
-                                                                range: 76..87,
+                                                                range: 342..361,
                                                                 func: Name(
                                                                     ExprName {
-                                                                        range: 76..77,
-                                                                        id: "g",
+                                                                        range: 342..347,
+                                                                        id: "call2",
                                                                         ctx: Load,
                                                                     },
                                                                 ),
                                                                 arguments: Arguments {
-                                                                    range: 77..87,
+                                                                    range: 347..361,
                                                                     args: [
                                                                         Call(
                                                                             ExprCall {
-                                                                                range: 78..86,
+                                                                                range: 348..360,
                                                                                 func: Attribute(
                                                                                     ExprAttribute {
-                                                                                        range: 78..84,
+                                                                                        range: 348..358,
                                                                                         value: Name(
                                                                                             ExprName {
-                                                                                                range: 78..82,
-                                                                                                id: "attr",
+                                                                                                range: 348..353,
+                                                                                                id: "value",
                                                                                                 ctx: Load,
                                                                                             },
                                                                                         ),
                                                                                         attr: Identifier {
-                                                                                            id: "H",
-                                                                                            range: 83..84,
+                                                                                            id: "attr",
+                                                                                            range: 354..358,
                                                                                         },
                                                                                         ctx: Load,
                                                                                     },
                                                                                 ),
                                                                                 arguments: Arguments {
-                                                                                    range: 84..86,
+                                                                                    range: 358..360,
                                                                                     args: [],
                                                                                     keywords: [],
                                                                                 },
@@ -320,18 +771,18 @@ Module(
                                                         ),
                                                         generators: [
                                                             Comprehension {
-                                                                range: 88..98,
+                                                                range: 362..381,
                                                                 target: Name(
                                                                     ExprName {
-                                                                        range: 92..93,
-                                                                        id: "c",
+                                                                        range: 366..373,
+                                                                        id: "element",
                                                                         ctx: Store,
                                                                     },
                                                                 ),
                                                                 iter: Name(
                                                                     ExprName {
-                                                                        range: 97..98,
-                                                                        id: "l",
+                                                                        range: 377..381,
+                                                                        id: "iter",
                                                                         ctx: Load,
                                                                     },
                                                                 ),


### PR DESCRIPTION
## Summary

This PR updates the existing valid test case for list expression and adds some invalid ones to check how the parser is recovering. It also updates the parsing function used to match the grammar.

The goal is mainly to check if the list parsing is correct or not as per the grammar.

There are test cases for unclosed bracket where the parser sometimes doesn't recover well or doesn't provide useful error messages. I think these will be improved by feeding the information back to the lexer. The lexer could then emit `Newline` where appropriate instead of `NonLogicalNewline` and the recovery set could include the `Newline` as the list terminator to recover from it.