### PR TITLE
space_around_operator: use same before/after numbers

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/space_around_operator.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/space_around_operator.rs
@@ -21,7 +21,7 @@ use super::{LogicalLine, Whitespace};
 ///
 /// Use instead:
 /// ```python
-/// a = 12 + 3
+/// a = 4 + 5
 /// ```
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#whitespace-in-expressions-and-statements
@@ -53,7 +53,7 @@ impl AlwaysFixableViolation for TabBeforeOperator {
 ///
 /// Use instead:
 /// ```python
-/// a = 12 + 3
+/// a = 4 + 5
 /// ```
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#whitespace-in-expressions-and-statements
@@ -85,7 +85,7 @@ impl AlwaysFixableViolation for MultipleSpacesBeforeOperator {
 ///
 /// Use instead:
 /// ```python
-/// a = 12 + 3
+/// a = 4 + 5
 /// ```
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#whitespace-in-expressions-and-statements
@@ -117,7 +117,7 @@ impl AlwaysFixableViolation for TabAfterOperator {
 ///
 /// Use instead:
 /// ```python
-/// a = 12 + 3
+/// a = 4 + 5
 /// ```
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#whitespace-in-expressions-and-statements
@@ -148,7 +148,7 @@ impl AlwaysFixableViolation for MultipleSpacesAfterOperator {
 ///
 /// Use instead:
 /// ```python
-/// a = 4, 3
+/// a = 4, 5
 /// ```
 ///
 #[violation]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The example for tab-after-comma (E242):
```python
a = 4,\t5
```
Use instead:
```python
a = 4, 3
```
is confusing since both the whitespace and the numbers are changed.

Change so the examples use the same numbers before/after.

## Test Plan

Untested.
