### PR TITLE
[Python Formatter] Preserve empty lines

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/docstring.py
@@ -155,3 +155,12 @@ class TabbedIndent:
 def single_quoted():
     ' content\     '
     return
+
+
+def multiline_semi():
+    """
+    This is a multiline string ending with a semicolon
+    """;
+
+    a = "Another normal string"
+    pass

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/module_trailing_semi.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/module_trailing_semi.py
@@ -1,0 +1,8 @@
+b = """
+    This is a multiline string
+    ending with a useless
+    semicolon.
+""";
+
+
+a = "Another string. Keep the distance between 'a' and 'b'."

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/module_trailing_semi.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/module_trailing_semi.py
@@ -1,8 +1,7 @@
-b = """
-    This is a multiline string
-    ending with a useless
-    semicolon.
+"""
+    This is a multiline docstring
+    ending with a useless semicolon.
 """;
 
 
-a = "Another string. Keep the distance between 'a' and 'b'."
+"Another string. Keep the distance between 'a' and 'b'."

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.py
@@ -6,7 +6,7 @@
 "another normal string"
 
 
-def raw_docstring():
+def compound_statement():
 
     a = """
     This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.py
@@ -7,9 +7,8 @@
 
 
 def compound_statement():
-
-    a = """
-    This is a multiline string ending with a semicolon
+    """
+    This is a docstring in a notebook
     """;
 
     b = "Another normal string"

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.py
@@ -9,9 +9,8 @@
 def compound_statement():
 
     a = """
-    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
-    Ruff should leave it as is
+    This is a multiline string ending with a semicolon
     """;
 
-    b = "another normal string"
+    b = "Another normal string"
     pass

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_docstring.py
@@ -4,3 +4,14 @@
 """;
 
 "another normal string"
