### PR TITLE
Allow f-strings with `%z` for `DTZ007`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_datetimez/DTZ007.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_datetimez/DTZ007.py
@@ -37,3 +37,5 @@ datetime.strptime("something", "something")
 # F-strings
 datetime.strptime("something", f"%Y-%m-%dT%H:%M:%S{('.%f' if millis else '')}%z")
 datetime.strptime("something", f"%Y-%m-%d %H:%M:%S%z")
+# F-string is implicitly concatenated to another string
+datetime.strptime("something", f"%Y-%m-%dT%H:%M:%S{('.%f' if millis else '')}" "%z")

--- a/crates/ruff_linter/resources/test/fixtures/flake8_datetimez/DTZ007.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_datetimez/DTZ007.py
@@ -33,3 +33,7 @@ from datetime import datetime
 
 # no replace orastimezone unqualified
 datetime.strptime("something", "something")
+
+# F-strings
+datetime.strptime("something", f"%Y-%m-%dT%H:%M:%S{('.%f' if millis else '')}%z")
+datetime.strptime("something", f"%Y-%m-%d %H:%M:%S%z")

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
@@ -102,11 +102,23 @@ pub(crate) fn call_datetime_strptime_without_zone(checker: &mut Checker, call: &
     }
 
     // Does the `strptime` call contain a format string with a timezone specifier?
-    if let Some(Expr::StringLiteral(ast::ExprStringLiteral { value: format, .. })) =
-        call.arguments.args.get(1).as_ref()
-    {
-        if format.to_str().contains("%z") {
-            return;
+    if let Some(expr) = call.arguments.args.get(1) {
+        match expr {
+            Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => {
+                if value.to_str().contains("%z") {
+                    return;
+                }
+            }
+            Expr::FString(ast::ExprFString { value, .. }) => {
+                // TODO(dhruvmanila): This doesn't consider f-strings that are implicitly concatenated
+                // to strings. For example, `f"%Y-%m-%dT%H:%M:%S{('.%f' if millis else '')}" "%z"`
+                for f_string in value.f_strings() {
+                    if f_string.literals().any(|literal| literal.contains("%z")) {
+                        return;
+                    }
+                }
+            }
+            _ => {}
         }
     };
 

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
@@ -110,11 +110,18 @@ pub(crate) fn call_datetime_strptime_without_zone(checker: &mut Checker, call: &
                 }
             }
             Expr::FString(ast::ExprFString { value, .. }) => {
-                // TODO(dhruvmanila): This doesn't consider f-strings that are implicitly concatenated
-                // to strings. For example, `f"%Y-%m-%dT%H:%M:%S{('.%f' if millis else '')}" "%z"`
-                for f_string in value.f_strings() {
-                    if f_string.literals().any(|literal| literal.contains("%z")) {
-                        return;
+                for f_string_part in value {
+                    match f_string_part {
+                        ast::FStringPart::Literal(string) => {
+                            if string.contains("%z") {
+                                return;
+                            }
+                        }
+                        ast::FStringPart::FString(f_string) => {
+                            if f_string.literals().any(|literal| literal.contains("%z")) {
+                                return;
+                            }
+                        }
                     }
                 }
             }

--- a/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ007_DTZ007.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/snapshots/ruff_linter__rules__flake8_datetimez__tests__DTZ007_DTZ007.py.snap
@@ -46,5 +46,7 @@ DTZ007.py:35:1: DTZ007 Naive datetime constructed using `datetime.datetime.strpt
 34 | # no replace orastimezone unqualified
 35 | datetime.strptime("something", "something")
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ DTZ007
+36 | 
+37 | # F-strings
    |
    = help: Call `.replace(tzinfo=<timezone>)` or `.astimezone()` to convert to an aware datetime


### PR DESCRIPTION
## Summary

This PR fixes the bug for `DTZ007` rule where it didn't consider to check for the presence of `%z` in f-strings. It also considers the string parts of an implicitly concatenated f-strings for which I want to find a better solution (#10308).

fixes: #10601 

## Test Plan

Add test cases and update the snapshots.