### PR TITLE
`DTZ` rules: Clarify error messages and docs

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_fromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_fromtimestamp.rs
@@ -18,7 +18,7 @@ use crate::checkers::ast::Checker;
 /// always use timezone-aware objects.
 ///
 /// `datetime.date.fromtimestamp(ts)` returns a naive datetime object.
-/// Instead, use `datetime.datetime.fromtimestamp(ts, tz=)` to return a
+/// Instead, use `datetime.datetime.fromtimestamp(ts, tz=...)` to create a
 /// timezone-aware object.
 ///
 /// ## Example
@@ -54,7 +54,7 @@ impl Violation for CallDateFromtimestamp {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some("Use `datetime.datetime.fromtimestamp(ts, tz=).date()` instead".to_string())
+        Some("Use `datetime.datetime.fromtimestamp(ts, tz=...).date()` instead".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_fromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_fromtimestamp.rs
@@ -50,10 +50,11 @@ pub struct CallDateFromtimestamp;
 impl Violation for CallDateFromtimestamp {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "The use of `datetime.date.fromtimestamp()` is not allowed, use \
-             `datetime.datetime.fromtimestamp(ts, tz=).date()` instead"
-        )
+        format!("`datetime.date.fromtimestamp()` used")
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Use `datetime.datetime.fromtimestamp(ts, tz=).date()` instead".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_today.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_today.rs
@@ -18,7 +18,7 @@ use crate::checkers::ast::Checker;
 /// always use timezone-aware objects.
 ///
 /// `datetime.date.today` returns a naive datetime object. Instead, use
-/// `datetime.datetime.now(tz=).date()` to return a timezone-aware object.
+/// `datetime.datetime.now(tz=...).date()` to create a timezone-aware object.
 ///
 /// ## Example
 /// ```python
@@ -53,7 +53,7 @@ impl Violation for CallDateToday {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some("Use `datetime.datetime.now(tz=).date()` instead".to_string())
+        Some("Use `datetime.datetime.now(tz=...).date()` instead".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_today.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_date_today.rs
@@ -49,10 +49,11 @@ pub struct CallDateToday;
 impl Violation for CallDateToday {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "The use of `datetime.date.today()` is not allowed, use \
-             `datetime.datetime.now(tz=).date()` instead"
-        )
+        format!("`datetime.date.today()` used")
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Use `datetime.datetime.now(tz=).date()` instead".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
@@ -21,8 +21,8 @@ use super::helpers::{self, DatetimeModuleAntipattern};
 ///
 /// `datetime.datetime.fromtimestamp(ts)` or
 /// `datetime.datetime.fromtimestampe(ts, tz=None)` returns a naive datetime
-/// object. Instead, use `datetime.datetime.fromtimestamp(ts, tz=)` to return a
-/// timezone-aware object.
+/// object. Instead, use `datetime.datetime.fromtimestamp(ts, tz=<timezone>)`
+/// to create a timezone-aware object.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
@@ -3,16 +3,14 @@ use ruff_macros::{derive_message_formats, violation};
 
 use ruff_python_ast::{self as ast};
 use ruff_python_semantic::Modules;
-use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
-use crate::rules::flake8_datetimez::rules::helpers::has_non_none_keyword;
 
-use super::helpers;
+use super::helpers::{self, DatetimeModuleAntipattern};
 
 /// ## What it does
-/// Checks for usage of `datetime.datetime.fromtimestamp()` without a `tz`
-/// argument.
+/// Checks for usage of `datetime.datetime.fromtimestamp()` that do not specify
+/// a timezone.
 ///
 /// ## Why is this bad?
 /// Python datetime objects can be naive or timezone-aware. While an aware
@@ -21,8 +19,9 @@ use super::helpers;
 /// datetime objects. Since this can lead to errors, it is recommended to
 /// always use timezone-aware objects.
 ///
-/// `datetime.datetime.fromtimestamp(ts)` returns a naive datetime object.
-/// Instead, use `datetime.datetime.fromtimestamp(ts, tz=)` to return a
+/// `datetime.datetime.fromtimestamp(ts)` or
+/// `datetime.datetime.fromtimestampe(ts, tz=None)` returns a naive datetime
+/// object. Instead, use `datetime.datetime.fromtimestamp(ts, tz=)` to return a
 /// timezone-aware object.
 ///
 /// ## Example
@@ -39,7 +38,7 @@ use super::helpers;
 /// datetime.datetime.fromtimestamp(946684800, tz=datetime.timezone.utc)
 /// ```
 ///
-/// Or, for Python 3.11 and later:
+/// Or, on Python 3.11 and later:
 /// ```python
 /// import datetime
 ///
@@ -49,14 +48,20 @@ use super::helpers;
 /// ## References
 /// - [Python documentation: Aware and Naive Objects](https://docs.python.org/3/library/datetime.html#aware-and-naive-objects)
 #[violation]
-pub struct CallDatetimeFromtimestamp;
+pub struct CallDatetimeFromtimestamp(DatetimeModuleAntipattern);
 
 impl Violation for CallDatetimeFromtimestamp {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "The use of `datetime.datetime.fromtimestamp()` without `tz` argument is not allowed"
-        )
+        let CallDatetimeFromtimestamp(antipattern) = self;
+        match antipattern {
+            DatetimeModuleAntipattern::NoTzArgumentPassed => format!(
+                "The use of `datetime.datetime.fromtimestamp()` without `tz` argument is not allowed"
+            ),
+            DatetimeModuleAntipattern::NonePassedToTzArgument => format!(
+                "Passing `tz=None` is forbidden, as it creates a naive datetime object"
+            ),
+        }
     }
 }
 
@@ -82,26 +87,14 @@ pub(crate) fn call_datetime_fromtimestamp(checker: &mut Checker, call: &ast::Exp
         return;
     }
 
-    // no args / no args unqualified
-    if call.arguments.args.len() < 2 && call.arguments.keywords.is_empty() {
-        checker
-            .diagnostics
-            .push(Diagnostic::new(CallDatetimeFromtimestamp, call.range()));
-        return;
-    }
+    let antipattern = match call.arguments.find_argument("tz", 1) {
+        Some(ast::Expr::NoneLiteral(_)) => DatetimeModuleAntipattern::NonePassedToTzArgument,
+        Some(_) => return,
+        None => DatetimeModuleAntipattern::NoTzArgumentPassed,
+    };
 
-    // none args
-    if call.arguments.args.len() > 1 && call.arguments.args[1].is_none_literal_expr() {
-        checker
-            .diagnostics
-            .push(Diagnostic::new(CallDatetimeFromtimestamp, call.range()));
-        return;
-    }
-
-    // wrong keywords / none keyword
-    if !call.arguments.keywords.is_empty() && !has_non_none_keyword(&call.arguments, "tz") {
-        checker
-            .diagnostics
-            .push(Diagnostic::new(CallDatetimeFromtimestamp, call.range()));
-    }
+    checker.diagnostics.push(Diagnostic::new(
+        CallDatetimeFromtimestamp(antipattern),
+        call.range,
+    ));
 }

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_fromtimestamp.rs
@@ -55,13 +55,17 @@ impl Violation for CallDatetimeFromtimestamp {
     fn message(&self) -> String {
         let CallDatetimeFromtimestamp(antipattern) = self;
         match antipattern {
-            DatetimeModuleAntipattern::NoTzArgumentPassed => format!(
-                "The use of `datetime.datetime.fromtimestamp()` without `tz` argument is not allowed"
-            ),
-            DatetimeModuleAntipattern::NonePassedToTzArgument => format!(
-                "Passing `tz=None` is forbidden, as it creates a naive datetime object"
-            ),
+            DatetimeModuleAntipattern::NoTzArgumentPassed => {
+                format!("`datetime.datetime.fromtimestamp()` called without a `tz` argument")
+            }
+            DatetimeModuleAntipattern::NonePassedToTzArgument => {
+                format!("`tz=None` passed to `datetime.datetime.fromtimestamp()`")
+            }
         }
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Pass a `datetime.timezone` object to the `tz` parameter".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
@@ -11,7 +11,7 @@ use crate::rules::flake8_datetimez::rules::helpers::has_non_none_keyword;
 use super::helpers;
 
 /// ## What it does
-/// Checks for usage of `datetime.datetime.now()` without a `tz` argument.
+/// Checks for usages of `datetime.datetime.now()` that do not specify a timezone.
 ///
 /// ## Why is this bad?
 /// Python datetime objects can be naive or timezone-aware. While an aware
@@ -20,8 +20,9 @@ use super::helpers;
 /// datetime objects. Since this can lead to errors, it is recommended to
 /// always use timezone-aware objects.
 ///
-/// `datetime.datetime.now()` returns a naive datetime object. Instead, use
-/// `datetime.datetime.now(tz=)` to return a timezone-aware object.
+/// `datetime.datetime.now()` or `datetime.datetime.now(tz=None)` returns a naive
+/// datetime object. Instead, use `datetime.datetime.now(tz=)` to return a
+/// timezone-aware object.
 ///
 /// ## Example
 /// ```python
@@ -42,13 +43,6 @@ use super::helpers;
 /// import datetime
 ///
 /// datetime.datetime.now(tz=datetime.UTC)
-/// ```
-///
-/// ## Why can't I use `datetime.datetime.now(tz=None)`?
-/// ```python
-/// datetime.datetime.now(tz=None)  # Returns a naive datetime for the machine's timezone.
-/// # So, for a timezone-aware datetime for the machine's timezone, use:
-/// datetime.datetime.now(tz=datetime.timezone.utc).astimezone()
 /// ```
 ///
 /// ## References

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
@@ -53,7 +53,7 @@ pub struct CallDatetimeNowWithoutTzinfo;
 impl Violation for CallDatetimeNowWithoutTzinfo {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("The use of `datetime.datetime.now()` without `tz` argument is not allowed")
+        format!("The use of `datetime.datetime.now()` without specifying a timezone is not allowed"")
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
@@ -19,8 +19,8 @@ use super::helpers::{self, DatetimeModuleAntipattern};
 /// always use timezone-aware objects.
 ///
 /// `datetime.datetime.now()` or `datetime.datetime.now(tz=None)` returns a naive
-/// datetime object. Instead, use `datetime.datetime.now(tz=)` to return a
-/// timezone-aware object.
+/// datetime object. Instead, use `datetime.datetime.now(tz=<timezone>)` to create
+/// a timezone-aware object.
 ///
 /// ## Example
 /// ```python
@@ -54,7 +54,7 @@ impl Violation for CallDatetimeNowWithoutTzinfo {
         let CallDatetimeNowWithoutTzinfo(antipattern) = self;
         match antipattern {
             DatetimeModuleAntipattern::NoTzArgumentPassed => {
-                format!("`datetime.datetime.now()` called without a `tz=` argument")
+                format!("`datetime.datetime.now()` called without a `tz` argument")
             }
             DatetimeModuleAntipattern::NonePassedToTzArgument => {
                 format!("`tz=None` passed to `datetime.datetime.now()`")

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
@@ -53,7 +53,7 @@ pub struct CallDatetimeNowWithoutTzinfo;
 impl Violation for CallDatetimeNowWithoutTzinfo {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("The use of `datetime.datetime.now()` without specifying a timezone is not allowed"")
+        format!("Using `datetime.datetime.now()` without specifying a timezone is not allowed")
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
@@ -54,12 +54,16 @@ impl Violation for CallDatetimeNowWithoutTzinfo {
         let CallDatetimeNowWithoutTzinfo(antipattern) = self;
         match antipattern {
             DatetimeModuleAntipattern::NoTzArgumentPassed => {
-                format!("Using `datetime.datetime.now()` without a `tz=` argument is not allowed")
+                format!("`datetime.datetime.now()` called without a `tz=` argument")
             }
             DatetimeModuleAntipattern::NonePassedToTzArgument => {
-                format!("Passing `tz=None` to `datetime.datetime.now()` is not allowed")
+                format!("`tz=None` passed to `datetime.datetime.now()`")
             }
         }
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Pass a `datetime.timezone` object to the `tz` parameter".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_now_without_tzinfo.rs
@@ -44,6 +44,13 @@ use super::helpers;
 /// datetime.datetime.now(tz=datetime.UTC)
 /// ```
 ///
+/// ## Why can't I use `datetime.datetime.now(tz=None)`?
+/// ```python
+/// datetime.datetime.now(tz=None)  # Returns a naive datetime for the machine's timezone.
+/// # So, for a timezone-aware datetime for the machine's timezone, use:
+/// datetime.datetime.now(tz=datetime.timezone.utc).astimezone()
+/// ```
+///
 /// ## References
 /// - [Python documentation: Aware and Naive Objects](https://docs.python.org/3/library/datetime.html#aware-and-naive-objects)
 #[violation]

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
@@ -2,10 +2,10 @@ use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::{self as ast, Expr};
 use ruff_python_semantic::Modules;
-use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
-use crate::rules::flake8_datetimez::rules::helpers::has_non_none_keyword;
+
+use super::helpers::DatetimeModuleAntipattern;
 
 /// ## What it does
 /// Checks for uses of `datetime.datetime.strptime()` that lead to naive
@@ -51,15 +51,22 @@ use crate::rules::flake8_datetimez::rules::helpers::has_non_none_keyword;
 /// - [Python documentation: Aware and Naive Objects](https://docs.python.org/3/library/datetime.html#aware-and-naive-objects)
 /// - [Python documentation: `strftime()` and `strptime()` Behavior](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior)
 #[violation]
-pub struct CallDatetimeStrptimeWithoutZone;
+pub struct CallDatetimeStrptimeWithoutZone(DatetimeModuleAntipattern);
 
 impl Violation for CallDatetimeStrptimeWithoutZone {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "The use of `datetime.datetime.strptime()` without %z must be followed by \
-             `.replace(tzinfo=)` or `.astimezone()`"
-        )
+        let CallDatetimeStrptimeWithoutZone(antipattern) = self;
+        match antipattern {
+            DatetimeModuleAntipattern::NoTzArgumentPassed => format!(
+                "The use of `datetime.datetime.strptime()` without %z must be followed by \
+                `.replace(tzinfo=)` or `.astimezone()`"
+            ),
+            DatetimeModuleAntipattern::NonePassedToTzArgument => format!(
+                "Passing `tzinfo=None` to `datetime.datetime.replace()` is forbidden, \
+                as it creates a naive datetime object"
+            ),
+        }
     }
 }
 
@@ -91,36 +98,44 @@ pub(crate) fn call_datetime_strptime_without_zone(checker: &mut Checker, call: &
         }
     };
 
-    let (Some(grandparent), Some(parent)) = (
-        checker.semantic().current_expression_grandparent(),
-        checker.semantic().current_expression_parent(),
-    ) else {
+    let semantic = checker.semantic();
+    if let Some(antipattern) = find_antipattern(
+        semantic.current_expression_grandparent(),
+        semantic.current_expression_parent(),
+    ) {
         checker.diagnostics.push(Diagnostic::new(
-            CallDatetimeStrptimeWithoutZone,
-            call.range(),
+            CallDatetimeStrptimeWithoutZone(antipattern),
+            call.range,
         ));
-        return;
-    };
-
-    if let Expr::Call(ast::ExprCall { arguments, .. }) = grandparent {
-        if let Expr::Attribute(ast::ExprAttribute { attr, .. }) = parent {
-            let attr = attr.as_str();
-            // Ex) `datetime.strptime(...).astimezone()`
-            if attr == "astimezone" {
-                return;
-            }
-
-            // Ex) `datetime.strptime(...).replace(tzinfo=UTC)`
-            if attr == "replace" {
-                if has_non_none_keyword(arguments, "tzinfo") {
-                    return;
-                }
-            }
-        }
     }
+}
 
-    checker.diagnostics.push(Diagnostic::new(
-        CallDatetimeStrptimeWithoutZone,
-        call.range(),
-    ));
+fn find_antipattern(
+    grandparent: Option<&Expr>,
+    parent: Option<&Expr>,
+) -> Option<DatetimeModuleAntipattern> {
+    let Some(Expr::Call(ast::ExprCall { arguments, .. })) = grandparent else {
+        return Some(DatetimeModuleAntipattern::NoTzArgumentPassed);
+    };
+    let Some(Expr::Attribute(ast::ExprAttribute { attr, .. })) = parent else {
+        return Some(DatetimeModuleAntipattern::NoTzArgumentPassed);
+    };
+    // Ex) `datetime.strptime(...).astimezone()`
+    if attr == "astimezone" {
+        return None;
+    }
+    if attr != "replace" {
+        return Some(DatetimeModuleAntipattern::NoTzArgumentPassed);
+    }
+    match arguments.find_keyword("tzinfo") {
+        // Ex) `datetime.strptime(...).replace(tz=None)`
+        Some(ast::Keyword {
+            value: Expr::NoneLiteral(_),
+            ..
+        }) => Some(DatetimeModuleAntipattern::NonePassedToTzArgument),
+        // Ex) `datetime.strptime(...).replace(tz=...)`
+        Some(_) => None,
+        // Ex) `datetime.strptime(...).replace(...)` with no tz= argument
+        None => Some(DatetimeModuleAntipattern::NoTzArgumentPassed),
+    }
 }

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
@@ -59,13 +59,24 @@ impl Violation for CallDatetimeStrptimeWithoutZone {
         let CallDatetimeStrptimeWithoutZone(antipattern) = self;
         match antipattern {
             DatetimeModuleAntipattern::NoTzArgumentPassed => format!(
-                "The use of `datetime.datetime.strptime()` without %z must be followed by \
-                `.replace(tzinfo=)` or `.astimezone()`"
+                "Naive datetime constructed using `datetime.datetime.strptime()` without %z"
             ),
-            DatetimeModuleAntipattern::NonePassedToTzArgument => format!(
-                "Passing `tzinfo=None` to `datetime.datetime.replace()` is forbidden, \
-                as it creates a naive datetime object"
+            DatetimeModuleAntipattern::NonePassedToTzArgument => {
+                format!("`datetime.datetime.strptime(...).replace(tz=None)` used")
+            }
+        }
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        let CallDatetimeStrptimeWithoutZone(antipattern) = self;
+        match antipattern {
+            DatetimeModuleAntipattern::NoTzArgumentPassed => Some(
+                "Call `.replace(tzinfo=)` or `.astimezone()` to convert to an aware datetime"
+                    .to_string(),
             ),
+            DatetimeModuleAntipattern::NonePassedToTzArgument => {
+                Some("Pass a `datetime.timezone` object to `tzinfo=`".to_string())
+            }
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
@@ -20,7 +20,7 @@ use super::helpers;
 /// time, unlike "naive" objects.
 ///
 /// `datetime.datetime.today()` creates a "naive" object; instead, use
-/// `datetime.datetime.now(tz=)` to create a timezone-aware object.
+/// `datetime.datetime.now(tz=...)` to create a timezone-aware object.
 ///
 /// ## Example
 /// ```python
@@ -52,7 +52,7 @@ impl Violation for CallDatetimeToday {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some("Use `datetime.datetime.now(tz=)` instead".to_string())
+        Some("Use `datetime.datetime.now(tz=...)` instead".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
@@ -48,10 +48,11 @@ pub struct CallDatetimeToday;
 impl Violation for CallDatetimeToday {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "The use of `datetime.datetime.today()` is not allowed, use \
-             `datetime.datetime.now(tz=)` instead"
-        )
+        format!("`datetime.datetime.today()` used")
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Use `datetime.datetime.now(tz=)` instead".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
@@ -19,10 +19,9 @@ use super::helpers;
 /// datetime objects. Since this can lead to errors, it is recommended to
 /// always use timezone-aware objects.
 ///
-/// `datetime.datetime.utcfromtimestamp()` or
-/// `datetime.datetime.utcfromtimestamp(tz=None)` returns a naive datetime
-/// object; instead, use `datetime.datetime.fromtimestamp(ts, tz=)` to return a
-/// timezone-aware object.
+/// `datetime.datetime.utcfromtimestamp()` returns a naive datetime
+/// object; instead, use `datetime.datetime.fromtimestamp(ts, tz=...)`
+/// to create a timezone-aware object.
 ///
 /// ## Example
 /// ```python
@@ -57,7 +56,7 @@ impl Violation for CallDatetimeUtcfromtimestamp {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some("Use `datetime.datetime.fromtimestamp(ts, tz=)` instead".to_string())
+        Some("Use `datetime.datetime.fromtimestamp(ts, tz=...)` instead".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
@@ -53,10 +53,11 @@ pub struct CallDatetimeUtcfromtimestamp;
 impl Violation for CallDatetimeUtcfromtimestamp {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "The use of `datetime.datetime.utcfromtimestamp()` is not allowed, use \
-             `datetime.datetime.fromtimestamp(ts, tz=)` instead"
-        )
+        format!("`datetime.datetime.utcfromtimestamp()` used")
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Use `datetime.datetime.fromtimestamp(ts, tz=)` instead".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcfromtimestamp.rs
@@ -19,15 +19,16 @@ use super::helpers;
 /// datetime objects. Since this can lead to errors, it is recommended to
 /// always use timezone-aware objects.
 ///
-/// `datetime.datetime.utcfromtimestamp()` returns a naive datetime object;
-/// instead, use `datetime.datetime.fromtimestamp(ts, tz=)` to return a
+/// `datetime.datetime.utcfromtimestamp()` or
+/// `datetime.datetime.utcfromtimestamp(tz=None)` returns a naive datetime
+/// object; instead, use `datetime.datetime.fromtimestamp(ts, tz=)` to return a
 /// timezone-aware object.
 ///
 /// ## Example
 /// ```python
 /// import datetime
 ///
-/// datetime.datetime.utcfromtimestamp()
+/// datetime.datetime.utcfromtimestamp(946684800)
 /// ```
 ///
 /// Use instead:
@@ -37,7 +38,7 @@ use super::helpers;
 /// datetime.datetime.fromtimestamp(946684800, tz=datetime.timezone.utc)
 /// ```
 ///
-/// Or, for Python 3.11 and later:
+/// Or, on Python 3.11 and later:
 /// ```python
 /// import datetime
 ///

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcnow.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcnow.rs
@@ -51,10 +51,11 @@ pub struct CallDatetimeUtcnow;
 impl Violation for CallDatetimeUtcnow {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "The use of `datetime.datetime.utcnow()` is not allowed, use \
-             `datetime.datetime.now(tz=)` instead"
-        )
+        format!("`datetime.datetime.utcnow()` used")
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Use `datetime.datetime.now(tz=)` instead".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcnow.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_utcnow.rs
@@ -20,7 +20,7 @@ use super::helpers;
 /// always use timezone-aware objects.
 ///
 /// `datetime.datetime.utcnow()` returns a naive datetime object; instead, use
-/// `datetime.datetime.now(tz=)` to return a timezone-aware object.
+/// `datetime.datetime.now(tz=...)` to create a timezone-aware object.
 ///
 /// ## Example
 /// ```python
@@ -55,7 +55,7 @@ impl Violation for CallDatetimeUtcnow {
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some("Use `datetime.datetime.now(tz=)` instead".to_string())
+        Some("Use `datetime.datetime.now(tz=...)` instead".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
@@ -50,12 +50,16 @@ impl Violation for CallDatetimeWithoutTzinfo {
         let CallDatetimeWithoutTzinfo(antipattern) = self;
         match antipattern {
             DatetimeModuleAntipattern::NoTzArgumentPassed => {
-                format!("The use of `datetime.datetime()` without `tzinfo` argument is not allowed")
+                format!("`datetime.datetime()` called without a `tzinfo` argument")
             }
             DatetimeModuleAntipattern::NonePassedToTzArgument => {
-                format!("Passing `tzinfo=None` if forbidden, as it creates a naive datetime object")
+                format!("`tzinfo=None` passed to `datetime.datetime()`")
             }
         }
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Pass a `datetime.timezone` object to the `tzinfo` parameter".to_string())
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_without_tzinfo.rs
@@ -1,17 +1,15 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 
-use ruff_python_ast::{self as ast, Expr};
+use ruff_python_ast as ast;
 use ruff_python_semantic::Modules;
-use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
-use crate::rules::flake8_datetimez::rules::helpers::has_non_none_keyword;
 
-use super::helpers;
+use super::helpers::{self, DatetimeModuleAntipattern};
 
 /// ## What it does
-/// Checks for `datetime` instantiations that lack a `tzinfo` argument.
+/// Checks for `datetime` instantiations that do not specify a timezone.
 ///
 /// ## Why is this bad?
 /// `datetime` objects are "naive" by default, in that they do not include
@@ -20,7 +18,8 @@ use super::helpers;
 /// `datetime` objects are preferred, as they represent a specific moment in
 /// time, unlike "naive" objects.
 ///
-/// By providing a `tzinfo` value, a `datetime` can be made timezone-aware.
+/// By providing a non-`None` value for `tzinfo`, a `datetime` can be made
+/// timezone-aware.
 ///
 /// ## Example
 /// ```python
@@ -36,19 +35,27 @@ use super::helpers;
 /// datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
 /// ```
 ///
-/// Or, for Python 3.11 and later:
+/// Or, on Python 3.11 and later:
 /// ```python
 /// import datetime
 ///
 /// datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=datetime.UTC)
 /// ```
 #[violation]
-pub struct CallDatetimeWithoutTzinfo;
+pub struct CallDatetimeWithoutTzinfo(DatetimeModuleAntipattern);
 
 impl Violation for CallDatetimeWithoutTzinfo {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("The use of `datetime.datetime()` without `tzinfo` argument is not allowed")
+        let CallDatetimeWithoutTzinfo(antipattern) = self;
+        match antipattern {
+            DatetimeModuleAntipattern::NoTzArgumentPassed => {
+                format!("The use of `datetime.datetime()` without `tzinfo` argument is not allowed")
+            }
+            DatetimeModuleAntipattern::NonePassedToTzArgument => {
+                format!("Passing `tzinfo=None` if forbidden, as it creates a naive datetime object")
+            }
+        }
     }
 }
 
@@ -69,23 +76,14 @@ pub(crate) fn call_datetime_without_tzinfo(checker: &mut Checker, call: &ast::Ex
         return;
     }
 
-    // No positional arg: keyword is missing or constant None.
-    if call.arguments.args.len() < 8 && !has_non_none_keyword(&call.arguments, "tzinfo") {
-        checker
-            .diagnostics
-            .push(Diagnostic::new(CallDatetimeWithoutTzinfo, call.range()));
-        return;
-    }
+    let antipattern = match call.arguments.find_argument("tzinfo", 7) {
+        Some(ast::Expr::NoneLiteral(_)) => DatetimeModuleAntipattern::NonePassedToTzArgument,
+        Some(_) => return,
+        None => DatetimeModuleAntipattern::NoTzArgumentPassed,
+    };
 
-    // Positional arg: is constant None.
-    if call
-        .arguments
-        .args
-        .get(7)
-        .is_some_and(Expr::is_none_literal_expr)
-    {
-        checker
-            .diagnostics
-            .push(Diagnostic::new(CallDatetimeWithoutTzinfo, call.range()));
-    }
+    checker.diagnostics.push(Diagnostic::new(
+        CallDatetimeWithoutTzinfo(antipattern),
+        call.range,
+    ));
 }

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/helpers.rs
@@ -1,6 +1,12 @@
-use ruff_python_ast::{Arguments, Expr, ExprAttribute};
+use ruff_python_ast::{Expr, ExprAttribute};
 
 use crate::checkers::ast::Checker;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(super) enum DatetimeModuleAntipattern {
+    NoTzArgumentPassed,
+    NonePassedToTzArgument,
+}
 
 /// Check if the parent expression is a call to `astimezone`. This assumes that
 /// the current expression is a `datetime.datetime` object.
@@ -8,11 +14,4 @@ pub(super) fn parent_expr_is_astimezone(checker: &Checker) -> bool {
     checker.semantic().current_expression_parent().is_some_and( |parent| {
         matches!(parent, Expr::Attribute(ExprAttribute { attr, .. }) if attr.as_str() == "astimezone")
     })
-}
-
-/// Return `true` if a keyword argument is present with a non-`None` value.
-pub(super) fn has_non_none_keyword(arguments: &Arguments, keyword: &str) -> bool {
-    arguments
-        .find_keyword(keyword)
-        .is_some_and(|keyword| !keyword.value.is_none_literal_expr())
 }

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ001_DTZ001.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ001_DTZ001.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_datetimez/mod.rs
 ---
-DTZ001.py:4:1: DTZ001 The use of `datetime.datetime()` without `tzinfo` argument is not allowed
+DTZ001.py:4:1: DTZ001 `datetime.datetime()` called without a `tzinfo` argument
   |
 3 | # no args
 4 | datetime.datetime(2000, 1, 1, 0, 0, 0)
@@ -9,8 +9,9 @@ DTZ001.py:4:1: DTZ001 The use of `datetime.datetime()` without `tzinfo` argument
 5 | 
 6 | # none args
   |
+  = help: Pass a `datetime.timezone` object to the `tzinfo` parameter
 
-DTZ001.py:7:1: DTZ001 Passing `tzinfo=None` if forbidden, as it creates a naive datetime object
+DTZ001.py:7:1: DTZ001 `tzinfo=None` passed to `datetime.datetime()`
   |
 6 | # none args
 7 | datetime.datetime(2000, 1, 1, 0, 0, 0, 0, None)
@@ -18,8 +19,9 @@ DTZ001.py:7:1: DTZ001 Passing `tzinfo=None` if forbidden, as it creates a naive 
 8 | 
 9 | # not none arg
   |
+  = help: Pass a `datetime.timezone` object to the `tzinfo` parameter
 
-DTZ001.py:13:1: DTZ001 The use of `datetime.datetime()` without `tzinfo` argument is not allowed
+DTZ001.py:13:1: DTZ001 `datetime.datetime()` called without a `tzinfo` argument
    |
 12 | # no kwargs
 13 | datetime.datetime(2000, 1, 1, fold=1)
@@ -27,8 +29,9 @@ DTZ001.py:13:1: DTZ001 The use of `datetime.datetime()` without `tzinfo` argumen
 14 | 
 15 | # none kwargs
    |
+   = help: Pass a `datetime.timezone` object to the `tzinfo` parameter
 
-DTZ001.py:16:1: DTZ001 Passing `tzinfo=None` if forbidden, as it creates a naive datetime object
+DTZ001.py:16:1: DTZ001 `tzinfo=None` passed to `datetime.datetime()`
    |
 15 | # none kwargs
 16 | datetime.datetime(2000, 1, 1, tzinfo=None)
@@ -36,8 +39,9 @@ DTZ001.py:16:1: DTZ001 Passing `tzinfo=None` if forbidden, as it creates a naive
 17 | 
 18 | from datetime import datetime
    |
+   = help: Pass a `datetime.timezone` object to the `tzinfo` parameter
 
-DTZ001.py:21:1: DTZ001 The use of `datetime.datetime()` without `tzinfo` argument is not allowed
+DTZ001.py:21:1: DTZ001 `datetime.datetime()` called without a `tzinfo` argument
    |
 20 | # no args unqualified
 21 | datetime(2000, 1, 1, 0, 0, 0)
@@ -45,3 +49,4 @@ DTZ001.py:21:1: DTZ001 The use of `datetime.datetime()` without `tzinfo` argumen
 22 | 
 23 | # uses `astimezone` method
    |
+   = help: Pass a `datetime.timezone` object to the `tzinfo` parameter

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ001_DTZ001.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ001_DTZ001.py.snap
@@ -10,7 +10,7 @@ DTZ001.py:4:1: DTZ001 The use of `datetime.datetime()` without `tzinfo` argument
 6 | # none args
   |
 
-DTZ001.py:7:1: DTZ001 The use of `datetime.datetime()` without `tzinfo` argument is not allowed
+DTZ001.py:7:1: DTZ001 Passing `tzinfo=None` if forbidden, as it creates a naive datetime object
   |
 6 | # none args
 7 | datetime.datetime(2000, 1, 1, 0, 0, 0, 0, None)
@@ -28,7 +28,7 @@ DTZ001.py:13:1: DTZ001 The use of `datetime.datetime()` without `tzinfo` argumen
 15 | # none kwargs
    |
 
-DTZ001.py:16:1: DTZ001 The use of `datetime.datetime()` without `tzinfo` argument is not allowed
+DTZ001.py:16:1: DTZ001 Passing `tzinfo=None` if forbidden, as it creates a naive datetime object
    |
 15 | # none kwargs
 16 | datetime.datetime(2000, 1, 1, tzinfo=None)
@@ -45,5 +45,3 @@ DTZ001.py:21:1: DTZ001 The use of `datetime.datetime()` without `tzinfo` argumen
 22 | 
 23 | # uses `astimezone` method
    |
-
-

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ002_DTZ002.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ002_DTZ002.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_datetimez/mod.rs
 ---
-DTZ002.py:4:1: DTZ002 The use of `datetime.datetime.today()` is not allowed, use `datetime.datetime.now(tz=)` instead
+DTZ002.py:4:1: DTZ002 `datetime.datetime.today()` used
   |
 3 | # qualified
 4 | datetime.datetime.today()
@@ -9,8 +9,9 @@ DTZ002.py:4:1: DTZ002 The use of `datetime.datetime.today()` is not allowed, use
 5 | 
 6 | from datetime import datetime
   |
+  = help: Use `datetime.datetime.now(tz=)` instead
 
-DTZ002.py:9:1: DTZ002 The use of `datetime.datetime.today()` is not allowed, use `datetime.datetime.now(tz=)` instead
+DTZ002.py:9:1: DTZ002 `datetime.datetime.today()` used
    |
  8 | # unqualified
  9 | datetime.today()
@@ -18,5 +19,4 @@ DTZ002.py:9:1: DTZ002 The use of `datetime.datetime.today()` is not allowed, use
 10 | 
 11 | # uses `astimezone` method
    |
-
-
+   = help: Use `datetime.datetime.now(tz=)` instead

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ002_DTZ002.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ002_DTZ002.py.snap
@@ -9,7 +9,7 @@ DTZ002.py:4:1: DTZ002 `datetime.datetime.today()` used
 5 | 
 6 | from datetime import datetime
   |
-  = help: Use `datetime.datetime.now(tz=)` instead
+  = help: Use `datetime.datetime.now(tz=...)` instead
 
 DTZ002.py:9:1: DTZ002 `datetime.datetime.today()` used
    |
@@ -19,4 +19,4 @@ DTZ002.py:9:1: DTZ002 `datetime.datetime.today()` used
 10 | 
 11 | # uses `astimezone` method
    |
-   = help: Use `datetime.datetime.now(tz=)` instead
+   = help: Use `datetime.datetime.now(tz=...)` instead

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ003_DTZ003.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ003_DTZ003.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_datetimez/mod.rs
 ---
-DTZ003.py:4:1: DTZ003 The use of `datetime.datetime.utcnow()` is not allowed, use `datetime.datetime.now(tz=)` instead
+DTZ003.py:4:1: DTZ003 `datetime.datetime.utcnow()` used
   |
 3 | # qualified
 4 | datetime.datetime.utcnow()
@@ -9,8 +9,9 @@ DTZ003.py:4:1: DTZ003 The use of `datetime.datetime.utcnow()` is not allowed, us
 5 | 
 6 | from datetime import datetime
   |
+  = help: Use `datetime.datetime.now(tz=)` instead
 
-DTZ003.py:9:1: DTZ003 The use of `datetime.datetime.utcnow()` is not allowed, use `datetime.datetime.now(tz=)` instead
+DTZ003.py:9:1: DTZ003 `datetime.datetime.utcnow()` used
    |
  8 | # unqualified
  9 | datetime.utcnow()
@@ -18,5 +19,4 @@ DTZ003.py:9:1: DTZ003 The use of `datetime.datetime.utcnow()` is not allowed, us
 10 | 
 11 | # uses `astimezone` method
    |
-
-
+   = help: Use `datetime.datetime.now(tz=)` instead

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ003_DTZ003.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ003_DTZ003.py.snap
@@ -9,7 +9,7 @@ DTZ003.py:4:1: DTZ003 `datetime.datetime.utcnow()` used
 5 | 
 6 | from datetime import datetime
   |
-  = help: Use `datetime.datetime.now(tz=)` instead
+  = help: Use `datetime.datetime.now(tz=...)` instead
 
 DTZ003.py:9:1: DTZ003 `datetime.datetime.utcnow()` used
    |
@@ -19,4 +19,4 @@ DTZ003.py:9:1: DTZ003 `datetime.datetime.utcnow()` used
 10 | 
 11 | # uses `astimezone` method
    |
-   = help: Use `datetime.datetime.now(tz=)` instead
+   = help: Use `datetime.datetime.now(tz=...)` instead

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ004_DTZ004.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ004_DTZ004.py.snap
@@ -9,7 +9,7 @@ DTZ004.py:4:1: DTZ004 `datetime.datetime.utcfromtimestamp()` used
 5 | 
 6 | from datetime import datetime
   |
-  = help: Use `datetime.datetime.fromtimestamp(ts, tz=)` instead
+  = help: Use `datetime.datetime.fromtimestamp(ts, tz=...)` instead
 
 DTZ004.py:9:1: DTZ004 `datetime.datetime.utcfromtimestamp()` used
    |
@@ -19,4 +19,4 @@ DTZ004.py:9:1: DTZ004 `datetime.datetime.utcfromtimestamp()` used
 10 | 
 11 | # uses `astimezone` method
    |
-   = help: Use `datetime.datetime.fromtimestamp(ts, tz=)` instead
+   = help: Use `datetime.datetime.fromtimestamp(ts, tz=...)` instead

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ004_DTZ004.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ004_DTZ004.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_datetimez/mod.rs
 ---
-DTZ004.py:4:1: DTZ004 The use of `datetime.datetime.utcfromtimestamp()` is not allowed, use `datetime.datetime.fromtimestamp(ts, tz=)` instead
+DTZ004.py:4:1: DTZ004 `datetime.datetime.utcfromtimestamp()` used
   |
 3 | # qualified
 4 | datetime.datetime.utcfromtimestamp(1234)
@@ -9,8 +9,9 @@ DTZ004.py:4:1: DTZ004 The use of `datetime.datetime.utcfromtimestamp()` is not a
 5 | 
 6 | from datetime import datetime
   |
+  = help: Use `datetime.datetime.fromtimestamp(ts, tz=)` instead
 
-DTZ004.py:9:1: DTZ004 The use of `datetime.datetime.utcfromtimestamp()` is not allowed, use `datetime.datetime.fromtimestamp(ts, tz=)` instead
+DTZ004.py:9:1: DTZ004 `datetime.datetime.utcfromtimestamp()` used
    |
  8 | # unqualified
  9 | datetime.utcfromtimestamp(1234)
@@ -18,5 +19,4 @@ DTZ004.py:9:1: DTZ004 The use of `datetime.datetime.utcfromtimestamp()` is not a
 10 | 
 11 | # uses `astimezone` method
    |
-
-
+   = help: Use `datetime.datetime.fromtimestamp(ts, tz=)` instead

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ005_DTZ005.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ005_DTZ005.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_datetimez/mod.rs
 ---
-DTZ005.py:4:1: DTZ005 `datetime.datetime.now()` called without a `tz=` argument
+DTZ005.py:4:1: DTZ005 `datetime.datetime.now()` called without a `tz` argument
   |
 3 | # no args
 4 | datetime.datetime.now()
@@ -11,7 +11,7 @@ DTZ005.py:4:1: DTZ005 `datetime.datetime.now()` called without a `tz=` argument
   |
   = help: Pass a `datetime.timezone` object to the `tz` parameter
 
-DTZ005.py:7:1: DTZ005 `datetime.datetime.now()` called without a `tz=` argument
+DTZ005.py:7:1: DTZ005 `datetime.datetime.now()` called without a `tz` argument
   |
 6 | # wrong keywords
 7 | datetime.datetime.now(bad=datetime.timezone.utc)
@@ -41,7 +41,7 @@ DTZ005.py:13:1: DTZ005 `tz=None` passed to `datetime.datetime.now()`
    |
    = help: Pass a `datetime.timezone` object to the `tz` parameter
 
-DTZ005.py:18:1: DTZ005 `datetime.datetime.now()` called without a `tz=` argument
+DTZ005.py:18:1: DTZ005 `datetime.datetime.now()` called without a `tz` argument
    |
 17 | # no args unqualified
 18 | datetime.now()

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ005_DTZ005.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ005_DTZ005.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_datetimez/mod.rs
 ---
-DTZ005.py:4:1: DTZ005 Using `datetime.datetime.now()` without specifying a timezone is not allowed
+DTZ005.py:4:1: DTZ005 Using `datetime.datetime.now()` without a `tz=` argument is not allowed
   |
 3 | # no args
 4 | datetime.datetime.now()
@@ -10,7 +10,7 @@ DTZ005.py:4:1: DTZ005 Using `datetime.datetime.now()` without specifying a timez
 6 | # wrong keywords
   |
 
-DTZ005.py:7:1: DTZ005 Using `datetime.datetime.now()` without specifying a timezone is not allowed
+DTZ005.py:7:1: DTZ005 Using `datetime.datetime.now()` without a `tz=` argument is not allowed
   |
 6 | # wrong keywords
 7 | datetime.datetime.now(bad=datetime.timezone.utc)
@@ -19,7 +19,7 @@ DTZ005.py:7:1: DTZ005 Using `datetime.datetime.now()` without specifying a timez
 9 | # none args
   |
 
-DTZ005.py:10:1: DTZ005 Using `datetime.datetime.now()` without specifying a timezone is not allowed
+DTZ005.py:10:1: DTZ005 Passing `tz=None` to `datetime.datetime.now()` is not allowed
    |
  9 | # none args
 10 | datetime.datetime.now(None)
@@ -28,7 +28,7 @@ DTZ005.py:10:1: DTZ005 Using `datetime.datetime.now()` without specifying a time
 12 | # none keywords
    |
 
-DTZ005.py:13:1: DTZ005 Using `datetime.datetime.now()` without specifying a timezone is not allowed
+DTZ005.py:13:1: DTZ005 Passing `tz=None` to `datetime.datetime.now()` is not allowed
    |
 12 | # none keywords
 13 | datetime.datetime.now(tz=None)
@@ -37,7 +37,7 @@ DTZ005.py:13:1: DTZ005 Using `datetime.datetime.now()` without specifying a time
 15 | from datetime import datetime
    |
 
-DTZ005.py:18:1: DTZ005 Using `datetime.datetime.now()` without specifying a timezone is not allowed
+DTZ005.py:18:1: DTZ005 Using `datetime.datetime.now()` without a `tz=` argument is not allowed
    |
 17 | # no args unqualified
 18 | datetime.now()

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ005_DTZ005.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ005_DTZ005.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_datetimez/mod.rs
 ---
-DTZ005.py:4:1: DTZ005 Using `datetime.datetime.now()` without a `tz=` argument is not allowed
+DTZ005.py:4:1: DTZ005 `datetime.datetime.now()` called without a `tz=` argument
   |
 3 | # no args
 4 | datetime.datetime.now()
@@ -9,8 +9,9 @@ DTZ005.py:4:1: DTZ005 Using `datetime.datetime.now()` without a `tz=` argument i
 5 | 
 6 | # wrong keywords
   |
+  = help: Pass a `datetime.timezone` object to the `tz` parameter
 
-DTZ005.py:7:1: DTZ005 Using `datetime.datetime.now()` without a `tz=` argument is not allowed
+DTZ005.py:7:1: DTZ005 `datetime.datetime.now()` called without a `tz=` argument
   |
 6 | # wrong keywords
 7 | datetime.datetime.now(bad=datetime.timezone.utc)
@@ -18,8 +19,9 @@ DTZ005.py:7:1: DTZ005 Using `datetime.datetime.now()` without a `tz=` argument i
 8 | 
 9 | # none args
   |
+  = help: Pass a `datetime.timezone` object to the `tz` parameter
 
-DTZ005.py:10:1: DTZ005 Passing `tz=None` to `datetime.datetime.now()` is not allowed
+DTZ005.py:10:1: DTZ005 `tz=None` passed to `datetime.datetime.now()`
    |
  9 | # none args
 10 | datetime.datetime.now(None)
@@ -27,8 +29,9 @@ DTZ005.py:10:1: DTZ005 Passing `tz=None` to `datetime.datetime.now()` is not all
 11 | 
 12 | # none keywords
    |
+   = help: Pass a `datetime.timezone` object to the `tz` parameter
 
-DTZ005.py:13:1: DTZ005 Passing `tz=None` to `datetime.datetime.now()` is not allowed
+DTZ005.py:13:1: DTZ005 `tz=None` passed to `datetime.datetime.now()`
    |
 12 | # none keywords
 13 | datetime.datetime.now(tz=None)
@@ -36,8 +39,9 @@ DTZ005.py:13:1: DTZ005 Passing `tz=None` to `datetime.datetime.now()` is not all
 14 | 
 15 | from datetime import datetime
    |
+   = help: Pass a `datetime.timezone` object to the `tz` parameter
 
-DTZ005.py:18:1: DTZ005 Using `datetime.datetime.now()` without a `tz=` argument is not allowed
+DTZ005.py:18:1: DTZ005 `datetime.datetime.now()` called without a `tz=` argument
    |
 17 | # no args unqualified
 18 | datetime.now()
@@ -45,3 +49,4 @@ DTZ005.py:18:1: DTZ005 Using `datetime.datetime.now()` without a `tz=` argument 
 19 | 
 20 | # uses `astimezone` method
    |
+   = help: Pass a `datetime.timezone` object to the `tz` parameter

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ005_DTZ005.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ005_DTZ005.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_datetimez/mod.rs
 ---
-DTZ005.py:4:1: DTZ005 The use of `datetime.datetime.now()` without `tz` argument is not allowed
+DTZ005.py:4:1: DTZ005 Using `datetime.datetime.now()` without specifying a timezone is not allowed
   |
 3 | # no args
 4 | datetime.datetime.now()
@@ -10,7 +10,7 @@ DTZ005.py:4:1: DTZ005 The use of `datetime.datetime.now()` without `tz` argument
 6 | # wrong keywords
   |
 
-DTZ005.py:7:1: DTZ005 The use of `datetime.datetime.now()` without `tz` argument is not allowed
+DTZ005.py:7:1: DTZ005 Using `datetime.datetime.now()` without specifying a timezone is not allowed
   |
 6 | # wrong keywords
 7 | datetime.datetime.now(bad=datetime.timezone.utc)
@@ -19,7 +19,7 @@ DTZ005.py:7:1: DTZ005 The use of `datetime.datetime.now()` without `tz` argument
 9 | # none args
   |
 
-DTZ005.py:10:1: DTZ005 The use of `datetime.datetime.now()` without `tz` argument is not allowed
+DTZ005.py:10:1: DTZ005 Using `datetime.datetime.now()` without specifying a timezone is not allowed
    |
  9 | # none args
 10 | datetime.datetime.now(None)
@@ -28,7 +28,7 @@ DTZ005.py:10:1: DTZ005 The use of `datetime.datetime.now()` without `tz` argumen
 12 | # none keywords
    |
 
-DTZ005.py:13:1: DTZ005 The use of `datetime.datetime.now()` without `tz` argument is not allowed
+DTZ005.py:13:1: DTZ005 Using `datetime.datetime.now()` without specifying a timezone is not allowed
    |
 12 | # none keywords
 13 | datetime.datetime.now(tz=None)
@@ -37,7 +37,7 @@ DTZ005.py:13:1: DTZ005 The use of `datetime.datetime.now()` without `tz` argumen
 15 | from datetime import datetime
    |
 
-DTZ005.py:18:1: DTZ005 The use of `datetime.datetime.now()` without `tz` argument is not allowed
+DTZ005.py:18:1: DTZ005 Using `datetime.datetime.now()` without specifying a timezone is not allowed
    |
 17 | # no args unqualified
 18 | datetime.now()
@@ -45,5 +45,3 @@ DTZ005.py:18:1: DTZ005 The use of `datetime.datetime.now()` without `tz` argumen
 19 | 
 20 | # uses `astimezone` method
    |
-
-

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ006_DTZ006.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ006_DTZ006.py.snap
@@ -19,7 +19,7 @@ DTZ006.py:7:1: DTZ006 The use of `datetime.datetime.fromtimestamp()` without `tz
 9 | # none args
   |
 
-DTZ006.py:10:1: DTZ006 The use of `datetime.datetime.fromtimestamp()` without `tz` argument is not allowed
+DTZ006.py:10:1: DTZ006 Passing `tz=None` is forbidden, as it creates a naive datetime object
    |
  9 | # none args
 10 | datetime.datetime.fromtimestamp(1234, None)
@@ -28,7 +28,7 @@ DTZ006.py:10:1: DTZ006 The use of `datetime.datetime.fromtimestamp()` without `t
 12 | # none keywords
    |
 
-DTZ006.py:13:1: DTZ006 The use of `datetime.datetime.fromtimestamp()` without `tz` argument is not allowed
+DTZ006.py:13:1: DTZ006 Passing `tz=None` is forbidden, as it creates a naive datetime object
    |
 12 | # none keywords
 13 | datetime.datetime.fromtimestamp(1234, tz=None)
@@ -45,5 +45,3 @@ DTZ006.py:18:1: DTZ006 The use of `datetime.datetime.fromtimestamp()` without `t
 19 | 
 20 | # uses `astimezone` method
    |
-
-

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ006_DTZ006.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ006_DTZ006.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_datetimez/mod.rs
 ---
-DTZ006.py:4:1: DTZ006 The use of `datetime.datetime.fromtimestamp()` without `tz` argument is not allowed
+DTZ006.py:4:1: DTZ006 `datetime.datetime.fromtimestamp()` called without a `tz` argument
   |
 3 | # no args
 4 | datetime.datetime.fromtimestamp(1234)
@@ -9,8 +9,9 @@ DTZ006.py:4:1: DTZ006 The use of `datetime.datetime.fromtimestamp()` without `tz
 5 | 
 6 | # wrong keywords
   |
+  = help: Pass a `datetime.timezone` object to the `tz` parameter
 
-DTZ006.py:7:1: DTZ006 The use of `datetime.datetime.fromtimestamp()` without `tz` argument is not allowed
+DTZ006.py:7:1: DTZ006 `datetime.datetime.fromtimestamp()` called without a `tz` argument
   |
 6 | # wrong keywords
 7 | datetime.datetime.fromtimestamp(1234, bad=datetime.timezone.utc)
@@ -18,8 +19,9 @@ DTZ006.py:7:1: DTZ006 The use of `datetime.datetime.fromtimestamp()` without `tz
 8 | 
 9 | # none args
   |
+  = help: Pass a `datetime.timezone` object to the `tz` parameter
 
-DTZ006.py:10:1: DTZ006 Passing `tz=None` is forbidden, as it creates a naive datetime object
+DTZ006.py:10:1: DTZ006 `tz=None` passed to `datetime.datetime.fromtimestamp()`
    |
  9 | # none args
 10 | datetime.datetime.fromtimestamp(1234, None)
@@ -27,8 +29,9 @@ DTZ006.py:10:1: DTZ006 Passing `tz=None` is forbidden, as it creates a naive dat
 11 | 
 12 | # none keywords
    |
+   = help: Pass a `datetime.timezone` object to the `tz` parameter
 
-DTZ006.py:13:1: DTZ006 Passing `tz=None` is forbidden, as it creates a naive datetime object
+DTZ006.py:13:1: DTZ006 `tz=None` passed to `datetime.datetime.fromtimestamp()`
    |
 12 | # none keywords
 13 | datetime.datetime.fromtimestamp(1234, tz=None)
@@ -36,8 +39,9 @@ DTZ006.py:13:1: DTZ006 Passing `tz=None` is forbidden, as it creates a naive dat
 14 | 
 15 | from datetime import datetime
    |
+   = help: Pass a `datetime.timezone` object to the `tz` parameter
 
-DTZ006.py:18:1: DTZ006 The use of `datetime.datetime.fromtimestamp()` without `tz` argument is not allowed
+DTZ006.py:18:1: DTZ006 `datetime.datetime.fromtimestamp()` called without a `tz` argument
    |
 17 | # no args unqualified
 18 | datetime.fromtimestamp(1234)
@@ -45,3 +49,4 @@ DTZ006.py:18:1: DTZ006 The use of `datetime.datetime.fromtimestamp()` without `t
 19 | 
 20 | # uses `astimezone` method
    |
+   = help: Pass a `datetime.timezone` object to the `tz` parameter

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ007_DTZ007.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ007_DTZ007.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_datetimez/mod.rs
 ---
-DTZ007.py:4:1: DTZ007 The use of `datetime.datetime.strptime()` without %z must be followed by `.replace(tzinfo=)` or `.astimezone()`
+DTZ007.py:4:1: DTZ007 Naive datetime constructed using `datetime.datetime.strptime()` without %z
   |
 3 | # bad format
 4 | datetime.datetime.strptime("something", "%H:%M:%S%Z")
@@ -9,8 +9,9 @@ DTZ007.py:4:1: DTZ007 The use of `datetime.datetime.strptime()` without %z must 
 5 | 
 6 | # no replace or astimezone
   |
+  = help: Call `.replace(tzinfo=)` or `.astimezone()` to convert to an aware datetime
 
-DTZ007.py:7:1: DTZ007 The use of `datetime.datetime.strptime()` without %z must be followed by `.replace(tzinfo=)` or `.astimezone()`
+DTZ007.py:7:1: DTZ007 Naive datetime constructed using `datetime.datetime.strptime()` without %z
   |
 6 | # no replace or astimezone
 7 | datetime.datetime.strptime("something", "something")
@@ -18,8 +19,9 @@ DTZ007.py:7:1: DTZ007 The use of `datetime.datetime.strptime()` without %z must 
 8 | 
 9 | # wrong replace
   |
+  = help: Call `.replace(tzinfo=)` or `.astimezone()` to convert to an aware datetime
 
-DTZ007.py:10:1: DTZ007 The use of `datetime.datetime.strptime()` without %z must be followed by `.replace(tzinfo=)` or `.astimezone()`
+DTZ007.py:10:1: DTZ007 Naive datetime constructed using `datetime.datetime.strptime()` without %z
    |
  9 | # wrong replace
 10 | datetime.datetime.strptime("something", "something").replace(hour=1)
@@ -27,8 +29,9 @@ DTZ007.py:10:1: DTZ007 The use of `datetime.datetime.strptime()` without %z must
 11 | 
 12 | # none replace
    |
+   = help: Call `.replace(tzinfo=)` or `.astimezone()` to convert to an aware datetime
 
-DTZ007.py:13:1: DTZ007 Passing `tzinfo=None` to `datetime.datetime.replace()` is forbidden, as it creates a naive datetime object
+DTZ007.py:13:1: DTZ007 `datetime.datetime.strptime(...).replace(tz=None)` used
    |
 12 | # none replace
 13 | datetime.datetime.strptime("something", "something").replace(tzinfo=None)
@@ -36,10 +39,12 @@ DTZ007.py:13:1: DTZ007 Passing `tzinfo=None` to `datetime.datetime.replace()` is
 14 | 
 15 | # OK
    |
+   = help: Pass a `datetime.timezone` object to `tzinfo=`
 
-DTZ007.py:35:1: DTZ007 The use of `datetime.datetime.strptime()` without %z must be followed by `.replace(tzinfo=)` or `.astimezone()`
+DTZ007.py:35:1: DTZ007 Naive datetime constructed using `datetime.datetime.strptime()` without %z
    |
 34 | # no replace orastimezone unqualified
 35 | datetime.strptime("something", "something")
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ DTZ007
    |
+   = help: Call `.replace(tzinfo=)` or `.astimezone()` to convert to an aware datetime

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ007_DTZ007.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ007_DTZ007.py.snap
@@ -9,7 +9,7 @@ DTZ007.py:4:1: DTZ007 Naive datetime constructed using `datetime.datetime.strpti
 5 | 
 6 | # no replace or astimezone
   |
-  = help: Call `.replace(tzinfo=)` or `.astimezone()` to convert to an aware datetime
+  = help: Call `.replace(tzinfo=<timezone>)` or `.astimezone()` to convert to an aware datetime
 
 DTZ007.py:7:1: DTZ007 Naive datetime constructed using `datetime.datetime.strptime()` without %z
   |
@@ -19,7 +19,7 @@ DTZ007.py:7:1: DTZ007 Naive datetime constructed using `datetime.datetime.strpti
 8 | 
 9 | # wrong replace
   |
-  = help: Call `.replace(tzinfo=)` or `.astimezone()` to convert to an aware datetime
+  = help: Call `.replace(tzinfo=<timezone>)` or `.astimezone()` to convert to an aware datetime
 
 DTZ007.py:10:1: DTZ007 Naive datetime constructed using `datetime.datetime.strptime()` without %z
    |
@@ -29,7 +29,7 @@ DTZ007.py:10:1: DTZ007 Naive datetime constructed using `datetime.datetime.strpt
 11 | 
 12 | # none replace
    |
-   = help: Call `.replace(tzinfo=)` or `.astimezone()` to convert to an aware datetime
+   = help: Call `.replace(tzinfo=<timezone>)` or `.astimezone()` to convert to an aware datetime
 
 DTZ007.py:13:1: DTZ007 `datetime.datetime.strptime(...).replace(tz=None)` used
    |
@@ -39,7 +39,7 @@ DTZ007.py:13:1: DTZ007 `datetime.datetime.strptime(...).replace(tz=None)` used
 14 | 
 15 | # OK
    |
-   = help: Pass a `datetime.timezone` object to `tzinfo=`
+   = help: Pass a `datetime.timezone` object to the `tzinfo` parameter
 
 DTZ007.py:35:1: DTZ007 Naive datetime constructed using `datetime.datetime.strptime()` without %z
    |
@@ -47,4 +47,4 @@ DTZ007.py:35:1: DTZ007 Naive datetime constructed using `datetime.datetime.strpt
 35 | datetime.strptime("something", "something")
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ DTZ007
    |
-   = help: Call `.replace(tzinfo=)` or `.astimezone()` to convert to an aware datetime
+   = help: Call `.replace(tzinfo=<timezone>)` or `.astimezone()` to convert to an aware datetime

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ007_DTZ007.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ007_DTZ007.py.snap
@@ -28,7 +28,7 @@ DTZ007.py:10:1: DTZ007 The use of `datetime.datetime.strptime()` without %z must
 12 | # none replace
    |
 
-DTZ007.py:13:1: DTZ007 The use of `datetime.datetime.strptime()` without %z must be followed by `.replace(tzinfo=)` or `.astimezone()`
+DTZ007.py:13:1: DTZ007 Passing `tzinfo=None` to `datetime.datetime.replace()` is forbidden, as it creates a naive datetime object
    |
 12 | # none replace
 13 | datetime.datetime.strptime("something", "something").replace(tzinfo=None)
@@ -43,5 +43,3 @@ DTZ007.py:35:1: DTZ007 The use of `datetime.datetime.strptime()` without %z must
 35 | datetime.strptime("something", "something")
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ DTZ007
    |
-
-

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ011_DTZ011.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ011_DTZ011.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_datetimez/mod.rs
 ---
-DTZ011.py:4:1: DTZ011 The use of `datetime.date.today()` is not allowed, use `datetime.datetime.now(tz=).date()` instead
+DTZ011.py:4:1: DTZ011 `datetime.date.today()` used
   |
 3 | # qualified
 4 | datetime.date.today()
@@ -9,12 +9,12 @@ DTZ011.py:4:1: DTZ011 The use of `datetime.date.today()` is not allowed, use `da
 5 | 
 6 | from datetime import date
   |
+  = help: Use `datetime.datetime.now(tz=).date()` instead
 
-DTZ011.py:9:1: DTZ011 The use of `datetime.date.today()` is not allowed, use `datetime.datetime.now(tz=).date()` instead
+DTZ011.py:9:1: DTZ011 `datetime.date.today()` used
   |
 8 | # unqualified
 9 | date.today()
   | ^^^^^^^^^^^^ DTZ011
   |
-
-
+  = help: Use `datetime.datetime.now(tz=).date()` instead

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ011_DTZ011.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ011_DTZ011.py.snap
@@ -9,7 +9,7 @@ DTZ011.py:4:1: DTZ011 `datetime.date.today()` used
 5 | 
 6 | from datetime import date
   |
-  = help: Use `datetime.datetime.now(tz=).date()` instead
+  = help: Use `datetime.datetime.now(tz=...).date()` instead
 
 DTZ011.py:9:1: DTZ011 `datetime.date.today()` used
   |
@@ -17,4 +17,4 @@ DTZ011.py:9:1: DTZ011 `datetime.date.today()` used
 9 | date.today()
   | ^^^^^^^^^^^^ DTZ011
   |
-  = help: Use `datetime.datetime.now(tz=).date()` instead
+  = help: Use `datetime.datetime.now(tz=...).date()` instead

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ012_DTZ012.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ012_DTZ012.py.snap
@@ -9,7 +9,7 @@ DTZ012.py:4:1: DTZ012 `datetime.date.fromtimestamp()` used
 5 | 
 6 | from datetime import date
   |
-  = help: Use `datetime.datetime.fromtimestamp(ts, tz=).date()` instead
+  = help: Use `datetime.datetime.fromtimestamp(ts, tz=...).date()` instead
 
 DTZ012.py:9:1: DTZ012 `datetime.date.fromtimestamp()` used
   |
@@ -17,4 +17,4 @@ DTZ012.py:9:1: DTZ012 `datetime.date.fromtimestamp()` used
 9 | date.fromtimestamp(1234)
   | ^^^^^^^^^^^^^^^^^^^^^^^^ DTZ012
   |
-  = help: Use `datetime.datetime.fromtimestamp(ts, tz=).date()` instead
+  = help: Use `datetime.datetime.fromtimestamp(ts, tz=...).date()` instead

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ012_DTZ012.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ012_DTZ012.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_datetimez/mod.rs
 ---
-DTZ012.py:4:1: DTZ012 The use of `datetime.date.fromtimestamp()` is not allowed, use `datetime.datetime.fromtimestamp(ts, tz=).date()` instead
+DTZ012.py:4:1: DTZ012 `datetime.date.fromtimestamp()` used
   |
 3 | # qualified
 4 | datetime.date.fromtimestamp(1234)
@@ -9,12 +9,12 @@ DTZ012.py:4:1: DTZ012 The use of `datetime.date.fromtimestamp()` is not allowed,
 5 | 
 6 | from datetime import date
   |
+  = help: Use `datetime.datetime.fromtimestamp(ts, tz=).date()` instead
 
-DTZ012.py:9:1: DTZ012 The use of `datetime.date.fromtimestamp()` is not allowed, use `datetime.datetime.fromtimestamp(ts, tz=).date()` instead
+DTZ012.py:9:1: DTZ012 `datetime.date.fromtimestamp()` used
   |
 8 | # unqualified
 9 | date.fromtimestamp(1234)
   | ^^^^^^^^^^^^^^^^^^^^^^^^ DTZ012
   |
-
-
+  = help: Use `datetime.datetime.fromtimestamp(ts, tz=).date()` instead


### PR DESCRIPTION
Fixes #10251. Closes #10590.

## Summary

This PR builds upon #10590, by @cclauss. The problem with DTZ005 pointed out in #10251 is really a common problem to most of the DTZ rules, so it makes sense to tackle them all at the same time.

Changes made:

- Clearly state in the documentation that passing `tz=None` is just as bad as not passing a `tz=` argument, from the perspective of these rules.
- Clearly state in the error messages exactly what the user is doing wrong, if the user is passing `tz=None` rather than failing to pass a `tz=` argument at all.
- Make error messages more concise, and separate out the suggested remedy from the thing that the user is identified as doing wrong.

## Test Plan

`cargo test`

---

Co-authored-by: Christian Clauss <cclauss@me.com>