+
+
+def raw_docstring():
+
+    a = """
+    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
+    Ruff should leave it as is
+    """;
+
+    b = "another normal string"
+    pass

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -359,7 +359,7 @@ impl FormatRule<Suite, PyFormatContext<'_>> for FormatSuite {
                     .map_or(preceding.end(), |comment| comment.slice().end());
 
                 match node_level {
-                    NodeLevel::TopLevel(_) => match lines_after(end, source) {
+                    NodeLevel::TopLevel(_) => match lines_after_ignoring_end_of_line_trivia(end, source) {
                         0 | 1 => hard_line_break().fmt(f)?,
                         2 => empty_line().fmt(f)?,
                         _ => match source_type {

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -359,26 +359,22 @@ impl FormatRule<Suite, PyFormatContext<'_>> for FormatSuite {
                     .map_or(preceding.end(), |comment| comment.slice().end());
 
                 match node_level {
-                    NodeLevel::TopLevel(_) => {
-                        match lines_after_ignoring_end_of_line_trivia(end, source) {
-                            0 | 1 => hard_line_break().fmt(f)?,
-                            2 => empty_line().fmt(f)?,
-                            _ => match source_type {
-                                PySourceType::Stub => {
-                                    empty_line().fmt(f)?;
-                                }
-                                PySourceType::Python | PySourceType::Ipynb => {
-                                    write!(f, [empty_line(), empty_line()])?;
-                                }
-                            },
-                        }
-                    }
-                    NodeLevel::CompoundStatement => {
-                        match lines_after_ignoring_end_of_line_trivia(end, source) {
-                            0 | 1 => hard_line_break().fmt(f)?,
-                            _ => empty_line().fmt(f)?,
-                        }
-                    }
+                    NodeLevel::TopLevel(_) => match lines_after(end, source) {
+                        0 | 1 => hard_line_break().fmt(f)?,
+                        2 => empty_line().fmt(f)?,
+                        _ => match source_type {
+                            PySourceType::Stub => {
+                                empty_line().fmt(f)?;
+                            }
+                            PySourceType::Python | PySourceType::Ipynb => {
+                                write!(f, [empty_line(), empty_line()])?;
+                            }
+                        },
+                    },
+                    NodeLevel::CompoundStatement => match lines_after(end, source) {
+                        0 | 1 => hard_line_break().fmt(f)?,
+                        _ => empty_line().fmt(f)?,
+                    },
                     NodeLevel::Expression(_) | NodeLevel::ParenthesizedExpression => {
                         hard_line_break().fmt(f)?;
                     }

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -359,22 +359,26 @@ impl FormatRule<Suite, PyFormatContext<'_>> for FormatSuite {
                     .map_or(preceding.end(), |comment| comment.slice().end());
 
                 match node_level {
-                    NodeLevel::TopLevel(_) => match lines_after_ignoring_end_of_line_trivia(end, source) {
-                        0 | 1 => hard_line_break().fmt(f)?,
-                        2 => empty_line().fmt(f)?,
-                        _ => match source_type {
-                            PySourceType::Stub => {
-                                empty_line().fmt(f)?;
-                            }
-                            PySourceType::Python | PySourceType::Ipynb => {
-                                write!(f, [empty_line(), empty_line()])?;
-                            }
-                        },
-                    },
-                    NodeLevel::CompoundStatement => match lines_after_ignoring_end_of_line_trivia(end, source) {
-                        0 | 1 => hard_line_break().fmt(f)?,
-                        _ => empty_line().fmt(f)?,
-                    },
+                    NodeLevel::TopLevel(_) => {
+                        match lines_after_ignoring_end_of_line_trivia(end, source) {
+                            0 | 1 => hard_line_break().fmt(f)?,
+                            2 => empty_line().fmt(f)?,
+                            _ => match source_type {
+                                PySourceType::Stub => {
+                                    empty_line().fmt(f)?;
+                                }
+                                PySourceType::Python | PySourceType::Ipynb => {
+                                    write!(f, [empty_line(), empty_line()])?;
+                                }
+                            },
+                        }
+                    }
+                    NodeLevel::CompoundStatement => {
+                        match lines_after_ignoring_end_of_line_trivia(end, source) {
+                            0 | 1 => hard_line_break().fmt(f)?,
+                            _ => empty_line().fmt(f)?,
+                        }
+                    }
                     NodeLevel::Expression(_) | NodeLevel::ParenthesizedExpression => {
                         hard_line_break().fmt(f)?;
                     }

--- a/crates/ruff_python_formatter/src/statement/suite.rs
+++ b/crates/ruff_python_formatter/src/statement/suite.rs
@@ -371,7 +371,7 @@ impl FormatRule<Suite, PyFormatContext<'_>> for FormatSuite {
                             }
                         },
                     },
-                    NodeLevel::CompoundStatement => match lines_after(end, source) {
+                    NodeLevel::CompoundStatement => match lines_after_ignoring_end_of_line_trivia(end, source) {
                         0 | 1 => hard_line_break().fmt(f)?,
                         _ => empty_line().fmt(f)?,
                     },

--- a/crates/ruff_python_formatter/tests/snapshots/format@docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@docstring.py.snap
@@ -161,6 +161,15 @@ class TabbedIndent:
 def single_quoted():
     ' content\     '
     return
+
+
+def multiline_semi():
+    """
+    This is a multiline string ending with a semicolon
+    """;
+
+    a = "Another normal string"
+    pass
 ```
 
 ## Outputs
@@ -337,6 +346,15 @@ class TabbedIndent:
 def single_quoted():
     "content\ "
     return
+
+
+def multiline_semi():
+    """
+    This is a multiline string ending with a semicolon
+    """
+
+    a = "Another normal string"
+    pass
 ```
 
 
@@ -513,6 +531,15 @@ class TabbedIndent:
 def single_quoted():
   "content\ "
   return
+
+
+def multiline_semi():
+  """
+  This is a multiline string ending with a semicolon
+  """
+
+  a = "Another normal string"
+  pass
 ```
 
 
@@ -689,6 +716,15 @@ class TabbedIndent:
 def single_quoted():
 	"content\ "
 	return
+
+
+def multiline_semi():
+	"""
+	This is a multiline string ending with a semicolon
+	"""
+
+	a = "Another normal string"
+	pass
 ```
 
 
@@ -865,6 +901,15 @@ class TabbedIndent:
 def single_quoted():
 	"content\ "
 	return
+
+
+def multiline_semi():
+	"""
+	This is a multiline string ending with a semicolon
+	"""
+
+	a = "Another normal string"
+	pass
 ```
 
 
@@ -1041,4 +1086,13 @@ class TabbedIndent:
 def single_quoted():
     "content\ "
     return
+
+
+def multiline_semi():
+    """
+    This is a multiline string ending with a semicolon
+    """
+
+    a = 'Another normal string'
+    pass
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@module_trailing_semi.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@module_trailing_semi.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_python_formatter/tests/fixtures.rs
-assertion_line: 264
 input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/module_trailing_semi.py
 ---
 ## Input

--- a/crates/ruff_python_formatter/tests/snapshots/format@module_trailing_semi.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@module_trailing_semi.py.snap
@@ -1,0 +1,28 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+assertion_line: 264
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/module_trailing_semi.py
+---
+## Input
+```python
+b = """
+    This is a multiline string
+    ending with a useless
+    semicolon.
+""";
+
+
+a = "Another string. Keep the distance between 'a' and 'b'."
+```
+
+## Output
+```python
+b = """
+    This is a multiline string
+    ending with a useless
+    semicolon.
+"""
+
+
+a = "Another string. Keep the distance between 'a' and 'b'."
+```

--- a/crates/ruff_python_formatter/tests/snapshots/format@module_trailing_semi.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@module_trailing_semi.py.snap
@@ -5,24 +5,21 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/module_tra
 ---
 ## Input
 ```python
-b = """
-    This is a multiline string
-    ending with a useless
-    semicolon.
+"""
+    This is a multiline docstring
+    ending with a useless semicolon.
 """;
 
 
-a = "Another string. Keep the distance between 'a' and 'b'."
+"Another string. Keep the distance between 'a' and 'b'."
 ```
 
 ## Output
 ```python
-b = """
-    This is a multiline string
-    ending with a useless
-    semicolon.
+"""
+This is a multiline docstring
+ending with a useless semicolon.
 """
 
-
-a = "Another string. Keep the distance between 'a' and 'b'."
+"Another string. Keep the distance between 'a' and 'b'."
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
@@ -43,6 +43,7 @@ source_type                = Ipynb
     This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
     Ruff should leave it as is
 """
+
 "another normal string"
 
 
@@ -50,6 +51,7 @@ def compound_statement():
     a = """
     This is a multiline string ending with a semicolon
     """
+
     b = "Another normal string"
     pass
 ```
@@ -83,6 +85,7 @@ def compound_statement():
     a = """
     This is a multiline string ending with a semicolon
     """
+
     b = "Another normal string"
     pass
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
@@ -12,7 +12,7 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_d
 "another normal string"
 
 
-def raw_docstring():
+def compound_statement():
 
     a = """
     This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
@@ -48,7 +48,7 @@ source_type                = Ipynb
 "another normal string"
 
 
-def raw_docstring():
+def compound_statement():
     a = """
     This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
     Ruff should leave it as is
@@ -83,7 +83,7 @@ Ruff should leave it as is
 "another normal string"
 
 
-def raw_docstring():
+def compound_statement():
     a = """
     This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
     Ruff should leave it as is

--- a/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
@@ -33,6 +33,7 @@ source_type                = Ipynb
     This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
     Ruff should leave it as is
 """
+
 "another normal string"
 ```
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
@@ -10,6 +10,17 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_d
 """;
 
 "another normal string"
+
+
+def raw_docstring():
+
+    a = """
+    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
+    Ruff should leave it as is
+    """;
+
+    b = "another normal string"
+    pass
 ```
 
 ## Outputs
@@ -35,6 +46,16 @@ source_type                = Ipynb
 """
 
 "another normal string"
+
+
+def raw_docstring():
+    a = """
+    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
+    Ruff should leave it as is
+    """
+
+    b = "another normal string"
+    pass
 ```
 
 
@@ -60,7 +81,14 @@ Ruff should leave it as is
 """
 
 "another normal string"
+
+
+def raw_docstring():
+    a = """
+    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
+    Ruff should leave it as is
+    """
+
+    b = "another normal string"
+    pass
 ```
-
-
-

--- a/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
@@ -13,9 +13,8 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_d
 
 
 def compound_statement():
-
-    a = """
-    This is a multiline string ending with a semicolon
+    """
+    This is a docstring in a notebook
     """;
 
     b = "Another normal string"
@@ -48,8 +47,8 @@ source_type                = Ipynb
 
 
 def compound_statement():
-    a = """
-    This is a multiline string ending with a semicolon
+    """
+    This is a docstring in a notebook
     """
 
     b = "Another normal string"
@@ -82,8 +81,8 @@ Ruff should leave it as is
 
 
 def compound_statement():
-    a = """
-    This is a multiline string ending with a semicolon
+    """
+    This is a docstring in a notebook
     """
 
     b = "Another normal string"

--- a/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@notebook_docstring.py.snap
@@ -15,11 +15,10 @@ input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/notebook_d
 def compound_statement():
 
     a = """
-    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
-    Ruff should leave it as is
+    This is a multiline string ending with a semicolon
     """;
 
-    b = "another normal string"
+    b = "Another normal string"
     pass
 ```
 
@@ -44,17 +43,14 @@ source_type                = Ipynb
     This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
     Ruff should leave it as is
 """
-
 "another normal string"
 
 
 def compound_statement():
     a = """
-    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
-    Ruff should leave it as is
+    This is a multiline string ending with a semicolon
     """
-
-    b = "another normal string"
+    b = "Another normal string"
     pass
 ```
 
@@ -85,10 +81,8 @@ Ruff should leave it as is
 
 def compound_statement():
     a = """
-    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
-    Ruff should leave it as is
+    This is a multiline string ending with a semicolon
     """
-
-    b = "another normal string"
+    b = "Another normal string"
     pass
 ```

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -1035,7 +1035,10 @@ mod tests {
     use ruff_python_parser::{Mode, Tok};
     use ruff_text_size::{TextLen, TextRange, TextSize};
 
-    use crate::tokenizer::{lines_after, lines_before, SimpleToken, SimpleTokenizer};
+    use crate::tokenizer::{
+        lines_after, lines_after_ignoring_end_of_line_trivia, lines_before, SimpleToken,
+        SimpleTokenizer,
+    };
     use crate::{BackwardsTokenizer, SimpleTokenKind};
 
     struct TokenizationTestCase {
@@ -1447,5 +1450,16 @@ mod tests {
                 }
             );
         }
+    }
+
+    #[test]
+    fn lines_after_ignoring_end_of_line_trivia_multiline_string_semi_delimiter() {
+        assert_eq!(
+            lines_after_ignoring_end_of_line_trivia(
+                TextSize::new(19),
+                "a=\"\"\"hello world\"\"\";\n\n\nb = 10"
+            ),
+            3
+        );
     }
 }

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -119,7 +119,7 @@ pub fn lines_after_ignoring_end_of_line_trivia(offset: TextSize, code: &str) -> 
     SimpleTokenizer::starts_at(offset, code)
         .skip_while(|token| token.kind != SimpleTokenKind::Newline && token.kind.is_trivia())
         .take_while(|token| {
-            token.kind == SimpleTokenKind::Newline || token.kind == SimpleTokenKind::Whitespace
+            token.kind == SimpleTokenKind::Newline || token.kind == SimpleTokenKind::Whitespace || token.kind == SimpleTokenKind::Semi
         })
         .filter(|token| token.kind == SimpleTokenKind::Newline)
         .count() as u32

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -76,6 +76,7 @@ pub fn lines_after(offset: TextSize, code: &str) -> u32 {
                 cursor.eat_char('\n');
                 newlines += 1;
             }
+            ';' => continue,
             c if is_python_whitespace(c) => {
                 continue;
             }
@@ -1426,6 +1427,14 @@ mod tests {
         assert_eq!(
             lines_after(TextSize::new(6), "a = 20\n# some comment\nb = 10"),
             1
+        );
+    }
+
+    #[test]
+    fn lines_after_multiline_string_semi_delimiter() {
+        assert_eq!(
+            lines_after(TextSize::new(19), "a=\"\"\"hello world\"\"\";\n\n\nb = 10"),
+            3
         );
     }
 

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -119,7 +119,9 @@ pub fn lines_after_ignoring_end_of_line_trivia(offset: TextSize, code: &str) -> 
     SimpleTokenizer::starts_at(offset, code)
         .skip_while(|token| token.kind != SimpleTokenKind::Newline && token.kind.is_trivia())
         .take_while(|token| {
-            token.kind == SimpleTokenKind::Newline || token.kind == SimpleTokenKind::Whitespace || token.kind == SimpleTokenKind::Semi
+            token.kind == SimpleTokenKind::Newline
+                || token.kind == SimpleTokenKind::Whitespace
+                || token.kind == SimpleTokenKind::Semi
         })
         .filter(|token| token.kind == SimpleTokenKind::Newline)
         .count() as u32

--- a/crates/ruff_python_trivia/src/tokenizer.rs
+++ b/crates/ruff_python_trivia/src/tokenizer.rs
@@ -119,9 +119,7 @@ pub fn lines_after_ignoring_end_of_line_trivia(offset: TextSize, code: &str) -> 
     SimpleTokenizer::starts_at(offset, code)
         .skip_while(|token| token.kind != SimpleTokenKind::Newline && token.kind.is_trivia())
         .take_while(|token| {
-            token.kind == SimpleTokenKind::Newline
-                || token.kind == SimpleTokenKind::Whitespace
-                || token.kind == SimpleTokenKind::Semi
+            token.kind == SimpleTokenKind::Newline || token.kind == SimpleTokenKind::Whitespace
         })
         .filter(|token| token.kind == SimpleTokenKind::Newline)
         .count() as u32
@@ -1035,10 +1033,7 @@ mod tests {
     use ruff_python_parser::{Mode, Tok};
     use ruff_text_size::{TextLen, TextRange, TextSize};
 
-    use crate::tokenizer::{
-        lines_after, lines_after_ignoring_end_of_line_trivia, lines_before, SimpleToken,
-        SimpleTokenizer,
-    };
+    use crate::tokenizer::{lines_after, lines_before, SimpleToken, SimpleTokenizer};
     use crate::{BackwardsTokenizer, SimpleTokenKind};
 
     struct TokenizationTestCase {
@@ -1450,16 +1445,5 @@ mod tests {
                 }
             );
         }
-    }
-
-    #[test]
-    fn lines_after_ignoring_end_of_line_trivia_multiline_string_semi_delimiter() {
-        assert_eq!(
-            lines_after_ignoring_end_of_line_trivia(
-                TextSize::new(19),
-                "a=\"\"\"hello world\"\"\";\n\n\nb = 10"
-            ),
-            3
-        );
     }
 }


### PR DESCRIPTION
## Summary
https://github.com/astral-sh/ruff/issues/9958 reported that code like
```python
b = """
    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
    Ruff should leave it as is
""";


a = "another normal string"
```
gets formatted as
```python
b = """
    This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
    Ruff should leave it as is
""";
a = "another normal string"
```
This is unexpected and the expected behaviour of the formatter should preserve the empty lines between b and a.

## What
* Modified `lines_after` such that it respects the semicolon. In my opinion, the extension makes a lot of sense in this function as it should not break counting of lines due to a semicolon
* Test call sides
* I intentionally did not modify `lines_before` as alone standing `;`'s are not allowed by the Python syntax anyway, e.g.
  ```python
  b = """
      This looks like a docstring but is not in a notebook because notebooks can't be imported as a module.
      Ruff should leave it as is
  """;
  
  ;
  a = "another normal string"
  ```
## Test Plan
* Correct tests
* Add tests

Closes https://github.com/astral-sh/ruff/issues/9958.
