### PR TITLE
Put flake8-logging next to the other flake8 plugins in registry

### DIFF
--- a/crates/ruff_linter/src/registry.rs
+++ b/crates/ruff_linter/src/registry.rs
@@ -115,6 +115,9 @@ pub enum Linter {
     /// [flake8-import-conventions](https://github.com/joaopalmeiro/flake8-import-conventions)
     #[prefix = "ICN"]
     Flake8ImportConventions,
+    /// [flake8-logging](https://pypi.org/project/flake8-logging/)
+    #[prefix = "LOG"]
+    Flake8Logging,
     /// [flake8-logging-format](https://pypi.org/project/flake8-logging-format/)
     #[prefix = "G"]
     Flake8LoggingFormat,
@@ -202,9 +205,6 @@ pub enum Linter {
     /// [refurb](https://pypi.org/project/refurb/)
     #[prefix = "FURB"]
     Refurb,
-    /// [flake8-logging](https://pypi.org/project/flake8-logging/)
-    #[prefix = "LOG"]
-    Flake8Logging,
     /// Ruff-specific rules
     #[prefix = "RUF"]
     Ruff,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This is just a nitpicky improvement, but I thought it'd be a good opportunity to look at the ruff source.

> The rules list in the documentation is generated using the registry order. Currently, flake8-logging is separated from the rest of the flake8 plugins. This patch puts it next to them.

https://docs.astral.sh/ruff/rules/

If it makes sense, we could alternatively just sort the linters in https://github.com/astral-sh/ruff/blob/main/crates/ruff_dev/src/generate_rules_table.rs.

## Test Plan

<!-- How was it tested? -->
