### PR TITLE
Support unused code formatting for `ruff server`

### DIFF
--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -106,6 +106,7 @@ fn to_lsp_diagnostic(
     lsp_types::Diagnostic {
         range: range.to_range(document.contents(), document.index(), encoding),
         severity: Some(severity(&code)),
+        tags: tags(&code),
         code: Some(lsp_types::NumberOrString::String(code)),
         code_description: rule.url().and_then(|url| {
             Some(lsp_types::CodeDescription {
@@ -115,7 +116,6 @@ fn to_lsp_diagnostic(
         source: Some(DIAGNOSTIC_NAME.into()),
         message: kind.body,
         related_information: None,
-        tags: None,
         data,
     }
 }
@@ -127,5 +127,14 @@ fn severity(code: &str) -> lsp_types::DiagnosticSeverity {
         // E999: SyntaxError
         "F821" | "E902" | "E999" => lsp_types::DiagnosticSeverity::ERROR,
         _ => lsp_types::DiagnosticSeverity::WARNING,
+    }
+}
+
+fn tags(code: &str) -> Option<Vec<lsp_types::DiagnosticTag>> {
+    match code {
+        // F401: <module> imported but unused
+        // F841: local variable <name> is assigned to but never used
+        "F401" | "F841" => Some(vec![lsp_types::DiagnosticTag::UNNECESSARY]),
+        _ => None,
     }
 }


### PR DESCRIPTION
## Summary

Fixes #10589.

Code that violates `F401` or `F841` (in other words, unused variables or imports) should now appear greyed out or 'unused' in an editor.

## Test Plan

Put the following test code in a new file within the extension development host window:

```python
import math
def func():
   if False:
      unused = "<- this should be greyed out"
```

The following test code should have greyed out/unused import and variable names, like so:
<img width="294" alt="Screenshot 2024-03-28 at 4 23 18 AM" src="https://github.com/astral-sh/ruff/assets/19577865/e84a6e7a-49e2-4fed-9624-f8f9559e0837">
