### PR TITLE
Add tests for set expression parsing

### DIFF
--- a/crates/ruff_python_parser/resources/invalid/expressions/set/missing_closing_curly_brace_0.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/set/missing_closing_curly_brace_0.py
@@ -1,0 +1,3 @@
+# Missing closing curly brace 0: No elements
+
+{

--- a/crates/ruff_python_parser/resources/invalid/expressions/set/missing_closing_curly_brace_1.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/set/missing_closing_curly_brace_1.py
@@ -1,0 +1,6 @@
+# Missing closing curly brace 1: No elements on the same line, the one on the next line
+# is considered to be part of the set.
+
+{
+
+x + y

--- a/crates/ruff_python_parser/resources/invalid/expressions/set/missing_closing_curly_brace_2.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/set/missing_closing_curly_brace_2.py
@@ -1,0 +1,6 @@
+# Missing closing curly brace 2: One element on the line, the other one on the next line
+# will be considered to be part of the set.
+
+{1,
+
+x + y

--- a/crates/ruff_python_parser/resources/invalid/expressions/set/missing_closing_curly_brace_3.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/set/missing_closing_curly_brace_3.py
@@ -1,0 +1,7 @@
+# Missing closing curly brace 3: Multiple elements without a trailing comma and the next
+# token starts a statement.
+
+{1, 2
+
+def foo():
+    pass

--- a/crates/ruff_python_parser/resources/invalid/expressions/set/recover.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/set/recover.py
@@ -1,0 +1,22 @@
+# Test cases for set expressions where the parser recovers from a syntax error.
+# There are valid expressions in between invalid ones to verify that.
+# These are same as for the list expressions.
+
+{,}
+
+{1,,2}
+
+{1,,}
+
+# Missing comma
+{1 2}
+
+# Dictionary element in a list
+{1: 2}
+
+# Missing expression
+{1, x + }
+
+{1; 2}
+
+[*]

--- a/crates/ruff_python_parser/resources/invalid/expressions/set/star_expression_precedence.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/set/star_expression_precedence.py
@@ -1,0 +1,10 @@
+# For set expression, the minimum binding power of star expression is bitwise or.
+
+{(*x), y}
+{*x in y, z}
+{*not x, z}
+{*x and y, z}
+{*x or y, z}
+{*x if True else y, z}
+{*lambda x: x, z}
+{*x := 2, z}

--- a/crates/ruff_python_parser/resources/valid/expressions/set.py
+++ b/crates/ruff_python_parser/resources/valid/expressions/set.py
@@ -1,3 +1,33 @@
+# Simple sets
+{}
+{1}
+{1,}
 {1, 2, 3}
-{1 + 2, (a, b), {1,2,3}, {a:b, **d}}
-{a}
+{1, 2, 3,}
+
+# Mixed with indentations
+{
+}
+{
+        1
+}
+{
+    1,
+        2,
+}
+
+# Nested
+{{1}}
+{{1, 2}, {3, 4}}
+
+# Named expression
+{x := 2}
+{1, x := 2, 3}
+{1, (x := 2),}
+
+# Star expression
+{1, *x, 3}
+{1, *x | y, 3}
+
+# Random expressions
+{1 + 2, (a, b), {1, 2, 3}, {a: b, **d}}

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__missing_closing_curly_brace_0.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__missing_closing_curly_brace_0.py.snap
@@ -1,0 +1,42 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/set/missing_closing_curly_brace_0.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..47,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 46..47,
+                    value: Set(
+                        ExprSet {
+                            range: 46..47,
+                            elts: [
+                                Name(
+                                    ExprName {
+                                        range: 47..47,
+                                        id: "",
+                                        ctx: Invalid,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | # Missing closing curly brace 0: No elements
+2 | 
+3 | {
+  |   Syntax Error: unexpected EOF while parsing
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__missing_closing_curly_brace_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__missing_closing_curly_brace_1.py.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/set/missing_closing_curly_brace_1.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..136,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 128..136,
+                    value: Set(
+                        ExprSet {
+                            range: 128..136,
+                            elts: [
+                                BinOp(
+                                    ExprBinOp {
+                                        range: 131..136,
+                                        left: Name(
+                                            ExprName {
+                                                range: 131..132,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        op: Add,
+                                        right: Name(
+                                            ExprName {
+                                                range: 135..136,
+                                                id: "y",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+4 | {
+5 | 
+6 | x + y
+  |       Syntax Error: unexpected EOF while parsing
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__missing_closing_curly_brace_2.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__missing_closing_curly_brace_2.py.snap
@@ -1,0 +1,63 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/set/missing_closing_curly_brace_2.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..144,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 134..144,
+                    value: Set(
+                        ExprSet {
+                            range: 134..144,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 135..136,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                BinOp(
+                                    ExprBinOp {
+                                        range: 139..144,
+                                        left: Name(
+                                            ExprName {
+                                                range: 139..140,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        op: Add,
+                                        right: Name(
+                                            ExprName {
+                                                range: 143..144,
+                                                id: "y",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+4 | {1,
+5 | 
+6 | x + y
+  |       Syntax Error: unexpected EOF while parsing
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__missing_closing_curly_brace_3.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__missing_closing_curly_brace_3.py.snap
@@ -1,0 +1,98 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/set/missing_closing_curly_brace_3.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..144,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 118..123,
+                    value: Set(
+                        ExprSet {
+                            range: 118..123,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 119..120,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 122..123,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            FunctionDef(
+                StmtFunctionDef {
+                    range: 125..144,
+                    is_async: false,
+                    decorator_list: [],
+                    name: Identifier {
+                        id: "foo",
+                        range: 129..132,
+                    },
+                    type_params: None,
+                    parameters: Parameters {
+                        range: 132..134,
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    returns: None,
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 140..144,
+                            },
+                        ),
+                    ],
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+4 | {1, 2
+5 | 
+6 | def foo():
+  | ^^^ Syntax Error: expected Comma, found Def
+7 |     pass
+  |
+
+
+  |
+2 |   # token starts a statement.
+3 |   
+4 | / {1, 2
+5 | | 
+6 | | def foo():
+  | |___^ Syntax Error: compound statements not allowed in the same line as simple statements
+7 |       pass
+  |
+
+
+  |
+6 | def foo():
+7 |     pass
+  |          Syntax Error: unexpected EOF while parsing
+  |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__recover.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__recover.py.snap
@@ -1,0 +1,302 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/set/recover.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..323,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 197..200,
+                    value: Set(
+                        ExprSet {
+                            range: 197..200,
+                            elts: [
+                                Name(
+                                    ExprName {
+                                        range: 198..198,
+                                        id: "",
+                                        ctx: Invalid,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 202..208,
+                    value: Set(
+                        ExprSet {
+                            range: 202..208,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 203..204,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 206..207,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 210..215,
+                    value: Set(
+                        ExprSet {
+                            range: 210..215,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 211..212,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 233..238,
+                    value: Set(
+                        ExprSet {
+                            range: 233..238,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 234..235,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 236..237,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 271..277,
+                    value: Dict(
+                        ExprDict {
+                            range: 271..277,
+                            keys: [
+                                Some(
+                                    NumberLiteral(
+                                        ExprNumberLiteral {
+                                            range: 272..273,
+                                            value: Int(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ],
+                            values: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 275..276,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 300..309,
+                    value: Set(
+                        ExprSet {
+                            range: 300..309,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 301..302,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                BinOp(
+                                    ExprBinOp {
+                                        range: 304..307,
+                                        left: Name(
+                                            ExprName {
+                                                range: 304..305,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        op: Add,
+                                        right: Name(
+                                            ExprName {
+                                                range: 307..307,
+                                                id: "",
+                                                ctx: Invalid,
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 311..317,
+                    value: Set(
+                        ExprSet {
+                            range: 311..317,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 312..313,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 315..316,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 319..322,
+                    value: List(
+                        ExprList {
+                            range: 319..322,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 320..321,
+                                        value: Name(
+                                            ExprName {
+                                                range: 321..321,
+                                                id: "",
+                                                ctx: Invalid,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+3 | # These are same as for the list expressions.
+4 | 
+5 | {,}
+  |  ^ Syntax Error: Expected an expression
+6 | 
+7 | {1,,2}
+  |
+
+
+  |
+5 | {,}
+6 | 
+7 | {1,,2}
+  |    ^ Syntax Error: Expected an expression or a '}'
+8 | 
+9 | {1,,}
+  |
+
+
+   |
+ 7 | {1,,2}
+ 8 | 
+ 9 | {1,,}
+   |    ^ Syntax Error: Expected an expression or a '}'
+10 | 
+11 | # Missing comma
+   |
+
+
+   |
+11 | # Missing comma
+12 | {1 2}
+   |    ^ Syntax Error: expected Comma, found Int
+13 | 
+14 | # Dictionary element in a list
+   |
+
+
+   |
+17 | # Missing expression
+18 | {1, x + }
+   |         ^ Syntax Error: Expected an expression
+19 | 
+20 | {1; 2}
+   |
+
+
+   |
+18 | {1, x + }
+19 | 
+20 | {1; 2}
+   |   ^ Syntax Error: Expected an expression or a '}'
+21 | 
+22 | [*]
+   |
+
+
+   |
+20 | {1; 2}
+21 | 
+22 | [*]
+   |   ^ Syntax Error: Expected an expression
+   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__star_expression_precedence.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__star_expression_precedence.py.snap
@@ -1,0 +1,447 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/set/star_expression_precedence.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..198,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 83..92,
+                    value: Set(
+                        ExprSet {
+                            range: 83..92,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 85..87,
+                                        value: Name(
+                                            ExprName {
+                                                range: 86..87,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 90..91,
+                                        id: "y",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 93..105,
+                    value: Set(
+                        ExprSet {
+                            range: 93..105,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 94..96,
+                                        value: Name(
+                                            ExprName {
+                                                range: 95..96,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 100..101,
+                                        id: "y",
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 103..104,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 106..117,
+                    value: Set(
+                        ExprSet {
+                            range: 106..117,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 107..113,
+                                        value: UnaryOp(
+                                            ExprUnaryOp {
+                                                range: 108..113,
+                                                op: Not,
+                                                operand: Name(
+                                                    ExprName {
+                                                        range: 112..113,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 115..116,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 118..131,
+                    value: Set(
+                        ExprSet {
+                            range: 118..131,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 119..121,
+                                        value: Name(
+                                            ExprName {
+                                                range: 120..121,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 126..127,
+                                        id: "y",
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 129..130,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 132..144,
+                    value: Set(
+                        ExprSet {
+                            range: 132..144,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 133..135,
+                                        value: Name(
+                                            ExprName {
+                                                range: 134..135,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 139..140,
+                                        id: "y",
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 142..143,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 145..166,
+                    value: Tuple(
+                        ExprTuple {
+                            range: 145..166,
+                            elts: [
+                                If(
+                                    ExprIf {
+                                        range: 145..163,
+                                        test: BooleanLiteral(
+                                            ExprBooleanLiteral {
+                                                range: 152..156,
+                                                value: true,
+                                            },
+                                        ),
+                                        body: Set(
+                                            ExprSet {
+                                                range: 145..148,
+                                                elts: [
+                                                    Starred(
+                                                        ExprStarred {
+                                                            range: 146..148,
+                                                            value: Name(
+                                                                ExprName {
+                                                                    range: 147..148,
+                                                                    id: "x",
+                                                                    ctx: Load,
+                                                                },
+                                                            ),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                        orelse: Name(
+                                            ExprName {
+                                                range: 162..163,
+                                                id: "y",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 165..166,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                            parenthesized: false,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 168..185,
+                    value: Set(
+                        ExprSet {
+                            range: 168..185,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 169..181,
+                                        value: Lambda(
+                                            ExprLambda {
+                                                range: 170..181,
+                                                parameters: Some(
+                                                    Parameters {
+                                                        range: 177..178,
+                                                        posonlyargs: [],
+                                                        args: [
+                                                            ParameterWithDefault {
+                                                                range: 177..178,
+                                                                parameter: Parameter {
+                                                                    range: 177..178,
+                                                                    name: Identifier {
+                                                                        id: "x",
+                                                                        range: 177..178,
+                                                                    },
+                                                                    annotation: None,
+                                                                },
+                                                                default: None,
+                                                            },
+                                                        ],
+                                                        vararg: None,
+                                                        kwonlyargs: [],
+                                                        kwarg: None,
+                                                    },
+                                                ),
+                                                body: Name(
+                                                    ExprName {
+                                                        range: 180..181,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 183..184,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 186..198,
+                    value: Set(
+                        ExprSet {
+                            range: 186..198,
+                            elts: [
+                                Starred(
+                                    ExprStarred {
+                                        range: 187..189,
+                                        value: Name(
+                                            ExprName {
+                                                range: 188..189,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 193..194,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                                Name(
+                                    ExprName {
+                                        range: 196..197,
+                                        id: "z",
+                                        ctx: Load,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+3 | {(*x), y}
+4 | {*x in y, z}
+  |     ^^ Syntax Error: Expected an expression or a '}'
+5 | {*not x, z}
+6 | {*x and y, z}
+  |
+
+
+  |
+3 | {(*x), y}
+4 | {*x in y, z}
+5 | {*not x, z}
+  |   ^^^^^ Syntax Error: unary `not` expression cannot be used here
+6 | {*x and y, z}
+7 | {*x or y, z}
+  |
+
+
+  |
+4 | {*x in y, z}
+5 | {*not x, z}
+6 | {*x and y, z}
+  |     ^^^ Syntax Error: expected Comma, found And
+7 | {*x or y, z}
+8 | {*x if True else y, z}
+  |
+
+
+  |
+5 | {*not x, z}
+6 | {*x and y, z}
+7 | {*x or y, z}
+  |     ^^ Syntax Error: expected Comma, found Or
+8 | {*x if True else y, z}
+9 | {*lambda x: x, z}
+  |
+
+
+   |
+ 6 | {*x and y, z}
+ 7 | {*x or y, z}
+ 8 | {*x if True else y, z}
+   |     ^^ Syntax Error: Expected an expression or a '}'
+ 9 | {*lambda x: x, z}
+10 | {*x := 2, z}
+   |
+
+
+   |
+ 6 | {*x and y, z}
+ 7 | {*x or y, z}
+ 8 | {*x if True else y, z}
+   |                      ^ Syntax Error: Expected a statement
+ 9 | {*lambda x: x, z}
+10 | {*x := 2, z}
+   |
+
+
+   |
+ 6 | {*x and y, z}
+ 7 | {*x or y, z}
+ 8 | {*x if True else y, z}
+   |                       ^ Syntax Error: Expected a statement
+ 9 | {*lambda x: x, z}
+10 | {*x := 2, z}
+   |
+
+
+   |
+ 7 | {*x or y, z}
+ 8 | {*x if True else y, z}
+ 9 | {*lambda x: x, z}
+   |   ^^^^^^^^^^^ Syntax Error: lambda expression cannot be used here
+10 | {*x := 2, z}
+   |
+
+
+   |
+ 8 | {*x if True else y, z}
+ 9 | {*lambda x: x, z}
+10 | {*x := 2, z}
+   |     ^^ Syntax Error: expected Comma, found ColonEqual
+   |

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__set.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__set.py.snap
@@ -7,18 +7,70 @@ input_file: crates/ruff_python_parser/resources/valid/expressions/set.py
 ```
 Module(
     ModModule {
-        range: 0..51,
+        range: 0..313,
         body: [
             Expr(
                 StmtExpr {
-                    range: 0..9,
+                    range: 14..16,
+                    value: Dict(
+                        ExprDict {
+                            range: 14..16,
+                            keys: [],
+                            values: [],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 17..20,
                     value: Set(
                         ExprSet {
-                            range: 0..9,
+                            range: 17..20,
                             elts: [
                                 NumberLiteral(
                                     ExprNumberLiteral {
-                                        range: 1..2,
+                                        range: 18..19,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 21..25,
+                    value: Set(
+                        ExprSet {
+                            range: 21..25,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 22..23,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 26..35,
+                    value: Set(
+                        ExprSet {
+                            range: 26..35,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 27..28,
                                         value: Int(
                                             1,
                                         ),
@@ -26,7 +78,7 @@ Module(
                                 ),
                                 NumberLiteral(
                                     ExprNumberLiteral {
-                                        range: 4..5,
+                                        range: 30..31,
                                         value: Int(
                                             2,
                                         ),
@@ -34,7 +86,7 @@ Module(
                                 ),
                                 NumberLiteral(
                                     ExprNumberLiteral {
-                                        range: 7..8,
+                                        range: 33..34,
                                         value: Int(
                                             3,
                                         ),
@@ -47,115 +99,117 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 10..46,
+                    range: 36..46,
                     value: Set(
                         ExprSet {
-                            range: 10..46,
+                            range: 36..46,
                             elts: [
-                                BinOp(
-                                    ExprBinOp {
-                                        range: 11..16,
-                                        left: NumberLiteral(
-                                            ExprNumberLiteral {
-                                                range: 11..12,
-                                                value: Int(
-                                                    1,
-                                                ),
-                                            },
-                                        ),
-                                        op: Add,
-                                        right: NumberLiteral(
-                                            ExprNumberLiteral {
-                                                range: 15..16,
-                                                value: Int(
-                                                    2,
-                                                ),
-                                            },
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 37..38,
+                                        value: Int(
+                                            1,
                                         ),
                                     },
                                 ),
-                                Tuple(
-                                    ExprTuple {
-                                        range: 18..24,
-                                        elts: [
-                                            Name(
-                                                ExprName {
-                                                    range: 19..20,
-                                                    id: "a",
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            Name(
-                                                ExprName {
-                                                    range: 22..23,
-                                                    id: "b",
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        ],
-                                        ctx: Load,
-                                        parenthesized: true,
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 40..41,
+                                        value: Int(
+                                            2,
+                                        ),
                                     },
                                 ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 43..44,
+                                        value: Int(
+                                            3,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 74..77,
+                    value: Dict(
+                        ExprDict {
+                            range: 74..77,
+                            keys: [],
+                            values: [],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 78..91,
+                    value: Set(
+                        ExprSet {
+                            range: 78..91,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 88..89,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 92..113,
+                    value: Set(
+                        ExprSet {
+                            range: 92..113,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 98..99,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 109..110,
+                                        value: Int(
+                                            2,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 124..129,
+                    value: Set(
+                        ExprSet {
+                            range: 124..129,
+                            elts: [
                                 Set(
                                     ExprSet {
-                                        range: 26..33,
+                                        range: 125..128,
                                         elts: [
                                             NumberLiteral(
                                                 ExprNumberLiteral {
-                                                    range: 27..28,
+                                                    range: 126..127,
                                                     value: Int(
                                                         1,
                                                     ),
-                                                },
-                                            ),
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    range: 29..30,
-                                                    value: Int(
-                                                        2,
-                                                    ),
-                                                },
-                                            ),
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    range: 31..32,
-                                                    value: Int(
-                                                        3,
-                                                    ),
-                                                },
-                                            ),
-                                        ],
-                                    },
-                                ),
-                                Dict(
-                                    ExprDict {
-                                        range: 35..45,
-                                        keys: [
-                                            Some(
-                                                Name(
-                                                    ExprName {
-                                                        range: 36..37,
-                                                        id: "a",
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                            ),
-                                            None,
-                                        ],
-                                        values: [
-                                            Name(
-                                                ExprName {
-                                                    range: 38..39,
-                                                    id: "b",
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            Name(
-                                                ExprName {
-                                                    range: 43..44,
-                                                    id: "d",
-                                                    ctx: Load,
                                                 },
                                             ),
                                         ],
@@ -168,16 +222,391 @@ Module(
             ),
             Expr(
                 StmtExpr {
-                    range: 47..50,
+                    range: 130..146,
                     value: Set(
                         ExprSet {
-                            range: 47..50,
+                            range: 130..146,
                             elts: [
-                                Name(
-                                    ExprName {
-                                        range: 48..49,
-                                        id: "a",
+                                Set(
+                                    ExprSet {
+                                        range: 131..137,
+                                        elts: [
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 132..133,
+                                                    value: Int(
+                                                        1,
+                                                    ),
+                                                },
+                                            ),
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 135..136,
+                                                    value: Int(
+                                                        2,
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                ),
+                                Set(
+                                    ExprSet {
+                                        range: 139..145,
+                                        elts: [
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 140..141,
+                                                    value: Int(
+                                                        3,
+                                                    ),
+                                                },
+                                            ),
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 143..144,
+                                                    value: Int(
+                                                        4,
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 167..175,
+                    value: Set(
+                        ExprSet {
+                            range: 167..175,
+                            elts: [
+                                Named(
+                                    ExprNamed {
+                                        range: 168..174,
+                                        target: Name(
+                                            ExprName {
+                                                range: 168..169,
+                                                id: "x",
+                                                ctx: Store,
+                                            },
+                                        ),
+                                        value: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                range: 173..174,
+                                                value: Int(
+                                                    2,
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 176..190,
+                    value: Set(
+                        ExprSet {
+                            range: 176..190,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 177..178,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                Named(
+                                    ExprNamed {
+                                        range: 180..186,
+                                        target: Name(
+                                            ExprName {
+                                                range: 180..181,
+                                                id: "x",
+                                                ctx: Store,
+                                            },
+                                        ),
+                                        value: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                range: 185..186,
+                                                value: Int(
+                                                    2,
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 188..189,
+                                        value: Int(
+                                            3,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 191..205,
+                    value: Set(
+                        ExprSet {
+                            range: 191..205,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 192..193,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                Named(
+                                    ExprNamed {
+                                        range: 196..202,
+                                        target: Name(
+                                            ExprName {
+                                                range: 196..197,
+                                                id: "x",
+                                                ctx: Store,
+                                            },
+                                        ),
+                                        value: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                range: 201..202,
+                                                value: Int(
+                                                    2,
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 225..235,
+                    value: Set(
+                        ExprSet {
+                            range: 225..235,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 226..227,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                Starred(
+                                    ExprStarred {
+                                        range: 229..231,
+                                        value: Name(
+                                            ExprName {
+                                                range: 230..231,
+                                                id: "x",
+                                                ctx: Load,
+                                            },
+                                        ),
                                         ctx: Load,
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 233..234,
+                                        value: Int(
+                                            3,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 236..250,
+                    value: Set(
+                        ExprSet {
+                            range: 236..250,
+                            elts: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 237..238,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                Starred(
+                                    ExprStarred {
+                                        range: 240..246,
+                                        value: BinOp(
+                                            ExprBinOp {
+                                                range: 241..246,
+                                                left: Name(
+                                                    ExprName {
+                                                        range: 241..242,
+                                                        id: "x",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                op: BitOr,
+                                                right: Name(
+                                                    ExprName {
+                                                        range: 245..246,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        ctx: Load,
+                                    },
+                                ),
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        range: 248..249,
+                                        value: Int(
+                                            3,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 273..312,
+                    value: Set(
+                        ExprSet {
+                            range: 273..312,
+                            elts: [
+                                BinOp(
+                                    ExprBinOp {
+                                        range: 274..279,
+                                        left: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                range: 274..275,
+                                                value: Int(
+                                                    1,
+                                                ),
+                                            },
+                                        ),
+                                        op: Add,
+                                        right: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                range: 278..279,
+                                                value: Int(
+                                                    2,
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Tuple(
+                                    ExprTuple {
+                                        range: 281..287,
+                                        elts: [
+                                            Name(
+                                                ExprName {
+                                                    range: 282..283,
+                                                    id: "a",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            Name(
+                                                ExprName {
+                                                    range: 285..286,
+                                                    id: "b",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ],
+                                        ctx: Load,
+                                        parenthesized: true,
+                                    },
+                                ),
+                                Set(
+                                    ExprSet {
+                                        range: 289..298,
+                                        elts: [
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 290..291,
+                                                    value: Int(
+                                                        1,
+                                                    ),
+                                                },
+                                            ),
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 293..294,
+                                                    value: Int(
+                                                        2,
+                                                    ),
+                                                },
+                                            ),
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    range: 296..297,
+                                                    value: Int(
+                                                        3,
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                ),
+                                Dict(
+                                    ExprDict {
+                                        range: 300..311,
+                                        keys: [
+                                            Some(
+                                                Name(
+                                                    ExprName {
+                                                        range: 301..302,
+                                                        id: "a",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            ),
+                                            None,
+                                        ],
+                                        values: [
+                                            Name(
+                                                ExprName {
+                                                    range: 304..305,
+                                                    id: "b",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            Name(
+                                                ExprName {
+                                                    range: 309..310,
+                                                    id: "d",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ],
                                     },
                                 ),
                             ],


### PR DESCRIPTION
## Summary

This PR updates the existing valid test case for set expression and adds some invalid ones to check how the parser is recovering.

The goal is mainly to check if the list parsing is correct or not.

This is similar to the list expression as the grammar is the same except that the set uses curly braces instead of brackets.
