### PR TITLE
Use expr range for invalid node

### DIFF
--- a/crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_4.py
+++ b/crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_4.py
@@ -1,0 +1,5 @@
+match subject:
+    # This `as` pattern is unparenthesized so the parser never takes the path
+    # where it might be confused as a mapping key pattern.
+    case {x as y: 1}:
+        pass

--- a/crates/ruff_python_parser/src/parser/pattern.rs
+++ b/crates/ruff_python_parser/src/parser/pattern.rs
@@ -548,8 +548,8 @@ impl<'src> Parser<'src> {
                 };
 
                 Pattern::MatchValue(ast::PatternMatchValue {
+                    range: invalid_node.range(),
                     value: Box::new(invalid_node),
-                    range: self.missing_node_range(),
                 })
             }
         }

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_4.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__match__as_pattern_4.py.snap
@@ -1,0 +1,116 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/statements/match/as_pattern_4.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..186,
+        body: [
+            Match(
+                StmtMatch {
+                    range: 0..186,
+                    subject: Name(
+                        ExprName {
+                            range: 6..13,
+                            id: "subject",
+                            ctx: Load,
+                        },
+                    ),
+                    cases: [
+                        MatchCase {
+                            range: 156..186,
+                            pattern: MatchMapping(
+                                PatternMatchMapping {
+                                    range: 161..172,
+                                    keys: [
+                                        Name(
+                                            ExprName {
+                                                range: 162..163,
+                                                id: "x",
+                                                ctx: Store,
+                                            },
+                                        ),
+                                        Name(
+                                            ExprName {
+                                                range: 167..168,
+                                                id: "y",
+                                                ctx: Store,
+                                            },
+                                        ),
+                                    ],
+                                    patterns: [
+                                        MatchValue(
+                                            PatternMatchValue {
+                                                range: 164..166,
+                                                value: Name(
+                                                    ExprName {
+                                                        range: 164..166,
+                                                        id: "as",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        MatchValue(
+                                            PatternMatchValue {
+                                                range: 170..171,
+                                                value: NumberLiteral(
+                                                    ExprNumberLiteral {
+                                                        range: 170..171,
+                                                        value: Int(
+                                                            1,
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    rest: None,
+                                },
+                            ),
+                            guard: None,
+                            body: [
+                                Pass(
+                                    StmtPass {
+                                        range: 182..186,
+                                    },
+                                ),
+                            ],
+                        },
+                    ],
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+2 |     # This `as` pattern is unparenthesized so the parser never takes the path
+3 |     # where it might be confused as a mapping key pattern.
+4 |     case {x as y: 1}:
+  |           ^ Syntax Error: invalid mapping pattern key
+5 |         pass
+  |
+
+
+  |
+2 |     # This `as` pattern is unparenthesized so the parser never takes the path
+3 |     # where it might be confused as a mapping key pattern.
+4 |     case {x as y: 1}:
+  |             ^^ Syntax Error: expected Colon, found As
+5 |         pass
+  |
+
+
+  |
+2 |     # This `as` pattern is unparenthesized so the parser never takes the path
+3 |     # where it might be confused as a mapping key pattern.
+4 |     case {x as y: 1}:
+  |                ^ Syntax Error: expected Comma, found Name
+5 |         pass
+  |


### PR DESCRIPTION
## Summary

This fixes the bug which I encountered in https://github.com/astral-sh/ruff/pull/10523#issue-2202130102

## Test Plan

Add the failing test case and update the snapshot.
