### PR TITLE
Select more rules for typeshed in the ecosystem checks

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -63,7 +63,7 @@ DEFAULT_TARGETS = [
             name="typeshed",
             ref="main",
         ),
-        check_options=CheckOptions(select="PYI"),
+        check_options=CheckOptions(select="E,F,FA,I,PYI,RUF,UP,W"),
     ),
     Project(repo=Repository(owner="python-poetry", name="poetry", ref="master")),
     Project(repo=Repository(owner="reflex-dev", name="reflex", ref="main")),


### PR DESCRIPTION
## Summary

This PR selects more rules for typeshed in the ecosystem checks, bringing the configuration slightly closer to the (somewhat complex) ruff config typeshed now uses in CI for `.pyi` files: https://github.com/python/typeshed/blob/f337eb8a5149a05528d19605b7ddd0bc9b5125e4/pyproject.toml#L26-L149. In particular, having `F` selected would have prevented https://github.com/astral-sh/ruff/issues/10509 from occuring, as the regression would have showed up in the ecosystem comment before I merged the PR that caused the regression (https://github.com/astral-sh/ruff/pull/10341).
