### PR TITLE
Group some NPM dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,51 +1,53 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": true,
-  "suppressNotifications": ["prEditedNotification"],
-  "extends": ["config:recommended"],
-  "labels": ["internal"],
-  "schedule": ["before 4am on Monday"],
-  "separateMajorMinor": false,
-  "enabledManagers": [
-    "github-actions",
-    "pre-commit",
-    "cargo",
-    "pep621",
-    "npm",
-  ],
-  "cargo": {
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  dependencyDashboard: true,
+  suppressNotifications: ["prEditedNotification"],
+  extends: ["config:recommended"],
+  labels: ["internal"],
+  schedule: ["before 4am on Monday"],
+  separateMajorMinor: false,
+  enabledManagers: ["github-actions", "pre-commit", "cargo", "pep621", "npm"],
+  cargo: {
     // See https://docs.renovatebot.com/configuration-options/#rangestrategy
-    "rangeStrategy": "update-lockfile",
+    rangeStrategy: "update-lockfile",
   },
-  "pep621": {
-    "fileMatch": [
-      "^(python|scripts)/.*pyproject\\.toml$",
-    ],
+  pep621: {
+    fileMatch: ["^(python|scripts)/.*pyproject\\.toml$"],
   },
-  "npm": {
-    "fileMatch": [
-      "^playground/.*package\\.json$",
-    ],
+  npm: {
+    fileMatch: ["^playground/.*package\\.json$"],
   },
   "pre-commit": {
-    "enabled": true,
+    enabled: true,
   },
-  "packageRules": [
+  packageRules: [
     {
       // Group upload/download artifact updates, the versions are dependent
-      "groupName": "Artifact GitHub Actions dependencies",
-      "matchManagers": ["github-actions"],
-      "matchPackagePatterns": ["actions/.*-artifact"],
-      "description": "Weekly update of artifact-related GitHub Actions dependencies",
+      groupName: "Artifact GitHub Actions dependencies",
+      matchManagers: ["github-actions"],
+      matchPackagePatterns: ["actions/.*-artifact"],
+      description: "Weekly update of artifact-related GitHub Actions dependencies",
     },
     {
-      "groupName": "pre-commit dependencies",
-      "matchManagers": ["pre-commit"],
-      "description": "Weekly update of pre-commit dependencies",
+      groupName: "pre-commit dependencies",
+      matchManagers: ["pre-commit"],
+      description: "Weekly update of pre-commit dependencies",
+    },
+    {
+      groupName: "NPM Development dependencies",
+      matchManagers: ["npm"],
+      matchDepTypes: ["devDependencies"],
+      description: "Weekly update of NPM development dependencies",
+    },
+    {
+      groupName: "Monaco",
+      matchManagers: ["npm"],
+      matchPackagePatterns: ["monaco"],
+      description: "Weekly update of the Monaco editor",
     },
   ],
-  "vulnerabilityAlerts": {
-    "commitMessageSuffix": "",
-    "labels": ["internal", "security"],
+  vulnerabilityAlerts: {
+    commitMessageSuffix: "",
+    labels: ["internal", "security"],
   },
 }


### PR DESCRIPTION
## Summary

Group some npm dependencies that should be upgraded together (e.g. all vite or monaco dependencies)

## Test Plan

I validate the configuration with `renovate-config-validator`
