### PR TITLE
Add `row_stack` to NumPy 2.0 migration rule

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/numpy/NPY201.py
+++ b/crates/ruff_linter/resources/test/fixtures/numpy/NPY201.py
@@ -104,3 +104,5 @@ def func():
     np.unicode_("asf")
 
     np.who()
+
+    np.row_stack(([1,2], [3,4]))

--- a/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
@@ -522,6 +522,14 @@ pub(crate) fn numpy_2_0_deprecation(checker: &mut Checker, expr: &Expr) {
                     guideline: Some("Use an IDE variable explorer or `locals()` instead."),
                 },
             }),
+            ["numpy", "row_stack"] => Some(Replacement {
+                existing: "row_stack",
+                details: Details::AutoImport {
+                    path: "numpy",
+                    name: "vstack",
+                    compatibility: Compatibility::BackwardsCompatible,
+                },
+            }),
             _ => None,
         });
 

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201.py.snap
@@ -836,6 +836,7 @@ NPY201.py:104:5: NPY201 [*] `np.unicode_` will be removed in NumPy 2.0. Use `num
     104 |+    np.str_("asf")
 105 105 | 
 106 106 |     np.who()
+107 107 | 
 
 NPY201.py:106:5: NPY201 `np.who` will be removed in NumPy 2.0. Use an IDE variable explorer or `locals()` instead.
     |
@@ -843,6 +844,24 @@ NPY201.py:106:5: NPY201 `np.who` will be removed in NumPy 2.0. Use an IDE variab
 105 | 
 106 |     np.who()
     |     ^^^^^^ NPY201
+107 | 
+108 |     np.row_stack(([1,2], [3,4]))
     |
+
+NPY201.py:108:5: NPY201 [*] `np.row_stack` will be removed in NumPy 2.0. Use `numpy.vstack` instead.
+    |
+106 |     np.who()
+107 | 
+108 |     np.row_stack(([1,2], [3,4]))
+    |     ^^^^^^^^^^^^ NPY201
+    |
+    = help: Replace with `numpy.vstack`
+
+ℹ Safe fix
+105 105 | 
+106 106 |     np.who()
+107 107 | 
+108     |-    np.row_stack(([1,2], [3,4]))
+    108 |+    np.vstack(([1,2], [3,4]))
 
 


### PR DESCRIPTION
Hi! 

I left out one of the functions in the migration rule which became deprecated/removed in NumPy 2.0 (https://github.com/numpy/numpy/issues/26032#issuecomment-1999870797).

cc @anntzer