### PR TITLE
[`refurb`] Implement `unnecessary-from-float` (`FURB164`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB164.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB164.py
@@ -1,0 +1,34 @@
+from decimal import Decimal
+from fractions import Fraction
+import decimal
+import fractions
+
+# Errors
+_ = Fraction.from_float(0.1)
+_ = Fraction.from_float(-0.5)
+_ = Fraction.from_float(5.0)
+_ = fractions.Fraction.from_float(4.2)
+_ = Fraction.from_decimal(Decimal("4.2"))
+_ = Fraction.from_decimal(Decimal("-4.2"))
+_ = Fraction.from_decimal(Decimal.from_float(4.2))
+_ = Decimal.from_float(0.1)
+_ = Decimal.from_float(-0.5)
+_ = Decimal.from_float(5.0)
+_ = decimal.Decimal.from_float(4.2)
+_ = Decimal.from_float(float("inf"))
+_ = Decimal.from_float(float("-inf"))
+_ = Decimal.from_float(float("Infinity"))
+_ = Decimal.from_float(float("-Infinity"))
+_ = Decimal.from_float(float("nan"))
+
+# OK
+_ = Fraction(0.1)
+_ = Fraction(-0.5)
+_ = Fraction(5.0)
+_ = fractions.Fraction(4.2)
+_ = Fraction(Decimal("4.2"))
+_ = Fraction(Decimal("-4.2"))
+_ = Decimal(0.1)
+_ = Decimal(-0.5)
+_ = Decimal(5.0)
+_ = decimal.Decimal(4.2)

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -929,6 +929,9 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
             if checker.enabled(Rule::VerboseDecimalConstructor) {
                 refurb::rules::verbose_decimal_constructor(checker, call);
             }
+            if checker.enabled(Rule::VerboseDecimalFractionConstruction) {
+                refurb::rules::verbose_decimal_fraction_construction(checker, call);
+            }
             if checker.enabled(Rule::QuadraticListSummation) {
                 ruff::rules::quadratic_list_summation(checker, call);
             }

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -929,8 +929,8 @@ pub(crate) fn expression(expr: &Expr, checker: &mut Checker) {
             if checker.enabled(Rule::VerboseDecimalConstructor) {
                 refurb::rules::verbose_decimal_constructor(checker, call);
             }
-            if checker.enabled(Rule::VerboseDecimalFractionConstruction) {
-                refurb::rules::verbose_decimal_fraction_construction(checker, call);
+            if checker.enabled(Rule::UnnecessaryFromFloat) {
+                refurb::rules::unnecessary_from_float(checker, call);
             }
             if checker.enabled(Rule::QuadraticListSummation) {
                 ruff::rules::quadratic_list_summation(checker, call);

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1051,7 +1051,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Refurb, "157") => (RuleGroup::Preview, rules::refurb::rules::VerboseDecimalConstructor),
         (Refurb, "161") => (RuleGroup::Preview, rules::refurb::rules::BitCount),
         (Refurb, "163") => (RuleGroup::Preview, rules::refurb::rules::RedundantLogBase),
-        (Refurb, "164") => (RuleGroup::Preview, rules::refurb::rules::VerboseDecimalFractionConstruction),
+        (Refurb, "164") => (RuleGroup::Preview, rules::refurb::rules::UnnecessaryFromFloat),
         (Refurb, "167") => (RuleGroup::Preview, rules::refurb::rules::RegexFlagAlias),
         (Refurb, "168") => (RuleGroup::Preview, rules::refurb::rules::IsinstanceTypeNone),
         (Refurb, "169") => (RuleGroup::Preview, rules::refurb::rules::TypeNoneComparison),

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1050,6 +1050,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Refurb, "157") => (RuleGroup::Preview, rules::refurb::rules::VerboseDecimalConstructor),
         (Refurb, "161") => (RuleGroup::Preview, rules::refurb::rules::BitCount),
         (Refurb, "163") => (RuleGroup::Preview, rules::refurb::rules::RedundantLogBase),
+        (Refurb, "164") => (RuleGroup::Preview, rules::refurb::rules::VerboseDecimalFractionConstruction),
         (Refurb, "167") => (RuleGroup::Preview, rules::refurb::rules::RegexFlagAlias),
         (Refurb, "168") => (RuleGroup::Preview, rules::refurb::rules::IsinstanceTypeNone),
         (Refurb, "169") => (RuleGroup::Preview, rules::refurb::rules::TypeNoneComparison),

--- a/crates/ruff_linter/src/rules/refurb/mod.rs
+++ b/crates/ruff_linter/src/rules/refurb/mod.rs
@@ -27,7 +27,7 @@ mod tests {
     #[test_case(Rule::UnnecessaryEnumerate, Path::new("FURB148.py"))]
     #[test_case(Rule::MathConstant, Path::new("FURB152.py"))]
     #[test_case(Rule::VerboseDecimalConstructor, Path::new("FURB157.py"))]
-    #[test_case(Rule::VerboseDecimalFractionConstruction, Path::new("FURB164.py"))]
+    #[test_case(Rule::UnnecessaryFromFloat, Path::new("FURB164.py"))]
     #[test_case(Rule::PrintEmptyString, Path::new("FURB105.py"))]
     #[test_case(Rule::ImplicitCwd, Path::new("FURB177.py"))]
     #[test_case(Rule::SingleItemMembershipTest, Path::new("FURB171.py"))]

--- a/crates/ruff_linter/src/rules/refurb/mod.rs
+++ b/crates/ruff_linter/src/rules/refurb/mod.rs
@@ -26,6 +26,7 @@ mod tests {
     #[test_case(Rule::UnnecessaryEnumerate, Path::new("FURB148.py"))]
     #[test_case(Rule::MathConstant, Path::new("FURB152.py"))]
     #[test_case(Rule::VerboseDecimalConstructor, Path::new("FURB157.py"))]
+    #[test_case(Rule::VerboseDecimalFractionConstruction, Path::new("FURB164.py"))]
     #[test_case(Rule::PrintEmptyString, Path::new("FURB105.py"))]
     #[test_case(Rule::ImplicitCwd, Path::new("FURB177.py"))]
     #[test_case(Rule::SingleItemMembershipTest, Path::new("FURB171.py"))]

--- a/crates/ruff_linter/src/rules/refurb/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/mod.rs
@@ -21,6 +21,7 @@ pub(crate) use slice_copy::*;
 pub(crate) use type_none_comparison::*;
 pub(crate) use unnecessary_enumerate::*;
 pub(crate) use verbose_decimal_constructor::*;
+pub(crate) use verbose_decimal_fraction_construction::*;
 
 mod bit_count;
 mod check_and_remove_from_set;
@@ -45,3 +46,4 @@ mod slice_copy;
 mod type_none_comparison;
 mod unnecessary_enumerate;
 mod verbose_decimal_constructor;
+mod verbose_decimal_fraction_construction;

--- a/crates/ruff_linter/src/rules/refurb/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/mod.rs
@@ -21,8 +21,8 @@ pub(crate) use single_item_membership_test::*;
 pub(crate) use slice_copy::*;
 pub(crate) use type_none_comparison::*;
 pub(crate) use unnecessary_enumerate::*;
+pub(crate) use unnecessary_from_float::*;
 pub(crate) use verbose_decimal_constructor::*;
-pub(crate) use verbose_decimal_fraction_construction::*;
 
 mod bit_count;
 mod check_and_remove_from_set;
@@ -47,5 +47,5 @@ mod single_item_membership_test;
 mod slice_copy;
 mod type_none_comparison;
 mod unnecessary_enumerate;
+mod unnecessary_from_float;
 mod verbose_decimal_constructor;
-mod verbose_decimal_fraction_construction;

--- a/crates/ruff_linter/src/rules/refurb/rules/unnecessary_from_float.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/unnecessary_from_float.rs
@@ -44,12 +44,12 @@ use crate::{checkers::ast::Checker, importer::ImportRequest};
 /// - [Python documentation: `decimal`](https://docs.python.org/3/library/decimal.html)
 /// - [Python documentation: `fractions`](https://docs.python.org/3/library/fractions.html)
 #[violation]
-pub struct VerboseDecimalFractionConstruction {
+pub struct UnnecessaryFromFloat {
     method_name: String,
     constructor: String,
 }
 
-impl Violation for VerboseDecimalFractionConstruction {
+impl Violation for UnnecessaryFromFloat {
     const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
 
     #[derive_message_formats]
@@ -66,7 +66,7 @@ impl Violation for VerboseDecimalFractionConstruction {
 }
 
 /// FURB164
-pub(crate) fn verbose_decimal_fraction_construction(checker: &mut Checker, call: &ExprCall) {
+pub(crate) fn unnecessary_from_float(checker: &mut Checker, call: &ExprCall) {
     let Some(qualified_name) = checker.semantic().resolve_qualified_name(&call.func) else {
         return;
     };
@@ -92,7 +92,7 @@ pub(crate) fn verbose_decimal_fraction_construction(checker: &mut Checker, call:
     };
 
     let mut diagnostic = Diagnostic::new(
-        VerboseDecimalFractionConstruction {
+        UnnecessaryFromFloat {
             method_name: (*method_name).to_string(),
             constructor: (*constructor).to_string(),
         },

--- a/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_constructor.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_constructor.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::{self as ast, Expr, ExprCall};
+use ruff_python_ast::{self as ast, Expr};
 use ruff_python_trivia::PythonWhitespace;
 use ruff_text_size::Ranged;
 
@@ -56,7 +56,7 @@ impl Violation for VerboseDecimalConstructor {
 }
 
 /// FURB157
-pub(crate) fn verbose_decimal_constructor(checker: &mut Checker, call: &ExprCall) {
+pub(crate) fn verbose_decimal_constructor(checker: &mut Checker, call: &ast::ExprCall) {
     if !checker
         .semantic()
         .resolve_qualified_name(&call.func)

--- a/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_fraction_construction.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_fraction_construction.rs
@@ -54,7 +54,10 @@ impl Violation for VerboseDecimalFractionConstruction {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Verbose method `{}` when constructing `{}`", self.method_name, self.constructor)
+        format!(
+            "Verbose method `{}` when constructing `{}`",
+            self.method_name, self.constructor
+        )
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_fraction_construction.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_fraction_construction.rs
@@ -54,7 +54,7 @@ impl Violation for VerboseDecimalFractionConstruction {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Verbose expression in constructing `{}`", self.constructor)
+        format!("Verbose method `{}` when constructing `{}`", self.method_name, self.constructor)
     }
 
     fn fix_title(&self) -> Option<String> {

--- a/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_fraction_construction.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_fraction_construction.rs
@@ -1,0 +1,161 @@
+use ruff_diagnostics::{Diagnostic, Edit, Fix, FixAvailability, Violation};
+use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::{self as ast, Expr, ExprCall};
+use ruff_text_size::Ranged;
+
+use crate::{checkers::ast::Checker, importer::ImportRequest};
+
+/// ## What it does
+/// Checks for unnecessary `from_float`, `from_decimal` method called
+/// when constructing `Decimal` and `Fraction`.
+///
+/// ## Why is this bad?
+/// From Python 3.2, it is possible to directly construct `Fraction`
+/// from `float` and `Decimal`, or `Decimal` from `float` by passing argument to
+/// the constructor.
+/// There is no need to use `from_float` or `from_decimal` instances, thus prefer directly using
+/// the constructor as it is more readable and idiomatic.
+///
+/// Further, if `Decimal` of special values i.e. `inf`, `-inf`, `Infinity`, `-Infinity` and `nan`
+/// is constructed, there is no need to construct via float instance.
+/// For example, expression like `Decimal("inf")` is possible.
+///
+/// ## Examples
+/// ```python
+/// Decimal.from_float(4.2)
+/// Decimal.from_float(float("inf"))
+/// Fraction.from_float(4.2)
+/// Fraction.from_decimal(Decimal("4.2"))
+/// ```
+///
+/// Use instead:
+/// ```python
+/// Decimal(4.2)
+/// Decimal("inf")
+/// Fraction(4.2)
+/// Fraction(Decimal("4.2"))
+/// ```
+/// ## Fix safety
+/// This rule's fix is marked as unsafe, as the target of the method call
+/// could be a user-defined `Decimal` or `Fraction` class, rather
+/// than method from the built-in module.
+///
+/// ## References
+/// - [Python documentation: `decimal`](https://docs.python.org/3/library/decimal.html)
+/// - [Python documentation: `fractions`](https://docs.python.org/3/library/fractions.html)
+#[violation]
+pub struct VerboseDecimalFractionConstruction {
+    method_name: String,
+    constructor: String,
+}
+
+impl Violation for VerboseDecimalFractionConstruction {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Verbose expression in constructing `{}`", self.constructor)
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some(format!("Use constructor `{}` directly", self.constructor))
+    }
+}
+
+/// FURB164
+pub(crate) fn verbose_decimal_fraction_construction(checker: &mut Checker, call: &ExprCall) {
+    let Some(qualified_name) = checker.semantic().resolve_qualified_name(&call.func) else {
+        return;
+    };
+
+    if !matches!(
+        qualified_name.segments(),
+        ["decimal", "Decimal", "from_float"]
+            | ["fractions", "Fraction", "from_float" | "from_decimal"]
+    ) {
+        return;
+    }
+
+    let [module, constructor, method_name] = qualified_name.segments() else {
+        return;
+    };
+
+    let Some(value) = (if method_name == &"from_float" {
+        call.arguments.find_argument("f", 0)
+    } else {
+        call.arguments.find_argument("dec", 0)
+    }) else {
+        return;
+    };
+
+    let mut diagnostic = Diagnostic::new(
+        VerboseDecimalFractionConstruction {
+            method_name: (*method_name).to_string(),
+            constructor: (*constructor).to_string(),
+        },
+        call.range(),
+    );
+
+    let new_constructor = checker.importer().get_or_import_symbol(
+        &ImportRequest::import_from(module, constructor),
+        call.start(),
+        checker.semantic(),
+    );
+    let Ok((_, new_constructor)) = new_constructor else {
+        checker.diagnostics.push(diagnostic);
+        return;
+    };
+    let edit = Edit::range_replacement(new_constructor, call.func.range());
+
+    // Short-circuit case for special values, such as
+    // `Decimal.from_float(float("inf"))` to `Decimal("inf")`.
+    'short_circuit: {
+        if !(constructor == &"Decimal" && method_name == &"from_float") {
+            break 'short_circuit;
+        };
+        let Expr::Call(
+            inner_call @ ast::ExprCall {
+                func, arguments, ..
+            },
+        ) = value
+        else {
+            break 'short_circuit;
+        };
+        let Some(func_name) = func.as_name_expr() else {
+            break 'short_circuit;
+        };
+        if !(func_name.id == "float" && checker.semantic().is_builtin("float")) {
+            break 'short_circuit;
+        };
+        // Must have exactly one argument, which is a string literal.
+        if arguments.keywords.len() != 0 {
+            break 'short_circuit;
+        };
+        let [float] = arguments.args.as_ref() else {
+            break 'short_circuit;
+        };
+        let Some(float) = float.as_string_literal_expr() else {
+            break 'short_circuit;
+        };
+        if !matches!(
+            float.value.to_str().to_lowercase().as_str(),
+            "inf" | "-inf" | "infinity" | "-infinity" | "nan"
+        ) {
+            break 'short_circuit;
+        };
+
+        diagnostic.set_fix(Fix::unsafe_edits(
+            edit,
+            [Edit::range_replacement(
+                format!("\"{}\"", float.value.to_str()),
+                inner_call.range(),
+            )],
+        ));
+        checker.diagnostics.push(diagnostic);
+
+        return;
+    }
+
+    diagnostic.set_fix(Fix::unsafe_edit(edit));
+    checker.diagnostics.push(diagnostic);
+}

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB164_FURB164.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB164_FURB164.py.snap
@@ -11,12 +11,12 @@ FURB164.py:7:5: FURB164 [*] Verbose method `from_float` when constructing `Fract
   |
   = help: Use constructor `Fraction` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 4 4 | import fractions
 5 5 | 
 6 6 | # Errors
 7   |-_ = Fraction.from_float(0.1)
-  7 |+_ = fractions.Fraction(0.1)
+  7 |+_ = Fraction(0.1)
 8 8 | _ = Fraction.from_float(-0.5)
 9 9 | _ = Fraction.from_float(5.0)
 10 10 | _ = fractions.Fraction.from_float(4.2)
@@ -32,12 +32,12 @@ FURB164.py:8:5: FURB164 [*] Verbose method `from_float` when constructing `Fract
    |
    = help: Use constructor `Fraction` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 5 5 | 
 6 6 | # Errors
 7 7 | _ = Fraction.from_float(0.1)
 8   |-_ = Fraction.from_float(-0.5)
-  8 |+_ = fractions.Fraction(-0.5)
+  8 |+_ = Fraction(-0.5)
 9 9 | _ = Fraction.from_float(5.0)
 10 10 | _ = fractions.Fraction.from_float(4.2)
 11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
@@ -53,12 +53,12 @@ FURB164.py:9:5: FURB164 [*] Verbose method `from_float` when constructing `Fract
    |
    = help: Use constructor `Fraction` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 6  6  | # Errors
 7  7  | _ = Fraction.from_float(0.1)
 8  8  | _ = Fraction.from_float(-0.5)
 9     |-_ = Fraction.from_float(5.0)
-   9  |+_ = fractions.Fraction(5.0)
+   9  |+_ = Fraction(5.0)
 10 10 | _ = fractions.Fraction.from_float(4.2)
 11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
 12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
@@ -74,7 +74,7 @@ FURB164.py:10:5: FURB164 [*] Verbose method `from_float` when constructing `Frac
    |
    = help: Use constructor `Fraction` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 7  7  | _ = Fraction.from_float(0.1)
 8  8  | _ = Fraction.from_float(-0.5)
 9  9  | _ = Fraction.from_float(5.0)
@@ -95,12 +95,12 @@ FURB164.py:11:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fr
    |
    = help: Use constructor `Fraction` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 8  8  | _ = Fraction.from_float(-0.5)
 9  9  | _ = Fraction.from_float(5.0)
 10 10 | _ = fractions.Fraction.from_float(4.2)
 11    |-_ = Fraction.from_decimal(Decimal("4.2"))
-   11 |+_ = fractions.Fraction(Decimal("4.2"))
+   11 |+_ = Fraction(Decimal("4.2"))
 12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
 13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
 14 14 | _ = Decimal.from_float(0.1)
@@ -116,12 +116,12 @@ FURB164.py:12:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fr
    |
    = help: Use constructor `Fraction` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 9  9  | _ = Fraction.from_float(5.0)
 10 10 | _ = fractions.Fraction.from_float(4.2)
 11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
 12    |-_ = Fraction.from_decimal(Decimal("-4.2"))
-   12 |+_ = fractions.Fraction(Decimal("-4.2"))
+   12 |+_ = Fraction(Decimal("-4.2"))
 13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
 14 14 | _ = Decimal.from_float(0.1)
 15 15 | _ = Decimal.from_float(-0.5)
@@ -137,12 +137,12 @@ FURB164.py:13:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fr
    |
    = help: Use constructor `Fraction` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 10 10 | _ = fractions.Fraction.from_float(4.2)
 11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
 12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
 13    |-_ = Fraction.from_decimal(Decimal.from_float(4.2))
-   13 |+_ = fractions.Fraction(Decimal.from_float(4.2))
+   13 |+_ = Fraction(Decimal.from_float(4.2))
 14 14 | _ = Decimal.from_float(0.1)
 15 15 | _ = Decimal.from_float(-0.5)
 16 16 | _ = Decimal.from_float(5.0)
@@ -158,7 +158,7 @@ FURB164.py:13:27: FURB164 [*] Verbose method `from_float` when constructing `Dec
    |
    = help: Use constructor `Decimal` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 10 10 | _ = fractions.Fraction.from_float(4.2)
 11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
 12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
@@ -179,7 +179,7 @@ FURB164.py:14:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
    |
    = help: Use constructor `Decimal` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
 12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
 13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
@@ -200,7 +200,7 @@ FURB164.py:15:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
    |
    = help: Use constructor `Decimal` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
 13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
 14 14 | _ = Decimal.from_float(0.1)
@@ -221,7 +221,7 @@ FURB164.py:16:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
    |
    = help: Use constructor `Decimal` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
 14 14 | _ = Decimal.from_float(0.1)
 15 15 | _ = Decimal.from_float(-0.5)
@@ -242,12 +242,12 @@ FURB164.py:17:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
    |
    = help: Use constructor `Decimal` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 14 14 | _ = Decimal.from_float(0.1)
 15 15 | _ = Decimal.from_float(-0.5)
 16 16 | _ = Decimal.from_float(5.0)
 17    |-_ = decimal.Decimal.from_float(4.2)
-   17 |+_ = Decimal(4.2)
+   17 |+_ = decimal.Decimal(4.2)
 18 18 | _ = Decimal.from_float(float("inf"))
 19 19 | _ = Decimal.from_float(float("-inf"))
 20 20 | _ = Decimal.from_float(float("Infinity"))
@@ -263,7 +263,7 @@ FURB164.py:18:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
    |
    = help: Use constructor `Decimal` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 15 15 | _ = Decimal.from_float(-0.5)
 16 16 | _ = Decimal.from_float(5.0)
 17 17 | _ = decimal.Decimal.from_float(4.2)
@@ -284,7 +284,7 @@ FURB164.py:19:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
    |
    = help: Use constructor `Decimal` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 16 16 | _ = Decimal.from_float(5.0)
 17 17 | _ = decimal.Decimal.from_float(4.2)
 18 18 | _ = Decimal.from_float(float("inf"))
@@ -305,7 +305,7 @@ FURB164.py:20:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
    |
    = help: Use constructor `Decimal` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 17 17 | _ = decimal.Decimal.from_float(4.2)
 18 18 | _ = Decimal.from_float(float("inf"))
 19 19 | _ = Decimal.from_float(float("-inf"))
@@ -325,7 +325,7 @@ FURB164.py:21:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
    |
    = help: Use constructor `Decimal` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 18 18 | _ = Decimal.from_float(float("inf"))
 19 19 | _ = Decimal.from_float(float("-inf"))
 20 20 | _ = Decimal.from_float(float("Infinity"))
@@ -346,7 +346,7 @@ FURB164.py:22:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
    |
    = help: Use constructor `Decimal` directly
 
-ℹ Unsafe fix
+ℹ Safe fix
 19 19 | _ = Decimal.from_float(float("-inf"))
 20 20 | _ = Decimal.from_float(float("Infinity"))
 21 21 | _ = Decimal.from_float(float("-Infinity"))

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB164_FURB164.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB164_FURB164.py.snap
@@ -1,0 +1,357 @@
+---
+source: crates/ruff_linter/src/rules/refurb/mod.rs
+---
+FURB164.py:7:5: FURB164 [*] Verbose expression in constructing `Fraction`
+  |
+6 | # Errors
+7 | _ = Fraction.from_float(0.1)
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+8 | _ = Fraction.from_float(-0.5)
+9 | _ = Fraction.from_float(5.0)
+  |
+  = help: Use constructor `Fraction` directly
+
+ℹ Unsafe fix
+4 4 | import fractions
+5 5 | 
+6 6 | # Errors
+7   |-_ = Fraction.from_float(0.1)
+  7 |+_ = fractions.Fraction(0.1)
+8 8 | _ = Fraction.from_float(-0.5)
+9 9 | _ = Fraction.from_float(5.0)
+10 10 | _ = fractions.Fraction.from_float(4.2)
+
+FURB164.py:8:5: FURB164 [*] Verbose expression in constructing `Fraction`
+   |
+ 6 | # Errors
+ 7 | _ = Fraction.from_float(0.1)
+ 8 | _ = Fraction.from_float(-0.5)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+ 9 | _ = Fraction.from_float(5.0)
+10 | _ = fractions.Fraction.from_float(4.2)
+   |
+   = help: Use constructor `Fraction` directly
+
+ℹ Unsafe fix
+5 5 | 
+6 6 | # Errors
+7 7 | _ = Fraction.from_float(0.1)
+8   |-_ = Fraction.from_float(-0.5)
+  8 |+_ = fractions.Fraction(-0.5)
+9 9 | _ = Fraction.from_float(5.0)
+10 10 | _ = fractions.Fraction.from_float(4.2)
+11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
+
+FURB164.py:9:5: FURB164 [*] Verbose expression in constructing `Fraction`
+   |
+ 7 | _ = Fraction.from_float(0.1)
+ 8 | _ = Fraction.from_float(-0.5)
+ 9 | _ = Fraction.from_float(5.0)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+10 | _ = fractions.Fraction.from_float(4.2)
+11 | _ = Fraction.from_decimal(Decimal("4.2"))
+   |
+   = help: Use constructor `Fraction` directly
+
+ℹ Unsafe fix
+6  6  | # Errors
+7  7  | _ = Fraction.from_float(0.1)
+8  8  | _ = Fraction.from_float(-0.5)
+9     |-_ = Fraction.from_float(5.0)
+   9  |+_ = fractions.Fraction(5.0)
+10 10 | _ = fractions.Fraction.from_float(4.2)
+11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
+12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
+
+FURB164.py:10:5: FURB164 [*] Verbose expression in constructing `Fraction`
+   |
+ 8 | _ = Fraction.from_float(-0.5)
+ 9 | _ = Fraction.from_float(5.0)
+10 | _ = fractions.Fraction.from_float(4.2)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+11 | _ = Fraction.from_decimal(Decimal("4.2"))
+12 | _ = Fraction.from_decimal(Decimal("-4.2"))
+   |
+   = help: Use constructor `Fraction` directly
+
+ℹ Unsafe fix
+7  7  | _ = Fraction.from_float(0.1)
+8  8  | _ = Fraction.from_float(-0.5)
+9  9  | _ = Fraction.from_float(5.0)
+10    |-_ = fractions.Fraction.from_float(4.2)
+   10 |+_ = fractions.Fraction(4.2)
+11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
+12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
+13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
+
+FURB164.py:11:5: FURB164 [*] Verbose expression in constructing `Fraction`
+   |
+ 9 | _ = Fraction.from_float(5.0)
+10 | _ = fractions.Fraction.from_float(4.2)
+11 | _ = Fraction.from_decimal(Decimal("4.2"))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+12 | _ = Fraction.from_decimal(Decimal("-4.2"))
+13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
+   |
+   = help: Use constructor `Fraction` directly
+
+ℹ Unsafe fix
+8  8  | _ = Fraction.from_float(-0.5)
+9  9  | _ = Fraction.from_float(5.0)
+10 10 | _ = fractions.Fraction.from_float(4.2)
+11    |-_ = Fraction.from_decimal(Decimal("4.2"))
+   11 |+_ = fractions.Fraction(Decimal("4.2"))
+12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
+13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
+14 14 | _ = Decimal.from_float(0.1)
+
+FURB164.py:12:5: FURB164 [*] Verbose expression in constructing `Fraction`
+   |
+10 | _ = fractions.Fraction.from_float(4.2)
+11 | _ = Fraction.from_decimal(Decimal("4.2"))
+12 | _ = Fraction.from_decimal(Decimal("-4.2"))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
+14 | _ = Decimal.from_float(0.1)
+   |
+   = help: Use constructor `Fraction` directly
+
+ℹ Unsafe fix
+9  9  | _ = Fraction.from_float(5.0)
+10 10 | _ = fractions.Fraction.from_float(4.2)
+11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
+12    |-_ = Fraction.from_decimal(Decimal("-4.2"))
+   12 |+_ = fractions.Fraction(Decimal("-4.2"))
+13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
+14 14 | _ = Decimal.from_float(0.1)
+15 15 | _ = Decimal.from_float(-0.5)
+
+FURB164.py:13:5: FURB164 [*] Verbose expression in constructing `Fraction`
+   |
+11 | _ = Fraction.from_decimal(Decimal("4.2"))
+12 | _ = Fraction.from_decimal(Decimal("-4.2"))
+13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+14 | _ = Decimal.from_float(0.1)
+15 | _ = Decimal.from_float(-0.5)
+   |
+   = help: Use constructor `Fraction` directly
+
+ℹ Unsafe fix
+10 10 | _ = fractions.Fraction.from_float(4.2)
+11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
+12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
+13    |-_ = Fraction.from_decimal(Decimal.from_float(4.2))
+   13 |+_ = fractions.Fraction(Decimal.from_float(4.2))
+14 14 | _ = Decimal.from_float(0.1)
+15 15 | _ = Decimal.from_float(-0.5)
+16 16 | _ = Decimal.from_float(5.0)
+
+FURB164.py:13:27: FURB164 [*] Verbose expression in constructing `Decimal`
+   |
+11 | _ = Fraction.from_decimal(Decimal("4.2"))
+12 | _ = Fraction.from_decimal(Decimal("-4.2"))
+13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+14 | _ = Decimal.from_float(0.1)
+15 | _ = Decimal.from_float(-0.5)
+   |
+   = help: Use constructor `Decimal` directly
+
+ℹ Unsafe fix
+10 10 | _ = fractions.Fraction.from_float(4.2)
+11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
+12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
+13    |-_ = Fraction.from_decimal(Decimal.from_float(4.2))
+   13 |+_ = Fraction.from_decimal(Decimal(4.2))
+14 14 | _ = Decimal.from_float(0.1)
+15 15 | _ = Decimal.from_float(-0.5)
+16 16 | _ = Decimal.from_float(5.0)
+
+FURB164.py:14:5: FURB164 [*] Verbose expression in constructing `Decimal`
+   |
+12 | _ = Fraction.from_decimal(Decimal("-4.2"))
+13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
+14 | _ = Decimal.from_float(0.1)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+15 | _ = Decimal.from_float(-0.5)
+16 | _ = Decimal.from_float(5.0)
+   |
+   = help: Use constructor `Decimal` directly
+
+ℹ Unsafe fix
+11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
+12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
+13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
+14    |-_ = Decimal.from_float(0.1)
+   14 |+_ = Decimal(0.1)
+15 15 | _ = Decimal.from_float(-0.5)
+16 16 | _ = Decimal.from_float(5.0)
+17 17 | _ = decimal.Decimal.from_float(4.2)
+
+FURB164.py:15:5: FURB164 [*] Verbose expression in constructing `Decimal`
+   |
+13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
+14 | _ = Decimal.from_float(0.1)
+15 | _ = Decimal.from_float(-0.5)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+16 | _ = Decimal.from_float(5.0)
+17 | _ = decimal.Decimal.from_float(4.2)
+   |
+   = help: Use constructor `Decimal` directly
+
+ℹ Unsafe fix
+12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
+13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
+14 14 | _ = Decimal.from_float(0.1)
+15    |-_ = Decimal.from_float(-0.5)
+   15 |+_ = Decimal(-0.5)
+16 16 | _ = Decimal.from_float(5.0)
+17 17 | _ = decimal.Decimal.from_float(4.2)
+18 18 | _ = Decimal.from_float(float("inf"))
+
+FURB164.py:16:5: FURB164 [*] Verbose expression in constructing `Decimal`
+   |
+14 | _ = Decimal.from_float(0.1)
+15 | _ = Decimal.from_float(-0.5)
+16 | _ = Decimal.from_float(5.0)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+17 | _ = decimal.Decimal.from_float(4.2)
+18 | _ = Decimal.from_float(float("inf"))
+   |
+   = help: Use constructor `Decimal` directly
+
+ℹ Unsafe fix
+13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
+14 14 | _ = Decimal.from_float(0.1)
+15 15 | _ = Decimal.from_float(-0.5)
+16    |-_ = Decimal.from_float(5.0)
+   16 |+_ = Decimal(5.0)
+17 17 | _ = decimal.Decimal.from_float(4.2)
+18 18 | _ = Decimal.from_float(float("inf"))
+19 19 | _ = Decimal.from_float(float("-inf"))
+
+FURB164.py:17:5: FURB164 [*] Verbose expression in constructing `Decimal`
+   |
+15 | _ = Decimal.from_float(-0.5)
+16 | _ = Decimal.from_float(5.0)
+17 | _ = decimal.Decimal.from_float(4.2)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+18 | _ = Decimal.from_float(float("inf"))
+19 | _ = Decimal.from_float(float("-inf"))
+   |
+   = help: Use constructor `Decimal` directly
+
+ℹ Unsafe fix
+14 14 | _ = Decimal.from_float(0.1)
+15 15 | _ = Decimal.from_float(-0.5)
+16 16 | _ = Decimal.from_float(5.0)
+17    |-_ = decimal.Decimal.from_float(4.2)
+   17 |+_ = Decimal(4.2)
+18 18 | _ = Decimal.from_float(float("inf"))
+19 19 | _ = Decimal.from_float(float("-inf"))
+20 20 | _ = Decimal.from_float(float("Infinity"))
+
+FURB164.py:18:5: FURB164 [*] Verbose expression in constructing `Decimal`
+   |
+16 | _ = Decimal.from_float(5.0)
+17 | _ = decimal.Decimal.from_float(4.2)
+18 | _ = Decimal.from_float(float("inf"))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+19 | _ = Decimal.from_float(float("-inf"))
+20 | _ = Decimal.from_float(float("Infinity"))
+   |
+   = help: Use constructor `Decimal` directly
+
+ℹ Unsafe fix
+15 15 | _ = Decimal.from_float(-0.5)
+16 16 | _ = Decimal.from_float(5.0)
+17 17 | _ = decimal.Decimal.from_float(4.2)
+18    |-_ = Decimal.from_float(float("inf"))
+   18 |+_ = Decimal("inf")
+19 19 | _ = Decimal.from_float(float("-inf"))
+20 20 | _ = Decimal.from_float(float("Infinity"))
+21 21 | _ = Decimal.from_float(float("-Infinity"))
+
+FURB164.py:19:5: FURB164 [*] Verbose expression in constructing `Decimal`
+   |
+17 | _ = decimal.Decimal.from_float(4.2)
+18 | _ = Decimal.from_float(float("inf"))
+19 | _ = Decimal.from_float(float("-inf"))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+20 | _ = Decimal.from_float(float("Infinity"))
+21 | _ = Decimal.from_float(float("-Infinity"))
+   |
+   = help: Use constructor `Decimal` directly
+
+ℹ Unsafe fix
+16 16 | _ = Decimal.from_float(5.0)
+17 17 | _ = decimal.Decimal.from_float(4.2)
+18 18 | _ = Decimal.from_float(float("inf"))
+19    |-_ = Decimal.from_float(float("-inf"))
+   19 |+_ = Decimal("-inf")
+20 20 | _ = Decimal.from_float(float("Infinity"))
+21 21 | _ = Decimal.from_float(float("-Infinity"))
+22 22 | _ = Decimal.from_float(float("nan"))
+
+FURB164.py:20:5: FURB164 [*] Verbose expression in constructing `Decimal`
+   |
+18 | _ = Decimal.from_float(float("inf"))
+19 | _ = Decimal.from_float(float("-inf"))
+20 | _ = Decimal.from_float(float("Infinity"))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+21 | _ = Decimal.from_float(float("-Infinity"))
+22 | _ = Decimal.from_float(float("nan"))
+   |
+   = help: Use constructor `Decimal` directly
+
+ℹ Unsafe fix
+17 17 | _ = decimal.Decimal.from_float(4.2)
+18 18 | _ = Decimal.from_float(float("inf"))
+19 19 | _ = Decimal.from_float(float("-inf"))
+20    |-_ = Decimal.from_float(float("Infinity"))
+   20 |+_ = Decimal("Infinity")
+21 21 | _ = Decimal.from_float(float("-Infinity"))
+22 22 | _ = Decimal.from_float(float("nan"))
+23 23 | 
+
+FURB164.py:21:5: FURB164 [*] Verbose expression in constructing `Decimal`
+   |
+19 | _ = Decimal.from_float(float("-inf"))
+20 | _ = Decimal.from_float(float("Infinity"))
+21 | _ = Decimal.from_float(float("-Infinity"))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+22 | _ = Decimal.from_float(float("nan"))
+   |
+   = help: Use constructor `Decimal` directly
+
+ℹ Unsafe fix
+18 18 | _ = Decimal.from_float(float("inf"))
+19 19 | _ = Decimal.from_float(float("-inf"))
+20 20 | _ = Decimal.from_float(float("Infinity"))
+21    |-_ = Decimal.from_float(float("-Infinity"))
+   21 |+_ = Decimal("-Infinity")
+22 22 | _ = Decimal.from_float(float("nan"))
+23 23 | 
+24 24 | # OK
+
+FURB164.py:22:5: FURB164 [*] Verbose expression in constructing `Decimal`
+   |
+20 | _ = Decimal.from_float(float("Infinity"))
+21 | _ = Decimal.from_float(float("-Infinity"))
+22 | _ = Decimal.from_float(float("nan"))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
+23 | 
+24 | # OK
+   |
+   = help: Use constructor `Decimal` directly
+
+ℹ Unsafe fix
+19 19 | _ = Decimal.from_float(float("-inf"))
+20 20 | _ = Decimal.from_float(float("Infinity"))
+21 21 | _ = Decimal.from_float(float("-Infinity"))
+22    |-_ = Decimal.from_float(float("nan"))
+   22 |+_ = Decimal("nan")
+23 23 | 
+24 24 | # OK
+25 25 | _ = Fraction(0.1)

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB164_FURB164.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB164_FURB164.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/refurb/mod.rs
 ---
-FURB164.py:7:5: FURB164 [*] Verbose method `from_float` when constructing `Fraction`
+FURB164.py:7:5: FURB164 [*] Verbose method `from_float` in `Fraction` construction
   |
 6 | # Errors
 7 | _ = Fraction.from_float(0.1)
@@ -9,7 +9,7 @@ FURB164.py:7:5: FURB164 [*] Verbose method `from_float` when constructing `Fract
 8 | _ = Fraction.from_float(-0.5)
 9 | _ = Fraction.from_float(5.0)
   |
-  = help: Use constructor `Fraction` directly
+  = help: Replace with `Fraction` constructor
 
 ℹ Safe fix
 4 4 | import fractions
@@ -21,7 +21,7 @@ FURB164.py:7:5: FURB164 [*] Verbose method `from_float` when constructing `Fract
 9 9 | _ = Fraction.from_float(5.0)
 10 10 | _ = fractions.Fraction.from_float(4.2)
 
-FURB164.py:8:5: FURB164 [*] Verbose method `from_float` when constructing `Fraction`
+FURB164.py:8:5: FURB164 [*] Verbose method `from_float` in `Fraction` construction
    |
  6 | # Errors
  7 | _ = Fraction.from_float(0.1)
@@ -30,7 +30,7 @@ FURB164.py:8:5: FURB164 [*] Verbose method `from_float` when constructing `Fract
  9 | _ = Fraction.from_float(5.0)
 10 | _ = fractions.Fraction.from_float(4.2)
    |
-   = help: Use constructor `Fraction` directly
+   = help: Replace with `Fraction` constructor
 
 ℹ Safe fix
 5 5 | 
@@ -42,7 +42,7 @@ FURB164.py:8:5: FURB164 [*] Verbose method `from_float` when constructing `Fract
 10 10 | _ = fractions.Fraction.from_float(4.2)
 11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
 
-FURB164.py:9:5: FURB164 [*] Verbose method `from_float` when constructing `Fraction`
+FURB164.py:9:5: FURB164 [*] Verbose method `from_float` in `Fraction` construction
    |
  7 | _ = Fraction.from_float(0.1)
  8 | _ = Fraction.from_float(-0.5)
@@ -51,7 +51,7 @@ FURB164.py:9:5: FURB164 [*] Verbose method `from_float` when constructing `Fract
 10 | _ = fractions.Fraction.from_float(4.2)
 11 | _ = Fraction.from_decimal(Decimal("4.2"))
    |
-   = help: Use constructor `Fraction` directly
+   = help: Replace with `Fraction` constructor
 
 ℹ Safe fix
 6  6  | # Errors
@@ -63,7 +63,7 @@ FURB164.py:9:5: FURB164 [*] Verbose method `from_float` when constructing `Fract
 11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
 12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
 
-FURB164.py:10:5: FURB164 [*] Verbose method `from_float` when constructing `Fraction`
+FURB164.py:10:5: FURB164 [*] Verbose method `from_float` in `Fraction` construction
    |
  8 | _ = Fraction.from_float(-0.5)
  9 | _ = Fraction.from_float(5.0)
@@ -72,7 +72,7 @@ FURB164.py:10:5: FURB164 [*] Verbose method `from_float` when constructing `Frac
 11 | _ = Fraction.from_decimal(Decimal("4.2"))
 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
    |
-   = help: Use constructor `Fraction` directly
+   = help: Replace with `Fraction` constructor
 
 ℹ Safe fix
 7  7  | _ = Fraction.from_float(0.1)
@@ -84,7 +84,7 @@ FURB164.py:10:5: FURB164 [*] Verbose method `from_float` when constructing `Frac
 12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
 13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
 
-FURB164.py:11:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fraction`
+FURB164.py:11:5: FURB164 [*] Verbose method `from_decimal` in `Fraction` construction
    |
  9 | _ = Fraction.from_float(5.0)
 10 | _ = fractions.Fraction.from_float(4.2)
@@ -93,7 +93,7 @@ FURB164.py:11:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fr
 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
    |
-   = help: Use constructor `Fraction` directly
+   = help: Replace with `Fraction` constructor
 
 ℹ Safe fix
 8  8  | _ = Fraction.from_float(-0.5)
@@ -105,7 +105,7 @@ FURB164.py:11:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fr
 13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
 14 14 | _ = Decimal.from_float(0.1)
 
-FURB164.py:12:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fraction`
+FURB164.py:12:5: FURB164 [*] Verbose method `from_decimal` in `Fraction` construction
    |
 10 | _ = fractions.Fraction.from_float(4.2)
 11 | _ = Fraction.from_decimal(Decimal("4.2"))
@@ -114,7 +114,7 @@ FURB164.py:12:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fr
 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
 14 | _ = Decimal.from_float(0.1)
    |
-   = help: Use constructor `Fraction` directly
+   = help: Replace with `Fraction` constructor
 
 ℹ Safe fix
 9  9  | _ = Fraction.from_float(5.0)
@@ -126,7 +126,7 @@ FURB164.py:12:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fr
 14 14 | _ = Decimal.from_float(0.1)
 15 15 | _ = Decimal.from_float(-0.5)
 
-FURB164.py:13:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fraction`
+FURB164.py:13:5: FURB164 [*] Verbose method `from_decimal` in `Fraction` construction
    |
 11 | _ = Fraction.from_decimal(Decimal("4.2"))
 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
@@ -135,7 +135,7 @@ FURB164.py:13:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fr
 14 | _ = Decimal.from_float(0.1)
 15 | _ = Decimal.from_float(-0.5)
    |
-   = help: Use constructor `Fraction` directly
+   = help: Replace with `Fraction` constructor
 
 ℹ Safe fix
 10 10 | _ = fractions.Fraction.from_float(4.2)
@@ -147,7 +147,7 @@ FURB164.py:13:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fr
 15 15 | _ = Decimal.from_float(-0.5)
 16 16 | _ = Decimal.from_float(5.0)
 
-FURB164.py:13:27: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
+FURB164.py:13:27: FURB164 [*] Verbose method `from_float` in `Decimal` construction
    |
 11 | _ = Fraction.from_decimal(Decimal("4.2"))
 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
@@ -156,7 +156,7 @@ FURB164.py:13:27: FURB164 [*] Verbose method `from_float` when constructing `Dec
 14 | _ = Decimal.from_float(0.1)
 15 | _ = Decimal.from_float(-0.5)
    |
-   = help: Use constructor `Decimal` directly
+   = help: Replace with `Decimal` constructor
 
 ℹ Safe fix
 10 10 | _ = fractions.Fraction.from_float(4.2)
@@ -168,7 +168,7 @@ FURB164.py:13:27: FURB164 [*] Verbose method `from_float` when constructing `Dec
 15 15 | _ = Decimal.from_float(-0.5)
 16 16 | _ = Decimal.from_float(5.0)
 
-FURB164.py:14:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
+FURB164.py:14:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
    |
 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
@@ -177,7 +177,7 @@ FURB164.py:14:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 15 | _ = Decimal.from_float(-0.5)
 16 | _ = Decimal.from_float(5.0)
    |
-   = help: Use constructor `Decimal` directly
+   = help: Replace with `Decimal` constructor
 
 ℹ Safe fix
 11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
@@ -189,7 +189,7 @@ FURB164.py:14:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 16 16 | _ = Decimal.from_float(5.0)
 17 17 | _ = decimal.Decimal.from_float(4.2)
 
-FURB164.py:15:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
+FURB164.py:15:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
    |
 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
 14 | _ = Decimal.from_float(0.1)
@@ -198,7 +198,7 @@ FURB164.py:15:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 16 | _ = Decimal.from_float(5.0)
 17 | _ = decimal.Decimal.from_float(4.2)
    |
-   = help: Use constructor `Decimal` directly
+   = help: Replace with `Decimal` constructor
 
 ℹ Safe fix
 12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
@@ -210,7 +210,7 @@ FURB164.py:15:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 17 17 | _ = decimal.Decimal.from_float(4.2)
 18 18 | _ = Decimal.from_float(float("inf"))
 
-FURB164.py:16:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
+FURB164.py:16:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
    |
 14 | _ = Decimal.from_float(0.1)
 15 | _ = Decimal.from_float(-0.5)
@@ -219,7 +219,7 @@ FURB164.py:16:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 17 | _ = decimal.Decimal.from_float(4.2)
 18 | _ = Decimal.from_float(float("inf"))
    |
-   = help: Use constructor `Decimal` directly
+   = help: Replace with `Decimal` constructor
 
 ℹ Safe fix
 13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
@@ -231,7 +231,7 @@ FURB164.py:16:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 18 18 | _ = Decimal.from_float(float("inf"))
 19 19 | _ = Decimal.from_float(float("-inf"))
 
-FURB164.py:17:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
+FURB164.py:17:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
    |
 15 | _ = Decimal.from_float(-0.5)
 16 | _ = Decimal.from_float(5.0)
@@ -240,7 +240,7 @@ FURB164.py:17:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 18 | _ = Decimal.from_float(float("inf"))
 19 | _ = Decimal.from_float(float("-inf"))
    |
-   = help: Use constructor `Decimal` directly
+   = help: Replace with `Decimal` constructor
 
 ℹ Safe fix
 14 14 | _ = Decimal.from_float(0.1)
@@ -252,7 +252,7 @@ FURB164.py:17:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 19 19 | _ = Decimal.from_float(float("-inf"))
 20 20 | _ = Decimal.from_float(float("Infinity"))
 
-FURB164.py:18:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
+FURB164.py:18:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
    |
 16 | _ = Decimal.from_float(5.0)
 17 | _ = decimal.Decimal.from_float(4.2)
@@ -261,7 +261,7 @@ FURB164.py:18:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 19 | _ = Decimal.from_float(float("-inf"))
 20 | _ = Decimal.from_float(float("Infinity"))
    |
-   = help: Use constructor `Decimal` directly
+   = help: Replace with `Decimal` constructor
 
 ℹ Safe fix
 15 15 | _ = Decimal.from_float(-0.5)
@@ -273,7 +273,7 @@ FURB164.py:18:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 20 20 | _ = Decimal.from_float(float("Infinity"))
 21 21 | _ = Decimal.from_float(float("-Infinity"))
 
-FURB164.py:19:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
+FURB164.py:19:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
    |
 17 | _ = decimal.Decimal.from_float(4.2)
 18 | _ = Decimal.from_float(float("inf"))
@@ -282,7 +282,7 @@ FURB164.py:19:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 20 | _ = Decimal.from_float(float("Infinity"))
 21 | _ = Decimal.from_float(float("-Infinity"))
    |
-   = help: Use constructor `Decimal` directly
+   = help: Replace with `Decimal` constructor
 
 ℹ Safe fix
 16 16 | _ = Decimal.from_float(5.0)
@@ -294,7 +294,7 @@ FURB164.py:19:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 21 21 | _ = Decimal.from_float(float("-Infinity"))
 22 22 | _ = Decimal.from_float(float("nan"))
 
-FURB164.py:20:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
+FURB164.py:20:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
    |
 18 | _ = Decimal.from_float(float("inf"))
 19 | _ = Decimal.from_float(float("-inf"))
@@ -303,7 +303,7 @@ FURB164.py:20:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 21 | _ = Decimal.from_float(float("-Infinity"))
 22 | _ = Decimal.from_float(float("nan"))
    |
-   = help: Use constructor `Decimal` directly
+   = help: Replace with `Decimal` constructor
 
 ℹ Safe fix
 17 17 | _ = decimal.Decimal.from_float(4.2)
@@ -315,7 +315,7 @@ FURB164.py:20:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 22 22 | _ = Decimal.from_float(float("nan"))
 23 23 | 
 
-FURB164.py:21:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
+FURB164.py:21:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
    |
 19 | _ = Decimal.from_float(float("-inf"))
 20 | _ = Decimal.from_float(float("Infinity"))
@@ -323,7 +323,7 @@ FURB164.py:21:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FURB164
 22 | _ = Decimal.from_float(float("nan"))
    |
-   = help: Use constructor `Decimal` directly
+   = help: Replace with `Decimal` constructor
 
 ℹ Safe fix
 18 18 | _ = Decimal.from_float(float("inf"))
@@ -335,7 +335,7 @@ FURB164.py:21:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 23 23 | 
 24 24 | # OK
 
-FURB164.py:22:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
+FURB164.py:22:5: FURB164 [*] Verbose method `from_float` in `Decimal` construction
    |
 20 | _ = Decimal.from_float(float("Infinity"))
 21 | _ = Decimal.from_float(float("-Infinity"))
@@ -344,7 +344,7 @@ FURB164.py:22:5: FURB164 [*] Verbose method `from_float` when constructing `Deci
 23 | 
 24 | # OK
    |
-   = help: Use constructor `Decimal` directly
+   = help: Replace with `Decimal` constructor
 
 ℹ Safe fix
 19 19 | _ = Decimal.from_float(float("-inf"))

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB164_FURB164.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB164_FURB164.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/refurb/mod.rs
 ---
-FURB164.py:7:5: FURB164 [*] Verbose expression in constructing `Fraction`
+FURB164.py:7:5: FURB164 [*] Verbose method `from_float` when constructing `Fraction`
   |
 6 | # Errors
 7 | _ = Fraction.from_float(0.1)
@@ -21,7 +21,7 @@ FURB164.py:7:5: FURB164 [*] Verbose expression in constructing `Fraction`
 9 9 | _ = Fraction.from_float(5.0)
 10 10 | _ = fractions.Fraction.from_float(4.2)
 
-FURB164.py:8:5: FURB164 [*] Verbose expression in constructing `Fraction`
+FURB164.py:8:5: FURB164 [*] Verbose method `from_float` when constructing `Fraction`
    |
  6 | # Errors
  7 | _ = Fraction.from_float(0.1)
@@ -42,7 +42,7 @@ FURB164.py:8:5: FURB164 [*] Verbose expression in constructing `Fraction`
 10 10 | _ = fractions.Fraction.from_float(4.2)
 11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
 
-FURB164.py:9:5: FURB164 [*] Verbose expression in constructing `Fraction`
+FURB164.py:9:5: FURB164 [*] Verbose method `from_float` when constructing `Fraction`
    |
  7 | _ = Fraction.from_float(0.1)
  8 | _ = Fraction.from_float(-0.5)
@@ -63,7 +63,7 @@ FURB164.py:9:5: FURB164 [*] Verbose expression in constructing `Fraction`
 11 11 | _ = Fraction.from_decimal(Decimal("4.2"))
 12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
 
-FURB164.py:10:5: FURB164 [*] Verbose expression in constructing `Fraction`
+FURB164.py:10:5: FURB164 [*] Verbose method `from_float` when constructing `Fraction`
    |
  8 | _ = Fraction.from_float(-0.5)
  9 | _ = Fraction.from_float(5.0)
@@ -84,7 +84,7 @@ FURB164.py:10:5: FURB164 [*] Verbose expression in constructing `Fraction`
 12 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
 13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
 
-FURB164.py:11:5: FURB164 [*] Verbose expression in constructing `Fraction`
+FURB164.py:11:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fraction`
    |
  9 | _ = Fraction.from_float(5.0)
 10 | _ = fractions.Fraction.from_float(4.2)
@@ -105,7 +105,7 @@ FURB164.py:11:5: FURB164 [*] Verbose expression in constructing `Fraction`
 13 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
 14 14 | _ = Decimal.from_float(0.1)
 
-FURB164.py:12:5: FURB164 [*] Verbose expression in constructing `Fraction`
+FURB164.py:12:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fraction`
    |
 10 | _ = fractions.Fraction.from_float(4.2)
 11 | _ = Fraction.from_decimal(Decimal("4.2"))
@@ -126,7 +126,7 @@ FURB164.py:12:5: FURB164 [*] Verbose expression in constructing `Fraction`
 14 14 | _ = Decimal.from_float(0.1)
 15 15 | _ = Decimal.from_float(-0.5)
 
-FURB164.py:13:5: FURB164 [*] Verbose expression in constructing `Fraction`
+FURB164.py:13:5: FURB164 [*] Verbose method `from_decimal` when constructing `Fraction`
    |
 11 | _ = Fraction.from_decimal(Decimal("4.2"))
 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
@@ -147,7 +147,7 @@ FURB164.py:13:5: FURB164 [*] Verbose expression in constructing `Fraction`
 15 15 | _ = Decimal.from_float(-0.5)
 16 16 | _ = Decimal.from_float(5.0)
 
-FURB164.py:13:27: FURB164 [*] Verbose expression in constructing `Decimal`
+FURB164.py:13:27: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
    |
 11 | _ = Fraction.from_decimal(Decimal("4.2"))
 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
@@ -168,7 +168,7 @@ FURB164.py:13:27: FURB164 [*] Verbose expression in constructing `Decimal`
 15 15 | _ = Decimal.from_float(-0.5)
 16 16 | _ = Decimal.from_float(5.0)
 
-FURB164.py:14:5: FURB164 [*] Verbose expression in constructing `Decimal`
+FURB164.py:14:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
    |
 12 | _ = Fraction.from_decimal(Decimal("-4.2"))
 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
@@ -189,7 +189,7 @@ FURB164.py:14:5: FURB164 [*] Verbose expression in constructing `Decimal`
 16 16 | _ = Decimal.from_float(5.0)
 17 17 | _ = decimal.Decimal.from_float(4.2)
 
-FURB164.py:15:5: FURB164 [*] Verbose expression in constructing `Decimal`
+FURB164.py:15:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
    |
 13 | _ = Fraction.from_decimal(Decimal.from_float(4.2))
 14 | _ = Decimal.from_float(0.1)
@@ -210,7 +210,7 @@ FURB164.py:15:5: FURB164 [*] Verbose expression in constructing `Decimal`
 17 17 | _ = decimal.Decimal.from_float(4.2)
 18 18 | _ = Decimal.from_float(float("inf"))
 
-FURB164.py:16:5: FURB164 [*] Verbose expression in constructing `Decimal`
+FURB164.py:16:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
    |
 14 | _ = Decimal.from_float(0.1)
 15 | _ = Decimal.from_float(-0.5)
@@ -231,7 +231,7 @@ FURB164.py:16:5: FURB164 [*] Verbose expression in constructing `Decimal`
 18 18 | _ = Decimal.from_float(float("inf"))
 19 19 | _ = Decimal.from_float(float("-inf"))
 
-FURB164.py:17:5: FURB164 [*] Verbose expression in constructing `Decimal`
+FURB164.py:17:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
    |
 15 | _ = Decimal.from_float(-0.5)
 16 | _ = Decimal.from_float(5.0)
@@ -252,7 +252,7 @@ FURB164.py:17:5: FURB164 [*] Verbose expression in constructing `Decimal`
 19 19 | _ = Decimal.from_float(float("-inf"))
 20 20 | _ = Decimal.from_float(float("Infinity"))
 
-FURB164.py:18:5: FURB164 [*] Verbose expression in constructing `Decimal`
+FURB164.py:18:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
    |
 16 | _ = Decimal.from_float(5.0)
 17 | _ = decimal.Decimal.from_float(4.2)
@@ -273,7 +273,7 @@ FURB164.py:18:5: FURB164 [*] Verbose expression in constructing `Decimal`
 20 20 | _ = Decimal.from_float(float("Infinity"))
 21 21 | _ = Decimal.from_float(float("-Infinity"))
 
-FURB164.py:19:5: FURB164 [*] Verbose expression in constructing `Decimal`
+FURB164.py:19:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
    |
 17 | _ = decimal.Decimal.from_float(4.2)
 18 | _ = Decimal.from_float(float("inf"))
@@ -294,7 +294,7 @@ FURB164.py:19:5: FURB164 [*] Verbose expression in constructing `Decimal`
 21 21 | _ = Decimal.from_float(float("-Infinity"))
 22 22 | _ = Decimal.from_float(float("nan"))
 
-FURB164.py:20:5: FURB164 [*] Verbose expression in constructing `Decimal`
+FURB164.py:20:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
    |
 18 | _ = Decimal.from_float(float("inf"))
 19 | _ = Decimal.from_float(float("-inf"))
@@ -315,7 +315,7 @@ FURB164.py:20:5: FURB164 [*] Verbose expression in constructing `Decimal`
 22 22 | _ = Decimal.from_float(float("nan"))
 23 23 | 
 
-FURB164.py:21:5: FURB164 [*] Verbose expression in constructing `Decimal`
+FURB164.py:21:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
    |
 19 | _ = Decimal.from_float(float("-inf"))
 20 | _ = Decimal.from_float(float("Infinity"))
@@ -335,7 +335,7 @@ FURB164.py:21:5: FURB164 [*] Verbose expression in constructing `Decimal`
 23 23 | 
 24 24 | # OK
 
-FURB164.py:22:5: FURB164 [*] Verbose expression in constructing `Decimal`
+FURB164.py:22:5: FURB164 [*] Verbose method `from_float` when constructing `Decimal`
    |
 20 | _ = Decimal.from_float(float("Infinity"))
 21 | _ = Decimal.from_float(float("-Infinity"))

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -3022,6 +3022,7 @@
         "FURB16",
         "FURB161",
         "FURB163",
+        "FURB164",
         "FURB167",
         "FURB168",
         "FURB169",


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Implement FURB164 in the issue #1348.
Relevant Refurb docs is here: https://github.com/dosisod/refurb/blob/v2.0.0/docs/checks.md#furb164-no-from-float

I've changed the name from `no-from-float` to `verbose-decimal-fraction-construction`.

## Test Plan

<!-- How was it tested? -->

I've written it in the `FURB164.py`.