### PR TITLE
Ignore `Q000`, `Q001` when string is inside forward ref

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_quotes/singles.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_quotes/singles.py
@@ -2,3 +2,6 @@ this_should_be_linted = 'single quote string'
 this_should_be_linted = u'double quote string'
 this_should_be_linted = f'double quote string'
 this_should_be_linted = f'double {"quote"} string'
+
+# https://github.com/astral-sh/ruff/issues/10546
+x: "Literal['foo', 'bar']"

--- a/crates/ruff_linter/src/rules/flake8_quotes/rules/check_string_quotes.rs
+++ b/crates/ruff_linter/src/rules/flake8_quotes/rules/check_string_quotes.rs
@@ -432,6 +432,12 @@ fn strings(checker: &mut Checker, sequence: &[TextRange]) {
 
 /// Generate `flake8-quote` diagnostics from a token stream.
 pub(crate) fn check_string_quotes(checker: &mut Checker, string_like: StringLike) {
+    // Ignore if the string is part of a forward reference. For example,
+    // `x: "Literal['foo', 'bar']"`.
+    if checker.semantic().in_string_type_definition() {
+        return;
+    }
+
     // If the string is part of a f-string, ignore it.
     if checker
         .indexer()

--- a/crates/ruff_linter/src/rules/flake8_quotes/snapshots/ruff_linter__rules__flake8_quotes__tests__require_doubles_over_singles.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_quotes/snapshots/ruff_linter__rules__flake8_quotes__tests__require_doubles_over_singles.py.snap
@@ -33,6 +33,7 @@ singles.py:2:25: Q000 [*] Single quotes found but double quotes preferred
   2 |+this_should_be_linted = u"double quote string"
 3 3 | this_should_be_linted = f'double quote string'
 4 4 | this_should_be_linted = f'double {"quote"} string'
+5 5 | 
 
 singles.py:3:25: Q000 [*] Single quotes found but double quotes preferred
   |
@@ -50,5 +51,5 @@ singles.py:3:25: Q000 [*] Single quotes found but double quotes preferred
 3   |-this_should_be_linted = f'double quote string'
   3 |+this_should_be_linted = f"double quote string"
 4 4 | this_should_be_linted = f'double {"quote"} string'
-
-
+5 5 | 
+6 6 | # https://github.com/astral-sh/ruff/issues/10546


### PR DESCRIPTION
## Summary

This is not the holistic solution but just to fix that issue.

fixes: #10546 

## Test Plan

Add a regression test for it and check the snapshots.
