### PR TITLE
[`Pylint`] Fixed false-positive on the rule `PLW1641` (`eq-without-hash`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/eq_without_hash.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/eq_without_hash.py
@@ -5,6 +5,7 @@ class Person:  # [eq-without-hash]
     def __eq__(self, other):
         return isinstance(other, Person) and other.name == self.name
 
+
 # OK
 class Language:
     def __init__(self):
@@ -16,11 +17,13 @@ class Language:
     def __hash__(self):
         return hash(self.name)
 
+
 class MyClass:
     def __eq__(self, other):
         return True
 
     __hash__ = None
+
 
 class SingleClass:
     def __eq__(self, other):
@@ -28,6 +31,7 @@ class SingleClass:
 
     def __hash__(self):
         return 7
+
 
 class ChildClass(SingleClass):
     def __eq__(self, other):

--- a/crates/ruff_linter/resources/test/fixtures/pylint/eq_without_hash.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/eq_without_hash.py
@@ -21,3 +21,16 @@ class MyClass:
         return True
 
     __hash__ = None
+
+class SingleClass:
+    def __eq__(self, other):
+        return True
+
+    def __hash__(self):
+        return 7
+
+class ChildClass(SingleClass):
+    def __eq__(self, other):
+        return True
+
+    __hash__ = SingleClass.__hash__

--- a/crates/ruff_linter/src/rules/pylint/rules/eq_without_hash.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/eq_without_hash.rs
@@ -67,20 +67,21 @@ fn has_eq_without_hash(body: &[Stmt]) -> bool {
     let mut has_eq = false;
     for statement in body {
         match statement {
-            Stmt::Assign(ast::StmtAssign { targets, value, .. }) => {
+            Stmt::Assign(ast::StmtAssign { targets, .. }) => {
                 let [Expr::Name(ast::ExprName { id, .. })] = targets.as_slice() else {
                     continue;
                 };
 
-                // Check if `__hash__` was explicitly set to `None`, as in:
+                // Check if `__hash__` was explicitly set, as in:
                 // ```python
-                // class Class:
+                // class Class(SuperClass):
                 //     def __eq__(self, other):
                 //         return True
                 //
-                //     __hash__ = None
+                //     __hash__ = SuperClass.__hash__
                 // ```
-                if id == "__hash__" && value.is_none_literal_expr() {
+
+                if id == "__hash__" {
                     has_hash = true;
                 }
             }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixed false-positive on the rule `PLW1641`, where the explicit assignment on the `__hash__` method is not counted as an definition of `__hash__`. (Discussed in #10557).

Also, added one new testcase.

## Test Plan

<!-- How was it tested? -->

Checked on `cargo test` in `eq_without_hash.py`.



Before the change, for the assignment into `__hash__`, only `__hash__ = None` was counted as an explicit definition of `__hash__` method.
Probably any assignment into `__hash__` property could be counted as an explicit definition of hash, so I removed `value.is_none_literal_expr()` check.