### PR TITLE
Update warning message for rule S305 to address insecure block cipher mode use

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
@@ -220,7 +220,7 @@ pub struct SuspiciousInsecureCipherModeUsage;
 impl Violation for SuspiciousInsecureCipherModeUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of insecure block cipher mode, replace with a known secure cipher such as CBC")
+        format!("Use of insecure block cipher mode, replace with a known secure mode such as CBC or CTR")
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
@@ -220,7 +220,7 @@ pub struct SuspiciousInsecureCipherModeUsage;
 impl Violation for SuspiciousInsecureCipherModeUsage {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Use of insecure cipher mode, replace with a known secure cipher such as AES")
+        format!("Use of insecure block cipher mode, replace with a known secure cipher such as CBC")
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR updates the warning message for rule S305 to accurately reflect the security concern over using ECB mode in block ciphers, which is considered insecure compared to other modes like CBC or CTR. The previous message incorrectly mentioned AES as a [block cipher mode](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation), which has been corrected to avoid confusion.

Ref: 
https://github.com/PyCQA/bandit/blob/c85576d903c213859634f4fbcb6304042442e62a/bandit/blacklists/calls.py#L99-L102

https://github.com/astral-sh/ruff/blob/825fd7c990e12569886127f7f7ca953b5516d327/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs#L187-L216

## Test Plan

No testing required as the change is limited to a minor change of warning message update.
