### PR TITLE
Add tests for list comprehension

### DIFF
--- a/crates/ruff_python_parser/resources/invalid/expressions/list/comprehension.py
+++ b/crates/ruff_python_parser/resources/invalid/expressions/list/comprehension.py
@@ -1,0 +1,20 @@
+# Iterable unpacking not allowed
+[*x for x in y]
+
+# Invalid target
+[x for 1 in y]
+[x for 'a' in y]
+[x for call() in y]
+[x for {a, b} in y]
+
+# Invalid iter
+[x for x in *y]
+[x for x in yield y]
+[x for x in yield from y]
+[x for x in lambda y: y]
+
+# Invalid if
+[x for x in data if *y]
+[x for x in data if yield y]
+[x for x in data if yield from y]
+[x for x in data if lambda y: y]

--- a/crates/ruff_python_parser/resources/valid/expressions/list_comprehension.py
+++ b/crates/ruff_python_parser/resources/valid/expressions/list_comprehension.py
@@ -14,3 +14,12 @@ x = [y for y in (1, 2, 3)]
 [i for i in (await x if True else X) if F]
 [i for i in await (x if True else X) if F]
 [f for f in c(x if True else [])]
+
+# Non-parenthesized iter/if for the following expressions aren't allowed, so make sure
+# it parses correctly for the parenthesized cases
+[x for x in (yield y)]
+[x for x in (yield from y)]
+[x for x in (lambda y: y)]
+[x for x in data if (yield y)]
+[x for x in data if (yield from y)]
+[x for x in data if (lambda y: y)]

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -117,6 +117,8 @@ pub enum ParseErrorType {
     DefaultArgumentError,
     /// A simple statement and a compound statement was found in the same line.
     SimpleStmtAndCompoundStmtInSameLine,
+    /// An invalid usage of iterable unpacking in a comprehension was found.
+    IterableUnpackingInComprehension,
 
     /// An invalid `match` case pattern was found.
     InvalidMatchPatternLiteral { pattern: TokenKind },
@@ -177,6 +179,9 @@ impl std::fmt::Display for ParseErrorType {
                     f,
                     "iterable argument unpacking follows keyword argument unpacking"
                 )
+            }
+            ParseErrorType::IterableUnpackingInComprehension => {
+                write!(f, "iterable unpacking cannot be used in a comprehension")
             }
             ParseErrorType::PositionalArgumentError => {
                 write!(f, "positional argument follows keyword argument unpacking")

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1264,6 +1264,15 @@ impl<'src> Parser<'src> {
 
         match self.current_token_kind() {
             TokenKind::Async | TokenKind::For => {
+                // Parenthesized starred expression isn't allowed either but that is
+                // handled by the `parse_parenthesized_expression` method.
+                if !first_element.is_parenthesized && first_element.is_starred_expr() {
+                    self.add_error(
+                        ParseErrorType::IterableUnpackingInComprehension,
+                        &first_element,
+                    );
+                }
+
                 Expr::ListComp(self.parse_list_comprehension_expression(first_element.expr, start))
             }
             _ => Expr::List(self.parse_list_expression(first_element.expr, start)),
@@ -1719,6 +1728,9 @@ impl<'src> Parser<'src> {
         }
     }
 
+    /// Parses a list comprehension expression.
+    ///
+    /// See: <https://docs.python.org/3/reference/expressions.html#displays-for-lists-sets-and-dictionaries>
     fn parse_list_comprehension_expression(
         &mut self,
         element: Expr,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__comprehension.py.snap
@@ -1,0 +1,796 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/expressions/list/comprehension.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        range: 0..376,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 33..48,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 33..48,
+                            elt: Starred(
+                                ExprStarred {
+                                    range: 34..36,
+                                    value: Name(
+                                        ExprName {
+                                            range: 35..36,
+                                            id: "x",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 37..47,
+                                    target: Name(
+                                        ExprName {
+                                            range: 41..42,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            range: 46..47,
+                                            id: "y",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 67..81,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 67..81,
+                            elt: Name(
+                                ExprName {
+                                    range: 68..69,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 70..80,
+                                    target: NumberLiteral(
+                                        ExprNumberLiteral {
+                                            range: 74..75,
+                                            value: Int(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            range: 79..80,
+                                            id: "y",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 82..98,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 82..98,
+                            elt: Name(
+                                ExprName {
+                                    range: 83..84,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 85..97,
+                                    target: StringLiteral(
+                                        ExprStringLiteral {
+                                            range: 89..92,
+                                            value: StringLiteralValue {
+                                                inner: Single(
+                                                    StringLiteral {
+                                                        range: 89..92,
+                                                        value: "a",
+                                                        flags: StringLiteralFlags {
+                                                            quote_style: Single,
+                                                            prefix: Empty,
+                                                            triple_quoted: false,
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            range: 96..97,
+                                            id: "y",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 99..118,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 99..118,
+                            elt: Name(
+                                ExprName {
+                                    range: 100..101,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 102..117,
+                                    target: Call(
+                                        ExprCall {
+                                            range: 106..112,
+                                            func: Name(
+                                                ExprName {
+                                                    range: 106..110,
+                                                    id: "call",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            arguments: Arguments {
+                                                range: 110..112,
+                                                args: [],
+                                                keywords: [],
+                                            },
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            range: 116..117,
+                                            id: "y",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 119..138,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 119..138,
+                            elt: Name(
+                                ExprName {
+                                    range: 120..121,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 122..137,
+                                    target: Set(
+                                        ExprSet {
+                                            range: 126..132,
+                                            elts: [
+                                                Name(
+                                                    ExprName {
+                                                        range: 127..128,
+                                                        id: "a",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                Name(
+                                                    ExprName {
+                                                        range: 130..131,
+                                                        id: "b",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            range: 136..137,
+                                            id: "y",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 155..170,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 155..170,
+                            elt: Name(
+                                ExprName {
+                                    range: 156..157,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 158..169,
+                                    target: Name(
+                                        ExprName {
+                                            range: 162..163,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Starred(
+                                        ExprStarred {
+                                            range: 167..169,
+                                            value: Name(
+                                                ExprName {
+                                                    range: 168..169,
+                                                    id: "y",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 171..191,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 171..191,
+                            elt: Name(
+                                ExprName {
+                                    range: 172..173,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 174..190,
+                                    target: Name(
+                                        ExprName {
+                                            range: 178..179,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Yield(
+                                        ExprYield {
+                                            range: 183..190,
+                                            value: Some(
+                                                Name(
+                                                    ExprName {
+                                                        range: 189..190,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 192..217,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 192..217,
+                            elt: Name(
+                                ExprName {
+                                    range: 193..194,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 195..216,
+                                    target: Name(
+                                        ExprName {
+                                            range: 199..200,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: YieldFrom(
+                                        ExprYieldFrom {
+                                            range: 204..216,
+                                            value: Name(
+                                                ExprName {
+                                                    range: 215..216,
+                                                    id: "y",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 218..242,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 218..242,
+                            elt: Name(
+                                ExprName {
+                                    range: 219..220,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 221..241,
+                                    target: Name(
+                                        ExprName {
+                                            range: 225..226,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Lambda(
+                                        ExprLambda {
+                                            range: 230..241,
+                                            parameters: Some(
+                                                Parameters {
+                                                    range: 237..238,
+                                                    posonlyargs: [],
+                                                    args: [
+                                                        ParameterWithDefault {
+                                                            range: 237..238,
+                                                            parameter: Parameter {
+                                                                range: 237..238,
+                                                                name: Identifier {
+                                                                    id: "y",
+                                                                    range: 237..238,
+                                                                },
+                                                                annotation: None,
+                                                            },
+                                                            default: None,
+                                                        },
+                                                    ],
+                                                    vararg: None,
+                                                    kwonlyargs: [],
+                                                    kwarg: None,
+                                                },
+                                            ),
+                                            body: Name(
+                                                ExprName {
+                                                    range: 240..241,
+                                                    id: "y",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 257..280,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 257..280,
+                            elt: Name(
+                                ExprName {
+                                    range: 258..259,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 260..279,
+                                    target: Name(
+                                        ExprName {
+                                            range: 264..265,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            range: 269..273,
+                                            id: "data",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [
+                                        Starred(
+                                            ExprStarred {
+                                                range: 277..279,
+                                                value: Name(
+                                                    ExprName {
+                                                        range: 278..279,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 281..309,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 281..309,
+                            elt: Name(
+                                ExprName {
+                                    range: 282..283,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 284..308,
+                                    target: Name(
+                                        ExprName {
+                                            range: 288..289,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            range: 293..297,
+                                            id: "data",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [
+                                        Yield(
+                                            ExprYield {
+                                                range: 301..308,
+                                                value: Some(
+                                                    Name(
+                                                        ExprName {
+                                                            range: 307..308,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 310..343,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 310..343,
+                            elt: Name(
+                                ExprName {
+                                    range: 311..312,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 313..342,
+                                    target: Name(
+                                        ExprName {
+                                            range: 317..318,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            range: 322..326,
+                                            id: "data",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [
+                                        YieldFrom(
+                                            ExprYieldFrom {
+                                                range: 330..342,
+                                                value: Name(
+                                                    ExprName {
+                                                        range: 341..342,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 344..376,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 344..376,
+                            elt: Name(
+                                ExprName {
+                                    range: 345..346,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 347..375,
+                                    target: Name(
+                                        ExprName {
+                                            range: 351..352,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            range: 356..360,
+                                            id: "data",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [
+                                        Lambda(
+                                            ExprLambda {
+                                                range: 364..375,
+                                                parameters: Some(
+                                                    Parameters {
+                                                        range: 371..372,
+                                                        posonlyargs: [],
+                                                        args: [
+                                                            ParameterWithDefault {
+                                                                range: 371..372,
+                                                                parameter: Parameter {
+                                                                    range: 371..372,
+                                                                    name: Identifier {
+                                                                        id: "y",
+                                                                        range: 371..372,
+                                                                    },
+                                                                    annotation: None,
+                                                                },
+                                                                default: None,
+                                                            },
+                                                        ],
+                                                        vararg: None,
+                                                        kwonlyargs: [],
+                                                        kwarg: None,
+                                                    },
+                                                ),
+                                                body: Name(
+                                                    ExprName {
+                                                        range: 374..375,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | # Iterable unpacking not allowed
+2 | [*x for x in y]
+  |  ^^ Syntax Error: iterable unpacking cannot be used in a comprehension
+3 | 
+4 | # Invalid target
+  |
+
+
+  |
+4 | # Invalid target
+5 | [x for 1 in y]
+  |        ^ Syntax Error: invalid assignment target
+6 | [x for 'a' in y]
+7 | [x for call() in y]
+  |
+
+
+  |
+4 | # Invalid target
+5 | [x for 1 in y]
+6 | [x for 'a' in y]
+  |        ^^^ Syntax Error: invalid assignment target
+7 | [x for call() in y]
+8 | [x for {a, b} in y]
+  |
+
+
+  |
+5 | [x for 1 in y]
+6 | [x for 'a' in y]
+7 | [x for call() in y]
+  |        ^^^^^^ Syntax Error: invalid assignment target
+8 | [x for {a, b} in y]
+  |
+
+
+   |
+ 6 | [x for 'a' in y]
+ 7 | [x for call() in y]
+ 8 | [x for {a, b} in y]
+   |        ^^^^^^ Syntax Error: invalid assignment target
+ 9 | 
+10 | # Invalid iter
+   |
+
+
+   |
+10 | # Invalid iter
+11 | [x for x in *y]
+   |             ^^ Syntax Error: starred expression cannot be used here
+12 | [x for x in yield y]
+13 | [x for x in yield from y]
+   |
+
+
+   |
+10 | # Invalid iter
+11 | [x for x in *y]
+12 | [x for x in yield y]
+   |             ^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+13 | [x for x in yield from y]
+14 | [x for x in lambda y: y]
+   |
+
+
+   |
+11 | [x for x in *y]
+12 | [x for x in yield y]
+13 | [x for x in yield from y]
+   |             ^^^^^^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+14 | [x for x in lambda y: y]
+   |
+
+
+   |
+12 | [x for x in yield y]
+13 | [x for x in yield from y]
+14 | [x for x in lambda y: y]
+   |             ^^^^^^^^^^^ Syntax Error: unparenthesized lambda expression cannot be used here
+15 | 
+16 | # Invalid if
+   |
+
+
+   |
+16 | # Invalid if
+17 | [x for x in data if *y]
+   |                     ^^ Syntax Error: starred expression cannot be used here
+18 | [x for x in data if yield y]
+19 | [x for x in data if yield from y]
+   |
+
+
+   |
+16 | # Invalid if
+17 | [x for x in data if *y]
+18 | [x for x in data if yield y]
+   |                     ^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+19 | [x for x in data if yield from y]
+20 | [x for x in data if lambda y: y]
+   |
+
+
+   |
+17 | [x for x in data if *y]
+18 | [x for x in data if yield y]
+19 | [x for x in data if yield from y]
+   |                     ^^^^^^^^^^^^ Syntax Error: unparenthesized yield expression cannot be used here
+20 | [x for x in data if lambda y: y]
+   |
+
+
+   |
+18 | [x for x in data if yield y]
+19 | [x for x in data if yield from y]
+20 | [x for x in data if lambda y: y]
+   |                     ^^^^^^^^^^^ Syntax Error: unparenthesized lambda expression cannot be used here
+   |

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__list_comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__list_comprehension.py.snap
@@ -7,7 +7,7 @@ input_file: crates/ruff_python_parser/resources/valid/expressions/list_comprehen
 ```
 Module(
     ModModule {
-        range: 0..458,
+        range: 0..776,
         body: [
             Assign(
                 StmtAssign {
@@ -945,6 +945,338 @@ Module(
                                         },
                                     ),
                                     ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 596..618,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 596..618,
+                            elt: Name(
+                                ExprName {
+                                    range: 597..598,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 599..617,
+                                    target: Name(
+                                        ExprName {
+                                            range: 603..604,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Yield(
+                                        ExprYield {
+                                            range: 609..616,
+                                            value: Some(
+                                                Name(
+                                                    ExprName {
+                                                        range: 615..616,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 619..646,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 619..646,
+                            elt: Name(
+                                ExprName {
+                                    range: 620..621,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 622..645,
+                                    target: Name(
+                                        ExprName {
+                                            range: 626..627,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: YieldFrom(
+                                        ExprYieldFrom {
+                                            range: 632..644,
+                                            value: Name(
+                                                ExprName {
+                                                    range: 643..644,
+                                                    id: "y",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 647..673,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 647..673,
+                            elt: Name(
+                                ExprName {
+                                    range: 648..649,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 650..672,
+                                    target: Name(
+                                        ExprName {
+                                            range: 654..655,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Lambda(
+                                        ExprLambda {
+                                            range: 660..671,
+                                            parameters: Some(
+                                                Parameters {
+                                                    range: 667..668,
+                                                    posonlyargs: [],
+                                                    args: [
+                                                        ParameterWithDefault {
+                                                            range: 667..668,
+                                                            parameter: Parameter {
+                                                                range: 667..668,
+                                                                name: Identifier {
+                                                                    id: "y",
+                                                                    range: 667..668,
+                                                                },
+                                                                annotation: None,
+                                                            },
+                                                            default: None,
+                                                        },
+                                                    ],
+                                                    vararg: None,
+                                                    kwonlyargs: [],
+                                                    kwarg: None,
+                                                },
+                                            ),
+                                            body: Name(
+                                                ExprName {
+                                                    range: 670..671,
+                                                    id: "y",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 674..704,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 674..704,
+                            elt: Name(
+                                ExprName {
+                                    range: 675..676,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 677..703,
+                                    target: Name(
+                                        ExprName {
+                                            range: 681..682,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            range: 686..690,
+                                            id: "data",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [
+                                        Yield(
+                                            ExprYield {
+                                                range: 695..702,
+                                                value: Some(
+                                                    Name(
+                                                        ExprName {
+                                                            range: 701..702,
+                                                            id: "y",
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 705..740,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 705..740,
+                            elt: Name(
+                                ExprName {
+                                    range: 706..707,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 708..739,
+                                    target: Name(
+                                        ExprName {
+                                            range: 712..713,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            range: 717..721,
+                                            id: "data",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [
+                                        YieldFrom(
+                                            ExprYieldFrom {
+                                                range: 726..738,
+                                                value: Name(
+                                                    ExprName {
+                                                        range: 737..738,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    range: 741..775,
+                    value: ListComp(
+                        ExprListComp {
+                            range: 741..775,
+                            elt: Name(
+                                ExprName {
+                                    range: 742..743,
+                                    id: "x",
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 744..774,
+                                    target: Name(
+                                        ExprName {
+                                            range: 748..749,
+                                            id: "x",
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            range: 753..757,
+                                            id: "data",
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [
+                                        Lambda(
+                                            ExprLambda {
+                                                range: 762..773,
+                                                parameters: Some(
+                                                    Parameters {
+                                                        range: 769..770,
+                                                        posonlyargs: [],
+                                                        args: [
+                                                            ParameterWithDefault {
+                                                                range: 769..770,
+                                                                parameter: Parameter {
+                                                                    range: 769..770,
+                                                                    name: Identifier {
+                                                                        id: "y",
+                                                                        range: 769..770,
+                                                                    },
+                                                                    annotation: None,
+                                                                },
+                                                                default: None,
+                                                            },
+                                                        ],
+                                                        vararg: None,
+                                                        kwonlyargs: [],
+                                                        kwarg: None,
+                                                    },
+                                                ),
+                                                body: Name(
+                                                    ExprName {
+                                                        range: 772..773,
+                                                        id: "y",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
                                     is_async: false,
                                 },
                             ],


### PR DESCRIPTION
## Summary

This PR adds tests for list comprehension.

It also adds a new parser error type which will be raised if a starred expression is being used in a comprehension.

```py
  [*x for x in y]
#  ^^
#  iterable unpacking cannot be used in a comprehension
```
