### PR TITLE
[`pylint`] Don't recommend decorating staticmethods with `@singledispatch` (`PLE1519`, `PLE1520`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/singledispatch_method.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/singledispatch_method.py
@@ -20,7 +20,7 @@ class Board:
     def place(self, position):
         pass
 
-    @singledispatch
+    @singledispatch  # [singledispatch-method]
     @staticmethod
     def do(position):
         pass

--- a/crates/ruff_linter/resources/test/fixtures/pylint/singledispatchmethod_function.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/singledispatchmethod_function.py
@@ -17,7 +17,7 @@ class Board:
     def move(self, position):
         pass
 
-    @singledispatchmethod  # [singledispatchmethod-function]
+    @singledispatchmethod  # Ok
     @staticmethod
     def do(position):
         pass

--- a/crates/ruff_linter/src/rules/pylint/rules/singledispatch_method.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/singledispatch_method.rs
@@ -88,7 +88,9 @@ pub(crate) fn singledispatch_method(
     );
     if !matches!(
         type_,
-        function_type::FunctionType::Method | function_type::FunctionType::ClassMethod
+        function_type::FunctionType::Method
+            | function_type::FunctionType::ClassMethod
+            | function_type::FunctionType::StaticMethod
     ) {
         return;
     }

--- a/crates/ruff_linter/src/rules/pylint/rules/singledispatch_method.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/singledispatch_method.rs
@@ -9,13 +9,13 @@ use crate::checkers::ast::Checker;
 use crate::importer::ImportRequest;
 
 /// ## What it does
-/// Checks for `@singledispatch` decorators on class and instance methods.
+/// Checks for methods decorated with `@singledispatch`.
 ///
 /// ## Why is this bad?
 /// The `@singledispatch` decorator is intended for use with functions, not methods.
 ///
 /// Instead, use the `@singledispatchmethod` decorator, or migrate the method to a
-/// standalone function or `@staticmethod`.
+/// standalone function.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff_linter/src/rules/pylint/rules/singledispatchmethod_function.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/singledispatchmethod_function.rs
@@ -85,10 +85,7 @@ pub(crate) fn singledispatchmethod_function(
         &checker.settings.pep8_naming.classmethod_decorators,
         &checker.settings.pep8_naming.staticmethod_decorators,
     );
-    if !matches!(
-        type_,
-        function_type::FunctionType::Function | function_type::FunctionType::StaticMethod
-    ) {
+    if !matches!(type_, function_type::FunctionType::Function) {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/singledispatchmethod_function.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/singledispatchmethod_function.rs
@@ -9,12 +9,11 @@ use crate::checkers::ast::Checker;
 use crate::importer::ImportRequest;
 
 /// ## What it does
-/// Checks for `@singledispatchmethod` decorators on functions or static
-/// methods.
+/// Checks for non-method functions decorated with `@singledispatchmethod`.
 ///
 /// ## Why is this bad?
-/// The `@singledispatchmethod` decorator is intended for use with class and
-/// instance methods, not functions.
+/// The `@singledispatchmethod` decorator is intended for use with methods, not
+/// functions.
 ///
 /// Instead, use the `@singledispatch` decorator.
 ///

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE1519_singledispatch_method.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE1519_singledispatch_method.py.snap
@@ -40,4 +40,25 @@ singledispatch_method.py:15:5: PLE1519 [*] `@singledispatch` decorator should no
    15 |+    @singledispatchmethod  # [singledispatch-method]
 16 16 |     def move(self, position):
 17 17 |         pass
-18 18 |
+18 18 | 
+
+singledispatch_method.py:23:5: PLE1519 [*] `@singledispatch` decorator should not be used on methods
+   |
+21 |         pass
+22 | 
+23 |     @singledispatch  # [singledispatch-method]
+   |     ^^^^^^^^^^^^^^^ PLE1519
+24 |     @staticmethod
+25 |     def do(position):
+   |
+   = help: Replace with `@singledispatchmethod`
+
+ℹ Unsafe fix
+20 20 |     def place(self, position):
+21 21 |         pass
+22 22 | 
+23    |-    @singledispatch  # [singledispatch-method]
+   23 |+    @singledispatchmethod  # [singledispatch-method]
+24 24 |     @staticmethod
+25 25 |     def do(position):
+26 26 |         pass

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE1520_singledispatchmethod_function.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE1520_singledispatchmethod_function.py.snap
@@ -19,31 +19,4 @@ singledispatchmethod_function.py:4:1: PLE1520 [*] `@singledispatchmethod` decora
   4 |+@singledispatch  # [singledispatchmethod-function]
 5 5 | def convert_position(position):
 6 6 |     pass
-7 7 | 
-
-singledispatchmethod_function.py:20:5: PLE1520 [*] `@singledispatchmethod` decorator should not be used on non-method functions
-   |
-18 |         pass
-19 | 
-20 |     @singledispatchmethod  # [singledispatchmethod-function]
-   |     ^^^^^^^^^^^^^^^^^^^^^ PLE1520
-21 |     @staticmethod
-22 |     def do(position):
-   |
-   = help: Replace with `@singledispatch`
-
-ℹ Unsafe fix
-1     |-from functools import singledispatchmethod
-   1  |+from functools import singledispatchmethod, singledispatch
-2  2  | 
-3  3  | 
-4  4  | @singledispatchmethod  # [singledispatchmethod-function]
---------------------------------------------------------------------------------
-17 17 |     def move(self, position):
-18 18 |         pass
-19 19 | 
-20    |-    @singledispatchmethod  # [singledispatchmethod-function]
-   20 |+    @singledispatch  # [singledispatchmethod-function]
-21 21 |     @staticmethod
-22 22 |     def do(position):
-23 23 |         pass
+7 7 |


### PR DESCRIPTION
…andling

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Fixes #10619 

The behaviour, introduced in this PR, is different from original `pylint`'s one, but this one is more natural.

According to the docs of [staticmethod](https://docs.python.org/3/library/functions.html#staticmethod), the method marked with `@staticmethod` can be called via class (`C.foo()`) and via the instance (`C().foo()` (UFCS: `C.foo(C())`). Marking such method with `@singledispatch` allows only call via class, but not via the instance. Marking such method with `@singledispatchmethod` supports both `C.foo()` and `C().foo()`. The latter also is supported by [`singledispatchmethod` docs](https://docs.python.org/3/library/functools.html#functools.singledispatchmethod) via 
> @singledispatchmethod supports nesting with other decorators such as [@classmethod](https://docs.python.org/3/library/functions.html#classmethod). 
> ... 
> The same pattern can be used for other similar decorators: [@staticmethod](https://docs.python.org/3/library/functions.html#staticmethod), [@abstractmethod](https://docs.python.org/3/library/abc.html#abc.abstractmethod), and others.

<details><summary>Example</summary>
<p>

```python
class C:
    @singledispatchmethod
    @staticmethod
    def foo(x): raise NotImplementedError()

    @foo.register
    @staticmethod
    def _(x: int) -> int: return x


print(C.foo(1))
print(C().foo(1))
```
prints
```
1
1
```
but 
```python
class C:
    @singledispatch
    @staticmethod
    def foo(x): raise NotImplementedError()

    @foo.register
    @staticmethod
    def _(x: int) -> int: return x


print(C.foo(1))
print(C().foo(1))
```
fails with
```
C.foo() takes 1 positional argument but 2 were given
```
</p>
</details> 



<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
cargo test

<!-- How was it tested? -->
