### PR TITLE
Get rid of SCARY SECURITY suffixes for security-related renovate PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,5 +39,9 @@
       "matchManagers": ["pre-commit"],
       "description": "Weekly update of pre-commit dependencies",
     },
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "commitMessageSuffix": "",
+    "labels": ["internal", "security"],
+  },
 }


### PR DESCRIPTION
Just use a `security` label instead